### PR TITLE
Fixed restrictions on input fields

### DIFF
--- a/JASP-Desktop/analysisforms/SEM/semsimpleform.ui
+++ b/JASP-Desktop/analysisforms/SEM/semsimpleform.ui
@@ -1054,12 +1054,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>GroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>widgets/groupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>BoundTextBox</class>
    <extends>QLineEdit</extends>
    <header>widgets/boundtextbox.h</header>
@@ -1084,6 +1078,12 @@
    <class>BoundComboBox</class>
    <extends>QComboBox</extends>
    <header>widgets/boundcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>GroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>widgets/groupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>BoundTextEdit</class>
@@ -1207,6 +1207,22 @@
     <hint type="destinationlabel">
      <x>478</x>
      <y>354</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>_3bootstrap</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>containerBootstrapSamples</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>174</x>
+     <y>553</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>175</x>
+     <y>580</y>
     </hint>
    </hints>
   </connection>

--- a/Resources/Library/Descriptives.json
+++ b/Resources/Library/Descriptives.json
@@ -38,7 +38,8 @@
 		{
 			"name": "percentileValuesEqualGroupsNo",
 			"type": "Integer",
-			"default": 4
+			"default": 4,
+			"min": 1
 		},
 		{
 			"name": "percentileValuesPercentilesPercentiles",

--- a/Resources/Library/ExploratoryFactorAnalysis.json
+++ b/Resources/Library/ExploratoryFactorAnalysis.json
@@ -22,7 +22,8 @@
         {
             "name": "numberOfFactors",
             "type": "Integer",
-            "default": 1
+            "default": 1,
+						"min": 1
         },
         {
             "name": "rotationMethod",

--- a/Resources/Library/PrincipalComponentAnalysis.json
+++ b/Resources/Library/PrincipalComponentAnalysis.json
@@ -22,7 +22,8 @@
         {
             "name": "numberOfFactors",
             "type": "Integer",
-            "default": 1
+            "default": 1,
+						"min": 1
         },
         {
             "name": "rotationMethod",

--- a/Resources/Library/RegressionLinear.json
+++ b/Resources/Library/RegressionLinear.json
@@ -99,7 +99,8 @@
 		{
 			"default": 3,
 			"name": "residualsCasewiseDiagnosticsOutliersOutside",
-			"type": "Integer"
+			"type": "Integer",
+			"min": 0
 		},
 		{
 			"name": "steppingMethodCriteriaType",
@@ -111,25 +112,31 @@
 			"format": "",
 			"name": "steppingMethodCriteriaPEntry",
 			"type": "Number",
-			"value": 0.050
+			"value": 0.050,
+			"max": 1,
+			"min": 0
 		},
 		{
 			"format": "",
 			"name": "steppingMethodCriteriaPRemoval",
 			"type": "Number",
-			"value": 0.10
+			"value": 0.10,
+			"max": 1,
+			"min": 0
 		},
 		{
 			"format": "",
 			"name": "steppingMethodCriteriaFEntry",
 			"type": "Number",
-			"value": 3.840
+			"value": 3.840,
+			"min": 0
 		},
 		{
 			"format": "",
 			"name": "steppingMethodCriteriaFRemoval",
 			"type": "Number",
-			"value": 2.710
+			"value": 2.710,
+			"min": 0
 		},
 		{
 			"default": true,

--- a/Resources/Library/SEMSimple.json
+++ b/Resources/Library/SEMSimple.json
@@ -36,7 +36,8 @@
 		{
 			"name": "errorCalculationBootstrapSamples",
 			"type": "Integer",
-			"default": 1000
+			"default": 1000,
+			"min": 0
 		},
 		{
 			"name": "outputMardiasCoefficients",
@@ -221,7 +222,8 @@
 		{
 			"name": "SampleSize",
 			"type": "Integer",
-			"default": 0
+			"default": 0,
+			"min": 0
 		}
 	]
 }


### PR DESCRIPTION
I went over all analyses and tried impossible values in input fields.
This resulted in added restrictions to:
- Descriptives
- Linear Regression
- EFA
- PCA
- SEM

Additionally, in the SEM module, I added an event to enable people to set the number of bootstrap samples.