### PR TITLE
Missing values efa pca

### DIFF
--- a/JASP-Desktop/analysisforms/Common/exploratoryfactoranalysisform.ui
+++ b/JASP-Desktop/analysisforms/Common/exploratoryfactoranalysisform.ui
@@ -20,10 +20,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_7">
-   <property name="verticalSpacing">
-    <number>0</number>
-   </property>
-   <item row="0" column="0" colspan="3">
+   <item row="0" column="0">
     <widget class="QWidget" name="topWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -138,168 +135,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QWidget" name="widget_9" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_6">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>3</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="ExpanderButton" name="pushButton_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Output options</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QWidget" name="containerOptions" native="true">
-        <layout class="QGridLayout" name="gridLayout_4">
-         <item row="0" column="0">
-          <widget class="BoundGroupBox" name="highlight">
-           <property name="maximumSize">
-            <size>
-             <width>81</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="title">
-            <string>Highlight</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_3">
-            <item row="1" column="0" alignment="Qt::AlignHCenter">
-             <widget class="QSlider" name="highlightSlider">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>70</height>
-               </size>
-              </property>
-              <property name="maximum">
-               <number>100</number>
-              </property>
-              <property name="pageStep">
-               <number>10</number>
-              </property>
-              <property name="value">
-               <number>40</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="BoundTextBox" name="highlightText">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>50</width>
-                <height>16777215</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-           <zorder>highlightText</zorder>
-           <zorder>highlightSlider</zorder>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="BoundGroupBox" name="includeTables">
-           <property name="title">
-            <string>Include tables</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_10">
-            <item row="3" column="0">
-             <widget class="BoundCheckBox" name="incl_screePlot">
-              <property name="text">
-               <string>Scree plot</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="BoundCheckBox" name="incl_correlations">
-              <property name="text">
-               <string>Factor correlations</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="BoundCheckBox" name="incl_fitIndices">
-              <property name="text">
-               <string>Additional fit indices</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="BoundCheckBox" name="incl_pathDiagram">
-              <property name="text">
-               <string>Path diagram</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
+   <item row="1" column="0">
     <widget class="QWidget" name="widget" native="true">
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="leftMargin">
@@ -627,6 +463,212 @@
         <zorder>_1eigenvalues</zorder>
         <zorder>nFactorWidget_2</zorder>
         <zorder>_3parallelAnalysis</zorder>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QWidget" name="widget_9" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="ExpanderButton" name="pushButton_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Output options</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QWidget" name="containerOptions" native="true">
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="0" column="0">
+          <widget class="BoundGroupBox" name="highlight">
+           <property name="maximumSize">
+            <size>
+             <width>81</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Highlight</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_3">
+            <item row="1" column="0" alignment="Qt::AlignHCenter">
+             <widget class="QSlider" name="highlightSlider">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>70</height>
+               </size>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+              <property name="pageStep">
+               <number>10</number>
+              </property>
+              <property name="value">
+               <number>40</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="BoundTextBox" name="highlightText">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>50</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+           <zorder>highlightText</zorder>
+           <zorder>highlightSlider</zorder>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="BoundGroupBox" name="includeTables">
+           <property name="title">
+            <string>Include tables</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_10">
+            <item row="3" column="0">
+             <widget class="BoundCheckBox" name="incl_screePlot">
+              <property name="text">
+               <string>Scree plot</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="BoundCheckBox" name="incl_correlations">
+              <property name="text">
+               <string>Factor correlations</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="BoundCheckBox" name="incl_fitIndices">
+              <property name="text">
+               <string>Additional fit indices</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="BoundCheckBox" name="incl_pathDiagram">
+              <property name="text">
+               <string>Path diagram</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="BoundGroupBox" name="missingValues">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Missing Values</string>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_9">
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="_1excludePairwise">
+              <property name="text">
+               <string>Exclude cases pairwise</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QRadioButton" name="_2excludeListwise">
+              <property name="text">
+               <string>Exclude cases listwise</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/JASP-Desktop/analysisforms/Common/exploratoryfactoranalysisform.ui
+++ b/JASP-Desktop/analysisforms/Common/exploratoryfactoranalysisform.ui
@@ -211,7 +211,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Oblique</string>
+            <string>Obli&amp;que</string>
            </property>
           </widget>
          </item>
@@ -303,7 +303,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Eigenvalues</string>
+            <string>Eigen&amp;values</string>
            </property>
           </widget>
          </item>
@@ -378,7 +378,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Manual</string>
+            <string>&amp;Manual</string>
            </property>
           </widget>
          </item>
@@ -502,6 +502,61 @@
       <item row="1" column="0">
        <widget class="QWidget" name="containerOptions" native="true">
         <layout class="QGridLayout" name="gridLayout_4">
