### PR TITLE
Directly support qgraph objects in plotting

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -1803,7 +1803,7 @@ callback <- function(results=NULL, progress=NULL) {
 		if (is.character(response)) {
 
 			ret <- fromJSON(base::paste("[", response, "]"))[[1]]
-			
+
 		} else {
 
 			ret <- response
@@ -2181,9 +2181,10 @@ as.list.footnotes <- function(footnotes) {
 		eval(plot())
 		if (obj) plot <- recordPlot() # save plot to R object
 	} else if (isRecordedPlot) { # function was called from editImage to resize the plot
-	    .redrawPlot(plot) #(see below)
+	  .redrawPlot(plot) #(see below)
 	} else {
-		print(plot)
+		# plot objects such as ggplot and qgraph
+		plot(plot)
 	}
 	dev.off()
 


### PR DESCRIPTION
`.writeImage()` now correctly plots `qgraph` objects and any other object with a correctly specified `plot()` S3 method in addition to `functions`, `recordedplots`, and `ggplots`.

(Not necessary for release 0.9.0)

