### PR TITLE
Inclusion probabilities for matched models

### DIFF
--- a/JASP-Desktop/analysisforms/ancovabayesianform.cpp
+++ b/JASP-Desktop/analysisforms/ancovabayesianform.cpp
@@ -101,14 +101,6 @@ AncovaBayesianForm::AncovaBayesianForm(QWidget *parent) :
 	ui->priorFixedEffects->setLabel("r scale fixed effects");
 	ui->priorRandomEffects->setLabel("r scale random effects");
 	ui->priorCovariates->setLabel("r scale covariates");
-
-#ifdef QT_DEBUG
-	ui->widgetPosteriorOptions->setStyleSheet("QWidget { background-color: pink; }");
-	ui->posteriorEstimates->setStyleSheet("QWidget { background-color: pink; }");
-#else
-	ui->widgetPosteriorOptions->hide();
-	ui->posteriorEstimates->hide();
-#endif
 }
 
 AncovaBayesianForm::~AncovaBayesianForm()

--- a/JASP-Desktop/analysisforms/ancovabayesianform.ui
+++ b/JASP-Desktop/analysisforms/ancovabayesianform.ui
@@ -1129,151 +1129,6 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="0" column="1">
-       <widget class="QWidget" name="widget_3" native="true">
-        <layout class="QGridLayout" name="gridLayout_21">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="GroupBox" name="groupBox_4">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Output</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_17">
-            <item row="3" column="0" colspan="3">
-             <widget class="QWidget" name="widgetPosteriorOptions" native="true">
-              <layout class="QGridLayout" name="gridLayout_19">
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <property name="verticalSpacing">
-                <number>3</number>
-               </property>
-               <item row="0" column="2">
-                <widget class="QLabel" name="label_12">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>%</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="BoundTextBox" name="posteriorEstimatesCredibleIntervalInterval">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>60</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>60</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_14">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Credible interval</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="0" column="0" colspan="2">
-             <widget class="BoundCheckBox" name="effects">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Effects</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="BoundCheckBox" name="descriptives">
-              <property name="text">
-               <string>Descriptives</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0" colspan="2">
-             <widget class="BoundCheckBox" name="posteriorEstimates">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Posterior estimates</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <spacer name="verticalSpacer_8">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>5</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
       <item row="0" column="0" rowspan="2">
        <widget class="QWidget" name="widget_2" native="true">
         <layout class="QGridLayout" name="gridLayout_20">
@@ -1292,7 +1147,7 @@
          <item row="1" column="0">
           <widget class="BoundGroupBox" name="bayesFactorOrder">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -1340,25 +1195,12 @@
            </property>
            <layout class="QGridLayout" name="gridLayout_13">
             <property name="leftMargin">
-             <number>13</number>
+             <number>12</number>
             </property>
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="_1">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>BF₁₀</string>
-              </property>
-             </widget>
-            </item>
             <item row="1" column="0">
              <widget class="QRadioButton" name="_2">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
@@ -1371,7 +1213,7 @@
             <item row="2" column="0">
              <widget class="QRadioButton" name="_3">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
@@ -1381,20 +1223,142 @@
               </property>
              </widget>
             </item>
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="_1">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>BF₁₀</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QWidget" name="widget_3" native="true">
+        <layout class="QGridLayout" name="gridLayout_8">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="GroupBox" name="groupBox_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Output</string>
+           </property>
+           <layout class="QFormLayout" name="formLayout">
+            <property name="verticalSpacing">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>12</number>
+            </property>
+            <item row="0" column="0" colspan="2">
+             <widget class="BoundCheckBox" name="effects">
+              <property name="text">
+               <string>Effects</string>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="1">
-             <spacer name="horizontalSpacer_4">
+             <widget class="BoundGroupBox" name="effectsType">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string/>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_12">
+               <property name="leftMargin">
+                <number>12</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>12</number>
+               </property>
+               <property name="bottomMargin">
+                <number>7</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>-1</number>
+               </property>
+               <item row="3" column="0">
+                <widget class="QRadioButton" name="excludeInteractions">
+                 <property name="text">
+                  <string>Across matched models</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QRadioButton" name="allModels">
+                 <property name="text">
+                  <string>Across all models</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="3" column="0" colspan="2">
+             <widget class="BoundCheckBox" name="descriptives">
+              <property name="text">
+               <string>Descriptives</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <spacer name="horizontalSpacer_5">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>40</width>
+                <width>225</width>
                 <height>20</height>
                </size>
               </property>
              </spacer>
             </item>
            </layout>
