### PR TITLE
Temporary files not always deleted and failing html export

### DIFF
--- a/JASP-Common/appinfo.cpp
+++ b/JASP-Common/appinfo.cpp
@@ -20,7 +20,7 @@
 
 const Version AppInfo::version = Version(0, 7, 5, 261);
 const std::string AppInfo::name = "JASP";
-const std::string AppInfo::builddate = "Tue Apr 21 2016 13:04:43 GMT+0100 (CET)";
+const std::string AppInfo::builddate = "Thu Apr 21 2016 13:04:43 GMT+0100 (CET)";
 
 std::string AppInfo::getShortDesc()
 {

--- a/JASP-Common/exporters/htmlexporter.cpp
+++ b/JASP-Common/exporters/htmlexporter.cpp
@@ -23,7 +23,18 @@ QString HTMLExporter::_transferFile = "";
 void HTMLExporter::saveDataSet(const std::string &path, DataSetPackage* package, boost::function<void (const std::string &, int)> progressCallback)
 {
 
-	Utils::renameOverwrite(_transferFile.toStdString(), path);
+	int maxSleepTime = 5000;
+	int sleepTime = 100;
+	int delay = 0;
+
+	while (Utils::renameOverwrite(_transferFile.toStdString(), path) == false)
+	{
+		if (delay > maxSleepTime)
+			break;
+
+		Utils::sleep(sleepTime);
+		delay += sleepTime;
+	}
 
 	progressCallback("Export Html Set", 100);
 

--- a/JASP-Common/utils.cpp
+++ b/JASP-Common/utils.cpp
@@ -212,3 +212,13 @@ void Utils::remove(vector<string> &target, const vector<string> &toRemove)
 	}
 }
 
+void Utils::sleep(int ms)
+{
+
+#ifdef __WIN32__
+	Sleep(uint(ms));
+#else
+	struct timespec ts = { ms / 1000, (ms % 1000) * 1000 * 1000 };
+	nanosleep(&ts, NULL);
+#endif
+}

--- a/JASP-Common/utils.h
+++ b/JASP-Common/utils.h
@@ -38,6 +38,7 @@ public:
 	static std::string osPath(const boost::filesystem::path &path);
 
 	static void remove(std::vector<std::string> &target, const std::vector<std::string> &toRemove);
+	static void sleep(int ms);
 };
 
 #endif // UTILS_H

--- a/JASP-Desktop/asyncloader.cpp
+++ b/JASP-Desktop/asyncloader.cpp
@@ -112,7 +112,7 @@ void AsyncLoader::saveTask(FileEvent *event, DataSetPackage *package)
 			if (delay > maxSleepTime)
 				break;
 
-			sleep(sleepTime);
+			Utils::sleep(sleepTime);
 			delay += sleepTime;
 		}
 
@@ -150,19 +150,6 @@ void AsyncLoader::saveTask(FileEvent *event, DataSetPackage *package)
 void AsyncLoader::progressHandler(string status, int progress)
 {
 	emit this->progress(QString::fromUtf8(status.c_str(), status.length()), progress);
-}
-
-
-
-void AsyncLoader::sleep(int ms)
-{
-
-#ifdef __WIN32__
-	Sleep(uint(ms));
-#else
-	struct timespec ts = { ms / 1000, (ms % 1000) * 1000 * 1000 };
-	nanosleep(&ts, NULL);
-#endif
 }
 
 void AsyncLoader::setOnlineDataManager(OnlineDataManager *odm)

--- a/JASP-Desktop/asyncloader.h
+++ b/JASP-Desktop/asyncloader.h
@@ -64,7 +64,6 @@ private:
 
 	QString fileChecksum(const QString &fileName, QCryptographicHash::Algorithm hashAlgorithm);
 
-	void sleep(int ms);
 	void progressHandler(std::string status, int progress);
 	QThread _thread;
 	DataSetLoader _loader;

--- a/JASP-Desktop/backstage/backstageosf.cpp
+++ b/JASP-Desktop/backstage/backstageosf.cpp
@@ -291,7 +291,7 @@ bool BackstageOSF::checkEntryName(QString name, QString entryTitle, bool allowFu
 void BackstageOSF::saveClicked()
 {
 	FSBMOSF::OnlineNodeData currentNodeData = _model->currentNodeData();
-	bool allowedfiletype;
+	bool allowedfiletype = true;
 
 	if (currentNodeData.canCreateFiles == false)
 	{

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -811,7 +811,7 @@ void MainWindow::dataSetIORequest(FileEvent *event)
 		// WebFrame->evaluateJavaScript can only be executed from main thread.
 		boost::filesystem::path temp = boost::filesystem::unique_path();
 		QString tempstr = QString::fromStdWString(temp.generic_wstring());
-		QString tmpFileName = QString::fromStdString(Dirs::tempDir()) +tempstr; // + QString::fromStdString(tempstr);
+		QString tmpFileName = QString::fromStdString(Dirs::tempDir()) + QDir::separator() + tempstr; // + QString::fromStdString(tempstr);
 
 		ui->webViewResults->page()->mainFrame()->evaluateJavaScript("window.exportHTML('" + tmpFileName + "');");
 


### PR DESCRIPTION
During the export of the html result of analyses the copy and deletion
of a temporary file sometimes failed. The export of the analyse failed
then too.