### PR TITLE
Make Rscript work for linux binary package, and use it to obtain the build variables

### DIFF
--- a/JASP-Common/JASP-Common.pro
+++ b/JASP-Common/JASP-Common.pro
@@ -1,4 +1,4 @@
-
+include( ../common.pri )
 QT       -= gui
 
 DESTDIR = ..

--- a/JASP-Desktop/JASP-Desktop.pro
+++ b/JASP-Desktop/JASP-Desktop.pro
@@ -1,3 +1,4 @@
+include(../common.pri)
 
 QT       += core gui webkit webkitwidgets svg
 

--- a/JASP-Desktop/JASP-Desktop.pro
+++ b/JASP-Desktop/JASP-Desktop.pro
@@ -31,6 +31,10 @@ windows {
 	}
 }
 
+linux:with_system_r {
+    DEFINES += DONT_ADD_ENVIRONMENT_VARIABLES_FOR_R_PACKAGE
+}
+
 PRE_TARGETDEPS += ../libJASP-Common.a
 
 LIBS += -L.. -lJASP-Common

--- a/JASP-Desktop/enginesync.cpp
+++ b/JASP-Desktop/enginesync.cpp
@@ -254,6 +254,8 @@ void EngineSync::startSlaveProcess(int no)
 #define ARCH_SUBPATH "x64"
 #endif
 
+#if !defined(DONT_ADD_ENVIRONMENT_VARIABLES_FOR_R_PACKAGE)
+
 	env.insert("PATH", programDir.absoluteFilePath("R\\library\\RInside\\libs\\" ARCH_SUBPATH) + ";" + programDir.absoluteFilePath("R\\library\\Rcpp\\libs\\" ARCH_SUBPATH) + ";" + programDir.absoluteFilePath("R\\bin\\" ARCH_SUBPATH));
 	env.insert("R_HOME", programDir.absoluteFilePath("R"));
 
@@ -267,6 +269,8 @@ void EngineSync::startSlaveProcess(int no)
 #else
     env.insert("LD_LIBRARY_PATH", programDir.absoluteFilePath("R/lib") + ";" + programDir.absoluteFilePath("R/library/RInside/lib") + ";" + programDir.absoluteFilePath("R/library/Rcpp/lib"));
     env.insert("R_HOME", programDir.absoluteFilePath("R"));
+#endif
+
 #endif
 
 

--- a/JASP-Engine/JASP-Engine.pro
+++ b/JASP-Engine/JASP-Engine.pro
@@ -86,8 +86,9 @@ win32:LIBS += \
 win32:LIBS += -lole32 -loleaut32
 
 RPackage.commands = $$R_EXE CMD INSTALL --library=$$R_HOME/library $$PWD/JASP
+RPackage.path = $$R_HOME/library
 QMAKE_EXTRA_TARGETS += RPackage
-PRE_TARGETDEPS += RPackage
+INSTALLS += RPackage
 
 SOURCES += main.cpp \
 	engine.cpp \

--- a/JASP-Engine/JASP-Engine.pro
+++ b/JASP-Engine/JASP-Engine.pro
@@ -43,6 +43,9 @@ linux {
 	LIBS           += $$system( $$R_EXE CMD config BLAS_LIBS )
 	LIBS           += -Wl,-rpath,$$R_HOME/lib
 	LIBS           += -Wl,-rpath,$$R_HOME/library/RInside/lib
+	# workaround for https://github.com/RcppCore/Rcpp/issues/178 in case
+	# R compiles with --export-dynamic
+        LIBS           += -Wl,--no-export-dynamic
 }
 
 windows {

--- a/JASP-Engine/JASP-Engine.pro
+++ b/JASP-Engine/JASP-Engine.pro
@@ -15,6 +15,8 @@ DEPENDPATH = ..
 
 PRE_TARGETDEPS += ../libJASP-Common.a
 
+include(../common.pri)
+
 LIBS += -L.. -lJASP-Common
 
 macx {

--- a/JASP-Engine/Rscript-wrapper
+++ b/JASP-Engine/Rscript-wrapper
@@ -1,0 +1,3 @@
+#!/bin/bash
+export RHOME=$(cd ../R && pwd)
+../R/bin/Rscript "$@"

--- a/JASP.pro
+++ b/JASP.pro
@@ -1,5 +1,6 @@
-
 cache()
+
+include(common.pri)
 
 TEMPLATE = subdirs
 

--- a/common.pri
+++ b/common.pri
@@ -1,0 +1,2 @@
+isEmpty(PREFIX) { PREFIX = /usr/local }
+!isEmpty(RSCRIPT) { CONFIG += with_system_r }


### PR DESCRIPTION
I *think* this will actually also make it possible to build against any other installed version of R, but I didn't test it so there's probably a bit of work to do for that. I just wanted to send an as-small-as-possible pull request with only "a view towards" linking against system R. Hopefully, you can review and merge this easily.