### PR TITLE
changed x-axis range according to prior width

### DIFF
--- a/JASP-Engine/JASP/R/ttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/ttestbayesianonesample.R
@@ -2880,8 +2880,15 @@ TTestBayesianOneSample <- function(dataset=NULL, options, perform="run", callbac
 	}
 	
 	#### get BFs ###
-	rValues <- seq(0.0005, 1.5, length.out = 400)
-	
+	if(r > 1.5)
+	{
+		rValues <- seq(0.0005, 2, length.out = 535)	
+	}
+	else
+	{
+		rValues <- seq(0.0005, 1.5, length.out = 400)
+	}
+
 	# BF10
 	BF10 <- vector("numeric", length(rValues))
 	
@@ -3325,7 +3332,15 @@ TTestBayesianOneSample <- function(dataset=NULL, options, perform="run", callbac
 	
 	####################### plot ###########################
 	
-	xLab <- c(0, 0.25, 0.5, 0.75, 1, 1.25, 1.5)
+	if(r > 1.5)
+	{
+		xLab <- c(0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2)
+	}
+	else
+	{
+		xLab <- c(0, 0.25, 0.5, 0.75, 1, 1.25, 1.5)
+	}
+
 	xlim <- range(xLab)
 	ylow <- log(eval(parse(text= yLab[1])))
 	yhigh <- log(eval(parse(text= yLab[length(yLab)])))


### PR DESCRIPTION
Fixes #1310 
By default, the range of 0 to 1.5 is used. 
If the user chooses a prior width more than 1.5, then the graph is plotted from 0 to 2