### PR TITLE
Change default application folder different platforms

### DIFF
--- a/JASP-Desktop/preferencesdialog.cpp
+++ b/JASP-Desktop/preferencesdialog.cpp
@@ -75,8 +75,17 @@ void PreferencesDialog::getSpreadsheetEditor()
 {
 	
 	QString filter = "File Description (*.*)";
+	QString applicationfolder;
 
-	QString filename = QFileDialog::getOpenFileName(this, "Select a file...", "/Applications", filter);
+#ifdef __WIN32__
+	applicationfolder = "c:\\Program Files";
+#elif __APPLE__
+	applicationfolder = "/Applications";
+#else
+	applicationfolder = "/usr/bin";
+#endif
+
+	QString filename = QFileDialog::getOpenFileName(this, "Select a file...", applicationfolder, filter);
 	if (filename != "")
 		ui->spreadsheetEditorName->setText(filename);
 	

--- a/JASP-Desktop/preferencesdialog.ui
+++ b/JASP-Desktop/preferencesdialog.ui
@@ -29,7 +29,7 @@
      <item>
       <widget class="QCheckBox" name="useDefaultSpreadsheetEditor">
        <property name="text">
-        <string> Use Prefered Spreadsheet Editor</string>
+        <string> Use default spreadsheet editor</string>
        </property>
       </widget>
      </item>
@@ -90,7 +90,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Choose Default Spreadsheet Editor</string>
+        <string>Choose prefered spreadsheet editor</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
For OSX, Windows, Linux a different application folder is selected during choosing the preferred spreadsheet editor