### PR TITLE
Fixes #1150 JASP does not support CSV in OSF

### DIFF
--- a/JASP-Common/datasetloader.cpp
+++ b/JASP-Common/datasetloader.cpp
@@ -18,6 +18,7 @@
 #include "datasetloader.h"
 
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include "sharedmemory.h"
 #include "dataset.h"
@@ -30,18 +31,22 @@ using namespace boost::interprocess;
 using namespace boost;
 using namespace std;
 
-
-void DataSetLoader::loadPackage(DataSetPackage *packageData, const string &locator, boost::function<void(const string &, int)> progress)
+void DataSetLoader::loadPackage(DataSetPackage *packageData, const string &locator, const string &extension, boost::function<void(const string &, int)> progress)
 {
 	filesystem::path path(locator);
+	string ext = path.extension().generic_string();
 
-	if (path.extension().compare(string(".sav")) == 0)
+	if (!ext.length()) ext=extension;
+
+	//compare case insensitive file extension to choose importer
+	if (boost::iequals(ext,".sav"))
 		SPSSImporter::loadDataSet(packageData, locator, progress);
-	else if (path.extension().compare(string(".csv")) == 0 || path.extension().compare(string(".txt")) == 0)
+	else if (boost::iequals(ext,".csv") || boost::iequals(ext,".txt"))
 		CSVImporter::loadDataSet(packageData, locator, progress);
 	else
 		JASPImporter::loadDataSet(packageData, locator, progress);
 }
+
 
 void DataSetLoader::freeDataSet(DataSet *dataSet)
 {

--- a/JASP-Common/datasetloader.h
+++ b/JASP-Common/datasetloader.h
@@ -26,7 +26,7 @@ class DataSetLoader
 {
 public:
 
-	static void loadPackage(DataSetPackage *packageData, const std::string &locator, boost::function<void (const std::string &stage, int progress)> progress = NULL);
+	static void loadPackage(DataSetPackage *packageData, const std::string &locator, const std::string &extension, boost::function<void (const std::string &stage, int progress)> progress = NULL);
 	static DataSet *getDataSet();
 	static void freeDataSet(DataSet *dataSet);
 

--- a/JASP-Desktop/asyncloader.cpp
+++ b/JASP-Desktop/asyncloader.cpp
@@ -174,15 +174,30 @@ void AsyncLoader::loadPackage(QString id)
 
 			if (_currentEvent->IsOnlineNode())
 			{
+				//Find file extension in the OSF
+				string extension=".jasp"; //default
+				QString qpath(path.c_str());
+				int slashPos = qpath.lastIndexOf("/");
+				int dotPos = qpath.lastIndexOf('.');
+				if (dotPos != -1 && dotPos > slashPos)
+				{
+					QString ext = qpath.mid(dotPos);
+					extension=ext.toStdString();
+				}
+
 				dataNode = _odm->getActionDataNode(id);
 
 				if (dataNode != NULL && dataNode->error())
 					throw runtime_error(fq(dataNode->errorMessage()));
 
+				//Generated local path has no extension
 				path = fq(_odm->getLocalPath(_currentEvent->path()));
-			}
 
-			_loader.loadPackage(_currentPackage, path, boost::bind(&AsyncLoader::progressHandler, this, _1, _2));
+				//loadPackage argument extension determines type
+				_loader.loadPackage(_currentPackage, path, extension, boost::bind(&AsyncLoader::progressHandler, this, _1, _2));
+			}
+			else
+				_loader.loadPackage(_currentPackage, path, "", boost::bind(&AsyncLoader::progressHandler, this, _1, _2));
 
 			QString calcMD5 = fileChecksum(tq(path), QCryptographicHash::Md5);
 

--- a/JASP-Desktop/backstage/fsbmosf.cpp
+++ b/JASP-Desktop/backstage/fsbmosf.cpp
@@ -134,8 +134,6 @@ FSBMOSF::OnlineNodeData FSBMOSF::currentNodeData()
 void FSBMOSF::loadProjects() {
 
 	QUrl url("https://api.osf.io/v2/users/me/nodes/");
-	//QUrl url("https://test-api.osf.io/v2/users/me/nodes/");
-	//QUrl url("https://staging2-api.osf.io/v2/users/me/nodes/");
 	QNetworkRequest request(url);
 	request.setHeader(QNetworkRequest::ContentTypeHeader, "application/vnd.api+json");
 	request.setRawHeader("Accept", "application/vnd.api+json");
@@ -260,7 +258,7 @@ void FSBMOSF::gotFilesAndFolders()
 					entryType = FSEntry::Folder;
 				else if (nodeData.name.endsWith(".jasp", Qt::CaseInsensitive))
 					entryType = FSEntry::JASP;
-				else if (nodeData.name.endsWith(".csv", Qt::CaseInsensitive))
+				else if (nodeData.name.endsWith(".csv", Qt::CaseInsensitive) || nodeData.name.endsWith(".txt", Qt::CaseInsensitive))
 					entryType = FSEntry::CSV;
 		#ifdef QT_DEBUG
 				else if (nodeData.name.endsWith(".spss", Qt::CaseInsensitive))


### PR DESCRIPTION
Related to #1142.
Txt files are treated as cvs files. In the OSF as well as on file
system.