### PR TITLE
rjson is required at runtime (linux build)

### DIFF
--- a/Docs/development/jasp-building-guide.md
+++ b/Docs/development/jasp-building-guide.md
@@ -109,5 +109,6 @@ In order to run, you will need:
  - r-cran-effects *
  - r-cran-logspline *
  - r-cran-hypergeo *
+   r-cran-rjson
 
 Those marked with asterisks are available from Jonathon's PPA.


### PR DESCRIPTION
In absence of `r-cran-rjson` on linux at runtime, JASP interface crashes.
Added the package to the development guide under the section *in order to run*