### PR TITLE
Bugfixes Bayesian correlation

### DIFF
--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -239,9 +239,11 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 	
 	if (flagSupported) {
 		if (bayesFactorType=="LogBF10") {
-			.addFootnote(footnotes, paste(bfTitle, " > log(10), ** , ", bfTitle, " > log(30), *** ", bfTitle, " > log(100)"), symbol="*")
+			.addFootnote(footnotes, paste(bfTitle, " > log(10), ** ", bfTitle, " > log(30), *** ", bfTitle, " > log(100)"), symbol="*")
+		} else if (bayesFactorType == "BF01") {
+			.addFootnote(footnotes, paste(bfTitle, " < .1, ** ", bfTitle, " < .03, *** ", bfTitle, " < .01"), symbol="*")
 		} else {
-			.addFootnote(footnotes, paste(bfTitle, " > 10, ** , ", bfTitle, " > 30, *** ", bfTitle, " > 100"), symbol="*")
+			.addFootnote(footnotes, paste(bfTitle, " > 10, ** ", bfTitle, " > 30, *** ", bfTitle, " > 100"), symbol="*")
 		}
 	}
 	
@@ -625,27 +627,15 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 							reportBf <- bfObject$bf10
 							reportLowerCi <- bfObject$ci$twoSided[1]
 							reportUpperCi <- bfObject$ci$twoSided[3]
-							
-							if (bayesFactorType == "BF01") {
-								reportBf <- 1/reportBf
-							}
 						} else if (hypothesis == "correlatedPositively") {
 							# TODO: Still need to implement this for general rho0, rather than rho0=0
 							reportBf <- bfObject$bfPlus0
 							reportLowerCi <- bfObject$ci$plusSided[1]
 							reportUpperCi <- bfObject$ci$plusSided[3]
-							
-							if (bayesFactorType == "BF01") {
-								reportBf <- 1/reportBf
-							}
 						} else if (hypothesis == "correlatedNegatively") {
 							reportBf <- bfObject$bfMin0
 							reportLowerCi <- bfObject$ci$minSided[1]
 							reportUpperCi <- bfObject$ci$minSided[3]
-							
-							if (bayesFactorType == "BF01") {
-								reportBf <- 1/reportBf
-							}
 						} 
 						
 						# MarkUp: Per row (variable): add footnote per row
@@ -664,7 +654,9 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 						# Note: Flagging and report bfs [report]
 						if (isTRUE(reportBayesFactors)) {
 							if (bayesFactorType == "LogBF10") {
-								reportBf <- base::log10(reportBf)
+								reportBf <- base::log(reportBf)
+							} else if (bayesFactorType == "BF01") {
+								reportBf <- 1/reportBf
 							}
 							
 							bayesFactorsList[[length(bayesFactorsList)+1]] <- .clean(reportBf)

--- a/JASP-Engine/JASP/R/correlationbayesianpairs.R
+++ b/JASP-Engine/JASP/R/correlationbayesianpairs.R
@@ -637,6 +637,11 @@ CorrelationBayesianPairs <- function(dataset=NULL, options, perform="run", callb
 				
 				v1 <- subDataSet[[ .v(pair[[1]]) ]]
 				v2 <- subDataSet[[ .v(pair[[2]]) ]]
+				
+				plotBF10post <- BF10post[i]
+				if (options$bayesFactorType == "LogBF10") {
+					plotBF10post <- exp(plotBF10post) # we don't use log(bf)'s in plots
+				}
 			
 			} else {
 			
@@ -763,7 +768,7 @@ CorrelationBayesianPairs <- function(dataset=NULL, options, perform="run", callb
 							# 
 							# plot[["data"]] <- .endSaveImage(image)
 							.plotFunc <- function() {
-								.plotPosterior.correlation(r=rs[i], n=ns[i], oneSided=oneSided, BF=BF10post[i], BFH1H0=BFH1H0, addInformation=options$plotPriorAndPosteriorAdditionalInfo, kappa=options$priorWidth,corCoefficient=options$corcoefficient)
+								.plotPosterior.correlation(r=rs[i], n=ns[i], oneSided=oneSided, BF=plotBF10post, BFH1H0=BFH1H0, addInformation=options$plotPriorAndPosteriorAdditionalInfo, kappa=options$priorWidth,corCoefficient=options$corcoefficient)
 							}
 							content <- .writeImage(width = 530, height = 400, plot = .plotFunc, obj = TRUE)
 							plot[["convertible"]] <- TRUE
@@ -832,7 +837,7 @@ CorrelationBayesianPairs <- function(dataset=NULL, options, perform="run", callb
 							# plot[["data"]] <- .endSaveImage(image)
 							
 							.plotFunc <- function() {
-								.plotBF.robustnessCheck.correlation(r=rs[i], n=ns[i], oneSided=oneSided, BF10post=BF10post[i], BFH1H0=BFH1H0, kappa=options$priorWidth, corCoefficient=options$corcoefficient)
+								.plotBF.robustnessCheck.correlation(r=rs[i], n=ns[i], oneSided=oneSided, BF10post=plotBF10post, BFH1H0=BFH1H0, kappa=options$priorWidth, corCoefficient=options$corcoefficient)
 							}
 							content <- .writeImage(width = 530, height = 400, plot = .plotFunc, obj = TRUE)
 							plot[["convertible"]] <- TRUE
@@ -909,7 +914,7 @@ CorrelationBayesianPairs <- function(dataset=NULL, options, perform="run", callb
 							# plot[["data"]] <- .endSaveImage(image)
 							
 							.plotFunc <- function() {
-								.plotSequentialBF.correlation(x=v1, y=v2, oneSided=oneSided, BF=BF10post[i], BFH1H0=BFH1H0, kappa=options$priorWidth,corCoefficient=options$corcoefficient)
+								.plotSequentialBF.correlation(x=v1, y=v2, oneSided=oneSided, BF=plotBF10post, BFH1H0=BFH1H0, kappa=options$priorWidth,corCoefficient=options$corcoefficient)
 							}
 							content <- .writeImage(width = 530, height = 400, plot = .plotFunc, obj = TRUE)
 							plot[["convertible"]] <- TRUE

--- a/JASP-Engine/JASP/R/correlationbayesianpairs.R
+++ b/JASP-Engine/JASP/R/correlationbayesianpairs.R
@@ -491,12 +491,13 @@ CorrelationBayesianPairs <- function(dataset=NULL, options, perform="run", callb
 					    # bf10: can't compute
 					    errorMessage <- errors$message
 					    unplotable <- TRUE
-					    unplotableMessage <- errors$message
+					    unplotableMessage <- errorMessage
 					    unplotableScatter <- TRUE
-					    unplotableMessageScatter <- errors$message
+					    unplotableMessageScatter <- errorMessage
 					    
 					    obsFootnote <- errors$message
 					    index <- .addFootnote(footnotes, obsFootnote)
+					    errorFootnotes[i] <- errorMessage
 						
 					    bfObject <- failedBfObject
 					} else {


### PR DESCRIPTION
Bayesian correlation matrix:
- logBF used base 10 instead of e (#1981)
- flagging of supported correlations was incorrect for BF01 

Bayesian correlation pairs:
- footnotes vanished when calculations were retrieved from state
- plots showed the incorrect BF when LogBF10 was selected