### PR TITLE
Solve small sync problems

### DIFF
--- a/JASP-Desktop/backstage/opensavewidget.cpp
+++ b/JASP-Desktop/backstage/opensavewidget.cpp
@@ -278,6 +278,7 @@ void OpenSaveWidget::dataSetIOCompleted(FileEvent *event)
 	{
 		_bsComputer->clearFileName();
 
+		setDataFileWatcher(false);
 		_currentFileHasPath = false;
 		_currentFilePath = "";
 	}

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -71,6 +71,11 @@ private:
 	Analyses *_analyses;
 	EngineSync* _engineSync;
 
+	void refreshAnalysesUsingColumns(std::vector<std::string> &changedColumns
+									, std::vector<std::string> &missingColumns
+									, std::map<std::string, std::string> &changeNameColumns);
+
+
 	void packageChanged(DataSetPackage *package);
 	void packageDataChanged(DataSetPackage *package
 							, std::vector<std::string> &changedColumns
@@ -150,7 +155,7 @@ private slots:
 	void removeAnalysisRequestHandler(int id);
 	void removeAllAnalyses();
 	void refreshAllAnalyses();
-	void refreshCurrentAnalysis();
+	void refreshAnalysesUsingColumn(QString col);
 	void resetTableView();
 	void showAnalysesMenuHandler(QString options);
 	void removeSelected();

--- a/JASP-Desktop/variablespage/levelstablemodel.cpp
+++ b/JASP-Desktop/variablespage/levelstablemodel.cpp
@@ -20,6 +20,12 @@ void LevelsTableModel::setColumn(Column *column)
 	endResetModel();
 }
 
+void LevelsTableModel::refresh()
+{
+	beginResetModel();
+	endResetModel();
+}
+
 void LevelsTableModel::clearColumn()
 {
 	setColumn(NULL);

--- a/JASP-Desktop/variablespage/levelstablemodel.h
+++ b/JASP-Desktop/variablespage/levelstablemodel.h
@@ -13,6 +13,7 @@ public:
 	LevelsTableModel(QObject *parent = 0);
 
 	void setColumn(Column *column);
+	void refresh();
 	void clearColumn();
 
 	int rowCount(const QModelIndex &parent) const OVERRIDE;

--- a/JASP-Desktop/variableswidget.cpp
+++ b/JASP-Desktop/variableswidget.cpp
@@ -25,9 +25,8 @@ VariablesWidget::VariablesWidget(QWidget *parent) :
 
 	connect(ui->moveUpButton, SIGNAL(clicked()), this, SLOT(moveUpClicked()));
     connect(ui->moveDownButton, SIGNAL(clicked()), this, SLOT(moveDownClicked()));
-	connect(ui->reverseButton, SIGNAL(clicked()), this, SLOT(reverseClicked()));\
+	connect(ui->reverseButton, SIGNAL(clicked()), this, SLOT(reverseClicked()));
 	connect(ui->closeButton, SIGNAL(clicked()), this, SLOT(close()));
-	connect(this, SIGNAL(dataTableColumnSelected(int, QString)), this, SLOT(tableColumnSelected(int, QString)));
 	connect(_levelsTableModel, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(labelDataChanged(QModelIndex, QModelIndex)));
 
 }
@@ -40,24 +39,13 @@ VariablesWidget::~VariablesWidget()
 void VariablesWidget::setDataSet(DataSet *dataSet)
 {
 	_dataSet = dataSet;
+	_levelsTableModel->refresh();
 }
 
 void VariablesWidget::clearDataSet()
 {
 	_dataSet = NULL;
 	_currentColumn = NULL;
-}
-
-void VariablesWidget::selectedVariableChanged(QModelIndex selection, QModelIndex old)
-{
-	Q_UNUSED(old);
-
-	int columnIndex = selection.row();
-	_currentColumn = &_dataSet->columns().at(columnIndex);
-
-	_levelsTableModel->setColumn(_currentColumn);
-
-	emit(reRun());
 }
 
 void VariablesWidget::moveUpClicked()
@@ -87,7 +75,8 @@ void VariablesWidget::moveUpClicked()
 	//ui->labelsView->setSelectionBehavior(QAbstractItemView::SelectRows);
 	ui->labelsView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-	emit(reRun());
+	if (_currentColumn != NULL)
+		emit(columnChanged(QString::fromStdString(_currentColumn->name())));
 
 }
 
@@ -118,7 +107,8 @@ void VariablesWidget::moveDownClicked()
 	//ui->labelsView->setSelectionBehavior(QAbstractItemView::SelectRows);
 	ui->labelsView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-	emit(reRun());
+	if (_currentColumn != NULL)
+		emit(columnChanged(QString::fromStdString(_currentColumn->name())));
 
 }
 
@@ -129,7 +119,8 @@ void VariablesWidget::reverseClicked()
 	ui->labelsView->setSelectionBehavior(QAbstractItemView::SelectRows);
 	ui->labelsView->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-	emit(reRun());
+	if (_currentColumn != NULL)
+		emit(columnChanged(QString::fromStdString(_currentColumn->name())));
 }
 
 void VariablesWidget::setCurrentColumn(int columnnumber)
@@ -144,19 +135,9 @@ void VariablesWidget::setCurrentColumn(int columnnumber)
 
 }
 
-void VariablesWidget::tableColumnSelected(int columnnumber, QString columnheader)
-{
-	_currentColumn = &_dataSet->columns().at(columnnumber);
-	std::string name = _currentColumn->name();
-
-	_levelsTableModel->setColumn(_currentColumn);
-
-	ui->columnheader->setText("<b>" + columnheader + "</b>");
-
-}
-
 void VariablesWidget::labelDataChanged(QModelIndex m1, QModelIndex m2)
 {
-	emit(reRun());
+	if (_currentColumn != NULL)
+		emit(columnChanged(QString::fromStdString(_currentColumn->name())));
 	emit(resetTableView());
 }

--- a/JASP-Desktop/variableswidget.h
+++ b/JASP-Desktop/variableswidget.h
@@ -25,16 +25,13 @@ public:
 	void setCurrentColumn(int columnindex);
 
 signals:
-	void dataTableColumnSelected(int columnselected, QString headername);
-	void reRun();
+	void columnChanged(QString col);
 	void resetTableView();
 
 private slots:
-	void selectedVariableChanged(QModelIndex selection, QModelIndex old);
 	void moveUpClicked();
 	void moveDownClicked();
     void reverseClicked();
-	void tableColumnSelected(int columnselected, QString columnheader);
 	void labelDataChanged(QModelIndex m1, QModelIndex m2);
 
 private:


### PR DESCRIPTION
When Jasp file is closed, the watcher should be off.
When data file is updated, JASP has to indicate that it is modified.
Also when labels are changed, JASP must indicate that ii is modified.