### PR TITLE
Show Variable name on hover. 

### DIFF
--- a/JASP-Desktop/JASP-Desktop.pri
+++ b/JASP-Desktop/JASP-Desktop.pri
@@ -181,6 +181,7 @@ HEADERS  += \
     $$PWD/backstage/verticaltabwidget.h \
     $$PWD/backstagewidget.h \
     $$PWD/bound.h \
+    $$PWD/customhoverdelegate.h \
     $$PWD/datasetloader.h \
     $$PWD/datasettablemodel.h \
     $$PWD/enginesync.h \

--- a/JASP-Desktop/analysisforms/Common/anovarepeatedmeasuresbayesianform.cpp
+++ b/JASP-Desktop/analysisforms/Common/anovarepeatedmeasuresbayesianform.cpp
@@ -45,7 +45,7 @@ AnovaRepeatedMeasuresBayesianForm::AnovaRepeatedMeasuresBayesianForm(QWidget *pa
 	_withinSubjectCellsListModel->setVariableTypesAllowed(Column::ColumnTypeScale | Column::ColumnTypeNominal | Column::ColumnTypeOrdinal);
 	ui->repeatedMeasuresCells->setModel(_withinSubjectCellsListModel);
 	ui->repeatedMeasuresCells->viewport()->setAttribute(Qt::WA_Hover);
-	ui->repeatedMeasuresCells->setItemDelegate(new AnovaHoverDelegate(ui->repeatedMeasuresCells));
+	ui->repeatedMeasuresCells->setItemDelegate(new CustomHoverDelegate(ui->repeatedMeasuresCells));
 
 	_betweenSubjectsFactorsListModel = new TableModelVariablesAssigned(this);
 	_betweenSubjectsFactorsListModel->setSource(&_availableVariablesModel);

--- a/JASP-Desktop/analysisforms/Common/anovarepeatedmeasuresform.cpp
+++ b/JASP-Desktop/analysisforms/Common/anovarepeatedmeasuresform.cpp
@@ -47,7 +47,7 @@ AnovaRepeatedMeasuresForm::AnovaRepeatedMeasuresForm(QWidget *parent) :
 	_withinSubjectCellsListModel->setVariableTypesAllowed(Column::ColumnTypeScale | Column::ColumnTypeNominal | Column::ColumnTypeOrdinal);
 	ui->repeatedMeasuresCells->setModel(_withinSubjectCellsListModel);
 	ui->repeatedMeasuresCells->viewport()->setAttribute(Qt::WA_Hover);
-	ui->repeatedMeasuresCells->setItemDelegate(new AnovaHoverDelegate(ui->repeatedMeasuresCells));
+	ui->repeatedMeasuresCells->setItemDelegate(new CustomHoverDelegate(ui->repeatedMeasuresCells));
 
 
 	_betweenSubjectsFactorsListModel = new TableModelVariablesAssigned(this);

--- a/JASP-Desktop/customhoverdelegate.h
+++ b/JASP-Desktop/customhoverdelegate.h
@@ -23,6 +23,7 @@
 #include <QItemDelegate>
 #include <QPainter>
 #include <QToolTip>
+#include <QColor>
 
 class CustomHoverDelegate : public QItemDelegate
 {
@@ -32,7 +33,7 @@ public:
 	{
 		if(option.state & QStyle::State_MouseOver)
 		{
-			painter->fillRect(option.rect, Qt::lightGray);
+			painter->fillRect(option.rect, QColor(220, 241, 251));
 			QString str = index.data().toString();
 			QToolTip::showText(QCursor::pos(), str);
 		}

--- a/JASP-Desktop/customhoverdelegate.h
+++ b/JASP-Desktop/customhoverdelegate.h
@@ -1,0 +1,43 @@
+//
+// Copyright (C) 2013-2017 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef CUSTOMHOVERDELEGATE_H
+#define CUSTOMHOVERDELEGATE_H
+
+#include <QStringListModel>
+#include <QItemDelegate>
+#include <QPainter>
+#include <QToolTip>
+
+class CustomHoverDelegate : public QItemDelegate
+{
+public:
+	CustomHoverDelegate(QObject *parent = 0) : QItemDelegate(parent) {}
+	void paint (QPainter *painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
+	{
+		if(option.state & QStyle::State_MouseOver)
+		{
+			painter->fillRect(option.rect, Qt::lightGray);
+			QString str = index.data().toString();
+			QToolTip::showText(QCursor::pos(), str);
+		}
+		QItemDelegate::paint(painter, option, index);
+	}
+};
+
+#endif // CUSTOMHOVERDELEGATE_H

--- a/JASP-Desktop/widgets/anovamodelwidget.h
+++ b/JASP-Desktop/widgets/anovamodelwidget.h
@@ -32,23 +32,7 @@
 
 #include "tablemodelvariablesavailable.h"
 #include "tablemodelanovamodel.h"
-
-
-class AnovaHoverDelegate : public QItemDelegate
-{
-public:
-	AnovaHoverDelegate(QObject *parent=0) : QItemDelegate(parent){}
-	void paint ( QPainter *painter, const QStyleOptionViewItem & option, const QModelIndex & index ) const
-	{
-		if(option.state & QStyle::State_MouseOver)
-		{
-			painter->fillRect(option.rect, Qt::lightGray);
-			QString str = index.data().toString();
-			QToolTip::showText(QCursor::pos(), str);
-		}
-		QItemDelegate::paint(painter, option, index);
-	}
-};
+#include "customhoverdelegate.h"
 
 namespace Ui {
 class AnovaModelWidget;
@@ -57,7 +41,7 @@ class AnovaModelWidget;
 class AnovaModelWidget : public QWidget, public Bound
 {
 	Q_OBJECT
-	
+
 public:
 	explicit AnovaModelWidget(QWidget *parent = 0);
 	~AnovaModelWidget();
@@ -66,7 +50,7 @@ public:
 	virtual void setModel(TableModelAnovaModel *model);
 
 	void setFactorsLabel(const QString &label);
-	
+
 private slots:
 
 	void variablesAvailableChanged();

--- a/JASP-Desktop/widgets/availablefieldslistview.cpp
+++ b/JASP-Desktop/widgets/availablefieldslistview.cpp
@@ -31,4 +31,6 @@ AvailableFieldsListView::AvailableFieldsListView(QWidget *parent) :
 	this->setDragEnabled(true);
 	this->viewport()->setAcceptDrops(true);
 	this->setDragDropMode(QAbstractItemView::DragDrop);
+	this->viewport()->setAttribute(Qt::WA_Hover);
+	this->setItemDelegate(new CustomHoverDelegate(this));
 }

--- a/JASP-Desktop/widgets/availablefieldslistview.h
+++ b/JASP-Desktop/widgets/availablefieldslistview.h
@@ -25,6 +25,8 @@
 
 #include "assignbutton.h"
 #include "listview.h"
+#include "customhoverdelegate.h"
+
 
 class AvailableFieldsListView : public ListView
 {

--- a/JASP-Desktop/widgets/boundlistview.cpp
+++ b/JASP-Desktop/widgets/boundlistview.cpp
@@ -53,7 +53,7 @@ BoundListView::BoundListView(QWidget *parent)
 	layout->setContentsMargins(4, 4, 4, 4);
 	_variableTypeKey->setLayout(layout);
 	_variableTypeKey->resize(_variableTypeKey->sizeHint());
-
+	this->viewport()->setAttribute(Qt::WA_Hover);
 	this->setItemDelegate(new TableViewMenuEditorDelegate(this));
 }
 

--- a/JASP-Desktop/widgets/boundlistview.h
+++ b/JASP-Desktop/widgets/boundlistview.h
@@ -32,6 +32,7 @@
 #include "dataset.h"
 #include "tablemodelvariablesassigned.h"
 #include "listview.h"
+#include "customhoverdelegate.h"
 
 class BoundListView : public ListView, public Bound
 {

--- a/JASP-Desktop/widgets/boundpairstable.cpp
+++ b/JASP-Desktop/widgets/boundpairstable.cpp
@@ -41,6 +41,8 @@ BoundPairsTable::BoundPairsTable(QWidget *parent) :
 	this->viewport()->setAcceptDrops(true);
 	this->setDropIndicatorShown(true);
 	this->setDragDropMode(QAbstractItemView::DragDrop);
+	this->viewport()->setAttribute(Qt::WA_Hover);
+	this->setItemDelegate(new CustomHoverDelegate(this));
 
 	horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
 	horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);

--- a/JASP-Desktop/widgets/boundpairstable.h
+++ b/JASP-Desktop/widgets/boundpairstable.h
@@ -25,6 +25,7 @@
 #include "assignbutton.h"
 #include "tablemodelpairsassigned.h"
 #include "tableview.h"
+#include "customhoverdelegate.h"
 
 class BoundPairsTable : public TableView, public Bound
 {

--- a/JASP-Desktop/widgets/boundtableview.cpp
+++ b/JASP-Desktop/widgets/boundtableview.cpp
@@ -27,6 +27,8 @@ BoundTableView::BoundTableView(QWidget *parent)
 	this->viewport()->setAcceptDrops(true);
 	this->setDropIndicatorShown(true);
 	this->setDragDropMode(QAbstractItemView::DragDrop);
+	this->viewport()->setAttribute(Qt::WA_Hover);
+	this->setItemDelegate(new CustomHoverDelegate(this));
 }
 
 void BoundTableView::bindTo(Option *option)

--- a/JASP-Desktop/widgets/boundtableview.h
+++ b/JASP-Desktop/widgets/boundtableview.h
@@ -22,6 +22,7 @@
 #include "tableview.h"
 #include "bound.h"
 #include "boundmodel.h"
+#include "customhoverdelegate.h"
 
 class BoundTableView : public TableView, public Bound
 {

--- a/JASP-Desktop/widgets/tableviewmenueditordelegate.h
+++ b/JASP-Desktop/widgets/tableviewmenueditordelegate.h
@@ -24,6 +24,9 @@
 #include "common.h"
 #include <QMenu>
 #include <QLabel>
+#include <QPainter>
+#include <QToolTip>
+#include <QColor>
 #include "tableviewmenueditor.h"
 
 class TableViewMenuEditorDelegate : public QStyledItemDelegate
@@ -34,6 +37,16 @@ public:
 
 	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const OVERRIDE;
 	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const OVERRIDE;
+	void paint (QPainter *painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
+	{
+		if(option.state & QStyle::State_MouseOver)
+		{
+			painter->fillRect(option.rect, QColor(220, 241, 251));
+			QString str = index.data().toString();
+			QToolTip::showText(QCursor::pos(), str);
+		}
+		QStyledItemDelegate::paint(painter, option, index);
+	}
 
 private slots:
 	void editingFinished();


### PR DESCRIPTION
1. Fixes #1954. 
2. Added `CustomHoverDelegate` class for hover behaviour.

![hover](https://user-images.githubusercontent.com/6959308/33325804-964f7be2-d453-11e7-9f94-0a0926a59a97.jpg)
