### PR TITLE
Bas fixes

### DIFF
--- a/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.ui
+++ b/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.ui
@@ -405,7 +405,7 @@
             <item row="0" column="0">
              <widget class="BoundCheckBox" name="plotLogPosteriorOdds">
               <property name="text">
-               <string>Posterior log odds</string>
+               <string>Log posterior odds</string>
               </property>
              </widget>
             </item>

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2606,7 +2606,10 @@ editImage <- function(plotName, type, height, width) {
 	} else {
 		# adjust the state of the analysis and save it
 		state[["figures"]][[plotName]] <- results[["obj"]]
+		# store the stateKey (which gets removed by .modifyStateFigures)
+		key <- attr(x = state, which = "key")
 		state <- .modifyStateFigures(state, identifier=plotName, replacement=results, completeObject = FALSE)
+		attr(state, "key") <- key
 		.saveState(state)
 	}
 

--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -716,13 +716,13 @@ RegressionLinearBayesian <- function (
 		coefficients <- coef$namesx
 		probne0 <- coef[["probne0"]]
 		if (estimator == "HPM") {
-		    loopIdx <- which(abs(coef$postmean) > sqrt(.Machine$double.eps))
+			loopIdx <- which(abs(coef$postmean) > sqrt(.Machine$double.eps))
 		} else if (estimator == "MPM") {
-		    loopIdx <- which(abs(coef$postmean) > sqrt(.Machine$double.eps))
+			loopIdx <- which(abs(coef$postmean) > sqrt(.Machine$double.eps))
 			coefficients[-1] <- d64(coefficients[-1])
 			probne0 <- bas_obj[["probne0"]]
 		} else {
-		    loopIdx <- seq_along(coefficients)
+			loopIdx <- seq_along(coefficients)
 		}
 
 		nModels <- coef$n.models
@@ -741,10 +741,6 @@ RegressionLinearBayesian <- function (
 					sd <- .clean(coef$postsd[i])
 				}
 
-				# skip if not in model
-				if ((estimator == "HPM" || estimator == "MPM") && abs(mean) < sqrt(.Machine$double.eps))
-					next
-				
 				rows[[length(rows) + 1]] <- list(coefficient = coefficient, mean = mean, sd = sd, pIncl = pIncl)
 
 			}
@@ -969,14 +965,14 @@ RegressionLinearBayesian <- function (
 		plot[["title"]] <- titles[which]
 
 		p <- try(silent = FALSE, expr = {
-		    
-		    if (c(which) != 4) {
-    		    w <- 530
-    		    h <- 400
-		    } else {
-		        w <- 700
-		        h <- 400
-		    }
+
+			if (c(which) != 4) {
+				w <- 530
+				h <- 400
+			} else {
+				w <- 700
+				h <- 400
+			}
 
 			plotObj <- .plotBas.basReg(bas_obj, which = c(which))
 			content <- .writeImage(width = w, height = h, plot = plotObj)
@@ -1076,8 +1072,13 @@ RegressionLinearBayesian <- function (
 	} else {
 		qmin = min(qnorm(e/2, means, sds))
 		qmax = max(qnorm(1 - e/2, means, sds))
-		xlower = min(qmin, 0)
-		xupper = max(0, qmax)
+		if (i > 1) {
+			xlower = min(qmin, 0)
+			xupper = max(0, qmax)
+		} else {
+			xlower <- qmin
+			xupper <- qmax
+		}
 	}
 
 	xx = seq(xlower, xupper, length.out = nsteps)


### PR DESCRIPTION
Many bugfixes, one in image rescaling (editImage) and the rest in BAS:

editImage:
- Fixed a huge bug that deleted the statekey from the state and as a consequence also the state itself.

BAS:
- Typos in plot/ ui
- Posterior summary for median model should no longer chrash
- Posterior summary for most complex model displayed summary for a wrong model.
- Plot with inclusion probabilities now includes a legend and shows correct prior predictor probabilities (instead of prior model probabilities).
- Adjusted the residual plot
- Added with and heights to the json files for all plots so they’re displayed at correct resolutions
- Ensured that plots of averaged posterior distributions always fall below the maximum y-axis value
- Draw the numeric value of the posterior inclusion probabilty in the plot (if it is larger than 0.05)