### PR TITLE
Crash when open a JASP file after closing another one

### DIFF
--- a/JASP-Desktop/analyses.cpp
+++ b/JASP-Desktop/analyses.cpp
@@ -79,10 +79,10 @@ void Analyses::clear()
 	for (Analyses::iterator itr = this->begin(); itr != this->end(); itr++)
 	{
 		Analysis *analysis = *itr;
-		if (analysis != NULL && analysis->status() != Analysis::Complete)
-			analysis->setStatus(Analysis::Aborted);
+		delete analysis;
 	}
 
+	_analyses.clear();
 	_defaults.clear();
 }
 

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -424,6 +424,8 @@ void MainWindow::refreshAnalysesUsingColumns(vector<string> &changedColumns
 	for (Analyses::iterator analysis_it = _analyses->begin(); analysis_it != _analyses->end(); ++analysis_it)
 	{
 		Analysis* analysis = *analysis_it;
+		if (analysis == NULL) continue;
+
 		bool analyse_to_refresh = false;
 		const vector<OptionVariables *> &analysis_variables = analysis->getVariables();
 		for (vector<OptionVariables *>::const_iterator var_it = analysis_variables.begin();


### PR DESCRIPTION
When closing, the analyses must be internally deleted.