### PR TITLE
Comment out visual tests

### DIFF
--- a/JASP-Tests/R/tests/testthat/test-anova.R
+++ b/JASP-Tests/R/tests/testthat/test-anova.R
@@ -79,7 +79,7 @@ test_that("Contrasts table results match", {
   options$dependent <- "contNormal"
   options$fixedFactors <- "facFive"
   options$modelTerms <- list(list(components="facFive"))
-  
+
   refTables <- list(
     deviation = list("2 - 1, 2, 3, 4, 5", -0.19513913461, 0.211517937182488, -0.922565420263354,
                      0.35857088018682, "TRUE", "3 - 1, 2, 3, 4, 5", 0.33149855864,
@@ -193,42 +193,42 @@ test_that("Descriptives table results match", {
   )
 })
 
-test_that("Q-Q plot matches", {
-  options <- jasptools::analysisOptions("Anova")
-  options$dependent <- "contNormal"
-  options$fixedFactors <- "contBinom"
-  options$modelTerms <- list(list(components="contBinom"))
-  options$qqPlot <- TRUE
-  results <- jasptools::run("Anova", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "q-q", dir="Anova")
-})
+# test_that("Q-Q plot matches", {
+#   options <- jasptools::analysisOptions("Anova")
+#   options$dependent <- "contNormal"
+#   options$fixedFactors <- "contBinom"
+#   options$modelTerms <- list(list(components="contBinom"))
+#   options$qqPlot <- TRUE
+#   results <- jasptools::run("Anova", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "q-q", dir="Anova")
+# })
 
-test_that("Descriptives plots match", {
-  options <- jasptools::analysisOptions("Anova")
-  options$dependent <- "contNormal"
-  options$fixedFactors <- c("facFive", "contBinom")
-  options$wlsWeights <- "facFifty"
-  options$modelTerms <- list(
-    list(components="facFive"),
-    list(components="contBinom"),
-    list(components=c("facFive", "contBinom"))
-  )
-  options$plotHorizontalAxis <- "contBinom"
-  options$plotSeparateLines <- "facFive"
-  options$plotErrorBars <- TRUE
-  options$confidenceIntervalInterval <- 0.90
-
-  options$errorBarType <- "confidenceInterval"
-  results <- jasptools::run("Anova", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives-ci", dir="Anova")
-
-  options$errorBarType <- "standardError"
-  results <- jasptools::run("Anova", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives-se", dir="Anova")
-})
+# test_that("Descriptives plots match", {
+#   options <- jasptools::analysisOptions("Anova")
+#   options$dependent <- "contNormal"
+#   options$fixedFactors <- c("facFive", "contBinom")
+#   options$wlsWeights <- "facFifty"
+#   options$modelTerms <- list(
+#     list(components="facFive"),
+#     list(components="contBinom"),
+#     list(components=c("facFive", "contBinom"))
+#   )
+#   options$plotHorizontalAxis <- "contBinom"
+#   options$plotSeparateLines <- "facFive"
+#   options$plotErrorBars <- TRUE
+#   options$confidenceIntervalInterval <- 0.90
+#
+#   options$errorBarType <- "confidenceInterval"
+#   results <- jasptools::run("Anova", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives-ci", dir="Anova")
+#
+#   options$errorBarType <- "standardError"
+#   results <- jasptools::run("Anova", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives-se", dir="Anova")
+# })
 
 test_that("Simple Main Effects table results match", {
   options <- jasptools::analysisOptions("Anova")

--- a/JASP-Tests/R/tests/testthat/test-binomialtest.R
+++ b/JASP-Tests/R/tests/testthat/test-binomialtest.R
@@ -16,16 +16,16 @@ test_that("Main table results match", {
   )
 })
 
-test_that("Descriptives plots match", {
-  options <- jasptools::analysisOptions("BinomialTest")
-  options$variables <- "contBinom"
-  options$descriptivesPlots <- TRUE
-  options$descriptivesPlotsConfidenceInterval <- 0.90
-  results <- jasptools::run("BinomialTest", "test.csv", options, view=FALSE, quiet=TRUE)
-
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives-1", dir="BinomialTest")
-
-  testPlot <- results[["state"]][["figures"]][[2]]
-  expect_equal_plots(testPlot, "descriptives-2", dir="BinomialTest")
-})
+# test_that("Descriptives plots match", {
+#   options <- jasptools::analysisOptions("BinomialTest")
+#   options$variables <- "contBinom"
+#   options$descriptivesPlots <- TRUE
+#   options$descriptivesPlotsConfidenceInterval <- 0.90
+#   results <- jasptools::run("BinomialTest", "test.csv", options, view=FALSE, quiet=TRUE)
+#
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives-1", dir="BinomialTest")
+#
+#   testPlot <- results[["state"]][["figures"]][[2]]
+#   expect_equal_plots(testPlot, "descriptives-2", dir="BinomialTest")
+# })

--- a/JASP-Tests/R/tests/testthat/test-binomialtestbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-binomialtestbayesian.R
@@ -16,29 +16,29 @@ test_that("Main table results match", {
   )
 })
 
-test_that("Prior posterior plots match", {
-  options <- jasptools::analysisOptions("BinomialTestBayesian")
-  options$variables <- "contBinom"
-  options$plotPriorAndPosterior <- TRUE
-  options$plotPriorAndPosteriorAdditionalInfo <- TRUE
-  results <- jasptools::run("BinomialTestBayesian", "test.csv", options, view=FALSE, quiet=TRUE)
-
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "prior-posterior-1", dir="BinomialTestBayesian")
-
-  testPlot <- results[["state"]][["figures"]][[2]]
-  expect_equal_plots(testPlot, "prior-posterior-2", dir="BinomialTestBayesian")
-})
-
-test_that("Sequential analysis plots match", {
-  options <- jasptools::analysisOptions("BinomialTestBayesian")
-  options$variables <- "contBinom"
-  options$plotSequentialAnalysis <- TRUE
-  results <- jasptools::run("BinomialTestBayesian", "test.csv", options, view=FALSE, quiet=TRUE)
-
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "sequential-analysis-1", dir="BinomialTestBayesian")
-
-  testPlot <- results[["state"]][["figures"]][[2]]
-  expect_equal_plots(testPlot, "sequential-analysis-2", dir="BinomialTestBayesian")
-})
+# test_that("Prior posterior plots match", {
+#   options <- jasptools::analysisOptions("BinomialTestBayesian")
+#   options$variables <- "contBinom"
+#   options$plotPriorAndPosterior <- TRUE
+#   options$plotPriorAndPosteriorAdditionalInfo <- TRUE
+#   results <- jasptools::run("BinomialTestBayesian", "test.csv", options, view=FALSE, quiet=TRUE)
+#
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "prior-posterior-1", dir="BinomialTestBayesian")
+#
+#   testPlot <- results[["state"]][["figures"]][[2]]
+#   expect_equal_plots(testPlot, "prior-posterior-2", dir="BinomialTestBayesian")
+# })
+# 
+# test_that("Sequential analysis plots match", {
+#   options <- jasptools::analysisOptions("BinomialTestBayesian")
+#   options$variables <- "contBinom"
+#   options$plotSequentialAnalysis <- TRUE
+#   results <- jasptools::run("BinomialTestBayesian", "test.csv", options, view=FALSE, quiet=TRUE)
+#
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "sequential-analysis-1", dir="BinomialTestBayesian")
+#
+#   testPlot <- results[["state"]][["figures"]][[2]]
+#   expect_equal_plots(testPlot, "sequential-analysis-2", dir="BinomialTestBayesian")
+# })

--- a/JASP-Tests/R/tests/testthat/test-correlation.R
+++ b/JASP-Tests/R/tests/testthat/test-correlation.R
@@ -36,16 +36,16 @@ test_that("Correlation table results match", {
   )
 })
 
