### PR TITLE
 Corrected file extension when writing to OSF and read jasp files  without analyses

### DIFF
--- a/JASP-Desktop/backstage/backstageosf.cpp
+++ b/JASP-Desktop/backstage/backstageosf.cpp
@@ -142,11 +142,19 @@ BackstageOSF::BackstageOSF(QWidget *parent) : BackstagePage(parent)
 	aboutLayout->addWidget(aboutOSF);
 	aboutLayout->addWidget(registerOSF);
 	aboutLayout->addStretch(1);
+	
+	_currentFileName = "";
 }
 
 void BackstageOSF::attemptToConnect()
 {
 	_model->attemptToConnect();
+}
+
+void BackstageOSF::setCurrentFileName(QString currentFileName)
+{
+	_currentFileName = currentFileName;
+	_fileNameTextBox->setText(_currentFileName);
 }
 
 void BackstageOSF::updateUserDetails()

--- a/JASP-Desktop/backstage/backstageosf.h
+++ b/JASP-Desktop/backstage/backstageosf.h
@@ -38,6 +38,7 @@ public:
 
 	void setOnlineDataManager(OnlineDataManager *odm);
 	void attemptToConnect();
+	void setCurrentFileName(QString currentFileName);
 
 	void setMode(FileEvent::FileMode mode) OVERRIDE;
 
@@ -75,6 +76,7 @@ private:
 	QLineEdit *_fileNameTextBox;
 	QPushButton *_saveButton;
 	QToolButton *_newFolderButton;
+	QString _currentFileName;
 
 	QSettings _settings;
 

--- a/JASP-Desktop/backstage/opensavewidget.cpp
+++ b/JASP-Desktop/backstage/opensavewidget.cpp
@@ -37,22 +37,6 @@ OpenSaveWidget::OpenSaveWidget(QWidget *parent) : QWidget(parent)
 	_tabWidget->setMaximumWidth(800);
 
 	QWidget *webWidget = new QWidget(this);
-	/*QGridLayout *webWidgetLayout = new QGridLayout(webWidget);
-	webWidgetLayout->setMargin(36);
-
-	QFrame *webFrame = new QFrame(webWidget);
-	QGridLayout *webLayout = new QGridLayout(webFrame);
-	webFrame->setLayout(webLayout);
-	webLayout->setMargin(0);
-	webFrame->setFrameShape(QFrame::Box);
-	webFrame->setFrameStyle(QFrame::Panel);
-	webFrame->setLineWidth(1);
-	webFrame->setMinimumWidth(200);
-
-	QWebView *webView = new QWebView(webFrame);
-	webLayout->addWidget(webView);
-
-	webWidgetLayout->addWidget(webFrame);*/
 
 	layout->addWidget(_tabWidget, 0, 0);
 	layout->addWidget(webWidget, 0, 1);
@@ -70,7 +54,6 @@ OpenSaveWidget::OpenSaveWidget(QWidget *parent) : QWidget(parent)
 	_bsComputer = new BackstageComputer(_tabWidget);
 
 	_bsOSF = new BackstageOSF(_tabWidget);
-
 
 	_bsExamples = new FSBrowser(_tabWidget);
 	_bsExamples->setFSModel(_fsmExamples);
@@ -123,6 +106,7 @@ void OpenSaveWidget::tabWidgetChanged(int index)
 	//Check the OSF tab
 	if (index == FileLocation::OSF)
 		_bsOSF->attemptToConnect();
+
 }
 
 VerticalTabWidget *OpenSaveWidget::tabWidget()
@@ -144,6 +128,7 @@ void OpenSaveWidget::setSaveMode(FileEvent::FileMode mode)
 	_bsComputer->setMode(_mode);
 
 	_bsOSF->setMode(_mode);
+	_bsOSF->setCurrentFileName(getDefaultOutFileName());
 
 
 	if (_mode == FileEvent::FileOpen)
@@ -389,6 +374,41 @@ void OpenSaveWidget::setDataFileWatcher(bool watch)
 Utils::FileType OpenSaveWidget::getCurrentFileType()
 {
 	return _currentFileType;
+}
+
+QString OpenSaveWidget::getCurrentFilePath()
+{
+	return _currentFilePath;
+}
+
+QString OpenSaveWidget::getDefaultOutFileName()
+{
+	QString path = getCurrentFilePath();
+	QString DefaultOutFileName="";
+	
+	if (path != "")
+	{
+		QString name =  QFileInfo(path).baseName();
+		QString ext = QFileInfo(path).suffix();
+		switch (_mode)
+		{
+			case FileEvent::FileSave:
+				ext="jasp";
+				break;
+			case FileEvent::FileExportResults:
+				ext="html";
+				break;
+			case FileEvent::FileExportData:
+				ext = "csv";
+				break;
+			default:
+				break;
+		}
+		DefaultOutFileName = name + "." + ext;
+	}
+
+	return DefaultOutFileName;
+			
 }
 
 void OpenSaveWidget::dataSetOpenCurrentRequestHandler(QString path)

--- a/JASP-Desktop/backstage/opensavewidget.h
+++ b/JASP-Desktop/backstage/opensavewidget.h
@@ -59,6 +59,8 @@ public:
 	void setDataFileWatcher(bool watch);
 
 	Utils::FileType getCurrentFileType();
+	QString getCurrentFilePath();
+	QString getDefaultOutFileName();
 
 public slots:
 	void dataSetIOCompleted(FileEvent *event);


### PR DESCRIPTION
When files are saved to the OSF the file extension in the OSF file
input window was not updated to .jasp. This has been fixed.
It is now also possible to read a data file and save it directly to a
jasp file and read the jasp file back with errors.