+           <zorder>effectsType</zorder>
+           <zorder>descriptives</zorder>
+           <zorder>effects</zorder>
           </widget>
          </item>
         </layout>
@@ -1475,6 +1439,22 @@
     <hint type="destinationlabel">
      <x>506</x>
      <y>1111</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>effects</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>effectsType</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>327</x>
+     <y>596</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>320</x>
+     <y>630</y>
     </hint>
    </hints>
   </connection>

--- a/JASP-Desktop/analysisforms/anovabayesianform.ui
+++ b/JASP-Desktop/analysisforms/anovabayesianform.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>615</width>
-    <height>1415</height>
+    <width>655</width>
+    <height>1424</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -985,7 +991,7 @@
        <number>0</number>
       </property>
       <property name="topMargin">
-       <number>9</number>
+       <number>12</number>
       </property>
       <property name="rightMargin">
        <number>0</number>
@@ -1010,38 +1016,107 @@
          </property>
          <item row="0" column="0">
           <widget class="GroupBox" name="groupBox_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="title">
             <string>Output</string>
            </property>
-           <layout class="QGridLayout" name="gridLayout_8">
-            <item row="2" column="0">
-             <spacer name="verticalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>10</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="0">
-             <widget class="BoundCheckBox" name="descriptives">
-              <property name="text">
-               <string>Descriptives</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
+           <layout class="QFormLayout" name="formLayout">
+            <property name="verticalSpacing">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>12</number>
+            </property>
+            <item row="0" column="0" colspan="2">
              <widget class="BoundCheckBox" name="effects">
               <property name="text">
                <string>Effects</string>
               </property>
              </widget>
             </item>
+            <item row="1" column="1">
+             <widget class="BoundGroupBox" name="effectsType">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string/>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_10">
+               <property name="leftMargin">
+                <number>12</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>12</number>
+               </property>
+               <property name="bottomMargin">
+                <number>7</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>-1</number>
+               </property>
+               <item row="3" column="0">
+                <widget class="QRadioButton" name="excludeInteractions">
+                 <property name="text">
+                  <string>Across matched models</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QRadioButton" name="allModels">
+                 <property name="text">
+                  <string>Across all models</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="3" column="0" colspan="2">
+             <widget class="BoundCheckBox" name="descriptives">
+              <property name="text">
+               <string>Descriptives</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>225</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
+           <zorder>effectsType</zorder>
+           <zorder>descriptives</zorder>
+           <zorder>effects</zorder>
+           <zorder>horizontalSpacer_4</zorder>
           </widget>
          </item>
         </layout>
@@ -1065,7 +1140,7 @@
          <item row="2" column="0">
           <widget class="BoundGroupBox" name="bayesFactorType">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -1077,6 +1152,13 @@
             <bool>false</bool>
            </property>
            <layout class="QGridLayout" name="gridLayout_13">
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="_1">
+              <property name="text">
+               <string>BF₁₀</string>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="0">
              <widget class="QRadioButton" name="_2">
               <property name="text">
@@ -1091,58 +1173,32 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="_1">
-              <property name="text">
-               <string>BF₁₀</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
            </layout>
           </widget>
          </item>
          <item row="3" column="0">
           <widget class="BoundGroupBox" name="bayesFactorOrder">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
            <property name="title">
             <string>Order</string>
            </property>
-           <layout class="QGridLayout" name="gridLayout_19">
-            <item row="1" column="0">
-             <widget class="QRadioButton" name="__4">
-              <property name="text">
-               <string>Compare to best model</string>
-              </property>
-             </widget>
-            </item>
+           <layout class="QGridLayout" name="gridLayout_8">
             <item row="0" column="0">
              <widget class="QRadioButton" name="__3">
               <property name="text">
                <string>Compare to null model</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QRadioButton" name="__4">
+              <property name="text">
+               <string>Compare to best model</string>
               </property>
              </widget>
             </item>
@@ -1227,6 +1283,22 @@
     <hint type="destinationlabel">
      <x>457</x>
      <y>948</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>effects</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>effectsType</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>339</x>
