### PR TITLE
Prevent window change after stacktrace click

### DIFF
--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -325,9 +325,10 @@ $(document).ready(function () {
 	window.unselectByClickingBody = function (event) {
 
 		var target = event.target || event.srcElement;
-
+		
+		var stacktraceClicked = $(target).is(".stack-trace-span, .stack-trace-arrow, .stack-trace-selector");
 		var noteClicked = $(target).is(".jasp-notes, .jasp-notes *");
-		var ignoreSelectionProcess = wasLastClickNote === true && noteClicked === false;
+		var ignoreSelectionProcess = (wasLastClickNote === true && noteClicked === false) || stacktraceClicked === true;
 		wasLastClickNote = noteClicked;
 		if (ignoreSelectionProcess)
 			return;
@@ -347,9 +348,11 @@ $(document).ready(function () {
 	var selectedHandler = function (event) {
 
 		var target = event.target || event.srcElement;
+		
+		var stacktraceClicked = $(target).is(".stack-trace-span, .stack-trace-arrow, .stack-trace-selector");
 		var noteClicked = $(target).is(".jasp-notes, .jasp-notes *");
 
-		var ignoreSelectionProcess = wasLastClickNote === true && noteClicked === false;
+		var ignoreSelectionProcess = (wasLastClickNote === true && noteClicked === false) || stacktraceClicked === true;
 
 		wasLastClickNote = noteClicked;
 
@@ -484,7 +487,7 @@ $(document).ready(function () {
 			window.scrollIntoView(jaspWidget.$el);
 	}
 	
-	$("#results").on("click", ".stack-trace-selector", function(e) {
+	$("#results").on("click", ".stack-trace-selector", function() {
 		$(this).next(".stack-trace").slideToggle(function() {
 			var $selectedInner = $(this).parent().siblings(".jasp-analysis");
 			var errorBoxHeight = $(this).parent(".analysis-error").outerHeight(true);
@@ -492,7 +495,7 @@ $(document).ready(function () {
 				$selectedInner.css("height", "");
 			}
 			if ($selectedInner.height() < errorBoxHeight) {
-				$selectedInner.height(errorBoxHeight)
+				$selectedInner.height(errorBoxHeight);
 			}
 		}.bind(this))
 	});

--- a/JASP-Engine/JASP/R/commonmessages.R
+++ b/JASP-Engine/JASP/R/commonmessages.R
@@ -20,7 +20,7 @@
   # error
   messages$error$opening <- "The following problem(s) occurred while running the analysis:"
   messages$error$grouping <- 'after grouping on {{grouping}}'
-  messages$error$exception <- "This analysis terminated unexpectedly.<br><br>{{error}}<br><div class=stack-trace-selector><span>Stack trace</span><div class=stack-trace-arrow></div></div><div class=stack-trace>{{stackTrace}}</div><br>To receive assistance with this problem, please report the message above at: https://jasp-stats.org/bug-reports"
+  messages$error$exception <- "This analysis terminated unexpectedly.<br><br>{{error}}<br><div class=stack-trace-selector><span class=stack-trace-span>Stack trace</span><div class=stack-trace-arrow></div></div><div class=stack-trace>{{stackTrace}}</div><br>To receive assistance with this problem, please report the message above at: https://jasp-stats.org/bug-reports"
   messages$error$infinity <- "Infinity found in {{variables}}"
   messages$error$factorLevels <- "Number of factor levels {{factorLevels.amount}} in {{variables}}"
   messages$error$variance <- "Variance = {{variance.equalTo}} in {{variables}}"


### PR DESCRIPTION
When you click on the stack-trace in an error the options window should not change.