### PR TITLE
Preference dialog does not close after closing mainwindow

### DIFF
--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -383,6 +383,9 @@ void MainWindow::closeEvent(QCloseEvent *event)
 	{
 		event->accept();
 	}
+	
+	PreferencesDialog *rd = ui->tabBar->getPreferencesDialog();
+	if (rd) rd->close();
 }
 
 void MainWindow::saveKeysSelected()

--- a/JASP-Desktop/widgets/tabbar.cpp
+++ b/JASP-Desktop/widgets/tabbar.cpp
@@ -240,6 +240,11 @@ int TabBar::count() const
 	return _tabButtons.length();
 }
 
+PreferencesDialog *TabBar::getPreferencesDialog()
+{
+	return _preferencesDialog;
+}
+
 void TabBar::setCurrentIndex(int index)
 {
 	int i = 0;

--- a/JASP-Desktop/widgets/tabbar.h
+++ b/JASP-Desktop/widgets/tabbar.h
@@ -52,6 +52,8 @@ public:
 	void addHelpTab();
 
 	int count() const;
+	PreferencesDialog *getPreferencesDialog();
+	
 
 
 signals:


### PR DESCRIPTION
If a preference dialog is opened while stopping JASP, by closing the
main window, the preference dialog is not closed and the JASP prices
stays running.