### PR TITLE
Kill JASPEngine processes after closing the mainwindow

### DIFF
--- a/JASP-Desktop/application.cpp
+++ b/JASP-Desktop/application.cpp
@@ -34,6 +34,17 @@ Application::Application(int &argc, char **argv) :
 		_mainWindow->open(args.at(1));
 }
 
+Application::~Application()
+{
+	try
+	{
+		delete _mainWindow;	
+	}
+	catch(...)
+	{		
+	}
+}
+
 bool Application::notify(QObject *receiver, QEvent *event)
 {
 	try

--- a/JASP-Desktop/application.h
+++ b/JASP-Desktop/application.h
@@ -29,6 +29,7 @@ class Application : public QApplication
 	Q_OBJECT
 public:
 	explicit Application(int &argc, char **argv);
+	~Application();
 
 	virtual bool notify(QObject *receiver, QEvent *event) OVERRIDE;
 	virtual bool event(QEvent *event) OVERRIDE;


### PR DESCRIPTION
Solves #1894

JASPEngine processes remain active in memory after opening/closing GUI
on Ubuntu #1894
https://github.com/jasp-stats/jasp-desktop/issues/1894