### PR TITLE
show application-crash message when rjson package is not installed

### DIFF
--- a/JASP-Desktop/enginesync.cpp
+++ b/JASP-Desktop/enginesync.cpp
@@ -460,7 +460,17 @@ void EngineSync::subProcessStandardOutput()
 void EngineSync::subProcessStandardError()
 {
 	QProcess *process = qobject_cast<QProcess *>(this->sender());
-	qDebug() << process->readAllStandardError();
+	// qDebug() << process->readAllStandardError();
+
+	QByteArray standardErrorMessage = process->readAllStandardError();
+	std::string errorMessage(standardErrorMessage.constData(), standardErrorMessage.length());
+
+	qDebug() << standardErrorMessage;
+
+	if (errorMessage.find("Error") != std::string::npos) {
+		emit errorReceived(errorMessage);
+	}
+
 }
 
 void EngineSync::subProcessStarted()
@@ -483,4 +493,3 @@ void EngineSync::subprocessFinished(int exitCode, QProcess::ExitStatus exitStatu
 
 	qDebug() << "subprocess finished" << exitCode;
 }
-

--- a/JASP-Desktop/enginesync.h
+++ b/JASP-Desktop/enginesync.h
@@ -62,6 +62,7 @@ public:
 signals:
 
 	void engineTerminated();
+	void errorReceived(std::string);
 
 private:
 

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -186,6 +186,7 @@ MainWindow::MainWindow(QWidget *parent) :
 	_analyses = new Analyses();
 	_engineSync = new EngineSync(_analyses, this);
 	connect(_engineSync, SIGNAL(engineTerminated()), this, SLOT(fatalError()));
+	connect(_engineSync, SIGNAL(errorReceived(std::string)), this, SLOT(handleErrorSignal(std::string)));
 
 	connect(_analyses, SIGNAL(analysisResultsChanged(Analysis*)), this, SLOT(analysisResultsChangedHandler(Analysis*)));
 	connect(_analyses, SIGNAL(analysisImageSaved(Analysis*)), this, SLOT(analysisImageSavedHandler(Analysis*)));
@@ -936,7 +937,7 @@ void MainWindow::dataSetIORequest(FileEvent *event)
 
 	}
 	else if (event->operation() == FileEvent::FileSave)
-	{		
+	{
 		if (_analyses->count() > 0)
 		{
 			_package->setWaitingForReady();
@@ -1312,9 +1313,16 @@ void MainWindow::fatalError()
 	{
 		exiting = true;
 
-		QMessageBox::warning(this, "Error", "JASP has experienced an unexpected internal error.\n\n\"" + _fatalError + "\"\n\nIf you could report your experiences to the JASP team that would be appreciated.\n\nJASP cannot continue and will now close.\n\n");
+		QMessageBox::warning(this, "Error", "JASP has experienced an unexpected internal error.\n\n\"\n" + _fatalError + "\"\n\nIf you could report your experiences to the JASP team that would be appreciated.\n\nJASP cannot continue and will now close.\n\n");
 		QApplication::exit(1);
 	}
+}
+
+void MainWindow::handleErrorSignal(std::string errorMessage)
+{
+	_fatalError = QString::fromStdString(errorMessage);
+
+	fatalError();
 }
 
 void MainWindow::helpFirstLoaded(bool ok)

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -205,6 +205,7 @@ private slots:
 
 	void illegalOptionStateChanged();
 	void fatalError();
+	void handleErrorSignal(std::string);
 
 	void helpFirstLoaded(bool ok);
 	void requestHelpPage(const QString &pageName);

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -137,7 +137,13 @@ run <- function(name, options.as.json.string, perform="run") {
 
 checkPackages <- function() {
 
-	rjson::toJSON(.checkPackages())
+	p <- try(silent = FALSE, expr = {
+		return(rjson::toJSON(.checkPackages()))
+	})
+
+	if (class(p) == "try-error") {
+		return (.extractErrorMessage(p))
+	}
 }
 
 isTryError <- function(obj){


### PR DESCRIPTION
JASP currently does not show an error message when it crashes (when rjson package is not installed). This is an **attempt** to solve this. 

(see #1507)