+     <y>490</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>339</x>
+     <y>529</y>
     </hint>
    </hints>
   </connection>

--- a/JASP-Desktop/analysisforms/anovarepeatedmeasuresbayesianform.ui
+++ b/JASP-Desktop/analysisforms/anovarepeatedmeasuresbayesianform.ui
@@ -117,25 +117,31 @@
       </property>
       <item row="0" column="1">
        <widget class="QWidget" name="widget_3" native="true">
-        <layout class="QGridLayout" name="gridLayout_17">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
          <item row="0" column="0">
           <widget class="GroupBox" name="groupBox_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="title">
             <string>Output</string>
            </property>
-           <layout class="QGridLayout" name="gridLayout_4">
+           <layout class="QFormLayout" name="formLayout">
+            <property name="verticalSpacing">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>12</number>
+            </property>
             <item row="0" column="0" colspan="2">
              <widget class="BoundCheckBox" name="effects">
               <property name="text">
@@ -143,27 +149,83 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
+            <item row="1" column="1">
+             <widget class="BoundGroupBox" name="effectsType">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string/>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_17">
+               <property name="leftMargin">
+                <number>12</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>12</number>
+               </property>
+               <property name="bottomMargin">
+                <number>7</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>-1</number>
+               </property>
+               <item row="3" column="0">
+                <widget class="QRadioButton" name="excludeInteractions">
+                 <property name="text">
+                  <string>Across matched models</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QRadioButton" name="allModels">
+                 <property name="text">
+                  <string>Across all models</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="3" column="0" colspan="2">
              <widget class="BoundCheckBox" name="descriptives">
               <property name="text">
                <string>Descriptives</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <spacer name="verticalSpacer">
+            <item row="4" column="1">
+             <spacer name="horizontalSpacer_5">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>20</width>
+                <width>225</width>
                 <height>20</height>
                </size>
               </property>
              </spacer>
             </item>
            </layout>
+           <zorder>effectsType</zorder>
+           <zorder>descriptives</zorder>
+           <zorder>effects</zorder>
           </widget>
          </item>
         </layout>
@@ -171,6 +233,12 @@
       </item>
       <item row="0" column="0">
        <widget class="QWidget" name="widget_2" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <layout class="QGridLayout" name="gridLayout_5">
          <property name="leftMargin">
           <number>0</number>
@@ -199,6 +267,13 @@
             <bool>false</bool>
            </property>
            <layout class="QGridLayout" name="gridLayout_13">
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="_1">
+              <property name="text">
+               <string>BF₁₀</string>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="0">
              <widget class="QRadioButton" name="_2">
               <property name="text">
@@ -212,26 +287,6 @@
                <string>Log(BF₁₀)</string>
               </property>
              </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="_1">
-              <property name="text">
-               <string>BF₁₀</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
             </item>
            </layout>
           </widget>
@@ -1407,6 +1462,22 @@
     <hint type="destinationlabel">
      <x>487</x>
      <y>1089</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>effects</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>effectsType</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>339</x>
+     <y>643</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>332</x>
+     <y>677</y>
     </hint>
    </hints>
   </connection>

--- a/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
+++ b/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
@@ -711,31 +711,14 @@
 		backward.title <- "BF<sub>Backward</sub>"
 	}
 
