### PR TITLE
Bugfix Contingency Tables

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -679,6 +679,9 @@ callback <- function(results=NULL) {
 	if (is.null(value))
 		return ("")
 
+	if (is.character(value))
+		return(value)
+
 	if (is.finite(value))
 		return(value)
 

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -1232,7 +1232,7 @@ ContingencyTables <- function(dataset=NULL, options, perform="run", callback=fun
 
 					chi.result <- vcd::oddsratio(counts.matrix)
 					CI <- stats::confint(chi.result, level = options$oddsRatioConfidenceIntervalInterval)
-					LogOR <- chi.result
+					LogOR <- unname(chi.result$coefficients)
 					log.CI.low <- CI[1]
 					log.CI.high <- CI[2]
 				})


### PR DESCRIPTION
The latest version of the VCD package appears to return a different value for its oddsratio() function.

Also made .clean() compatible with character values.