### PR TITLE
Remove icons from file menu

### DIFF
--- a/JASP-Desktop/backstage/opensavewidget.cpp
+++ b/JASP-Desktop/backstage/opensavewidget.cpp
@@ -75,7 +75,7 @@ OpenSaveWidget::OpenSaveWidget(QWidget *parent) : QWidget(parent)
 	_tabWidget->addTab(_bsRecent, "Recent");
 	_tabWidget->addTab(_bsComputer, "Computer");
 
-	_tabWidget->addTab(_bsOSF, "OSF", QIcon(":/icons/logo-osf.png"));
+	_tabWidget->addTab(_bsOSF, "OSF");
 
 	_tabWidget->addTab(_bsExamples, "Examples");
 

--- a/JASP-Desktop/backstagewidget.cpp
+++ b/JASP-Desktop/backstagewidget.cpp
@@ -59,7 +59,7 @@ BackStageWidget::BackStageWidget(QWidget *parent) : QWidget(parent)
 
 	_tabBar->addTab("Open");
 	_tabBar->addTab("Save");
-	_tabBar->addTab("Save As", QIcon(":/icons/document-save-as.png"));
+	_tabBar->addTab("Save As");
 	_tabBar->addTab("Export");
 	_tabBar->addTab("Close");
 


### PR DESCRIPTION
Some options in File tabs contains icons. Others don’t