### PR TITLE
Fixes Corrupted data in OSF #1429

### DIFF
--- a/JASP-Desktop/backstage/backstageosf.cpp
+++ b/JASP-Desktop/backstage/backstageosf.cpp
@@ -265,7 +265,7 @@ void BackstageOSF::setMode(FileEvent::FileMode mode)
 void BackstageOSF::notifyDataSetOpened(QString path)
 {
 	FSBMOSF::OnlineNodeData nodeData = _model->getNodeData(path);
-	openFile(nodeData.nodePath, nodeData.name);
+	openSaveFile(nodeData.nodePath, nodeData.name);
 }
 
 void BackstageOSF::notifyDataSetSelected(QString path)
@@ -318,10 +318,10 @@ void BackstageOSF::saveClicked()
 	if (_model->hasFileEntry(filename.toLower(), path))
 		notifyDataSetOpened(path);
 	else
-		openFile(currentNodeData.nodePath, filename);
+		openSaveFile(currentNodeData.nodePath, filename);
 }
 
-void BackstageOSF::openFile(const QString &nodePath, const QString &filename)
+void BackstageOSF::openSaveFile(const QString &nodePath, const QString &filename)
 {
 	bool storedata = (_mode == FileEvent::FileSave || _mode == FileEvent::FileExportResults || _mode ==FileEvent::FileExportData);
 
@@ -349,6 +349,7 @@ void BackstageOSF::openFile(const QString &nodePath, const QString &filename)
 	{
 		QMessageBox::warning(this, "File Types", event->getLastError());
 		event->setComplete(false, "Failed to open file from OSF");
+		return;
 	}
 
 	emit dataSetIORequest(event);

--- a/JASP-Desktop/backstage/backstageosf.h
+++ b/JASP-Desktop/backstage/backstageosf.h
@@ -50,7 +50,7 @@ private slots:
 	void notifyDataSetOpened(QString path);
 	void saveClicked();
 
-	void openFile(const QString &nodePath, const QString &filename);
+	void openSaveFile(const QString &nodePath, const QString &filename);
 	void userDetailsReceived();
 	void openSaveCompleted(FileEvent* event);
 	void updateUserDetails();

--- a/JASP-Desktop/backstage/opensavewidget.cpp
+++ b/JASP-Desktop/backstage/opensavewidget.cpp
@@ -21,6 +21,7 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QFileInfo>
+#include <QMessageBox>
 
 #include "fsbmrecent.h"
 
@@ -166,6 +167,12 @@ FileEvent *OpenSaveWidget::save()
 	{
 		event = new FileEvent(this, FileEvent::FileSave);
 		event->setPath(_currentFilePath);
+		if (event->getLastError() != "")
+		{
+			QMessageBox::warning(this, "File Types", event->getLastError());
+			event->setComplete(false, "Failed to open file from OSF");
+			return event;
+		}
 	}
 
 	dataSetIORequestHandler(event);

--- a/JASP-Desktop/exporters/jaspexporter.cpp
+++ b/JASP-Desktop/exporters/jaspexporter.cpp
@@ -222,26 +222,23 @@ void JASPExporter::saveDataArchive(archive *a, DataSetPackage *package, boost::f
 
 	archive_entry_free(entry);
 
-	//Take out for the time being
-	if (package->hasAnalyses)
-	{
-		//Create new entry for archive: HTML results
-		string html = package->analysesHTML;
-		int htmlSize = html.size();
-		entry = archive_entry_new();
-		string dd3 = string("index.html");
-		archive_entry_set_pathname(entry, dd3.c_str());
-		archive_entry_set_size(entry, htmlSize);
-		archive_entry_set_filetype(entry, AE_IFREG);
-		archive_entry_set_perm(entry, 0644); // Not sure what this does
-		archive_write_header(a, entry);
+	//Create new entry for archive: HTML results
+	string html = package->analysesHTML;
+	int htmlSize = html.size();
+	entry = archive_entry_new();
+	string dd3 = string("index.html");
+	archive_entry_set_pathname(entry, dd3.c_str());
+	archive_entry_set_size(entry, htmlSize);
+	archive_entry_set_filetype(entry, AE_IFREG);
+	archive_entry_set_perm(entry, 0644); // Not sure what this does
+	archive_write_header(a, entry);
 
-		int ws = archive_write_data(a, html.c_str(), htmlSize);
-		if (ws != htmlSize)
-			throw runtime_error("Can't save jasp archive writing ERROR");
+	int ws = archive_write_data(a, html.c_str(), htmlSize);
+	if (ws != htmlSize)
+		throw runtime_error("Can't save jasp archive writing ERROR");
 
-		archive_entry_free(entry);
-	}
+	archive_entry_free(entry);
+
 }
 
 void JASPExporter::saveJASPArchive(archive *a, DataSetPackage *package, boost::function<void (const std::string &, int)> progressCallback)


### PR DESCRIPTION
During JASP Workshop users saved files in the OSF
Some JASP files appeared to be corrupted.
Four test scenarios:
> Open data file from OSF and direct save it. File is saves as jasp
file in OSF but with cvs extension so not readable anymore.
> Export result to the OSF but give a .jasp extension. File is saved as
gasp file but only contains html.  Warning about extension is ignored.
> Same as above but Export data
> Save a jasp file to the OSF but without results. This file is seen as
corrupted in the OSF