### PR TITLE
Enable Export function

### DIFF
--- a/JASP-Common/JASP-Common.pro
+++ b/JASP-Common/JASP-Common.pro
@@ -1,5 +1,6 @@
 
 QT -= gui
+QT += webkitwidgets printsupport
 
 DESTDIR = ..
 TARGET = JASP-Common
@@ -90,7 +91,9 @@ SOURCES += \
 	importers/spss/variablerecord.cpp \
 	importers/spss/verylongstringrecord.cpp \
 	importers/spss/integerinforecord.cpp \
-	importers/spss/stringutils.cpp
+	importers/spss/stringutils.cpp \
+    exporters/htmlexporter.cpp \
+    exporters/pdfexporter.cpp
 
 
 HEADERS += \
@@ -183,6 +186,8 @@ HEADERS += \
 	importers/spss/vardisplayparamrecord.h \
 	importers/spss/variablerecord.h \
 	importers/spss/verylongstringrecord.h \
-	importers/spss/stringutils.h
+	importers/spss/stringutils.h \
+    exporters/htmlexporter.h \
+    exporters/pdfexporter.h
 
 

--- a/JASP-Common/exporters/htmlexporter.cpp
+++ b/JASP-Common/exporters/htmlexporter.cpp
@@ -1,0 +1,37 @@
+//
+// Copyright (C) 2016 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "htmlexporter.h"
+#include "utils.h"
+
+QString HTMLExporter::_transferFile = "";
+
+void HTMLExporter::saveDataSet(const std::string &path, DataSetPackage* package, boost::function<void (const std::string &, int)> progressCallback)
+{
+
+	Utils::renameOverwrite(_transferFile.toStdString(), path);
+
+	progressCallback("Export Html Set", 100);
+
+}
+
+void HTMLExporter::setTransferFile(QString filename)
+{
+	_transferFile = filename;
+}
+
+

--- a/JASP-Common/exporters/htmlexporter.h
+++ b/JASP-Common/exporters/htmlexporter.h
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2016 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef HTMLEXPORTER_H
+#define HTMLEXPORTER_H
+
+#include "datasetpackage.h"
+#include <QWebFrame>
+
+class HTMLExporter
+{
+
+public:
+	static void saveDataSet(const std::string &path, DataSetPackage* package, boost::function<void (const std::string &, int)> progressCallback);
+	static void setTransferFile(QString filename);
+
+	static QString _transferFile;
+
+};
+
+#endif // HTMLEXPORTER_H

--- a/JASP-Common/exporters/pdfexporter.cpp
+++ b/JASP-Common/exporters/pdfexporter.cpp
@@ -1,0 +1,62 @@
+//
+// Copyright (C) 2016 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "pdfexporter.h"
+#include "utils.h"
+#include <QFile>
+#include <QTextDocument>
+#include <QPrinter>
+#include <QWebView>
+
+QString PDFExporter::_transferFile = "";
+
+void PDFExporter::saveDataSet(const std::string &path, DataSetPackage* package, boost::function<void (const std::string &, int)> progressCallback)
+{
+
+	QFile file(_transferFile);
+	file.open(QIODevice::ReadOnly);
+	QString htmlContent;
+	QTextStream s1(&file);
+	htmlContent.append(s1.readAll());
+
+	//Next code could be a hack to show plots in pdf
+	//QUrl url = QUrl::fromLocalFile(QDir::current().absoluteFilePath("htmloutput.html"));
+	//QUrl url = QUrl::fromLocalFile(_transferFile);
+	//QWebView wdocument;
+	//wdocument.setHtml(htmlContent, url); // str1 is the html file stored as QString.
+
+	QTextDocument *document = new QTextDocument();
+	document->setHtml(htmlContent);
+	QPrinter printer(QPrinter::PrinterResolution);
+	printer.setPaperSize(QPrinter::A4);
+	printer.setOutputFormat(QPrinter::PdfFormat);
+	printer.setOutputFileName(_transferFile);
+	document->print(&printer);
+	delete document;
+
+	Utils::renameOverwrite(_transferFile.toStdString(), path);
+
+	progressCallback("Export pdf Set", 100);
+
+}
+
+void PDFExporter::setTransferFile(QString filename)
+{
+	_transferFile = filename;
+}
+
+

