### PR TITLE
Fixes #1265

### DIFF
--- a/JASP-Common/importers/csv.cpp
+++ b/JASP-Common/importers/csv.cpp
@@ -372,27 +372,32 @@ bool CSV::readLine(vector<string> &items)
 		}
 		else if (ch == '\r')
 		{
-			string token(&_utf8Buffer[_utf8BufferStartPos], i - _utf8BufferStartPos);
-			trim(token);
-
-			items.push_back(token);
+            if (items.size() > 0 || i > _utf8BufferStartPos) {
+                string token(&_utf8Buffer[_utf8BufferStartPos], i - _utf8BufferStartPos);
+                trim(token);
+                items.push_back(token);
+            }
 
 			if (i + 1 < _utf8BufferEndPos && _utf8Buffer[i + 1] == '\n')
 				_utf8BufferStartPos = i + 2;
 			else
 				_utf8BufferStartPos = i + 1;
 
-			break;
+            if (items.size() > 0)
+                break;
 		}
 		else if (ch == '\n')
 		{
-			string token(&_utf8Buffer[_utf8BufferStartPos], i - _utf8BufferStartPos);
-			trim(token);
-
-			items.push_back(token);
+            if (items.size() > 0 || i > _utf8BufferStartPos) {
+                string token(&_utf8Buffer[_utf8BufferStartPos], i - _utf8BufferStartPos);
+                trim(token);
+                items.push_back(token);
+            }
 
 			_utf8BufferStartPos = i + 1;
-			break;
+
+            if (items.size() > 0)
+                break;
 		}
 
 		if (i >= _utf8BufferEndPos - 1)
@@ -405,10 +410,11 @@ bool CSV::readLine(vector<string> &items)
 			}
 			else // eof
 			{
-				string token(&_utf8Buffer[_utf8BufferStartPos], _utf8BufferEndPos - _utf8BufferStartPos);
-				trim(token);
-
-				items.push_back(token);
+                if (items.size() > 0 || _utf8BufferEndPos > _utf8BufferStartPos) {
+                    string token(&_utf8Buffer[_utf8BufferStartPos], _utf8BufferEndPos - _utf8BufferStartPos);
+                    trim(token);
+                    items.push_back(token);
+                }
 				_eof = true;
 				break;
 			}
@@ -417,12 +423,12 @@ bool CSV::readLine(vector<string> &items)
 		i++;
 	}
 
-	for (int i = 0; i < items.size(); i++)
+    for (size_t index = 0; index < items.size(); index++)
 	{
-		string item = items.at(i);
+        string item = items.at(index);
 		if (item.size() >= 2 && item[0] == '"' && item[item.size()-1] == '"')
 			item = item.substr(1, item.size()-2);
-		items[i] = item;
+        items[index] = item;
 	}
 
 	return true;

--- a/JASP-Common/importers/csvimporter.cpp
+++ b/JASP-Common/importers/csvimporter.cpp
@@ -61,11 +61,13 @@ void CSVImporter::loadDataSet(DataSetPackage *packageData, const string &locator
 			lastProgress = progress;
 		}
 
-		int i = 0;
-		for (; i < line.size() && i < columnCount; i++)
-			cells[i].push_back(line[i]);
-		for (; i < columnCount; i++)
-			cells[i].push_back(string());
+        if (line.size() != 0) {
+            int i = 0;
+            for (; i < line.size() && i < columnCount; i++)
+                cells[i].push_back(line[i]);
+            for (; i < columnCount; i++)
+                cells[i].push_back(string());
+        }
 
 		line.clear();
 		success = csv.readLine(line);

--- a/JASP-Desktop/variablespage/levelstablemodel.cpp
+++ b/JASP-Desktop/variablespage/levelstablemodel.cpp
@@ -109,3 +109,38 @@ void LevelsTableModel::moveUp(QModelIndexList &selection) {
 void LevelsTableModel::moveDown(QModelIndexList &selection) {
 	_moveRows(selection, false);
 }
+
+Qt::ItemFlags LevelsTableModel::flags(const QModelIndex &index) const
+{
+    if (index.column() == 1) {
+        return Qt::ItemIsEditable | QAbstractTableModel::flags(index);
+    } else {
+        return QAbstractTableModel::flags(index);
+    }
+}
+
+bool LevelsTableModel::setData(const QModelIndex & index, const QVariant & value, int role)
+{
+    if (_column == NULL)
+        return false;
+
+    if (role == Qt::EditRole)
+    {
+        Labels &labels = _column->labels();
+        std::vector<LabelEntry> new_labels(labels.begin(), labels.end());
+//        const LabelEntry &old_label_entry = labels.at(index.row());
+//        Label *new_label = new Label(old_label_entry.second.text(), value.toInt());
+//        LabelEntry *new_label_entry = new LabelEntry(value.toInt(), *new_label);
+
+        LabelEntry new_label_entry = new_labels[index.row()];
+        int new_value = new_label_entry.first; //2;//value.toInt();
+        new_label_entry.first = new_value;
+        new_label_entry.second.setValue(new_value);
+        new_labels[index.row()] = new_label_entry;
+        labels.set(new_labels);
+
+        //_column->labels().setValue(index.row(), value.toInt());
+        //entry.second = value.toString();
+    }
+    return true;
+}

--- a/JASP-Desktop/variablespage/levelstablemodel.h
+++ b/JASP-Desktop/variablespage/levelstablemodel.h
@@ -19,6 +19,8 @@ public:
 	int columnCount(const QModelIndex &parent) const OVERRIDE;
 	QVariant data(const QModelIndex &index, int role) const OVERRIDE;
 	QVariant headerData(int section, Qt::Orientation orientation, int role) const OVERRIDE;
+    Qt::ItemFlags flags(const QModelIndex &index) const OVERRIDE;
+    bool setData(const QModelIndex & index, const QVariant & value, int role) OVERRIDE;
 
 	void moveUp(QModelIndexList &selection);
 	void moveDown(QModelIndexList &selection);


### PR DESCRIPTION
CSV Importer reads file by chunks. If one chunk just finishes after a
‘\r’ and before a ‘\n’ then a empty line is artificially added.