### PR TITLE
Hotfix p-value chi-square Logistic Regression

### DIFF
--- a/JASP-Engine/JASP/R/commonglm.R
+++ b/JASP-Engine/JASP/R/commonglm.R
@@ -688,7 +688,7 @@
   if (chisq == 0) {
     p <- NULL
   } else {
-    p <- dchisq(chisq, df)
+    p <- 1-pchisq(chisq, df)
   }
   return(list(stat = chisq, df = df, pval = p))
 }


### PR DESCRIPTION
@JohnnyDoorn found this critical bug playing around with logreg: the p-value was calculated wrong! This needs to be merged before the new release, sorry all.

