### PR TITLE
Prevent figures from being added to an empty state

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -1021,7 +1021,7 @@ saveImage <- function(plotName, format, height, width){
 .imgToState <- function(imgobj) {
 
 	result <- list()
-	if (!is.list(imgobj))
+	if (!is.list(imgobj) || is.null(names(imgobj)))
 		return(NULL)
 
 	if (all(c("data", "obj") %in% names(imgobj), is.character(imgobj[["data"]]))) {

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -1021,6 +1021,8 @@ saveImage <- function(plotName, format, height, width){
 .imgToState <- function(imgobj) {
 
 	result <- list()
+	
+	# if the state is empty, prevent that a figure entry is added
 	if (!is.list(imgobj) || is.null(names(imgobj)))
 		return(NULL)
 


### PR DESCRIPTION
This fixes the crashing problem of the Bayesian Independent Samples T-Test. 
I closed PR #1772 as this is a more permanent fix.