### PR TITLE
Update regressionlinear.R

### DIFF
--- a/JASP-Engine/JASP/R/regressionlinear.R
+++ b/JASP-Engine/JASP/R/regressionlinear.R
@@ -656,7 +656,7 @@ RegressionLinear <- function(dataset=NULL, options, perform="run", callback=func
 					df1 <- 1
 					if (m > 1){
 					
-						df1 <- abs(length(lm.model[[ m ]]$variables) - length(lm.model[[ m-1 ]]$variables) )
+						df1 <- abs(length(lm.model[[ m ]]$variables))
 					}
 					
 					df2 <- length( dataset[[ dependent.base64 ]]) - length(lm.model[[ m ]]$variables) - 1


### PR DESCRIPTION
Hi! There is problem with the R squared change option in Linear Regression. 
The overall problem is that the R squared change option does not make really sense as long as one cannot add blocks of parameters (hierarchical regression). I am really waiting for this feature because it is so basic.
Thus, for the time being the R squared change option just repeats R squared of the model (r.squared.old <- r.squared, line 673), and the F.change statistic should repeat the model F-Test. It doesn't, however, in case of more than one predictor, because the df1 always  equals 1. This is because abs(length(lm.model[[ m ]]$variables) - length(lm.model[[ m-1 ]]$variables)) always equals 1. As soon as you have the "real" F-change function you need: df1 <- abs(length(lm.model[[ m ]]$variables) - length(lm.model[[ m-(NUMBER OF ADDED PARAMETERS)  ]]$variables)).
But as long as you can't report a real F-Change-Statistic, you need to set df1 = m (number of predictors). Otherwise you get the correct model F-value * m in the F-Change outcome.
Thanks!
Boris