### PR TITLE
Show file name in main window after opening

### DIFF
--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -825,6 +825,8 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 		if (event->successful())
 		{
 			populateUIfromDataSet();
+			QString name =  QFileInfo(event->path()).baseName();
+			setWindowTitle(name);
 		}
 		else
 		{


### PR DESCRIPTION
At the moment the current file name is only shown when saving the file.
Not is also shown when the file is opened.