### PR TITLE
Avoid help from not returning after clicking on a link

### DIFF
--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -282,6 +282,8 @@ MainWindow::MainWindow(QWidget *parent) :
 	QUrl userGuide = QUrl::fromLocalFile(AppDirs::help() + "/index.html");
 	ui->webViewHelp->setUrl(userGuide);
 	connect(ui->webViewHelp, SIGNAL(loadFinished(bool)), this, SLOT(helpFirstLoaded(bool)));
+	ui->webViewHelp->page()->setLinkDelegationPolicy(QWebPage::DelegateAllLinks);
+	connect(ui->webViewHelp, SIGNAL( linkClicked( QUrl ) ), this, SLOT( linkClickedSlot( QUrl ) ) );
 	ui->panel_4_Help->hide();
 
 	setAcceptDrops(true);
@@ -1435,6 +1437,11 @@ void MainWindow::emptyValuesChangedHandler()
 		_package->setModified(true);
 		packageDataChanged(_package, colChanged, missingColumns, changeNameColumns);
 	}
+}
+
+void MainWindow::linkClickedSlot(QUrl url)
+{
+	QDesktopServices::openUrl ( url );
 }
 
 void MainWindow::itemSelected(const QString &item)

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -212,6 +212,7 @@ private slots:
     void setExactPValuesHandler(bool exactPValues);
     void setFixDecimalsHandler(QString numDecimals);
     void emptyValuesChangedHandler();
+	void linkClickedSlot(QUrl url);
 
 };
 


### PR DESCRIPTION
In the network module help file some href links are added. When these
link are opened in the current help window it is impossible to return to
the original help info.