### PR TITLE
OSF Login Text cutoff on Windows

### DIFF
--- a/JASP-Desktop/backstage/authwidget.ui
+++ b/JASP-Desktop/backstage/authwidget.ui
@@ -161,9 +161,9 @@
     <property name="geometry">
      <rect>
       <x>24</x>
-      <y>24</y>
+      <y>14</y>
       <width>181</width>
-      <height>19</height>
+      <height>41</height>
      </rect>
     </property>
     <property name="sizePolicy">


### PR DESCRIPTION
On the OSF Login Screen the text was cutoff at the bottom