### PR TITLE
Summary bayesian ttest subjective prior

### DIFF
--- a/JASP-Engine/JASP/R/summarystatsttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianindependentsamples.R
@@ -235,7 +235,7 @@ SummaryStatsTTestBayesianIndependentSamples <- function(dataset = NULL, options,
 
 				## Compute the statistics
 				
-				bayesFactorObject <- .generalSummaryTtestBF(options = options)
+				bayesFactorObject <- .generalSummaryTtestBF(options = options, paired = FALSE)
 				
 				
 				## Format the statistics for output

--- a/JASP-Engine/JASP/R/summarystatsttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianonesample.R
@@ -112,7 +112,7 @@ SummaryStatsTTestBayesianOneSample <- function(dataset = NULL, options, perform 
 	  fields[[length(fields)+1]] <- 
 	    list(name = "errorEstimate", type = "number", format = "sf:4;dp:3", title = "error %")
 	}
-	table[["schema"]] <- list(fields = fields)
+	table[["schema"]] <- list(fields = fields[c(1:3,5,4)]) # fields proper order
 	
 	# Populate the table
 	table[["data"]] <- list(rowsTTestBayesianOneSample)
@@ -326,7 +326,7 @@ SummaryStatsTTestBayesianOneSample <- function(dataset = NULL, options, perform 
 #              - Add uniform informed prior
 
 .generalSummaryTtestBF <- 
-  function(tValue=options$tStatistic, size=options$n1Size, options) { 
+  function(tValue=options$tStatistic, size=options$n1Size, options, paired=TRUE) { 
   # Converts a t-statistic and sample size into the corresponding Bayes Factor.
   #
   # Args:
@@ -344,14 +344,14 @@ SummaryStatsTTestBayesianOneSample <- function(dataset = NULL, options, perform 
   
   # help vars
   n1 <- size
-  n2 <- if (!is.null(options$n2Size)) options$n2Size else 0
-  oneSided = options$hypothesis != "notEqualToTestValue"
+  n2 <- if (!is.null(options$n2Size)) options$n2Size else 0 # single sample case
+  oneSided = !(options$hypothesis %in% c("notEqualToTestValue","groupsNotEqual"))
   
   ### Default case: a non-informative zero-centered Cauchy prior
   if(options$effectSizeStandardized == "default") {
     nullInterval <- 
-      switch(options$hypothesis, greaterThanTestValue = c(0, Inf), 
-             lessThanTestValue = c(-Inf,0), c(-Inf,Inf))    # default is notEqualToTestValue
+      switch(options$hypothesis, greaterThanTestValue = c(0, Inf), groupOneGreater = c(0, Inf),
+             lessThanTestValue = c(-Inf,0), groupTwoGreater = c(-Inf, 0), c(-Inf,Inf))    # default is notEqualToTestValue
     
     bfObject <- BayesFactor::ttest.tstat(t=tValue, n1=n1, n2=n2, rscale=options$priorWidth, 
                                          nullInterval = nullInterval)
@@ -368,11 +368,13 @@ SummaryStatsTTestBayesianOneSample <- function(dataset = NULL, options, perform 
     # not matter whether we swap the two, we retain this order for easier extension
     # of the one-sample case.
 
-    side = switch(options$hypothesis, greaterThanTestValue = "right", lessThanTestValue= "left", FALSE)
+    side = switch(options$hypothesis, greaterThanTestValue = "right", groupOneGreater = "right",
+                  lessThanTestValue= "left", groupTwoGreater = "left", FALSE)
     
+    # Note: .bf10_ functions gives weired value if paired = FALSE in single sample case
     if (options[["informativeStandardizedEffectSize"]] == "cauchy") { 
       bfObject <- .bf10_t(t = tValue, ny = n1, nx = n2, oneSided = side,
-                          independentSamples = FALSE,
+                          independentSamples = !paired,
                           prior.location = options[["informativeCauchyLocation"]],
                           prior.scale = options[["informativeCauchyScale"]],
                           prior.df = 1)
@@ -380,7 +382,7 @@ SummaryStatsTTestBayesianOneSample <- function(dataset = NULL, options, perform 
       error <- 100*bfObject$error
     } else if (options[["informativeStandardizedEffectSize"]] == "t") {
       bfObject <- .bf10_t(t = tValue, ny = n1, nx = n2, oneSided = side,
-                          independentSamples = FALSE,
+                          independentSamples = !paired,
                           prior.location = options[["informativeTLocation"]],
                           prior.scale = options[["informativeTScale"]],
                           prior.df = options[["informativeTDf"]])
@@ -388,7 +390,7 @@ SummaryStatsTTestBayesianOneSample <- function(dataset = NULL, options, perform 
       error <- 100*bfObject$error
     } else if (options[["informativeStandardizedEffectSize"]] == "normal") {
       bf <- .bf10_normal(t = tValue, ny = n1, nx = n2, oneSided = side,
-                         independentSamples = FALSE,
+                         independentSamples = !paired,
                          prior.mean = options[["informativeNormalMean"]],
                          prior.variance = options[["informativeNormalStd"]]^2)
       error <- NULL

--- a/JASP-Engine/JASP/R/summarystatsttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianonesample.R
@@ -112,7 +112,7 @@ SummaryStatsTTestBayesianOneSample <- function(dataset = NULL, options, perform 
 	  fields[[length(fields)+1]] <- 
 	    list(name = "errorEstimate", type = "number", format = "sf:4;dp:3", title = "error %")
 	}
-	table[["schema"]] <- list(fields = fields[c(1:3,5,4)]) # fields proper order
+	table[["schema"]] <- list(fields = fields[c(1:3, 5, 4)]) # fields in proper order
 	
 	# Populate the table
 	table[["data"]] <- list(rowsTTestBayesianOneSample)

--- a/JASP-Engine/JASP/R/summarystatsttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/summarystatsttestbayesianpairedsamples.R
@@ -208,7 +208,7 @@ SummaryStatsTTestBayesianPairedSamples <- function(dataset = NULL, options, perf
 			  
 				## Compute the statistics
 				
-				bayesFactorObject <- .generalSummaryTtestBF(options = options)
+				bayesFactorObject <- .generalSummaryTtestBF(options = options, paired=TRUE)
 				
 				## Format the statistics for output
 				


### PR DESCRIPTION
Fixes the issue, plus a couple more which all came down to properly
handling the inconsistencies in the ‘hypothesis’ option names across
interfaces to One sample, Two paired samples, and Two independent
samples interfaces.