### PR TITLE
force filename end with .jasp

### DIFF
--- a/JASP-Desktop/backstage/backstagecomputer.cpp
+++ b/JASP-Desktop/backstage/backstagecomputer.cpp
@@ -99,6 +99,11 @@ FileEvent *BackstageComputer::browseSave(const QString &path)
 
 	if (finalPath != "")
 	{
+		// force the filename end with .jasp - workaround for linux saving issue
+		if(!finalPath.endsWith(".jasp", Qt::CaseInsensitive))
+		{
+			finalPath.append(QString(".jasp"));
+		}
 		event->setPath(finalPath);
 		emit dataSetIORequest(event);
 	}


### PR DESCRIPTION
fix for linux systems - issue : (https://github.com/jasp-stats/jasp-desktop/issues/1158)