--- a/JASP-Common/exporters/pdfexporter.h
+++ b/JASP-Common/exporters/pdfexporter.h
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2016 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef PDFEXPORTER_H
+#define PDFEXPORTER_H
+
+#include "datasetpackage.h"
+#include <QWebFrame>
+
+class PDFExporter
+{
+public:
+	static void saveDataSet(const std::string &path, DataSetPackage* package, boost::function<void (const std::string &, int)> progressCallback);
+	static void setTransferFile(QString filename);
+
+	static QString _transferFile;
+};
+
+#endif // PDFEXPORTER_H

--- a/JASP-Desktop/JASP-Desktop.pro
+++ b/JASP-Desktop/JASP-Desktop.pro
@@ -1,5 +1,5 @@
 
-QT += core gui webkit webkitwidgets svg network
+QT += core gui webkit webkitwidgets svg network printsupport
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 

--- a/JASP-Desktop/asyncloader.h
+++ b/JASP-Desktop/asyncloader.h
@@ -31,6 +31,11 @@
 
 #include "onlinedatamanager.h"
 
+#include "exporters/jaspexporter.h"
+#include "exporters/csvexporter.h"
+#include "exporters/htmlexporter.h"
+#include "exporters/pdfexporter.h"
+
 class AsyncLoader : public QObject
 {
 	Q_OBJECT

--- a/JASP-Desktop/backstage/backstagecomputer.h
+++ b/JASP-Desktop/backstage/backstagecomputer.h
@@ -36,7 +36,7 @@ public:
 	~BackstageComputer();
 
 	FileEvent *browseOpen(const QString &path = "");
-	FileEvent *browseSave(const QString &path = "");
+	FileEvent *browseSave(const QString &path = "", FileEvent::FileMode mode = FileEvent::FileSave);
 
 	void addRecent(const QString &path);
 

--- a/JASP-Desktop/backstage/backstageosf.cpp
+++ b/JASP-Desktop/backstage/backstageosf.cpp
@@ -252,8 +252,9 @@ void BackstageOSF::setOnlineDataManager(OnlineDataManager *odm)
 void BackstageOSF::setMode(FileEvent::FileMode mode)
 {
 	BackstagePage::setMode(mode);
-	_fileNameContainer->setVisible(mode == FileEvent::FileSave);
-	_newFolderButton->setVisible(mode == FileEvent::FileSave);
+	bool visible = (mode == FileEvent::FileSave || mode == FileEvent::FileExportResults || mode == FileEvent::FileExportData);
+	_fileNameContainer->setVisible(visible);
+	_newFolderButton->setVisible(visible);
 }
 
 void BackstageOSF::notifyDataSetOpened(QString path)
@@ -289,7 +290,8 @@ bool BackstageOSF::checkEntryName(QString name, QString entryTitle, bool allowFu
 
 void BackstageOSF::saveClicked()
 {
-	 FSBMOSF::OnlineNodeData currentNodeData = _model->currentNodeData();
+	FSBMOSF::OnlineNodeData currentNodeData = _model->currentNodeData();
+	bool allowedfiletype;
 
 	if (currentNodeData.canCreateFiles == false)
 	{
@@ -307,11 +309,36 @@ void BackstageOSF::saveClicked()
 	if (checkEntryName(filename, "File", true) == false)
 		return;
 
-	if (filename.endsWith(".jasp") == false)
+	FileEvent::FileType filetype = FileEvent::getTypeFromPath(filename);
+
+	switch(_mode)
 	{
-		filename = filename + ".jasp";
-		_fileNameTextBox->setText(filename);
+		case FileEvent::FileExportResults:
+#ifdef QT_DEBUG
+			allowedfiletype = (filetype == FileEvent::FileType::html || filetype == FileEvent::FileType::pdf || filetype == FileEvent::FileType::empty);
+			if (!allowedfiletype)
+				QMessageBox::warning(this, "File Types", "Export result files must be of type html or pdf");
+#else
+			allowedfiletype = (filetype == FileEvent::FileType::html || filetype == FileEvent::FileType::empty);
+			if (!allowedfiletype)
+				QMessageBox::warning(this, "File Types", "Export result files must be of type html");
+#endif
+			break;
+
+		case FileEvent::FileExportData:
+			allowedfiletype = (filetype == FileEvent::FileType::csv || filetype == FileEvent::FileType::txt || filetype == FileEvent::FileType::empty);
+			if (!allowedfiletype )
+				QMessageBox::warning(this, "File Types", "Export data files must be of type csv or txt");
+			break;
+
+		case FileEvent::FileSave:
+			allowedfiletype = (filetype == FileEvent::FileType::jasp || filetype == FileEvent::FileType::empty);
+			if (!allowedfiletype )
+				QMessageBox::warning(this, "File Types", "Saving jasp files must be of type jasp");
+			break;
 	}
+
+	if (!allowedfiletype) return;
 
 	QString path;
 
@@ -323,27 +350,50 @@ void BackstageOSF::saveClicked()
 
 void BackstageOSF::openFile(const QString &nodePath, const QString &filename)
 {
+	QString usedfilename = filename;
+	bool storedata = (_mode == FileEvent::FileSave || _mode == FileEvent::FileExportResults || _mode ==FileEvent::FileExportData);
+
 	FileEvent *event = new FileEvent(this);
 	event->setOperation(_mode);
+	event->setTypeFromPath(usedfilename);
 
+	if ( event->type() == FileEvent::FileType::empty)
+	{
+		switch (_mode)
+		{
+		case FileEvent::FileSave:
+			usedfilename = filename + ".jasp";
+			event->setType(FileEvent::FileType::jasp);
+			break;
+		case FileEvent::FileExportResults:
+			usedfilename = filename + ".html";
+			event->setType(FileEvent::FileType::html);
+			break;
+		case FileEvent::FileExportData:
+			usedfilename = filename + ".csv";
+			event->setType(FileEvent::FileType::csv);
+			break;
+		}
+	}
 
-	if (_mode == FileEvent::FileSave)
+	if (storedata)
 	{
 		_breadCrumbs->setEnabled(false);
 		_saveButton->setEnabled(false);
 		_fileNameTextBox->setEnabled(false);
 		_newFolderButton->setEnabled(false);
+		_fileNameTextBox->setText(usedfilename);
 
 		_fsBrowser->StartProcessing();
 
 		connect(event, SIGNAL(completed(FileEvent*)), this, SLOT(openSaveCompleted(FileEvent*)));
 	}
 
-	if (filename != "")
+	if (usedfilename != "")
 	{
-		event->setPath(nodePath + "#file://" + filename);
+		event->setPath(nodePath + "#file://" + usedfilename);
 
-		if ( ! filename.endsWith(".jasp", Qt::CaseInsensitive))
+		if ( event->type() == FileEvent::FileType::jasp)
 			event->setReadOnly();
 	}
 	else

--- a/JASP-Desktop/backstage/fsbmosf.cpp
+++ b/JASP-Desktop/backstage/fsbmosf.cpp
@@ -264,6 +264,8 @@ void FSBMOSF::gotFilesAndFolders()
 					entryType = FSEntry::JASP;
 				else if (nodeData.name.endsWith(".csv", Qt::CaseInsensitive) || nodeData.name.endsWith(".txt", Qt::CaseInsensitive))
 					entryType = FSEntry::CSV;
+				else if (nodeData.name.endsWith(".html", Qt::CaseInsensitive))
+					entryType = FSEntry::Other;
 		#ifdef QT_DEBUG
 				else if (nodeData.name.endsWith(".spss", Qt::CaseInsensitive))
 					entryType = FSEntry::SPSS;

--- a/JASP-Desktop/backstage/fsbrowser.h
+++ b/JASP-Desktop/backstage/fsbrowser.h
@@ -37,7 +37,7 @@ public:
 
 	void setFSModel(FSBModel *model);
 
-	enum BrowseMode { BrowseOpenFile, BrowseOpenFolder, BrowseSaveFile };
+	enum BrowseMode { BrowseOpenFile, BrowseOpenFolder, BrowseSaveFile, BrowseExportFile};
 	enum ViewType   { IconView, ListView };
 
 	void setBrowseMode(BrowseMode mode);

--- a/JASP-Desktop/backstagewidget.cpp
+++ b/JASP-Desktop/backstagewidget.cpp
@@ -60,17 +60,15 @@ BackStageWidget::BackStageWidget(QWidget *parent) : QWidget(parent)
 	_tabBar->addTab("Open");
 	_tabBar->addTab("Save");
 	_tabBar->addTab("Save As");
-	_tabBar->addTab("Export");
+	_tabBar->addTab("Export Results");
+	_tabBar->addTab("Export Data");
 	_tabBar->addTab("Close");
-
-#ifndef QT_DEBUG
-	_tabBar->hideTab(3);
-#endif
 
 	_tabBar->setTabEnabled(1, false);
 	_tabBar->setTabEnabled(2, false);
 	_tabBar->setTabEnabled(3, false);
 	_tabBar->setTabEnabled(4, false);
+	_tabBar->setTabEnabled(5, false);
 
 	connect(_openAndSaveWidget, SIGNAL(dataSetIORequest(FileEvent*)), this, SLOT(dataSetIORequestHandler(FileEvent*)));
 	connect(_tabBar, SIGNAL(currentChanging(int,bool&)), this, SLOT(tabPageChanging(int,bool&)));
@@ -120,10 +118,11 @@ void BackStageWidget::dataSetIORequestCompleted(FileEvent *event)
 		{
 			_dataSetHasPathAndIsntReadOnly = ! event->isReadOnly();
 
-			_tabBar->setTabEnabled(1, true);
-			_tabBar->setTabEnabled(2, true);
-			_tabBar->setTabEnabled(3, true);
-			_tabBar->setTabEnabled(4, true);
+			_tabBar->setTabEnabled(1, true); //Save
+			_tabBar->setTabEnabled(2, true); //Save As
+			_tabBar->setTabEnabled(3, true); //Export Results
+			_tabBar->setTabEnabled(4, true); //Export Data
+			_tabBar->setTabEnabled(5, true); //Close
 		}
 		else if (event->operation() == FileEvent::FileSave)
 		{
@@ -136,6 +135,7 @@ void BackStageWidget::dataSetIORequestCompleted(FileEvent *event)
 			_tabBar->setTabEnabled(2, false);
 			_tabBar->setTabEnabled(3, false);
 			_tabBar->setTabEnabled(4, false);
+			_tabBar->setTabEnabled(5, false);
 		}
 	}
 }
@@ -148,11 +148,10 @@ void BackStageWidget::tabPageChanging(int index, bool &cancel)
 		_openAndSaveWidget->setSaveMode(FileEvent::FileOpen);
 		_tabPages->setCurrentWidget(_openAndSaveWidget);
 		break;
+
 	case 1:  // Save
 		if (_dataSetHasPathAndIsntReadOnly)
-		{
 			_openAndSaveWidget->save();
-		}
 		else
 		{
 			_tabBar->setCurrentIndex(2);
@@ -161,13 +160,23 @@ void BackStageWidget::tabPageChanging(int index, bool &cancel)
 		}
 		cancel = true;
 		break;
+
 	case 2:  // Save As
 		_openAndSaveWidget->setSaveMode(FileEvent::FileSave);
 		_tabPages->setCurrentWidget(_openAndSaveWidget);
 		break;
-	case 3:  // Export
+
+	case 3:  // Export Results
+		_openAndSaveWidget->setSaveMode(FileEvent::FileExportResults);
+		_tabPages->setCurrentWidget(_openAndSaveWidget);
 		break;
-	case 4: // Close
+
+	case 4:  // Export Data
+		_openAndSaveWidget->setSaveMode(FileEvent::FileExportData);
+		_tabPages->setCurrentWidget(_openAndSaveWidget);
+		break;
+
+	case 5: // Close
 		_openAndSaveWidget->close();
 		_tabBar->setCurrentIndex(0);
 		_openAndSaveWidget->setSaveMode(FileEvent::FileOpen);

--- a/JASP-Desktop/fileevent.cpp
+++ b/JASP-Desktop/fileevent.cpp
@@ -33,6 +33,42 @@ void FileEvent::setOperation(FileEvent::FileMode fileMode)
 	_operation = fileMode;
 }
 
+void FileEvent::setType(FileEvent::FileType fileType)
+{
+	_type = fileType;
+}
+
+void FileEvent::setTypeFromPath(const QString &path)
+{
+
+	FileEvent::FileType filetype;
+
+	filetype = getTypeFromPath(path);
+
+	_type = filetype;
+}
+
+FileEvent::FileType FileEvent::getTypeFromPath(const QString &path)
+{
+
+	FileEvent::FileType filetype =  FileEvent::FileType::unknown;
+
+	if (path.endsWith(".jasp", Qt::CaseInsensitive)) filetype = FileEvent::FileType::jasp;
+	else if (path.endsWith(".html", Qt::CaseInsensitive)) filetype = FileEvent::FileType::html;
+	else if (path.endsWith(".csv", Qt::CaseInsensitive)) filetype = FileEvent::FileType::csv;
+	else if (path.endsWith(".txt", Qt::CaseInsensitive)) filetype =  FileEvent::FileType::txt;
+	else if (path.endsWith(".pdf", Qt::CaseInsensitive)) filetype =  FileEvent::FileType::pdf;
+
+	if (filetype == FileEvent::FileType::unknown)
+	{
+		int dotPos = path.lastIndexOf('.');
+		if (dotPos == -1 )
+			filetype =  FileEvent::FileType::empty;
+	}
+
+	return filetype;
+}
+
 void FileEvent::setPath(const QString &path)
 {
 	_path = path;
@@ -47,6 +83,12 @@ FileEvent::FileMode FileEvent::operation() const
 {
 	return _operation;
 }
+
+FileEvent::FileType FileEvent::type() const
+{
+	return _type;
+}
+
 
 const QString &FileEvent::path() const
 {

--- a/JASP-Desktop/fileevent.h
+++ b/JASP-Desktop/fileevent.h
@@ -31,15 +31,20 @@ public:
 	~FileEvent() = default;
 	FileEvent(const FileEvent&) = default;
 
-	enum FileMode { FileSave, FileOpen, FileExport, FileClose };
+	enum FileMode { FileSave, FileOpen, FileExportResults, FileExportData, FileClose };
+	enum FileType { jasp, html, csv, txt, pdf, empty, unknown };
 
 	void setOperation(FileMode fileMode);
+	void setType(FileType fileType);
+	void setTypeFromPath(const QString &path);
+	static FileType getTypeFromPath(const QString &path);
 	void setPath(const QString &path);
 	void setReadOnly();
 
 	bool IsOnlineNode() const;
 
 	FileMode operation() const;
+	FileType type() const;
 	const QString &path() const;
 	bool isReadOnly() const;
 
@@ -60,6 +65,7 @@ private slots:
 
 private:
 	FileMode _operation;
+	FileType _type;
 	QString _path;
 	bool _readOnly;
 

--- a/JASP-Tests/JASP-Tests-app.pro
+++ b/JASP-Tests/JASP-Tests-app.pro
@@ -1,5 +1,5 @@
 
-QT += core gui webkit webkitwidgets svg network testlib
+QT += core gui webkit webkitwidgets svg network testlib printsupport
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 


### PR DESCRIPTION
In the previous version of JASP the Export function disappeared.
This has been rollbacked. Moreover a possibility to export the data has
been added.