### PR TITLE
Add exact p-value option

### DIFF
--- a/JASP-Desktop/html/js/analyses.js
+++ b/JASP-Desktop/html/js/analyses.js
@@ -97,6 +97,10 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 	getAnalysis: function(id) {
 		return _.find(this.analyses, function (cv) { return cv.model.get("id") === id; });
 	},
+	
+	reRender: function() {
+		this.analyses.forEach(function(analysis) {analysis.render();});
+	},
 
 	getAllUserData: function () {
 		var notes = [];

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -8,11 +8,17 @@ window.getPPI = function () {
 
 
 
+
 $(document).ready(function () {
 	var ua = navigator.userAgent.toLowerCase();
 
 	if (ua.indexOf("windows") !== -1)
 		$("body").addClass("windows")
+
+	// Global settings for analysis output. Add here if making new setting.
+	window.globSet = {
+		"pExact" : false
+	}
 
 	var selectedAnalysisId = -1;
 	var selectedAnalysis = null
@@ -26,6 +32,10 @@ $(document).ready(function () {
 	var showInstructions = false;
 	
 	var analyses = new JASPWidgets.Analyses({ className: "jasp-report" });
+	
+	window.reRenderAnalyses = function () {
+		analyses.reRender();
+	}
 
 	window.select = function (id) {
 

--- a/JASP-Desktop/html/js/table.js
+++ b/JASP-Desktop/html/js/table.js
@@ -225,8 +225,15 @@ JASPWidgets.tablePrimative = JASPWidgets.View.extend({
 
 			var f = formats[i]
 
-			if (f.indexOf("p:") != -1)
-				p = f.substring(2)
+			if (f.indexOf("p:") != -1) {
+				// override APA style if exact p-values wanted
+				if (window.globSet.pExact){
+					sf = 4;
+				} else {
+					p = f.substring(2);
+				}
+			}
+				
 
 			if (f.indexOf("dp:") != -1)
 				dp = f.substring(3)

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -232,6 +232,7 @@ MainWindow::MainWindow(QWidget *parent) :
 	connect(this, SIGNAL(updateUserData(int, QString)), this, SLOT(updateUserDataHandler(int, QString)));
 	connect(this, SIGNAL(simulatedMouseClick(int, int, int)), this, SLOT(simulatedMouseClickHandler(int, int, int)));
 	connect(this, SIGNAL(resultsDocumentChanged()), this, SLOT(resultsDocumentChangedHandler()));
+	connect(ui->tabBar, SIGNAL(setExactPValuesHandler(bool)), this, SLOT(setExactPValuesHandler(bool)));
 
 #ifdef __APPLE__
 	_scrollbarWidth = 3;
@@ -1262,6 +1263,8 @@ void MainWindow::resultsPageLoaded(bool success)
 		QString version = tq(AppInfo::version.asString());
 		ui->webViewResults->page()->mainFrame()->evaluateJavaScript("window.setAppVersion('" + version + "')");
 
+		setExactPValuesHandler(_settings.value("exactPVals", 1).toBool());
+
 		QVariant ppiv = ui->webViewResults->page()->mainFrame()->evaluateJavaScript("window.getPPI()");
 
 		bool success;
@@ -1343,6 +1346,13 @@ void MainWindow::requestHelpPage(const QString &pageName)
 	QString js = "window.render(\"" + content + "\")";
 
 	ui->webViewHelp->page()->mainFrame()->evaluateJavaScript(js);
+}
+
+void MainWindow::setExactPValuesHandler(bool exactPValues)
+{
+	QString exactPValueString = (exactPValues ? "true" : "false");
+	QString js = "window.globSet.pExact = " + exactPValueString + "; window.reRenderAnalyses();";
+	ui->webViewResults->page()->mainFrame()->evaluateJavaScript(js);
 }
 
 void MainWindow::itemSelected(const QString &item)

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -1263,7 +1263,7 @@ void MainWindow::resultsPageLoaded(bool success)
 		QString version = tq(AppInfo::version.asString());
 		ui->webViewResults->page()->mainFrame()->evaluateJavaScript("window.setAppVersion('" + version + "')");
 
-		setExactPValuesHandler(_settings.value("exactPVals", 1).toBool());
+		setExactPValuesHandler(_settings.value("exactPVals", 0).toBool());
 
 		QVariant ppiv = ui->webViewResults->page()->mainFrame()->evaluateJavaScript("window.getPPI()");
 

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -209,6 +209,8 @@ private slots:
 	void helpFirstLoaded(bool ok);
 	void requestHelpPage(const QString &pageName);
 
+	void setExactPValuesHandler(bool exactPValues);
+
 };
 
 #endif // MAINWIDGET_H

--- a/JASP-Desktop/preferencesdialog.cpp
+++ b/JASP-Desktop/preferencesdialog.cpp
@@ -10,7 +10,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
 
 
 	//Exact p-value
-	int check_exact_pval = _settings.value("exactPVals", 1).toInt();
+	int check_exact_pval = _settings.value("exactPVals", 0).toInt();
 	ui->displayExactPVals->setChecked(check_exact_pval > 0);
 
 	//Auto Sync

--- a/JASP-Desktop/preferencesdialog.cpp
+++ b/JASP-Desktop/preferencesdialog.cpp
@@ -8,10 +8,15 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
 	ui->setupUi(this);
 	_tabBar = dynamic_cast<TabBar *>(parent);
 
+
+	//Exact p-value
+	int check_exact_pval = _settings.value("exactPVals", 1).toInt();
+	ui->displayExactPVals->setChecked(check_exact_pval > 0);
+
 	//Auto Sync
 	int check_data_sync = _settings.value("dataAutoSynchronization", 1).toInt();
 	ui->syncAutoCheckBox->setChecked(check_data_sync > 0);
-	
+
 	//Default Editor
 	int check_default_editor = _settings.value("useDefaultSpreadsheetEditor", 1).toInt();
 	bool defaulteditor = check_default_editor > 0;
@@ -50,10 +55,16 @@ void PreferencesDialog::savePreferences()
 	//Use Default Editor Switch
 	checked = (ui->useDefaultSpreadsheetEditor->checkState()==Qt::Checked) ? 1 : 0;
 	_settings.setValue("useDefaultSpreadsheetEditor", checked);
-	
+
 	_settings.setValue("spreadsheetEditorName", ui->spreadsheetEditorName->text());
 			
+	//Exact p values
+	checked = (ui->displayExactPVals->checkState()==Qt::Checked) ? 1 : 0;
+	_settings.setValue("exactPVals", checked);
+	_tabBar->setExactPValues(checked);
+
 	_settings.sync();
+
 	this->close();
 	
 }

--- a/JASP-Desktop/preferencesdialog.h
+++ b/JASP-Desktop/preferencesdialog.h
@@ -18,6 +18,7 @@ public:
 	explicit PreferencesDialog(QWidget *parent = 0);
 	~PreferencesDialog();
 
+
 private:
 	Ui::PreferencesDialog *ui;
 	QSettings _settings;

--- a/JASP-Desktop/preferencesdialog.ui
+++ b/JASP-Desktop/preferencesdialog.ui
@@ -17,11 +17,18 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Data Synchronization Preferences</string>
+   <string>Preferences</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QCheckBox" name="displayExactPVals">
+       <property name="text">
+        <string>Display exact p-values</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QCheckBox" name="syncAutoCheckBox">
        <property name="layoutDirection">

--- a/JASP-Desktop/widgets/tabbar.cpp
+++ b/JASP-Desktop/widgets/tabbar.cpp
@@ -250,6 +250,11 @@ void TabBar::setCurrentIndex(int index)
 	emit currentChanged(index);
 }
 
+void TabBar::setExactPValues(bool exactPValues)
+{
+	emit setExactPValuesHandler(exactPValues);
+}
+
 void TabBar::tabSelectedHandler()
 {
 	QObject *source = this->sender();

--- a/JASP-Desktop/widgets/tabbar.h
+++ b/JASP-Desktop/widgets/tabbar.h
@@ -40,6 +40,7 @@ public:
 	void removeTab(QString tabName);
 	void removeTab(int index);
 	QString getCurrentActiveTab();
+	void setExactPValues(bool exactPValues);
 
 	void addOptionsTab();
 	void addHelpTab();
@@ -51,6 +52,7 @@ signals:
 	void currentChanged(int index);
 	void helpToggled(bool on);
 	void dataAutoSynchronizationChanged(bool on);
+	void setExactPValuesHandler(bool exactPValues);
 
 public slots:
 	void setCurrentIndex(int index);


### PR DESCRIPTION
Added an exact p-value global preferences option. This option is persistent across sessions. Exact p-values are displayed with scientific notation in the form 1.234e-56. This fixes issue #1184. 

