### PR TITLE
B correlation pairs: fixes sequential plot Inf BF

### DIFF
--- a/JASP-Engine/JASP/R/correlationbayesianpairs.R
+++ b/JASP-Engine/JASP/R/correlationbayesianpairs.R
@@ -466,9 +466,12 @@
 			
 			if (is.na(BF10[i]))
 				stop("One or more Bayes factors cannot be computed")
+			
+			if (is.infinite(BF10[i]))
+				stop("One or more Bayes factors are infinity")
 		}
 	}
-	
+
 	
 	if (BFH1H0) {
 	


### PR DESCRIPTION
If one of the BFs in the sequential analysis is inifinity, an error message is displayed.