+         <item row="1" column="0">
+          <widget class="BoundGroupBox" name="missingValues">
+           <property name="maximumSize">
+            <size>
+             <width>180000</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Missing values</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_8">
+            <item row="2" column="1">
+             <widget class="QRadioButton" name="_2excludeListwise">
+              <property name="text">
+               <string>Exclude cases listwise</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="3">
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="1">
+             <widget class="QRadioButton" name="_1excludePairwise">
+              <property name="text">
+               <string>E&amp;xclude cases pairwise</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
          <item row="0" column="0">
           <widget class="BoundGroupBox" name="highlight">
            <property name="maximumSize">
@@ -573,7 +628,7 @@
            <zorder>highlightSlider</zorder>
           </widget>
          </item>
-         <item row="0" column="1">
+         <item row="0" column="2">
           <widget class="BoundGroupBox" name="includeTables">
            <property name="title">
             <string>Include tables</string>
@@ -623,39 +678,7 @@
            </layout>
           </widget>
          </item>
-         <item row="1" column="0">
-          <widget class="BoundGroupBox" name="missingValues">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Missing Values</string>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_9">
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="_1excludePairwise">
-              <property name="text">
-               <string>Exclude cases pairwise</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QRadioButton" name="_2excludeListwise">
-              <property name="text">
-               <string>Exclude cases listwise</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="1" column="1">
+         <item row="1" column="2">
           <spacer name="horizontalSpacer_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/JASP-Desktop/analysisforms/Common/principalcomponentanalysisform.ui
+++ b/JASP-Desktop/analysisforms/Common/principalcomponentanalysisform.ui
@@ -59,7 +59,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Manual</string>
+            <string>&amp;Manual</string>
            </property>
           </widget>
          </item>
@@ -196,7 +196,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Eigenvalues</string>
+            <string>Eigen&amp;values</string>
            </property>
           </widget>
          </item>
@@ -280,7 +280,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Oblique</string>
+            <string>Obli&amp;que</string>
            </property>
           </widget>
          </item>
@@ -481,6 +481,19 @@
       <property name="bottomMargin">
        <number>3</number>
       </property>
+      <item row="0" column="0">
+       <widget class="ExpanderButton" name="pushButton_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Output options</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QWidget" name="containerOptions" native="true">
         <layout class="QGridLayout" name="gridLayout_4">
@@ -557,11 +570,9 @@
              </spacer>
             </item>
            </layout>
-           <zorder>highlightText</zorder>
-           <zorder>highlightSlider</zorder>
           </widget>
          </item>
-         <item row="0" column="1">
+         <item row="0" column="1" colspan="2">
           <widget class="BoundGroupBox" name="includeTables">
            <property name="title">
             <string>Include tables</string>
@@ -617,52 +628,62 @@
            </property>
           </spacer>
          </item>
-         <item row="1" column="0">
+         <item row="2" column="0">
           <widget class="BoundGroupBox" name="missingValues">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+           <property name="maximumSize">
+            <size>
+             <width>180000</width>
+             <height>16777215</height>
+            </size>
            </property>
            <property name="title">
-            <string>Missing Values</string>
+            <string>Missing values</string>
            </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_9">
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="_1excludePairwise">
-              <property name="text">
-               <string>Exclude cases pairwise</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QRadioButton" name="_2excludeListwise">
+           <layout class="QGridLayout" name="gridLayout_8">
+            <item row="2" column="1">
+             <widget class="QRadioButton" name="_2excludeListwise_2">
               <property name="text">
                <string>Exclude cases listwise</string>
               </property>
              </widget>
             </item>
+            <item row="1" column="3">
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="1">
+             <widget class="QRadioButton" name="_1excludePairwise_2">
+              <property name="text">
+               <string>E&amp;xclude cases pairwise</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="ExpanderButton" name="pushButton_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Output options</string>
-        </property>
        </widget>
       </item>
      </layout>

