### PR TITLE
Support hi-dpi on windows

### DIFF
--- a/JASP-Desktop/main.cpp
+++ b/JASP-Desktop/main.cpp
@@ -27,6 +27,7 @@
 
 int main(int argc, char *argv[])
 {
+	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QCoreApplication::setOrganizationName("JASP");
 	QCoreApplication::setOrganizationDomain("jasp-stats.org");
 	QCoreApplication::setApplicationName("JASP");

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -1231,16 +1231,16 @@ void MainWindow::resultsPageLoaded(bool success, int ppi)
 {
 	if (success)
 	{
-#ifdef __WIN32__
-		const int verticalDpi = QApplication::desktop()->screen()->logicalDpiY();
-		qreal zoom = ((qreal)(verticalDpi) / (qreal)ppi);
-		ui->webViewResults->setZoomFactor(zoom);
-		ui->webViewHelp->setZoomFactor(zoom);
-		ppi = verticalDpi;
-		_resultsJsInterface->setZoom(zoom);
-
-		this->resize(this->width() + (ui->webViewResults->width() * (zoom - 1)), this->height() + (ui->webViewResults->height() * (zoom - 1)));
-#endif
+// #ifdef __WIN32__
+// 		const int verticalDpi = QApplication::desktop()->screen()->logicalDpiY();
+// 		qreal zoom = ((qreal)(verticalDpi) / (qreal)ppi);
+// 		ui->webViewResults->setZoomFactor(zoom);
+// 		ui->webViewHelp->setZoomFactor(zoom);
+// 		ppi = verticalDpi;
+// 		_resultsJsInterface->setZoom(zoom);
+//
+// 		this->resize(this->width() + (ui->webViewResults->width() * (zoom - 1)), this->height() + (ui->webViewResults->height() * (zoom - 1)));
+// #endif
 		_engineSync->setPPI(ppi);
 
 		if (_openOnLoadFilename != "")


### PR DESCRIPTION
__What is this?__
This PR finally grants support for hi-dpi (usually high resolution laptop displays) on windows. 🎈 🎈 🎈 

❗️ __NB: This branch needs to be built using Qt 5.10.1 or higher__ ❗️ 
Qt 5.10 results in a bug where the webengine windows will have enormous scroll bars.
Testing still needed on: 
- [x] mac
- [ ] linux

__Why is this even necessary?__
 :+1: This branch fixes the long-standing and often-documented issues with drawing JASP on a high-dpi screen in windows: #2049, #2047, #2046, #2045, #2027, #1234 and #1212.

__What's next?__
Unfortunately, drawing issues are not completely solved yet: dragging the window from a HIDPI display to a lower dpi display will result in a black bar on the left and top of the main window. The reverse is true for the opposite operation. This holds for both Qt 5.10.0 and Qt 5.10.1. Issue #2322.
