### PR TITLE
No QT code in Engine

### DIFF
--- a/JASP-Engine/engine.cpp
+++ b/JASP-Engine/engine.cpp
@@ -44,7 +44,6 @@ Engine * Engine::_EngineInstance = NULL;
 
 Engine::Engine(int slaveNo, unsigned long parentPID)
 {
-	Q_ASSERT(_EngineInstance == NULL);
 	_EngineInstance = this;
 
 	_slaveNo = slaveNo;


### PR DESCRIPTION
- Remove QT code from Engine
- QT+= core is stlli used in JASP-Engine.pro but it must be removed too if defines are checked

