### PR TITLE
t-test fix

### DIFF
--- a/JASP-Engine/JASP/R/commonerrorcheck.R
+++ b/JASP-Engine/JASP/R/commonerrorcheck.R
@@ -354,7 +354,12 @@
     
   } else {
     
-    result <- plyr::ddply(dataset, .v(grouping), function(data, target) func(data[[.v(target)]]), target)
+    result <- plyr::ddply(dataset, .v(grouping), 
+      function(data, target) {
+        if (any(is.na(data[.v(grouping)])) == FALSE) {
+          func(data[[.v(target)]])
+        }
+      },  target)
     result <- result[[ncol(result)]] # The last column holds the func results.
     
   }

--- a/JASP-Engine/JASP/R/ttestindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestindependentsamples.R
@@ -204,7 +204,7 @@ TTestIndependentSamples <- function(dataset = NULL, options, perform = "run",
 			
 			errors <- .hasErrors(dataset, perform, message = 'short', type = c('observations', 'variance', 'infinity'),
 													all.target = variable, all.grouping = options$groupingVariable,
-													observations.amount = '< 1')
+													observations.amount = '< 2')
 
 			variableData <- dataset[[ .v(variable) ]]
 


### PR DESCRIPTION
- If a factor has a NA level which only has NA values in the dependent var, the analysis would not be performed. This fix solves issue #1702

- Changed the minimum amount of samples per group to 2 (otherwise the sample variance is undefined).