### PR TITLE
Added Z-test to one sample t-test

### DIFF
--- a/JASP-Desktop/analysisforms/Common/ttestonesampleform.ui
+++ b/JASP-Desktop/analysisforms/Common/ttestonesampleform.ui
@@ -41,335 +41,6 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="3" column="0" rowspan="3">
-       <widget class="BoundGroupBox" name="hypothesis">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="title">
-         <string>Hypothesis</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_5">
-         <item row="0" column="1" rowspan="3">
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>5</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="1" column="0">
-          <widget class="QRadioButton" name="_2groupOneGreater">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>&gt; Test value</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QRadioButton" name="_1notEqual">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>≠ Test value</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QRadioButton" name="_3groupTwoGreater">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>&lt; Test value</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>5</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="GroupBox" name="groupBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="title">
-         <string>Assumption Checks</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_12">
-         <item row="0" column="0">
-          <widget class="BoundCheckBox" name="normalityTests">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Normality</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>5</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QWidget" name="widget_5" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>240</width>
-          <height>0</height>
-         </size>
-        </property>
-        <layout class="QGridLayout" name="gridLayout">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Test value:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="BoundTextBox" name="testValue">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>50</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>50</width>
-             <height>16777215</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>5</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="0" rowspan="2">
-       <widget class="GroupBox" name="tests">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="title">
-         <string>Tests</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_11">
-         <item row="1" column="0">
-          <widget class="BoundCheckBox" name="mannWhitneyU">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Wilcoxon signed-rank</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="BoundCheckBox" name="students">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Student</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1" rowspan="2">
-          <spacer name="horizontalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>5</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="BoundGroupBox" name="missingValues">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="title">
-         <string>Missing Values</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_6">
-         <item row="0" column="1">
-          <spacer name="horizontalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>5</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="0">
-          <widget class="QRadioButton" name="_1excludeAnalysisByAnalysis">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Exclude cases analysis by analysis</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QRadioButton" name="_2excludeListwise">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Exclude cases listwise</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>5</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
       <item row="0" column="1" rowspan="6">
        <widget class="GroupBox" name="groupBox_7">
         <property name="sizePolicy">
@@ -663,6 +334,411 @@
         </layout>
        </widget>
       </item>
+      <item row="6" column="1">
+       <widget class="BoundGroupBox" name="missingValues">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Missing Values</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_6">
+         <item row="0" column="1">
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="0">
+          <widget class="QRadioButton" name="_1excludeAnalysisByAnalysis">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Exclude cases analysis by analysis</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QRadioButton" name="_2excludeListwise">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Exclude cases listwise</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>5</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="0" rowspan="3">
+       <widget class="BoundGroupBox" name="hypothesis">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Hypothesis</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="0" column="1" rowspan="3">
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="0">
+          <widget class="QRadioButton" name="_2groupOneGreater">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&gt; Test value</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QRadioButton" name="_1notEqual">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>≠ Test value</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QRadioButton" name="_3groupTwoGreater">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&lt; Test value</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>5</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="0" rowspan="2">
+       <widget class="GroupBox" name="tests">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Tests</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_11">
+         <item row="0" column="1" rowspan="2">
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="0">
+          <widget class="BoundCheckBox" name="students">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Student</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="BoundCheckBox" name="mannWhitneyU">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Wilcoxon signed-rank</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="BoundCheckBox" name="zTest">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Z test</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="GroupBox" name="groupBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Assumption Checks</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_12">
+         <item row="0" column="0">
+          <widget class="BoundCheckBox" name="normalityTests">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Normality</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QWidget" name="widget_5" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>240</width>
+          <height>0</height>
+         </size>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <item row="1" column="2">
+          <spacer name="horizontalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="2">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="1">
+          <widget class="BoundTextBox" name="testValue">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>50</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Test value:        </string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Std. deviation:  </string>
+           </property>
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="BoundTextBox" name="stddev">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>50</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -877,22 +953,6 @@
  <resources/>
  <connections>
   <connection>
-   <sender>descriptivesPlots</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>widgetDescriptivesPlotsConfidenceInterval</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>332</x>
-     <y>409</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>382</x>
-     <y>438</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>meanDifference</sender>
    <signal>toggled(bool)</signal>
    <receiver>widgetMeanDiffConfidenceInterval</receiver>
