### PR TITLE
Windows build error

### DIFF
--- a/JASP-Desktop/preferencesdialog.ui
+++ b/JASP-Desktop/preferencesdialog.ui
@@ -79,9 +79,6 @@ QTabWidget#background {
      <property name="elideMode">
       <enum>Qt::ElideNone</enum>
      </property>
-     <property name="tabBarAutoHide">
-      <bool>false</bool>
-     </property>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">
        <string>Data Editing</string>


### PR DESCRIPTION
Due to the use of different Qt versions:
ui_preferencesdialog.h:117: error: 'class QTabWidget' has no member
named 'setTabBarAutoHide'
tabsPreferences->setTabBarAutoHide(false);
^