### PR TITLE
Added dormant replication BF for the correlation, cleaned out code

### DIFF
--- a/Docs/development/r-style-guide.md
+++ b/Docs/development/r-style-guide.md
@@ -6,36 +6,184 @@ This guide describes good practice and good approaches to writing analyses in R 
 Good Practice
 -------------
 
-1. do not use global variables
-
-2. functions from outside the JASP package must always be called with their full namespace, like these:
+1. Do not use global variables, as this causes namespace problems.
+1. functions from outside the JASP package must always be called with their full namespace, like these:
     * `stats::anova()`
     * `base::options()`
-    
-3. do not use:
-    * `library()`
-    * `require()`
+1. do not use:
+    * `library()` (causes namespace problems)
+    * `require()` (causes namespace problems)
     * `exists()`
-    * `attach()`
-    * `assign()`
-    * `<<-`
+    * `attach()` (causes namespace problems)
+    * `assign()` (causes namespace problems)
+    * `<<-` (This assigns to a global variable)
+1. Write code to be readable. It is common in the R programming community to do many things in a single line of code. This is either because it is less lines of code to write, or because it improves performance (or because it looks clever). Best practice is to only optimise code once performance has been demonstrated to be a problem. Start by writing code that is understandable. For instance, a for-loop is easier to read than an `lapply()`. When you do use an apply, please add a comment.
+1. Do not mix functions for mark-up with functions that are used for the computations.
+1. Try to save the output of the computations in a list and include the function call.
+1. Use dividers to make your code more readable.
+````
+	## Data screening -----------------------------------------------
+  # Tim's error handling
+  .hasErrors(dataset=dataset, perform=perform, type=c('factorLevels', 'variance'),
+    factorLevels.target='groupingVar', factorLevels.amount='!= 2',
+    variance.target='dependentVar',
+    exitAnalysisIfErrors=TRUE)`
 
-4. Write code to be readable. It is common in the R programming community to do many things in a single line of code. This is either because it is less lines of code to write, or because it improves performance (or because it looks clever). In general it is better to write code which is more verbose but easier to read. for-loops, for example, can be much easier to read than a `lapply()`. Best practice is to only optimise code once performance has been demonstrated to be a problem.
+  ## JSON mark-up initialisation  ----------------------------------------
+  #
+  result <- .createCorrelationMatrixTable(tableName=options$name)
+
+  ## Retrieving data from state or compute -------------------------
+  #
+  outputTableElements <- .getOutputRowCorrelationMatrix(run=run, options=options,
+                                                        state=state)
+
+  ## Retrieving data from state or compute -------------------------
+  #
+  priorAndPosteriorPlot <- .getPriorAndPosteriorPlot(run=run, options=options,
+                                                        state=state)
+
+  ## State save ----------------------------------------------------
+  #
+  for (plot in plotsCorrelationMatrix) {
+		keep <- c(keep, plot$data)
+	}
+
+	if (run) {
+	   status <- "complete"
+		state <- list(options = options, bayesFactorObject = bayesFactorObject,
+								rowsCorrelationMatrix = rowsCorrelationMatrix,
+								plotsCorrelationMatrix = plotsCorrelationMatrix, plotTypes = plotTypes)
+	} else {
+		status <- "inited"
+	}
+
+	return(list(results = results,
+							status = status,
+							state = state,
+							keep = keep)
+				)
+````
+1. Suggest a reviewer for your code, after you submitted a pull request.
 
 
 Style
 -----
+The JASP style guide is based on the [google style guide](https://google-styleguide.googlecode.com/svn/trunk/Rguide.xml).
 
-All R code for JASP should follow the [google style guide](https://google-styleguide.googlecode.com/svn/trunk/Rguide.xml).
-
-However a couple of exceptions should be observed
-
-1. function names that aren't the name of an analysis (i.e. those
-privately used by the JASP R package) begin with a . and lowercase.
-    * `NotLikeThis()`
-    * `.butLikeThis()`
-
-2. tabs are used rather than two spaces (you should set up your editor so that tabs appear four spaces wide)
+1. General style: camelCasing
+  - no underscores, no full stops, no hyphens between variables names and function names. Use verbs for functions and nouns for variables
+    * bad: this_variable.x
+    * GOOD: firstVariable
+1. Defining functions:
+  -  function names that aren't the name of an analysis (i.e. those privately used by the JASP R package) begin with a . and lowercase.
+    * bad:
+    ```
+    correlationFunction()
+    ```
+    * GOOD:
+    ```
+    .getOutputRowCorrelationMatrix()
+    ```     
+  - Use descriptive names, longer variables names are okay.
+    * bad:
+    ```
+    x <- 5
+    y <- function(x){sqrt(x)}
+    ```
+    * GOOD:
+    ```
+    firstVariable <- 5
+    .takeSquareRoot <- function(x){
+      sqrt(x)
+    }
+    ```
+  - Function definitions should first list arguments without default values, followed by those with default values. In both function definitions and function calls, multiple arguments per line are allowed; line breaks are only allowed between assignments.
+    * bad:
+    ```
+    .bfPearsonCorrelation <- function(kappa=1, n, r, hyperGeoOverFlowThreshold=24, ciValue =
+      0.95)
+    ```
+    * GOOD:
+    ```
+    .bfPearsonCorrelation <- function(n, r, kappa=1, hyperGeoOverFlowThreshold=24,
+      ciValue = 0.95)
+    ```     
+1. Using functions:   
+  - Use the full name space for functions outside of base.
+    * bad: <br>
+    ```
+    library("utils")
+    result <- modifyList(result, tempResult)
+    ```
+    * GOOD:
+    ```
+    result <- utils::modifyList(x=result, val=tempResult)
+    ```    
+  - Pass arguments through a function by their argument name when possible.
+    * bad:
+    ```
+    BayesFactor::ttest.tstat(7, 3)
+    ```
+    * GOOD:
+    ```
+    BayesFactor::ttest.tstat(t=7, n1=3)
+    ```    
+1. Assignment:
+  - use `<-`, not `=` (The "=" sign is reserved for arguments in a function call)
+  - Don't use global assignment operator <<-
+1. Semicolons:
+  - Don't use them
+    * bad:
+    ```
+    x <- 3; y <- 4; x <- y <- 6 ;
+    ```
+    * GOOD:
+        ```
+        x <- 3
+        y <- 4
+        ```
+1. Indentations:
+  - Use four spaces (Insert spaces for tab [tab width=4])
+1. Spacing
+  - Spaces: Between binary operators (e.g., `+`, `*`, `||`, `<-`, commas.
+	   * BAD:
+     ```
+     displayEstimate <-bfObject$x+bfObject$y
+     correlationMatrix[1 ,2]
+     correlationMatrix[1,]
+     ```
+	   * GOOD:
+     ```
+     displayEstimate <- bfObject$x + bfObject$y
+     correlationMatrix[1, 2]
+     correlationMatrix[1, ]
+     ```
+1. Spacing Curly Braces:
+  - first on same line, last on own line.
+  - Surround else with braces
+    * bad:
+    ```
+    if (is.null(r))
+      return(NA)
+    else if (is.na(r))  {return(NA)}
+    else
+    {
+      result <- computeBf(r=r)
+    }
+    ```
+    * GOOD:
+      ```
+      if (is.null(r)) {
+        return(NA)
+      } else if {
+        return(NA)
+      } else {
+        result <- computeBf(r=r)
+      }
+      ```
+1. Commenting Guidelines: all comments begin with # followed by a space; inline comments need two spaces before the #.
+1. TODO Style: TODO(username)
 
 
 Analysis Design
@@ -55,14 +203,14 @@ We will begin with the `Anova()` function itself.
 After the reading of the dataset, the analysis runs as follows:
 
 	status <- .anovaCheck(dataset, options, perform)
-	
+
 
 
 	## Setup Contrasts
 
 	if (perform == "run" && status$ready && status$error == FALSE)
 		dataset <- .anovaSetupContrasts(dataset, options)
-	
+
 
 
 	## Perform ANOVA
@@ -76,25 +224,25 @@ After the reading of the dataset, the analysis runs as follows:
 	## Create ANOVA Table
 
 	result <- .anovaTable(dataset, options, perform, model, status)
-	
+
 	results[["anova"]] <- result$result
 	status <- result$status
-		
-	
+
+
 
 	## Create Contrasts Table
-	
+
 	result <- .anovaContrastsTable(dataset, options, perform, model, status)
-	
+
 	results[["contrasts"]] <- result$result
 	status <- result$status
-	
-	
-	
+
+
+
 	## Create Post Hoc Table
-	
+
 	result <- .anovaPostHocTable(dataset, options, perform, status)
-	
+
 	results[["posthoc"]] <- result$result
 	status <- result$status
 
@@ -108,8 +256,8 @@ The .anovaCheck() function, checks that the analysis can run and returns a statu
 
 	if (perform == "run" && status$ready && status$error == FALSE)
 		dataset <- .anovaSetupContrasts(dataset, options)
-	
-	
+
+
 	## Perform ANOVA
 
 	model <- NULL
@@ -121,19 +269,18 @@ Finally this status object is passed into, and returned from the functions which
 	## Create ANOVA Table
 
 	result <- .anovaTable(dataset, options, perform, model, status)
-	
+
 	results[["anova"]] <- result$result
 	status <- result$status
-	
+
 
 	## Create Contrasts Table
-	
+
 	result <- .anovaContrastsTable(dataset, options, perform, model, status)
-	
+
 	results[["contrasts"]] <- result$result
 	status <- result$status
 
 In this way, the status object is passed from one function to the next. Earlier functions which encounter an error can notify later functions that an error has occurred, allowing them to adjust their behaviour accordingly. In this case, passing in a status object with either `error == TRUE` or `ready == FALSE`, causes the functions to not attempt to read values from the model,  but instead simply generate blank tables (like when `perform == "init"`).
 
 This approach is good, because it provides both neat encapsulation of the different parts of the analysis, but still allows these encapsulated parts to communicate with one another in the case or errors.
-

--- a/Docs/development/r-style-guide.md
+++ b/Docs/development/r-style-guide.md
@@ -64,12 +64,13 @@ Good Practice
 							keep = keep)
 				)
 ````
+1. Remove trailing white space. In RStudio choose: Tools - Global options - Code - Saving and tick "Strip trailing horizontal whitespace when saving"
 1. Suggest a reviewer for your code, after you submitted a pull request.
 
 
 Style
 -----
-The JASP style guide is based on the [google style guide](https://google-styleguide.googlecode.com/svn/trunk/Rguide.xml).
+The JASP style guide is based on the [google style guide](https://google.github.io/styleguide/Rguide.xml).
 
 1. General style: camelCasing
   - no underscores, no full stops, no hyphens between variables names and function names. Use verbs for functions and nouns for variables
@@ -129,9 +130,14 @@ The JASP style guide is based on the [google style guide](https://google-stylegu
     ```
     BayesFactor::ttest.tstat(t=7, n1=3)
     ```    
+1. Function output:
+  - Lists are R's standard
+  - When calling a named column in a list always use the full name.
+  - Don't merge lists using append as this can result in lists with the same names for different columns. Instead use `utils::modifyList`
 1. Assignment:
   - use `<-`, not `=` (The "=" sign is reserved for arguments in a function call)
   - Don't use global assignment operator <<-
+  - Don't use the right assignment operator `3 -> a`.
 1. Semicolons:
   - Don't use them
     * bad:
@@ -182,7 +188,7 @@ The JASP style guide is based on the [google style guide](https://google-stylegu
         result <- computeBf(r=r)
       }
       ```
-1. Commenting Guidelines: all comments begin with # followed by a space; inline comments need two spaces before the #.
+1. Commenting Guidelines: all comments begin with # followed by a space; inline comments need four spaces before the #.
 1. TODO Style: TODO(username)
 
 

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -130,6 +130,14 @@ checkPackages <- function() {
 	rjson::toJSON(.checkPackages())
 }
 