-test_that("Correlation matrix plot matches", {
-  options <- jasptools::analysisOptions("Correlation")
-  options$variables <- list("contGamma", "contNormal")
-  options$plotCorrelationMatrix <- TRUE
-  options$plotDensities <- TRUE
-  options$plotStatistics <- TRUE
-  results <- jasptools::run("Correlation", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "correlation-matrix", dir="Correlation")
-})
+# test_that("Correlation matrix plot matches", {
+#   options <- jasptools::analysisOptions("Correlation")
+#   options$variables <- list("contGamma", "contNormal")
+#   options$plotCorrelationMatrix <- TRUE
+#   options$plotDensities <- TRUE
+#   options$plotStatistics <- TRUE
+#   results <- jasptools::run("Correlation", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "correlation-matrix", dir="Correlation")
+# })
 
 test_that("Analysis handles errors", {
   options <- jasptools::analysisOptions("Correlation")

--- a/JASP-Tests/R/tests/testthat/test-correlationbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-correlationbayesian.R
@@ -30,16 +30,16 @@ test_that("Main table results match", {
   )
 })
 
-test_that("Correlation plot matches", {
-  options <- jasptools::analysisOptions("CorrelationBayesian")
-  options$variables <- c("contcor1", "contcor2")
-  options$plotCorrelationMatrix <- TRUE
-  options$plotDensitiesForVariables <- TRUE
-  options$plotPosteriors <- TRUE
-  results <- jasptools::run("CorrelationBayesian", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "correlation", dir="CorrelationBayesian")
-})
+# test_that("Correlation plot matches", {
+#   options <- jasptools::analysisOptions("CorrelationBayesian")
+#   options$variables <- c("contcor1", "contcor2")
+#   options$plotCorrelationMatrix <- TRUE
+#   options$plotDensitiesForVariables <- TRUE
+#   options$plotPosteriors <- TRUE
+#   results <- jasptools::run("CorrelationBayesian", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "correlation", dir="CorrelationBayesian")
+# })
 
 test_that("Analysis handles errors", {
   options <- jasptools::analysisOptions("CorrelationBayesian")

--- a/JASP-Tests/R/tests/testthat/test-correlationbayesianpairs.R
+++ b/JASP-Tests/R/tests/testthat/test-correlationbayesianpairs.R
@@ -19,43 +19,43 @@ test_that("Main table results match", {
   )
 })
 
-test_that("Scatterplot matches", {
-  options <- jasptools::analysisOptions("CorrelationBayesianPairs")
-  options$pairs <- list(c("contcor1", "contcor2"))
-  options$plotScatter <- TRUE
-  results <- jasptools::run("CorrelationBayesianPairs", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "scatterplot", dir="CorrelationBayesianPairs")
-})
-
-test_that("Prior posterior plot matches", {
-  options <- jasptools::analysisOptions("CorrelationBayesianPairs")
-  options$pairs <- list(c("contcor1", "contcor2"))
-  options$plotPriorAndPosterior <- TRUE
-  options$plotPriorAndPosteriorAdditionalInfo <- TRUE
-  results <- jasptools::run("CorrelationBayesianPairs", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "prior-posterior", dir="CorrelationBayesianPairs")
-})
-
-test_that("BF robustness check plot matches", {
-  options <- jasptools::analysisOptions("CorrelationBayesianPairs")
-  options$pairs <- list(c("contcor1", "contcor2"))
-  options$plotBayesFactorRobustness <- TRUE
-  options$plotBayesFactorRobustnessAdditionalInfo <- FALSE
-  results <- jasptools::run("CorrelationBayesianPairs", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "robustness-check", dir="CorrelationBayesianPairs")
-})
-
-test_that("Sequential analysis plot matches", {
-  options <- jasptools::analysisOptions("CorrelationBayesianPairs")
-  options$pairs <- list(c("contcor1", "contcor2"))
-  options$plotSequentialAnalysis <- TRUE
-  results <- jasptools::run("CorrelationBayesianPairs", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "sequential-analysis", dir="CorrelationBayesianPairs")
-})
+# test_that("Scatterplot matches", {
+#   options <- jasptools::analysisOptions("CorrelationBayesianPairs")
+#   options$pairs <- list(c("contcor1", "contcor2"))
+#   options$plotScatter <- TRUE
+#   results <- jasptools::run("CorrelationBayesianPairs", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "scatterplot", dir="CorrelationBayesianPairs")
+# })
+#
+# test_that("Prior posterior plot matches", {
+#   options <- jasptools::analysisOptions("CorrelationBayesianPairs")
+#   options$pairs <- list(c("contcor1", "contcor2"))
+#   options$plotPriorAndPosterior <- TRUE
+#   options$plotPriorAndPosteriorAdditionalInfo <- TRUE
+#   results <- jasptools::run("CorrelationBayesianPairs", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "prior-posterior", dir="CorrelationBayesianPairs")
+# })
+#
+# test_that("BF robustness check plot matches", {
+#   options <- jasptools::analysisOptions("CorrelationBayesianPairs")
+#   options$pairs <- list(c("contcor1", "contcor2"))
+#   options$plotBayesFactorRobustness <- TRUE
+#   options$plotBayesFactorRobustnessAdditionalInfo <- FALSE
+#   results <- jasptools::run("CorrelationBayesianPairs", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "robustness-check", dir="CorrelationBayesianPairs")
+# })
+#
+# test_that("Sequential analysis plot matches", {
+#   options <- jasptools::analysisOptions("CorrelationBayesianPairs")
+#   options$pairs <- list(c("contcor1", "contcor2"))
+#   options$plotSequentialAnalysis <- TRUE
+#   results <- jasptools::run("CorrelationBayesianPairs", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "sequential-analysis", dir="CorrelationBayesianPairs")
+# })
 
 test_that("Analysis handles errors", {
   options <- jasptools::analysisOptions("CorrelationBayesianPairs")

--- a/JASP-Tests/R/tests/testthat/test-descriptives.R
+++ b/JASP-Tests/R/tests/testthat/test-descriptives.R
@@ -77,36 +77,36 @@ test_that("Frequencies table matches with missing values", {
   )
 })
 
-test_that("Distribution plot matches", {
-  options <- jasptools::analysisOptions("Descriptives")
-  options$variables <- "contNormal"
-  options$plotVariables <- TRUE
-  results <- jasptools::run("Descriptives", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "distribution", dir="Descriptives")
-})
-
-test_that("Correlation plot matches", {
-  options <- jasptools::analysisOptions("Descriptives")
-  options$variables <- c("contNormal", "contGamma")
-  options$plotCorrelationMatrix <- TRUE
-  results <- jasptools::run("Descriptives", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "correlation", dir="Descriptives")
-})
-
-test_that("Boxplot matches", {
-  set.seed(0)
-  options <- jasptools::analysisOptions("Descriptives")
-  options$variables <- "contNormal"
-  options$splitby <- "contBinom"
-  options$splitPlotBoxplot <- TRUE
-  options$splitPlotColour <- TRUE
-  options$splitPlotJitter <- TRUE
-  options$splitPlotOutlierLabel <- TRUE
-  options$splitPlotViolin <- TRUE
-  options$splitPlots <- TRUE
-  results <- jasptools::run("Descriptives", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "boxplot", dir="Descriptives")
-})
+# test_that("Distribution plot matches", {
+#   options <- jasptools::analysisOptions("Descriptives")
+#   options$variables <- "contNormal"
+#   options$plotVariables <- TRUE
+#   results <- jasptools::run("Descriptives", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "distribution", dir="Descriptives")
+# })
+#
+# test_that("Correlation plot matches", {
+#   options <- jasptools::analysisOptions("Descriptives")
+#   options$variables <- c("contNormal", "contGamma")
+#   options$plotCorrelationMatrix <- TRUE
+#   results <- jasptools::run("Descriptives", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "correlation", dir="Descriptives")
+# })
+#
+# test_that("Boxplot matches", {
+#   set.seed(0)
+#   options <- jasptools::analysisOptions("Descriptives")
+#   options$variables <- "contNormal"
+#   options$splitby <- "contBinom"
+#   options$splitPlotBoxplot <- TRUE
+#   options$splitPlotColour <- TRUE
+#   options$splitPlotJitter <- TRUE
+#   options$splitPlotOutlierLabel <- TRUE
+#   options$splitPlotViolin <- TRUE
+#   options$splitPlots <- TRUE
+#   results <- jasptools::run("Descriptives", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "boxplot", dir="Descriptives")
+# })

--- a/JASP-Tests/R/tests/testthat/test-exploratoryfactoranalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-exploratoryfactoranalysis.R
@@ -30,14 +30,14 @@ test_that("Main tables' results match", {
   )
 })
 
-test_that("Path diagram matches", {
-  options <- jasptools::analysisOptions("ExploratoryFactorAnalysis")
-  options$variables <- list("contWide", "contcor1", "facFifty", "contExpon")
-  options$incl_pathDiagram <- TRUE
-  results <- jasptools::run("ExploratoryFactorAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "path-diagram", dir="ExploratoryFactorAnalysis")
-})
+# test_that("Path diagram matches", {
+#   options <- jasptools::analysisOptions("ExploratoryFactorAnalysis")
+#   options$variables <- list("contWide", "contcor1", "facFifty", "contExpon")
+#   options$incl_pathDiagram <- TRUE
+#   results <- jasptools::run("ExploratoryFactorAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "path-diagram", dir="ExploratoryFactorAnalysis")
+# })
 
 test_that("Scree plot option creates .png", {
   options <- jasptools::analysisOptions("ExploratoryFactorAnalysis")
@@ -60,12 +60,12 @@ test_that("Missing values works", {
 	options <- jasptools::analysisOptions("ExploratoryFactorAnalysis")
 	options$variables <- list("contNormal", "contGamma", "contcor1", "debMiss30")
 	options$incl_correlations <- TRUE
-	
+
 	options$missingValues <- "pairwise"
 	results <- jasptools::run("ExploratoryFactorAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
 	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
 	expect_equal_tables(table, list("Model", 1.42781053334818, 2L, 0.489727939944839), label = "pairwise")
-	
+
 	options$missingValues <- "listwise"
 	results <- jasptools::run("ExploratoryFactorAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
 	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]

--- a/JASP-Tests/R/tests/testthat/test-multinomialtest.R
+++ b/JASP-Tests/R/tests/testthat/test-multinomialtest.R
@@ -28,13 +28,13 @@ test_that("Main table results match", {
                            "totallyridiculoussuperlongfactorme", 0.01, 0.03))
 })
 
-test_that("Descriptives plot matches", {
-  options <- jasptools::analysisOptions("MultinomialTest")
-  options$factor <- "facFive"
-  options$descriptivesPlot <- TRUE
-  results <- jasptools::run("MultinomialTest", "test.csv", options,
-                            view=FALSE, quiet=TRUE)
-
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives-1", dir="MultinomialTest")
-})
+# test_that("Descriptives plot matches", {
+#   options <- jasptools::analysisOptions("MultinomialTest")
+#   options$factor <- "facFive"
+#   options$descriptivesPlot <- TRUE
+#   results <- jasptools::run("MultinomialTest", "test.csv", options,
+#                             view=FALSE, quiet=TRUE)
+#
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives-1", dir="MultinomialTest")
+# })

--- a/JASP-Tests/R/tests/testthat/test-principalcomponentanalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-principalcomponentanalysis.R
@@ -32,14 +32,14 @@ test_that("Main tables' results match", {
   )
 })
 
-test_that("Path diagram matches", {
-  options <- jasptools::analysisOptions("PrincipalComponentAnalysis")
-  options$variables <- list("contNormal", "contGamma")
-  options$incl_pathDiagram <- TRUE
-  results <- jasptools::run("PrincipalComponentAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "path-diagram", dir="PrincipalComponentAnalysis")
-})
+# test_that("Path diagram matches", {
+#   options <- jasptools::analysisOptions("PrincipalComponentAnalysis")
+#   options$variables <- list("contNormal", "contGamma")
+#   options$incl_pathDiagram <- TRUE
+#   results <- jasptools::run("PrincipalComponentAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "path-diagram", dir="PrincipalComponentAnalysis")
+# })
 
 test_that("Scree plot option creates .png", {
   options <- jasptools::analysisOptions("PrincipalComponentAnalysis")
@@ -66,10 +66,9 @@ test_that("Missing values works", {
 	results <- jasptools::run("PrincipalComponentAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
 	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
 	expect_equal_tables(table, list("Model", 20.7622398603288, 2, 3.10125086457269e-05), label = "pairwise")
-	
+
 	options$missingValues <- "listwise"
 	results <- jasptools::run("PrincipalComponentAnalysis", "test.csv", options, view=FALSE, quiet=TRUE, sideEffects="pkgLoading")
 	table <- results[["results"]][["goodnessOfFit"]][["data"]][[1]]
 	expect_equal_tables(table, list("Model", 13.8130059031587, 2, 0.00100125311189221), label = "listwise")
 })
-

--- a/JASP-Tests/R/tests/testthat/test-regressionlinear.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionlinear.R
@@ -218,71 +218,71 @@ test_that("Casewise Diagnostics table results match", {
   )
 })
 
-test_that("Residuals vs. Dependent plot matches", {
-  options <- jasptools::analysisOptions("RegressionLinear")
-  options$dependent <- "contNormal"
-  options$covariates <- "contGamma"
-  options$modelTerms <- list(
-    list(components="contGamma", isNuisance=FALSE)
-  )
-  options$plotResidualsDependent <- TRUE
-  results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "residuals-dependent", dir="RegressionLinear")
-})
-
-test_that("Residuals vs. Covariates plot matches", {
-  options <- jasptools::analysisOptions("RegressionLinear")
-  options$dependent <- "contNormal"
-  options$covariates <- "contGamma"
-  options$modelTerms <- list(
-    list(components="contGamma", isNuisance=FALSE)
-  )
-  options$plotResidualsCovariates <- TRUE
-  results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "residuals-covariates", dir="RegressionLinear")
-})
-
-test_that("Residuals vs. Predicted plot matches", {
-  options <- jasptools::analysisOptions("RegressionLinear")
-  options$dependent <- "contNormal"
-  options$covariates <- "contGamma"
-  options$modelTerms <- list(
-    list(components="contGamma", isNuisance=FALSE)
-  )
-  options$plotResidualsPredicted <- TRUE
-  results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "residuals-predicted", dir="RegressionLinear")
-})
-
-test_that("Standardized Residuals Histogram matches", {
-  options <- jasptools::analysisOptions("RegressionLinear")
-  options$dependent <- "contNormal"
-  options$covariates <- "contGamma"
-  options$modelTerms <- list(
-    list(components="contGamma", isNuisance=FALSE)
-  )
-  options$plotResidualsHistogram <- TRUE
-  options$plotResidualsHistogramStandardized <- TRUE
-  results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "residuals-histogram", dir="RegressionLinear")
-})
-
-test_that("Q-Q Plot Standardized Residuals matches", {
-  options <- jasptools::analysisOptions("RegressionLinear")
-  options$dependent <- "contNormal"
-  options$covariates <- "contGamma"
-  options$modelTerms <- list(
-    list(components="contGamma", isNuisance=FALSE)
-  )
-  options$plotResidualsQQ <- TRUE
-  results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "residuals-q-q", dir="RegressionLinear")
-})
+# test_that("Residuals vs. Dependent plot matches", {
+#   options <- jasptools::analysisOptions("RegressionLinear")
+#   options$dependent <- "contNormal"
+#   options$covariates <- "contGamma"
+#   options$modelTerms <- list(
+#     list(components="contGamma", isNuisance=FALSE)
+#   )
+#   options$plotResidualsDependent <- TRUE
+#   results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "residuals-dependent", dir="RegressionLinear")
+# })
+#
+# test_that("Residuals vs. Covariates plot matches", {
+#   options <- jasptools::analysisOptions("RegressionLinear")
+#   options$dependent <- "contNormal"
+#   options$covariates <- "contGamma"
+#   options$modelTerms <- list(
+#     list(components="contGamma", isNuisance=FALSE)
+#   )
+#   options$plotResidualsCovariates <- TRUE
+#   results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "residuals-covariates", dir="RegressionLinear")
+# })
+#
+# test_that("Residuals vs. Predicted plot matches", {
+#   options <- jasptools::analysisOptions("RegressionLinear")
+#   options$dependent <- "contNormal"
+#   options$covariates <- "contGamma"
+#   options$modelTerms <- list(
+#     list(components="contGamma", isNuisance=FALSE)
+#   )
+#   options$plotResidualsPredicted <- TRUE
+#   results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "residuals-predicted", dir="RegressionLinear")
+# })
+#
+# test_that("Standardized Residuals Histogram matches", {
+#   options <- jasptools::analysisOptions("RegressionLinear")
+#   options$dependent <- "contNormal"
+#   options$covariates <- "contGamma"
+#   options$modelTerms <- list(
+#     list(components="contGamma", isNuisance=FALSE)
+#   )
+#   options$plotResidualsHistogram <- TRUE
+#   options$plotResidualsHistogramStandardized <- TRUE
+#   results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "residuals-histogram", dir="RegressionLinear")
+# })
+#
+# test_that("Q-Q Plot Standardized Residuals matches", {
+#   options <- jasptools::analysisOptions("RegressionLinear")
+#   options$dependent <- "contNormal"
+#   options$covariates <- "contGamma"
+#   options$modelTerms <- list(
+#     list(components="contGamma", isNuisance=FALSE)
+#   )
+#   options$plotResidualsQQ <- TRUE
+#   results <- jasptools::run("RegressionLinear", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "residuals-q-q", dir="RegressionLinear")
+# })
 
 test_that("Analysis handles errors", {
   options <- jasptools::analysisOptions("RegressionLinear")

--- a/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
@@ -19,50 +19,50 @@ test_that("Main table results match", {
   expect_equal_tables(table, list("contNormal", 0.123677493243643, 0.0895633315624481))
 })
 
-test_that("Prior posterior plot matches", {
-  set.seed(0)
-  options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
-  options$variables <- "contNormal"
-  options$groupingVariable <- "contBinom"
-  options$plotPriorAndPosterior <- TRUE
-  options$plotPriorAndPosteriorAdditionalInfo <- TRUE
-  results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "prior-posterior", dir="TTestBayesianIndependentSamples")
-})
-
-test_that("BF robustness check plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
-  options$variables <- "contNormal"
-  options$groupingVariable <- "contBinom"
-  options$plotBayesFactorRobustness <- TRUE
-  options$plotBayesFactorRobustnessAdditionalInfo <- FALSE
-  results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "robustness-check", dir="TTestBayesianIndependentSamples")
-})
-
-test_that("Sequential analysis plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
-  options$variables <- "contNormal"
-  options$groupingVariable <- "contBinom"
-  options$plotSequentialAnalysis <- TRUE
-  options$plotSequentialAnalysisRobustness <- TRUE
-  results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "sequential-analysis", dir="TTestBayesianIndependentSamples")
-})
-
-test_that("Descriptives plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
-  options$variables <- "contNormal"
-  options$groupingVariable <- "contBinom"
-  options$descriptivesPlots <- TRUE
-  options$descriptivesPlotsCredibleInterval <- 0.90
-  results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives", dir="TTestBayesianIndependentSamples")
-})
+# test_that("Prior posterior plot matches", {
+#   set.seed(0)
+#   options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
+#   options$variables <- "contNormal"
+#   options$groupingVariable <- "contBinom"
+#   options$plotPriorAndPosterior <- TRUE
+#   options$plotPriorAndPosteriorAdditionalInfo <- TRUE
+#   results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "prior-posterior", dir="TTestBayesianIndependentSamples")
+# })
+#
+# test_that("BF robustness check plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
+#   options$variables <- "contNormal"
+#   options$groupingVariable <- "contBinom"
+#   options$plotBayesFactorRobustness <- TRUE
+#   options$plotBayesFactorRobustnessAdditionalInfo <- FALSE
+#   results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "robustness-check", dir="TTestBayesianIndependentSamples")
+# })
+#
+# test_that("Sequential analysis plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
+#   options$variables <- "contNormal"
+#   options$groupingVariable <- "contBinom"
+#   options$plotSequentialAnalysis <- TRUE
+#   options$plotSequentialAnalysisRobustness <- TRUE
+#   results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "sequential-analysis", dir="TTestBayesianIndependentSamples")
+# })
+#
+# test_that("Descriptives plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
+#   options$variables <- "contNormal"
+#   options$groupingVariable <- "contBinom"
+#   options$descriptivesPlots <- TRUE
+#   options$descriptivesPlotsCredibleInterval <- 0.90
+#   results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives", dir="TTestBayesianIndependentSamples")
+# })
 
 test_that("Descriptives table matches", {
   options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
@@ -111,12 +111,12 @@ test_that("Analysis handles integer overflow", {
   set.seed(4491)
   dat <- data.frame(dependent_var = rnorm(2e5),
                     grouping      = rep(c(1, 2), each = 1e5))
-  
+
   options <- jasptools::analysisOptions("TTestBayesianIndependentSamples")
   options$variables <- 'dependent_var'
   options$groupingVariable <- 'grouping'
   results <- jasptools::run("TTestBayesianIndependentSamples", dat, options, view=FALSE, quiet=TRUE)
-  
+
   table <- results[["results"]][["ttest"]][["data"]]
   expect_equal_tables(table, list("dependent_var", 0.00511047418810093, 0.311955453811728))
 })

--- a/JASP-Tests/R/tests/testthat/test-ttestbayesianonesample.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestbayesianonesample.R
@@ -17,46 +17,46 @@ test_that("Main table results match", {
   expect_equal_tables(table, list("contNormal", 0.508160332089536, 2.80907441042415e-05))
 })
 
-test_that("Prior posterior plot matches", {
-  set.seed(0)
-  options <- jasptools::analysisOptions("TTestBayesianOneSample")
-  options$variables <- "contNormal"
-  options$plotPriorAndPosterior <- TRUE
-  options$plotPriorAndPosteriorAdditionalInfo <- TRUE
-  results <- jasptools::run("TTestBayesianOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "prior-posterior", dir="TTestBayesianOneSample")
-})
-
-test_that("BF robustness check plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianOneSample")
-  options$variables <- "contNormal"
-  options$plotBayesFactorRobustness <- TRUE
-  options$plotBayesFactorRobustnessAdditionalInfo <- FALSE
-  results <- jasptools::run("TTestBayesianOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "robustness-check", dir="TTestBayesianOneSample")
-})
-
-test_that("Sequential analysis plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianOneSample")
-  options$variables <- "contNormal"
-  options$plotSequentialAnalysis <- TRUE
-  options$plotSequentialAnalysisRobustness <- TRUE
-  results <- jasptools::run("TTestBayesianOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "sequential-analysis", dir="TTestBayesianOneSample")
-})
-
-test_that("Descriptives plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianOneSample")
-  options$variables <- "contNormal"
-  options$descriptivesPlots <- TRUE
-  options$descriptivesPlotsCredibleInterval <- 0.90
-  results <- jasptools::run("TTestBayesianOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives", dir="TTestBayesianOneSample")
-})
+# test_that("Prior posterior plot matches", {
+#   set.seed(0)
+#   options <- jasptools::analysisOptions("TTestBayesianOneSample")
+#   options$variables <- "contNormal"
+#   options$plotPriorAndPosterior <- TRUE
+#   options$plotPriorAndPosteriorAdditionalInfo <- TRUE
+#   results <- jasptools::run("TTestBayesianOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "prior-posterior", dir="TTestBayesianOneSample")
+# })
+#
+# test_that("BF robustness check plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianOneSample")
+#   options$variables <- "contNormal"
+#   options$plotBayesFactorRobustness <- TRUE
+#   options$plotBayesFactorRobustnessAdditionalInfo <- FALSE
+#   results <- jasptools::run("TTestBayesianOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "robustness-check", dir="TTestBayesianOneSample")
+# })
+#
+# test_that("Sequential analysis plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianOneSample")
+#   options$variables <- "contNormal"
+#   options$plotSequentialAnalysis <- TRUE
+#   options$plotSequentialAnalysisRobustness <- TRUE
+#   results <- jasptools::run("TTestBayesianOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "sequential-analysis", dir="TTestBayesianOneSample")
+# })
+#
+# test_that("Descriptives plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianOneSample")
+#   options$variables <- "contNormal"
+#   options$descriptivesPlots <- TRUE
+#   options$descriptivesPlotsCredibleInterval <- 0.90
+#   results <- jasptools::run("TTestBayesianOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives", dir="TTestBayesianOneSample")
+# })
 
 test_that("Descriptives table matches", {
   options <- jasptools::analysisOptions("TTestBayesianOneSample")

--- a/JASP-Tests/R/tests/testthat/test-ttestbayesianpairedsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestbayesianpairedsamples.R
@@ -20,46 +20,46 @@ test_that("Main table results match", {
   expect_equal_tables(table, list("contNormal", "-", "contGamma", 293915424756.037, 1.32616895200622e-19))
 })
 
-test_that("Prior posterior plot matches", {
-  set.seed(0)
-  options <- jasptools::analysisOptions("TTestBayesianPairedSamples")
-  options$pairs <- list(c("contNormal", "contGamma"))
-  options$plotPriorAndPosterior <- TRUE
-  options$plotPriorAndPosteriorAdditionalInfo <- TRUE
-  results <- jasptools::run("TTestBayesianPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "prior-posterior", dir="TTestBayesianPairedSamples")
-})
-
-test_that("BF robustness check plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianPairedSamples")
-  options$pairs <- list(c("contNormal", "contGamma"))
-  options$plotBayesFactorRobustness <- TRUE
-  options$plotBayesFactorRobustnessAdditionalInfo <- FALSE
-  results <- jasptools::run("TTestBayesianPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "robustness-check", dir="TTestBayesianPairedSamples")
-})
-
-test_that("Sequential analysis plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianPairedSamples")
-  options$pairs <- list(c("contNormal", "contGamma"))
-  options$plotSequentialAnalysis <- TRUE
-  options$plotSequentialAnalysisRobustness <- TRUE
-  results <- jasptools::run("TTestBayesianPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "sequential-analysis", dir="TTestBayesianPairedSamples")
-})
-
-test_that("Descriptives plot matches", {
-  options <- jasptools::analysisOptions("TTestBayesianPairedSamples")
-  options$pairs <- list(c("contNormal", "contGamma"))
-  options$descriptivesPlots <- TRUE
-  options$descriptivesPlotsCredibleInterval <- 0.90
-  results <- jasptools::run("TTestBayesianPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives", dir="TTestBayesianPairedSamples")
-})
+# test_that("Prior posterior plot matches", {
+#   set.seed(0)
+#   options <- jasptools::analysisOptions("TTestBayesianPairedSamples")
+#   options$pairs <- list(c("contNormal", "contGamma"))
+#   options$plotPriorAndPosterior <- TRUE
+#   options$plotPriorAndPosteriorAdditionalInfo <- TRUE
+#   results <- jasptools::run("TTestBayesianPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "prior-posterior", dir="TTestBayesianPairedSamples")
+# })
+#
+# test_that("BF robustness check plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianPairedSamples")
+#   options$pairs <- list(c("contNormal", "contGamma"))
+#   options$plotBayesFactorRobustness <- TRUE
+#   options$plotBayesFactorRobustnessAdditionalInfo <- FALSE
+#   results <- jasptools::run("TTestBayesianPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "robustness-check", dir="TTestBayesianPairedSamples")
+# })
+#
+# test_that("Sequential analysis plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianPairedSamples")
+#   options$pairs <- list(c("contNormal", "contGamma"))
+#   options$plotSequentialAnalysis <- TRUE
+#   options$plotSequentialAnalysisRobustness <- TRUE
+#   results <- jasptools::run("TTestBayesianPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "sequential-analysis", dir="TTestBayesianPairedSamples")
+# })
+#
+# test_that("Descriptives plot matches", {
+#   options <- jasptools::analysisOptions("TTestBayesianPairedSamples")
+#   options$pairs <- list(c("contNormal", "contGamma"))
+#   options$descriptivesPlots <- TRUE
+#   options$descriptivesPlotsCredibleInterval <- 0.90
+#   results <- jasptools::run("TTestBayesianPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives", dir="TTestBayesianPairedSamples")
+# })
 
 test_that("Descriptives table matches", {
   options <- jasptools::analysisOptions("TTestBayesianPairedSamples")

--- a/JASP-Tests/R/tests/testthat/test-ttestindependentsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestindependentsamples.R
@@ -64,16 +64,16 @@ test_that("Descriptives table matches", {
          0.15347202634745)
   )
 })
-
-test_that("Descriptives plot matches", {
-  options <- jasptools::analysisOptions("TTestIndependentSamples")
-  options$variables <- "contNormal"
-  options$groupingVariable <- "contBinom"
-  options$descriptivesPlots <- TRUE
-  results <- jasptools::run("TTestIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives", dir="TTestIndependentSamples")
-})
+#
+# test_that("Descriptives plot matches", {
+#   options <- jasptools::analysisOptions("TTestIndependentSamples")
+#   options$variables <- "contNormal"
+#   options$groupingVariable <- "contBinom"
+#   options$descriptivesPlots <- TRUE
+#   results <- jasptools::run("TTestIndependentSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives", dir="TTestIndependentSamples")
+# })
 
 test_that("Analysis handles errors", {
   options <- jasptools::analysisOptions("TTestIndependentSamples")

--- a/JASP-Tests/R/tests/testthat/test-ttestonesample.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestonesample.R
@@ -27,10 +27,10 @@ test_that("Main table results match for Wilcoxon signed rank", {
   options$effSizeConfidenceIntervalCheckbox <- TRUE
   options$students <- FALSE
   options$mannWhitneyU <- TRUE
-  
+
   results <- jasptools::run("TTestOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
   table <- results[["results"]][["ttest"]][["data"]]
-  
+
   expect_equal_tables(table,
                       list("contGamma", "", 3.955912e-18, 1.813483, 1,
                            1.553513, 2.158945, 1, 1, 5050, "Wilcoxon"))
@@ -74,14 +74,14 @@ test_that("Descriptives table matches", {
   )
 })
 
-test_that("Descriptives plot matches", {
-  options <- jasptools::analysisOptions("TTestOneSample")
-  options$variables <- "contGamma"
-  options$descriptivesPlots <- TRUE
-  results <- jasptools::run("TTestOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives", dir="TTestOneSample")
-})
+# test_that("Descriptives plot matches", {
+#   options <- jasptools::analysisOptions("TTestOneSample")
+#   options$variables <- "contGamma"
+#   options$descriptivesPlots <- TRUE
+#   results <- jasptools::run("TTestOneSample", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives", dir="TTestOneSample")
+# })
 
 test_that("Analysis handles errors", {
   options <- jasptools::analysisOptions("TTestOneSample")

--- a/JASP-Tests/R/tests/testthat/test-ttestpairedsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestpairedsamples.R
@@ -47,14 +47,14 @@ test_that("Descriptives table matches", {
   )
 })
 
-test_that("Descriptives plot matches", {
-  options <- jasptools::analysisOptions("TTestPairedSamples")
-  options$pairs <- list(c("contNormal", "contGamma"))
-  options$descriptivesPlots <- TRUE
-  results <- jasptools::run("TTestPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
-  testPlot <- results[["state"]][["figures"]][[1]]
-  expect_equal_plots(testPlot, "descriptives", dir="TTestPairedSamples")
-})
+# test_that("Descriptives plot matches", {
+#   options <- jasptools::analysisOptions("TTestPairedSamples")
+#   options$pairs <- list(c("contNormal", "contGamma"))
+#   options$descriptivesPlots <- TRUE
+#   results <- jasptools::run("TTestPairedSamples", "test.csv", options, view=FALSE, quiet=TRUE)
+#   testPlot <- results[["state"]][["figures"]][[1]]
+#   expect_equal_plots(testPlot, "descriptives", dir="TTestPairedSamples")
+# })
 
 test_that("Analysis handles errors", {
   options <- jasptools::analysisOptions("TTestPairedSamples")


### PR DESCRIPTION
They are not run anyway now and it makes the Travis CI output hard to read. By commenting the visual tests out, we have a few advantages:
- Fewer errors
- Easier to read test output
- We can focus on removing _actual_ warnings such as these:

![image](https://user-images.githubusercontent.com/11596858/37394796-e9bd1176-2774-11e8-8e79-8cde8e1c4974.png)

Once we've moved to `ggplot2` we will re-implement these checks by comparing ggplot objects.