-	if (options$effectsStepwise) {
-		fields <-
-			list (
-				list (name = "Effects", type = "string"),
-				list (name = "P(incl)", type = "number", format = "sf:4;dp:3"),
-				list (name = "P(incl|data)", type = "number", format = "sf:4;dp:3"),
-				list (name = "BF<sub>Inclusion</sub>", type="number", format = "sf:4;dp:3", 
-					title = paste (inclusion.title, sep = "")),
-				list (name = "BF<sub>Backward</sub>", type="number", format = "sf:4;dp:3", 
-					title = paste (backward.title, sep = "")),
-				list (name = "% errorB", type = "number", format = "sf:4;dp:3"),
-				list (name = "BF<sub>Forward</sub>", type = "number", format = "sf:4;dp:3", 
-					title = paste (forward.title, sep = "")),
-				list (name = "% errorF", type = "number", format = "sf:4;dp:3")
-			)
-	} else{
-		fields <-
-			list (
-				list (name = "Effects", type = "string"),
-				list (name = "P(incl)", type = "number", format = "sf:4;dp:3"),
-				list (name = "P(incl|data)", type = "number", format = "sf:4;dp:3"),
-				list (name = "BF<sub>Inclusion</sub>", type = "number", format = "sf:4;dp:3", 
-					title = paste (inclusion.title, sep = ""))
-			)
-	}
+
+	fields <- list (
+			list (name = "Effects", type = "string"),
+			list (name = "P(incl)", type = "number", format = "sf:4;dp:3"),
+			list (name = "P(incl|data)", type = "number", format = "sf:4;dp:3"),
+			list (name = "BF<sub>Inclusion</sub>", type = "number", format = "sf:4;dp:3", 
+				title = paste (inclusion.title, sep = ""))
+		)
 
 	effectsTable [["schema"]] <- list (fields = fields)
 
@@ -779,62 +762,6 @@
 					row$"BF<sub>Inclusion</sub>" = .clean (log (bayes.factor.inclusion [e]))
 				} else {
 					row$"BF<sub>Inclusion</sub>" = .clean (bayes.factor.inclusion [e])
-				}
-
-				if (options$effectsStepwise && no.effects > 1) {
-					#Forward
-					include <- which (effects.matrix[, e] == TRUE)
-					forward <- include [which (model.complexity [include] == min (model.complexity [include]))]
-					if (model.complexity [forward] > 1){
-						effects.forward <- effects.matrix [forward, ]
-						effects.forward [e] <- FALSE
-						forward.effects <- sapply (1:no.models, function (m) {
-							(sum (effects.matrix [m, effects.forward == TRUE]) == sum (effects.forward))
-						})
-						exclude <- which (!effects.matrix[, e] & forward.effects)
-						comparison <- exclude [which (model.complexity [exclude] == min (model.complexity [exclude]))]
-						if (model.complexity [comparison] < model.complexity [forward]) {
-							bf.forward <- model$models [[forward]]$bf / model$models [[comparison]]$bf
-						} else {
-							bf.forward <- model$models [[forward]]$bf
-						}
-					} else {
-						bf.forward <- model$models [[forward]]$bf
-					}
-					#Backward
-					if (sum (effects.matrix [, e]) == 1 ) {
-						bf.bacward <- model$models [[which (effects.matrix [, e] == TRUE)]]$bf
-					} else {
-						no.interactions <- sapply (1:no.models, function (m) {
-							sum (effects.matrix [m, model$interactions.matrix[e, ] == TRUE]) == 0
-						})
-						include <- which ((effects.matrix [, e] == TRUE) & no.interactions)
-						backward <- include [which (model.complexity [include] == max (model.complexity [include]))]
-						if (model.complexity [backward] > 1) {
-							effects.backward <- effects.matrix [backward, ]
-							effects.backward [e] <- FALSE
-							backward.effects <- sapply (1:no.models, function (m) {
-								((sum (effects.matrix [m, effects.backward == TRUE]) == sum (effects.backward))
-								&&
-								(sum (effects.matrix[m, effects.backward == FALSE]) == 0))
-							})
-							exclude <- which (backward.effects)
-							comparison <- exclude [which (model.complexity [exclude] == max (model.complexity [exclude]))]
-							bf.backward <- model$models [[backward]]$bf / model$models [[comparison]]$bf
-						} else {
-							bf.backward <- model$models [[backward]]$bf
-						}
-					}
-					#Output
-					if (options$bayesFactorType == "LogBF10"){
-						row [["BF<sub>Forward</sub>"]] <- .clean (bf.forward@bayesFactor$bf)
-						row [["BF<sub>Backward</sub>"]] <- .clean (bf.backward@bayesFactor$bf)
-					} else {
-						row [["BF<sub>Forward</sub>"]] <- .clean (exp (bf.forward@bayesFactor$bf))
-						row [["BF<sub>Backward</sub>"]] <- .clean (exp (bf.backward@bayesFactor$bf))
-					}
-					row [["% errorF"]] <- .clean (100 * bf.forward@bayesFactor$error)
-					row [["% errorB"]] <- .clean (100 * bf.backward@bayesFactor$error)
 				}
 			}
 			rows [[length (rows) + 1]] <- row

