### PR TITLE
Fixed data file loading issue

### DIFF
--- a/JASP-Common/datasetloader.cpp
+++ b/JASP-Common/datasetloader.cpp
@@ -19,9 +19,9 @@ void DataSetLoader::loadPackage(DataSetPackage *packageData, const string &locat
 	filesystem::path path(locator);
 
 	if (path.extension().compare(string(".sav")) == 0)
-		packageData->dataSet = SPSSImporter::loadDataSet(locator, progress);
+		SPSSImporter::loadDataSet(packageData, locator, progress);
 	else if (path.extension().compare(string(".csv")) == 0)
-		packageData->dataSet = CSVImporter::loadDataSet(locator, progress);
+		CSVImporter::loadDataSet(packageData, locator, progress);
 	else
 		JASPImporter::loadDataSet(packageData, locator, progress);
 }

--- a/JASP-Common/importers/csvimporter.h
+++ b/JASP-Common/importers/csvimporter.h
@@ -1,7 +1,7 @@
 #ifndef CSVIMPORTER_H
 #define CSVIMPORTER_H
 
-#include "../dataset.h"
+#include "datasetpackage.h"
 
 #include <boost/function.hpp>
 
@@ -12,7 +12,7 @@ class CSVImporter
 {
 public:
 
-	static DataSet *loadDataSet(const std::string &locator, boost::function<void (const std::string &, int)> progressCallback);
+	static void loadDataSet(DataSetPackage *packageData, const std::string &locator, boost::function<void (const std::string &, int)> progressCallback);
 
 private:
 	static void initColumn(Column &column, const std::string &name, const std::vector<std::string> &cells);

--- a/JASP-Common/importers/spssimporter.cpp
+++ b/JASP-Common/importers/spssimporter.cpp
@@ -6,10 +6,11 @@
 
 using namespace std;
 
-DataSet *SPSSImporter::loadDataSet(const string &locator, boost::function<void (const string &, int)> progress)
+void SPSSImporter::loadDataSet(DataSetPackage *packageData, const string &locator, boost::function<void (const string &, int)> progress)
 {
 	(void)locator;
 	(void)progress;
 
-	return SharedMemory::createDataSet();
+	packageData->dataSet = SharedMemory::createDataSet(); // this is required incase the loading of the data fails so that the SharedMemory::createDataSet() can be later freed.
+
 }

--- a/JASP-Common/importers/spssimporter.h
+++ b/JASP-Common/importers/spssimporter.h
@@ -1,7 +1,7 @@
 #ifndef SPSSIMPORTER_H
 #define SPSSIMPORTER_H
 
-#include "dataset.h"
+#include "datasetpackage.h"
 #include <boost/function.hpp>
 #include <string>
 
@@ -9,7 +9,7 @@ class SPSSImporter
 {
 public:
 
-	static DataSet *loadDataSet(const std::string &locator, boost::function<void (const std::string &, int)> progress);
+	static void loadDataSet(DataSetPackage *packageData, const std::string &locator, boost::function<void (const std::string &, int)> progress);
 };
 
 #endif // SPSSIMPORTER_H

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -224,6 +224,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
 void MainWindow::open(QString filename)
 {
+	_openedUsingArgs = true;
 	if (_resultsViewLoaded)
 		dataSetSelected(filename);
 	else
@@ -722,7 +723,15 @@ void MainWindow::dataSetLoaded(const QString &dataSetName, DataSetPackage *packa
 void MainWindow::dataSetLoadFailed(const QString &message)
 {
 	_alert->hide();
+
+	if (_package->dataSet != null)
+		_loader.free(_package->dataSet);
+	_package->reset();
+
 	QMessageBox::warning(this, "", "An error was detected and the data could not be loaded.\n\n" + message);
+
+	if (_openedUsingArgs)
+		close();
 }
 
 void MainWindow::updateMenuEnabledDisabledStatus()

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -724,7 +724,7 @@ void MainWindow::dataSetLoadFailed(const QString &message)
 {
 	_alert->hide();
 
-	if (_package->dataSet != null)
+	if (_package->dataSet != NULL)
 		_loader.free(_package->dataSet);
 	_package->reset();
 

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -71,6 +71,7 @@ private:
 	int _tableViewWidthBeforeOptionsMadeVisible;
 
 	bool _resultsViewLoaded = false;
+	bool _openedUsingArgs = false;
 	QString _openOnLoadFilename;
 	QSettings _settings;
 	ActivityLog *_log;


### PR DESCRIPTION
- Fixed issue that arises when a file fails to load and another file is
selected instead. This resulted in the software crashing because the
shared memory was not cleaned up.
- If a corrupted file is loaded using a new process the new process is
terminated.