### PR TITLE
SEM Module has mixed up option list

### DIFF
--- a/JASP-Desktop/analysisforms/SEM/semsimpleform.ui
+++ b/JASP-Desktop/analysisforms/SEM/semsimpleform.ui
@@ -261,21 +261,24 @@
                 <number>0</number>
                </property>
                <item row="2" column="0">
-                <widget class="QRadioButton" name="bootstrap">
+                <widget class="QRadioButton" name="_3bootstrap">
                  <property name="text">
                   <string>Bootstrap</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QRadioButton" name="robust">
+                <widget class="QRadioButton" name="_2robust">
                  <property name="text">
                   <string>Robust</string>
                  </property>
                 </widget>
                </item>
                <item row="0" column="0">
-                <widget class="QRadioButton" name="standard">
+                <widget class="QRadioButton" name="_1standard">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
                  <property name="text">
                   <string>Standard</string>
                  </property>
@@ -554,28 +557,28 @@
                 <number>0</number>
                </property>
                <item row="3" column="0">
-                <widget class="QRadioButton" name="WLS">
+                <widget class="QRadioButton" name="_4WLS">
                  <property name="text">
                   <string>WLS</string>
                  </property>
                 </widget>
                </item>
                <item row="5" column="0">
-                <widget class="QRadioButton" name="DWLS">
+                <widget class="QRadioButton" name="_6DWLS">
                  <property name="text">
                   <string>DWLS</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QRadioButton" name="ML">
+                <widget class="QRadioButton" name="_2ML">
                  <property name="text">
                   <string>ML</string>
                  </property>
                 </widget>
                </item>
                <item row="0" column="0">
-                <widget class="QRadioButton" name="automatic">
+                <widget class="QRadioButton" name="_1automatic">
                  <property name="text">
                   <string>Auto</string>
                  </property>
@@ -585,14 +588,14 @@
                 </widget>
                </item>
                <item row="4" column="0">
-                <widget class="QRadioButton" name="ULS">
+                <widget class="QRadioButton" name="_5ULS">
                  <property name="text">
                   <string>ULS</string>
                  </property>
                 </widget>
                </item>
                <item row="2" column="0">
-                <widget class="QRadioButton" name="GLS">
+                <widget class="QRadioButton" name="_3GLS">
                  <property name="text">
                   <string>GLS</string>
                  </property>
@@ -734,7 +737,7 @@
                 <number>0</number>
                </property>
                <item row="0" column="0">
-                <widget class="QRadioButton" name="none">
+                <widget class="QRadioButton" name="_1none">
                  <property name="text">
                   <string>None</string>
                  </property>
@@ -744,14 +747,14 @@
                 </widget>
                </item>
                <item row="2" column="0">
-                <widget class="QRadioButton" name="EQS">
+                <widget class="QRadioButton" name="_3EQS">
                  <property name="text">
                   <string>EQS</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QRadioButton" name="Mplus">
+                <widget class="QRadioButton" name="_2Mplus">
                  <property name="text">
                   <string>Mplus</string>
                  </property>
@@ -858,7 +861,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>bootstrap</sender>
+   <sender>_3bootstrap</sender>
    <signal>toggled(bool)</signal>
    <receiver>containerBootstrapSamples</receiver>
    <slot>setEnabled(bool)</slot>

--- a/Resources/Library/SEMSimple.json
+++ b/Resources/Library/SEMSimple.json
@@ -73,7 +73,8 @@
 				"WLS",
 				"ULS",
 				"DWLS"
-			]
+			],
+			"default": "automatic"
 		},
 		{
 			"name": "includeMeanStructure",
@@ -144,7 +145,8 @@
 				"none",
 				"Mplus",
 				"EQS"
-			]
+			],
+			"default": "none"
 		}
 	]
 }


### PR DESCRIPTION
The errorCalcualation, emulation and estimator option lists in the SEM
mouse used the wrong options because the sequence of the options were
wrong.