### PR TITLE
Map application with JASP window

### DIFF
--- a/Tools/debian/jasp.desktop
+++ b/Tools/debian/jasp.desktop
@@ -6,6 +6,6 @@ Exec=JASP %f
 Terminal=false
 Type=Application
 MimeType=application/jasp
+StartupWMClass=JASP
 StartupNotify=true
 Icon=/usr/lib/JASP/Resources/jasp.svg
-


### PR DESCRIPTION
Problem - In unity desktop, sometimes, the application window and the launcher do not connect. This leads to a generic icon to be shown on the launcher.

Fix - `StartupWMClass` will map jasp window with its WM class.
