### PR TITLE
Ignore extracted testfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Tools/includeFiles*.nsi
 JASP.pro.user.b601785
 .Rproj.user
 
+#Extracted testfiles 
+Resources/TestFiles
+


### PR DESCRIPTION
Ignore extracted testfiles for git.
Only zip file is needed.