### PR TITLE
Generate log file on Windows

### DIFF
--- a/JASP-Desktop/enginesync.cpp
+++ b/JASP-Desktop/enginesync.cpp
@@ -414,8 +414,10 @@ void EngineSync::startSlaveProcess(int no)
 #endif
 
 	QProcess *slave = new QProcess(this);
+	slave->setProcessChannelMode(QProcess::ForwardedChannels);
 	slave->setProcessEnvironment(env);
 	slave->start(engineExe, args);
+
 
 	_slaveProcesses.push_back(slave);
 


### PR DESCRIPTION
Enable generating log on windows by starting JASP from the command line by typing  <installdir>\JASP.exe > c:\temp\JASP.log