### PR TITLE
linux - recognize jasp filetype

### DIFF
--- a/Tools/debian/jasp.desktop
+++ b/Tools/debian/jasp.desktop
@@ -2,9 +2,10 @@
 Name=JASP
 Comment=Statistical analysis package
 Keywords=statistics;data
-Exec=JASP
+Exec=JASP %f
 Terminal=false
 Type=Application
+MimeType=application/jasp
 StartupNotify=true
 Icon=/usr/lib/JASP/Resources/jasp.svg
 

--- a/Tools/debian/jasp.install
+++ b/Tools/debian/jasp.install
@@ -4,4 +4,5 @@ R/*                 usr/lib/JASP/R
 Resources/*         usr/lib/JASP/Resources
 debian/jasp.svg     usr/lib/JASP/Resources
 debian/jasp.desktop usr/share/applications
-
+debian/jasp.svg     usr/share/icons/gnome/scalable/mimetypes/application-jasp.svg
+debian/jasp.xml     usr/share/mime/packages

--- a/Tools/debian/jasp.xml
+++ b/Tools/debian/jasp.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+	<mime-type type="application/jasp">
+		<comment>JASP File</comment>
+		<icon name="jasp.svg"/>
+		<glob-deleteall/>
+		<glob pattern="*.jasp"/>
+	</mime-type>
+</mime-info>


### PR DESCRIPTION
1) jasp.desktop file modified to add a mimetype "application/jasp" in the linux system - .jasp files are now recognized by the system
2) .jasp files have the jasp icon 