### PR TITLE
Bug fix

### DIFF
--- a/JASP-Engine/JASP/R/ttestpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestpairedsamples.R
@@ -26,6 +26,15 @@ TTestPairedSamples <- function(dataset = NULL, options, perform = "run",
 	results <- init[["results"]]
 	dataset <- init[["dataset"]]
 	
+	# test whether pairs are identical
+	if (length(options$pairs) > 0) {
+	  for (i in 1:length(options$pairs)) {
+	    datasetErrorCheck <- data.frame(dataset[[.v(options$pairs[[i]][[1]])]] - dataset[[.v(options$pairs[[i]][[2]])]])
+	    colnames(datasetErrorCheck) <- .v(paste0("Difference between ", options$pairs[[i]][[1]], " and ", options$pairs[[i]][[2]]))
+	    .hasErrors(datasetErrorCheck, perform, type = "variance", exitAnalysisIfErrors = TRUE)
+	  }
+	}
+	
 	## call the specific paired T-Test functions
 	results[["ttest"]] <- .ttestPairedSamples(dataset, options, perform)
 	descriptivesTable <- .ttestPairedSamplesDescriptives(dataset, options, perform)


### PR DESCRIPTION
Fix the following problem:
debEqual1 - deEqual2 produces an error with normality check, the main results table says "missing value when TRUE/FALSE needed" in the footnote instead of giving a meaningful information (the differences of the two measures have a variance of 0)