@@ -921,6 +981,38 @@
     <hint type="destinationlabel">
      <x>417</x>
      <y>357</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>zTest</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>label_6</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>52</x>
+     <y>324</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>63</x>
+     <y>412</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>zTest</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>stddev</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>52</x>
+     <y>324</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>163</x>
+     <y>415</y>
     </hint>
    </hints>
   </connection>

--- a/JASP-Engine/JASP/R/ttestonesample.R
+++ b/JASP-Engine/JASP/R/ttestonesample.R
@@ -103,6 +103,7 @@ TTestOneSample <- function(dataset = NULL, options, perform = "run",
 	if (wantsWilcox && onlyTest) {
 		.addFootnote(footnotes, symbol = "<em>Note.</em>", text = "Wilcoxon signed-rank test.")
 		testStat <- "V"
+		# potentially dangerous next line - removing df. Not posssible to remove by name
 		fields <- fields[-2] #Wilcoxon's test doesn't have degrees of freedoms
 		nameOfLocationParameter <- "Hodges-Lehmann Estimate"
 		nameOfEffectSize <- "Rank-Biserial Correlation"
@@ -114,6 +115,7 @@ TTestOneSample <- function(dataset = NULL, options, perform = "run",
 	} else if(wantsZtest && onlyTest){
 	  .addFootnote(footnotes, symbol = "<em>Note.</em>", text = "Z test.")
 	  testStat <- "Z"
+	  # potentially dangerous next line - removing df. Not posssible to remove by name
 	  fields <- fields[-2] #Z test doesn't have degrees of freedoms
 	  nameOfLocationParameter <- "Mean Difference"
 	  nameOfEffectSize <- "Cohen's d"
@@ -132,7 +134,7 @@ TTestOneSample <- function(dataset = NULL, options, perform = "run",
 	fields <- append(fields, list(list(name = testStat,
 								  type = "number", format = "sf:4;dp:3")), 1)
 
-	## if the user wants at least two tests, add a column called "Test"
+	## if the user wants more than one tests, add a column called "Test"
 	if (sum(allTests) > 1) {
 		fields <- append(fields, list(list(name = "test",
 									  type = "string", title = "Test")), 1)
@@ -153,43 +155,30 @@ TTestOneSample <- function(dataset = NULL, options, perform = "run",
 	if (wantsDifference) {
 		fields[[length(fields) + 1]] <- list(name = "m", title = nameOfLocationParameter,
 											 type = "number", format = "sf:4;dp:3")
-		# preparing footnote - if one of the method is selected; or general if more selected
-		if(wantsWilcox && onlyTest){
-		  textDifference <- "For the Wilcoxon test, effect size is given by the Hodges-Lehmann estimate."
-		} else if(wantsStudents && onlyTest){
-		  textDifference <- "For the Student t-test, location parameter 
-		  is given by mean difference <em>d</em>."
-		} else if(wantsZtest && onlyTest){
-		  textDifference <- "For the Z-test, location parameter 
-		  is given by mean difference <em>d</em>."
-		} else {
-		  textDifference <- "For the Student t-test and Z-test, location parameter 
-is given by mean difference <em>d</em>; for the Wilcoxon test, effect size is given by the Hodges-Lehmann estimate."
-		}
 		
-		# adding a footnote (do not view methods which are not selected)
-		if (!wantsWilcox && !wantsStudents && !wantsZtest) {
-	  } else if(wantsWilcox && wantsStudents && !wantsZtest){
-		  .addFootnote(footnotes, symbol = "<em>Note.</em>",
-		               text = gsub(pattern = " and Z-test",
-		                           replacement = "",
-		                           textDifference)
-		  )
-		} else if(wantsWilcox && !wantsStudents && wantsZtest){
-		  .addFootnote(footnotes, symbol = "<em>Note.</em>",
-		               text = gsub(pattern = "Student t-test and ",
-		                           replacement = "",
-		                           textDifference)
-		  )
-		} else if(!wantsWilcox && wantsStudents && wantsZtest){
-		  .addFootnote(footnotes, symbol = "<em>Note.</em>",
-		               text = gsub(pattern = "; for the Wilcoxon test, effect size is given by the Hodges-Lehmann estimate",
-		                           replacement = "",
-		                           textDifference)
-		  )
-		} else{
-		  .addFootnote(footnotes, symbol = "<em>Note.</em>", text = textDifference)
+		# preparing footnote - paste if selected
+		textDifference <- ""
+		if(wantsStudents){
+		  textDifference <- "For the Student t-test, location parameter is given by mean difference <em>d</em>"
 		}
+		if(wantsWilcox){
+		  if(wantsStudents){
+		    textDifference <- paste0(textDifference, 
+		                             "; for the Wilcoxon test, location parameter is given by the Hodges-Lehmann estimate")
+		  } else{
+		    textDifference <- "For the Wilcoxon test, location parameter is given by the Hodges-Lehmann estimate"
+		  }
+		}
+		if(wantsZtest){
+		  if(onlyTest){
+		    textDifference <- "For the Z-test, location parameter is given by mean difference <em>d</em>"
+		  } else{
+		    textDifference <- paste0(textDifference, 
+		                          "; for the Z-test, location parameter is given by mean difference <em>d</em>")
+		  }
+		}
+		textDifference <- paste0(textDifference, ".")
+		.addFootnote(footnotes, symbol = "<em>Note.</em>", text = textDifference)
 	}
 	
 	if (wantsConfidenceMeanDiff) {
@@ -208,44 +197,32 @@ is given by mean difference <em>d</em>; for the Wilcoxon test, effect size is gi
 		fields[[length(fields) + 1]] <- list(name = "d", title = nameOfEffectSize,
 											 type = "number",  format = "sf:4;dp:3")
 		
-		# preparing footnote - if one of the method is selected; or general if more selected
-		if(wantsWilcox && onlyTest){
-		  textEffect <- "For the Wilcoxon test, effect size is given by the matched rank biserial correlation"
-		} else if(wantsStudents && onlyTest){
-		  textEffect <- "For the Student t-test, effect size is given by Cohen's <em>d</em>."
-		} else if(wantsZtest && onlyTest){
-		  textEffect <- "For the Z test, effect size is given by Cohen's <em>d</em> (based on population deviation)."
-		} else {
-		  textEffect <- "For the Student t-test, effect size is given by Cohen's <em>d</em>; 
-		  for the Wilcoxon test, effect size is given by the matched rank biserial correlation; 
-		  for the Z test, effect size is given by Cohen's <em>d</em> (based on population deviation)."
+		# preparing footnote - paste if selected
+		textEffect <- ""
+		if(wantsStudents){
+		  textEffect <- "For the Student t-test, effect size is given by Cohen's <em>d</em>"
 		}
 		
-		# adding a footnote (do not view methods which are not selected)
-		if (!wantsWilcox && !wantsStudents && !wantsZtest) {
-		} else if(wantsWilcox && wantsStudents && !wantsZtest){
-		  .addFootnote(footnotes, symbol = "<em>Note.</em>",
-		               text = gsub(pattern = "; 
-		  for the Z test, effect size is given by Cohen's <em>d</em> \\(based on population deviation\\)",
-		                           replacement = "",
-		                           textEffect)
-		  )
-		} else if(wantsWilcox && !wantsStudents && wantsZtest){
-		  .addFootnote(footnotes, symbol = "<em>Note.</em>",
-		               text = gsub(pattern = "For the Student t-test, effect size is given by Cohen's <em>d</em>; 
-		  f",
-		                           replacement = "F",
-		                           textEffect)
-		  )
-		} else if(!wantsWilcox && wantsStudents && wantsZtest){
-		  .addFootnote(footnotes, symbol = "<em>Note.</em>",
-		               text = gsub(pattern = "for the Wilcoxon test, effect size is given by the matched rank biserial correlation; ",
-		                           replacement = "",
-		                           textEffect)
-		  )
-		} else{
-		  .addFootnote(footnotes, symbol = "<em>Note.</em>", text = textEffect)
+		if(wantsWilcox){
+		  if(wantsStudents){
+		    textEffect <- paste0(textEffect,
+		                         "; for the Wilcoxon test, effect size is given by the matched rank biserial correlation")
+		  } else{
+		    textEffect <- "For the Wilcoxon test, effect size is given by the matched rank biserial correlation"
+		  }
 		}
+		
+		if(wantsZtest){
+		  if(onlyTest){
+		    textEffect <- "For the Z test, effect size is given by Cohen's <em>d</em> (based on the provided population standard deviation)"
+		  } else{
+		    textEffect <- paste0(textEffect,
+		                         "; for the Z test, effect size is given by Cohen's <em>d</em> (based on the provided population standard deviation)")
+		  }
+		}
+		
+		textEffect <- paste0(textEffect, ".")
+		.addFootnote(footnotes, symbol = "<em>Note.</em>", text = textEffect)
 	}
 
 	if (wantsConfidenceEffSize) {
@@ -416,7 +393,7 @@ is given by mean difference <em>d</em>; for the Wilcoxon test, effect size is gi
 					ciUp <- .clean(as.numeric(r$conf.int[2]))
           ciLowEffSize = .clean(as.numeric(confIntEffSize[1]))
           ciUpEffSize = .clean(as.numeric(confIntEffSize[2]))
-					if (is.na(t)) {
+					if (suppressWarnings(is.na(t))) { # do not throw warning when test stat is not 't' 
 						stop("data are essentially constant")
 					}
 

--- a/JASP-Tests/R/tests/testthat/test-ttestonesample.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestonesample.R
@@ -4,10 +4,9 @@ context("One Sample TTest")
 # - missing values exclusion
 # - error handling of plots
 
-test_that("Main table results match", {
+test_that("Main table results match for t-test", {
   options <- jasptools::analysisOptions("TTestOneSample")
   options$variables <- "contGamma"
-  options$wilcoxonSignedRank <- TRUE
   options$meanDifference <- TRUE
   options$effectSize <- TRUE
   options$VovkSellkeMPR <- TRUE
@@ -16,8 +15,42 @@ test_that("Main table results match", {
   expect_equal_tables(table,
     list("contGamma", 99, 1.08315413981152e-23, 2.03296079621, 1.32664189226908,
          1.72889718286736, 2.33702440955264, 0, 0, 13.2664189226908,
-         6.42284229078859e+20)
+         6.42284229078859e+20, "Student")
   )
+})
+
+test_that("Main table results match for Wilcoxon signed rank", {
+  options <- jasptools::analysisOptions("TTestOneSample")
+  options$variables <- "contGamma"
+  options$meanDifference <- TRUE
+  options$effectSize <- TRUE
+  options$effSizeConfidenceIntervalCheckbox <- TRUE
+  options$students <- FALSE
+  options$mannWhitneyU <- TRUE
+  
+  results <- jasptools::run("TTestOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
+  table <- results[["results"]][["ttest"]][["data"]]
+  
+  expect_equal_tables(table,
+                      list("contGamma", "", 3.955912e-18, 1.813483, 1,
+                           1.553513, 2.158945, 1, 1, 5050, "Wilcoxon"))
+})
+
+test_that("Main table results match for Z-test", {
+  options <- jasptools::analysisOptions("TTestOneSample")
+  options$variables <- "contNormal"
+  options$students <- FALSE
+  options$zTest <- TRUE
+  options$stddev <- 1.5
+  options$effectSize <- TRUE
+  options$effSizeConfidenceIntervalCheckbox <- TRUE
+  results <- jasptools::run("TTestOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
+  table <- results[["results"]][["ttest"]][["data"]]
+  expect_equal_tables(table,
+                      list("contNormal", "", 0.2082746, -0.1887486, -0.1258324,
+                          -0.4827432, 0.105246, -0.3218288, 0.07016401, -1.258324,
+                          "Z")
+                      )
 })
 
 test_that("Normality table matches", {

--- a/Resources/Library/TTestOneSample.json
+++ b/Resources/Library/TTestOneSample.json
@@ -14,12 +14,23 @@
 			"value": 0.0
 		},
 		{
+			"format": "",
+			"name": "stddev",
+			"type": "Number",
+			"value": 1.0,
+			"min": 0.000
+		},
+		{
 			"name": "students",
 			"type": "Boolean",
 			"default" : true
 		},
 		{
 			"name": "mannWhitneyU",
+			"type": "Boolean"
+		},
+		{
+			"name": "zTest",
 			"type": "Boolean"
 		},
 		{


### PR DESCRIPTION
Added Z-test to the One Sample T-test options. #2142 

Changes:
- ttestonesample.R
    enabling new input, structure output for the z-test (the main table), footnotes
- ttestonesampleform.ui
    adding two widgets: checkbox button for selecting Z-test, popup window for specifying std. deviation
- TTestOneSample.json
    creating the two new widgets

Consulted with @AlexanderLyNL 
