### PR TITLE
Fixes #1270

### DIFF
--- a/JASP-Desktop/terms.cpp
+++ b/JASP-Desktop/terms.cpp
@@ -23,7 +23,6 @@
 
 #include <QDataStream>
 #include <QIODevice>
-
 using namespace std;
 
 Terms::Terms(const QList<QList<QString> > &terms, Terms *parent)
@@ -120,6 +119,10 @@ void Terms::set(const QList<QString> &terms)
 void Terms::setSortParent(const Terms &parent)
 {
 	_parent = &parent;
+}
+
+void Terms::removeParent() {
+	_parent = NULL;
 }
 
 void Terms::add(const Term &term)

--- a/JASP-Desktop/terms.h
+++ b/JASP-Desktop/terms.h
@@ -47,6 +47,7 @@ public:
 	void set(const Terms &terms);
 	void set(QByteArray &array);
 
+	void removeParent();
 	void setSortParent(const Terms &parent);
 
 	void add(const Term &term);

--- a/JASP-Desktop/widgets/tablemodelvariablesavailable.cpp
+++ b/JASP-Desktop/widgets/tablemodelvariablesavailable.cpp
@@ -47,7 +47,6 @@ void TableModelVariablesAvailable::setVariables(const Terms &variables)
 		else
 			allowed.add(term);
 	}
-
 	Terms ordered; // present them in a nice order
 
 	ordered.add(suggested);
@@ -55,6 +54,7 @@ void TableModelVariablesAvailable::setVariables(const Terms &variables)
 	ordered.add(forbidden);
 
 	_allVariables.set(ordered);
+	_variables.removeParent();
 	_variables.set(ordered);
 
 	_variables.setSortParent(_allVariables);

--- a/Resources/Library/Descriptives.json
+++ b/Resources/Library/Descriptives.json
@@ -58,7 +58,7 @@
 			"type": "Boolean"
 		},
 		{
-			"name": "valuesAreGroupMidpoints",
+			"name": "statisticsValuesAreGroupMidpoints",
 			"type": "Boolean"
 		},
 		{


### PR DESCRIPTION
When a file contains many columns, the display of the columns in an
analysis form could take a really long time.