### PR TITLE
Added: p-values to SumStats module

### DIFF
--- a/JASP-Engine/JASP/R/commonsummarystatsttestbayesian.R
+++ b/JASP-Engine/JASP/R/commonsummarystatsttestbayesian.R
@@ -126,16 +126,16 @@
     result <- .pValueFromT(t=t, n1=n-1, n2=0, var.equal=TRUE)
   } else if (method == "kendall"){
     # TODO: Add support for SuppDists 
-    if (n > 2 && n < 50) {
-      # Exact sampling distribution
-      # tau neq 0
-      result$twoSided <- 2*SuppDists::pKendall(-abs(corrie), N=n)
-      # tau < 0
-      result$minSided <- SuppDists::pKendall(corrie, N=n)
-      # tau > 0
-      result$plusSided <- SuppDists::pKendall(corrie, N=n, lower.tail = FALSE)
-
-    } else if (n >= 50){
+    # if (n > 2 && n < 50) {
+    #   # Exact sampling distribution
+    #   # tau neq 0
+    #   result$twoSided <- 2*SuppDists::pKendall(-abs(corrie), N=n)
+    #   # tau < 0
+    #   result$minSided <- SuppDists::pKendall(corrie, N=n)
+    #   # tau > 0
+    #   result$plusSided <- SuppDists::pKendall(corrie, N=n, lower.tail = FALSE)
+    # 
+    # } else if (n >= 50){
       # normal approximation 
       #
       someSd <- sqrt(2*(2*n+5)/(9*n*(n-1)))
@@ -146,7 +146,7 @@
       result$minSided <- pnorm(corrie, sd=someSd)
       # tau > 0
       result$plusSided <- pnorm(corrie, sd=someSd, lower.tail = FALSE)
-    }
+    # }
   } else if (method == "spearman"){
     # TODO: Johnny
   }

--- a/JASP-Engine/JASP/R/commonsummarystatsttestbayesian.R
+++ b/JASP-Engine/JASP/R/commonsummarystatsttestbayesian.R
@@ -54,8 +54,7 @@
 		pValue <- .pValueFromT(
 								t = options$tStatistic,
 								n1 = options$n1Size,
-								n2 = n2Value,
-								oneSided = hypothesis.variables$oneSided
+								n2 = n2Value
 						)
 	}
 
@@ -63,21 +62,20 @@
 }
 
 
