### PR TITLE
Fixes #1170 Remove unclear ... menu button

### DIFF
--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -227,20 +227,14 @@ MainWindow::MainWindow(QWidget *parent) :
 	_okButton = new QPushButton(QString("OK"), _buttonPanel);
 	_okButton->setDefault(true);
 	_runButton = new QPushButton(QString("Run"), _buttonPanel);
-	_menuButton = new QPushButton(QString("..."), _buttonPanel);
 
 	QMenuBar *_mMenuBar = new QMenuBar(parent=0);
 	QMenu *aboutMenu = _mMenuBar->addMenu("JASP");
 	aboutMenu->addAction("About",this,SLOT(showAbout()));
 	_mMenuBar->addMenu(aboutMenu);
 
-	QMenu *menu = new QMenu(_menuButton);
-	menu->addAction("Remove Analysis", this, SLOT(analysisRemoved()));
-	_menuButton->setMenu(menu);
-
 	_buttonPanelLayout->addWidget(_okButton);
 	_buttonPanelLayout->addWidget(_runButton);
-	_buttonPanelLayout->addWidget(_menuButton);
 	_buttonPanelLayout->addStretch();
 
 	_buttonPanel->resize(_buttonPanel->sizeHint());

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -93,7 +93,6 @@ private:
 	QVBoxLayout *_buttonPanelLayout;
 	QPushButton *_okButton;
 	QPushButton *_runButton;
-	QPushButton *_menuButton;
 	QTabBar *_mTabBar;
 
 	OptionsForm *_optionsForm;


### PR DESCRIPTION
At the moment the unclear ... menu button (below the OK button on the
variables/parameter screen) only has the functionality of removing an
analysis. This is already implemented in the dropdown of each analysis.