### PR TITLE
Replaced ItemDelegate with StyledItemDelegate

### DIFF
--- a/JASP-Desktop/customhoverdelegate.h
+++ b/JASP-Desktop/customhoverdelegate.h
@@ -19,16 +19,15 @@
 #ifndef CUSTOMHOVERDELEGATE_H
 #define CUSTOMHOVERDELEGATE_H
 
-#include <QStringListModel>
-#include <QItemDelegate>
+#include <QStyledItemDelegate>
 #include <QPainter>
 #include <QToolTip>
 #include <QColor>
 
-class CustomHoverDelegate : public QItemDelegate
+class CustomHoverDelegate : public QStyledItemDelegate
 {
 public:
-	CustomHoverDelegate(QObject *parent = 0) : QItemDelegate(parent) {}
+	CustomHoverDelegate(QObject *parent = 0) : QStyledItemDelegate(parent) {}
 	void paint (QPainter *painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
 	{
 		if(option.state & QStyle::State_MouseOver)
@@ -37,7 +36,7 @@ public:
 			QString str = index.data().toString();
 			QToolTip::showText(QCursor::pos(), str);
 		}
-		QItemDelegate::paint(painter, option, index);
+		QStyledItemDelegate::paint(painter, option, index);
 	}
 };
 

--- a/JASP-Desktop/widgets/anovamodelwidget.h
+++ b/JASP-Desktop/widgets/anovamodelwidget.h
@@ -21,7 +21,6 @@
 
 #include <QWidget>
 #include <QStringListModel>
-#include <QItemDelegate>
 #include <QPainter>
 #include <QToolTip>
 

--- a/JASP-Desktop/widgets/tableviewmenueditordelegate.cpp
+++ b/JASP-Desktop/widgets/tableviewmenueditordelegate.cpp
@@ -18,10 +18,8 @@
 
 #include "tableviewmenueditordelegate.h"
 
-#include <QDebug>
-
 TableViewMenuEditorDelegate::TableViewMenuEditorDelegate(QObject *parent) :
-	QStyledItemDelegate(parent)
+	CustomHoverDelegate(parent)
 {
 }
 

--- a/JASP-Desktop/widgets/tableviewmenueditordelegate.h
+++ b/JASP-Desktop/widgets/tableviewmenueditordelegate.h
@@ -19,17 +19,11 @@
 #ifndef TABLEVIEWCOMBOBOXDELEGATE_H
 #define TABLEVIEWCOMBOBOXDELEGATE_H
 
-#include <QStyledItemDelegate>
-
 #include "common.h"
-#include <QMenu>
-#include <QLabel>
-#include <QPainter>
-#include <QToolTip>
-#include <QColor>
 #include "tableviewmenueditor.h"
+#include "customhoverdelegate.h"
 
-class TableViewMenuEditorDelegate : public QStyledItemDelegate
+class TableViewMenuEditorDelegate : public CustomHoverDelegate
 {
 	Q_OBJECT
 public:
@@ -37,20 +31,9 @@ public:
 
 	virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const OVERRIDE;
 	virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const OVERRIDE;
-	void paint (QPainter *painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
-	{
-		if(option.state & QStyle::State_MouseOver)
-		{
-			painter->fillRect(option.rect, QColor(220, 241, 251));
-			QString str = index.data().toString();
-			QToolTip::showText(QCursor::pos(), str);
-		}
-		QStyledItemDelegate::paint(painter, option, index);
-	}
 
 private slots:
 	void editingFinished();
-
 };
 
 #endif // TABLEVIEWCOMBOBOXDELEGATE_H


### PR DESCRIPTION
1. Fixes different sized margins bug
2. CustomHoverDelegate used in TableViewMenuEditorDelegate

