### PR TITLE
Initial implementation of Posterior estimates B LMs

### DIFF
--- a/JASP-Engine/JASP/R/ancovabayesian.R
+++ b/JASP-Engine/JASP/R/ancovabayesian.R
@@ -48,7 +48,9 @@ AncovaBayesian	 <- function (dataset = NULL, options, perform = "run", callback 
 				change$dependent ||
 				change$covariates ||
 				change$fixedFactors ||
-				change$randomFactors)) {
+				change$randomFactors ||
+				change$posteriorEstimates ||
+				change$posteriorEstimatesMCMCIterations)) {
 			state <- NULL
 		} else {
 			perform <- "run"
@@ -61,6 +63,7 @@ AncovaBayesian	 <- function (dataset = NULL, options, perform = "run", callback 
 	meta [[1]] <- list (name = "title", type = "title")
 	meta [[2]] <- list (name = "model comparison", type = "table")
 	meta [[3]] <- list (name = "effects", type = "table")
+	meta [[4]] <- list (name = "estimates", type = "table")
 	results [[".meta"]] <- meta
 	results [["title"]] <- "Bayesian ANCOVA"
 
@@ -91,6 +94,9 @@ AncovaBayesian	 <- function (dataset = NULL, options, perform = "run", callback 
 
 ## Effects Table
 	results [["effects"]] <- .theBayesianLinearModelsEffects (model, options, perform, status, populate = FALSE)
+
+## Posterior Estimates
+	results [["estimates"]] <- .theBayesianLinearModelEstimates (model, options, perform, status)
 
 	new.state <- list (options = options, model = model, status = status)
 	

--- a/JASP-Engine/JASP/R/anovabayesian.R
+++ b/JASP-Engine/JASP/R/anovabayesian.R
@@ -58,6 +58,7 @@ AnovaBayesian <- function (dataset = NULL, options, perform = "run", callback = 
 	meta [[1]] <- list (name = "title", type = "title")
 	meta [[2]] <- list (name = "model comparison", type = "table")
 	meta [[3]] <- list (name = "effects", type = "table")
+	meta [[4]] <- list (name = "estimates", type = "table")
 	results [[".meta"]] <- meta
 	results [["title"]] <- "Bayesian ANOVA"
 
@@ -90,6 +91,9 @@ AnovaBayesian <- function (dataset = NULL, options, perform = "run", callback = 
 
 ## Effects Table
 	results [["effects"]] <- .theBayesianLinearModelsEffects (model, options, perform, status, populate = FALSE)
+
+## Posterior Estimates
+	results [["estimates"]] <- .theBayesianLinearModelEstimates (model, options, perform, status)
 
 	new.state <- list (options = options, model = model, status = status)
 	

--- a/JASP-Engine/JASP/R/anovarepeatedmeasuresbayesian.R
+++ b/JASP-Engine/JASP/R/anovarepeatedmeasuresbayesian.R
@@ -66,6 +66,7 @@ AnovaRepeatedMeasuresBayesian <- function (dataset = NULL, options, perform = "r
 	meta [[1]] <- list (name = "title", type = "title")
 	meta [[2]] <- list (name = "model comparison", type = "table")
 	meta [[3]] <- list (name = "effects", type = "table")
+	meta [[4]] <- list (name = "estimates", type = "table")
 	results [[".meta"]] <- meta
 	results [["title"]] <- "Bayesian Repeated Measures ANOVA"
 
@@ -113,6 +114,9 @@ if (is.null(state)) {
 
 ## Effects Table
 	results [["effects"]] <- .theBayesianLinearModelsEffects (model, options, perform, status, populate = FALSE)
+
+## Posterior Estimates
+	results [["estimates"]] <- .theBayesianLinearModelEstimates (model, options, perform, status)
 
 	new.state <- list (options = options, model = model, status = status)
 	

--- a/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
+++ b/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
@@ -511,7 +511,8 @@
 			ln.prob [index] <- ln.prob [index] - log (sum (exp (ln.prob [index])))
 			ln.BF.model <- sapply (1:(no.models+1),function(m) {
 				if (m %in% index) {
-					bayes.factors [m] - maxLBF - log (sum (exp (bayes.factors[-m] - maxLBF))) + log (no.models)					
+					i <- which (index == m)
+					bayes.factors [m] - maxLBF - log (sum (exp (bayes.factors[index] [-i] - maxLBF))) + log (no.models)
 				} else {
 					NA
 				}

--- a/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
+++ b/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
@@ -187,6 +187,18 @@
 			nuisance = neverExclude,
 			null.model = null.model), 
 		options, perform = "run", status, populate = TRUE)
+	
+	if (options$posteriorEstimates) {
+		results [["effects"]] <- .theBayesianLinearModelEstimates (
+			list (
+				models = model.object, 
+				effects = effects.matrix,
+				interactions.matrix = interactions.matrix, 
+				nuisance = neverExclude,
+				null.model = null.model), 
+			options, perform = "init", status, populate = TRUE)
+	}
+	
 	return(results)
 }
 
@@ -384,15 +396,30 @@
 					options <- response$options
 			}
 		}
-#		if (options$posteriorEstimates) {
-#			complexity <- rowSums (effects)
-#			m <- which (complexity == max (complexity))
-#			chains <- posterior ( model.object [[m]]$bf, iterations = mcmc.iterations)
-#			model.object [[m]]$chains <- chains
-#			return (list (model =  list (models = model.object, effects = effects.matrix,
-#				interactions.matrix = interactions.matrix, nuisance = neverExclude,
-#				null.model = null.model), status = status, mcmc.model = m))
-#		}
+
+		if (options$posteriorEstimates && perform == "run" && status$ready) {
+			complexity <- rowSums (effects.matrix)
+			m <- which (complexity == max (complexity))
+			chains <- try (BayesFactor::lmBF (model.list [[m]],
+					data = dataset, whichRandom = .v (unlist (options$randomFactors)),
+					progress = FALSE, posterior = TRUE, callback = .callbackBFpackage, 
+					iterations = options$posteriorEstimatesMCMCIterations))
+			
+			if (inherits (bf, "try-error")) {
+				message <- .extractErrorMessage (bf)
+				if (message == "Operation cancelled by callback function.")
+					return()
+				model.object [[m]]$error.message <- "Posterior could not be computed"
+				return (list (model =  list (models = model.object, effects = effects.matrix,
+					interactions.matrix = interactions.matrix, nuisance = neverExclude,
+					null.model = null.model), status = status))
+			} 		
+			
+			model.object [[m]]$chains <- chains
+			return (list (model =  list (models = model.object, effects = effects.matrix,
+				interactions.matrix = interactions.matrix, nuisance = neverExclude,
+				null.model = null.model), status = status))
+		}
 		return (list (model = list (models = model.object, effects = effects.matrix,
 			interactions.matrix = interactions.matrix, nuisance = neverExclude,
 			null.model = null.model), status = status))
@@ -502,11 +529,7 @@
 				rows [[1]] [["BFM"]] <- .clean (ln.BF.model [1] / log (10))
 			}
 		}
-		if (options$bayesFactorType == "LogBF10") {
-			rows [[1]] [["BF10"]] <- 0
-		} else {
-			rows [[1]] [["BF10"]] <- 1
-		}
+		rows [[1]] [["BF10"]] <- 0
 		rows [[1]] [["% error"]] <- ""
 
 		for (m in 1:no.models) {
@@ -709,3 +732,149 @@
 	return (effectsTable)
 }
 
+.theBayesianLinearModelEstimates <- function (model = NULL, options = list (), perform = "init", status = list (), populate = FALSE) {
+	if (! options$posteriorEstimates)
+		return (NULL)
+
+	estimatesTable <- list ()
+	estimatesTable [["title"]] <- "Parameter Estimates"
+	estimatesTable [["citation"]] <-
+		list (
+			"Morey, R. D. & Rouder, J. N. (2015). BayesFactor (Version 0.9.10-2)[Computer software].",
+			"Rouder, J. N., Morey, R. D., Speckman, P. L., Province, J. M., (2012) Default Bayes Factors for ANOVA Designs. Journal of Mathematical Psychology. 56. p. 356-374."
+		)
+	
+	alpha <- (1 - options$posteriorEstimatesCredibleIntervalInterval) / 2
+	fields <-
+		list (
+			list (name = "Effects", type = "string"),
+			list (name = "Posterior Median", type = "number", format = "sf:4;dp:3"),
+			list (name = "Posterior SD", type = "number", format = "sf:4;dp:3"),
+			list (name = "Lower Bound", title = paste (alpha, "%", sep=""), type = "number", format = "sf:4;dp:3"),
+			list (name = "Upper Bound", title = paste (1-alpha, "%", sep=""), type = "number", format = "sf:4;dp:3")
+		)
+	estimatesTable [["schema"]] <- list (fields = fields)
+
+	if ( !status$ready && is.null (status$error.message))
+		return (estimatesTable)
+	
+	if ( perform == "init" && ! populate)
+		return (estimatesTable)
+
+	if (! populate ) {
+		effects.matrix <- matrix (model$effects [1:nrow (model$effects), 1:(ncol (model$effects) - 2)],
+			nrow = nrow (model$effects),
+			ncol = ncol (model$effects) - 2)
+		complexity <- rowSums (effects.matrix)
+		m <- which (complexity == max (complexity))
+	} else {
+		effects.matrix <- model$effects
+		complexity <- rowSums (effects.matrix)
+		m <- which (complexity == max (complexity))
+	}
+	
+	
+	if (! populate && is.null (model$models[[m]]$error.message)) {
+		chains <- model$models[[m]]$chains
+		parameters <- colnames (chains)
+		if (length (options$randomFactors) > 0) {
+			rfnames <- .v (unlist (options$randomFactors))
+			remove <- NULL
+			for (name in rfnames) 
+				remove <- c (remove, base::grep (x = parameters, pattern = name, fixed = TRUE, ignore.case = TRUE))
+			chains <- chains [, - remove]
+			parameters <- colnames (chains)
+		}
+	
+		estimates <- matrix (0, nrow = length (parameters), ncol = 4)
+		for (e in 1:length (parameters)) {
+			estimates [e, 1] <- median (chains[, e])
+			estimates [e, 2] <- sd (chains[, e])
+			estimates [e, 3] <- quantile (chains [, e], alpha)
+			estimates [e, 4] <- quantile (chains [, e], 1-alpha)
+		}
+		
+		for (parameter in 1:length (parameters)) {
+			name <- stringr::str_trim (parameters [parameter])
+			name <- base::strsplit (name, split = "-", fixed = TRUE) [[1]]
+			if (length (name) > 1) {
+				levels <- base::strsplit (name [2], split = ".&.", fixed = TRUE) [[1]]
+				effects <- base::strsplit (name [1], split = ":", fixed = TRUE) [[1]]
+				name <- NULL
+				for (e in 1:length (effects)) {
+					if (stringr::str_trim (effects [e]) == stringr::str_trim (levels [e])) {
+						name <- c (name, .unvf (effects [e]))
+					} else {
+						name <- c (name, paste (.unvf (effects [e]), levels [e], sep = " -- "))
+					}
+				}
+				name <- paste (name, collapse = " & ")
+			} else {
+				if (base::substr (name, 1, 1) == "X") {
+					name <- .unv (name)
+				} else {
+					if (name == "sig2") {
+						name <- "\u03C3\u00B2"
+					} else if (name == "mu") {
+						name <- "Intercept"
+					} else if (name == "g") {
+						name <- "g (prior)"
+					} else if (base::substr(name,1,2) == "g_") {
+						name <- base::substr(name,3, base::nchar(name))
+						if (base::substr (name, 1, 1) == "X")
+							name <- .unvf (name)
+						name <- paste ("g (prior: ", name,")", sep = "")
+					}
+				}
+			}
+			parameters [parameter] <- name
+		}
+		no.effects <- ncol (chains)
+		rows <- list ()
+		for (e in 1:no.effects) {
+			row <- list ()
+			row$"Effects" <- parameters [e]
+			row$"Posterior Median" <- .clean ( estimates [e, 1])
+			row$"Posterior SD" <- .clean ( estimates [e, 2])
+			row$"Lower Bound" <- .clean ( estimates [e, 3])
+			row$"Upper Bound" <- .clean ( estimates [e, 4])
+			rows [[length (rows) + 1]] <- row
+		}
+		estimatesTable [["data"]] <- rows
+	} else {
+		if (! is.null (model$models[[m]]$error.message)) {
+			## Footnotes
+			footnotes <- .newFootnotes()
+			if (length (model$nuisance) > 0) {
+					footnote <- paste (model$models[[m]]$error.message, sep = "")
+					.addFootnote (footnotes, symbol = "<em>Note.</em>", text = footnote)
+			}
+			estimatesTable [["footnotes"]] <- as.list (footnotes)
+		}
+
+		if ( length (options$fixedFactors) == 0) {
+			parameters <- c(.unvf(colnames (effects.matrix)), "\u03C3\u00B2", "g (prior)")
+		} else {
+			parameters <- c("Intercept", .unvf(colnames (effects.matrix)), "\u03C3\u00B2", "g (prior)")
+		}
+		no.effects <- length (parameters)
+		rows <- list ()
+		for (e in 1:no.effects) {
+			row <- list ()
+			row$"Effects" <- parameters [e]
+			row$"Posterior Median" <- ""
+			row$"Posterior SD" <- ""
+			row$"Lower Bound" <- ""
+			row$"Upper Bound" <- ""
+			rows [[length (rows) + 1]] <- row
+		}
+		estimatesTable [["data"]] <- rows
+	}
+
+	if (!status$ready)
+		estimatesTable [["error"]] <- list (errorType = "badData")
+
+ 	estimatesTable [["title"]] <- paste ("Parameter Estimates - ", options$dependent, sep = "")
+	
+	return (estimatesTable)
+}

--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -46,6 +46,7 @@ RegressionLinearBayesian <- function (dataset = NULL, options, perform = "run", 
 	meta [[1]] <- list (name = "title", type = "title")
 	meta [[2]] <- list (name = "model comparison", type = "table")
 	meta [[3]] <- list (name = "effects", type = "table")
+	meta [[4]] <- list (name = "estimates", type = "table")
 	results [[".meta"]] <- meta
 	results [["title"]] <- "Bayesian Linear Regression"
 
@@ -79,8 +80,11 @@ RegressionLinearBayesian <- function (dataset = NULL, options, perform = "run", 
 ## Effects Table
 	results [["effects"]] <- .theBayesianLinearModelsEffects (model, options, perform, status, populate = FALSE)
 
+## Posterior Estimates
+	results [["estimates"]] <- .theBayesianLinearModelEstimates (model, options, perform, status)
+
 	new.state <- list (options = options, model = model, status = status)
-	
+
 	if (perform == "run" || !status$ready || ! is.null (state)) {
 		return (list (results = results, status = "complete", state = new.state))
 	} else {


### PR DESCRIPTION
This affects:
- Bayesian Linear Regression
- Bayesian ANOVA
- Bayesian ANCOVA
- Bayesian RM ANOVA

It contains an initial implementation of Posterior estimates using MCMC
output.
It takes the arguments:
posteriorEstimates (logical)
posteriorEstimatesCredibleIntervalInterval (number between 0 and 1)
posteriorEstimatesMCMCIterations (positive integer larger than 1)

The output is very basic, for now, and contains a Table with:
- posterior median
- posterior SD
- Credible Interval