### PR TITLE
Bugfix diff

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -787,7 +787,7 @@ as.list.footnotes <- function(footnotes) {
 				item1 <- one[[name]]
 				item2 <- two[[name]]
 				
-				if (identical(item1, item2) == FALSE) {
+				if (base::identical(item1, item2) == FALSE) {
 				
 					changed[[name]] <- TRUE
 					
@@ -795,7 +795,13 @@ as.list.footnotes <- function(footnotes) {
 				
 					changed[[name]] <- FALSE
 				}
+				
+			} else {
+				
+				changed[[name]] <- TRUE
+				
 			}
+			
 		}
 		
 		for (name in names2) {
@@ -804,7 +810,7 @@ as.list.footnotes <- function(footnotes) {
 				changed[[name]] <- TRUE
 		}
 		
-	} else if (base::indentical(one, two)) {
+	} else if (base::identical(one, two)) {
 		
 		return(FALSE)
 		


### PR DESCRIPTION
Fixed two bugs in the .diff function:
1) typo in function name (would result in a general error if two non-named structures are provided to .diff)
2) if two named lists are provided, entries in list1 that are not in list2 will be omitted rather than marked as changed. Entries in list2 not in list1 will be marked.

Should be checked thoroughly as every analysis uses this function.