--- a/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
+++ b/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
@@ -688,15 +688,15 @@
 	return (list (modelTable = modelTable, model = model))
 }
 
-.theBayesianLinearModelsEffects <- function (model = NULL, options = list (), perform = "init", status = list (), populate = TRUE) {
+.theBayesianLinearModelsEffects <- function(model = NULL, options = list(), perform = "init", status = list(), populate = TRUE) {
 
-	if ( ! options$effects)
+	if (! options$effects)
 		return (NULL)
 
-	effectsTable <- list ()
-	effectsTable [["title"]] <- "Analysis of Effects"
-	effectsTable [["citation"]] <-
-		list (
+	effectsTable <- list()
+	effectsTable[["title"]] <- "Analysis of Effects"
+	effectsTable[["citation"]] <-
+		list(
 			"Morey, R. D. & Rouder, J. N. (2015). BayesFactor (Version 0.9.10-2)[Computer software].",
 			"Rouder, J. N., Morey, R. D., Speckman, P. L., Province, J. M., (2012) Default Bayes Factors for ANOVA Designs. Journal of Mathematical Psychology. 56. p. 356-374."
 		)
@@ -712,71 +712,71 @@
 	}
 
 
-	fields <- list (
-			list (name = "Effects", type = "string"),
-			list (name = "P(incl)", type = "number", format = "sf:4;dp:3"),
-			list (name = "P(incl|data)", type = "number", format = "sf:4;dp:3"),
-			list (name = "BF<sub>Inclusion</sub>", type = "number", format = "sf:4;dp:3", 
-				title = paste (inclusion.title, sep = ""))
+	fields <- list(
+			list(name = "Effects", type = "string"),
+			list(name = "P(incl)", type = "number", format = "sf:4;dp:3"),
+			list(name = "P(incl|data)", type = "number", format = "sf:4;dp:3"),
+			list(name = "BF<sub>Inclusion</sub>", type = "number", format = "sf:4;dp:3", 
+				title = paste(inclusion.title, sep = ""))
 		)
 
-	effectsTable [["schema"]] <- list (fields = fields)
+	effectsTable[["schema"]] <- list(fields = fields)
 
 	if (! status$ready && ! status$error)
-		return (effectsTable)
+		return(effectsTable)
 
 	effects.matrix <- model$effects
 	if (perform == "run" && status$ready && !populate) {
-		prior.probabilities <- model$effects [, ncol (effects.matrix) - 1]
-		posterior.probabilities <- model$effects [, ncol (effects.matrix)]
-		effects.matrix <- matrix (model$effects [1:nrow (model$effects), 1:(ncol (model$effects) - 2)],
-			nrow = nrow (model$effects),
-			ncol = ncol (model$effects) - 2)
+		prior.probabilities <- model$effects[, ncol (effects.matrix) - 1]
+		posterior.probabilities <- model$effects[, ncol (effects.matrix)]
+		effects.matrix <- matrix(model$effects[1:nrow(model$effects), 1:(ncol(model$effects) - 2)],
+			nrow = nrow(model$effects),
+			ncol = ncol(model$effects) - 2)
 
-		effectNames <- colnames (effects.matrix) <- colnames (model$effects) [1:(ncol (model$effects) - 2)]
-		no.models <- nrow (effects.matrix)
-		no.effects <- ncol (effects.matrix)
+		effectNames <- colnames(effects.matrix) <- colnames(model$effects)[1:(ncol(model$effects) - 2)]
+		no.models <- nrow(effects.matrix)
+		no.effects <- ncol(effects.matrix)
 
-		dim (prior.probabilities) <- c (1, no.models)
-		dim (posterior.probabilities) <- c (1, no.models)
+		dim(prior.probabilities) <- c(1, no.models)
+		dim(posterior.probabilities) <- c(1, no.models)
 		prior.inclusion.probabilities <- prior.probabilities %*% effects.matrix
 		posterior.inclusion.probabilities <- posterior.probabilities %*% effects.matrix
 		posterior.inclusion.probabilities[posterior.inclusion.probabilities > 1] <- 1
 		posterior.inclusion.probabilities[posterior.inclusion.probabilities < 0] <- 0
 		bayes.factor.inclusion <- (posterior.inclusion.probabilities / (1 - posterior.inclusion.probabilities)) /
 			(prior.inclusion.probabilities / (1 - prior.inclusion.probabilities))
-		model.complexity <- rowSums (effects.matrix)
+		model.complexity <- rowSums(effects.matrix)
 	}
 
-	no.effects <- ncol (effects.matrix)
-	effectNames <- colnames (effects.matrix)
-	if (!is.null (no.effects) && no.effects > 0) {
-		rows <- list ()
+	no.effects <- ncol(effects.matrix)
+	effectNames <- colnames(effects.matrix)
+	if (! is.null(no.effects) && no.effects > 0) {
+		rows <- list()
 		for (e in 1:no.effects) {
 			row <- list ()
-			row$"Effects" <- .unvf (effectNames [e])
+			row$"Effects" <- .unvf(effectNames[e])
 			if (perform == "run" && status$ready && !populate) {
-				row$"P(incl)" = .clean (prior.inclusion.probabilities [e])
-				row$"P(incl|data)" = .clean (posterior.inclusion.probabilities [e])
+				row$"P(incl)" = .clean(prior.inclusion.probabilities[e])
+				row$"P(incl|data)" = .clean(posterior.inclusion.probabilities[e])
 				if (options$bayesFactorType == "LogBF10"){
-					row$"BF<sub>Inclusion</sub>" = .clean (log (bayes.factor.inclusion [e]))
+					row$"BF<sub>Inclusion</sub>" = .clean(log(bayes.factor.inclusion[e]))
 				} else {
-					row$"BF<sub>Inclusion</sub>" = .clean (bayes.factor.inclusion [e])
+					row$"BF<sub>Inclusion</sub>" = .clean(bayes.factor.inclusion[e])
 				}
 			}
-			rows [[length (rows) + 1]] <- row
+			rows[[length(rows) + 1]] <- row
 		}
-		effectsTable [["data"]] <- rows
+		effectsTable[["data"]] <- rows
 	}
 
 	if (is.null(status$analysis.type) || status$analysis.type != "rmANOVA") {
-		effectsTable [["title"]] <- paste ("Analysis of Effects - ", options$dependent, sep = "")
+		effectsTable[["title"]] <- paste("Analysis of Effects - ", options$dependent, sep = "")
 	}
 
-	if (! status$ready) # TODO why do we need this?
-		effectsTable [["error"]] <- list (errorType = "badData")
+	if (! status$ready)
+		effectsTable[["error"]] <- list(errorType = "badData")
 
-	return (effectsTable)
+	return(effectsTable)
 }
 
 .theBayesianLinearModelEstimates <- function (model = NULL, options = list (), perform = "init", status = list (), populate = FALSE) {

--- a/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
+++ b/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
@@ -752,7 +752,7 @@
 			dim(posterior.probabilities) <- c(1, no.models)
 			prior.inclusion.probabilities <- prior.probabilities %*% effects.matrix
 			posterior.inclusion.probabilities <- posterior.probabilities %*% effects.matrix
-			posterior.inclusion.probabilities[posterior.inclusion.probabilities > 1] <- 1 #FIXME: why do we need this?
+			posterior.inclusion.probabilities[posterior.inclusion.probabilities > 1] <- 1 # deals with numerical error
 			posterior.inclusion.probabilities[posterior.inclusion.probabilities < 0] <- 0
 			bayes.factor.inclusion <- (posterior.inclusion.probabilities / (1 - posterior.inclusion.probabilities)) /
 				(prior.inclusion.probabilities / (1 - prior.inclusion.probabilities))
@@ -798,11 +798,17 @@
 				outModelPriors <- modelsWithout[indices, ncol(effects.matrix) - 1]
 				outModelPosteriors <- modelsWithout[indices, ncol(effects.matrix)]
 
+				# Deal with numerical error around the extremes 0 and 1
+				sumInModelPost <- ifelse(sum(inModelPosteriors) < 0, 0, sum(inModelPosteriors))
+				sumInModelPost <- ifelse(sumInModelPost > 1, 1, sumInModelPost)
+				sumOutModelPost <- ifelse(sum(outModelPosteriors) < 0, 0, sum(outModelPosteriors))
+				sumOutModelPost <- ifelse(sumOutModelPost > 1, 1, sumOutModelPost)
+				
 				# Calculate the inclusion probabilities
 				index <- which(effectNames == effect)
 				prior.inclusion.probabilities[index] <- sum(inModelPriors)
-				posterior.inclusion.probabilities[index] <- sum(inModelPosteriors)
-				bayes.factor.inclusion[index] <- (sum(inModelPosteriors) / sum(outModelPosteriors)) / (sum(inModelPriors) / sum(outModelPriors))
+				posterior.inclusion.probabilities[index] <- sumInModelPost
+				bayes.factor.inclusion[index] <- (sumInModelPost / sumOutModelPost) / (sum(inModelPriors) / sum(outModelPriors))
 			
 			}
 

--- a/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
+++ b/JASP-Engine/JASP/R/commonbayesianlinearmodels.R
@@ -757,56 +757,56 @@
 			bayes.factor.inclusion <- (posterior.inclusion.probabilities / (1 - posterior.inclusion.probabilities)) /
 				(prior.inclusion.probabilities / (1 - prior.inclusion.probabilities))
 				
-			} else { # perform a targeted analysis on matched models
+		} else { # perform a targeted analysis on matched models
 				
-				effects.matrix <- as.data.frame(effects.matrix)
-				prior.inclusion.probabilities <- posterior.inclusion.probabilities <- 
-					bayes.factor.inclusion <- numeric(length(effectNames))
-				for (effect in effectNames) {
-					
-					# Exclude all higher-order interactions
-					higherInteractions <- effectNames[model$interactions.matrix[effect, ] == TRUE]
-					if (! is.null(dim(effects.matrix[, higherInteractions]))) {
-						hasInteraction <- rowSums(effects.matrix[, higherInteractions])
-					} else {
-						hasInteraction <- effects.matrix[, higherInteractions]
-					}
-					effect.matrix <- effects.matrix[hasInteraction == 0, ]
-					
-					# Find all models that contain the effect
-					hasEffect <- effect.matrix[[effect]] == 1
-					modelsWith <- effect.matrix[hasEffect, ]
-					inModelPriors <- modelsWith[[ncol(effects.matrix) - 1]]
-					inModelPosteriors <- modelsWith[[ncol(effects.matrix)]]
-					modelsWith <- modelsWith[, 1:(ncol(effects.matrix) - 2), drop=FALSE]
-					
-					# Get the remaining models
-					remaining <- effect.matrix[[effect]] == 0
-					modelsWithout <- effect.matrix[remaining, ]
-
-					# From the remaining models find all models equivalent to the effect models, but without the effect
-					if (nrow(modelsWithout) > 1) {
-						refMatrix <- modelsWithout[, 1:(ncol(effects.matrix) - 2), drop=FALSE]
-						refMatrix <- refMatrix[, names(refMatrix) != effect, drop=FALSE]
-						indices <- apply(modelsWith[, names(modelsWith) != effect, drop=FALSE], 1, function(row) {
-								intersection <- row == t(refMatrix)
-									which(colSums(intersection) == length(row))
-							})
-					} else { # There is only the null model
-						indices <- 1 
-					}
-					outModelPriors <- modelsWithout[indices, ncol(effects.matrix) - 1]
-					outModelPosteriors <- modelsWithout[indices, ncol(effects.matrix)]
-
-					# Calculate the inclusion probabilities
-					index <- which(effectNames == effect)
-					prior.inclusion.probabilities[index] <- sum(inModelPriors)
-					posterior.inclusion.probabilities[index] <- sum(inModelPosteriors)
-					bayes.factor.inclusion[index] <- (sum(inModelPosteriors) / sum(outModelPosteriors)) / (sum(inModelPriors) / sum(outModelPriors))
+			effects.matrix <- as.data.frame(effects.matrix)
+			prior.inclusion.probabilities <- posterior.inclusion.probabilities <- 
+				bayes.factor.inclusion <- numeric(length(effectNames))
+			for (effect in effectNames) {
 				
+				# Exclude all higher-order interactions
+				higherInteractions <- effectNames[model$interactions.matrix[effect, ] == TRUE]
+				if (! is.null(dim(effects.matrix[, higherInteractions]))) {
+					hasInteraction <- rowSums(effects.matrix[, higherInteractions])
+				} else {
+					hasInteraction <- effects.matrix[, higherInteractions]
 				}
+				effect.matrix <- effects.matrix[hasInteraction == 0, ]
+				
+				# Find all models that contain the effect
+				hasEffect <- effect.matrix[[effect]] == 1
+				modelsWith <- effect.matrix[hasEffect, ]
+				inModelPriors <- modelsWith[[ncol(effects.matrix) - 1]]
+				inModelPosteriors <- modelsWith[[ncol(effects.matrix)]]
+				modelsWith <- modelsWith[, 1:(ncol(effects.matrix) - 2), drop=FALSE]
+				
+				# Get the remaining models
+				remaining <- effect.matrix[[effect]] == 0
+				modelsWithout <- effect.matrix[remaining, ]
 
+				# From the remaining models find all models equivalent to the effect models, but without the effect
+				if (nrow(modelsWithout) > 1) {
+					refMatrix <- modelsWithout[, 1:(ncol(effects.matrix) - 2), drop=FALSE]
+					refMatrix <- refMatrix[, names(refMatrix) != effect, drop=FALSE]
+					indices <- apply(modelsWith[, names(modelsWith) != effect, drop=FALSE], 1, function(row) {
+							intersection <- row == t(refMatrix)
+								which(colSums(intersection) == length(row))
+						})
+				} else { # There is only the null model
+					indices <- 1 
+				}
+				outModelPriors <- modelsWithout[indices, ncol(effects.matrix) - 1]
+				outModelPosteriors <- modelsWithout[indices, ncol(effects.matrix)]
+
+				# Calculate the inclusion probabilities
+				index <- which(effectNames == effect)
+				prior.inclusion.probabilities[index] <- sum(inModelPriors)
+				posterior.inclusion.probabilities[index] <- sum(inModelPosteriors)
+				bayes.factor.inclusion[index] <- (sum(inModelPosteriors) / sum(outModelPosteriors)) / (sum(inModelPriors) / sum(outModelPriors))
+			
 			}
+
+		}
 			
 	}
 	

--- a/Resources/Library/AncovaBayesian.json
+++ b/Resources/Library/AncovaBayesian.json
@@ -86,8 +86,10 @@
 			"value": 0.95
 		},
 		{
-			"name": "effectsStepwise",
-			"type": "Boolean"
+			"name": "effectsType",
+			"options": [ "allModels", "matchedModels" ],
+			"default": "allModels",
+			"type": "List"
 		},
 		{
 			"name": "posteriorEstimates",

--- a/Resources/Library/AnovaBayesian.json
+++ b/Resources/Library/AnovaBayesian.json
@@ -93,8 +93,10 @@
 			"value": 0.95
 		},
 		{
-			"name": "effectsStepwise",
-			"type": "Boolean"
+			"name": "effectsType",
+			"options": [ "allModels", "matchedModels" ],
+			"default": "allModels",
+			"type": "List"
 		},
 		{
 			"name": "posteriorEstimates",

--- a/Resources/Library/AnovaRepeatedMeasuresBayesian.json
+++ b/Resources/Library/AnovaRepeatedMeasuresBayesian.json
@@ -90,8 +90,10 @@
 			"value": 0.95
 		},
 		{
-			"name": "effectsStepwise",
-			"type": "Boolean"
+			"name": "effectsType",
+			"options": [ "allModels", "matchedModels" ],
+			"default": "allModels",
+			"type": "List"
 		},
 		{
 			"name": "bayesFactorType",

--- a/Resources/Library/RegressionLinearBayesian.json
+++ b/Resources/Library/RegressionLinearBayesian.json
@@ -31,8 +31,10 @@
 			"type": "Boolean"
 		},
 		{
-			"name": "effectsStepwise",
-			"type": "Boolean"
+			"name": "effectsType",
+			"options": [ "allModels", "matchedModels" ],
+			"default": "allModels",
+			"type": "List"
 		},
 		{
 			"name": "posteriorEstimates",


### PR DESCRIPTION
Adds an option to perform a targeted inclusion analysis for Bayesian (RM) AN(C)OVA. See also https://www.cogsci.nl/blog/interpreting-bayesian-repeated-measures-in-jasp

Additionally I
- removed stepwise code (no longer used)
- made style changes