### PR TITLE
Network: temporarily remove mgm method

### DIFF
--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.ui
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.ui
@@ -2909,11 +2909,6 @@
                 <string>adalasso</string>
                </property>
               </item>
-              <item>
-               <property name="text">
-                <string>mgm</string>
-               </property>
-              </item>
              </widget>
             </item>
             <item row="3" column="0">


### PR DESCRIPTION
It crashes and items overlap.
We’ll add this again later.