### PR TITLE
Fixed bug in Bayesian Contingency Tables

### DIFF
--- a/JASP-Engine/JASP/R/contingencytablesbayesian.R
+++ b/JASP-Engine/JASP/R/contingencytablesbayesian.R
@@ -539,7 +539,7 @@ ContingencyTablesBayesian <- function(dataset, options, perform, callback, ...) 
 		odds.ratio.plot[["convertible"]] <- TRUE
 		odds.ratio.plot[["status"]] <- "complete"
 		
-		new.plot.state <- list(keep=plot)
+		new.plot.state <- list(keep=plot[["png"]])
 		
 		complete <- TRUE
 	


### PR DESCRIPTION
This solves the disappearing plot and the unnecessary dumping of the state.
Issue #1756 