### PR TITLE
Bugfix printing eps

### DIFF
--- a/JASP-Engine/JASP/R/summarystatsttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianpairedsamples.R
@@ -34,7 +34,7 @@ SummaryStatsTTestBayesianPairedSamples <- function(dataset = NULL, options, perf
 							)
 	bf.title <- bftype$bftitle
 	BFH1H0 <- bftype$BFH1H0
-	print(state)
+	
 	hypothesis.variables <- .hypothesisType.summarystats.ttest.paired(options$hypothesis)
 	oneSided <- hypothesis.variables$oneSided
 


### PR DESCRIPTION
JASP crashes if you print the state that contains an image (I will try to
find out what’s wrong exactly)