### PR TITLE
Fix Warning Bayes Factor Robustness Check Plot

### DIFF
--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -601,7 +601,8 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 						plot <- plots.ttest[[z]]
 
 						if (options$effectSizeStandardized == "informative") {
-						  plot[["error"]] <- list(error="badData", errorMessage="Bayes factor robustness check plot currently not supported for informed prior.")
+						  errorMessage="Bayes factor robustness check plot currently not supported for informed prior."
+						  plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
 						}
 
 						if (!is.null(errorMessage)) {


### PR DESCRIPTION
Define error message as a variable so that it is recognized in the next step.
This fixes issue # 2336

