### PR TITLE
Windows build failure & JASP-R-Interface versioning

### DIFF
--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -270,10 +270,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
 	setAcceptDrops(true);
 
-#ifdef __WIN32__
-	QApplication::setFont(ui->tableView->font());
-#endif
-
 	ui->panel_1_Data->hide();
 	ui->panel_2_Options->hide();
 

--- a/JASP-R-Interface/jasprcpp.cpp
+++ b/JASP-R-Interface/jasprcpp.cpp
@@ -33,11 +33,17 @@ ReadDataSetDescriptionCB readDataSetDescriptionCB;
 RequestStateFileSourceCB requestStateFileSourceCB;
 
 static const string NullString = "null";
-
+const int VersionMajor(1); // Interface changes
+const int VersionMinor(0); // Code changes
 
 extern "C" {
 void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks* callbacks)
 {
+
+#ifdef QT_DEBUG		
+	std::cout << "JASP-R-Interface Version : " << std::to_string(VersionMajor) << "." << std::to_string(VersionMinor) << "\n" << std::flush;
+#endif
+	
 	rinside = new RInside();
 	rinside_consoleLog = new RInside_ConsoleLogging();
 	rinside->set_callbacks(rinside_consoleLog);


### PR DESCRIPTION
Windows build failure & JASP-R-Interface versioning:
Every time the  JASP-R-Interface changes the static.jasp-stats.org and
the GitHub info should be updated