+isTryError <- function(obj){
+    if (is.list(obj)){
+        return(any(sapply(obj, function(obj){isTRUE(class(obj)=="try-error")})))
+    } else {
+        return(any(sapply(list(obj), function(obj){isTRUE(class(obj)=="try-error")})))
+    }
+}
+
 .addCitationToTable <- function(table) {
 
 	if ("citation" %in% names(table) ) {

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -156,15 +156,15 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	# hypothesis="correlated"
 	#
 	#
-	correlation.table <- list()
+	correlationTable <- list()
 	if(pearson & kendallsTauB){
-	  correlation.table[["citation"]] <- list(
+	  correlationTable[["citation"]] <- list(
 		  "Ly, A., Verhagen, A. J. & Wagenmakers, E.-J. (2015). Harold Jeffreys's Default Bayes Factor Hypothesis Tests: Explanation, Extension, and Application in Psychology. Manuscript submitted for publication.\n \nvan Doorn, J.B., Ly, A., Marsman, M. & Wagenmakers, E.-J. (2016). Bayesian Inference for Kendall’s Rank Correlation Coefficient. Manuscript submitted for publication."
 	  )} else if(pearson){
-	    correlation.table[["citation"]] <- list(
+	    correlationTable[["citation"]] <- list(
 	      "Ly, A., Verhagen, A. J. & Wagenmakers, E.-J. (2015). Harold Jeffreys's Default Bayes Factor Hypothesis Tests: Explanation, Extension, and Application in Psychology. Manuscript submitted for publication."
     )} else if(kendallsTauB){
-	    correlation.table[["citation"]] <- list(
+	    correlationTable[["citation"]] <- list(
 	    "van Doorn, J.B., Ly, A., Marsman, M. & Wagenmakers, E.-J. (2016). Bayesian Inference for Kendall’s Rank Correlation Coefficient. Manuscript submitted for publication."
 	  )}
 	
@@ -176,27 +176,27 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	}
 	if (hypothesis == "correlated") {
 		if (bayesFactorType=="BF10"){
-			bf.title <- "BF\u2081\u2080"
+			bfTitle <- "BF\u2081\u2080"
 		} else if (bayesFactorType == "BF01") {
-			bf.title <- "BF\u2080\u2081"
+			bfTitle <- "BF\u2080\u2081"
 		} else if (bayesFactorType=="LogBF10"){
-			bf.title <- "log(BF\u2081\u2080)"
+			bfTitle <- "log(BF\u2081\u2080)"
 		}
 	} else if (hypothesis == "correlatedPositively") {
 		if (bayesFactorType == "BF10"){
-			bf.title <- "BF\u208A\u2080"
+			bfTitle <- "BF\u208A\u2080"
 		} else if (bayesFactorType == "BF01") {
-			bf.title <- "BF\u2080\u208A"
+			bfTitle <- "BF\u2080\u208A"
 		} else if (bayesFactorType=="LogBF10"){
-			bf.title <- "log(BF\u208A\u2080)"
+			bfTitle <- "log(BF\u208A\u2080)"
 		}
 	} else if (hypothesis == "correlatedNegatively"){
 		if (bayesFactorType == "BF10"){
-			bf.title <- "BF\u208B\u2080"
+			bfTitle <- "BF\u208B\u2080"
 		} else if (bayesFactorType == "BF01") {
-			bf.title <- "BF\u2080\u208B"
+			bfTitle <- "BF\u2080\u208B"
 		} else if (bayesFactorType=="LogBF10"){
-			bf.title <- "log(BF\u208B\u2080)"
+			bfTitle <- "log(BF\u208B\u2080)"
 		}
 	}
 	# Note: test contains the tests that are performed
@@ -209,15 +209,15 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 		tests <- c(tests, "kendall")
 	# Note: Naming of the table
 	if (length(tests) != 1) {
-		correlation.table[["title"]] <- paste("Bayesian Correlation Table")
+		correlationTable[["title"]] <- paste("Bayesian Correlation Table")
 	} else if (pearson) {
-		correlation.table[["title"]] <- paste("Bayesian Pearson Correlations")
+		correlationTable[["title"]] <- paste("Bayesian Pearson Correlations")
 	} else if (spearman) {
-		correlation.table[["title"]] <- paste("Bayesian Spearman Correlations")
+		correlationTable[["title"]] <- paste("Bayesian Spearman Correlations")
 	} else if (kendallsTauB) {
-		correlation.table[["title"]] <- paste("Bayesian Kendall's Tau")
+		correlationTable[["title"]] <- paste("Bayesian Kendall's Tau")
 	} else {
-		correlation.table[["title"]] <- paste("Bayesian Correlation Table")
+		correlationTable[["title"]] <- paste("Bayesian Correlation Table")
 	}
 	
 	# Note: Describe column names to the returned object
@@ -237,9 +237,9 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	
 	if (flagSupported) {
 		if (bayesFactorType=="LogBF10"){
-			.addFootnote(footnotes, paste(bf.title, " > log(10), ** , ", bf.title, " > log(30), *** ", bf.title, " > log(100)"), symbol="*")
+			.addFootnote(footnotes, paste(bfTitle, " > log(10), ** , ", bfTitle, " > log(30), *** ", bfTitle, " > log(100)"), symbol="*")
 		} else {
-			.addFootnote(footnotes, paste(bf.title, " > 10, ** , ", bf.title, " > 30, *** ", bf.title, " > 100"), symbol="*")
+			.addFootnote(footnotes, paste(bfTitle, " > 10, ** , ", bfTitle, " > 30, *** ", bfTitle, " > 100"), symbol="*")
 		}
 	}
 	
@@ -268,55 +268,55 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 			temp <- list(temp)
 			
 			if (levels==2){
-				# Structure is [[variable.name]][[column.name]]
+				# Structure is [[variableName]][[columnName]]
 				rValuesListExcludePairwise <- temp
 				footnotesListExcludePairwise <- temp
 				
 				# Not necessary to consider the names only need the ns
-				# Structure is [[n.label]][[r.label]]
+				# Structure is [[nLabel]][[rLabel]]
 				footnotesListExcludeListwise <- temp
 			} else if (levels==3){
-				# Structure is [[prior.label]][[variable.name]][[column.name]]
+				# Structure is [[priorLabel]][[variableName]][[columnName]]
 				bfValuesListExcludePairwise <- temp 
 				
 				# Not necessary to consider the names only need the rs
-				# Structure is [[prior.label]][[n.label]][[r.label]]
+				# Structure is [[priorLabel]][[nLabel]][[rLabel]]
 				bfValuesListExcludeListwise <- temp
 			}
 		}
 	}
 	
 	
-	prior.label <- as.character(round(priorWidth, 5))
+	priorLabel <- as.character(round(priorWidth, 5))
 	
 	if (v.c > 0) {
 		# Note: There are variables: 
-		test.names <- list(pearson="Pearson's r", spearman="Spearman's rho", kendall="Kendall's tau")
-		column.names <- c()
+		testNames <- list(pearson="Pearson's r", spearman="Spearman's rho", kendall="Kendall's tau")
+		columnNames <- c()
 		for (test in tests) {
 			# Note: create columns per test
 			if (length(tests) > 1 || reportBayesFactors) {
-				column.name <- paste(".test[", test, "]", sep="")
-				column.names[[length(column.names)+1]] <- column.name
-				fields[[length(fields)+1]] <- list(name=column.name, title="", type="string")
+				columnName <- paste(".test[", test, "]", sep="")
+				columnNames[[length(columnNames)+1]] <- columnName
+				fields[[length(fields)+1]] <- list(name=columnName, title="", type="string")
 			}
 			
 			# Note: create columns per test variable 
-			for (variable.name in variables) {
-				column.name <- paste(variable.name, "[", test, "]", sep="")
-				column.names[[length(column.names)+1]] <- column.name
-				fields[[length(fields)+1]] <- list(name=column.name, title=variable.name, type="number", format="dp:3")
+			for (variableName in variables) {
+				columnName <- paste(variableName, "[", test, "]", sep="")
+				columnNames[[length(columnNames)+1]] <- columnName
+				fields[[length(fields)+1]] <- list(name=columnName, title=variableName, type="number", format="dp:3")
 			}
 			
 			# Note: create column for bfs
 			if (reportBayesFactors) {
-				column.name <- paste(".test[", test, "Bf]", sep="")
-				column.names[[length(column.names)+1]] <- column.name
-				fields[[length(fields)+1]] <- list(name=column.name, title=bf.title, type="string")
-				for (variable.name in variables) {
-					column.name <- paste(variable.name, "[", test, "Bf]", sep="")
-					column.names[[length(column.names)+1]] <- column.name
-					fields[[length(fields)+1]] <- list(name=column.name, title=variable.name, type="number", format="sf:4;dp:3")
+				columnName <- paste(".test[", test, "Bf]", sep="")
+				columnNames[[length(columnNames)+1]] <- columnName
+				fields[[length(fields)+1]] <- list(name=columnName, title=bfTitle, type="string")
+				for (variableName in variables) {
+					columnName <- paste(variableName, "[", test, "Bf]", sep="")
+					columnNames[[length(columnNames)+1]] <- columnName
+					fields[[length(fields)+1]] <- list(name=columnName, title=variableName, type="number", format="sf:4;dp:3")
 				}
 			}
 		}
@@ -324,35 +324,35 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 		for (i in 1:v.c) {
 			# Note: Create row given a column
 			row <- list()
-			row.footnotes <- list()
+			rowFootnotes <- list()
 			
-			variable.name <- variables[[i]]
+			variableName <- variables[[i]]
 			
 			for (test in tests) {
-				# Note: Create test row given a column
-				bayes.factors <- list()
+				# Note: For each test create list of Bayes factors
+				bayesFactorsList <- list()
 				
 				if (length(tests) > 1 || reportBayesFactors)
 					# Note: Create test name for each test row given a column
-					row[[length(row)+1]] <- test.names[[test]]
+					row[[length(row)+1]] <- testNames[[test]]
 				
 				if (reportBayesFactors)
 					# Note: Create bf row each test given each column (variable)
-					bayes.factors[[length(bayes.factors)+1]] <- bf.title
+					bayesFactorsList[[length(bayesFactorsList)+1]] <- bfTitle
 				
 				for (j in .seqx(1, i-1)) {
 					# Note: Fill in blanks
 					row[[length(row)+1]] <- ""
-					bayes.factors[[length(bayes.factors)+1]] <- ""
+					bayesFactorsList[[length(bayesFactorsList)+1]] <- ""
 				}
 				
 				row[[length(row)+1]] <- "\u2014" # em-dash # Note: Fill in blanks
-				bayes.factors[[length(bayes.factors)+1]] <- "\u2014"
+				bayesFactorsList[[length(bayesFactorsList)+1]] <- "\u2014"
 				
 				for (j in .seqx(i+1, v.c)) {
 					# Note: fill in blanks in table upper left-hand off diaganols
-					variable.2.name <- variables[[j]]
-					column.name <- paste(variable.2.name, "[", test, "]", sep="")
+					variable2Name <- variables[[j]]
+					columnName <- paste(variable2Name, "[", test, "]", sep="")
 					
 					
 					# State retrieval block ----
@@ -368,19 +368,19 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 					recalculateCIs <- FALSE
 					
 					if (missingValues=="excludePairwise"){
-						retrievedBFs <- bfValuesListExcludePairwise[[prior.label]][[variable.name]][[column.name]]
+						retrievedBFs <- bfValuesListExcludePairwise[[priorLabel]][[variableName]][[columnName]]
 						
 						if (!is.null(retrievedBFs)){
 							# State: Retrieval
-							some.r <- unlist(rValuesListExcludePairwise[[variable.name]][[column.name]])
-							all.bfs <- retrievedBFs
+							obsR <- unlist(rValuesListExcludePairwise[[variableName]][[columnName]])
+							bfObject <- retrievedBFs
 							
-							retrievedFootnote <- footnotesListExcludePairwise[[variable.name]][[column.name]]
+							retrievedFootnote <- footnotesListExcludePairwise[[variableName]][[columnName]]
 							
 							if (!is.null(retrievedFootnote)){
-								some.footnote <- unlist(retrievedFootnote)
-								index <- .addFootnote(footnotes, some.footnote)
-								row.footnotes[[column.name]] <- c(row.footnotes[[column.name]], list(index))
+								obsFootnote <- unlist(retrievedFootnote)
+								index <- .addFootnote(footnotes, obsFootnote)
+								rowFootnotes[[columnName]] <- c(rowFootnotes[[columnName]], list(index))
 							}
 							
 							retrievalFailure <- FALSE
@@ -389,23 +389,23 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 							# CIs check:
 							#
 							if (credibleIntervals){
-								calculatedCIValues <- all.bfs$ciValues
+								calculatedCIValues <- bfObject$ciValues
 								
-								if (!is.na(all.bfs$bf10) && !(credibleIntervalsInterval %in% calculatedCIValues)){
+								if (!is.na(bfObject$bf10) && !(credibleIntervalsInterval %in% calculatedCIValues)){
 									# put this in for the next time
 									# Output prepare
-									new.ci.label <- as.character(round(credibleIntervalsInterval, 5))
+									newCiLabel <- as.character(round(credibleIntervalsInterval, 5))
 									calculatedCIValues <- c(calculatedCIValues, credibleIntervalsInterval)
-									ciList <- all.bfs$CIs
+									ciList <- bfObject$CIs
 									
 									# Calculate
-									newCIList <- .credibleIntervals(alpha=all.bfs$betaA, beta=all.bfs$betaB, credibleIntervalsInterval)[[2]]
+									newCIList <- .credibleIntervals(alpha=bfObject$betaA, beta=bfObject$betaB, credibleIntervalsInterval)[[2]]
 									
 									# Store in State
-									ciList[[new.ci.label]] <- newCIList
-									all.bfs$CIs <- ciList
-									all.bfs$ciValues <- calculatedCIValues
-									bfValuesListExcludePairwise[[prior.label]][[variable.name]][[column.name]] <- all.bfs
+									ciList[[newCiLabel]] <- newCIList
+									bfObject$CIs <- ciList
+									bfObject$ciValues <- calculatedCIValues
+									bfValuesListExcludePairwise[[priorLabel]][[variableName]][[columnName]] <- bfObject
 								}	
 							}
 							#
@@ -416,34 +416,34 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 					} else if (missingValues=="excludeListwise"){
 						# Load: data
 						#
-						v1 <- dataset[[ .v(variable.name) ]]
-						v2 <- dataset[[ .v(variable.2.name) ]]
+						v1 <- dataset[[ .v(variableName) ]]
+						v2 <- dataset[[ .v(variable2Name) ]]
 						
 						if (!is.null(v1) && !is.null(v2)){
 							# Note: Data: PREPARE
 							#
-							some.n <- length(v1)
-							some.r <- cor(v1, v2)
+							obsN <- length(v1)
+							obsR <- cor(v1, v2)
 							
 							# For stateRetrieval
-							n.label <- as.character(round(some.r, 5))
-							r.label <- as.character(round(some.r, 5))
+							nLabel <- as.character(round(obsR, 5))
+							rLabel <- as.character(round(obsR, 5))
 							
 							# Try state retrieval
 							#
-							retrievedBFs <- bfValuesListExcludeListwise[[prior.label]][[n.label]][[r.label]]
+							retrievedBFs <- bfValuesListExcludeListwise[[priorLabel]][[nLabel]][[rLabel]]
 							
 							if (!is.null(retrievedBFs)){
 								# State: Retrieval
-								some.r <- some.r
-								all.bfs <- retrievedBFs
+								obsR <- obsR
+								bfObject <- retrievedBFs
 								
-								retrievedFootnote <- footnotesListExcludeListwise[[n.label]][[r.label]]
+								retrievedFootnote <- footnotesListExcludeListwise[[nLabel]][[rLabel]]
 								
 								if (!is.null(retrievedFootnote)){
-									some.footnote <- unlist(retrievedFootnote)
-									index <- .addFootnote(footnotes, some.footnote)
-									row.footnotes[[column.name]] <- c(row.footnotes[[column.name]], list(index))
+									obsFootnote <- unlist(retrievedFootnote)
+									index <- .addFootnote(footnotes, obsFootnote)
+									rowFootnotes[[columnName]] <- c(rowFootnotes[[columnName]], list(index))
 								}
 								
 								retrievalFailure <- FALSE
@@ -452,23 +452,23 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 								# CIs check:
 								#
 								if (credibleIntervals){
-									calculatedCIValues <- all.bfs$ciValues
+									calculatedCIValues <- bfObject$ciValues
 									
-									if (!is.na(all.bfs$bf10) && !(credibleIntervalsInterval %in% calculatedCIValues)){
+									if (!is.na(bfObject$bf10) && !(credibleIntervalsInterval %in% calculatedCIValues)){
 										# put this in for the next time
 										# Output prepare
-										new.ci.label <- as.character(round(credibleIntervalsInterval, 5))
+										newCiLabel <- as.character(round(credibleIntervalsInterval, 5))
 										calculatedCIValues <- c(calculatedCIValues, credibleIntervalsInterval)
-										ciList <- all.bfs$CIs
+										ciList <- bfObject$CIs
 										
 										# Calculate
-										newCIList <- .credibleIntervals(alpha=all.bfs$betaA, beta=all.bfs$betaB, credibleIntervalsInterval)[[2]]
+										newCIList <- .credibleIntervals(alpha=bfObject$betaA, beta=bfObject$betaB, credibleIntervalsInterval)[[2]]
 										
 										# Store in State
-										ciList[[new.ci.label]] <- newCIList
-										all.bfs$CIs <- ciList
-										all.bfs$ciValues <- calculatedCIValues
-										bfValuesListExcludeListwise[[prior.label]][[n.label]][[r.label]] <- all.bfs
+										ciList[[newCiLabel]] <- newCIList
+										bfObject$CIs <- ciList
+										bfObject$ciValues <- calculatedCIValues
+										bfValuesListExcludeListwise[[priorLabel]][[nLabel]][[rLabel]] <- bfObject
 									}	
 								}
 								#
@@ -489,90 +489,82 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 						if (perform == "run") {
 							# Note: Data screening 
 							#
-							v1 <- dataset[[ .v(variable.name) ]]
-							v2 <- dataset[[ .v(variable.2.name) ]]
+							v1 <- dataset[[ .v(variableName) ]]
+							v2 <- dataset[[ .v(variable2Name) ]]
 							
 							if (missingValues=="excludePairwise"){
-								pairwise.excluded.data <- .excludePairwiseCorData(v1, v2)
-								v1 <- pairwise.excluded.data$v1
-								v2 <- pairwise.excluded.data$v2
+							    tempList <- .excludePairwiseCorData(v1, v2)
+								v1 <- tempList$v1
+								v2 <- tempList$v2
 							}
 							
 							# Note: Data: PREPARE
 							#
-							some.r <- cor(v1, v2)
-							some.n <- length(v1)
-							if(test == "kendall"){some.r <- cor(v1,v2,method = "kendall")}
+							# TODO (Johnny): Thus, always calculate "kendall" use switch or if else if 
+							obsR <- cor(v1, v2)
+							obsN <- length(v1)
+							
+							if (test == "kendall"){
+							    obsR <- cor(v1, v2, method = "kendall")
+							}
 							
 							# Initialise output
-							all.bfs <- list(bf10=NA, bfPlus0=NA, bfMin0=NA)
-							method.number <- 1
+							bfObject <- list(bf10=NA, bfPlus0=NA, bfMin0=NA)
+							#methodNumber <- 1
 							
 							# Note: Data and bfs check [start]
-							if (is.na(some.r) || some.n <= 1) {
+							if (is.na(obsR) || obsN <= 1) {
 								# Note: Data: NOT ok, 
 								# 		bf10: can't
-								if (some.n <= 1){
-									some.footnote <- "Pearson's sample correlation coefficient r is undefined -- too few observations"
-									index <- .addFootnote(footnotes, some.footnote)
-								} else if (base::any(base::is.infinite(v1)) || base::any(base::is.infinite(v2))) {
-									some.footnote <- "Pearson's sample correlation coefficient r is undefined -- one or more variables contain infinity"
-									index <- .addFootnote(footnotes, some.footnote)
+								if (obsN <= 1){
+									obsFootnote <- "Pearson's sample correlation coefficient r is undefined -- too few observations"
+									index <- .addFootnote(footnotes, obsFootnote)
+								} else if (any(is.infinite(v1)) || any(is.infinite(v2))) {
+									obsFootnote <- "Pearson's sample correlation coefficient r is undefined -- one or more variables contain infinity"
+									index <- .addFootnote(footnotes, obsFootnote)
 								} else {
-									some.footnote <- "Pearson's sample correlation coefficient r is undefined -- one or more variables do not vary"
-									index <- .addFootnote(footnotes, some.footnote)
+									obsFootnote <- "Pearson's sample correlation coefficient r is undefined -- one or more variables do not vary"
+									index <- .addFootnote(footnotes, obsFootnote)
 								}
 								
-								some.r <- NaN
+								obsR <- NA
 								
 								# Store in state
 								#
 								if (missingValues=="excludePairwise"){
-									footnotesListExcludePairwise[[variable.name]][[column.name]] <- list(some.footnote)
+									footnotesListExcludePairwise[[variableName]][[columnName]] <- list(obsFootnote)
 								} else if (missingValues=="excludeListwise"){
 									# TODO: these should be defined above in the retrieval block
-									n.label <- as.character(round(some.n))
-									r.label <- as.character(round(some.r))
-									footnotesListExcludeListwise[[n.label]][[r.label]] <- list(some.footnote)
+									nLabel <- as.character(round(obsN))
+									rLabel <- as.character(round(obsR))
+									footnotesListExcludeListwise[[nLabel]][[rLabel]] <- list(obsFootnote)
 								}
 								
-								#row.footnotes[[variable.2.name]] <- c(row.footnotes[[variable.name]], list(index))
-								row.footnotes[[column.name]] <- c(row.footnotes[[column.name]], list(index))
+								#rowFootnotes[[variable2Name]] <- c(rowFootnotes[[variableName]], list(index))
+								rowFootnotes[[columnName]] <- c(rowFootnotes[[columnName]], list(index))
 								
-								if (some.n==1){
-									all.bfs$bf10 <- 1
+								if (obsN==1){
+									bfObject$bf10 <- 1
 								}
 							} else {
 								# Data: OK
 								# Try: bfs
+							  
+							  # TODO (Johnny): without a test=="kendall" we always calculate Pearson
+							  bfObject <- .bfPearsonCorrelation(n=obsN, r=obsR, kappa=priorWidth, ciValue=credibleIntervalsInterval)
 								
-								while (any(is.na(c(all.bfs$bf10, all.bfs$bfPlus0, all.bfs$bfMin0))) && method.number <=3){
-									# Note: Try all normal methods
-									if (credibleIntervals==TRUE){
-										all.bfs <- .bfCorrieKernel(n=some.n, r=some.r, kappa=priorWidth, method=method.number, ciValue=credibleIntervalsInterval)
-									}
-									# Calculated at standard level 0.95
-									all.bfs <- .bfCorrieKernel(n=some.n, r=some.r, kappa=priorWidth, method=method.number)
-									method.number <- method.number + 1
-								}
-								
-								if (any(is.na(c(all.bfs$bf10, all.bfs$bfPlus0, all.bfs$bfMin0)))){
-									# Note: all normal methods FAILED. Use Jeffreys approximation
-									# NO CI INTERVALS FOR credibleIntervalsInterval
-									all.bfs <- .bfCorrieKernel(n=some.n, r=some.r, kappa=priorWidth, method="jeffreysApprox")
-								}
 							  if(test == "kendall"){
-							    all.bfs <- .bfCorrieKernelKendallTau(n=some.n, tau=some.r, kappa = priorWidth, var = 1)
+							    bfObject <- .bfCorrieKernelKendallTau(n=obsN, tau=obsR, kappa = priorWidth, var = 1)
 							  }
 							}
 							
 							# Store in State
 							#
 							if (missingValues=="excludePairwise"){
-								rValuesListExcludePairwise[[variable.name]][[column.name]] <- list(some.r)
-								bfValuesListExcludePairwise[[prior.label]][[variable.name]][[column.name]] <- all.bfs
+								rValuesListExcludePairwise[[variableName]][[columnName]] <- list(obsR)
+								bfValuesListExcludePairwise[[priorLabel]][[variableName]][[columnName]] <- bfObject
 							} else if (missingValues=="excludeListwise"){
-								bfValuesListExcludeListwise[[prior.label]][[n.label]][[r.label]] <- all.bfs
+								bfValuesListExcludeListwise[[priorLabel]][[nLabel]][[rLabel]] <- bfObject
 							}
 							resultProcessing <- TRUE
 						}
@@ -583,52 +575,52 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 						# Note: Result reporting: sample r
 						# TODO: also for other kappas and find place to report the credible interval
 						
-						report.r <- some.r
-						row[[length(row)+1]] <- .clean(report.r)
+						reportR <- obsR
+						row[[length(row)+1]] <- .clean(reportR)
 						
 						
 						# Note: Result processing: bf
 						# 
 						if (hypothesis == "correlated") {
-							report.bf <- all.bfs$bf10
+							reportBf <- bfObject$bf10
 							
 							if (bayesFactorType == "BF01"){
-								report.bf <- 1/report.bf
+								reportBf <- 1/reportBf
 							}
 						} else if (hypothesis == "correlatedPositively"){
 							# TODO: Still need to implement this for general rho0, rather than rho0=0
 							
-							report.bf <- all.bfs$bfPlus0
+							reportBf <- bfObject$bfPlus0
 							
 							if (bayesFactorType == "BF01"){
-								report.bf <- 1/report.bf
+								reportBf <- 1/reportBf
 							}
 						} else if (hypothesis == "correlatedNegatively") {
-							report.bf <- all.bfs$bfMin0
+							reportBf <- bfObject$bfMin0
 							
 							if (bayesFactorType == "BF01"){
-								report.bf <- 1/report.bf
+								reportBf <- 1/reportBf
 							}
 						} 
 						
 						# Note: Flagging at the data [report]
-						if (flagSupported && is.na(report.bf) == FALSE) {
-							if (report.bf > 100) {
-								row.footnotes[[column.name]] <- list("***")
-							} else if (report.bf > 30) {
-								row.footnotes[[column.name]] <- list("**")
-							} else if (report.bf > 10) {
-								row.footnotes[[column.name]] <- list("*")
+						if (flagSupported && is.na(reportBf) == FALSE) {
+							if (reportBf > 100) {
+								rowFootnotes[[columnName]] <- list("***")
+							} else if (reportBf > 30) {
+								rowFootnotes[[columnName]] <- list("**")
+							} else if (reportBf > 10) {
+								rowFootnotes[[columnName]] <- list("*")
 							}
 						}
 						
 						# Note: Flagging and report bfs [report]
 						if (reportBayesFactors) {
 							if (bayesFactorType == "LogBF10") {
-								report.bf <- base::log10(report.bf)
+								reportBf <- base::log10(reportBf)
 							}
 							
-							bayes.factors[[length(bayes.factors)+1]] <- .clean(report.bf)
+							bayesFactorsList[[length(bayesFactorsList)+1]] <- .clean(reportBf)
 						}
 					} # Close: Results reporting from 1 retrieved or 2 performed
 					
@@ -638,28 +630,28 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 					if (retrievalFailure && perform!="run"){
 						# No data retrieved from state and nothing run
 						row[[length(row)+1]] <- "."
-						bayes.factors[[length(bayes.factors)+1]] <- "."
+						bayesFactorsList[[length(bayesFactorsList)+1]] <- "."
 					} # Close: Results reporting from initialisation
 				} # Close loop: each column
 				if (reportBayesFactors) {
-					for (bf in bayes.factors){
+					for (bf in bayesFactorsList){
 						row[[length(row)+1]] <- bf
 					}
 				}
 			} # Close loop: each test	
-			names(row) <- column.names
-			row[[".variable"]] <- variable.name
-			if (length(row.footnotes) > 0)
-				row[[".footnotes"]] <- row.footnotes
+			names(row) <- columnNames
+			row[[".variable"]] <- variableName
+			if (length(rowFootnotes) > 0)
+				row[[".footnotes"]] <- rowFootnotes
 			rows[[i]] <- row
 		} # Note: close each variable
 	}
 	schema <- list(fields=fields)
-	correlation.table[["schema"]] <- schema
-	correlation.table[["data"]] <- rows
-	correlation.table[["footnotes"]] <- as.list(footnotes)
+	correlationTable[["schema"]] <- schema
+	correlationTable[["data"]] <- rows
+	correlationTable[["footnotes"]] <- as.list(footnotes)
 	
-	return(list(correlationTable=correlation.table, 
+	return(list(correlationTable=correlationTable, 
 				test=tests, 
 				variables=variables, 
 				rows=rows, 
@@ -674,17 +666,17 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 .excludePairwiseCorData <- function(v1, v2){
 	# To exclude the data pairwise
 	#
-	screened.data <- list(v1=v1, v2=v2)
+	screenedData <- list(v1=v1, v2=v2)
 	
-	remove.index.1 <- which(is.na(v1))
-	remove.index.2 <- which(is.na(v2))
-	remove.index <- unique(c(remove.index.1, remove.index.2))
-	if (length(remove.index) > 0){
-		screened.data$v1 <- v1[-(remove.index)]
-		screened.data$v2 <- v2[-(remove.index)]
+	removeIndex1 <- which(is.na(v1))
+	removeIndex2 <- which(is.na(v2))
+	removeIndex <- unique(c(removeIndex1, removeIndex2))
+	if (length(removeIndex) > 0){
+		screenedData$v1 <- v1[-(removeIndex)]
+		screenedData$v2 <- v2[-(removeIndex)]
 	}
 	
-	return(screened.data)
+	return(screenedData)
 }
 
 .stretchedBeta <- function(rho, alpha, beta){
@@ -698,20 +690,20 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 }
 
 .priorRhoPlus <- function(rho, kappa=1) {
-	non.negative.index <- rho >=0
-	less.than.one.index <- rho <=1
-	value.index <- as.logical(non.negative.index*less.than.one.index)
+	nonNegativeIndex <- rho >=0
+	lessThanOneIndex <- rho <=1
+	valueIndex <- as.logical(nonNegativeIndex*lessThanOneIndex)
 	result <- rho*0
-	result[value.index] <- 2*.priorRho(rho[value.index], kappa)
+	result[valueIndex] <- 2*.priorRho(rho[valueIndex], kappa)
 	return(result)
 }
 
 .priorRhoMin <- function(rho, kappa=1) {
-	negative.index <- rho <=0
-	greater.than.min.one.index <- rho >= -1
-	value.index <- as.logical(negative.index*greater.than.min.one.index)
+	negativeIndex <- rho <=0
+	greaterThanMinOneIndex <- rho >= -1
+	valueIndex <- as.logical(negativeIndex*greaterThanMinOneIndex)
 	result <- rho*0
-	result[value.index] <- 2*.priorRho(rho[value.index], kappa)
+	result[valueIndex] <- 2*.priorRho(rho[valueIndex], kappa)
 	return(result)
 }
 # 0.2 Prior specification Kendall's Tau
@@ -725,66 +717,71 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 }
 
 .priorTauPlus <- function(tau, kappa=1) {
-  non.negative.index <- tau >=0
-  less.than.one.index <- tau <=1
-  value.index <- as.logical(non.negative.index*less.than.one.index)
+  nonNegativeIndex <- tau >=0
+  lessThanOneIndex <- tau <=1
+  valueIndex <- as.logical(nonNegativeIndex*lessThanOneIndex)
   result <- tau*0
-  result[value.index] <- 2*.priorTau(tau[value.index], kappa)
+  result[valueIndex] <- 2*.priorTau(tau[valueIndex], kappa)
   return(result)
 }
 
 .priorTauMin <- function(tau, kappa=1) {
-  negative.index <- tau <=0
-  greater.than.min.one.index <- tau >= -1
-  value.index <- as.logical(negative.index*greater.than.min.one.index)
+  negativeIndex <- tau <=0
+  greaterThanMinOneIndex <- tau >= -1
+  valueIndex <- as.logical(negativeIndex*greaterThanMinOneIndex)
   result <- tau*0
-  result[value.index] <- 2*.priorTau(tau[value.index], kappa)
+  result[valueIndex] <- 2*.priorTau(tau[valueIndex], kappa)
   return(result)
 }
 
 # 1.0. Built-up for likelihood functions
 .aFunction <- function(n, r, rho) {
-	#hyper.term <- Re(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), (1/2), (r*rho)^2))
-	hyper.term <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=(1/2), z=(r*rho)^2))
-	result <- (1-rho^2)^((n-1)/2)*hyper.term
+	#hyperTerm <- Re(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), (1/2), (r*rho)^2))
+	hyperTerm <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=(1/2), z=(r*rho)^2))
+	result <- (1-rho^2)^((n-1)/2)*hyperTerm
 	return(result)
 }
 
 .bFunction <- function(n, r, rho) {
-	#hyper.term.1 <- Re(hypergeo::hypergeo((n/2), (n/2), (1/2), (r*rho)^2))
-	#hyper.term.2 <- Re(hypergeo::hypergeo((n/2), (n/2), (-1/2), (r*rho)^2))
-	#hyper.term.1 <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=(1/2), z=(r*rho)^2))
-	#hyper.term.2 <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=(-1/2), z=(r*rho)^2))
-	#result <- 2^(-1)*(1-rho^2)^((n-1)/2)*exp(log.term)*
-	#	((1-2*n*(r*rho)^2)/(r*rho)*hyper.term.1-(1-(r*rho)^2)/(r*rho)*hyper.term.2)
+	#hyperTerm1 <- Re(hypergeo::hypergeo((n/2), (n/2), (1/2), (r*rho)^2))
+	#hyperTerm2 <- Re(hypergeo::hypergeo((n/2), (n/2), (-1/2), (r*rho)^2))
+	#hyperTerm1 <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=(1/2), z=(r*rho)^2))
+	#hyperTerm2 <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=(-1/2), z=(r*rho)^2))
+	#result <- 2^(-1)*(1-rho^2)^((n-1)/2)*exp(logTerm)*
+	#	((1-2*n*(r*rho)^2)/(r*rho)*hyperTerm1-(1-(r*rho)^2)/(r*rho)*hyperTerm2)
 	#
-	hyper.term <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=(3/2), z=(r*rho)^2))
-	log.term <- 2*(lgamma(n/2)-lgamma((n-1)/2))+((n-1)/2)*log(1-rho^2)
-	result <- 2*r*rho*exp(log.term)*hyper.term
+	hyperTerm <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=(3/2), z=(r*rho)^2))
+	logTerm <- 2*(lgamma(n/2)-lgamma((n-1)/2))+((n-1)/2)*log(1-rho^2)
+	result <- 2*r*rho*exp(logTerm)*hyperTerm
 	return(result)
 }
 
 .hFunction <- function(n, r, rho) {
-	result <- .aFunction(n, r, rho) + .bFunction(n, r, rho)
+	result <- .aFunction(n=n, r=r, rho) + .bFunction(n=n, r=r, rho)
 	return(result)
 }
 
+.hFunctionCombined <- function(nOri, rOri, nRep, rRep, rho){
+    result <- .aFunction(n=nOri, r=rOri, rho)*.aFunction(n=nRep, r=rRep, rho)+
+        .bFunction(n=nOri, r=rOri, rho)*.bFunction(n=nRep, r=rRep, rho)
+    return(result)
+}
 
-.jeffreysApproxH <- function(n, r, rho) {	
+.hJeffreysApprox <- function(n, r, rho) {	
 	result <- ((1 - rho^(2))^(0.5*(n - 1)))/((1 - rho*r)^(n - 1 - 0.5))
 	return(result)
 }
 
 # 1.1 Explicit marginal likelihood functions
 .m0MarginalLikelihood <- function(s, t, n) {
-	log.term <- 2*lgamma(0.5*(n-1))
-	result <- 1/4*n^(0.5*(1-2*n))*pi^(1-n)*(s*t)^(1-n)*exp(log.term)
+	logTerm <- 2*lgamma(0.5*(n-1))
+	result <- 1/4*n^(0.5*(1-2*n))*pi^(1-n)*(s*t)^(1-n)*exp(logTerm)
 	return(result)
 }
 
 .m1MarginalLikelihoodNoRho <- function(s, t, n, r, rho) {
 	return(.m0MarginalLikelihood(s, t, n)*
-		   	(.aFunction(n, r, rho)+.bFunction(n, r, rho)))
+		   	(.aFunction(n=n, r=r, rho)+.bFunction(n=n, r=r, rho)))
 }
 
 #
@@ -798,20 +795,25 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	if (n <= 2){
 		return(1)
 	} else if (any(is.na(r))){
-		return(NaN)
+		return(NA)
 	}
-	# TODO: use which
-	check.r <- abs(r) >= 1 # check whether |r| >= 1
-	if (kappa >= 1 && n > 2 && check.r) {
+	# TODO: use or vectorise with an apply function
+    checkR <- abs(r) >= 1 # check whether |r| >= 1
+	if (kappa >= 1 && n > 2 && checkR) {
 		return(Inf)
 	}
-	#log.hyper.term <- log(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
-	log.hyper.term <- log(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=((n+2/kappa)/2), z=r^2))
-	log.result <- log(2^(1-2/kappa))+0.5*log(pi)-lbeta(1/kappa, 1/kappa)+
-		lgamma((n+2/kappa-1)/2)-lgamma((n+2/kappa)/2)+log.hyper.term
-	real.result <- exp(Re(log.result))
-	#return(realResult)
-	return(real.result)
+	#logHyperTerm <- log(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
+    logHyperTerm <- log(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=((n+2/kappa)/2), z=r^2))
+    logResult <- log(2^(1-2/kappa))+0.5*log(pi)-lbeta(1/kappa, 1/kappa)+
+		lgamma((n+2/kappa-1)/2)-lgamma((n+2/kappa)/2)+logHyperTerm
+    realResult <- exp(Re(logResult))
+	
+    if (realResult < 0){
+        return(NA)
+    }
+    
+    # Fail
+    return(realResult)
 }
 
 # 2.2 Two-sided secondairy Bayes factor
@@ -823,68 +825,173 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	if (n <= 2){
 		return(1)
 	} else if ( any(is.na(r)) ){
-		return(NaN)
+		return(NA)
 	}
 	
 	# TODO: use which
 	if (n > 2 && abs(r)==1) {
 		return(Inf)
 	}
-	hyper.term <- Re(hypergeo::genhypergeo(U=c((2*n-3)/4, (2*n-1)/4), L=(n+2/kappa)/2, z=r^2))
-	log.term <- lgamma((n+2/kappa-1)/2)-lgamma((n+2/kappa)/2)-lbeta(1/kappa, 1/kappa)
-	result <- sqrt(pi)*2^(1-2/kappa)*exp(log.term)*hyper.term
-	return(result)
+  
+    hyperTerm <- Re(hypergeo::genhypergeo(U=c((2*n-3)/4, (2*n-1)/4), L=(n+2/kappa)/2, z=r^2))
+    logTerm <- lgamma((n+2/kappa-1)/2)-lgamma((n+2/kappa)/2)-lbeta(1/kappa, 1/kappa)
+    result <- sqrt(pi)*2^(1-2/kappa)*exp(logTerm)*hyperTerm
+	
+    if (result < 0){
+        return(NA)
+    }
+    return(result)
 }
 
 # 2.3 Two-sided third Bayes factor
-.bfCorNumerical <- function(n, r, kappa=1, lowerRho=-1, upperRho=1) {
-	# Numerically integrate Jeffreys approximation of the likelihood
-	integrand <- function(rho){.jeffreysApproxH(n, r, rho)*.priorRho(rho, kappa)}
-	some.integral <- try(integrate(integrand, lowerRho, upperRho))
-	
-	if (is(some.integral, "try-error")) {
-		return(NA)
-	}
-	
-	if (some.integral$message=="OK"){
-		return(some.integral$value)
-	} else {
-		return(NA)
-	}
+# .bfCorNumerical <- function(n, r, kappa=1, lowerRho=-1, upperRho=1) {
+# 	# Numerically integrate Jeffreys approximation of the likelihood
+# 	integrand <- function(rho){.hJeffreysApprox(n=n, r=r, rho)*.priorRho(rho, kappa)}
+# 	someIntegral <- try(silent=TRUE, integrate(integrand, lowerRho, upperRho))
+# 	
+# 	if (isTryError(someIntegral)){
+# 		return(NA)
+# 	}
+# 	
+# 	if (someIntegral$message=="OK"){
+# 		return(someIntegral$value)
+# 	} else {
+# 		return(NA)
+# 	}
+# }
+# 
+# .bf10Numerical <- function(n, r, kappa=1, lowerRho=-1, upperRho=1) {
+# 	# Jeffreys' test for whether a correlation is zero or not
+# 	# Jeffreys (1961), pp. 289-292
+# 	# This is a numerical approximation for .bf10JeffreysIntegrate,
+# 	# when it explodes
+# 	# #
+# 	# TODO: 1. check for n=1, n=2, as r is then undefined
+# 	# 2. check for r=1, r=-1
+# 	#
+# 	# TODO: REMOVE ALL NUMERICAL STUFF
+# 	if ( any(is.na(r)) ){
+# 		return(NA)
+# 	}
+# 	# TODO: use which
+# 	if (n > 2 && abs(r)==1) {
+# 		return(Inf)
+# 	}
+# 	
+# 	
+# 	# TODO: be very careful here, might integrate over non-finite function
+# 	jeffreysNumericalIntegrate <- .bfCorNumerical(n=n, r=r, kappa, lowerRho=-1, upperRho=1)
+# 	
+# 	if (is.na(jeffreysNumericalIntegrate) || jeffreysNumericalIntegrate < 0){
+# 		return(NA)
+# 	} else if (jeffreysNumericalIntegrate >= 0){
+# 		# jeffreys numerical integrate success
+# 		return(jeffreysNumericalIntegrate)
+# 	} else {
+# 		# NO IDEA, EVERYTHING FAILED :(
+# 		return(NA)
+# 	}
+# 	return(jeffreysNumericalIntegrate)
+# }
+
+# 2.3 Savage-Dickey beta approximation
+.bfSavageDickeyBetaData <- function(n, r, kappa=1, rho0=0){
+    # Savage-Dickey based on a beta approximation
+    #
+    #
+    fit <- .posteriorBetaParameters(n=n, r=r, kappa=kappa)
+    return(.bfSavageDickeyBeta(a=fit$betaA, b=fit$betaB, kappa=kappa, rho0=rho0))
 }
 
-.bf10Numerical <- function(n, r, kappa=1, lowerRho=-1, upperRho=1) {
-	# Jeffreys' test for whether a correlation is zero or not
-	# Jeffreys (1961), pp. 289-292
-	# This is a numerical approximation for .bf10JeffreysIntegrate,
-	# when it explodes
-	# #
-	# TODO: 1. check for n=1, n=2, as r is then undefined
-	# 2. check for r=1, r=-1
-	#
-	# TODO: REMOVE ALL NUMERICAL STUFF
-	if ( any(is.na(r)) ){
-		return(NA)
-	}
-	# TODO: use which
-	if (n > 2 && abs(r)==1) {
-		return(Inf)
-	}
-	
-	
-	# TODO: be very careful here, might integrate over non-finite function
-	jeffreysNumericalIntegrate <- .bfCorNumerical(n, r, kappa, lowerRho=-1, upperRho=1)
-	
-	if (is.na(jeffreysNumericalIntegrate) || jeffreysNumericalIntegrate < 0){
-		return(NA)
-	} else if (jeffreysNumericalIntegrate >= 0){
-		# jeffreys numerical integrate success
-		return(jeffreysNumericalIntegrate)
-	} else {
-		# NO IDEA, EVERYTHING FAILED :(
-		return(NA)
-	}
-	return(jeffreysNumericalIntegrate)
+.bfSavageDickeyOneSidedAdapt <- function(bf10, a, b, kappa=1, rho0=0){
+    return(.bfSavageDickeyBeta(bf10=bf10, a=a, b=b, kappa))
+}
+
+
+.bfSavageDickeyBeta <- function(a, b, kappa=1, rho0=0, bf10=NULL){
+    # Savage-Dickey based on a beta approximation
+    # Default failure for infinite bf10
+    # Depending on bf10 define the result list
+    #
+    #
+    
+    if (is.null(bf10)){
+        result <- list(bf10=NA, bfPlus0=NA, bfMin0=NA, betaA=a, betaB=b)
+        
+        savageDickeyNumerator <- .priorRho(rho0, kappa)
+        savageDickeyDenominator <- .stretchedBeta(rho0, alpha=a, beta=b)
+        bf10 <- try(savageDickeyNumerator/savageDickeyDenominator)
+        
+        if (isTryError(bf10)){
+            # NAs
+            return(result)
+        } else {
+            result$bf10 <- bf10
+        }
+    } else {
+        result <- list(bf10=bf10, bfPlus0=NA, bfMin0=NA, betaA=a, betaB=b)
+    }
+    
+    if (is.na(bf10)){
+        # Failure
+        return(result)
+    } 
+    
+    if (bf10 < 0){
+        # Total failure it's true
+        return(result)
+    }
+    
+    if (is.infinite(bf10)){
+        # .bfCorrieKernel gives the default values for the one sided ones
+        #
+        result$bf10 <- Inf
+        return(result)
+    } 
+    
+    if (is.finite(bf10)){
+        # bf10 is finite, now calculate one-sided stuff
+        #
+        
+        result$bf10 <- bf10
+        result$twoSidedTooPeaked <- FALSE
+        
+        leftProportion <- stats::pbeta(1/2, shape1=a, shape2=b)
+        
+        if (is.na(leftProportion)){
+            result <- utils::modifyList(result, list(bfPlus0=NA, bfMin0=NA, minSidedTooPeaked=TRUE, plusSidedTooPeaked=TRUE))
+            return(result)
+        }
+        
+        if (leftProportion > 0 && leftProportion < 1){
+            result$plusSidedTooPeaked <- FALSE
+            result$minSidedTooPeaked <- FALSE
+            
+            result$bfMin0 <- 2*bf10*leftProportion
+            result$bfPlus0 <- 2*bf10*(1-leftProportion)	
+        } else {
+            rightProportion <- stats::pbeta(1/2, shape1=a, shape2=b, lower.tail=FALSE)
+            
+            if (!is.na(rightProportion) && rightProportion < 1){
+                result$plusSidedTooPeaked <- FALSE
+                result$minSidedTooPeaked <- FALSE
+                
+                result$bfMin0 <- 2*bf10*(1-rightProportion)
+                result$bfPlus0 <- 2*bf10*rightProportion
+            } else if (leftProportion >= 1){
+                result$bfMin0 <- 2*bf10
+                result$bfPlus0 <- 0
+            } else if (rightProportion >= 1){
+                result$bfMin0 <- 0
+                result$bfPlus0 <- 2*bf10
+            } else {
+                # TODO: either leftProportion <= 0 or rightProportion < = 0
+                # this shouldn't happen, but actually I have no idea
+                return(result)
+            }
+        }
+    }
+    return(result)
 }
 
 # 2.4 The Marsman MH sampler 
@@ -913,8 +1020,8 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	zCurrent <- atanh(rhoCurrent)
 	zCandidate <- rnorm(1, mean=atanh(r), sd=1/sqrt(n-3))
 	
-	candidateAcceptance <- .logTarget(zCandidate, n, r, kappa)+.logProposal(zCurrent, n, r)-
-		(.logTarget(zCurrent, n, r, kappa)+.logProposal(zCandidate, n, r))
+	candidateAcceptance <- .logTarget(zCandidate, n=n, r=r, kappa)+.logProposal(zCurrent, n, r)-
+		(.logTarget(zCurrent, n=n, r=r, kappa)+.logProposal(zCandidate, n, r))
 	
 	if (log(runif (1)) <= candidateAcceptance) {
 		rhoCandidate <- tanh(zCandidate)
@@ -929,7 +1036,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	yTemp <- r
 	
 	for (iter in 1:nIters) {
-		yTemp <- .metropolisOneStep(yTemp, n, r, kappa)
+		yTemp <- .metropolisOneStep(yTemp, n=n, r=r, kappa)
 		rhoMetropolisChain[iter] <- yTemp
 	}
 	
@@ -943,11 +1050,13 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	return(mhFit)
 }
 
-# 2.5. Two-sided fourth Bayes factor
+# 2.5. Two-sided asymptotic approximation of the Bayes factor 
 .bf10JeffreysApprox <- function(n, r) {
 	#Jeffreys' test for whether a correlation is zero or not
 	#Jeffreys (1961), pp. 291 Eq. 14
 	#
+    result <- list(bf10=NA, bfPlus0=NA, bfMin0=NA)
+    
 	if (n <= 2){
 		return(1)
 	} else if ( any(is.na(r)) ){
@@ -957,8 +1066,41 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	if (n > 2 && abs(r)==1) {
 		return(Inf)
 	}
-	result <- ((2*n-3)/pi)^(.5)*(1-r^2)^((n-4)/2)
-	return(1/result)
+	
+    bf01 <- ((2*n-3)/pi)^(.5)*(1-r^2)^((n-4)/2)
+    bf10 <- 1/bf01
+    
+    if (bf10 < 0){
+        return(result)
+    }
+    
+    if (is.na(bf10)) {
+        return(result)
+    }
+    
+    if (is.finite(bf10)){
+        result$bf10 <- bf10 
+        result$twoSidedTooPeaked <- FALSE
+        
+        return(result)
+    }
+	
+    if (is.infinite(bf10)){
+        # Note: Check extreme
+        if (r >= 0){
+            result$bfPlus0 <- Inf
+            result$bfMin0 <- 0
+        } else if (r < 0){
+            result$bfPlus0 <- 0
+            result$bfMin0 <- Inf
+        }
+        
+        # Posterior too peaked
+        result$twoSidedTooPeaked <- TRUE 
+        result$plusSidedTooPeaked <- TRUE 
+        result$minSidedTooPeaked <- TRUE
+        return(result)
+    }
 }
 
 # 3.0 One-sided preparation ----------------------------------------------------
@@ -972,21 +1114,21 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	# TODO: 1. check for n=1, n=2, as r is then undefined
 	# 2. check for r=1, r=-1
 	#
-	#hyper.term.1 <- Re(hypergeo::genhypergeo(U=c(1, (n+2)/2, (n+2)/2),
+	#hyperTerm1 <- Re(hypergeo::genhypergeo(U=c(1, (n+2)/2, (n+2)/2),
 	#										 L=c(1/2, (n+2/kappa+3)/2), z=r^2))
-	#hyper.term.2 <- Re(hypergeo::genhypergeo(U=c(1, (n+2)/2, (n+2)/2),
+	#hyperTerm2 <- Re(hypergeo::genhypergeo(U=c(1, (n+2)/2, (n+2)/2),
 	#										 L=c(3/2, (n+2/kappa+1)/2), z=r^2))
-	#hyper.term.3 <- Re(hypergeo::genhypergeo(U=c(1, (n+2)/2, (n+2)/2),
+	#hyperTerm3 <- Re(hypergeo::genhypergeo(U=c(1, (n+2)/2, (n+2)/2),
 	#										 L=c(3/2, (n+2/kappa+3)/2), z=r^2))
-	#sum.term <- -((n*r)^2*hyper.term.1-n^2*(n+2/kappa+1)*hyper.term.2+2*n^3*r^2*
-	#			  	hyper.term.3+(2*n^2-2/kappa*(1-2*n)+n-1))
+	#sum.term <- -((n*r)^2*hyperTerm1-n^2*(n+2/kappa+1)*hyperTerm2+2*n^3*r^2*
+	#			  	hyperTerm3+(2*n^2-2/kappa*(1-2*n)+n-1))
 	#product.term <- (2^(1-2/kappa)*r)/((n+2/kappa-1)*(n+2/kappa+1))
-	#log.term <- 2*lgamma(n/2)-2*lgamma((n+1)/2)-lbeta(1/kappa, 1/kappa)
-	#result <- product.term*exp(log.term)*sum.term
-	
-	hyper.term <- Re(hypergeo::genhypergeo(U=c(1, n/2, n/2), L=c(3/2, (2+kappa*(n+1))/(2*kappa)), z=r^2))
-	log.term <- 2*(lgamma(n/2)-lgamma((n-1)/2))-lbeta(1/kappa, 1/kappa)
-	result <- 2^((3*kappa-2)/kappa)*kappa*r/(2+(n-1)*kappa)*exp(log.term)*hyper.term
+	#logTerm <- 2*lgamma(n/2)-2*lgamma((n+1)/2)-lbeta(1/kappa, 1/kappa)
+	#result <- product.term*exp(logTerm)*sum.term
+    
+	hyperTerm <- Re(hypergeo::genhypergeo(U=c(1, n/2, n/2), L=c(3/2, (2+kappa*(n+1))/(2*kappa)), z=r^2))
+	logTerm <- 2*(lgamma(n/2)-lgamma((n-1)/2))-lbeta(1/kappa, 1/kappa)
+	result <- 2^((3*kappa-2)/kappa)*kappa*r/(2+(n-1)*kappa)*exp(logTerm)*hyperTerm
 	return(result)
 }
 
@@ -997,521 +1139,405 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	# This is the contribution of one-sided test
 	#
 	#	
-	hyper.term <- Re(hypergeo::genhypergeo(U=c(1, (2*n-1)/4, (2*n+1)/4),
+	hyperTerm <- Re(hypergeo::genhypergeo(U=c(1, (2*n-1)/4, (2*n+1)/4),
 										   L=c(3/2, (n+1+2/kappa)/2), z=r^2))
-	log.term <- -lbeta(1/kappa, 1/kappa)
-	result <- 2^(1-2/kappa)*r*(2*n-3)/(n+2/kappa-1)*exp(log.term)*hyper.term
+	logTerm <- -lbeta(1/kappa, 1/kappa)
+	result <- 2^(1-2/kappa)*r*(2*n-3)/(n+2/kappa-1)*exp(logTerm)*hyperTerm
 	return(result)
 }
 
-.bfPlus0Numerical <- function(n, r, kappa=1, lowerRho=0, upperRho=1){
-	# Ly et al 2015
-	# This is a numerical approximation
-	# with parameter kappa. If kappa = 1 then uniform prior on rho
-	# bf positive vs null
-	#
-	# Ly et al 2015
-	# This is the contribution of one-sided test
-	#
-	#
-	if ( any(is.na(r)) ){
-		return(NA)
-	}
-	if (kappa >= 1 && n > 2 && r>=1) {
-		return(Inf)
-	} else if (kappa >= 1 && n > 2 && r<=-1){
-		return(0)
-	}
-	
-	my.numerical.Jeffreys <- .bfCorNumerical(n, r, kappa, lowerRho, upperRho)
-	# TODO: be very careful here, might integrate over non-finite function
-	# in particular with the exact h function. 
-	#
-	if (!is.na(my.numerical.Jeffreys) && my.numerical.Jeffreys >= 0){
-		# Note: Numerical Jeffreys okay
-		return(my.numerical.Jeffreys)
-	} else if (is.na(my.numerical.Jeffreys) || my.numerical.Jeffreys < 0){
-		# All numerical failed
-		return(NaN)
-	} 
-	return (NaN)
-}
-
-.bfPlus0JeffreysIntegrate <- function(n, r, kappa=1){
-	# Ly et al 2015
-	# This is the exact result with symmetric beta prior on rho
-	#	
-	if ( any(is.na(r)) ){
-		return(NaN)
-	}
-	if (n > 2 && r>=1) {
-		return(Inf)
-	} else if (n > 2 && r<=-1){
-		return(0)
-	}
-	
-	bf10 <- .bf10JeffreysIntegrate(n, r, kappa)
-	m.plus <- .mPlusJeffreysIntegrate(n, r, kappa)
-	
-	if (is.na(bf10) || is.na(m.plus)){
-		return(NA)
-	}
-	
-	result <- bf10+m.plus	
-	return(result)
-}
+# 
+# .bfPlus0Numerical <- function(n, r, kappa=1, lowerRho=0, upperRho=1){
+# 	# Ly et al 2015
+# 	# This is a numerical approximation
+# 	# with parameter kappa. If kappa = 1 then uniform prior on rho
+# 	# bf positive vs null
+# 	#
+# 	# Ly et al 2015
+# 	# This is the contribution of one-sided test
+# 	#
+# 	#
+# 	if ( any(is.na(r)) ){
+# 		return(NA)
+# 	}
+# 	if (kappa >= 1 && n > 2 && r>=1) {
+# 		return(Inf)
+# 	} else if (kappa >= 1 && n > 2 && r<=-1){
+# 		return(0)
+# 	}
+# 	
+# 	my.numerical.Jeffreys <- .bfCorNumerical(n, r, kappa, lowerRho, upperRho)
+# 	# TODO: be very careful here, might integrate over non-finite function
+# 	# in particular with the exact h function. 
+# 	#
+# 	if (!is.na(my.numerical.Jeffreys) && my.numerical.Jeffreys >= 0){
+# 		# Note: Numerical Jeffreys okay
+# 		return(my.numerical.Jeffreys)
+# 	} else if (is.na(my.numerical.Jeffreys) || my.numerical.Jeffreys < 0){
+# 		# All numerical failed
+# 		return(NA)
+# 	} 
+# 	return (NA)
+# }
 
 ## Suit:
-.bfCorrieKernel <- function(n, r, kappa=1, method="exact", ciValue=0.95){
-	# The idea is incremental when it comes to method numbers, if 1 doesn't work then go down. 
-	# In particular, when 
-	#	methodNumber=1 we use the exact result Ly et al (2015)
-	#	methodNumber=2 we use the semi-exact result, based on approximation of the likelihood JeffreysExact, see Wagenmakers et al (2015) bathing
-	#	methodNumber=3 we use a numerical approximation of Jeffreys approximation likleihood
-	#	methodNumber=4 we use the Marsman sampler and report a posterior beta fit summarised by betaA, betaB
-	# 	methodNumber=5 we use the Jeffreys approximation 
-	#   methodNumber=6 we use the Jeffreys BF the asymptotic approximation of the BF
-	#
-	# Ex. 	if we want confidence intervals and the bfs are based on method 1, 
-	#		then we can find betaA, betaB based on .posteriorMean and .posteriorVariance
-	# 		if this doens't work we use the Marsman sampler
-	# Ex.	if we retrieve bfs from methodNumber 4, we know that we already have betaA and betaB, 
-	#		so we do not need to try .posteriorMean and .posteriorVariance 
-	# Ex.	if we retrieve bfs from methodNumber 6, we don't know anything about the posterior, so no report at all
-	#
-	tempList <- list(vector())
-	output <- list(n=n, r=r, bf10=NA, bfPlus0=NA, bfMin0=NA, methodNumber=NA, betaA=NA, betaB=NA, 
-				   twoSidedTooPeaked=FALSE, plusSidedTooPeaked=FALSE, minSidedTooPeaked=FALSE, 
-				   CIs=tempList, ciValues=ciValue, acceptanceRate=1)
-	# Note: If log(bf10) then use beta fit for the one sided bfs
-	# The 24 is based on n=430, r=-0.3500786
-	hyperGeoOverFlowThreshold <- 24
+.bfHypergeo <- function(n, r, kappa=1, methodNumber=1, hyperGeoOverFlowThreshold=24){
+    # Outputs: 
+    #   list of bfs and the beta fits based on the exact form of the reduced likelihood,
+    #   see Ly, Marsman and Wagenmakers (2017) "Analytic Posteriors for Pearson’s Correlation Coefficient".  
+    #
+    # This is the exact result with symmetric beta prior on rho
+    # with parameter alpha. If kappa = 1 then uniform prior on rho
+    #
+    
+    result <- list(bf10=NA, bfPlus0=NA, bfMin0=NA)
+    tempList <- .posteriorBetaParameters(n=n, r=r, kappa=kappa)
+    result <- utils::modifyList(result, tempList)
+    
+    bf10 <- switch(methodNumber, 
+                   try(silent=TRUE, .bf10Exact(n=n, r=r, kappa=kappa)), 
+                   try(silent=TRUE, .bf10JeffreysIntegrate(n=n, r=r, kappa))
+    )
+    
+    if (isTryError(bf10)){
+        # all NAs
+        return(result)
+    } 
+    
+    if (is.na(bf10)){
+        # all NAs
+        return(result)
+    } 
+    
+    if (bf10 <0){
+        # Total failure it's true
+        return(result)
+    }
+    
+    if (is.finite(bf10)){
+        # Store
+        result$bf10 <- bf10 
+        result$twoSidedTooPeaked <- FALSE
+        
+        if (log(bf10) < hyperGeoOverFlowThreshold){
+            # No overflow, can use exact result
+            
+            switch(methodNumber, 
+                   {
+                       bfPlus0 <- try(silent=TRUE, bf10 + .mPlusExact(n=n, r=r, kappa))
+                       bfMin0 <- try(silent=TRUE, bf10 + .mPlusExact(n, -r, kappa))
+                   }, 
+                   {
+                       bfPlus0 <- try(silent=TRUE, bf10 + .mPlusJeffreysIntegrate(n=n, r=r, kappa=kappa))
+                       bfMin0 <- try(silent=TRUE, bf10 + .mPlusJeffreysIntegrate(n=n, r=-r, kappa=kappa))	    
+                   }
+            )
+            
+            if (is.finite(bfPlus0) && is.finite(bfMin0)){
+                tempList <- list(bfPlus0=bfPlus0, bfMin0=bfMin0, plusSidedTooPeaked=FALSE, minSidedTooPeaked=FALSE) 
+                result <- utils::modifyList(result, tempList)
+                return(result)
+            }
+        }
+        
+        # bf10 either overflow, or exact one-sided bfs failed: 
+        # but bf10 is finite, so try Savage-Dickey adaptation for one-sided bfs
+        tempList <- .bfSavageDickeyOneSidedAdapt(bf10, a=result$betaA, b=result$betaB, kappa=kappa)
+        result <- utils::modifyList(result, tempList)
+        return(result)
+    }
+    
+    if (is.infinite(bf10)) {
+        # Note: Information consistency check is done at a higher level
+        #  For information consistent data it actually outputs the NA list
+        #
+        # Exact bf10 is infinite, perhaps due to hypergeometric, try numerical integrate
+        twoSidedIntegrand <- switch(methodNumber, {
+            function(x){.hFunction(n=n, r=r, x)*.priorRho(x, kappa=kappa)} }, {
+            function(x){.hJeffreysApprox(n=n, r=r, x)*.priorRho(x, kappa=kappa)}
+        })
+        
+        
+        bf10 <- try(silent=TRUE, exp=integrate(twoSidedIntegrand, -1, 1)$value)
+        result$bf10 <- bf10
+        
+        if (is.infinite(result$bf10)){
+            # .bfCorrieKernel gives the default values for the one sided ones
+            #
+            return(result)
+        } 
+        
+        if (is.finite(bf10)){
+            # Numerical integrated bf10 is finite
+            result$twoSidedTooPeaked <- FALSE
+            
+            if (methodNumber==1){
+                plusSidedIntegrand <- function(x){.hFunction(n=n, r=r, x)*.priorRhoPlus(x, kappa=kappa)}
+                minSidedIntegrand <- function(x){.hFunction(n=n, r=r, x)*.priorRhoMin(x, kappa=kappa)}
+            }
+            
+            if (methodNumber==2){
+                plusSidedIntegrand <- function(x){.hJeffreysApprox(n=n, r=r, x)*.priorRhoPlus(x, kappa=kappa)}
+                minSidedIntegrand <- function(x){.hJeffreysApprox(n=n, r=r, x)*.priorRhoMin(x, kappa=kappa)}	    
+            }
+            
+            bfPlus0 <- try(silent=TRUE, exp=integrate(plusSidedIntegrand, 0, 1)$value)
+            bfMin0 <- try(silent=TRUE, exp=integrate(minSidedIntegrand, -1, 0)$value)
+            
+            if (is.finite(bfPlus0) && is.finite(bfMin0)){
+                tempList <- list(bf10=bf10, bfMin0=bfMin0, bfPlus0=bfPlus0, plusSidedTooPeaked=FALSE, minSidedTooPeaked=FALSE)
+                result <- utils::modifyList(result, tempList)
+                return(result)
+            }
+            
+            # Numerical procedure failed, but bf10 is finite, try savage-dickey adapt
+            tempList <- .bfSavageDickeyOneSidedAdapt(bf10, a=result$betaA, b=result$betaB, kappa=kappa)
+            result <- utils::modifyList(result, tempList)
+        }
+        
+        # numerical bf10 is infinite
+        #
+        
+        
+        # Numerical bf10 is not finite nor infinite
+        # All NAs
+        return(result)
+    }
+    # Exact bf10 is not finite, nor infinite, nor NA, nor try-error No clue what happened here
+    # All NAs
+    return(result)
+}
 
-	# Note: Data check
-	#
-	if (any(is.na(r)) ){
-		output$methodNumber <- 6
-		output$twoSidedTooPeaked <- TRUE 
-		output$plusSidedTooPeaked <- TRUE 
-		output$minSidedTooPeaked <- TRUE
-		return(output)
-	}
-	
-	# Note: Data: OK
-	# "No" prior, alternative model is the same as the null model
-	# TODO: however this bound of 0.002 is arbitrarily chosen. I should choose this based on a trade off
-	# between r and n, but it doesn't really matter. 
-	if (kappa <= 0.002){
-		output$bf10 <- 1
-		output$bfPlus0 <- 1
-		output$bfMin0 <- 1
-		output$methodNumber <- 6
-		return(output)
-	}
-	
-	check.r <- abs(r) >= 1 # check whether |r| >= 1
-	if (n <= 2 || kappa==0){
-		output$bf10 <- 1
-	} else if (kappa >= 1 && n > 2 && check.r) {
-		output$bf10 <- Inf
-		output$twoSidedTooPeaked <- TRUE 
-		output$plusSidedTooPeaked <- TRUE 
-		output$minSidedTooPeaked <- TRUE
-		if (r > 0){
-			output$bfPlus0 <- Inf
-			output$bfMin0 <- 0
-		} else if (r <= 0){
-			output$bfPlus0 <- 0
-			output$bfMin0 <- Inf
-		}
-		output$methodNumber <- 6
-		return(output)
-	}
-	
-	# Note: Different methods
-	#
-	if (method=="exact" || method==1){
-		output$methodNumber <- 1
-		output$bf10 <- .bf10Exact(n, r, kappa)
-		
-		# Note: bf10: CHECK
-		if (is.na(output$bf10) || output$bf10 < 0){
-			output$bf10 <- NA
-			
-			# Posterior not interesting
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		}
-		
-		# Note: bf10: EXTREME
-		if (base::is.infinite(output$bf10)){
-			# Note: Check extreme
-			if (r >= 0){
-				output$bfPlus0 <- Inf
-				output$bfMin0 <- 0
-			} else if (r < 0){
-				output$bfPlus0 <- 0
-				output$bfMin0 <- Inf
-			}
-			# Posterior is too peaked
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		} else if (!base::is.infinite(output$bf10)){
-			# Calculate beta fit
-			someFit <- .posteriorBetaParameters(n, r, kappa)
-			# Store output
-			output$betaA <- someFit$betaA
-			output$betaB <- someFit$betaB
-			
-			if (log(output$bf10) > hyperGeoOverFlowThreshold){
-				# Avoid overflow in hypergeo
-				# Recalculate BF10
-				savageDickyNumerator <- .priorRho(0, kappa)
-				savageDickyDenominator <- .stretchedBeta(0, someFit$betaA, someFit$betaB)
-				#
-				output$bf10 <- savageDickyNumerator/savageDickyDenominator
-				
-				if (base::is.infinite(output$bf10)){
-					# Note: Check extreme
-					if (r >= 0){
-						output$bfPlus0 <- Inf
-						output$bfMin0 <- 0
-					} else if (r < 0){
-						output$bfPlus0 <- 0
-						output$bfMin0 <- Inf
-					}
-					# Posterior is too peaked
-					output$twoSidedTooPeaked <- TRUE 
-					output$plusSidedTooPeaked <- TRUE 
-					output$minSidedTooPeaked <- TRUE
-					return(output)
-				} else if (!base::is.infinite(output$bf10)){
-					# Note: bfPlus0, bfMin0: PREPARE
-					leftProportion <- pbeta(1/2, someFit$betaA, someFit$betaB)
-					
-					if (!is.na(leftProportion) && leftProportion <1){
-						output$bfMin0 <- 2*output$bf10*leftProportion
-						output$bfPlus0 <- 2*output$bf10*(1-leftProportion)	
-					} else {
-						rightProportion <- pbeta(1/2, someFit$betaA, someFit$betaB, lower.tail=FALSE)
-						output$bfMin0 <- 2*output$bf10*(1-rightProportion)
-						output$bfPlus0 <- 2*output$bf10*rightProportion
-					}
-				}
-			} else {
-				# Note: bfPlus0, bfMin0: PREPARE
-				output$bfPlus0 <- output$bf10 + .mPlusExact(n, r, kappa)
-				output$bfMin0 <- output$bf10 + .mPlusExact(n, -r, kappa)
-			}
-		}
-	} else if (method=="jeffreysIntegrate" || method==2){
-		output$methodNumber <- 2
-		output$bf10 <- .bf10JeffreysIntegrate(n, r, kappa)
-		
-		# Note: bf10: CHECK
-		if (is.na(output$bf10) || output$bf10 < 0){
-			output$bf10 <- NA
-			
-			# Posterior not interesting
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		}
-		
-		# Note: bf10: EXTREME
-		if (base::is.infinite(output$bf10)){
-			# Note: Check extreme
-			if (r >= 0){
-				output$bfPlus0 <- Inf
-				output$bfMin0 <- 0
-			} else if (r < 0){
-				output$bfPlus0 <- 0
-				output$bfMin0 <- Inf
-			}
-			# Posterior too peaked
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			
-			return(output)
-		} else if (!base::is.infinite(output$bf10)){
-			# Calculate beta fit
-			someFit <- .posteriorBetaParameters(n, r, kappa)
-			# Store output
-			output$betaA <- someFit$betaA
-			output$betaB <- someFit$betaB
-			
-			if (log(output$bf10) > hyperGeoOverFlowThreshold){
-				# To avoid overflow in the hypergeometric function
-				# Recalculate BF10
-				savageDickyNumerator <- .priorRho(0, kappa)
-				savageDickyDenominator <- .stretchedBeta(0, someFit$betaA, someFit$betaB)
-				#
-				output$bf10 <- savageDickyNumerator/savageDickyDenominator
-				
-				if (base::is.infinite(output$bf10)){
-					# Note: Check extreme
-					if (r >= 0){
-						output$bfPlus0 <- Inf
-						output$bfMin0 <- 0
-					} else if (r < 0){
-						output$bfPlus0 <- 0
-						output$bfMin0 <- Inf
-					}
-					# Posterior is too peaked
-					output$twoSidedTooPeaked <- TRUE 
-					output$plusSidedTooPeaked <- TRUE 
-					output$minSidedTooPeaked <- TRUE
-					return(output)
-				} else if (!base::is.infinite(output$bf10)){
-					# Note: bfPlus0, bfMin0: PREPARE
-					leftProportion <- pbeta(1/2, someFit$betaA, someFit$betaB)
-					
-					if (!is.na(leftProportion) && leftProportion <1){
-						output$bfMin0 <- 2*output$bf10*leftProportion
-						output$bfPlus0 <- 2*output$bf10*(1-leftProportion)	
-					} else {
-						rightProportion <- pbeta(1/2, someFit$betaA, someFit$betaB, lower.tail=FALSE)
-						output$bfMin0 <- 2*output$bf10*(1-rightProportion)
-						output$bfPlus0 <- 2*output$bf10*rightProportion
-					}
-				}
-			} else {
-				# Note: bfPlus0, bfMin0: PREPARE
-				output$bfPlus0 <- output$bf10 + .mPlusJeffreysIntegrate(n, r, kappa)
-				output$bfMin0 <- output$bf10 + .mPlusJeffreysIntegrate(n, -r, kappa)
-			}
-		}
-	} else if (method=="numerical" || method==3){
-		output$methodNumber <- 3
-		output$bf10 <- .bf10Numerical(n, r, kappa, lowerRho=-1, upperRho=1)
-		
-		# Note: bf10: CHECK
-		if (is.na(output$bf10) || output$bf10 < 0){
-			output$bf10 <- NA
-			
-			# Posterior not interesting
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		}
-		
-		# Note: bf10: EXTREME
-		if (base::is.infinite(output$bf10)){
-			# Note: Check extreme
-			if (r >= 0){
-				output$bfPlus0 <- Inf
-				output$bfMin0 <- 0
-			} else if (r < 0){
-				output$bfPlus0 <- 0
-				output$bfMin0 <- Inf
-			}
-			
-			# Posterior too peaked
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		} else if (!base::is.infinite(output$bf10)){
-			# Calculate beta fit
-			someFit <- .posteriorBetaParameters(n, r, kappa)
-			# Store output
-			output$betaA <- someFit$betaA
-			output$betaB <- someFit$betaB
-			
-			if (log(output$bf10) > hyperGeoOverFlowThreshold){
-				# To avoid overflow in the numerical integration
-				# Recalculate BF10
-				savageDickyNumerator <- .priorRho(0, kappa)
-				savageDickyDenominator <- .stretchedBeta(0, someFit$betaA, someFit$betaB)
-				#
-				output$bf10 <- savageDickyNumerator/savageDickyDenominator
-				
-				if (base::is.infinite(output$bf10)){
-					# Note: Check extreme
-					if (r >= 0){
-						output$bfPlus0 <- Inf
-						output$bfMin0 <- 0
-					} else if (r < 0){
-						output$bfPlus0 <- 0
-						output$bfMin0 <- Inf
-					}
-					# Posterior is too peaked
-					output$twoSidedTooPeaked <- TRUE 
-					output$plusSidedTooPeaked <- TRUE 
-					output$minSidedTooPeaked <- TRUE
-					return(output)
-				} else if (!base::is.infinite(output$bf10)){
-					# Note: bfPlus0, bfMin0: PREPARE
-					leftProportion <- pbeta(1/2, someFit$betaA, someFit$betaB)
-					
-					if (!is.na(leftProportion) && leftProportion <1){
-						output$bfMin0 <- 2*output$bf10*leftProportion
-						output$bfPlus0 <- 2*output$bf10*(1-leftProportion)	
-					} else {
-						rightProportion <- pbeta(1/2, someFit$betaA, someFit$betaB, lower.tail=FALSE)
-						output$bfMin0 <- 2*output$bf10*(1-rightProportion)
-						output$bfPlus0 <- 2*output$bf10*rightProportion
-					}
-				}
-			} else {
-				# Note: bfPlus0, bfMin0: PREPARE
-				output$bfPlus0 <- .bfPlus0Numerical(n, r, kappa, lowerRho=0, upperRho=1)
-				output$bfMin0 <- .bfPlus0Numerical(n, r, kappa, lowerRho=-1, upperRho=0)
-			}
-		}
-	} else if  (method=="metropolisHastings" || method==4){
-		# We use the Marsman Sampler (c) here based on posterior model fit. 
-		output$methodNumber <- 4
-		marsmanResult <- .marsmanMHSampler(n,r,kappa)
-		
-		# Calculate bf10
-		savageDickyNumerator <- .priorRho(0, kappa)
-		savageDickyDenominator <- .stretchedBeta(0, marsmanResult$betaA, marsmanResult$betaB)
-		
-		# Save output
-		output$bf10 <- savageDickyNumerator/savageDickyDenominator
-		output$betaA <- marsmanResult$betaA
-		output$betaB <- marsmanResult$betaB
-		output$acceptanceRate <- marsmanResult$acceptanceRate
-		
-		# Note: bf10: CHECK
-		if (is.na(output$bf10) || output$bf10 < 0){
-			output$bf10 <- NA
-			
-			# Posterior not interesting
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		}
-		
-		# Note: bf10: EXTREME
-		if (base::is.infinite(output$bf10)){
-			# Note: Check extreme
-			if (r >= 0){
-				output$bfPlus0 <- Inf
-				output$bfMin0 <- 0
-			} else if (r < 0){
-				output$bfPlus0 <- 0
-				output$bfMin0 <- Inf
-			}
-			# Posterior is too peaked
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		} else if (!base::is.infinite(output$bf10)){
-			# Note: bfPlus0, bfMin0: PREPARE
-			leftProportion <- pbeta(1/2, marsmanResult$betaA, marsmanResult$betaB)
-			
-			if (!is.na(leftProportion) && leftProportion <1){
-				output$bfMin0 <- 2*output$bf10*leftProportion
-				output$bfPlus0 <- 2*output$bf10*(1-leftProportion)	
-			} else {
-				rightProportion <- pbeta(1/2, marsmanResult$betaA, marsmanResult$betaB, lower.tail=FALSE)
-				output$bfMin0 <- 2*output$bf10*(1-rightProportion)
-				output$bfPlus0 <- 2*output$bf10*rightProportion
-			}
-		}
-	} else if (method=="jeffreysApprox" || method==5){
-		output$methodNumber <- 5
-		output$bf10 <- .bf10JeffreysApprox(n, r)
-		
-		# Note: bf10: CHECK
-		if (is.na(output$bf10) || output$bf10 < 0){
-			output$bf10 <- NA
-			
-			# Posterior not interesting
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		}
-		
-		# Note: bf10: EXTREME
-		if (base::is.infinite(output$bf10)){
-			# Note: Check extreme
-			if (r >= 0){
-				output$bfPlus0 <- Inf
-				output$bfMin0 <- 0
-			} else if (r < 0){
-				output$bfPlus0 <- 0
-				output$bfMin0 <- Inf
-			}
-			
-			# Posterior too peaked
-			output$twoSidedTooPeaked <- TRUE 
-			output$plusSidedTooPeaked <- TRUE 
-			output$minSidedTooPeaked <- TRUE
-			return(output)
-		}
-		return(output)
-	}
-	
-	# Note: Calculate credible intervals
-	if (!is.na(output$betaA) && !is.na(output$betaB)){
-		output$CIs <- .credibleIntervals(output$betaA, output$betaB, ciValue)
-	}
-	
-	# Note: bfPlus0, bfMin0: CHECK
-	if (any(is.na(c(output$bfPlus0, output$bfMin0)))){
-		# Note: bfPlus0, bfMin0: NOT ok
-		# 	if one is NA, then both are NA
-		output$bfPlus0 <- NA
-		output$bfMin0 <- NA
-		
-		# Posterior not interesting 
-		output$plusSidedTooPeaked <- TRUE 
-		output$minSidedTooPeaked <- TRUE
-		return(output)
-	} else if (any(c(output$bfPlus0, output$bfMin0)==0)){
-		# Note: bfPlus0, bfMin0: EXTREME
-		# 	if one is extreme, so is the other
-		if (output$bfPlus0==0){
-			output$bfPlus0 <- 0
-			output$bfMin0 <- Inf
-		} else if (output$bfMin0==0){
-			output$bfPlus0 <- Inf
-			output$bfMin0 <- 0
-		}
-		
-		# Posterior too peaked
-		output$plusSidedTooPeaked <- TRUE 
-		output$minSidedTooPeaked <- TRUE
-		return(output)
-	} 
-	
-	
-	# Note: bfPlus0, bfMin0: CHECK COHERENCE:
-	if (output$bfPlus0 > 1 && output$bfMin0 > 1 || any(c(output$bfPlus0, output$bfMin0)<0)){
-		if (r>0){
-			# Note: Data: OK, 
-			# 		bf10: OK. 
-			#		bfPlus0: OK
-			#		bfMin0: NOT ok 
-			# 
-			# bfMin0 is bigger than one due to overflow: bfMin0 = 2*bf10 - bfPlus0. 
-			# Example: 2*1.2.... 10^ 24 - 2.... 10^24 = 1... 10^12 (due to round off)
-			#
-			output$bfMin0 <- 10^(-317) 
-			output$bfPlus0 <- 2*output$bf10 - output$bfMin0
-		} else if (r < 0) {
-			# Note: Data: OK, 
-			# 		bf10: OK. 
-			#		bfPlus0: NOT ok
-			#		bfMin0: OK
-			output$bfPlus0 <- 10^(-317) 
-			output$bfMin0 <- 2*output$bf10 - output$bfPlus0
-		}
-	}
-	return(output)
+.bfCorrieKernel <- function(n, r, kappa=1, method="exact", ciValue=0.95, hyperGeoOverFlowThreshold=24){
+    # The idea is incremental when it comes to method numbers, if 1 doesn't work then go down. 
+    # In particular, when 
+    #	methodNumber=1: exact result Ly et al (2015)
+    #	methodNumber=2: semi-exact result, based on approximation of the likelihood JeffreysExact, see Wagenmakers et al (2015) bathing
+    #	methodNumber=3: Savage Dickey beta approximation 
+    #	methodNumber=4: Marsman's IMH sampler and report a posterior beta fit summarised by betaA, betaB
+    # methodNumber=5: Jeffreys asymptotic approximation of the BF 
+    # methodNumber=6: invalid data, or point prior
+    #   
+    #   hyperGeoOverFlowThreshold=25 implies that if log(bf10) > 24 that we use Savage-Dickey adaptation
+    #   for the one-sided bfs. 
+    #
+    # Ex. 	if we want confidence intervals and the bfs are based on method 1, 
+    #		then we can find betaA, betaB based on .posteriorBetaParameters
+    # 		if this doens't work we use the Marsman sampler
+    # Ex.	if we retrieve bfs from methodNumber 4, we know that we already have betaA and betaB, 
+    #		so we do not need to try .posteriorMean and .posteriorVariance 
+    # Ex.	if we retrieve bfs from methodNumber 6, we don't know anything about the posterior, so no report at all
+    #
+    
+    tempList <- list()
+    # TODO: MIGHT just not fill in everything yet
+    # result <- list(n=n, r=r, kappa=kappa, bf10=NA, bfPlus0=NA, bfMin0=NA, methodNumber=NA, betaA=NA, betaB=NA, 
+    # 			   twoSidedTooPeaked=FALSE, plusSidedTooPeaked=FALSE, minSidedTooPeaked=FALSE, 
+    # 			   CIs=tempList, ciValues=ciValue, acceptanceRate=1)
+    result <- list(n=n, r=r, kappa=kappa, bf10=NULL, bfPlus0=NULL, bfMin0=NULL, methodNumber=NULL, betaA=NULL, betaB=NULL, 
+                   twoSidedTooPeaked=NULL, plusSidedTooPeaked=NULL, minSidedTooPeaked=NULL, 
+                   CIs=tempList, ciValues=ciValue, acceptanceRate=1)
+    
+    # When bf10 is na, modify result with naList
+    #
+    tooPeakedList <- list(twoSidedTooPeaked=TRUE, plusSidedTooPeaked=TRUE, minSidedTooPeaked=TRUE)
+    
+    naList <- append(list(bfPlus0=NA, bfMin0=NA), tooPeakedList)
+    
+    # When the prior is trivial (null is alternative) or when the data is predictively matched
+    #
+    predictiveMatchingList <- list(bf10=1, bfPlus0=1, bfMin0=1, twoSidedTooPeaked=FALSE, plusSidedTooPeaked=FALSE, minSidedTooPeaked=FALSE, methodNumber=0)
+    
+    # Information consistent result
+    #
+    infoConsistentList <- append(list(bf10=Inf, methodNumber=0), tooPeakedList)
+    
+    # Note: If log(bf10) then use beta fit for the one sided bfs
+    # The 24 is based on n=30, r=-0.3500786
+    hyperGeoOverFlowThreshold <- 24
+    
+    # Note: Data check
+    #
+    if (any(is.na(r)) ){
+        result$methodNumber <- 6
+        result <- utils::modifyList(result, naList)
+        return(result)
+    }
+    
+    # Note: Data: OK
+    # "No" prior, alternative model is the same as the null model
+    # TODO: however this bound of 0.002 is arbitrarily chosen. I should choose this based on a trade off
+    # between r and n, but it doesn't really matter. 
+    if (kappa <= 0.002){
+        result <- utils::modifyList(result, predictiveMatchingList)
+        return(result)
+    }
+    
+    check.r <- abs(r) >= 1 # check whether |r| >= 1
+    if (n <= 2 || kappa==0){
+        result <- utils::modifyList(result, predictiveMatchingList)
+        return(result)
+    } else if (kappa >= 1 && n > 2 && check.r) {
+        if (r > 0){
+            result$bfPlus0 <- Inf
+            result$bfMin0 <- 0
+        } else if (r <= 0){
+            result$bfPlus0 <- 0
+            result$bfMin0 <- Inf
+        }
+        result <- utils::modifyList(result, infoConsistentList)
+        return(result)
+    }
+    
+    # Note: Define different methods and method number
+    #
+    if (method=="exact" || method==1){
+        result$methodNumber <- 1
+        tempList <- .bfHypergeo(n=n, r=r, kappa=kappa, methodNumber=1, hyperGeoOverFlowThreshold=hyperGeoOverFlowThreshold)
+        result <- utils::modifyList(result, tempList)
+    } 
+    
+    if (method=="jeffreysIntegrate" || method==2){
+        result$methodNumber <- 2
+        tempList <- .bfHypergeo(n=n, r=r, kappa=kappa, methodNumber=2, hyperGeoOverFlowThreshold=hyperGeoOverFlowThreshold)
+        result <- utils::modifyList(result, tempList)
+    } 
+    
+    if (method=="savageDickeyBeta" || method==3){
+        result$methodNumber <- 3
+        tempList <- .bfSavageDickeyBetaData(n=n, r=r, kappa=kappa)
+        result <- utils::modifyList(result, tempList)
+    } 
+    
+    if  (method=="metropolisHastings" || method==4){
+        # We use the Marsman Sampler (c) here based on posterior model fit. 
+        result$methodNumber <- 4
+        marsmanResult <- .marsmanMHSampler(n=n, r=r, kappa=kappa)
+        result$acceptanceRate <- marsmanResult$acceptanceRate
+        
+        tempResult <- .bfSavageDickeyBeta(a=marsmanResult$betaA, b=marsmanResult$betaB, kappa=kappa)
+        result <- utils::modifyList(result, tempResult)
+    } 
+    
+    if (method=="jeffreysApprox" || method==5){
+        result$methodNumber <- 5
+        tempResult <- .bf10JeffreysApprox(n=n, r=r)
+        result <- utils::modifyList(result, tempResult)
+        return(result)
+    }
+    
+    if (is.infinite(result$bf10)){
+        if (r >= 0){
+            result$bfPlus0 <- Inf
+            result$bfMin0 <- 0
+        } else if (r < 0){
+            result$bfPlus0 <- 0
+            result$bfMin0 <- Inf
+        }
+        
+        result <- utils::modifyList(result, tooPeakedList)
+        return(result)
+    }
+    
+    # Note: bf10: CHECK
+    if (is.na(result$bf10)){
+        # Posterior not interesting
+        result <- utils::modifyList(result, naList)
+        return(result)
+    }
+    
+    # Note: Calculate credible intervals
+    if (!any(is.na(result$betaA), is.na(result$betaB))) {
+        result$CIs <- .credibleIntervals(alpha=result$betaA, beta=result$betaB, ciValue=ciValue)
+    }
+    
+    # Note: bfPlus0, bfMin0: CHECK
+    #
+    
+    if (any(is.na(result$bfPlus0), is.na(result$bfMin0))) {
+        # Note: bfPlus0, bfMin0: NOT ok
+        # 	if one is NA, then both are NA
+        result$bfPlus0 <- NA
+        result$bfMin0 <- NA
+        
+        # Posterior not interesting 
+        result$plusSidedTooPeaked <- TRUE 
+        result$minSidedTooPeaked <- TRUE
+        return(result)
+    } 
+    
+    if (any(c(result$bfPlus0, result$bfMin0)==0)){
+        # Note: bfPlus0, bfMin0: EXTREME
+        # 	if one is extreme, so is the other
+        if (result$bfPlus0==0){
+            result$bfPlus0 <- 0
+            result$bfMin0 <- Inf
+        } else if (result$bfMin0==0){
+            result$bfPlus0 <- Inf
+            result$bfMin0 <- 0
+        }
+        
+        # Posterior too peaked
+        result$plusSidedTooPeaked <- TRUE 
+        result$minSidedTooPeaked <- TRUE
+        return(result)
+    } 
+    
+    
+    # Note: bfPlus0, bfMin0: CHECK COHERENCE:
+    if (result$bfPlus0 > 1 && result$bfMin0 > 1 || any(c(result$bfPlus0, result$bfMin0)<0)){
+        if (r>0){
+            # Note: Data: OK, 
+            # 		bf10: OK. 
+            #		bfPlus0: OK
+            #		bfMin0: NOT ok 
+            # 
+            # bfMin0 is bigger than one due to overflow: bfMin0 = 2*bf10 - bfPlus0. 
+            # Example: 2*1.2.... 10^ 24 - 2.... 10^24 = 1... 10^12 (due to round off)
+            #
+            result$bfMin0 <- 10^(-317) 
+            result$bfPlus0 <- 2*result$bf10 - result$bfMin0
+        } else if (r < 0) {
+            # Note: Data: OK, 
+            # 		bf10: OK. 
+            #		bfPlus0: NOT ok
+            #		bfMin0: OK
+            result$bfPlus0 <- 10^(-317) 
+            result$bfMin0 <- 2*result$bf10 - result$bfPlus0
+        }
+    }
+    return(result)
+}
+
+.bfPearsonCorrelation <- function(n, r, kappa=1, ciValue=0.95){
+    # Wrapper around .bfCorrieKernel
+    #
+    result <- list(bf10=NA, bfPlus0=NA, bfMin0=NA)
+    methodNumber <- 1
+    
+    while (any(is.na(c(result$bf10, result$bfPlus0, result$bfMin0)), 
+               is.infinite(c(result$bf10, result$bfPlus0, result$bfMin0))) 
+           && methodNumber <= 4){
+        # Note: Try all normal methods
+        # 1. Exact
+        # 2. semi-exact result
+        # 3. Savage-Dickey beta approximation
+        # 4. Marsman sampler
+        
+        result <- .bfCorrieKernel(n=n, r=r, kappa=kappa, method=methodNumber, ciValue=ciValue)
+        #}
+        methodNumber <- methodNumber+1
+    }
+    
+    if (any(is.na(c(result$bf10, result$bfPlus0, result$bfMin0)))  || 
+        any(is.infinite(c(result$bf10, result$bfPlus0, result$bfMin0)))
+    ){
+        # Note: all normal methods FAILED. Use Jeffreys approximation
+        # NO CI INTERVALS FOR credibleIntervalsInterval
+        result <- .bfCorrieKernel(n=n, r=r, kappa=kappa, method="jeffreysApprox")
+    }
+    
+    return(result)
 }
 
 .postDensKendallTau <- function(delta,Tstar,n,kappa=1,var=var,test="two-sided"){ 
@@ -1519,7 +1545,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
   } else if(test == "positive"){priorDens <- .priorTauPlus(delta,kappa)
   } else if(test == "negative"){priorDens <- .priorTauMin(delta,kappa)}
   priorDens <- .priorTau(delta,kappa)
-  dens <- dnorm(Tstar,(1.5*delta*sqrt(n)),sd=sqrt(var))* priorDens
+  dens <- stats::dnorm(Tstar,(1.5*delta*sqrt(n)),sd=sqrt(var))* priorDens
   return(dens)
 }
 .posteriorTau <- function(delta,kentau,n,kappa=1,var=1,test="two-sided"){
@@ -1562,15 +1588,214 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 
 # Replication Bayes factors
 # 
-.bfR0Josine <- function(nOri, rOri, nRep, rRep, kappa=1){
-	# Verhagen & Wagenmakers 2014
-	integrand <- function(rho){.hFunction(nRep, rRep, rho)*.hFunction(nOri, rOri, rho)*.priorRho(rho, kappa)}
-	logNumerator <- log(integrate(integrand, -1, 1)$value)
-	logDenominator <- log(.bf10Exact(n=nOri, r=rOri, kappa))
-	
-	logBfR0 <- logNumerator-logDenominator
-	return(exp(logBfR0))
+.bfCorrieRepJosine <- function(nOri, rOri, nRep, rRep, kappa=1, methodNumber=1, hyperGeoOverFlowThreshold=24){
+    # 
+    #  Ly, A., Etz, A., Marsman, M., & Wagenmakers, E.--J. (2017) Replication Bayes factors. Manuscript in preparation
+    #  Ly, A., Marsman, M., & Wagenmakers, E.-J. (2017) Analytic Posteriors for Pearson’s Correlation Coefficient. Under review
+    #  Wagenmakers, E.-J., Verhagen, A. J., & Ly, A. (2016). How to quantify the evidence for the absence of a correlation. Behavior Research Methods, 48, 413-426.
+    # 
+    # Replication BF for the correlation
+    #
+    # 1:2 are based on the exact reduced likelihood functions
+    # 3:4 are based on the beta approximations to the reduced likelihood functions
+    #
+    #	methodNumber=1: Use exact likelihood Ly, Marsman, Wagenmakers (2017)
+    #	methodNumber=2: Use semi-exact result, based on approximation of the likelihood JeffreysExact, see Wagenmakers et al (2015) bathing
+    #	methodNumber=3: Savage Dickey beta approximation 
+    #	methodNumber=4: Marsman's IMH sampler and then Savage Dickey beta approximation
+    #
+    # Output is a list of the 
+    #   - original data, 
+    #   - rep data, 
+    #   - combined inference 
+    #   - replication BFs given the original 
+    # 
+    # 
+    
+    # TODO: avoid when pass through object
+    oriObj <- .bfCorrieKernel(n=nOri, r=rOri, method=methodNumber, kappa=kappa)
+    
+    # Default is "NA" list
+    result <- list(ori=oriObj, rep=list(NULL), 
+                   combined=list(n=c(nOri, nRep), r=c(rOri, rRep), 
+                                 repMethodNumber=methodNumber,
+                                 bf10=NA, bfPlus0=NA, bfMin0=NA, 
+                                 betaA=NA, betaB=NA) , 
+                   repGivenOri=list(n=c(nOri, nRep), r=c(rOri, rRep), 
+                                    bf10=NA, bfPlus0=NA, bfMin0=NA), 
+                   repMethodNumber=methodNumber)
+    
+    if (is.infinite(oriObj$bf10)){
+        # No use, too big too great, it's true
+        #
+        return(result)
+    }
+    
+    # Calculate beta fits of the combined likelihood
+    if (kappa==1){
+        #
+        # methods 3 and 4 are highly dependent on the beta fits based on kappa = 1
+        if (methodNumber %in% 3:4 && any(is.na(c(oriObj$betaA, oriObj$betaB)))){
+            # Total failure, real sad
+            return(result)
+        }
+        
+        repObj <- .bfCorrieKernel(n=nRep, r=rRep, method=methodNumber, kappa=kappa)
+        result$rep <- repObj
+        
+        if (methodNumber %in% 3:4 && any(is.na(c(repObj$betaA, repObj$betaB)))){
+            # Failed 
+            return(result)
+        }
+        
+        result$combined$betaA <- oriObj$betaA-1+repObj$betaA
+        result$combined$betaB <- oriObj$betaB-1+repObj$betaB
+    } else {
+        # kappa \neq 1
+        
+        if (methodNumber %in% 1:3){
+            oriLikelihoodFit <- .posteriorBetaParameters(n=nOri, r=rOri, kappa=1)
+            repLikelihoodFit <- .posteriorBetaParameters(n=nRep, r=rRep, kappa=1)
+        }
+        
+        if (methodNumber==4){
+            oriLikelihoodFit <- .marsmanMHSampler(n=nOri, r=rOri, kappa=1)
+            
+            if (is.na(oriLikelihoodFit$betaA) || is.na(oriLikelihoodFit$betaB)) {
+                # Total failure, it's sad
+                #
+                return(result)
+            }
+            
+            repLikelihoodFit <- .marsmanMHSampler(n=nRep, r=rRep, kappa=1)
+        }
+        
+        if (methodNumber %in% 3:4){
+            if (any(is.na(c(oriLikelihoodFit$betaA, oriLikelihoodFit$betaB, 
+                            repLikelihoodFit$betaA, repLikelihoodFit$betaB)))){
+                # Failure
+                return(result)
+            }
+        }
+        # combine here
+        result$combined$betaA <- oriLikelihoodFit$betaA-1+repLikelihoodFit$betaA-1+1/kappa
+        result$combined$betaB <- oriLikelihoodFit$betaB-1+repLikelihoodFit$betaB-1+1/kappa
+        
+        
+        # Here kappa not 1, but still can see what the original default bfs will do for the rep data
+        repObj <- .bfCorrieKernel(n=nRep, r=rRep, method=methodNumber, kappa=kappa)
+        result$rep <- repObj
+    }
+    
+    if (methodNumber=="exact" || methodNumber==1) {
+        twoSidedIntegrand <- function(x){.hFunctionCombined(nOri, rOri, nRep, rRep, x)*.priorRho(x, kappa=kappa)}
+        plusSidedIntegrand <- function(x){.hFunctionCombined(nOri, rOri, nRep, rRep, x)*.priorRhoPlus(x, kappa=kappa)}
+        minSidedIntegrand <- function(x){.hFunctionCombined(nOri, rOri, nRep, rRep, x)*.priorRhoMin(x, kappa=kappa)}
+    } else if (methodNumber=="jeffreysIntegrate" || methodNumber==2) {
+        twoSidedIntegrand <- function(x){.hJeffreysApprox(nRep, rRep, x)*.hJeffreysApprox(nOri, rOri, x)*.priorRho(x, kappa=kappa)}
+        plusSidedIntegrand <- function(x){.hJeffreysApprox(nRep, rRep, x)*.hJeffreysApprox(nOri, rOri, x)*.priorRhoPlus(x, kappa=kappa)}
+        minSidedIntegrand <- function(x){.hJeffreysApprox(nRep, rRep, x)*.hJeffreysApprox(nOri, rOri, x)*.priorRhoMin(x, kappa=kappa)}
+    } 
+    
+    
+    if (methodNumber %in% 1:2){
+        bf10Combined <- try(silent=TRUE, exp=integrate(twoSidedIntegrand, -1, 1)$value)
+        
+        if (isTryError(bf10Combined)){
+            # Total loser, can't even calculate the combined bf10
+            return(result)
+        }
+        
+        if (is.na(bf10Combined)){
+            # So sad combined bf10 not available
+            result$combined$bf10 <- NA
+            return(result)
+        }
+        
+        if (is.infinite(bf10Combined)){
+            # So big, totally infinite
+            #
+            result$combined$bf10 <- Inf
+            result$repGivenOri$bf10 <- Inf
+            
+            if (r >= 0){
+                result$combined$bfPlus0 <- Inf
+                result$combined$bfMin0 <- 0
+                
+                result$repGivenOri$bfPlus0 <- Inf
+                result$repGivenOri$bfMin0 <- 0
+            } else if (r < 0){
+                result$combined$bfPlus0 <- 0
+                result$combined$bfMin0 <- Inf
+                
+                result$repGivenOri$bfPlus0 <- 0
+                result$repGivenOri$bfMin0 <- Inf
+            }
+            return(result)
+        }
+        
+        if (is.finite(bf10Combined)){
+            # Total winner, real great, it's the best
+            
+            
+            result$combined$bf10 <- bf10Combined
+            result$repGivenOri$bf10 <- bf10Combined/oriObj$bf10
+            
+            if (log(bf10Combined) > hyperGeoOverFlowThreshold){
+                # So big like my hands, can't handle it need to adjust
+                tempList <- .bfSavageDickeyOneSidedAdapt(bf10Combined, a=result$combined$betaA, b=result$combined$betaB, kappa=kappa)
+                
+                result$combined$bfPlus0 <- tempList$bfPlus0
+                result$combined$bfMin0 <- tempList$bfMin0
+            } else {
+                # No overflow, thus, try numerically integrate
+                #
+                bfPlus0Combined <- try(silent=TRUE, exp=integrate(plusSidedIntegrand, 0, 1)$value)
+                bfMin0Combined <- try(silent=TRUE, exp=integrate(minSidedIntegrand, -1, 0)$value)
+                
+                if (isTryError(list(bfPlus0Combined, bfMin0Combined))){
+                    # One sided failed
+                    return(result)
+                }
+                
+                if ( bfPlus0Combined < 0 || bfMin0Combined < 0) {
+                    # One sided failed
+                    return(result)
+                }
+                
+                if (is.na(bfPlus0Combined) || is.na(bfMin0Combined) || is.infinite(bfPlus0Combined) || is.infinite(bfMin0Combined) ){
+                    tempList <- .bfSavageDickeyOneSidedAdapt(bf10Combined, a=result$combined$betaA, b=result$combined$betaB, kappa=kappa)
+                    
+                    result$combined$bfPlus0 <- tempList$bfPlus0
+                    result$combined$bfMin0 <- tempList$bfMin0
+                } else{
+                    result$combined$bfPlus0 <- bfPlus0Combined
+                    result$combined$bfMin0 <- bfMin0Combined
+                }
+            }
+        } 
+    } 
+    
+    
+    if (methodNumber %in% 3:4){
+        # TODO:
+        if (!is.na(result$combined$betaA) && !is.na(result$combined$betaB)) {
+            # Use beta fit and Savage-Dickey 
+            tempList <- .bfSavageDickeyBeta(a=result$combined$betaA, b=result$combined$betaB, kappa=kappa)
+            result$combined$bf10 <- tempList$bf10
+            result$combined$bfPlus0 <- tempList$bfPlus0
+            result$combined$bfMin0 <- tempList$bfMin0
+        }
+    }
+    
+    # TODO: checks for bf10Combined, bfPlus0Combined, bfMin0Combined for zeroes and infinities
+    result$repGivenOri$bf10 <- (result$combined$bf10) / (oriObj$bf10)
+    result$repGivenOri$bfPlus0 <- (result$combined$bfPlus0) / (oriObj$bfPlus0)
+    result$repGivenOri$bfMin0 <- (result$combined$bfMin0) / (oriObj$bfMin0)
+    
+    return(result)
 }
+
 
 
 # 4.0 Posteriors to graph TODO: we have to think about this, different
@@ -1581,40 +1806,40 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 # 4.1 Two-sided
 .posteriorRho <- function(n, r, rho, kappa=1){
 	if (!is.na(r) && !r==0){
-		return(1/.bf10Exact(n, r, kappa)*.hFunction(n, r, rho)*.priorRho(rho, kappa))
+		return(1/.bf10Exact(n=n, r=r, kappa)*.hFunction(n=n, r=r, rho)*.priorRho(rho, kappa))
 	} else if (!is.na(r) && r==0){
-		return(1/.bf10JeffreysIntegrate(n, r, kappa)*.jeffreysApproxH(n, r, rho)*.priorRho(rho, kappa))
+		return(1/.bf10JeffreysIntegrate(n=n, r=r, kappa)*.hJeffreysApprox(n=n, r=r, rho)*.priorRho(rho, kappa))
 	}	
 }
 
 .posteriorRhoPlus <- function(n, r, rho, kappa=1){
 	if (!is.na(r) && !r==0){
-		return(1/.bfCorrieKernel(n, r, kappa, method="exact")$bfPlus0*.hFunction(n, r, rho)*.priorRhoPlus(rho, kappa))
+		return(1/.bfCorrieKernel(n=n, r=r, kappa, method="exact")$bfPlus0*.hFunction(n=n, r=r, rho)*.priorRhoPlus(rho, kappa))
 	} else if (!is.na(r) && r==0){
-		return(1/.bfCorrieKernel(n, r, kappa, method="jeffreysIntegrate")$bfPlus0*.jeffreysApproxH(n, r, rho)*.priorRhoPlus(rho, kappa))
+		return(1/.bfCorrieKernel(n=n, r=r, kappa, method="jeffreysIntegrate")$bfPlus0*.hJeffreysApprox(n=n, r=r, rho)*.priorRhoPlus(rho, kappa))
 	}	
 }
 
 .posteriorRhoMin <- function(n, r, rho, kappa=1){
 	if (!is.na(r) && !r==0){.approximatePosteriorRho
-		return(1/.bfCorrieKernel(n, r, kappa, method="exact")$bfMin0*.hFunction(n, r, rho)*.priorRhoMin(rho, kappa))
+		return(1/.bfCorrieKernel(n=n, r=r, kappa, method="exact")$bfMin0*.hFunction(n=n, r=r, rho)*.priorRhoMin(rho, kappa))
 	} else if (!is.na(r) && r==0){
-		return(1/.bfCorrieKernel(n, r, kappa, method="jeffreysIntegrate")$bfMin0*.jeffreysApproxH(n, r, rho)*.priorRhoMin(rho, kappa))
+		return(1/.bfCorrieKernel(n=n, r=r, kappa, method="jeffreysIntegrate")$bfMin0*.hJeffreysApprox(n=n, r=r, rho)*.priorRhoMin(rho, kappa))
 	}	
 	
 }
 
 
 .approximatePosteriorRho <- function(rho, n, r) {
-  1/(1-rho^2)*dnorm(atanh(rho), mean=atanh(r), sd=1/sqrt(n))
+  1/(1-rho^2)*stats::dnorm(atanh(rho), mean=atanh(r), sd=1/sqrt(n))
 }
 
 .approximatePosteriorRhoPlus <- function(rho, n, r) {
-  (.approximatePosteriorRho(rho,n,r) * (rho>0)) / (pnorm(0,mean=atanh(r),sd=1/sqrt(n),lower.tail = FALSE))
+  (.approximatePosteriorRho(rho,n,r) * (rho>0)) / (stats::pnorm(0,mean=atanh(r),sd=1/sqrt(n),lower.tail = FALSE))
 }
 
 .approximatePosteriorRhoMin <- function(rho, n, r) {
-    (.approximatePosteriorRho(rho,n,r) * (rho<0)) / (pnorm(0,mean=atanh(r),sd=1/sqrt(n)))
+    (.approximatePosteriorRho(rho,n,r) * (rho<0)) / (stats::pnorm(0,mean=atanh(r),sd=1/sqrt(n)))
 }
   
 
@@ -1624,24 +1849,24 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	# Posterior mean of the .bf10Exact
 	#	That is, (rho+1)/2, thus, on 0,1 scale to estimate a, b in a beta distribution
 	#
-	# TODO: add safeguard for large n as then hyper.term.1/hyper.term.2 is almost 1
-	# 	and also for log.term almost being 1 (it works okay if I cut off the hyper.term.1 
-	# 	with three terms and hyper.term.2 with three terms and then divide them, though, 
+	# TODO: add safeguard for large n as then hyperTerm1/hyperTerm2 is almost 1
+	# 	and also for logTerm almost being 1 (it works okay if I cut off the hyperTerm1 
+	# 	with three terms and hyperTerm2 with three terms and then divide them, though, 
 	#	this is rather bad as a formal procedure due to the fact that it violates the 
 	#	definition of products of sum sequences. Though it yields a good approximation.
 	#
 	# 	if (abs(r) < 0.5 && n <= 200){
-	# 		log.term <- 2*(lgamma(n/2)-lgamma((n-1)/2))
-	# 		hyper.term.1 <- Re(hypergeo::hypergeo((n/2), (n/2), ((n+2/kappa+2)/2), r^2))
-	# 		hyper.term.2 <- Re(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
+	# 		logTerm <- 2*(lgamma(n/2)-lgamma((n-1)/2))
+	# 		hyperTerm1 <- Re(hypergeo::hypergeo((n/2), (n/2), ((n+2/kappa+2)/2), r^2))
+	# 		hyperTerm2 <- Re(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
 	# 		
-	# 		some.factor <- exp(log.term)*hyper.term.1/hyper.term.2
+	# 		some.factor <- exp(logTerm)*hyperTerm1/hyperTerm2
 	# 	} else {
 	# 		# TODO: a linear approximation, needs proof
 	# 		some.factor <- n/2
 	# 	}
 	#
-	#log.term <- 2*(lgamma(n/2)-lgamma((n-1)/2))
+	#logTerm <- 2*(lgamma(n/2)-lgamma((n-1)/2))
 	#
 	# Note: interestingly, it breaks down from n=199 to n=200 when using hypergeo
 	# that is:
@@ -1649,8 +1874,8 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	# 	.posteriorMean(200, 0.8) yields -2.600069e+26
 	# 	.posteriorMean(199, 0.8) yields 0.7948551
 	#
-	#hyper.term.1 <- Re(hypergeo::hypergeo((n/2), (n/2), ((n+2/kappa+2)/2), r^2))
-	#hyper.term.2 <- Re(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
+	#hyperTerm1 <- Re(hypergeo::hypergeo((n/2), (n/2), ((n+2/kappa+2)/2), r^2))
+	#hyperTerm2 <- Re(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
 	
 	# Note: interestingly, it breaks down from n=199 to n=200 when using the integral form f15.3.1
 	# that is:
@@ -1662,8 +1887,8 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	#			value out of range in 'gammafn'
 	#
 	#
-	#hyper.term.1 <- Re(hypergeo::f15.3.1((n/2), (n/2), ((n+2/kappa+2)/2), r^2))
-	#hyper.term.2 <- Re(hypergeo::f15.3.1(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
+	#hyperTerm1 <- Re(hypergeo::f15.3.1((n/2), (n/2), ((n+2/kappa+2)/2), r^2))
+	#hyperTerm2 <- Re(hypergeo::f15.3.1(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
 	#
 	# Note: interestingly, the continued fraction solution goes haywire, that is:
 	#
@@ -1671,21 +1896,21 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	#	.posteriorMean(n=67, 0.8) yielding 0.8526101  (a peak)
 	#	.posteriorMean(n=299, 0.8) yielding -1.179415
 	#
-	#hyper.term.1 <- Re(hypergeo::hypergeo_contfrac((n/2), (n/2), ((n+2/kappa+2)/2), r^2))
-	#hyper.term.2 <- Re(hypergeo::hypergeo_contfrac(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
+	#hyperTerm1 <- Re(hypergeo::hypergeo_contfrac((n/2), (n/2), ((n+2/kappa+2)/2), r^2))
+	#hyperTerm2 <- Re(hypergeo::hypergeo_contfrac(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
 	#
-	#hyper.term.1 <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=c((n+2/kappa+2)/2), z=r^2))
-	#hyper.term.2 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=c((n+2/kappa)/2), z=r^2))
+	#hyperTerm1 <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=c((n+2/kappa+2)/2), z=r^2))
+	#hyperTerm2 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=c((n+2/kappa)/2), z=r^2))
 	#
-	#some.factor <- exp(log.term)*hyper.term.1/hyper.term.2
+	#some.factor <- exp(logTerm)*hyperTerm1/hyperTerm2
 	#
 	#result <- 2*r/(n+2/kappa)*some.factor
 	#return(result)
 	
 	if (n <= 2){
-		return(NaN)
+		return(NA)
 	} else if (any(is.na(r))){
-		return(NaN)
+		return(NA)
 	}
 	# TODO: use which
 	check.r <- abs(r) >= 1 # check whether |r| >= 1
@@ -1693,12 +1918,12 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	if (kappa >= 1 && n > 2 && check.r) {
 		return(r)
 	}
-	#log.hyper.term <- log(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
-	hyper.term.1 <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=c((2+(n+2)*kappa)/(2*kappa)), z=r^2))
-	hyper.term.2 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=c((2+n*kappa)/(2*kappa)), z=r^2))
+	#logHyperTerm <- log(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
+	hyperTerm1 <- Re(hypergeo::genhypergeo(U=c(n/2, n/2), L=c((2+(n+2)*kappa)/(2*kappa)), z=r^2))
+	hyperTerm2 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=c((2+n*kappa)/(2*kappa)), z=r^2))
 	
-	log.result <- 2*(lgamma(n/2)-lgamma((n-1)/2))
-	result <- (2*kappa*r)/(2+n*kappa)*exp(log.result)*hyper.term.1/hyper.term.2
+	logResult <- 2*(lgamma(n/2)-lgamma((n-1)/2))
+	result <- (2*kappa*r)/(2+n*kappa)*exp(logResult)*hyperTerm1/hyperTerm2
 	
 	if (is.na(result) || abs(result) > 1){
 		return(r)
@@ -1712,9 +1937,9 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	#
 	#
 	if (n <= 2){
-		return(NaN)
+		return(NA)
 	} else if (any(is.na(r))){
-		return(NaN)
+		return(NA)
 	}
 	# TODO: use which
 	check.r <- abs(r) >= 1 # check whether |r| >= 1
@@ -1723,11 +1948,11 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 		return(r)
 	}
 	#log.hyper.term <- log(hypergeo::hypergeo(((n-1)/2), ((n-1)/2), ((n+2/kappa)/2), r^2))
-	hyper.term.1 <- Re(hypergeo::genhypergeo(U=c(3/2, (n-1)/2, (n-1)/2), 
+	hyperTerm1 <- Re(hypergeo::genhypergeo(U=c(3/2, (n-1)/2, (n-1)/2), 
 											 L=c(1/2, (2+(n+2)*kappa)/(2*kappa)), z=r^2))
-	hyper.term.2 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=c((2+n*kappa)/(2*kappa)), z=r^2))
+	hyperTerm2 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=c((2+n*kappa)/(2*kappa)), z=r^2))
 	
-	result <- kappa/(n*kappa+2)*hyper.term.1/hyper.term.2
+	result <- kappa/(n*kappa+2)*hyperTerm1/hyperTerm2
 	
 	if (is.na(result) || result <= 0){
 		return(NA)
@@ -1740,18 +1965,18 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	# Posterior mean of the .bf10Exact
 	#	That is, (rho+1)/2, thus, on 0,1 scale to estimate a, b in a beta distribution
 	#
-	# TODO: add safeguard for large n as then hyper.term.1/hyper.term.2 is almost 1
-	# 	and also for log.term almost being 1
+	# TODO: add safeguard for large n as then hyperTerm1/hyperTerm2 is almost 1
+	# 	and also for logTerm almost being 1
 	#
 	# 	.posteriorVariance(199, 0.8) yields 6808.702
 	# 	
 	#
-	#hyper.term.3 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n+1)/2),L=(n+2/kappa)/2, z=r^2))
-	#hyper.term.4 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=(n+2/kappa)/2, z=r^2))
+	#hyperTerm3 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n+1)/2),L=(n+2/kappa)/2, z=r^2))
+	#hyperTerm4 <- Re(hypergeo::genhypergeo(U=c((n-1)/2, (n-1)/2), L=(n+2/kappa)/2, z=r^2))
 	# result.0 <- 1/((r+2/kappa*r)^2)*(
 	#(n-1)*(n+2/kappa-1)-
 	#	(2/kappa+1)*(n-2)*r^2+
-	#	(n-1)*(n+2/kappa-1)*(r^2-1)*hyper.term.3/hyper.term.4)
+	#	(n-1)*(n+2/kappa-1)*(r^2-1)*hyperTerm3/hyperTerm4)
 	#result <- .posteriorSecondMoment(n,r,kappa)-(.posteriorMean(n,r,kappa))^2
 	
 	result <- .posteriorSecondMoment(n,r,kappa)-(.posteriorMean(n,r,kappa))^2
@@ -1774,8 +1999,8 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 }
 
 .posteriorBetaParameters <- function(n, r, kappa=1){
-	some.mu <- try((.posteriorMean(n, r, kappa)+1)/2)
-	some.var <- try(.posteriorVariance(n, r, kappa)/2^2)
+	some.mu <- try((.posteriorMean(n=n, r=r, kappa)+1)/2)
+	some.var <- try(.posteriorVariance(n=n, r=r, kappa)/2^2)
 	
 	if (is(some.mu, "try-error") || is(some.var, "try-error") || is.na(some.mu) || is.na(some.var)){
 		# TODO: Before doing this try the MH sampler
@@ -1785,7 +2010,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	}
 }
 # 
-# .posteriorAParameter <- function(n, r, alpha=1){
+# .posteriorAParameter <- function(n=n, r=r, alpha=1){
 # 	# Method of moments estimate for a beta distribution
 # 	# First scale back to means on the (0, 1) domain
 # 	
@@ -1794,11 +2019,11 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 # 	return(myA)
 # }
 # 
-# .posteriorBParameter <- function(n, r, alpha=1){
+# .posteriorBParameter <- function(n=n, r=r, alpha=1){
 # 	# Method of moments estimate for a beta distribution
 # 	# First scale back to means on the (0, 1) domain
-# 	some.mu <- (.posteriorMean(n, r, alpha)+1)/2
-# 	some.var <- .posteriorVariance(n, r, alpha)/2^2
+# 	some.mu <- (.posteriorMean(n=n, r=r, alpha)+1)/2
+# 	some.var <- .posteriorVariance(n=n, r=r, alpha)/2^2
 # 	
 # 	myB <- (1-some.mu)*(some.mu*(1-some.mu)/some.var-1)
 # 	return(myB)
@@ -1861,9 +2086,9 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 #}
 # 
 # 
-# .rhoQuantile <- function(n, r, kappa=1, ciPercentage=.95){
+# .rhoQuantile <- function(n=n, r=r, kappa=1, ciPercentage=.95){
 # 	# Fitting parameters
-# 	beta.fit <- try(.posteriorBetaParameters(n, r, kappa))
+# 	beta.fit <- try(.posteriorBetaParameters(n=n, r=r, kappa))
 # 	
 # 	if (is(beta.fit, "try-error") || is.na(beta.fit$alpha) || is.na(beta.fit$beta)) {
 # 		return(c(NA, r, NA))

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -1320,8 +1320,8 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
     #	methodNumber=2: semi-exact result, based on approximation of the likelihood JeffreysExact, see Wagenmakers et al (2015) bathing
     #	methodNumber=3: Savage Dickey beta approximation 
     #	methodNumber=4: Marsman's IMH sampler and report a posterior beta fit summarised by betaA, betaB
-    # methodNumber=5: Jeffreys asymptotic approximation of the BF 
-    # methodNumber=6: invalid data, or point prior
+    #   methodNumber=5: Jeffreys asymptotic approximation of the BF 
+    #   methodNumber=6: invalid data, or point prior
     #   
     #   hyperGeoOverFlowThreshold=25 implies that if log(bf10) > 24 that we use Savage-Dickey adaptation
     #   for the one-sided bfs. 
@@ -1359,7 +1359,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
     
     # Note: If log(bf10) then use beta fit for the one sided bfs
     # The 24 is based on n=30, r=-0.3500786
-    hyperGeoOverFlowThreshold <- 24
+    # hyperGeoOverFlowThreshold <- 24
     
     # Note: Data check
     #
@@ -1514,7 +1514,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
     return(result)
 }
 
-.bfPearsonCorrelation <- function(n, r, kappa=1, ciValue=0.95){
+.bfPearsonCorrelation <- function(n, r, kappa=1, ciValue=0.95, hyperGeoOverFlowThreshold=24){
     # Wrapper around .bfCorrieKernel
     #
     result <- list(bf10=NA, bfPlus0=NA, bfMin0=NA)
@@ -1529,7 +1529,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
         # 3. Savage-Dickey beta approximation
         # 4. Marsman sampler
         
-        result <- .bfCorrieKernel(n=n, r=r, kappa=kappa, method=methodNumber, ciValue=ciValue)
+        result <- .bfCorrieKernel(n=n, r=r, kappa=kappa, method=methodNumber, ciValue=ciValue, hyperGeoOverFlowThreshold=hyperGeoOverFlowThreshold)
         #}
         methodNumber <- methodNumber+1
     }
@@ -1542,7 +1542,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
         result <- .bfCorrieKernel(n=n, r=r, kappa=kappa, method="jeffreysApprox")
     }
     
-    result$call <- paste0(".bfPearsonCorrelation(n=", n, ", r=", r, ", kappa=", kappa, ", ciValue=", ciValue, ")")
+    result$call <- paste0(".bfPearsonCorrelation(n=", n, ", r=", r, ", kappa=", kappa, ", ciValue=", ciValue, ", hyperGeoOverFlowThreshold=", hyperGeoOverFlowThreshold, ")")
     return(result)
 }
 

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -168,11 +168,13 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	    "van Doorn, J.B., Ly, A., Marsman, M. & Wagenmakers, E.-J. (2016). Bayesian Inference for Kendall’s Rank Correlation Coefficient. Manuscript submitted for publication."
 	  )}
 	
+	numberOfVariables <- length(variables)
+	
 	if (perform == "init") {
-		if (length(variables) < 2)
+		if (numberOfVariables < 2)
 			variables <- c(variables, "...")
-		if (length(variables) < 2)
-			variables <- c(variables, "... ")
+		# if (numberOfVariables < 2)
+		# 	variables <- c(variables, "... ")
 	}
 	if (hypothesis == "correlated") {
 		if (bayesFactorType=="BF10"){
@@ -243,9 +245,6 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 		}
 	}
 	
-	# Note: Go over each variable
-	v.c <- length(variables)
-	
 	# State:
 	#
 	if (!is.null(state)){
@@ -289,7 +288,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	
 	priorLabel <- as.character(round(priorWidth, 5))
 	
-	if (v.c > 0) {
+	if (numberOfVariables > 0) {
 		# Note: There are variables: 
 		testNames <- list(pearson="Pearson's r", spearman="Spearman's rho", kendall="Kendall's tau")
 		columnNames <- c()
@@ -321,7 +320,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 			}
 		}
 		
-		for (i in 1:v.c) {
+		for (i in 1:numberOfVariables) {
 			# Note: Create row given a column
 			row <- list()
 			rowFootnotes <- list()
@@ -349,7 +348,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 				row[[length(row)+1]] <- "\u2014" # em-dash # Note: Fill in blanks
 				bayesFactorsList[[length(bayesFactorsList)+1]] <- "\u2014"
 				
-				for (j in .seqx(i+1, v.c)) {
+				for (j in .seqx(i+1, numberOfVariables)) {
 					# Note: fill in blanks in table upper left-hand off diaganols
 					variable2Name <- variables[[j]]
 					columnName <- paste(variable2Name, "[", test, "]", sep="")


### PR DESCRIPTION
Added:
- isTryError in common
- .bfPearsonCorrelation, a wrapper around .bfCorrieKernel that loops
over the methods automatically
- Rewrote .bfCorrieKernel. The method numbers in .bfCorrieKernel now refer to 1. exact likelihood, 2. jeffreysApprox likelihood, 3. Savage-Dickey beta approximation to the likelihood, 4. Marsman sampler, 5. Jeffreys asymptotic approximation, 6. Error. Thus, numerical is swapped for Savage-Dickey beta approximation
- .bfHypergeo is a wrapper for method 1 and 2. Automatically switches
from hypergeometric result to numerical integration whenever the
two-sided bf10 > 10^(hyperGeoOverFlowThreshold)
- Added .bfCorrieRepJosine, which is not activated in the UI.
.bfCorrieRepJosine takes on the role of .bfCorrieKernel for replication
(summary stats) data.

Changed (mostly style changes):
- camelCases: Changed variable.names to variableNames to adhere to the
style guide
- all.bfs to bfObject
- some.r to obsR
- .jeffreysApproxH function to . hJeffreysApprox
- changed return(NaN) to return(NA) in .bf10Exact - though I had some
semantical reasons to use NAN instead NA, but this can be solved by
identifying NULL to not calculated yet
- changed function call by name rather than position
- added name spaces to some functions calls, such
- removed base name space for is.infinite

Removed:
- Removed .bf10Numerical, it isn’t used anyways, but hard coded in