### PR TITLE
Bas updates

### DIFF
--- a/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.cpp
+++ b/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.cpp
@@ -32,20 +32,20 @@ RegressionLinearBayesianForm::RegressionLinearBayesianForm(QWidget *parent) :
 
 	_dependentListModel = new TableModelVariablesAssigned(this);
 	_dependentListModel->setVariableTypesSuggested(Column::ColumnTypeScale);
-	_dependentListModel->setVariableTypesAllowed(Column::ColumnTypeScale | Column::ColumnTypeOrdinal | Column::ColumnTypeNominal);
+	_dependentListModel->setVariableTypesAllowed(Column::ColumnTypeScale);
 	_dependentListModel->setSource(&_availableVariablesModel);
 	ui->dependent->setModel(_dependentListModel);
 
 	_covariatesListModel = new TableModelVariablesAssigned(this);
 	_covariatesListModel->setSource(&_availableVariablesModel);
 	_covariatesListModel->setVariableTypesSuggested(Column::ColumnTypeScale);
-	_covariatesListModel->setVariableTypesAllowed(Column::ColumnTypeScale | Column::ColumnTypeNominal | Column::ColumnTypeOrdinal);
+	_covariatesListModel->setVariableTypesAllowed(Column::ColumnTypeScale);
 	ui->covariates->setModel(_covariatesListModel);
 
 	_wlsWeightsListModel = new TableModelVariablesAssigned();
 	_wlsWeightsListModel->setSource(&_availableVariablesModel);
 	_wlsWeightsListModel->setVariableTypesSuggested(Column::ColumnTypeScale);
-	_wlsWeightsListModel->setVariableTypesAllowed(Column::ColumnTypeScale | Column::ColumnTypeNominal | Column::ColumnTypeOrdinal);
+	_wlsWeightsListModel->setVariableTypesAllowed(Column::ColumnTypeScale);
 	ui->wlsWeights->setModel(_wlsWeightsListModel);
 
 	ui->buttonAssignDependent->setSourceAndTarget(ui->listAvailableFields, ui->dependent);

--- a/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.cpp
+++ b/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.cpp
@@ -284,7 +284,7 @@ void RegressionLinearBayesianForm::factorsChanged()
 
 // two functions below enable posteriorSummaryPlotCredibleIntervalBox
 // when either postSummary or postSummaryPlot are checked.
