### PR TITLE
log(BF) option added to output tables

### DIFF
--- a/JASP-Engine/JASP/R/summarystatsregressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/summarystatsregressionlinearbayesian.R
@@ -53,6 +53,11 @@ SummaryStatsRegressionLinearBayesian <- function(dataset=NULL, options, perform 
 		fields[[length(fields)+1]] <- list(name="sampleSize", type="string", title=sampleSize.title)
 
 		bf.title <- "BF"
+
+		if(options$bayesFactorType == "LogBF10")
+		{
+			bf.title <- "Log(\u2009\u0042\u0046\u2081\u2080\u2009)"
+		}
 	}
 	else
 	{
@@ -74,7 +79,9 @@ SummaryStatsRegressionLinearBayesian <- function(dataset=NULL, options, perform 
 	}
 	fields[[length(fields)+1]] <- list(name="numberOfCovariates", type="integer", title="Number of covariates")
 	fields[[length(fields)+1]] <- list(name="unadjustedRSquared", type="number", title="R\u00B2", format = "dp:3")
+
 	fields[[length(fields)+1]] <- list(name="BF", type="number", format="sf:4;dp:3", title=bf.title)
+
 	fields[[length(fields)+1]] <- list(name="properror", type="number", format="sf:4;dp:3", title="% error")
 
 	table <- list()
@@ -125,9 +132,27 @@ SummaryStatsRegressionLinearBayesian <- function(dataset=NULL, options, perform 
 			{
 				if(nullModelSpecified)
 				{
+					BFType <- options$bayesFactorType
+					BFRequiresNewRow <- TRUE
+
+					if(!is.null(state))
+					{
+						BFRequiresNewRow <- FALSE
+						BFTypeState <- state$options$bayesFactorType
+
+						if((BFTypeState=="BF10" || BFTypeState=="BF01") && BFType=="LogBF10")
+						{
+							BFRequiresNewRow <- TRUE
+						}
+						else if((BFType=="BF10" || BFType=="BF01") && BFTypeState=="LogBF10")
+						{
+							BFRequiresNewRow <- TRUE
+						}
+					}
+
 					if (!is.null(state) && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) &&
 					    (diff$sampleSize==FALSE && diff$numberOfCovariatesNull==FALSE && diff$unadjustedRSquaredNull==FALSE && diff$numberOfCovariatesAlternative==FALSE &&
-						  diff$unadjustedRSquaredAlternative==FALSE && diff$priorWidth == FALSE))) && !is.null(state$bayesFactorObjectAlternative))
+						  diff$unadjustedRSquaredAlternative==FALSE && diff$priorWidth == FALSE))) && !is.null(state$bayesFactorObjectAlternative) && !BFRequiresNewRow)
 					{
 						row <- state$rowsRegressiontest
 						bayesFactorObjectAlternative <- state$bayesFactorObjectAlternative
@@ -140,6 +165,12 @@ SummaryStatsRegressionLinearBayesian <- function(dataset=NULL, options, perform 
 
 						BFNull <- exp(bayesFactorObjectNull[["bf"]])/exp(bayesFactorObjectAlternative[["bf"]])
 						BFAlternative <- exp(bayesFactorObjectAlternative[["bf"]])/exp(bayesFactorObjectNull[["bf"]])
+
+						if(options$bayesFactorType=="LogBF10")
+						{
+							BFNull <- log(BFNull)
+							BFAlternative <- log(BFAlternative)
+						}
 
 						row[[1]] <- list(numberOfCovariates=options$numberOfCovariatesNull, sampleSize="Null model", unadjustedRSquared=.clean(options$unadjustedRSquaredNull), BF=.clean(BFNull), properror=.clean(bayesFactorObjectNull[["properror"]]))
 						row[[2]] <- list(sampleSize="Alternative model", numberOfCovariates=.clean(options$numberOfCovariatesAlternative), unadjustedRSquared=.clean(options$unadjustedRSquaredAlternative), BF=.clean(BFAlternative), properror=.clean(bayesFactorObjectAlternative[["properror"]]))
@@ -237,9 +268,27 @@ SummaryStatsRegressionLinearBayesian <- function(dataset=NULL, options, perform 
 	{
 		if(nullModelSpecified)
 		{
+			BFType <- options$bayesFactorType
+			BFRequiresNewRow <- TRUE
+
+			if(!is.null(state))
+			{
+				BFRequiresNewRow <- FALSE
+				BFTypeState <- state$options$bayesFactorType
+
+				if((BFTypeState=="BF10" || BFTypeState=="BF01") && BFType=="LogBF10")
+				{
+					BFRequiresNewRow <- TRUE
+				}
+				else if((BFType=="BF10" || BFType=="BF01") && BFTypeState=="LogBF10")
+				{
+					BFRequiresNewRow <- TRUE
+				}
+			}
+
 			if (!is.null(state) && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (
 					diff$sampleSize==FALSE && diff$numberOfCovariatesAlternative==FALSE && diff$unadjustedRSquaredAlternative==FALSE && diff$priorWidth == FALSE &&
-					diff$numberOfCovariatesNull==FALSE && diff$unadjustedRSquaredNull==FALSE))) && !is.null(state$bayesFactorObjectAlternative))
+					diff$numberOfCovariatesNull==FALSE && diff$unadjustedRSquaredNull==FALSE))) && !is.null(state$bayesFactorObjectAlternative) && !BFRequiresNewRow)
 			{
 				rowsRegressiontest <- state$rowsRegressiontest
 				bayesFactorObjectNull <- state$bayesFactorObjectNull

--- a/JASP-Engine/JASP/R/summarystatsttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianonesample.R
@@ -207,7 +207,7 @@ SummaryStatsTTestBayesianOneSample <- function(dataset=NULL, options, perform = 
 			}
 			else
 			{
-				results[["inferentialPlots"]][["priorAndPosteriorPlot"]][["status"]] <- "running"
+				BF10 <- exp(bayesFactorObject$bf)
 
 				width  <- 530
 				height <- 400
@@ -219,11 +219,38 @@ SummaryStatsTTestBayesianOneSample <- function(dataset=NULL, options, perform = 
 				plot[["height"]] <- height
 				plot[["status"]] <- "waiting"
 
-				image <- .beginSaveImage(width, height)
-				.plotPosterior.ttest.summaryStats (t=options$tStatistic, n1=options$n1Size, n2=NULL, paired=FALSE, BFH1H0=(options$bayesFactorType == "BF10"), 
-												   dontPlotData= FALSE, rscale=options$priorWidth, addInformation = options$plotPriorAndPosteriorAdditionalInfo,
-												   BF = exp(bayesFactorObject$bf), oneSided = oneSidedHypothesis)
-				plot[["data"]]   <- .endSaveImage(image)
+				p <- try(silent=FALSE, expr = {
+					image <- .beginSaveImage(width, height)
+					.plotPosterior.ttest.summaryStats (t=options$tStatistic, n1=options$n1Size, n2=NULL, paired=FALSE, BFH1H0=(options$bayesFactorType == "BF10"), 
+													   dontPlotData= FALSE, rscale=options$priorWidth, addInformation = options$plotPriorAndPosteriorAdditionalInfo,
+													   BF = BF10, oneSided = oneSidedHypothesis)
+					plot[["data"]]   <- .endSaveImage(image)
+				})
+
+				if (class(p) == "try-error")
+				{
+					errorMessage <- .extractErrorMessage(p)
+
+					if (errorMessage == "not enough data")
+					{
+						errorMessage <- "The Bayes factor is too small"
+					}
+					else if (errorMessage == "'from' cannot be NA, NaN or infinite")
+					{
+						errorMessage <- "The Bayes factor is infinite"
+					}
+					else if (.clean(BF10) == "\u221E")
+					{
+						errorMessage <- "The Bayes factor is infinite"
+					}
+					else if (.clean(BF10) == "NaN")
+					{
+						errorMessage <- "Bayes factor could not be calcluated"
+					}
+
+					plot[["error"]] <- list(error="badData", errorMessage=paste("Plotting is not possible: ", errorMessage))
+				}
+
 				plot[["status"]] <- "complete"
 
 				plots.sumstats.ttest[[length(plots.sumstats.ttest)+1]] <- plot
@@ -280,11 +307,21 @@ SummaryStatsTTestBayesianOneSample <- function(dataset=NULL, options, perform = 
 				plot[["height"]] <- height
 				plot[["status"]] <- "waiting"
 
-				image <- .beginSaveImage(width, height)
-				.plotBF.robustnessCheck.bffromt (t=options$tStatistic, n1=options$n1Size, n2=0, BFH1H0=(options$bayesFactorType == "BF10"), 
-												 dontPlotData= FALSE, rscale=options$priorWidth, 
-												 BF10post = ifelse((options$bayesFactorType == "BF10"),.clean(exp(bayesFactorObject$bf)), .clean(1/exp(bayesFactorObject$bf))), oneSided = oneSidedHypothesis)
-				plot[["data"]]   <- .endSaveImage(image)
+				p <- try(silent=FALSE, expr = {
+					image <- .beginSaveImage(width, height)
+					.plotBF.robustnessCheck.bffromt (t=options$tStatistic, n1=options$n1Size, n2=0, BFH1H0=(options$bayesFactorType == "BF10"), 
+													 dontPlotData= FALSE, rscale=options$priorWidth, 
+													 BF10post = ifelse((options$bayesFactorType == "BF10"),.clean(exp(bayesFactorObject$bf)), .clean(1/exp(bayesFactorObject$bf))), oneSided = oneSidedHypothesis)
+					plot[["data"]]   <- .endSaveImage(image)
+				})
+
+				if ( class(p) == "try-error")
+				{
+					errorMessage <- .extractErrorMessage(p)
+
+					plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
+				}
+
 				plot[["status"]] <- "complete"
 
 				plots.sumstats.ttest[[length(plots.sumstats.ttest)+1]] <- plot

--- a/JASP-Engine/JASP/R/summarystatsttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianpairedsamples.R
@@ -203,6 +203,8 @@ SummaryStatsTTestBayesianPairedSamples <- function(dataset=NULL, options, perfor
 			}
 			else
 			{
+				BF10 <- exp(bayesFactorObject$bf)
+
 				width  <- 530
 				height <- 400
 
@@ -213,11 +215,38 @@ SummaryStatsTTestBayesianPairedSamples <- function(dataset=NULL, options, perfor
 				plot[["height"]] <- height
 				plot[["status"]] <- "waiting"
 
-				image <- .beginSaveImage(width, height)
-				.plotPosterior.ttest.summaryStats (t=options$tStatistic, n1=options$n1Size, n2=NULL, paired=TRUE, BFH1H0=(options$bayesFactorType == "BF10"), 
-												   dontPlotData= FALSE, rscale=options$priorWidth, addInformation = options$plotPriorAndPosteriorAdditionalInfo,
-												   BF = exp(bayesFactorObject$bf), oneSided = oneSidedHypothesis)
-				plot[["data"]]   <- .endSaveImage(image)
+				p <- try(silent=FALSE, expr = {
+					image <- .beginSaveImage(width, height)
+					.plotPosterior.ttest.summaryStats (t=options$tStatistic, n1=options$n1Size, n2=NULL, paired=TRUE, BFH1H0=(options$bayesFactorType == "BF10"), 
+													   dontPlotData= FALSE, rscale=options$priorWidth, addInformation = options$plotPriorAndPosteriorAdditionalInfo,
+													   BF = BF10, oneSided = oneSidedHypothesis)
+					plot[["data"]]   <- .endSaveImage(image)
+				})
+
+				if (class(p) == "try-error")
+				{
+					errorMessage <- .extractErrorMessage(p)
+
+					if (errorMessage == "not enough data")
+					{
+						errorMessage <- "The Bayes factor is too small"
+					}
+					else if (errorMessage == "'from' cannot be NA, NaN or infinite")
+					{
+						errorMessage <- "The Bayes factor is infinite"
+					}
+					else if (.clean(BF10) == "\u221E")
+					{
+						errorMessage <- "The Bayes factor is infinite"
+					}
+					else if (.clean(BF10) == "NaN")
+					{
+						errorMessage <- "Bayes factor could not be calcluated"
+					}
+
+					plot[["error"]] <- list(error="badData", errorMessage=paste("Plotting is not possible: ", errorMessage))
+				}
+
 				plot[["status"]] <- "complete"
 
 				plots.sumstats.ttest[[length(plots.sumstats.ttest)+1]] <- plot
@@ -274,11 +303,20 @@ SummaryStatsTTestBayesianPairedSamples <- function(dataset=NULL, options, perfor
 				plot[["height"]] <- height
 				plot[["status"]] <- "waiting"
 
-				image <- .beginSaveImage(width, height)
-				.plotBF.robustnessCheck.bffromt (t=options$tStatistic, n1=options$n1Size, n2=0, BFH1H0=(options$bayesFactorType == "BF10"), 
-												 dontPlotData= FALSE, rscale=options$priorWidth, 
-												 BF10post = ifelse((options$bayesFactorType == "BF10"),.clean(exp(bayesFactorObject$bf)), .clean(1/exp(bayesFactorObject$bf))), oneSided = oneSidedHypothesis)
-				plot[["data"]]   <- .endSaveImage(image)
+				p <- try(silent=FALSE, expr = {
+					image <- .beginSaveImage(width, height)
+					.plotBF.robustnessCheck.bffromt (t=options$tStatistic, n1=options$n1Size, n2=0, BFH1H0=(options$bayesFactorType == "BF10"), 
+													 dontPlotData= FALSE, rscale=options$priorWidth, 
+													 BF10post = ifelse((options$bayesFactorType == "BF10"),.clean(exp(bayesFactorObject$bf)), .clean(1/exp(bayesFactorObject$bf))), oneSided = oneSidedHypothesis)
+					plot[["data"]]   <- .endSaveImage(image)
+				})
+
+				if ( class(p) == "try-error")
+				{
+					errorMessage <- .extractErrorMessage(p)
+					
+					plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
+				}
 				plot[["status"]] <- "complete"
 
 				plots.sumstats.ttest[[length(plots.sumstats.ttest)+1]] <- plot


### PR DESCRIPTION
1) Regression analysis in Sum stats module - log(BF) option is enabled for the output tables
2) ttest and correlation pairs in sum stats module - If BF robustness and posterior plots are unplottable, error message is shown