### PR TITLE
Fixed bug in backward stepwise regression

### DIFF
--- a/JASP-Desktop/analysisforms/Common/ancovaform.ui
+++ b/JASP-Desktop/analysisforms/Common/ancovaform.ui
@@ -1360,7 +1360,7 @@
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Error bars displaying</string>
+               <string>Display error bars</string>
               </property>
              </widget>
             </item>
@@ -1545,7 +1545,7 @@
             <item row="1" column="0" colspan="2">
              <widget class="BoundCheckBox" name="marginalMeansCompareMainEffects">
               <property name="text">
-               <string>Compare main effects</string>
+               <string>Compare marginal means to 0</string>
               </property>
              </widget>
             </item>

--- a/JASP-Desktop/analysisforms/Common/anovaform.ui
+++ b/JASP-Desktop/analysisforms/Common/anovaform.ui
@@ -1113,7 +1113,7 @@
             <item row="0" column="0">
              <widget class="BoundCheckBox" name="plotErrorBars">
               <property name="text">
-               <string>Error bars displaying</string>
+               <string>Display error bars</string>
               </property>
              </widget>
             </item>
@@ -1371,7 +1371,7 @@
             <item row="1" column="0" colspan="2">
              <widget class="BoundCheckBox" name="marginalMeansCompareMainEffects">
               <property name="text">
-               <string>Compare main effects</string>
+               <string>Compare marginal means to 0</string>
               </property>
              </widget>
             </item>

--- a/JASP-Desktop/analysisforms/Common/anovarepeatedmeasuresform.ui
+++ b/JASP-Desktop/analysisforms/Common/anovarepeatedmeasuresform.ui
@@ -1312,7 +1312,7 @@
             <item row="0" column="0">
              <widget class="BoundCheckBox" name="plotErrorBars">
               <property name="text">
-               <string>Error bars displaying</string>
+               <string>Display error bars</string>
               </property>
              </widget>
             </item>
@@ -1553,7 +1553,7 @@
             <item row="1" column="0" colspan="2">
              <widget class="BoundCheckBox" name="marginalMeansCompareMainEffects">
               <property name="text">
-               <string>Compare main effects</string>
+               <string>Compare marginal means to 0</string>
               </property>
              </widget>
             </item>

--- a/JASP-Engine/JASP/R/regressionlinear.R
+++ b/JASP-Engine/JASP/R/regressionlinear.R
@@ -3168,7 +3168,7 @@ RegressionLinear <- function(dataset=NULL, options, perform="run", callback=func
 
 	while ( ! identical(old.independent.variables, new.independent.variables) && length(new.independent.variables) > 0) {
 
-	  old.independent.variables <- .vWithInteraction(lm.model[[ length(lm.model) ]]$variables)
+    old.independent.variables <- .vWithInteraction(lm.model[[ length(lm.model) ]]$variables)
 		lm.model[[ length(lm.model) + 1 ]] <- .removeVariable(dependent.variable, old.independent.variables, independent.null.variables, data, options, weights)
 		new.independent.variables <- .vWithInteraction(lm.model[[ length(lm.model) ]]$variables) 
 

--- a/JASP-Engine/JASP/R/regressionlinear.R
+++ b/JASP-Engine/JASP/R/regressionlinear.R
@@ -1927,8 +1927,10 @@ RegressionLinear <- function(dataset=NULL, options, perform="run", callback=func
 	plots.regression <- list()
 	plotTypes <- list()
 	plotsResVsCov <- list()
-
-	lm.model <- lm.model[[length(lm.model)]]
+	
+	if (perform == "run" && length(list.of.errors) == 0 && dependent.variable != "") {
+	  lm.model <- lm.model[[length(lm.model)]]
+	}
 
 	if (options$plotResidualsDependent) {
 
@@ -3077,9 +3079,9 @@ RegressionLinear <- function(dataset=NULL, options, perform="run", callback=func
 
 	}
 
-	tValues <- tValues[- (names(tValues) %in% independent.null.variables)]
-	pValues <- pValues[- (names(tValues) %in% independent.null.variables)]
-
+	tValues <- tValues[! (names(tValues) %in% independent.null.variables)]
+	pValues <- pValues[! (names(pValues) %in% independent.null.variables)]
+  
 	fValues <- tValues^2
 
 	if (options$steppingMethodCriteriaType == "useFValue") {
@@ -3102,7 +3104,6 @@ RegressionLinear <- function(dataset=NULL, options, perform="run", callback=func
 		maximumPvalue <- max(pValues)
 
 		if (maximumPvalue > options$steppingMethodCriteriaPRemoval) {
-
 			maximumPvalueVariable <- names(which.max(pValues))
 			new.independent.variables <- independent.variables[independent.variables != maximumPvalueVariable]
 
@@ -3167,9 +3168,9 @@ RegressionLinear <- function(dataset=NULL, options, perform="run", callback=func
 
 	while ( ! identical(old.independent.variables, new.independent.variables) && length(new.independent.variables) > 0) {
 
-		old.independent.variables <- .vWithInteraction(lm.model[[ length(lm.model) ]]$variables)
+	  old.independent.variables <- .vWithInteraction(lm.model[[ length(lm.model) ]]$variables)
 		lm.model[[ length(lm.model) + 1 ]] <- .removeVariable(dependent.variable, old.independent.variables, independent.null.variables, data, options, weights)
-		new.independent.variables <- .vWithInteraction(lm.model[[ length(lm.model) ]]$variables)
+		new.independent.variables <- .vWithInteraction(lm.model[[ length(lm.model) ]]$variables) 
 
 	}
 


### PR DESCRIPTION
Fix #2248 
Also changed names of "Compare main effects" (new name: "Compare marginal means to 0") and "Error bars displaying" (new name: "Display error bars") in ANOVA to be a bit more informative.