-.pValueFromT <- function(t, n1, n2 = 0, oneSided = FALSE, var.equal = TRUE) {
+.pValueFromT <- function(t, n1, n2 = 0, var.equal = TRUE) {
 	# Function returns the p value from t statistic
 	#
 	# Args:
 	#   t: t value input by user
 	#   n1: sample size of group 1
 	#   n2: sample size of group 2 (Note the hack by setting n2 = 0)
-	#   oneSided: hypothesis type
 	#   var.equal: Note: always true: var.equal, we do not have enough info for different
 	#              variances. In that case we also need s1 and s2
 	#
 	# Output:
 	#   number in [0, 1] which is the p value
 
-	result <- NA
+	result <- list()
 
 	if (n2 > 0) {
 		# If n2 > 0, then two-sample
@@ -86,21 +84,75 @@
 		# If n2 <= 0, then one-sample
 		someDf <- n1 - 1
 	}
-
-	if (oneSided == FALSE) {
-		# mu \neq 0
-		result <- 2 * pt(-abs(t), df = someDf)
-	} else if (oneSided == "left") {
-		# mu < 0
-		result <- pt(t, df = someDf)
-	} else if (oneSided == "right") {
-		# mu > 0
-		result <- pt(t, df = someDf, lower.tail = FALSE)
-	}
-
+	
+	# mu \neq 0
+	result$twoSided <- 2 * pt(-abs(t), df = someDf)
+	# mu < 0
+	result$minSided <- pt(t, df = someDf)
+	# mu > 0
+	result$plusSided <- pt(t, df = someDf, lower.tail = FALSE)
+	
 	return(result)
 }
 
+.pValueFromCor <- function(corrie, n, method="pearson") {
+  # Function returns the p value from correlation, thus,
+  ##  corrie = r    when  method = "pearson"
+  #   corrie = tau  when  method = "kendall"
+  #   corrie = rho  when  method = "spearman"
+  #
+  # Args:
+  #   corrie: correlation input by user
+  #   n: sample size
+  #   oneSided: hypothesis type: left or right
+  #   method: pearson, kenall, or spearman
+  #
+  # Output:
+  #   list of three p-values
+  
+  result <- list()
+  
+  if (method == "pearson"){
+    # Use t-distribution based on bivariate normal assumption using r to t transformation
+    #
+    if (n > 2 ){
+      df <- n - 2
+    } else {
+      # TODO return error, n needs to be larger than 2
+      df <- 1
+    }
+    
+    t <- corrie*sqrt(df/(1-corrie^2))
+    result <- .pValueFromT(t=t, n1=n-1, n2=0, var.equal=TRUE)
+  } else if (method == "kendall"){
+    # TODO: Add support for SuppDists 
+    if (n > 2 && n < 50) {
+      # Exact sampling distribution
+      # tau neq 0
+      result$twoSided <- 2*SuppDists::pKendall(-abs(corrie), N=n)
+      # tau < 0
+      result$minSided <- SuppDists::pKendall(corrie, N=n)
+      # tau > 0
+      result$plusSided <- SuppDists::pKendall(corrie, N=n, lower.tail = FALSE)
+
+    } else if (n >= 50){
+      # normal approximation 
+      #
+      someSd <- sqrt(2*(2*n+5)/(9*n*(n-1)))
+      
+      # tau neq 0
+      result$twoSided <- 2*pnorm(-abs(corrie), sd=someSd)
+      # tau < 0
+      result$minSided <- pnorm(corrie, sd=someSd)
+      # tau > 0
+      result$plusSided <- pnorm(corrie, sd=someSd, lower.tail = FALSE)
+    }
+  } else if (method == "spearman"){
+    # TODO: Johnny
+  }
+  
+  return(result)
+}
 
 .isInputValid.summarystats.ttest <- function(options, independent) {
 	# Checks if the input given is valid

--- a/JASP-Engine/JASP/R/commonsummarystatsttestbayesian.R
+++ b/JASP-Engine/JASP/R/commonsummarystatsttestbayesian.R
@@ -86,11 +86,11 @@
 	}
 	
 	# mu \neq 0
-	result$twoSided <- 2 * pt(-abs(t), df = someDf)
+	result$twoSided <- 2 * stats::pt(-abs(t), df = someDf)
 	# mu < 0
-	result$minSided <- pt(t, df = someDf)
+	result$minSided <- stats::pt(t, df = someDf)
 	# mu > 0
-	result$plusSided <- pt(t, df = someDf, lower.tail = FALSE)
+	result$plusSided <- stats::pt(t, df = someDf, lower.tail = FALSE)
 	
 	return(result)
 }
@@ -141,14 +141,15 @@
       someSd <- sqrt(2*(2*n+5)/(9*n*(n-1)))
       
       # tau neq 0
-      result$twoSided <- 2*pnorm(-abs(corrie), sd=someSd)
+      result$twoSided <- 2 * stats::pnorm(-abs(corrie), sd=someSd)
       # tau < 0
-      result$minSided <- pnorm(corrie, sd=someSd)
+      result$minSided <- stats::pnorm(corrie, sd=someSd)
       # tau > 0
-      result$plusSided <- pnorm(corrie, sd=someSd, lower.tail = FALSE)
+      result$plusSided <- stats::pnorm(corrie, sd=someSd, lower.tail = FALSE)
     # }
   } else if (method == "spearman"){
     # TODO: Johnny
+    # Without code this will print a NULL, if we go through here 
   }
   
   return(result)

--- a/JASP-Engine/JASP/R/summarystatsbinomialtestbayesian.R
+++ b/JASP-Engine/JASP/R/summarystatsbinomialtestbayesian.R
@@ -79,6 +79,7 @@ SummaryStatsBinomialTestBayesian <- function(dataset = NULL, options, perform = 
 	fields[[length(fields)+1]] <- list(name = "failures", type = "integer", title = "Failures")
 	fields[[length(fields)+1]] <- list(name = "testValue", type = "number", title = "Test value")
 	fields[[length(fields)+1]] <- list(name = "BF", type = "number", format = "sf:4;dp:3", title = bf.title)
+	fields[[length(fields)+1]] <- list(name = "pValue", type = "number", format = "sf:4;dp:3", title = "p")
 
 	table <- list()
 	table[["title"]] <- "Bayesian Binomial Test"
@@ -249,6 +250,8 @@ SummaryStatsBinomialTestBayesian <- function(dataset = NULL, options, perform = 
 				}
 
 				rowsBinomialTest$BF <- .clean(BF)
+				rowsBinomialTest$pValue <- .clean(stats::binom.test(x=c(options$successes, options$failures), 
+				                                                    p=options$testValue, alternative=hyp)$p.value)
 			}
 		}
 	}