-void RegressionLinearBayesianForm::on_postSummary_toggled(bool checked)
+void RegressionLinearBayesianForm::on_postSummaryTable_toggled(bool checked)
 {
     bool turnOn = checked || ui->postSummaryPlot->isChecked();
     ui->posteriorSummaryPlotCredibleIntervalBox->setEnabled(turnOn);
@@ -292,6 +292,6 @@ void RegressionLinearBayesianForm::on_postSummary_toggled(bool checked)
 
 void RegressionLinearBayesianForm::on_postSummaryPlot_toggled(bool checked)
 {
-    bool turnOn = checked || ui->postSummary->isChecked();
+    bool turnOn = checked || ui->postSummaryTable->isChecked();
     ui->posteriorSummaryPlotCredibleIntervalBox->setEnabled(turnOn);
 }

--- a/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.h
+++ b/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.h
@@ -62,7 +62,7 @@ private slots:
 	void on_eb_local_clicked();
 	void factorsChanging();
 	void factorsChanged();
-    void on_postSummaryTable_toggled(bool checked);
+	void on_postSummaryTable_toggled(bool checked);
 	void on_postSummaryPlot_toggled(bool checked);
 
 private:

--- a/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.h
+++ b/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.h
@@ -62,7 +62,7 @@ private slots:
 	void on_eb_local_clicked();
 	void factorsChanging();
 	void factorsChanged();
-	void on_postSummary_toggled(bool checked);
+    void on_postSummaryTable_toggled(bool checked);
 	void on_postSummaryPlot_toggled(bool checked);
 
 private:

--- a/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.ui
+++ b/JASP-Desktop/analysisforms/Common/regressionlinearbayesianform.ui
@@ -338,7 +338,7 @@
           </widget>
          </item>
          <item row="0" column="0">
-          <widget class="BoundCheckBox" name="postSummary">
+          <widget class="BoundCheckBox" name="postSummaryTable">
            <property name="text">
             <string>Posterior summary</string>
            </property>

--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -539,6 +539,22 @@ RegressionLinearBayesian <- function (
 	}
 
 	nuisanceTerms <- bas_obj$nuisanceTerms # vector of TRUE / FALSE
+	if (length(nuisanceTerms) != length(bas_obj$namesx) - 1) {
+	# if there are categorical predictors
+
+		nuisanceTerms2 <- logical(length(bas_obj$namesx) - 1)
+		names(nuisanceTerms2) <- bas_obj$namesx[-1]
+		for (i in which(nuisanceTerms[nuisanceTerms])) {
+
+			idx <- grep(pattern = names(nuisanceTerms[i],
+				x = names(nuisanceTerms2)[i]), fixed = TRUE)
+			nuisanceTerms2[idx] <- TRUE
+		}
+		nuisanceTerms <- nuisanceTerms2
+
+	} else {
+		names(nuisanceTerms) <- .unvf(names(nuisanceTerms))
+	}
 
 	# default number of models to be shown
 	nRows <- NULL
@@ -575,7 +591,7 @@ RegressionLinearBayesian <- function (
 	# generate all model names
   allModelsVisited <- any(lengths(models) == 0) # analysis will chrash if TRUE
   model.names <- vector("character", length(models))
-  names(nuisanceTerms) <- .unvf(names(nuisanceTerms))
+
   for (i in 1:length(models)) {
     model <- models[[i]]
     if (length(model) == 1) { # only has intercept
@@ -673,7 +689,7 @@ RegressionLinearBayesian <- function (
 }
 
 .calcInlusionBF <- function(bas_obj) {
-	
+
 	nModels <- bas_obj[["n.models"]]
 	nPred <- length(bas_obj[["probne0"]])
 	

--- a/JASP-Tests/R/tests/testthat/test-regressionlinearbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionlinearbayesian.R
@@ -11,7 +11,7 @@ test_that("Main tables results match", {
     options$modelTerms <- list(
         list(components="contGamma", isNuisance=FALSE)
     )
-    options$postSummary <- TRUE
+    options$postSummaryTable <- TRUE
     options$descriptives <- TRUE
     
     results <- jasptools::run("RegressionLinearBayesian", "test.csv", options, view=FALSE)#, quiet=TRUE)
@@ -27,9 +27,10 @@ test_that("Main tables results match", {
     table <- results[["results"]][["posteriorSummary"]][["posteriorSummaryTable"]][["data"]]
     expect_equal_tables(
         table,
-        list("Intercept", -0.255843391953333, 0.0993902662352492, 1, -0.453055243040002,
-             -0.0586315408666647, "contGamma", -0.000690480780951939, 0.0586422991479854,
-             0.772565707223374, -0.117049524830386, 0.115668563268482), 
+        list("Intercept", -0.255843391953333, 0.0993902662352492, 1, 1, 1,
+             -0.453055243040002, -0.0586315408666647, "contGamma", -0.000690480780951939,
+             0.0586422991479854, 0.772565707223374, 0.5, 3.39687431385796,
+             -0.117049524830386, 0.115668563268482), 
         label = "posteriorSummaryTable"
     )
     

--- a/Resources/Library/RegressionLinearBayesian.json
+++ b/Resources/Library/RegressionLinearBayesian.json
@@ -36,7 +36,7 @@
 			"default": false
 		},
 		{
-			"name": "postSummary",
+            "name": "postSummaryTable",
 			"type": "Boolean",
 			"default": false
 		},

--- a/Resources/Library/RegressionLinearBayesian.json
+++ b/Resources/Library/RegressionLinearBayesian.json
@@ -36,7 +36,7 @@
 			"default": false
 		},
 		{
-            "name": "postSummaryTable",
+			"name": "postSummaryTable",
 			"type": "Boolean",
 			"default": false
 		},
@@ -84,7 +84,7 @@
 		{
 			"name": "shownModels",
 			"options": [ "limited", "unlimited" ],
-			"default": "unlimited",
+			"default": "limited",
 			"type": "List"
 		},
 		{


### PR DESCRIPTION
Fixes: #2400 and #2425 

New features:
- Inclusion BF
- Forbids users from entering non-continuous data (which the analyses doesn't support).
- Enforces principle of marginality (in an inefficient manner, the only way BAS currently supports).
- Some cleanup of code and state.