--- a/JASP-Desktop/analysisforms/Common/principalcomponentanalysisform.ui
+++ b/JASP-Desktop/analysisforms/Common/principalcomponentanalysisform.ui
@@ -20,285 +20,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_7">
-   <property name="verticalSpacing">
-    <number>0</number>
-   </property>
-   <item row="0" column="0" colspan="3">
-    <widget class="QWidget" name="topWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>300</height>
-      </size>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>12</number>
-      </property>
-      <property name="verticalSpacing">
-       <number>3</number>
-      </property>
-      <item row="0" column="0" rowspan="4">
-       <widget class="AvailableFieldsListView" name="listAvailableFields">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="selectionMode">
-         <enum>QAbstractItemView::ExtendedSelection</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_4">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Included Variables</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="BoundListView" name="variables">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>200</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>200</height>
-         </size>
-        </property>
-        <property name="selectionMode">
-         <enum>QAbstractItemView::ExtendedSelection</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="AssignButton" name="buttonAssignVariables">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>50</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>50</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QWidget" name="widget_9" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_6">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>3</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="ExpanderButton" name="pushButton_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Output options</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QWidget" name="containerOptions" native="true">
-        <layout class="QGridLayout" name="gridLayout_4">
-         <item row="0" column="0">
-          <widget class="BoundGroupBox" name="highlight">
-           <property name="maximumSize">
-            <size>
-             <width>81</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="title">
-            <string>Highlight</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_3">
-            <item row="1" column="0" alignment="Qt::AlignHCenter">
-             <widget class="QSlider" name="highlightSlider">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>70</height>
-               </size>
-              </property>
-              <property name="maximum">
-               <number>100</number>
-              </property>
-              <property name="pageStep">
-               <number>10</number>
-              </property>
-              <property name="value">
-               <number>40</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="BoundTextBox" name="highlightText">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>50</width>
-                <height>16777215</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-           <zorder>highlightText</zorder>
-           <zorder>highlightSlider</zorder>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="BoundGroupBox" name="includeTables">
-           <property name="title">
-            <string>Include tables</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_10">
-            <item row="2" column="0">
-             <widget class="BoundCheckBox" name="incl_screePlot">
-              <property name="text">
-               <string>Scree plot</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="BoundCheckBox" name="incl_correlations">
-              <property name="text">
-               <string>Factor correlations</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="BoundCheckBox" name="incl_pathDiagram">
-              <property name="text">
-               <string>Path diagram</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
+   <item row="1" column="0" colspan="2">
     <widget class="QWidget" name="widget" native="true">
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="leftMargin">
@@ -621,6 +343,326 @@
           </spacer>
          </item>
         </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QWidget" name="topWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>300</height>
