### PR TITLE
Removed "keep" attribute state retrieval

### DIFF
--- a/Docs/development/r-analyses-guide.md
+++ b/Docs/development/r-analyses-guide.md
@@ -473,10 +473,7 @@ attr(state, "key") <- stateKey
 ```
 
 Now if the analysis is called again and e.g. `sampleMode` changes, only the plot will be returned.
-If there are state items you would like to keep indefinitely -- regardless of the options a user changes -- you may also specify this in the state, e.g.:
-```
-attr(state, "keep") <- c("model", "options")
-```
+If there are state items you would like to keep indefinitely -- regardless of the options a user changes -- you must omit these in the stateKey.
 
 ### Error handling
 

--- a/JASP-Engine/JASP/R/basregressionlinearlink.R
+++ b/JASP-Engine/JASP/R/basregressionlinearlink.R
@@ -198,7 +198,6 @@ BASRegressionLinearLink <- function (
 			keep = keep
 		)
 		attr(state, "key") <- stateKey
-		attr(state, "keep") <- c("status", "keep")
 	}
 
 	return (list(

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -48,7 +48,7 @@ run <- function(name, options.as.json.string, perform="run") {
 	if ('state' %in% names(formals(analysis))) {
 		state <- .retrieveState()
 		if (! is.null(state) && 'key' %in% names(attributes(state))) {
-			state <- .getStateItems(state=state, options=options, key=attributes(state)$key, keep=attributes(state)$keep)
+			state <- .getStateItems(state=state, options=options, key=attributes(state)$key)
 		}
 	}
 	
@@ -888,7 +888,7 @@ as.list.footnotes <- function(footnotes) {
 }
 
 
-.getStateItems <- function(state, options, key, keep=NULL) {
+.getStateItems <- function(state, options, key) {
 	
   if (is.null(names(state)) || is.null(names(state$options)) || 
       is.null(names(options)) || is.null(names(key))) {
@@ -897,13 +897,9 @@ as.list.footnotes <- function(footnotes) {
 
   result <- list()
   for (item in names(state)) {
-    
-		if (! is.null(keep) && item %in% keep) {
-			result[[item]] <- state[[item]]
-			next
-	  } 
 		
 		if (item %in% names(key) == FALSE) {
+      result[[item]] <- state[[item]]
       next
     }
     


### PR DESCRIPTION
Only remove items if they have a state key and relevant options were changed. If they have no key always return the items.