### PR TITLE
Small adds to debian packaging

### DIFF
--- a/Tools/debian/changelog
+++ b/Tools/debian/changelog
@@ -1,4 +1,4 @@
-jasp (0.8.5.0-1) UNRELEASED; urgency=medium
+jasp (0.8.5-1) UNRELEASED; urgency=medium
 
   * Initial release. (Closes ITP: #XXXXXX)
 

--- a/Tools/debian/control
+++ b/Tools/debian/control
@@ -3,7 +3,7 @@ Maintainer: jasp-uva <b.boutin@uva.nl>
 Section: science
 Priority: optional
 Standards-Version: 3.9.8
-Build-Depends: libboost-dev, r-base-core, r-cran-rcpp, r-cran-rinside, libqt5widgets5, libqt5webkit5-dev, libqt5svg5-dev, qt5-qmake, libarchive-dev, libboost-filesystem-dev, libboost-system-dev, libjsoncpp-dev, debhelper (>= 9)
+Build-Depends: libboost-dev, r-base-core, r-cran-rcpp, r-cran-rinside, libqt5widgets5, libqt5webkit5-dev, libqt5svg5-dev, qt5-qmake, libarchive-dev, libboost-filesystem-dev, libboost-system-dev, libjsoncpp-dev, qt5-default, debhelper (>= 9)
 
 Package: jasp
 Architecture: any

--- a/Tools/make-debian-package.sh
+++ b/Tools/make-debian-package.sh
@@ -3,10 +3,10 @@
 MajorVersion=`grep -oP		'VersionMajor\(\K[0123456789]+(?=\))' ../JASP-Common/appinfo.cpp`
 MinorVersion=`grep -oP		'VersionMinor\(\K[0123456789]+(?=\))' ../JASP-Common/appinfo.cpp` 
 RevisionVersion=`grep -oP	'VersionRevision\(\K[0123456789]+(?=\))' ../JASP-Common/appinfo.cpp`
-BuildVersion=`grep -oP		'VersionBuildNumber\(\K[0123456789]+(?=\))' ../JASP-Common/appinfo.cpp`
+#BuildVersion=`grep -oP		'VersionBuildNumber\(\K[0123456789]+(?=\))' ../JASP-Common/appinfo.cpp`
 
-JASPFolder=jasp-$MajorVersion.$MinorVersion.$RevisionVersion.0
-JASPTar=jasp_$MajorVersion.$MinorVersion.$RevisionVersion.0.orig.tar.gz
+JASPFolder=jasp-$MajorVersion.$MinorVersion.$RevisionVersion
+JASPTar=jasp_$MajorVersion.$MinorVersion.$RevisionVersion.orig.tar.gz
 
 echo Making debian package $JASPFolder
 

--- a/Tools/ubuntu/control
+++ b/Tools/ubuntu/control
@@ -3,7 +3,7 @@ Maintainer: jasp-uva <b.boutin@uva.nl>
 Section: science
 Priority: optional
 Standards-Version: 3.9.8
-Build-Depends: libboost-dev, r-base-core, r-cran-rcpp, r-cran-rinside, libqt5widgets5, libqt5webkit5-dev, libqt5svg5-dev, qt5-qmake, libarchive-dev, libboost-filesystem-dev, libboost-system-dev, libjsoncpp-dev, debhelper (>= 9)
+Build-Depends: libboost-dev, r-base-core, r-cran-rcpp, r-cran-rinside, libqt5widgets5, libqt5webkit5-dev, libqt5svg5-dev, qt5-qmake, libarchive-dev, libboost-filesystem-dev, libboost-system-dev, libjsoncpp-dev, qt5-default, debhelper (>= 9)
 
 Package: jasp
 Architecture: any


### PR DESCRIPTION
Extra zero in version is not needed but the qt5-default build-dependency is. 