### PR TITLE
File loading error checking + bugs

### DIFF
--- a/JASP-Common/exporters/jaspexporter.cpp
+++ b/JASP-Common/exporters/jaspexporter.cpp
@@ -228,6 +228,9 @@ void JASPExporter::saveDataSet(const std::string &path, DataSetPackage* package,
 					}
 
 					archive_entry_free(entry);
+
+					if (bytes < 0)
+						throw runtime_error("Error reading files. Could not save jasp archive");
 				}
 				fileInfo.close();
 			}

--- a/JASP-Common/filereader.cpp
+++ b/JASP-Common/filereader.cpp
@@ -88,6 +88,7 @@ void FileReader::openEntry(const string &archivePath, const string &entryPath)
 				if (string(archive_entry_pathname(entry)) == entryPath)//pathEntry.native())
 				//#endif
 				{
+					
 					_size = archive_entry_size(entry);
 					_exists = true;
 					success = true;
@@ -152,6 +153,11 @@ int FileReader::bytesAvailable() const
 	return 0;
 }
 
+int FileReader::pos() const
+{
+	return _currentRead;
+}
+
 bool FileReader::isSequential() const
 {
 	return true;
@@ -177,11 +183,29 @@ int FileReader::readData(char *data, int maxSize)
 		count = _file->gcount();
 	}
 
-	_currentRead += count;
+	if (count > 0)
+		_currentRead += count;
+
 	if (_currentRead >= _size)
 		close();
 
 	return count;
+}
+
+char* FileReader::readAllData(int blockSize, int &errorCode)
+{
+	int size = bytesAvailable();
+	if (size == 0)
+		return NULL;
+
+	char *data = new char[size];
+
+	int startOffset = _currentRead;
+
+	errorCode = 0;
+	while ((errorCode = readData(&data[_currentRead - startOffset], blockSize)) > 0 );
+
+	return data;
 }
 
 

--- a/JASP-Common/filereader.h
+++ b/JASP-Common/filereader.h
@@ -17,9 +17,11 @@ public:
 	~FileReader();
 
 	int size() const;
+	int pos() const;
 	int bytesAvailable() const;
 	bool isSequential() const;
 	int readData(char * data, int maxSize);
+	char* readAllData(int blockSize, int &errorCode);
 	void close();
 	void reset();
 	bool isClosed();

--- a/JASP-Desktop/analyses.cpp
+++ b/JASP-Desktop/analyses.cpp
@@ -31,6 +31,9 @@ Analysis *Analyses::create(const QString &name, Json::Value *optionsData, Analys
 
 Analysis *Analyses::create(const QString &name, int id, Json::Value *options, Analysis::Status status)
 {
+	if (id >= _nextId)
+		_nextId = id + 1;
+
 	Analysis *analysis = AnalysisLoader::load(id, name.toStdString(), options);
 	analysis->setStatus(status);
 
@@ -55,7 +58,7 @@ void Analyses::clear()
 	for (Analyses::iterator itr = this->begin(); itr != this->end(); itr++)
 	{
 		Analysis *analysis = *itr;
-		if (analysis->status() != Analysis::Complete)
+		if (analysis != NULL && analysis->status() != Analysis::Complete)
 			analysis->setStatus(Analysis::Aborted);
 	}
 }

--- a/JASP-Desktop/enginesync.cpp
+++ b/JASP-Desktop/enginesync.cpp
@@ -269,6 +269,8 @@ void EngineSync::sendMessages()
 	for (Analyses::iterator itr = _analyses->begin(); itr != _analyses->end(); itr++)
 	{
 		Analysis *analysis = *itr;
+		if (analysis == NULL)
+			continue;
 
 		if (analysis->status() == Analysis::Empty)
 		{


### PR DESCRIPTION
- changed the way that an analysis status is saved. This will cause analyses saved prior to this update to load without any of the analyses that do not comply. (i.e. all of them)
- increased the robustness of loading jasp files with broader error
checking. 
- fixed analysis id management bug and the resulting null references.