--- a/JASP-Engine/JASP/R/summarystatscorrelationbayesianpairs.R
+++ b/JASP-Engine/JASP/R/summarystatscorrelationbayesianpairs.R
@@ -471,8 +471,7 @@ SummaryStatsCorrelationBayesianPairs <- function(dataset = NULL, options,
 		all.pValues <- .pValueFromCor(corrie=some.r, n=some.n, method="kendall")
 	} else if (options$correlationCoefficient == "spearman"){
 	  # TODO: Johnny
-	  some.r <- "error"
-	  all.bfs <- "error"
+	  # Without code this will print a NULL, if we go through here 
 	}
 	return(list(bf = all.bfs, pValue=all.pValues))
 }

--- a/JASP-Engine/JASP/R/summarystatsttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianindependentsamples.R
@@ -214,7 +214,17 @@ SummaryStatsTTestBayesianIndependentSamples <- function(dataset = NULL, options,
 
 				rowsTTestBayesianIndependentSamples$BF <- BF
 				rowsTTestBayesianIndependentSamples$errorEstimate <- .clean(bayesFactorObject$properror)
-				rowsTTestBayesianIndependentSamples$pValue <- .clean(bayesFactorObject$pValue)
+				
+				allPValues <- bayesFactorObject$pValue
+				
+				# TODO: switch function? 
+				if (hypothesis.variables$oneSided == FALSE){
+				  rowsTTestBayesianIndependentSamples$pValue <- .clean(allPValues$twoSided)
+				} else if (hypothesis.variables$oneSided == "left") {
+				  rowsTTestBayesianIndependentSamples$pValue <- .clean(allPValues$minSided)
+				} else if (hypothesis.variables$oneSided == "right") {
+				  rowsTTestBayesianIndependentSamples$pValue <- .clean(allPValues$plusSided)
+				}
 			}
 		}
 	}

--- a/JASP-Engine/JASP/R/summarystatsttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianonesample.R
@@ -213,7 +213,16 @@ SummaryStatsTTestBayesianOneSample <- function(dataset = NULL, options, perform 
 
 				rowsTTestBayesianOneSample$BF <- BF
 				rowsTTestBayesianOneSample$errorEstimate <- .clean(bayesFactorObject$properror)
-				rowsTTestBayesianOneSample$pValue <- .clean(bayesFactorObject$pValue)
+				
+				allPValues <- bayesFactorObject$pValue
+				
+				if (hypothesis.variables$oneSided == FALSE){
+				  rowsTTestBayesianOneSample$pValue <- .clean(allPValues$twoSided)
+				} else if (hypothesis.variables$oneSided == "left") {
+				  rowsTTestBayesianOneSample$pValue <- .clean(allPValues$minSided)
+				} else if (hypothesis.variables$oneSided == "right") {
+				  rowsTTestBayesianOneSample$pValue <- .clean(allPValues$plusSided)
+				}
 			}
 		}
 	}

--- a/JASP-Engine/JASP/R/summarystatsttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianpairedsamples.R
@@ -214,7 +214,16 @@ SummaryStatsTTestBayesianPairedSamples <- function(dataset = NULL, options, perf
 
 				rowsTTestBayesianPairedSamples$BF <- BF
 				rowsTTestBayesianPairedSamples$errorEstimate <- .clean(bayesFactorObject$properror)
-				rowsTTestBayesianPairedSamples$pValue <- .clean(bayesFactorObject$pValue)
+				
+				allPValues <- bayesFactorObject$pValue
+				
+				if (hypothesis.variables$oneSided == FALSE){
+				  rowsTTestBayesianPairedSamples$pValue <- .clean(allPValues$twoSided)
+				} else if (hypothesis.variables$oneSided == "left") {
+				  rowsTTestBayesianPairedSamples$pValue <- .clean(allPValues$minSided)
+				} else if (hypothesis.variables$oneSided == "right") {
+				  rowsTTestBayesianPairedSamples$pValue <- .clean(allPValues$plusSided)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Added p-values to sumstats

commonsummarystatsttestbayesian
- .pValueFromT output to a list producing all three p-values at the
same time

Checked all dependencies on the repository.
- summarystatsttestbayesianindependentsamples.R
- summarystatsttestbayesianonesample.R
- summarystatsttestbayesianpairedsamples.R

Add: .pValueFromCor output a list

summarystatscorrelationbayesianpairs
	Change: correlation output title for Kendall from “t” to “tau"

TODO:
- Discrepancy between cor.test method=“kendall” and the SuppDists
package
- Add SuppDists package to library
- Change plot functions for it take bfObjects