### PR TITLE
Populate text from option if available

### DIFF
--- a/JASP-Desktop/widgets/boundtextedit.cpp
+++ b/JASP-Desktop/widgets/boundtextedit.cpp
@@ -61,9 +61,17 @@ BoundTextEdit::BoundTextEdit(QWidget *parent) :
 
 void BoundTextEdit::bindTo(Option *option)
 {
-	if (_model != NULL)
+	if (_model != NULL) {
 		_model->bindTo(option);
 
+		populateFromOption(option);
+	}
+}
+
+void BoundTextEdit::populateFromOption(Option *option)
+{
+	OptionString *text = dynamic_cast<OptionString *>(option);
+	this->setPlainText(QString::fromStdString(text->value()));
 }
 
 void BoundTextEdit::cursorPositionChangedHandler()

--- a/JASP-Desktop/widgets/boundtextedit.h
+++ b/JASP-Desktop/widgets/boundtextedit.h
@@ -33,6 +33,7 @@ public:
 	explicit BoundTextEdit(QWidget *parent = 0);
 
 	virtual void bindTo(Option *option) OVERRIDE;
+	void populateFromOption(Option *option);
 
 signals:
 


### PR DESCRIPTION
If SEM analysis jasp file is opened, the model specified is not shown in the text area. This pull request fixes it.