### PR TITLE
Remove warnings

### DIFF
--- a/JASP-Common/JASP-Common.pro
+++ b/JASP-Common/JASP-Common.pro
@@ -18,8 +18,8 @@ windows:INCLUDEPATH += ../../boost_1_54_0
 windows:LIBS += -lole32 -loleaut32 -larchive.dll
 
 
+QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-parameter -Wno-unused-local-typedef
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extensions
-QMAKE_CXXFLAGS += -Wno-unused-parameter
 macx:QMAKE_CXXFLAGS += -Wno-c++11-long-long
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extra-semi
 

--- a/JASP-Desktop/JASP-Desktop.pro
+++ b/JASP-Desktop/JASP-Desktop.pro
@@ -35,8 +35,8 @@ windows:LIBS += -lboost_filesystem-mt -lboost_system-mt -larchive.dll
 windows:LIBS += -lole32 -loleaut32
   linux:LIBS += -lrt
 
+QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-parameter -Wno-unused-local-typedef
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extensions
-QMAKE_CXXFLAGS += -Wno-unused-parameter
 macx:QMAKE_CXXFLAGS += -Wno-c++11-long-long
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extra-semi
 

--- a/JASP-Engine/JASP-Engine.pro
+++ b/JASP-Engine/JASP-Engine.pro
@@ -59,8 +59,8 @@ windows {
 	R_EXE  = $$_R_HOME/bin/$$ARCH/R
 }
 
+QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-parameter -Wno-unused-local-typedef
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extensions
-QMAKE_CXXFLAGS += -Wno-unused-parameter
 macx:QMAKE_CXXFLAGS += -Wno-c++11-long-long
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extra-semi
 

--- a/JASP-Tests/JASP-Desktop-staticlib.pro
+++ b/JASP-Tests/JASP-Desktop-staticlib.pro
@@ -44,8 +44,8 @@ windows:LIBS += -lboost_filesystem-mt -lboost_system-mt -larchive.dll
 windows:LIBS += -lole32 -loleaut32
   linux:LIBS += -lrt
 
+QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-parameter -Wno-unused-local-typedef
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extensions
-QMAKE_CXXFLAGS += -Wno-unused-parameter
 macx:QMAKE_CXXFLAGS += -Wno-c++11-long-long
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extra-semi
 

--- a/JASP-Tests/JASP-Tests-app.pro
+++ b/JASP-Tests/JASP-Tests-app.pro
@@ -36,8 +36,8 @@ windows:LIBS += -lboost_filesystem-mt -lboost_system-mt -larchive.dll
 
 windows:LIBS += -lole32 -loleaut32
 
+QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-parameter -Wno-unused-local-typedef
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extensions
-QMAKE_CXXFLAGS += -Wno-unused-parameter
 macx:QMAKE_CXXFLAGS += -Wno-c++11-long-long
 macx:QMAKE_CXXFLAGS += -Wno-c++11-extra-semi
 


### PR DESCRIPTION
Use QMAKE_CXXFLAGS_WARN_ON to remove warning about used parameter and
used local typedef