### PR TITLE
Changed error msg when analysis is not found

### DIFF
--- a/JASP-Common/analysisloader.cpp
+++ b/JASP-Common/analysisloader.cpp
@@ -57,5 +57,5 @@ Analysis *AnalysisLoader::load(int id, string moduleName, string analysisName, c
 		return new Analysis(id, moduleName, analysisName, options, version, autorun, usedata);
 	}
 
-	throw runtime_error("Could not access analysis definition.");
+	throw runtime_error(analysisName + " does not exist in your JASP version.");
 }


### PR DESCRIPTION
If a .jasp file containing recently added analyses is opened in an old JASP version, the thrown error message was very cryptic.