### PR TITLE
Fix network layout

### DIFF
--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
@@ -98,6 +98,13 @@ NetworkAnalysisForm::NetworkAnalysisForm(QWidget *parent) :
     ui->_4parametric->hide();
     ui->_5person->hide();
     ui->_6jackknife->hide();
+    ui->showMgmVariableType->setVisible(false);
+    // for the next release
+//#ifdef QT_NO_DEBUG
+//    ui->plotClustering->setVisible(false);
+//    ui->tableClustering->setVisible(false);
+//#endif
+    
 }
 
 NetworkAnalysisForm::~NetworkAnalysisForm()
@@ -122,7 +129,7 @@ void NetworkAnalysisForm::on_estimator_currentIndexChanged(const QString &choice
     ui->gridLayout_3->removeWidget(ui->thresholdBox);
     ui->gridLayout_3->removeWidget(ui->network);
     ui->gridLayout_3->removeWidget(ui->normalizeCentrality);
-    ui->gridLayout_12->removeWidget(ui->showMgmVariableType);
+//    ui->gridLayout_12->removeWidget(ui->showMgmVariableType);
 
     ui->correlationMethod->hide();
     ui->tuningParameterBox->hide();
@@ -137,7 +144,8 @@ void NetworkAnalysisForm::on_estimator_currentIndexChanged(const QString &choice
     ui->thresholdBox->hide();
     ui->network->hide();
     ui->normalizeCentrality->hide();
-    ui->showMgmVariableType->hide();
+//    ui->showMgmVariableType->hide();
+    ui->showMgmVariableType->setVisible(false);
 
     if (choice_str.compare("EBICglasso") == 0) {
         ui->correlationMethod->setVisible(true);
@@ -224,11 +232,12 @@ void NetworkAnalysisForm::on_estimator_currentIndexChanged(const QString &choice
         ui->gridLayout_3->addWidget(ui->rule, 0, 1);
         ui->gridLayout_3->addWidget(ui->boxMgmVariableType, 2, 0);
         ui->gridLayout_3->addWidget(ui->crossValidation, 1, 1);
-        ui->gridLayout_12->addWidget(ui->showMgmVariableType, 5, 1);
+        ui->showMgmVariableType->setVisible(true);
+//        ui->gridLayout_12->addWidget(ui->showMgmVariableType, 5, 1);
     }
 
     ui->analysisOptions->setLayout(ui->gridLayout_3);
-    ui->analysisOptions->setLayout(ui->gridLayout_12);
+//    ui->analysisOptions->setLayout(ui->gridLayout_12);
 }
 
 void NetworkAnalysisForm::on__4cv_clicked()

--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
@@ -102,8 +102,9 @@ NetworkAnalysisForm::NetworkAnalysisForm(QWidget *parent) :
     
     // for the next release
 #ifdef QT_NO_DEBUG
-    ui->plotClustering->setVisible(false);
-    ui->tableClustering->setVisible(false);
+//    ui->plotClustering->setVisible(false);
+//    ui->tableClustering->setVisible(false);
+    ui->parallelBootstrap->setVisible(false);
 #endif
     
 }

--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
@@ -216,10 +216,10 @@ void NetworkAnalysisForm::on_estimator_currentIndexChanged(const QString &choice
         ui->_4cv->setEnabled(true);
 
         ui->analysisOptionsExpander->setText("Analysis Options - mgm");
-        ui->gridLayout_3->addWidget(ui->tuningParameterBox, 1, 1);
+        ui->gridLayout_3->addWidget(ui->tuningParameterBox, 1, 0);
         ui->gridLayout_3->addWidget(ui->criterion, 0, 0);
         ui->gridLayout_3->addWidget(ui->rule, 0, 1);
-        ui->gridLayout_3->addWidget(ui->boxMgmVariableType, 1, 0);
+        ui->gridLayout_3->addWidget(ui->boxMgmVariableType, 2, 0);
         ui->gridLayout_3->addWidget(ui->crossValidation, 1, 1);
         ui->gridLayout_12->addWidget(ui->showMgmVariableType, 5, 1);
     }

--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
@@ -95,6 +95,9 @@ NetworkAnalysisForm::NetworkAnalysisForm(QWidget *parent) :
     ui->_1spring->setChecked(true);
     ui->label_repulsion->setVisible(true);
     ui->repulsion->setVisible(true);
+    ui->_4parametric->hide();
+    ui->_5person->hide();
+    ui->_6jackknife->hide();
 }
 
 NetworkAnalysisForm::~NetworkAnalysisForm()