+      </size>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>12</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>3</number>
+      </property>
+      <item row="0" column="0" rowspan="4">
+       <widget class="AvailableFieldsListView" name="listAvailableFields">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::ExtendedSelection</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Included Variables</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="BoundListView" name="variables">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>200</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>200</height>
+         </size>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::ExtendedSelection</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="AssignButton" name="buttonAssignVariables">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>50</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QWidget" name="widget_9" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item row="1" column="0">
+       <widget class="QWidget" name="containerOptions" native="true">
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="0" column="0">
+          <widget class="BoundGroupBox" name="highlight">
+           <property name="maximumSize">
+            <size>
+             <width>81</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Highlight</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_3">
+            <item row="2" column="0">
+             <widget class="BoundTextBox" name="highlightText">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>50</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0" alignment="Qt::AlignHCenter">
+             <widget class="QSlider" name="highlightSlider">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>70</height>
+               </size>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+              <property name="pageStep">
+               <number>10</number>
+              </property>
+              <property name="value">
+               <number>40</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+           <zorder>highlightText</zorder>
+           <zorder>highlightSlider</zorder>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="BoundGroupBox" name="includeTables">
+           <property name="title">
+            <string>Include tables</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_10">
+            <item row="2" column="0">
+             <widget class="BoundCheckBox" name="incl_screePlot">
+              <property name="text">
+               <string>Scree plot</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="BoundCheckBox" name="incl_correlations">
+              <property name="text">
+               <string>Factor correlations</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="BoundCheckBox" name="incl_pathDiagram">
+              <property name="text">
+               <string>Path diagram</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="0">
+          <widget class="BoundGroupBox" name="missingValues">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Missing Values</string>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_9">
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="_1excludePairwise">
+              <property name="text">
+               <string>Exclude cases pairwise</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QRadioButton" name="_2excludeListwise">
+              <property name="text">
+               <string>Exclude cases listwise</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="ExpanderButton" name="pushButton_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Output options</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/JASP-Engine/JASP/R/principalcomponentanalysis.R
+++ b/JASP-Engine/JASP/R/principalcomponentanalysis.R
@@ -371,8 +371,12 @@ mainFunctionPCAEFA <- function(type, dataset = NULL, options, perform = "run",
 	if (is.null(dataset)) {
 	## if we are ready to run, read in the dataset
 		if (perform == "run" && length(options$variables) > 1) {
+			
+			exclude <- c()
+			if (options[["missingValues"]] == "listwise")
+				exclude <- c(depvars, groups)
 
-			dataset <- .readDataSetToEnd(columns.as.numeric = depvars, columns.as.factor = groups, exclude.na.listwise = c(depvars, groups))
+			dataset <- .readDataSetToEnd(columns.as.numeric = depvars, columns.as.factor = groups, exclude.na.listwise = exclude)
 		} else {
 			dataset <- .readDataSetHeader(columns.as.numeric = depvars, columns.as.factor = groups)
 		}

--- a/JASP-Tests/R/tests/testthat/test-exploratoryfactoranalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-exploratoryfactoranalysis.R
@@ -58,16 +58,16 @@ test_that("Factor correlation table matches", {
 
 test_that("Missing values works", {
 	options <- jasptools::analysisOptions("ExploratoryFactorAnalysis")
-	options$variables <- list("contWide", "contcor1", "facFifty", "debMiss30")
+	options$variables <- list("contNormal", "contGamma", "contcor1", "debMiss30")
 	options$incl_correlations <- TRUE
 	
 	options$missingValues <- "pairwise"
 	results <- jasptools::run("ExploratoryFactorAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
 	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
-	expect_equal_tables(table, list(model = "Model", chisq = ".", df = ".", p = "."), label = "pairwise")
+	expect_equal_tables(table, list("Model", 1.42781053334818, 2L, 0.489727939944839), label = "pairwise")
 	
 	options$missingValues <- "listwise"
 	results <- jasptools::run("ExploratoryFactorAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
 	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
-	expect_equal_tables(table, list("RC 1", 1, "RC 2", 0.0433504307183835, 1), label = "listwise")
+	expect_equal_tables(table, list("Model", 0.491396758561133, 2L, 0.782158104440787), label = "listwise")
 })

--- a/JASP-Tests/R/tests/testthat/test-exploratoryfactoranalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-exploratoryfactoranalysis.R
@@ -55,3 +55,19 @@ test_that("Factor correlation table matches", {
   table <- results[["results"]][["factorCorrelations"]][["data"]]
   expect_equal_tables(table, list("RC 1", 1, "RC 2", 0.0433504307183835, 1))
 })
+
+test_that("Missing values works", {
+	options <- jasptools::analysisOptions("ExploratoryFactorAnalysis")
+	options$variables <- list("contWide", "contcor1", "facFifty", "debMiss30")
+	options$incl_correlations <- TRUE
+	
+	options$missingValues <- "pairwise"
+	results <- jasptools::run("ExploratoryFactorAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
+	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
+	expect_equal_tables(table, list(model = "Model", chisq = ".", df = ".", p = "."), label = "pairwise")
+	
+	options$missingValues <- "listwise"
+	results <- jasptools::run("ExploratoryFactorAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
+	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
+	expect_equal_tables(table, list("RC 1", 1, "RC 2", 0.0433504307183835, 1), label = "listwise")
+})

--- a/JASP-Tests/R/tests/testthat/test-principalcomponentanalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-principalcomponentanalysis.R
@@ -57,3 +57,19 @@ test_that("Factor correlation table matches", {
   table <- results[["results"]][["factorCorrelations"]][["data"]]
   expect_equal_tables(table, list("RC 1", 1, "RC 2", 0.143153250525087, 1))
 })
+
+test_that("Missing values works", {
+	options <- jasptools::analysisOptions("PrincipalComponentAnalysis")
+	options$variables <- list("contNormal", "contGamma", "contcor1", "debMiss30")
+
+	options$missingValues <- "pairwise"
+	results <- jasptools::run("PrincipalComponentAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
+	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
+	expect_equal_tables(table, list("Model", 20.7622398603288, 2, 3.10125086457269e-05), label = "pairwise")
+	
+	options$missingValues <- "listwise"
+	results <- jasptools::run("PrincipalComponentAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
+	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
+	expect_equal_tables(table, list("Model", 13.8130059031587, 2, 0.00100125311189221), label = "listwise")
+})
+

--- a/Resources/Library/ExploratoryFactorAnalysis.json
+++ b/Resources/Library/ExploratoryFactorAnalysis.json
@@ -76,6 +76,12 @@
 			"default": false
 		},
 		{
+            "name": "missingValues",
+            "options": [ "pairwise", "listwise" ],
+            "default": "pairwise",
+            "type": "List"
+        },
+		{
 			"name": "incl_pathDiagram",
 			"type": "Boolean",
 			"default": false

--- a/Resources/Library/PrincipalComponentAnalysis.json
+++ b/Resources/Library/PrincipalComponentAnalysis.json
@@ -81,6 +81,12 @@
 			"default": false
 		},
 		{
+            "name": "missingValues",
+            "options": [ "pairwise", "listwise" ],
+            "default": "pairwise",
+            "type": "List"
+        },
+		{
 			"name": "plotWidthPathDiagram",
 			"type": "Integer",
 			"default": 480


### PR DESCRIPTION
Previous updates to exploratory factor analysis and principal component analysis accidentally changed the missing value handling from pairwise deletion to listwise deletion (which led to #2249). This PR makes missing value handling a user option for both efa and pca and adds additional tests to check if the missing value handling is actually correct.