### PR TITLE
Meta-analysis: fix missing namespace

### DIFF
--- a/JASP-Engine/JASP/R/classicalmetaanalysis.R
+++ b/JASP-Engine/JASP/R/classicalmetaanalysis.R
@@ -372,7 +372,7 @@ ClassicalMetaAnalysis <- function(dataset=NULL, options, perform="run", callback
     
     table <- list(title = title)
     if (! is.null(egger)) {
-      table$x <- coef(summary(egger$fit))[egger$predictor, c(paste0(cols[1], "val"), "pval")]
+      table$x <- metafor::coef.summary.rma(summary(egger$fit))[egger$predictor, c(paste0(cols[1], "val"), "pval")]
       colnames(table$x) <- cols
     } else {
       table$x <- cols


### PR DESCRIPTION
This bug occurred because the code relied on the S3 method of a package (metafor) that was not loaded.

To clarify why it only happened when compiled in release vs debug:
In release init and run are performed in distinct processes, while in debug they are performed in the same process (and apparently in the same R session).