--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.cpp
@@ -99,11 +99,12 @@ NetworkAnalysisForm::NetworkAnalysisForm(QWidget *parent) :
     ui->_5person->hide();
     ui->_6jackknife->hide();
     ui->showMgmVariableType->setVisible(false);
+    
     // for the next release
-//#ifdef QT_NO_DEBUG
-//    ui->plotClustering->setVisible(false);
-//    ui->tableClustering->setVisible(false);
-//#endif
+#ifdef QT_NO_DEBUG
+    ui->plotClustering->setVisible(false);
+    ui->tableClustering->setVisible(false);
+#endif
     
 }
 
@@ -129,7 +130,6 @@ void NetworkAnalysisForm::on_estimator_currentIndexChanged(const QString &choice
     ui->gridLayout_3->removeWidget(ui->thresholdBox);
     ui->gridLayout_3->removeWidget(ui->network);
     ui->gridLayout_3->removeWidget(ui->normalizeCentrality);
-//    ui->gridLayout_12->removeWidget(ui->showMgmVariableType);
 
     ui->correlationMethod->hide();
     ui->tuningParameterBox->hide();
@@ -144,7 +144,6 @@ void NetworkAnalysisForm::on_estimator_currentIndexChanged(const QString &choice
     ui->thresholdBox->hide();
     ui->network->hide();
     ui->normalizeCentrality->hide();
-//    ui->showMgmVariableType->hide();
     ui->showMgmVariableType->setVisible(false);
 
     if (choice_str.compare("EBICglasso") == 0) {
@@ -223,8 +222,8 @@ void NetworkAnalysisForm::on_estimator_currentIndexChanged(const QString &choice
         ui->boxMgmVariableType->setVisible(true);
         ui->crossValidation->setVisible(false);
         ui->showMgmVariableType->setVisible(true);
-
-        ui->_4cv->setEnabled(true);
+        
+//        ui->_4cv->setEnabled(true);
 
         ui->analysisOptionsExpander->setText("Analysis Options - mgm");
         ui->gridLayout_3->addWidget(ui->tuningParameterBox, 1, 0);
@@ -233,11 +232,14 @@ void NetworkAnalysisForm::on_estimator_currentIndexChanged(const QString &choice
         ui->gridLayout_3->addWidget(ui->boxMgmVariableType, 2, 0);
         ui->gridLayout_3->addWidget(ui->crossValidation, 1, 1);
         ui->showMgmVariableType->setVisible(true);
-//        ui->gridLayout_12->addWidget(ui->showMgmVariableType, 5, 1);
+        
+        if(ui->_4cv->isChecked()) {
+            ui->crossValidation->setVisible(true);        
+        }
     }
 
     ui->analysisOptions->setLayout(ui->gridLayout_3);
-//    ui->analysisOptions->setLayout(ui->gridLayout_12);
+
 }
 
 void NetworkAnalysisForm::on__4cv_clicked()

--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.ui
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.ui
@@ -352,60 +352,8 @@
                <bool>false</bool>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
-               <item row="2" column="0">
-                <widget class="QRadioButton" name="nonparametric">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>&amp;Node</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QRadioButton" name="parametric">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Person</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
-                <widget class="QRadioButton" name="person">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>&amp;Jackknife</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QRadioButton" name="jackknife">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Nonparametric</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QRadioButton" name="node">
+               <item row="4" column="0">
+                <widget class="QRadioButton" name="_4parametric">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                    <horstretch>0</horstretch>
@@ -417,8 +365,73 @@
                  </property>
                 </widget>
                </item>
-               <item row="4" column="0">
-                <widget class="QRadioButton" name="parametric_2">
+               <item row="11" column="0">
+                <widget class="QRadioButton" name="_6jackknife">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>&amp;Jackknife</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QRadioButton" name="_1nonparametric">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>&amp;Nonparametric</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QRadioButton" name="_5person">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Person</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QRadioButton" name="_3node">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>&amp;Node</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <spacer name="horizontalSpacer_10">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="2" column="0">
+                <widget class="QRadioButton" name="_2case">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                    <horstretch>0</horstretch>
@@ -430,15 +443,15 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1">
-                <spacer name="horizontalSpacer_10">
+               <item row="12" column="0">
+                <spacer name="verticalSpacer_14">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>40</width>
-                   <height>20</height>
+                   <width>20</width>
+                   <height>40</height>
                   </size>
                  </property>
                 </spacer>
@@ -2724,140 +2737,6 @@
          <property name="sizeConstraint">
           <enum>QLayout::SetNoConstraint</enum>
          </property>
-         <item row="2" column="2">
-          <widget class="BoundGroupBox" name="isingEstimator_2">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Results</string>
-           </property>
-           <property name="flat">
-            <bool>false</bool>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_7">
-            <item row="0" column="0">
-             <spacer name="verticalSpacer_12">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>5</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="0">
-             <widget class="BoundCheckBox" name="plotNetwork">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Network plot</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="BoundCheckBox" name="plotCentrality">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Centrality plot</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <spacer name="horizontalSpacer_28">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="3" column="0">
-             <widget class="BoundCheckBox" name="tableWeightsMatrix">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Weights matrix</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="BoundCheckBox" name="tableCentrality">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Centrality table</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="BoundCheckBox" name="tableLayout">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Layout matrix</string>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="0">
-             <widget class="QWidget" name="widgetTableLayoutValuesOnly" native="true">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_27">
-               <property name="leftMargin">
-                <number>24</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item row="0" column="0">
-                <widget class="BoundCheckBox" name="tableLayoutValuesOnly">
-                 <property name="text">
-                  <string>Show variable names</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
          <item row="2" column="1">
           <widget class="BoundGroupBox" name="correlationMethod_2">
            <property name="sizePolicy">
@@ -2932,7 +2811,203 @@
                 <string>adalasso</string>
                </property>
               </item>
+              <item>
+               <property name="text">
+                <string>mgm</string>
+               </property>
+              </item>
              </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="BoundGroupBox" name="correlationMethod_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Plots</string>
+           </property>
+           <property name="flat">
+            <bool>false</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_51">
+            <item row="2" column="0">
+             <widget class="BoundCheckBox" name="plotNetwork">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Network plot</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <spacer name="horizontalSpacer_32">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="3" column="0">
+             <widget class="BoundCheckBox" name="plotCentrality">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Centrality plot</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="BoundCheckBox" name="plotClustering">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Clustering plot</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="2" column="2" rowspan="2">
+          <widget class="BoundGroupBox" name="isingEstimator_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Tables</string>
+           </property>
+           <property name="flat">
+            <bool>false</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_7">
+            <item row="5" column="0">
+             <widget class="BoundCheckBox" name="tableClustering">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Clustering table</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="BoundCheckBox" name="tableCentrality">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Centrality table</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="0">
+             <widget class="BoundCheckBox" name="tableLayout">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Layout matrix</string>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="0">
+             <widget class="QWidget" name="widgetTableLayoutValuesOnly" native="true">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_27">
+               <property name="leftMargin">
+                <number>24</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="BoundCheckBox" name="tableLayoutValuesOnly">
+                 <property name="text">
+                  <string>Show variable names</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="6" column="0">
+             <widget class="BoundCheckBox" name="tableWeightsMatrix">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Weights matrix</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <spacer name="horizontalSpacer_28">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="9" column="0">
+             <spacer name="verticalSpacer_12">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>5</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </widget>

--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.ui
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.ui
@@ -1897,7 +1897,7 @@
                <item row="5" column="0">
                 <widget class="QLabel" name="label_8_7">
                  <property name="text">
-                  <string>Color scheme:</string>
+                  <string>Edge palette</string>
                  </property>
                 </widget>
                </item>
@@ -2708,7 +2708,7 @@
                   <item row="5" column="0">
                    <widget class="QLabel" name="label_8_5">
                     <property name="text">
-                     <string>Color scheme:</string>
+                     <string>Node palette</string>
                     </property>
                    </widget>
                   </item>

--- a/JASP-Desktop/analysisforms/Network/networkanalysisform.ui
+++ b/JASP-Desktop/analysisforms/Network/networkanalysisform.ui
@@ -266,10 +266,10 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="2" column="0">
           <widget class="QWidget" name="bootstrapOptions" native="true">
            <property name="enabled">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <layout class="QGridLayout" name="gridLayout_14">
             <item row="1" column="0">
@@ -288,7 +288,7 @@
                <item row="2" column="2">
                 <widget class="BoundTextBox" name="numberOfBootstraps">
                  <property name="enabled">
-                  <bool>false</bool>
+                  <bool>true</bool>
                  </property>
                  <property name="minimumSize">
                   <size>
@@ -307,7 +307,7 @@
                <item row="4" column="0">
                 <widget class="BoundCheckBox" name="parallelBootstrap">
                  <property name="text">
-                  <string>Run in Parallel</string>
+                  <string>Run in parallel</string>
                  </property>
                 </widget>
                </item>
@@ -323,6 +323,16 @@
                   </size>
                  </property>
                 </spacer>
+               </item>
+               <item row="0" column="0">
+                <widget class="BoundCheckBox" name="bootstrapOnOff">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="text">
+                  <string>Bootstrap network</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>
@@ -530,169 +540,6 @@
             <property name="sizeConstraint">
              <enum>QLayout::SetNoConstraint</enum>
             </property>
-            <item row="2" column="2">
-             <widget class="BoundGroupBox" name="isingEstimator">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Ising Estimator</string>
-              </property>
-              <property name="flat">
-               <bool>false</bool>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_35">
-               <item row="4" column="0">
-                <spacer name="verticalSpacer_11">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>5</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="0" column="0">
-                <widget class="QRadioButton" name="_1pseudoLikelihood">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Pseudo-li&amp;kelihood</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QRadioButton" name="_3bivariateRegressions">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Bivariate regressions</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QRadioButton" name="_4logLinear">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>&amp;Loglinear</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QRadioButton" name="_2univariateRegressions">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>&amp;Univariate regressions</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <spacer name="horizontalSpacer_16">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="5" column="2">
-             <widget class="BoundGroupBox" name="tuningParameterBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Tuning Parameter</string>
-              </property>
-              <property name="flat">
-               <bool>false</bool>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_34">
-               <item row="2" column="1">
-                <widget class="BoundTextBox" name="tuningParameter">
-                 <property name="minimumSize">
-                  <size>
-                   <width>60</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>60</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_8_12">
-                 <property name="text">
-                  <string>value</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="2">
-                <spacer name="horizontalSpacer_15">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="3" column="1">
-                <spacer name="verticalSpacer_8">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
             <item row="2" column="1">
              <widget class="BoundGroupBox" name="correlationMethod">
               <property name="sizePolicy">
@@ -999,7 +846,7 @@
               </layout>
              </widget>
             </item>
-            <item row="7" column="1" rowspan="2">
+            <item row="8" column="1" rowspan="2">
              <widget class="BoundGroupBox" name="boxMgmVariableType">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1064,7 +911,253 @@
               </layout>
              </widget>
             </item>
+            <item row="2" column="2">
+             <widget class="BoundGroupBox" name="isingEstimator">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>Ising Estimator</string>
+              </property>
+              <property name="flat">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_35">
+               <item row="4" column="0">
+                <spacer name="verticalSpacer_11">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>5</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="0">
+                <widget class="QRadioButton" name="_1pseudoLikelihood">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Pseudo-li&amp;kelihood</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QRadioButton" name="_3bivariateRegressions">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Bivariate regressions</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QRadioButton" name="_4logLinear">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>&amp;Loglinear</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QRadioButton" name="_2univariateRegressions">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>&amp;Univariate regressions</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <spacer name="horizontalSpacer_16">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="5" column="2">
+             <widget class="BoundGroupBox" name="tuningParameterBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>Tuning Parameter</string>
+              </property>
+              <property name="flat">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_34">
+               <item row="2" column="1">
+                <widget class="BoundTextBox" name="tuningParameter">
+                 <property name="minimumSize">
+                  <size>
+                   <width>60</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>60</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_8_12">
+                 <property name="text">
+                  <string>value</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <spacer name="horizontalSpacer_15">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="3" column="1">
+                <spacer name="verticalSpacer_8">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
             <item row="7" column="2">
+             <widget class="BoundGroupBox" name="normalizeCentrality">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>Centrality Measures</string>
+              </property>
+              <property name="flat">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_44">
+               <item row="1" column="0">
+                <widget class="QRadioButton" name="centNormRelative">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Relative</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <spacer name="verticalSpacer_13">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="2" column="0">
+                <widget class="QRadioButton" name="centNormRaw">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Raw</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QRadioButton" name="centNormNorm">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Normali&amp;zed</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <spacer name="horizontalSpacer_25">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="8" column="2">
              <widget class="BoundGroupBox" name="crossValidation">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1118,7 +1211,7 @@
               </layout>
              </widget>
             </item>
-            <item row="8" column="2">
+            <item row="9" column="2">
              <widget class="BoundGroupBox" name="thresholdBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1405,7 +1498,7 @@
               </layout>
              </widget>
             </item>
-            <item row="6" column="1">
+            <item row="7" column="1">
              <widget class="BoundGroupBox" name="network">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1456,89 +1549,6 @@
                   <size>
                    <width>20</width>
                    <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="6" column="2">
-             <widget class="BoundGroupBox" name="normalizeCentrality">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Centrality Measures</string>
-              </property>
-              <property name="flat">
-               <bool>false</bool>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_44">
-               <item row="1" column="0">
-                <widget class="QRadioButton" name="centNormRelative">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Relative</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <spacer name="verticalSpacer_13">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="2" column="0">
-                <widget class="QRadioButton" name="centNormRaw">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Raw</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QRadioButton" name="centNormNorm">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Normali&amp;zed</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <spacer name="horizontalSpacer_25">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
                   </size>
                  </property>
                 </spacer>
@@ -2863,7 +2873,20 @@
             <bool>false</bool>
            </property>
            <layout class="QGridLayout" name="gridLayout_50">
-            <item row="0" column="0">
+            <item row="2" column="1">
+             <spacer name="horizontalSpacer_31">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="2" column="0">
              <widget class="BoundComboBox" name="estimator">
               <property name="enabled">
                <bool>true</bool>
@@ -2910,39 +2933,6 @@
                </property>
               </item>
              </widget>
-            </item>
-            <item row="3" column="0">
-             <spacer name="verticalSpacer_22">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>5</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="0">
-             <widget class="BoundCheckBox" name="bootstrapOnOff">
-              <property name="text">
-               <string>Bootstrap Network</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <spacer name="horizontalSpacer_31">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
             </item>
            </layout>
           </widget>
@@ -3011,38 +3001,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>bootstrapOnOff</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>bootstrapOptions</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>108</x>
-     <y>558</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>454</x>
-     <y>1617</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>bootstrapOnOff</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>numberOfBootstraps</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>108</x>
-     <y>558</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>233</x>
-     <y>1507</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>thresholdOptValue</sender>
    <signal>toggled(bool)</signal>

--- a/JASP-Engine/JASP/R/networkanalysis.R
+++ b/JASP-Engine/JASP/R/networkanalysis.R
@@ -792,36 +792,41 @@ NetworkAnalysis <- function (
 	table <- list(
 		title = "Summary of Network",
 		schema = list(fields = list(
-			list(name = "info", title = "", type = "string")
-			#list(name = "value", title = "", type = "number", format="sf:4;dp:3")
+			list(name = "info", title = "Network", type = "string"),
+			list(name = "nodes", title = "Number of nodes", type = "integer"),
+			list(name = "nonZero", title = "Number of non-zero edges", type = "string"),
+			list(name = "Sparsity", title = "Sparsity", type = "number", format="sf:4;dp:3")
 		))
 	)
-	for (i in seq_len(nGraphs)) {
-		table[["schema"]][["fields"]][[i+1]] <-
-			list(name = paste0("value", i), title = names(network[["network"]])[i], type = "number", format="sf:4;dp:3")
-	}
+	
+	# we only want to show this if there are more than 2 networks (but as the first column not the last)
+	if (nGraphs == 1)
+	  table[["schema"]][["fields"]][[1]] <- NULL
 
 	footnotes <- .newFootnotes()
 	msg <- NULL
-
-	TBcolumns <- list(info = c("Number of nodes", "Number of non-zero edges", "Sparsity"))
-
+  # browser()
 	if (is.null(network[["network"]])) { # fill in with .
 
-		TBcolumns[["value"]] <- rep(".", 3*nGraphs)
-		table[["schema"]][["fields"]][[2]][["title"]] <- "Network"
+	  TBcolumns <- list(
+	    info = paste("Network", 1:nGraphs),
+	    nodes = rep(".", nGraphs),
+	    nonZero = rep(".", nGraphs),
+	    Sparsity = rep(".", nGraphs)
+	  )
 
 	} else { # fill in with info from bootnet:::print.bootnet
+	  
+	  TBcolumns <- list(info = names(network[["network"]]),
+	                    nodes = NULL, nonZero = NULL, Sparsity = NULL)
 
+	  nVar <- ncol(network[["network"]][[1]][["graph"]])
 		for (i in seq_len(nGraphs)) {
 
 			nw <- network[["network"]][[i]]
-
-			TBcolumns[[paste0("value", i)]] <- c(
-				nrow(nw[["graph"]]),
-				sum(nw[["graph"]][upper.tri(nw[["graph"]], diag = FALSE)] != 0),
-				mean(nw[["graph"]][upper.tri(nw[["graph"]], diag = FALSE)] == 0)
-			)
+ 			TBcolumns[["nodes"]][i] <- nrow(nw[["graph"]])
+ 			TBcolumns[["nonZero"]][i] <- paste(sum(nw[["graph"]][upper.tri(nw[["graph"]], diag = FALSE)] != 0), "/", nVar * (nVar-1) / 2)
+ 		  TBcolumns[["Sparsity"]][i] <- mean(nw[["graph"]][upper.tri(nw[["graph"]], diag = FALSE)] == 0)
 
 		}
 

--- a/JASP-Engine/JASP/R/networkanalysis.R
+++ b/JASP-Engine/JASP/R/networkanalysis.R
@@ -794,7 +794,7 @@ NetworkAnalysis <- function (
 		schema = list(fields = list(
 			list(name = "info", title = "Network", type = "string"),
 			list(name = "nodes", title = "Number of nodes", type = "integer"),
-			list(name = "nonZero", title = "Number of non-zero edges", type = "string"),
+			list(name = "nonZero", title = "Number of non-zero edges"),
 			list(name = "Sparsity", title = "Sparsity", type = "number", format="sf:4;dp:3")
 		))
 	)

--- a/JASP-Tests/R/tests/testthat/test-networkanalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-networkanalysis.R
@@ -10,34 +10,39 @@ test_that("All tables results match", {
   options$tableClustering <- TRUE
   options$tableWeightsMatrix <- TRUE
   options$tableLayout <- TRUE
-  results <- JASPTools::run("NetworkAnalysis", "debug.csv", options, view=FALSE, quiet=TRUE, , sideEffects = "pkgLoading")
+  results <- JASPTools::run("NetworkAnalysis", "debug.csv", options, view=FALSE, quiet=TRUE, sideEffects = "pkgLoading")
 
   table <- results[["results"]][["generalTB"]][["data"]]
   expect_equal_tables(table,
-    list("Network", 3, "2 / 3", 0.333333333333333)
+    list("Network", 3, "2 / 3", 0.333333333333333),
+    label="generalTB"
   )
 
   table <- results[["results"]][["centralityTB"]][["data"]]
   expect_equal_tables(table,
     list("contNormal", -0.577350269189626, -1.12003079401266, -1.14291478283658,
       "contcor1", 1.15470053837925, 0.803219560925303, 0.713968266021615,
-      "contcor2", -0.577350269189626, 0.316811233087358, 0.428946516814968)
+      "contcor2", -0.577350269189626, 0.316811233087358, 0.428946516814968),
+      label="centralityTB"
   )
 
   table <- results[["results"]][["clusteringTB"]][["data"]]
   expect_equal_tables(table,
     list("contcor1", 0, 0, 0, 0, "contcor2", 0, 0, 0, 0, "contNormal",
-      0, 0, 0, 0)
+      0, 0, 0, 0),
+      label="clusteringTB"
   )
 
   table <- results[["results"]][["weightmatrixTB"]][["data"]]
   expect_equal_tables(table,
     list(3, 0, 0.0939476582188346, 0, 1, 0.0939476582188346, 0, 0.612057902640958,
-      2, 0, 0.612057902640958, 0)
+      2, 0, 0.612057902640958, 0),
+      label="weightmatrixTB"
   )
 
   table <- results[["results"]][["layoutTB"]][["data"]]
   expect_equal_tables(table,
-    list(1, 1, -1, 0.0611664081106051, -0.270697752594105, -1)
+    list(1, 1, -1, 0.0611664081106051, -0.270697752594105, -1),
+    label="layoutTB"
   )
 })

--- a/JASP-Tests/R/tests/testthat/test-networkanalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-networkanalysis.R
@@ -1,0 +1,43 @@
+context("Network Analysis")
+
+# does not test
+# - error handling
+
+test_that("All tables results match", {
+  options <- JASPTools::analysisOptions("NetworkAnalysis")
+  options$variables <- c("contNormal", "contcor1", "contcor2")
+  options$tableCentrality <- TRUE
+  options$tableClustering <- TRUE
+  options$tableWeightsMatrix <- TRUE
+  options$tableLayout <- TRUE
+  results <- JASPTools::run("NetworkAnalysis", "debug.csv", options, view=FALSE, quiet=TRUE, , sideEffects = "pkgLoading")
+
+  table <- results[["results"]][["generalTB"]][["data"]]
+  expect_equal_tables(table,
+    list("Network", 3, "2 / 3", 0.333333333333333)
+  )
+
+  table <- results[["results"]][["centralityTB"]][["data"]]
+  expect_equal_tables(table,
+    list("contNormal", -0.577350269189626, -1.12003079401266, -1.14291478283658,
+      "contcor1", 1.15470053837925, 0.803219560925303, 0.713968266021615,
+      "contcor2", -0.577350269189626, 0.316811233087358, 0.428946516814968)
+  )
+
+  table <- results[["results"]][["clusteringTB"]][["data"]]
+  expect_equal_tables(table,
+    list("contcor1", 0, 0, 0, 0, "contcor2", 0, 0, 0, 0, "contNormal",
+      0, 0, 0, 0)
+  )
+
+  table <- results[["results"]][["weightmatrixTB"]][["data"]]
+  expect_equal_tables(table,
+    list(3, 0, 0.0939476582188346, 0, 1, 0.0939476582188346, 0, 0.612057902640958,
+      2, 0, 0.612057902640958, 0)
+  )
+
+  table <- results[["results"]][["layoutTB"]][["data"]]
+  expect_equal_tables(table,
+    list(1, 1, -1, 0.0611664081106051, -0.270697752594105, -1)
+  )
+})

--- a/JASP-Tests/R/tests/testthat/test-networkanalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-networkanalysis.R
@@ -2,22 +2,26 @@ context("Network Analysis")
 
 # does not test
 # - error handling
+# - bootstrapping
+# - plots or graphical options
 
-test_that("All tables results match", {
-  options <- JASPTools::analysisOptions("NetworkAnalysis")
-  options$variables <- c("contNormal", "contcor1", "contcor2")
-  options$tableCentrality <- TRUE
-  options$tableClustering <- TRUE
-  options$tableWeightsMatrix <- TRUE
-  options$tableLayout <- TRUE
-  results <- JASPTools::run("NetworkAnalysis", "debug.csv", options, view=FALSE, quiet=TRUE, sideEffects = "pkgLoading")
+options <- JASPTools::analysisOptions("NetworkAnalysis")
+options$variables <- c("contNormal", "contcor1", "contcor2")
+options$tableCentrality <- TRUE
+options$tableClustering <- TRUE
+options$tableWeightsMatrix <- TRUE
+options$tableLayout <- TRUE
+results <- JASPTools::run("NetworkAnalysis", "debug.csv", options, view=FALSE, quiet=TRUE, sideEffects = "pkgLoading")
+
+test_that("generalTB table results match", {
 
   table <- results[["results"]][["generalTB"]][["data"]]
   expect_equal_tables(table,
-    list("Network", 3, "2 / 3", 0.333333333333333),
-    label="generalTB"
+    list("Network", 3, "2 / 3", 0.333333333333333)
   )
+})
 
+test_that("centralityTB table results match", {
   table <- results[["results"]][["centralityTB"]][["data"]]
   expect_equal_tables(table,
     list("contNormal", -0.577350269189626, -1.12003079401266, -1.14291478283658,
@@ -25,21 +29,27 @@ test_that("All tables results match", {
       "contcor2", -0.577350269189626, 0.316811233087358, 0.428946516814968),
       label="centralityTB"
   )
+})
 
+test_that("clusteringTB table results match", { 
   table <- results[["results"]][["clusteringTB"]][["data"]]
   expect_equal_tables(table,
     list("contcor1", 0, 0, 0, 0, "contcor2", 0, 0, 0, 0, "contNormal",
       0, 0, 0, 0),
       label="clusteringTB"
   )
+})
 
+test_that("weightmatrixTB table results match", {
   table <- results[["results"]][["weightmatrixTB"]][["data"]]
   expect_equal_tables(table,
     list(3, 0, 0.0939476582188346, 0, 1, 0.0939476582188346, 0, 0.612057902640958,
       2, 0, 0.612057902640958, 0),
       label="weightmatrixTB"
   )
+})
 
+test_that("layoutTB table results match", {
   table <- results[["results"]][["layoutTB"]][["data"]]
   expect_equal_tables(table,
     list(1, 1, -1, 0.0611664081106051, -0.270697752594105, -1),

--- a/Resources/Help/analyses/networkanalysis.md
+++ b/Resources/Help/analyses/networkanalysis.md
@@ -196,7 +196,7 @@ Friedman, J., Hastie, T., & Tibshirani, R. (2008). Sparse inverse covariance est
 
 Friedman, J. H., Hastie, T., & Tibshirani, R. (2014). glasso: Graphical lasso estimation of gaussian graphical models. Retrieved from https://CRAN.R-project.org/package=glasso
 
-Fruchterman, T. M., & Reingold, E. M. (1991). Graph drawing by force‐directed placement. Software: Practice and experience, 21(11), 1129-1164.
+Fruchterman, T. M., & Reingold, E. M. (1991). Graph drawing by force-directed placement. Software: Practice and experience, 21(11), 1129-1164.
 
 Haslbeck, J., & Waldorp, L. J. (2015). mgm: Structure Estimation for time-varying mixed graphical models in high-dimensional data. arXiv preprint arXiv:1510.06871.
 

--- a/Resources/Library/NetworkAnalysis.json
+++ b/Resources/Library/NetworkAnalysis.json
@@ -186,9 +186,9 @@
 		{
 			"name": "numberOfBootstraps",
 			"type": "Integer",
-			"min": 1,
+			"min": 0,
 			"max": 100000,
-			"default": 3
+			"default": 0
 		},
 		{
 			"name": "parallelBootstrap",

--- a/Resources/Library/NetworkAnalysis.json
+++ b/Resources/Library/NetworkAnalysis.json
@@ -53,6 +53,11 @@
 			"type": "Boolean"
 		},
 		{
+			"name": "tableClustering",
+			"type": "Boolean",
+			"default": false
+		},
+		{
 			"default": false,
 			"name": "plotNetwork",
 			"type": "Boolean"
@@ -60,6 +65,11 @@
 		{
 			"default": false,
 			"name": "plotCentrality",
+			"type": "Boolean"
+		},
+		{
+			"default": false,
+			"name": "plotClustering",
 			"type": "Boolean"
 		},
 		{
@@ -208,7 +218,7 @@
 		{
 			"name": "BootstrapType",
 			"type": "List",
-			"options": ["nonparametric", "parametric", "node", "person", "case", "jackknife"],
+			"options": ["nonparametric", "case", "node", "parametric", "person", "jackknife"],
 			"default": "nonparametric"
 		},
 		{
@@ -374,6 +384,16 @@
 		},
 		{
 			"name": "plotHeightCentrality",
+			"type": "Integer",
+			"default": 320
+		},
+		{
+			"name": "plotWidthClustering",
+			"type": "Integer",
+			"default": 480
+		},
+		{
+			"name": "plotHeightClustering",
 			"type": "Integer",
 			"default": 320
 		},


### PR DESCRIPTION
Some updates to the network module:

- Reintroduces mgm since nobody could reproduce the bug.
- Hides the parallel bootstrap option to avoid firewall issues.
- Fixes the nonzero edges bug.
- Introduces clustering plot and clustering table.
- Slightly reorganized the ui (plots and tables now in separate boxes, enable bootstrap moved to the bootstrap tab).
- Fixed more issues related to Sacha's and Denny's comments
- Included a first unit test (more to come!).