### PR TITLE
Independent Bayesian T-test new state system

### DIFF
--- a/Docs/development/r-analyses-guide.md
+++ b/Docs/development/r-analyses-guide.md
@@ -533,17 +533,15 @@ attr(state, "key") <- stateKey
 ```
 
 Now if the analysis is called again and e.g. `sampleMode` changes, only the plot will be returned.
-If there are state items you would like to keep indefinitely -- regardless of the options a user changes -- you must omit these in the stateKey. Elements of the statekey can also be a list instead of a character vector. The only reason to use a list is to mix expressions in the stateKey with options. This allows for more complicated dependency checks. For example:
+If there are state items you would like to keep indefinitely -- regardless of the options a user changes -- you must omit these in the stateKey. 
+
+Elements of the statekey can also be a list instead of a character vector. The only reason to use a list is to mix expressions in the stateKey with characters. Expressions allow for more complicated dependency checks. For example:
 ```
 # a descriptives plot for each variable
 state[["plotDescriptives"]] <- plotDescriptives
 stateKey[["plotDescriptives"]] <- list(expression("contNormal" %in% options[["variables"]]), "fixedFactors")
 ```
-Expressions are evaluated in a stand-alone environment where two other variables are present:
-`options`, the *new* options, and `state`, the state. These are the only objects that can be called. If the expression succeeds, TRUE should be returned. For all other outputs this element in the state will be discarded. If the expression gives an error, a warning is given inside QT.
-
-
-Some analyses contain collections of object, e.g., a descriptive plot for every variable. Now if a variable is removed from the anlayses, all plots except for one are still useable. The stateKey can be specified individually for each element of a collection. An example is given below.
+The above state entry `"plotDescriptives"` now also depends on wether the specific variable `"contNormal"` is present in `options[["variables"]]`. Expressions are primarily useful when you want to save a collection of objects, e.g., a descriptive plot for every variable. Now if a variable is removed from the anlayses, all plots except for one are still useable. The stateKey can be specified individually for each element of a collection. An example is given below.
 ```
 state <- list(
   descriptivesPlot = list(v1 = ggplotObjectV1,
@@ -553,18 +551,23 @@ state <- list(
 stateKey <- list(
   descriptivesPlot = c("showDescriptivesPlot") # changing this removes the entire element 'descriptivesPlot'.
 )
-attr(stateKey[["descriptivesPlot"]], "collection") <- list(
-  # each subselement also depends on the presence of a variable
-  v1 = list(expression(v1 %in% options[["variables"]])),
-  v2 = list(expression(v2 %in% options[["variables"]])),
-  v3 = list(expression(v3 %in% options[["variables"]]))
+# each subselement also depends on the presence of a variable
+collectionKey <- list(
+  list(expression('v1' %in% options[["variables"]])),
+  list(expression('v2' %in% options[["variables"]])),
+  list(expression('v3' %in% options[["variables"]]))
 )
+attr(stateKey[["descriptivesPlot"]], "collection") <- collectionKey
 # the above is the likely the most common case, hence there exists a convenience function
 variables <- paste0("v", 1:3)
 collectionKey <- .stateDependsOnVar(variables)
 attr(stateKey[["descriptivesPlot"]], "collection") <- collectionKey
 ```
-In the example above, all ggplot objects in the state depend on the option `showDescriptivesPlot`. In addition, each individual ggplot object depends on whether a variable is included in `options[["variables"]]`. The subelements of a collection are checked by name, or if there are no names in order. Subelements without checks are kept by default. Collections keys cannot be nested inside collection keys (there is no recursion). Also, it would be bad practice to organize the state that way.
+In the example above, all ggplot objects in the state depend on the option `showDescriptivesPlot`. In addition, each individual ggplot object depends on whether a variable is included in `options[["variables"]]`. The subelements of a collection are checked in order. Subelements without checks are kept by default. Collections keys cannot be nested inside collection keys (there is no recursion). Also, it would be bad practice to organize the state that way.
+
+Since the most common case is that subcollections depend on a number of variables, there exists a convenience function called `.stateDependsOnVar`. This function can be called with either a vector of names or with a matrix of names. For a vector, each element will corresponds to one element in the collection. For a matrix, each row corresponds to one element collection. The option element to look for can be changed using the argument `optionsName` (which defaults to `"variables"`).
+
+Expressions are evaluated in a stand-alone environment where two other variables are present: `options`, the *new* options, and `state`, the state. These are the only objects that can be called. If the expression succeeds, TRUE should be returned. For all other outputs this element in the state will be discarded. If the expression gives an error, a warning is given inside QT.
 
 
 Error handling

--- a/Docs/development/r-analyses-guide.md
+++ b/Docs/development/r-analyses-guide.md
@@ -533,7 +533,39 @@ attr(state, "key") <- stateKey
 ```
 
 Now if the analysis is called again and e.g. `sampleMode` changes, only the plot will be returned.
-If there are state items you would like to keep indefinitely -- regardless of the options a user changes -- you must omit these in the stateKey.
+If there are state items you would like to keep indefinitely -- regardless of the options a user changes -- you must omit these in the stateKey. Elements of the statekey can also be a list instead of a character vector. The only reason to use a list is to mix expressions in the stateKey with options. This allows for more complicated dependency checks. For example:
+```
+# a descriptives plot for each variable
+state[["plotDescriptives"]] <- plotDescriptives
+stateKey[["plotDescriptives"]] <- list(expression("contNormal" %in% options[["variables"]]), "fixedFactors")
+```
+Expressions are evaluated in a stand-alone environment where two other variables are present:
+`options`, the *new* options, and `state`, the state. These are the only objects that can be called. If the expression succeeds, TRUE should be returned. For all other outputs this element in the state will be discarded. If the expression gives an error, a warning is given inside QT.
+
+
+Some analyses contain collections of object, e.g., a descriptive plot for every variable. Now if a variable is removed from the anlayses, all plots except for one are still useable. The stateKey can be specified individually for each element of a collection. An example is given below.
+```
+state <- list(
+  descriptivesPlot = list(v1 = ggplotObjectV1,
+                          v2 = ggplotObjectV2,
+                          v3 = ggplotObjectV3)
+)
+stateKey <- list(
+  descriptivesPlot = c("showDescriptivesPlot") # changing this removes the entire element 'descriptivesPlot'.
+)
+attr(stateKey[["descriptivesPlot"]], "collection") <- list(
+  # each subselement also depends on the presence of a variable
+  v1 = list(expression(v1 %in% options[["variables"]])),
+  v2 = list(expression(v2 %in% options[["variables"]])),
+  v3 = list(expression(v3 %in% options[["variables"]]))
+)
+# the above is the likely the most common case, hence there exists a convenience function
+variables <- paste0("v", 1:3)
+collectionKey <- .stateDependsOnVar(variables)
+attr(stateKey[["descriptivesPlot"]], "collection") <- collectionKey
+```
+In the example above, all ggplot objects in the state depend on the option `showDescriptivesPlot`. In addition, each individual ggplot object depends on whether a variable is included in `options[["variables"]]`. The subelements of a collection are checked by name, or if there are no names in order. Subelements without checks are kept by default. Collections keys cannot be nested inside collection keys (there is no recursion). Also, it would be bad practice to organize the state that way.
+
 
 Error handling
 --------------

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2778,3 +2778,36 @@ editImage <- function(plotName, type, height, width) {
 
   return(v)
 }
+
+.recodeBFtype <- function(bfOld, newBFtype, oldBFtype) {
+
+	# Arguments:
+	# bfOld: the current value of the Bayes factor
+	# newBFtype: the new type of Bayes factor, e.g., BF10, BF01,
+	# oldBFtype: the current type of the Bayes factor, e.g., BF10, BF01,
+	#
+	# note: log(BF10) is the 'else' type, it is not explicitly checked.
+
+	if (oldBFtype == newBFtype)
+		return(bfOld)
+
+	if (oldBFtype == "BF10") {
+		if (newBFtype == "BF01") {
+			return(1 / bfOld)
+		} else {
+			return(log(bfOld))
+		}
+	} else if (oldBFtype == "BF01") {
+		if (newBFtype == "BF10") {
+			return(1 / bfOld)
+		} else {
+			return(log(1 / bfOld))
+		}
+	} else { # log(BF10)
+		if (newBFtype == "BF10") {
+			return(exp(bfOld))
+		} else {
+			return(1 / exp(bfOld))
+		}
+	}
+}

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -1611,7 +1611,6 @@ isTryError <- function(obj){
 		} else {
 			return(NULL)
 		}
-	  print("getting state items")
 		state <- .getStateItems(state=state, options=options, key=key)
 	}
 	return(state)
@@ -2092,94 +2091,86 @@ as.list.footnotes <- function(footnotes) {
 .optionsChanged <- function(stateOptions, newOptions, subset=NULL, state = NULL, insideCollection = FALSE) {
 
   changed <- .diff(stateOptions, newOptions)
-
-	if (! is.null(subset)) {
-	  if (is.list(subset)) {
-	    
-	    subsetChar <- unlist(subset[sapply(subset, is.character)])
-	    subsetExpr <- subset[sapply(subset, is.expression)]
-	    
-	  } else {
-	    
-	    subsetChar <- subset
-	    subsetExpr <- NULL
-	    
-	  }
-		
-	  # deal with character input
-	  if (length(subsetChar) > 0 && is.list(changed)) {
-	    print("Handling Character")
-	    changed <- changed[names(changed) %in% subsetChar]
-	    if (length(changed) == 0) {
-	      stop(paste0("None of the gui options (", paste(subsetChar, collapse=", "), ") is in the options list."))
-	    }
-	    # if changes detected, discard state item and exit early
-	    if (sum(sapply(changed, isTRUE)) > 0) {
-	    	print(changed[sapply(changed, isTRUE)])
-	      return(TRUE)
-	    }
-	  }
-
-	  # deal with expression input
-	  if (length(subsetExpr) > 0) {
-	    print("Handling Expression")
-	    for (expr in subsetExpr) {
-	      # execute expressions inside empty environments
-	      # to avoid contamination across expressions.
-    	  e <- new.env()
+  if (! is.list(changed)) {
+    return(TRUE)
+  }
+  
+  if (! is.null(subset)) {
+    if (is.list(subset)) {
+      
+      subsetChar <- unlist(subset[sapply(subset, is.character)])
+      subsetExpr <- subset[sapply(subset, is.expression)]
+      
+    } else {
+      
+      subsetChar <- subset
+      subsetExpr <- NULL
+      
+    }
+    
+    # deal with character input
+    if (length(subsetChar) > 0) {
+      changed <- changed[names(changed) %in% subsetChar]
+      if (length(changed) == 0) {
+        stop(paste0("None of the gui options (", paste(subsetChar, collapse=", "), ") is in the options list."))
+      }
+      # if changes detected, discard state item and exit early
+      if (sum(sapply(changed, isTRUE)) > 0) {
+        return(TRUE)
+      }
+    }
+    
+    # deal with expression input
+    if (length(subsetExpr) > 0) {
+      for (expr in subsetExpr) {
+        # execute expressions inside empty environments
+        # to avoid contamination across expressions.
+        e <- new.env()
         e$options <- newOptions
         e$state <- state
-	      r <- try(eval(expr = expr, envir = e))
-	      if (isTryError(r)) { # give developer an informative error
-	        print(r)
-	        warning(sprintf("Statekey expression gave an error! Expression was: %s", expr))
-	      } else if (!isTRUE(r)) { # if expression not TRUE, discard state item and exit early
-	      	print(expr)
-	      	print(r)
-	        return(TRUE)
-	      }
-	    }
-	  }
-	  
-	  # if we got here, the item is useable
-	  # now check if we have a collection with subdependencies
-		if (!is.null(attr(subset, "collection"))) {
-			if (insideCollection)
-				stop("Nested collections are not allowed in the state!")
-			print("Handling collection")
-
-			collectionKey <- attr(subset, "collection")
-			resExpr <- sapply(collectionKey, .optionsChanged,
-												stateOptions = stateOptions, 
-												newOptions = newOptions, 
-												state = state,
-												insideCollection = TRUE
-			)
-
-			# if any subsets where TRUE they should be omitted
-			if (!is.logical(resExpr))
-				stop("collection key gave non-logical output!")
-			# r <- c(r, rep(FALSE, length()))
-			if (any(resExpr)) { # if false, all subsets are kept
-				if (all(resExpr)) { # if true, all subsets unuseable
-					print("resExpr")
-					print(resExpr)
-					return(TRUE)
-				} else { # some subsets useable
-					print("resExpr")
-					print(resExpr)
-					return(which(!resExpr))
-				}
-			}
-		}
-	}
+        r <- try(eval(expr = expr, envir = e))
+        if (isTryError(r)) { # give developer an informative error
+          warning(sprintf("Statekey expression gave an error! Expression was: %s", expr))
+        } else if (!isTRUE(r)) { # if expression not TRUE, discard state item and exit early
+          return(TRUE)
+        }
+      }
+    }
+    
+    # if we got here, the item is useable
+    # now check if we have a collection with subdependencies
+    if (!is.null(attr(subset, "collection"))) {
+      if (insideCollection)
+        stop("Nested collections are not allowed in the state!")
+      
+      collectionKey <- attr(subset, "collection")
+      resExpr <- sapply(collectionKey, .optionsChanged,
+                        stateOptions = stateOptions, 
+                        newOptions = newOptions, 
+                        state = state,
+                        insideCollection = TRUE
+      )
+      
+      # if any subsets where TRUE they should be omitted
+      if (!is.logical(resExpr))
+        stop("collection key gave non-logical output!")
+      
+      if (any(resExpr)) { # if false, all subsets are kept
+        if (all(resExpr)) { # if true, all subsets unuseable
+          return(TRUE)
+        } else { # some subsets useable
+          return(which(!resExpr))
+        }
+      }
+    }
+  }
   return(FALSE)
 }
 
 
 .getStateItems <- function(state, options, key) {
 
-  if (is.null(names(state)) || is.null(names(state$options)) ||
+  if (is.null(names(state)) || is.null(names(state[["options"]])) ||
       is.null(names(options)) || is.null(names(key))) {
     return(NULL)
   }
@@ -2192,19 +2183,13 @@ as.list.footnotes <- function(footnotes) {
       result[[item]] <- state[[item]]
       next
     }
-    print(sprintf("Item: %s", item))
-    change <- .optionsChanged(stateOptions = state$options, 
-															newOptions   = options, 
-															subset       = key[[item]], 
-															state        = state)
+    change <- .optionsChanged(stateOptions = state[["options"]], newOptions = options,
+															subset = key[[item]], state = state)
     if (isTRUE(change)) { # item unuseable
-    	print(sprintf("Item %s not in state", item))
       next
     } else if (identical(change, FALSE)) { # item completely useable
-    	print(sprintf("Item %s completly in state", item))
       result[[item]] <- state[[item]]
     } else if (is.integer(change)) { # item partially useable
-    	print(sprintf("Item %s partially in state", item))
    		result[[item]] <- state[[item]][change]
 		}
 
@@ -2218,7 +2203,18 @@ as.list.footnotes <- function(footnotes) {
 }
 
 .stateDependsOnVar <- function(variables, optionsName = "variables") {
-  collectionKey <- paste0('"', variables, '"', ' %in% options[["', optionsName, '"]]')
+	if (is.null(variables) || identical(variables, ""))
+		return(NULL)
+	if (!is.character(variables))
+		stop(sprintf("Argument variables must be of type character, got a %s", class(variables)))
+	if (is.vector(variables)) {
+  	tmp <- paste0('"', variables, '"')
+	} else if (is.matrix(variables)) {
+		tmp <- apply(variables, 1, function(x) paste0("c(", paste0('"', x, '"', collapse = ", "), ")"))
+	} else {
+		stop("Argument variables not understood. Must be a character vector or a character matrix.")
+	}
+	collectionKey <- paste0(tmp, ' %in% options[["', optionsName, '"]]')
   return(lapply(collectionKey, function(x) list(as.expression(parse(text = x)))))
 }
 

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -70,10 +70,7 @@ run <- function(name, title, dataKey, options, resultsMeta, stateKey, requiresIn
 
 	oldState <- NULL
 	if ('state' %in% names(formals(analysis))) {
-	  print("newsystem")
 		oldState <- .getStateFromKey(stateKey, options)
-	} else {
-	  print("oldsystem")
 	}
 
 	if (perform == "init" && ! requiresInit) {
@@ -2095,9 +2092,6 @@ as.list.footnotes <- function(footnotes) {
 .optionsChanged <- function(stateOptions, newOptions, subset=NULL, state = NULL, insideCollection = FALSE) {
 
   changed <- .diff(stateOptions, newOptions)
-  if (! is.list(changed)) {
-    return(TRUE)
-  }
 
 	if (! is.null(subset)) {
 	  if (is.list(subset)) {
@@ -2113,16 +2107,15 @@ as.list.footnotes <- function(footnotes) {
 	  }
 		
 	  # deal with character input
-	  if (length(subsetChar) > 0) {
+	  if (length(subsetChar) > 0 && is.list(changed)) {
 	    print("Handling Character")
 	    changed <- changed[names(changed) %in% subsetChar]
-	    print("changed")
-	    print(changed)
 	    if (length(changed) == 0) {
 	      stop(paste0("None of the gui options (", paste(subsetChar, collapse=", "), ") is in the options list."))
 	    }
 	    # if changes detected, discard state item and exit early
 	    if (sum(sapply(changed, isTRUE)) > 0) {
+	    	print(changed[sapply(changed, isTRUE)])
 	      return(TRUE)
 	    }
 	  }
@@ -2130,7 +2123,6 @@ as.list.footnotes <- function(footnotes) {
 	  # deal with expression input
 	  if (length(subsetExpr) > 0) {
 	    print("Handling Expression")
-	  	print(subsetExpr)
 	    for (expr in subsetExpr) {
 	      # execute expressions inside empty environments
 	      # to avoid contamination across expressions.
@@ -2138,12 +2130,12 @@ as.list.footnotes <- function(footnotes) {
         e$options <- newOptions
         e$state <- state
 	      r <- try(eval(expr = expr, envir = e))
-	      print(expr)
-	      print(r)
 	      if (isTryError(r)) { # give developer an informative error
 	        print(r)
 	        warning(sprintf("Statekey expression gave an error! Expression was: %s", expr))
 	      } else if (!isTRUE(r)) { # if expression not TRUE, discard state item and exit early
+	      	print(expr)
+	      	print(r)
 	        return(TRUE)
 	      }
 	    }
@@ -2153,9 +2145,9 @@ as.list.footnotes <- function(footnotes) {
 	  # now check if we have a collection with subdependencies
 		if (!is.null(attr(subset, "collection"))) {
 			if (insideCollection)
-				stop("Nested collections are not allowed in the state")
+				stop("Nested collections are not allowed in the state!")
 			print("Handling collection")
-			print(subset)
+
 			collectionKey <- attr(subset, "collection")
 			resExpr <- sapply(collectionKey, .optionsChanged,
 												stateOptions = stateOptions, 
@@ -2163,16 +2155,19 @@ as.list.footnotes <- function(footnotes) {
 												state = state,
 												insideCollection = TRUE
 			)
-			print("resExpr")
-			print(resExpr)
+
 			# if any subsets where TRUE they should be omitted
 			if (!is.logical(resExpr))
 				stop("collection key gave non-logical output!")
 			# r <- c(r, rep(FALSE, length()))
 			if (any(resExpr)) { # if false, all subsets are kept
 				if (all(resExpr)) { # if true, all subsets unuseable
+					print("resExpr")
+					print(resExpr)
 					return(TRUE)
 				} else { # some subsets useable
+					print("resExpr")
+					print(resExpr)
 					return(which(!resExpr))
 				}
 			}
@@ -2183,7 +2178,7 @@ as.list.footnotes <- function(footnotes) {
 
 
 .getStateItems <- function(state, options, key) {
-print(".getStateItems0")
+
   if (is.null(names(state)) || is.null(names(state$options)) ||
       is.null(names(options)) || is.null(names(key))) {
     return(NULL)
@@ -2199,9 +2194,9 @@ print(".getStateItems0")
     }
     print(sprintf("Item: %s", item))
     change <- .optionsChanged(stateOptions = state$options, 
-                              newOptions   = options, 
-                              subset       = key[[item]], 
-                              state        = state)
+															newOptions   = options, 
+															subset       = key[[item]], 
+															state        = state)
     if (isTRUE(change)) { # item unuseable
     	print(sprintf("Item %s not in state", item))
       next
@@ -2210,15 +2205,15 @@ print(".getStateItems0")
       result[[item]] <- state[[item]]
     } else if (is.integer(change)) { # item partially useable
     	print(sprintf("Item %s partially in state", item))
-		  result[[item]] <- state[[item]][change]
+   		result[[item]] <- state[[item]][change]
 		}
 
   }
-print(".getStateItems3")
+
 	if (length(names(result)) > 0) {
 		return(result)
 	}
-print(".getStateItems4")
+
   return(NULL)
 }
 

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2092,7 +2092,7 @@ as.list.footnotes <- function(footnotes) {
 }
 
 
-.optionsChanged <- function(stateOptions, newOptions, subset=NULL, state = NULL) {
+.optionsChanged <- function(stateOptions, newOptions, subset=NULL, state = NULL, insideCollection = FALSE) {
 
   changed <- .diff(stateOptions, newOptions)
   if (! is.list(changed)) {
@@ -2100,7 +2100,6 @@ as.list.footnotes <- function(footnotes) {
   }
 
 	if (! is.null(subset)) {
-	  
 	  if (is.list(subset)) {
 	    
 	    subsetChar <- unlist(subset[sapply(subset, is.character)])
@@ -2117,19 +2116,21 @@ as.list.footnotes <- function(footnotes) {
 	  if (length(subsetChar) > 0) {
 	    print("Handling Character")
 	    changed <- changed[names(changed) %in% subsetChar]
+	    print("changed")
+	    print(changed)
 	    if (length(changed) == 0) {
 	      stop(paste0("None of the gui options (", paste(subsetChar, collapse=", "), ") is in the options list."))
 	    }
+	    # if changes detected, discard state item and exit early
+	    if (sum(sapply(changed, isTRUE)) > 0) {
+	      return(TRUE)
+	    }
 	  }
-	  # if changes detected, discard state item and exit early
-	  if (sum(sapply(changed, isTRUE)) > 0) {
-	    return(TRUE)
-	  }
-	  
+
 	  # deal with expression input
-	  subsetExpr <- subset[sapply(subset, is.expression)]
 	  if (length(subsetExpr) > 0) {
 	    print("Handling Expression")
+	  	print(subsetExpr)
 	    for (expr in subsetExpr) {
 	      # execute expressions inside empty environments
 	      # to avoid contamination across expressions.
@@ -2137,6 +2138,8 @@ as.list.footnotes <- function(footnotes) {
         e$options <- newOptions
         e$state <- state
 	      r <- try(eval(expr = expr, envir = e))
+	      print(expr)
+	      print(r)
 	      if (isTryError(r)) { # give developer an informative error
 	        print(r)
 	        warning(sprintf("Statekey expression gave an error! Expression was: %s", expr))
@@ -2148,37 +2151,39 @@ as.list.footnotes <- function(footnotes) {
 	  
 	  # if we got here, the item is useable
 	  # now check if we have a collection with subdependencies
-	  if (!is.null(attr(subset, "collection"))) {
-	      print("Handling collection")
-	      print(subset)
-	      collectionKey <- attr(subset, "collection")
-	      r <- sapply(collectionKey, .optionsChanged, 
-	             stateOptions = stateOptions, 
-	             newOptions = newOptions, 
-	             state = state
-	      )
-	      print(r)
-	      # if any subsets where TRUE they should be omitted
-	      if (!is.logical(r))
-	        stop("collection key gave non-logical output!")
-	      # r <- c(r, rep(FALSE, length()))
-	      if (any(r)) { # if false, all subsets are kept
-	        if (all(r)) { # if true, all subsets unuseable
-	          return(TRUE)
-	        } else { # some subsets useable
-	          return(which(!r)) 
-	        }
-	      }
-
-	  }
+		if (!is.null(attr(subset, "collection"))) {
+			if (insideCollection)
+				stop("Nested collections are not allowed in the state")
+			print("Handling collection")
+			print(subset)
+			collectionKey <- attr(subset, "collection")
+			resExpr <- sapply(collectionKey, .optionsChanged,
+												stateOptions = stateOptions, 
+												newOptions = newOptions, 
+												state = state,
+												insideCollection = TRUE
+			)
+			print("resExpr")
+			print(resExpr)
+			# if any subsets where TRUE they should be omitted
+			if (!is.logical(resExpr))
+				stop("collection key gave non-logical output!")
+			# r <- c(r, rep(FALSE, length()))
+			if (any(resExpr)) { # if false, all subsets are kept
+				if (all(resExpr)) { # if true, all subsets unuseable
+					return(TRUE)
+				} else { # some subsets useable
+					return(which(!resExpr))
+				}
+			}
+		}
 	}
-
   return(FALSE)
 }
 
 
 .getStateItems <- function(state, options, key) {
-
+print(".getStateItems0")
   if (is.null(names(state)) || is.null(names(state$options)) ||
       is.null(names(options)) || is.null(names(key))) {
     return(NULL)
@@ -2198,28 +2203,28 @@ as.list.footnotes <- function(footnotes) {
                               subset       = key[[item]], 
                               state        = state)
     if (isTRUE(change)) { # item unuseable
+    	print(sprintf("Item %s not in state", item))
       next
     } else if (identical(change, FALSE)) { # item completely useable
+    	print(sprintf("Item %s completly in state", item))
       result[[item]] <- state[[item]]
     } else if (is.integer(change)) { # item partially useable
+    	print(sprintf("Item %s partially in state", item))
 		  result[[item]] <- state[[item]][change]
 		}
-    if (is.null(result[[item]]))
-      print(sprintf("Item %s not in state", item))
-    else 
-      print(sprintf("Item %s in state", item))
-  }
 
+  }
+print(".getStateItems3")
 	if (length(names(result)) > 0) {
 		return(result)
 	}
-
+print(".getStateItems4")
   return(NULL)
 }
 
 .stateDependsOnVar <- function(variables, optionsName = "variables") {
-  collectionKey <- paste0(variables, ' %in% options[["', optionsName, '"]]')
-  return(lapply(collectionKey, function(x) list(as.expression(x))))
+  collectionKey <- paste0('"', variables, '"', ' %in% options[["', optionsName, '"]]')
+  return(lapply(collectionKey, function(x) list(as.expression(parse(text = x)))))
 }
 
 

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -15,8 +15,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run", callback=function(...) 0, ...) {
+TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run", callback=function(...) 0, state = NULL, ...) {
   # 
+  print(perform)
+  print('str(state$descriptivesPlots, max.level = 3)')
+  print(str(state$descriptivesPlots, max.level = 3))
+  print('str(state, max.level = 3)')
+  print(str(state, max.level = 3))
 	dependents <- unlist(options$variables)
 	grouping   <- options$groupingVariable
 	options[["wilcoxTest"]] <- options$testStatistic ==  "Wilcoxon"
@@ -75,7 +80,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	results[[".meta"]] <- meta
 	results[["title"]] <- ifelse(options$wilcoxTest, "Bayesian Mann-Whitney U Test", "Bayesian Independent Samples T-Test")
 
-	state <- .retrieveState()
+	# state <- .retrieveState()
 	diff <- NULL
 
 	if (!is.null(state)) {
@@ -778,20 +783,40 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	descriptivesPlots <- descriptivesPlots
 	plots.ttest <- plots.ttest
 
+	stateKey <- list(
+	  descriptivesPlots = c("groupingVariable", "missingValues", "descriptivesPlotsCredibleInterval")
+	)
+	
+	collectionKey <- .stateDependsOnVar(descriptPlotVariables)
+	attr(stateKey[["descriptivesPlots"]], "collection") <- collectionKey
+
 	if (perform == "init") {
 
+	  print("after init")
+    str(state, max.level = 3)
+    if (!is.null(state) && is.null(attr(state, "key"))) {
+      print("init had no stateKey")
+      attr(state, "key") <- stateKey
+    }
 		return(list(results=results, status="inited", state=state, keep=keep))
 
 	} else {
-		
-		state <- list(
-			options = options, results = results, plotsTtest = plots.ttest, 
-			plotTypes = plotTypes, plotVariables = plotVariables,
-			descriptPlotVariables = descriptPlotVariables, descriptivesPlots = descriptivesPlots, 
-			status = status, plottingError = plottingError, BF10post = BF10post, errorFootnotes = errorFootnotes,
-			tValue = tValue, n_group2 = n_group2, n_group1 = n_group1, delta = deltaSamplesWilcox
-		)
 
+		state <- list(
+			options = options, results = results, 
+			plotsTtest = plots.ttest, 
+			plotTypes = plotTypes, 
+			plotVariables = plotVariables,
+			descriptPlotVariables = descriptPlotVariables, 
+			descriptivesPlots = descriptivesPlots, 
+			status = status, plottingError = plottingError, 
+			BF10post = BF10post, errorFootnotes = errorFootnotes,
+			tValue = tValue, n_group2 = n_group2, n_group1 = n_group1, 
+			delta = deltaSamplesWilcox
+		)
+		attr(state, "key") <- stateKey
+    print("after run")
+    str(state, max.level = 3)
 		return(list(results=results, status="complete", state = state, keep = keep))
 	}
 

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -83,12 +83,6 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	results[[".meta"]] <- meta
 	results[["title"]] <- ifelse(options$wilcoxTest, "Bayesian Mann-Whitney U Test", "Bayesian Independent Samples T-Test")
 
-	diff <- NULL
-
-	if (!is.null(state)) {
-		diff <- .diff(options, state$options)
-	}
-
 	# Needs to include following function for reactive progress bar for MCMC sampling
 	env <- environment()
 	callBackWilcoxonMCMC <- function(results = NULL, progress = NULL) {
@@ -137,8 +131,8 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	if(is.null(options()$BFprogress)) options(BFprogress = interactive())
 	if(is.null(options()$BFfactorsMax)) options(BFfactorsMax = 5)
 
-	descriptivesTable <- .ttestBayesianIndependentSamplesDescriptives(dataset, options, perform)
-	results[["descriptives"]] <- list(descriptivesTable = descriptivesTable, title = "Descriptives")
+	descriptivesTable <- .ttestBayesianIndependentSamplesDescriptives(dataset, options, perform, state)
+	results[["descriptives"]] <- list(descriptivesTable = descriptivesTable[["descriptives"]], title = "Descriptives")
 
 	if (options$hypothesis == "groupOneGreater") {
 
@@ -461,7 +455,6 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 					if ( ! .shouldContinue(callback(results)))
 						return()
-
 				}
 
 				if (options$plotSequentialAnalysis) {
@@ -532,7 +525,6 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	for (plot in sequentialPlots)
 		keep <- c(keep, plot$data)
 
-	# wilcoxExpr <- bquote(options[["testStatistic"]] == .(options[["testStatistic"]]))
 	defaults <- c("priorWidth", "hypothesis", "groupingVariable", "missingValues",
 								"effectSizeStandardized", "informativeStandardizedEffectSize",
 								"informativeCauchyLocation", "informativeCauchyScale", "informativeTLocation",
@@ -544,14 +536,16 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 		priorAndPosteriorPlots = c(defaults, "plotHeight", "plotWidth", "plotPriorAndPosteriorAdditionalInfo"),
 		robustnessPlots = c(defaults, "plotHeight", "plotWidth", "plotBayesFactorRobustnessAdditionalInfo"),
 		sequentialPlots = c(defaults, "plotHeight", "plotWidth", "plotSequentialAnalysisRobustness"),
-		delta = c("hypothesis", "priorWidth", "groupingVariable", "missingValues", "wilcoxonSamplesNumber")
+		delta = c("hypothesis", "priorWidth", "groupingVariable", "missingValues", "wilcoxonSamplesNumber"),
+		descriptivesData = c("descriptives", "groupingVariable", "missingValues", "descriptivesPlotsCredibleInterval")
 	)
 	
 	# all collection keys are the same!
 	collectionKey <- .stateDependsOnVar(dependents)
-	for (e in c("ttestData", "descriptivesPlots", "priorAndPosteriorPlots", "robustnessPlots", "sequentialPlots", "delta"))
+	for (e in c("ttestData", "descriptivesPlots", "priorAndPosteriorPlots", "robustnessPlots", "sequentialPlots", 
+							"delta", "descriptivesData")) {
 		attr(stateKey[[e]], "collection") <- collectionKey
-
+	}
 	if (perform == "init") {
 
     if (!is.null(state) && is.null(attr(state, "key")))
@@ -562,8 +556,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	} else {
 
 		state <- list(
-			options = options, results = results, 
+			options = options,
 			ttestData = ttest.results[["ttestData"]],
+			descriptivesData = descriptivesTable[["descriptivesData"]],
 			descriptivesPlots = descriptivesPlots, 
 			priorAndPosteriorPlots = priorAndPosteriorPlots,
 			robustnessPlots = robustnessPlots,
@@ -819,7 +814,6 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
                                           cauchyPriorParameter = options$priorWidth, progressbar = progressbar)
                 if(is.null(r)) return() # Return null if settings are changed
                 delta[[variable]] <- r[["deltaSamples"]]
-
                 bf.raw <- .computeBayesFactorWilcoxon(deltaSamples = r[["deltaSamples"]], cauchyPriorParameter = options$priorWidth, oneSided = oneSided)
                 
               }
@@ -953,7 +947,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 }
 
 .ttestBayesianIndependentSamplesDescriptives <- function(dataset, options, perform,
-												 state = NULL, diff = NULL) {
+												 state = NULL) {
 	if (options$descriptives == FALSE) return(NULL)
 
 	descriptives = list("title" = "Group Descriptives")
@@ -981,135 +975,69 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	}
 
 	descriptives[["schema"]] <- list(fields = fields)
-	data <- list()
-
-
-	## function to check if everything is alright with the options
-	isAllright <- function(variable, options, state = NULL, diff = NULL) {
-
-		# check if the variable is in the state variables
-		cond1 <- !is.null(state) && variable %in% state$options$variables
-
-		# check if either diff is true, or it's a list and descriptives,
-		# and groupingVariable, missingValues are FALSE
-		cond2 <- (!is.null(diff) && (is.logical(diff) && diff == FALSE) || (is.list(diff)
-				 && !any(diff$descriptives,diff$groupingVariable, diff$missingValues)))
-
-		cond1 && cond2
-	}
-
+	data <- state[["descriptivesData"]]
+	nvar <- length(options[["variables"]])
 	variables <- options$variables
+	groups <- options$groupingVariable
 	if (length(variables) == 0) variables <- "."
 
+	if (perform == "init" || nvar == 0 || groups == "")
 	for (variable in variables) {
-
-		if (isAllright(variable, options, state, diff)) {
-
-			stateDat <- state$results$descriptives$data
-			descriptivesVariables <- as.character(length(stateDat))
-
-			for (i in seq_along(stateDat))
-				descriptivesVariables[i] <- stateDat[[i]]$variable
-
-			indices <- which(descriptivesVariables == variable)
-			data[[length(data) + 1]] <- stateDat[[indices[1]]]
-			data[[length(data) + 1]] <- stateDat[[indices[2]]]
-
-		} else {
-			data[[length(data) + 1]] <- list(variable = variable, .isNewGroup = TRUE)
-			data[[length(data) + 1]] <- list(variable = variable)
+		if (is.null(data[[variable]])) {
+			data[[variable]][[1]] <- list(variable = variable, .isNewGroup = TRUE)
+			data[[variable]][[2]] <- list(variable = variable)
 		}
 	}
-
-	## check if we are done with all this crap
-	done <- (!is.null(state) &&
-			 state$options$descriptives &&
-			 all(variables %in% state$options$variables))
-
-	if (done) descriptives[["status"]] <- "complete"
-
-	groups <- options$groupingVariable
-
-	## if we actually have to do the test, and we have a grouping variable
-	if (perform == "run" && groups != "") {
+	if (perform == "run" && nvar >= 1 && groups != "") {
 		levels <- base::levels(dataset[[ .v(groups) ]])
+		groupingData <- dataset[[.v(groups)]]
+		for (variable in variables) {
+			if (is.null(data[[variable]])) {
+				for (i in 1:2) {
 
-		## if people don't know what a t-test is...
-		if (length(levels) != 2) {
-			descriptives[["error"]] <- list(errorType = "badData")
+					level <- levels[i]
+					variableData <- dataset[[.v(variable)]]
 
-		} else {
+					groupData <- variableData[groupingData == level]
+					groupDataOm <- na.omit(groupData)
 
-			rowNo <- 1
-			groupingData <- dataset[[.v(groups)]]
+					if (class(groupDataOm) != "factor") {
 
-			## do the whole loop as above again
-			for (variable in variables) {
+						posteriorSummary <- .posteriorSummaryGroupMean(variable=groupDataOm, descriptivesPlotsCredibleInterval=options$descriptivesPlotsCredibleInterval)
+						ciLower <- .clean(posteriorSummary$ciLower)
+						ciUpper <- .clean(posteriorSummary$ciUpper)
 
-				# if everything is alright, add stuff to data
-				if (isAllright(variable, options, state, diff)) {
+						n <- .clean(length(groupDataOm))
+						mean <- .clean(mean(groupDataOm))
+						std <- .clean(sd(groupDataOm))
+						sem <- .clean(sd(groupDataOm) / sqrt(length(groupDataOm)))
 
-					stateDat <- state$results$descriptives$data
-					descriptivesVariables <- as.character(length(stateDat))
+						result <- list(variable = variable, group = level,
+													 N = n, mean = mean, sd = std, se = sem, lowerCI = ciLower,
+													 upperCI = ciUpper)
 
-					for (i in seq_along(stateDat))
-						descriptivesVariables[i] <- stateDat[[i]]$variable
-
-					indices <- which(descriptivesVariables == variable)
-
-					data[[rowNo]] <- stateDat[[indices[1]]]
-					data[[rowNo]] <- stateDat[[indices[2]]]
-
-					rowNo <- rowNo + 2
-
-				} else {
-
-					for (i in 1:2) {
-
-					  level <- levels[i]
-					  variableData <- dataset[[.v(variable)]]
-
-					  groupData <- variableData[groupingData == level]
-					  groupDataOm <- na.omit(groupData)
-
-					  if (class(groupDataOm) != "factor") {
-
-							posteriorSummary <- .posteriorSummaryGroupMean(variable=groupDataOm, descriptivesPlotsCredibleInterval=options$descriptivesPlotsCredibleInterval)
-							ciLower <- .clean(posteriorSummary$ciLower)
-							ciUpper <- .clean(posteriorSummary$ciUpper)
-
-						  n <- .clean(length(groupDataOm))
-						  mean <- .clean(mean(groupDataOm))
-						  std <- .clean(sd(groupDataOm))
-						  sem <- .clean(sd(groupDataOm) / sqrt(length(groupDataOm)))
-
-						  result <- list(variable = variable, group = level,
-										 N = n, mean = mean, sd = std, se = sem, lowerCI = ciLower,
-										 upperCI = ciUpper)
-
-					  } else {
+					} else {
 
 						n <- .clean(length(groupDataOm))
 						result <- list(variable = variable, group = "",
-									   N = n, mean = "", sd = "", se = "", lowerCI = "",
-										 upperCI = "")
+													 N = n, mean = "", sd = "", se = "", lowerCI = "",
+													 upperCI = "")
 					}
 
 					if (i == 1) {
 						result[[".isNewGroup"]] <- TRUE
 					}
 
-					data[[rowNo]] <- result
-					rowNo <- rowNo + 1
-					}
+					data[[variable]][[i]] <- result
 				}
 			}
 		}
 		descriptives[["status"]] <- "complete"
 	}
 
-	descriptives[["data"]] <- data
-	descriptives
+	# drop the names
+	descriptives[["data"]] <- unlist(data, recursive = FALSE, use.names = FALSE)
+	return(list(descriptives = descriptives, descriptivesData = data))
 }
 
 

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -20,6 +20,14 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	dependents <- unlist(options$variables)
 	grouping   <- options$groupingVariable
 	options[["wilcoxTest"]] <- options$testStatistic ==  "Wilcoxon"
+	AtTheEndResetPlotRobustnessSequential <- NULL
+	if (options[["wilcoxTest"]]) {
+		# when a user requests robustness/ sequential plots first and then selects wilcoxTest
+		# jasp will still provide these as TRUE, but they shouldn't be.
+		AtTheEndResetPlotRobustnessSequential <- options[c("plotBayesFactorRobustness", "plotSequentialAnalysis")]
+		options[["plotBayesFactorRobustness"]] <- FALSE
+		options[["plotSequentialAnalysis"]] <- FALSE
+	}
 	
 	if (grouping == "")
 		grouping <- NULL
@@ -75,7 +83,6 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	results[[".meta"]] <- meta
 	results[["title"]] <- ifelse(options$wilcoxTest, "Bayesian Mann-Whitney U Test", "Bayesian Independent Samples T-Test")
 
-	# state <- .retrieveState()
 	diff <- NULL
 
 	if (!is.null(state)) {
@@ -105,7 +112,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	  
 	}
 	
-	ttest.results <- .ttestBayesianIndependentSamplesTTest(dataset, options, perform, state=state, diff=diff, callBackWilcoxonMCMC)
+	ttest.results <- .ttestBayesianIndependentSamplesTTest(dataset, options, perform, state=state, callBackWilcoxonMCMC)
   # If relevant settings are changed during sampling, ttest.results will be NULL
 	# This triggers an automatic redo of the analysis
 	if(is.null(ttest.results)) return(list(results = NULL, status = "inited"))
@@ -147,12 +154,6 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	}
 
 	plotGroups <- list()
-	# plots.ttest <- list()
-	descriptPlotVariables <- list()
-	descriptivesPlots <- list()
-	# plotTypes <- list()
-	# plotVariables <- list()
-
 	descriptivesPlots <- state[["descriptivesPlots"]]
 	priorAndPosteriorPlots <- state[["priorAndPosteriorPlots"]]
 	robustnessPlots <- state[["robustnessPlots"]]
@@ -183,8 +184,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 			plotGroups[[variable]][["name"]] <- variable
 
 			if (options[["descriptivesPlots"]]) {
-
-				# if the element is null it needs to be remade, otherwise it's useable!
+				# if the element is null it needs to be remade, otherwise it's already reused
 				if (is.null(descriptivesPlots[[variable]])) {
 					descriptivesPlot <- list()
 
@@ -201,7 +201,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 			}
 
 			if (options$plotPriorAndPosterior){
-				# if the element is null it needs to be remade, otherwise it's useable!
+				# if the element is null it needs to be remade, otherwise it's already reused
 				if (is.null(priorAndPosteriorPlots[[variable]])) {
 					plot <- list()
 
@@ -227,7 +227,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 			}
 
 			if (options$plotBayesFactorRobustness) {
-				# if the element is null it needs to be remade, otherwise it's useable!
+				# if the element is null it needs to be remade, otherwise it's already reused
 				if (is.null(robustnessPlots[[variable]])) {
 					plot <- list()
 
@@ -251,7 +251,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 			}
 
 			if (options$plotSequentialAnalysis) {
-
+				# if the element is null it needs to be remade, otherwise it's already reused
 				if (is.null(sequentialPlots[[variable]])) {
 					plot <- list()
 
@@ -278,23 +278,19 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 		if (options$plotPriorAndPosterior || options$plotBayesFactorRobustness || options$plotSequentialAnalysis)
 			results[["inferentialPlots"]] <- list(title=ifelse(length(options[["variables"]]) > 1 || sum(c(options$plotPriorAndPosterior, options$plotBayesFactorRobustness, options$plotSequentialAnalysis)) > 1,
-				"Inferential Plots", "Inferential Plot"), collection=stats::setNames(plotGroups, seq_along(dependents)))
+				"Inferential Plots", "Inferential Plot"), collection=unname(plotGroups))
 
 		if (options$descriptivesPlots)
 			results[["descriptives"]][["descriptivesPlots"]] <- list(title=ifelse(length(options[["variables"]]) > 1, "Descriptives Plots", "Descriptives Plot"),
-																															 collection=setNames(descriptivesPlots, seq_along(dependents)))
+																															 collection=unname(descriptivesPlots))
 
 
 		if (perform == "run" && length(options$variables) > 0 && !is.null(grouping)) {
 
-		# make everything indexable by name
-		names(tValue) <- names(n_group1) <- names(n_group2) <-
-		names(BF10post) <- names(deltaSamplesWilcox) <-
-			dependents
-
 			if ( ! .shouldContinue(callback(results)))
 				return()
 
+			hasNoData <- function(x) identical(x[["status"]], "waiting")
 			for (variable in options[["variables"]]) {
 
 			    errors <- .hasErrors(dataset, perform, message = 'short', type = c('infinity','observations','variance'),
@@ -318,13 +314,10 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 				if (options$descriptivesPlots) {
 
 					# if the plot data is empty it wasn't obtained from state and needs to be remade
-					if (identical(descriptivesPlots[[variable]][["data"]], "")) {
+					if (hasNoData(descriptivesPlots[[variable]])) {
 
-						# JS sorts alphabetically, so we need to change to collection indices to 1, 2, ...
-						# there ought to be a better way to handle this. 
-						# the names are not reset because they persist in descriptivesPlots
-						results[["descriptives"]][["descriptivesPlots"]][["collection"]][[variable]][["status"]] <- "running"
-						names(results[["descriptives"]][["descriptivesPlots"]][["collection"]]) <- seq_along(dependents)
+						descriptivesPlots[[variable]][["status"]] <- "running"
+						results[["descriptives"]][["descriptivesPlots"]][["collection"]] <- unname(descriptivesPlots)
 
 						if ( ! .shouldContinue(callback(results)))
 							return()
@@ -357,14 +350,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 						descriptivesPlots[[variable]] <- plot
 					}
 
-					print("before callback")
-					print(names(descriptivesPlots))
-					results[["descriptives"]][["descriptivesPlots"]][["collection"]] <- descriptivesPlots # also resets the
-
-					# JS sorts alphabetically, so we need to change to collection indices to 1, 2, ...
-					# there ought to be a better way to handle this.
-					names(results[["descriptives"]][["descriptivesPlots"]][["collection"]]) <- seq_along(dependents)
-					# descriptInd <- descriptInd + 1
+					results[["descriptives"]][["descriptivesPlots"]][["collection"]] <- unname(descriptivesPlots)
 
 					if ( ! .shouldContinue(callback(results)))
 						return()
@@ -373,15 +359,15 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 				if (options$plotPriorAndPosterior) {
 
-					if (identical(priorAndPosteriorPlots[[variable]][["status"]], "waiting")) {
+					if (hasNoData(priorAndPosteriorPlots[[variable]])) {
 
-						results[["inferentialPlots"]][["collection"]][[variable]][["PriorPosteriorPlot"]][["status"]] <- "running"
-						names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
+						plotGroups[[variable]][["PriorPosteriorPlot"]][["status"]] <- "running"
+						results[["inferentialPlots"]][["collection"]] <- unname(plotGroups)
 
 						if ( ! .shouldContinue(callback(results)))
 							return()
 
-						plot <- priorAndPosteriorPlots[[variable]] # plots.ttest[[z]]
+						plot <- priorAndPosteriorPlots[[variable]]
 
 						if (!is.null(errorMessage)) {
 
@@ -419,23 +405,19 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 					}
 
-					plotGroups[[variable]][["PriorPosteriorPlot"]] <- priorAndPosteriorPlots[[variable]]#plots.ttest[[z]]
-
-
-					results[["inferentialPlots"]][["collection"]] <- plotGroups
-					names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
+					plotGroups[[variable]][["PriorPosteriorPlot"]] <- priorAndPosteriorPlots[[variable]]
+					results[["inferentialPlots"]][["collection"]] <- unname(plotGroups)
 
 					if ( ! .shouldContinue(callback(results)))
 						return()
-
 				}
 
 				if (options$plotBayesFactorRobustness) {
 
-					if (identical(robustnessPlots[[variable]][["status"]], "waiting")) {
+					if (hasNoData(robustnessPlots[[variable]])) {
 
-						results[["inferentialPlots"]][["collection"]][[variable]][["BFrobustnessPlot"]][["status"]] <- "running"
-						names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
+						plotGroups[[variable]][["BFrobustnessPlot"]][["status"]] <- "running"
+						results[["inferentialPlots"]][["collection"]] <- unname(plotGroups)
 
 						if ( ! .shouldContinue(callback(results)))
 							return()
@@ -443,21 +425,21 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 						plot <- robustnessPlots[[variable]]
 
 						if (options$effectSizeStandardized == "informative") {
-							errorMessage="Bayes factor robustness check plot currently not supported for informed prior."
-							plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
+						  errorMessage="Bayes factor robustness check plot currently not supported for informed prior."
+						  plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
 						}
 
 						if (!is.null(errorMessage)) {
 
-							plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
+						   plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
 
 						} else {
 
-							p <- try(silent= FALSE, expr= {
+						  p <- try(silent= FALSE, expr= {
 
 								.plotFunc <- function() {
 									.plotBF.robustnessCheck.ttest(x= group2, y= group1, BF10post=ifelse((options$bayesFactorType=="LogBF10"), exp(BF10post[variable]), BF10post[variable]), paired= FALSE, oneSided= oneSided,
-																								rscale = options$priorWidth, BFH1H0= BFH1H0, additionalInformation=options$plotBayesFactorRobustnessAdditionalInfo)
+                                                rscale = options$priorWidth, BFH1H0= BFH1H0, additionalInformation=options$plotBayesFactorRobustnessAdditionalInfo)
 								}
 								content <- .writeImage(width = 530, height = 400, plot = .plotFunc, obj = TRUE)
 
@@ -475,8 +457,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					}
 
 					plotGroups[[variable]][["BFrobustnessPlot"]] <- robustnessPlots[[variable]]
-					results[["inferentialPlots"]][["collection"]] <- plotGroups
-					names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
+					results[["inferentialPlots"]][["collection"]] <- unname(plotGroups)
 
 					if ( ! .shouldContinue(callback(results)))
 						return()
@@ -484,10 +465,10 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 				}
 
 				if (options$plotSequentialAnalysis) {
-					if (identical(sequentialPlots[[variable]][["status"]], "waiting")) {
+					if (hasNoData(sequentialPlots[[variable]])) {
 
-						results[["inferentialPlots"]][["collection"]][[variable]][["BFsequentialPlot"]][["status"]] <- "running"
-						names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
+						plotGroups[[variable]][["BFsequentialPlot"]][["status"]] <- "running"
+						results[["inferentialPlots"]][["collection"]] <- unname(plotGroups)
 
 						if ( ! .shouldContinue(callback(results)))
 							return()
@@ -526,8 +507,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					}
 
 					plotGroups[[variable]][["BFsequentialPlot"]] <- sequentialPlots[[variable]]
-					results[["inferentialPlots"]][["collection"]] <- plotGroups
-					names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
+					results[["inferentialPlots"]][["collection"]] <- unname(plotGroups)
 
 
 					if ( ! .shouldContinue(callback(results)))
@@ -537,6 +517,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 			}
 		}
 	}
+	
+	if (!is.null(AtTheEndResetPlotRobustnessSequential))
+		options[c("plotBayesFactorRobustness", "plotSequentialAnalysis")] <- AtTheEndResetPlotRobustnessSequential
 
 	keep <- NULL
 
@@ -549,36 +532,25 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	for (plot in sequentialPlots)
 		keep <- c(keep, plot$data)
 
-	# plots.ttest <- plots.ttest
-
-	wilcoxExpr <- bquote(options[["testStatistic"]] == .(options[["testStatistic"]]))
+	# wilcoxExpr <- bquote(options[["testStatistic"]] == .(options[["testStatistic"]]))
+	defaults <- c("priorWidth", "hypothesis", "groupingVariable", "missingValues",
+								"effectSizeStandardized", "informativeStandardizedEffectSize",
+								"informativeCauchyLocation", "informativeCauchyScale", "informativeTLocation",
+								"informativeTScale", "informativeTDf", "informativeNormalMean",
+								"informativeNormalStd", "testStatistic", "wilcoxonSamplesNumber")
 	stateKey <- list(
+		ttestData = defaults,
 		descriptivesPlots = c("groupingVariable", "missingValues", "descriptivesPlotsCredibleInterval"),
-		priorAndPosteriorPlots = list("priorWidth", "hypothesis", "groupingVariable", "missingValues", 
-															 "plotHeight", "plotWidth", "effectSizeStandardized", "informativeStandardizedEffectSize", 
-															 "informativeCauchyLocation", "informativeCauchyScale", "informativeTLocation", 
-															 "informativeTScale", "informativeTDf", "informativeNormalMean", 
-															 "informativeNormalStd", wilcoxExpr, "wilcoxonSamplesNumber"
-		),
-		robustnessPlots = c("priorWidth", "hypothesis", "groupingVariable", "missingValues", 
-												"plotHeight", "plotWidth", "effectSizeStandardized", "informativeStandardizedEffectSize", 
-												"informativeCauchyLocation", "informativeCauchyScale", "informativeTLocation", 
-												"informativeTScale", "informativeTDf", "informativeNormalMean", 
-												"informativeNormalStd"
-		),
-		sequentialPlots = c("priorWidth", "hypothesis", "groupingVariable", "missingValues", 
-												"plotHeight", "plotWidth", "effectSizeStandardized", "informativeStandardizedEffectSize", 
-												"informativeCauchyLocation", "informativeCauchyScale", "informativeTLocation", 
-												"informativeTScale", "informativeTDf", "informativeNormalMean", 
-												"informativeNormalStd"
-		)
+		priorAndPosteriorPlots = c(defaults, "plotHeight", "plotWidth", "plotPriorAndPosteriorAdditionalInfo"),
+		robustnessPlots = c(defaults, "plotHeight", "plotWidth", "plotBayesFactorRobustnessAdditionalInfo"),
+		sequentialPlots = c(defaults, "plotHeight", "plotWidth", "plotSequentialAnalysisRobustness"),
+		delta = c("hypothesis", "priorWidth", "groupingVariable", "missingValues", "wilcoxonSamplesNumber")
 	)
 	
+	# all collection keys are the same!
 	collectionKey <- .stateDependsOnVar(dependents)
-	attr(stateKey[["descriptivesPlots"]], "collection") <- collectionKey
-	attr(stateKey[["priorAndPosteriorPlots"]], "collection") <- collectionKey
-	attr(stateKey[["robustnessPlots"]], "collection") <- collectionKey
-	attr(stateKey[["sequentialPlots"]], "collection") <- collectionKey
+	for (e in c("ttestData", "descriptivesPlots", "priorAndPosteriorPlots", "robustnessPlots", "sequentialPlots", "delta"))
+		attr(stateKey[[e]], "collection") <- collectionKey
 
 	if (perform == "init") {
 
@@ -591,10 +563,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 		state <- list(
 			options = options, results = results, 
-			# plotsTtest = plots.ttest,
-			# plotTypes = plotTypes,
-			# plotVariables = plotVariables,
-			descriptPlotVariables = descriptPlotVariables, 
+			ttestData = ttest.results[["ttestData"]],
 			descriptivesPlots = descriptivesPlots, 
 			priorAndPosteriorPlots = priorAndPosteriorPlots,
 			robustnessPlots = robustnessPlots,
@@ -613,7 +582,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 }
 
 
-.ttestBayesianIndependentSamplesTTest <- function(dataset, options, perform, state, diff, callBackWilcoxonMCMC) {
+.ttestBayesianIndependentSamplesTTest <- function(dataset, options, perform, state, callBackWilcoxonMCMC) {
 
 
 	g1 <- NULL
@@ -702,16 +671,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 	levels <- base::levels(dataset[[ .v(options$groupingVariable) ]])
 
-	if (length(levels) != 2) {
+	g1 <- levels[1]
+	g2 <- levels[2]
 
-		g1 <- "1"
-		g2 <- "2"
-
-	} else {
-
-		g1 <- levels[1]
-		g2 <- levels[2]
-	}
 
 	if (options$hypothesis == "groupOneGreater") {
 
@@ -725,97 +687,41 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	}
 
 
-	ttest.rows <- list()
-
-	status <- rep("ok", length(options$variables))
-	BF10post <- numeric(length(options$variables))
-	tValue <- rep(NA, length(options[["variables"]]))
-	n_group2 <- rep(NA, length(options[["variables"]]))
-	n_group1 <- rep(NA, length(options[["variables"]]))
-	plottingError <- rep("error", length(options$variables))
-	errorFootnotes <- rep("no", length(options$variables))
+	nvar <- length(options[["variables"]])
+	status <- rep("ok", nvar)
+	BF10post <- numeric(nvar)
+	tValue <- rep(NA, nvar)
+	n_group2 <- rep(NA, nvar)
+	n_group1 <- rep(NA, nvar)
+	plottingError <- rep("error", nvar)
+	errorFootnotes <- rep("no", nvar)
 	delta <- list()
 	
-	for (variable in options[["variables"]]) {
+	ttest.rows <- state[["ttestData"]]
 
-		if (!is.null(state) && variable %in% state$options$variables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-			&& diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE &&
-			diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE &&
-			diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE && diff$wilcoxTest == FALSE && diff$wilcoxonSamplesNumber == FALSE)))) {
-
-				index <- which(state$options$variables == variable)
-
-				if (state$errorFootnotes[index] == "no") {
-
-					ttest.rows[[length(ttest.rows)+1]] <- state$results$ttest$data[[index]]
-
-					if (! (is.logical(diff) && diff == FALSE) && diff$bayesFactorType) {
-
-						if (state$options$bayesFactorType == "BF10") {
-
-							if (options$bayesFactorType == "BF01") {
-								ttest.rows[[length(ttest.rows)]]$BF <- 1 / state$results$ttest$data[[index]]$BF
-							} else if (options$bayesFactorType == "LogBF10") {
-								ttest.rows[[length(ttest.rows)]]$BF <- log(state$results$ttest$data[[index]]$BF)
-							}
-
-						} else if (state$options$bayesFactorType == "BF01") {
-
-							if (options$bayesFactorType == "BF10") {
-								ttest.rows[[length(ttest.rows)]]$BF <- 1 / state$results$ttest$data[[index]]$BF
-							} else if (options$bayesFactorType == "LogBF10") {
-								ttest.rows[[length(ttest.rows)]]$BF <- log(1 / state$results$ttest$data[[index]]$BF)
-							}
-
-						} else if (state$options$bayesFactorType == "LogBF10") {
-
-							if (options$bayesFactorType == "BF10") {
-								ttest.rows[[length(ttest.rows)]]$BF <- exp(state$results$ttest$data[[index]]$BF)
-							} else if (options$bayesFactorType == "BF01") {
-								ttest.rows[[length(ttest.rows)]]$BF <- 1 / exp(state$results$ttest$data[[index]]$BF)
-							}
-						}
-					}
-
-				} else {
-
-					index2 <- .addFootnote(footnotes, state$errorFootnotes[index])
-
-					ttest.rows[[length(ttest.rows)+1]] <- list(.variable=variable, BF=.clean(NaN), error="", .footnotes=list(BF=list(index2)))
-
-				}
-
-			} else {
-
-				ttest.rows[[length(ttest.rows)+1]] <- list(.variable=variable)
+	if (perform == "init" || nvar == 0 || options$groupingVariable == "") {
+		for (variable in options[["variables"]]) {
+			if (is.null(ttest.rows[[variable]])) {
+				ttest.rows[[variable]] <- list(.variable=variable)
 			}
+		}
 	}
 
-	rowCompleted <- logical(length(ttest.rows))
-
-	for (i in seq_along(ttest.rows))
-		rowCompleted[i] <- ifelse(length(ttest.rows[[i]]) > 1, TRUE, FALSE)
-
-	if (!is.null(state) && all(options[["variables"]] %in% state$options$variables) && options$groupingVariable == state$options$groupingVariable && all(rowCompleted))
+	rowCompleted <- lengths(ttest.rows) > 1
+	if (all(rowCompleted))
 		ttest[["status"]] <- "complete"
 
-	if (perform == "run" && length(options$variables) != 0 && options$groupingVariable != "") {
+	if (perform == "run" && nvar != 0 && options$groupingVariable != "") {
 
-		if (length(levels) != 2) {
-
-			ttest[["error"]] <- list(errorType="badData", errorMessage="The Grouping Variable must have 2 levels")
-
-			status <- rep("error", length(options$variables))
-			plottingError <- rep("Plotting is not possible: The Grouping Variable must have 2 levels", length(options$variables))
-
-		} else {
-
-			rowNo <- 1
-
-			i <- 1
-			
 			if (options$wilcoxTest) {
-			  progressbar <- .newProgressbar(ticks=length(options[["variables"]]) * round(options$wilcoxonSamplesNumber / 1e2, 0), 
+
+			  # all variables - the ones we sampled before
+				print(str(state$delta))
+				todo <- nvar
+				if (!is.null(state$delta))
+			  	todo <- todo - sum(sapply(state$delta, function(x) isTRUE(!is.null(x) && !is.na(x))))
+			  if (todo > 0)
+				  progressbar <- .newProgressbar(ticks=todo * round(options$wilcoxonSamplesNumber / 1e2, 0),
 			                                                 callback = callBackWilcoxonMCMC, response=TRUE)
 			}
 			
@@ -850,63 +756,27 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					oneSided <- FALSE
 				}
 
+				if (!is.null(ttest.rows[[variable]])) {
 
-				if (!is.null(state) && variable %in% state$options$variables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-				&& diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE &&
-				diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE &&
-				diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE && diff$wilcoxTest == FALSE && diff$wilcoxonSamplesNumber == FALSE)))) {
-          
-					index <- which(state$options$variables == variable)
+					# row retrieved from state, only possible change is BF01 to BF10/ log(BF01)
+					if (is.null(ttest.rows[[variable]][[".footnotes"]])) {
 
-					if (state$errorFootnotes[index] == "no") {
-
-						ttest.rows[[rowNo]] <- state$results$ttest$data[[index]]
-
-						if (! (is.logical(diff) && diff == FALSE) && diff$bayesFactorType) {
-
-							if (state$options$bayesFactorType == "BF10") {
-
-								if (options$bayesFactorType == "BF01") {
-									ttest.rows[[rowNo]]$BF <- 1 / state$results$ttest$data[[index]]$BF
-								} else if (options$bayesFactorType == "LogBF10") {
-									ttest.rows[[rowNo]]$BF <- log(state$results$ttest$data[[index]]$BF)
-								}
-
-							} else if (state$options$bayesFactorType == "BF01") {
-
-								if (options$bayesFactorType == "BF10") {
-									ttest.rows[[rowNo]]$BF <- 1 / state$results$ttest$data[[index]]$BF
-								} else if (options$bayesFactorType == "LogBF10") {
-									ttest.rows[[rowNo]]$BF <- log(1 / state$results$ttest$data[[index]]$BF)
-								}
-
-							} else if (state$options$bayesFactorType == "LogBF10") {
-
-								if (options$bayesFactorType == "BF10") {
-									ttest.rows[[rowNo]]$BF <- exp(state$results$ttest$data[[index]]$BF)
-								} else if (options$bayesFactorType == "BF01") {
-									ttest.rows[[rowNo]]$BF <- 1 / exp(state$results$ttest$data[[index]]$BF)
-								}
-							}
-						}
-
-					} else {
-
-						index2 <- .addFootnote(footnotes, state$errorFootnotes[index])
-
-						errorFootnotes[rowNo] <- state$errorFootnotes[index]
-
-						ttest.rows[[rowNo]] <- list(.variable=variable, BF=.clean(NaN), error="", .footnotes=list(BF=list(index2)))
+						# if BFtype changed, change it. (BF01, BF10, log(BF01))
+						ttest.rows[[variable]][["BF"]] <-
+							.recodeBFtype(bfOld = ttest.rows[[variable]][["BF"]],
+														newBFtype = options[["bayesFactorType"]],
+														oldBFtype = state[["options"]][["bayesFactorType"]]
+							)
 
 					}
 
-					BF10post[rowNo] <- ttest.rows[[rowNo]]$BF # state$BF10post[index]
-					tValue[rowNo] <- state$tValue[index]
-					n_group2[rowNo] <- state$n_group2[index]
-					n_group1[rowNo] <- state$n_group1[index]
-					status[rowNo] <- state$status[index]
-					plottingError[rowNo] <- state$plottingError[index]
-					delta[[rowNo]] <- state$delta[[index]]
+					BF10post[variable] <- ttest.rows[[variable]]$BF # state$BF10post[index]
+					tValue[variable] <- state$tValue[variable]
+					n_group2[variable] <- state$n_group2[variable]
+					n_group1[variable] <- state$n_group1[variable]
+					status[variable] <- state$status[variable]
+					plottingError[variable] <- state$plottingError[variable]
+					delta[[variable]] <- state$delta[[variable]]
 
 				} else {
 
@@ -923,95 +793,68 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 					result <- try (silent=FALSE, expr= {
 					  
-					  n_group2[i] <- length(group2)
-					  n_group1[i] <- length(group1)
+					  n_group2[variable] <- length(group2)
+					  n_group1[variable] <- length(group1)
             
 					  if (!options$wilcoxTest) {
 					    
   					  r <- .generalTtestBF(x = group2, y = group1, paired = FALSE, oneSided = oneSided, options = options)
   					  bf.raw <- r[["bf"]]
   					  error <- .clean(r[["error"]])
-  					  tValue[i] <- r[["tValue"]]
-  					  delta[[i]] <- NA
-  					  
-  					  
+  					  tValue[variable] <- r[["tValue"]]
+  					  delta[[variable]] <- NA
+
 					  } else if (options$wilcoxTest) {
+
 					    # If the samples can be reused, don't call the Gibbs sampler again, but recalculate the
 					    # Bayes factor with new settings and take the samples from state.
-					    if (!is.null(diff) && length(state$delta) >= i && !is.null(state$delta[[i]]) && diff$hypothesis == TRUE && diff$priorWidth == FALSE && diff$groupingVariable == FALSE &&
-					        diff$missingValues == FALSE && diff$wilcoxonSamplesNumber == FALSE) {
-                
-                delta[[i]] <- state$delta[[i]]
-                bf.raw <- .computeBayesFactorWilcoxon(deltaSamples = delta[[i]], cauchyPriorParameter = options$priorWidth, oneSided = oneSided)
+					    if (!is.null(state$delta[[variable]]) && !is.na(state$delta[[variable]])) {
+
+                delta[[variable]] <- state$delta[[variable]]
+                bf.raw <- .computeBayesFactorWilcoxon(deltaSamples = delta[[variable]], cauchyPriorParameter = options$priorWidth, oneSided = oneSided)
                 
               } else {
-                
+
                 r <- .rankSumGibbsSampler(x = group2, y = group1, nSamples = options$wilcoxonSamplesNumber, nBurnin = 0,
                                           cauchyPriorParameter = options$priorWidth, progressbar = progressbar)
                 if(is.null(r)) return() # Return null if settings are changed
-                delta[[i]] <- r[["deltaSamples"]]
+                delta[[variable]] <- r[["deltaSamples"]]
+
                 bf.raw <- .computeBayesFactorWilcoxon(deltaSamples = r[["deltaSamples"]], cauchyPriorParameter = options$priorWidth, oneSided = oneSided)
                 
               }
 					    
 					    wValue <- unname(wilcox.test(group2, group1, paired = FALSE)$statistic)
 					    error <- wValue
-					    tValue[i] <- median(delta[[i]])
+					    tValue[variable] <- median(delta[[variable]])
 					    
 					  }
 					  
-						if (options$bayesFactorType == "BF01")
-							bf.raw <- 1 / bf.raw
+					  bf.raw <- .recodeBFtype(bfOld = bf.raw,
+					  												newBFtype = options$bayesFactorType,
+					  												oldBFtype = "BF10"
+					  )
 
-						BF10post[i] <- bf.raw
+						BF10post[variable] <- bf.raw
 						BF <- .clean(bf.raw)
-
-						if (options$bayesFactorType == "LogBF10") {
-
-							BF <- log(BF10post[i])
-							BF <- .clean(BF)
-						}
 
 						if (is.na(bf.raw)) {
 
-							status[rowNo] <- "error"
-							plottingError[rowNo] <- "Plotting is not possible: Bayes factor could not be calculated"
+							status[variable] <- "error"
+							plottingError[variable] <- "Plotting is not possible: Bayes factor could not be calculated"
 						}
 
-						if(is.infinite(bf.raw)){
+						if (is.infinite(bf.raw) || is.infinite(1/bf.raw)) {
 
 							if(options$plotPriorAndPosterior | options$plotSequentialAnalysis | options$plotSequentialAnalysisRobustness | options$plotBayesFactorRobustness){
 
 
-								status[rowNo] <- "error"
-								plottingError[rowNo] <- "Plotting is not possible: Bayes factor is infinite"
-							}
-						}
-
-						if(is.infinite(1/bf.raw)){
-
-							if(options$plotPriorAndPosterior | options$plotSequentialAnalysis | options$plotSequentialAnalysisRobustness | options$plotBayesFactorRobustness){
-
-								status[rowNo] <- "error"
-								plottingError[rowNo] <- "Plotting is not possible: The Bayes factor is too small"
-							}
-						}
-
-						ind <- which(group1 == group1[1])
-						idData <- sum((ind+1)-(1:(length(ind))) == 1)
-
-						ind2 <- which(group2 == group2[1])
-						idData2 <- sum((ind2+1)-(1:(length(ind2))) == 1)
-
-						if(idData > 1 && idData2 > 1 && (options$plotSequentialAnalysis | options$plotSequentialAnalysisRobustness)){
-
-							if(options$plotPriorAndPosterior | options$plotSequentialAnalysis | options$plotSequentialAnalysisRobustness | options$plotBayesFactorRobustness){
-
-								# errorMessage <- paste("Sequential Analysis not possible: The first observations are identical")
-								# index <- .addFootnote(footnotes, errorMessage)
-
-								# status[rowNo] <- "sequentialNotPossible"
-								# plottingError[rowNo] <- "Sequential Analysis not possible: The first observations are identical"
+								status[variable] <- "error"
+								if (is.infinite(bf.raw)) {
+									plottingError[variable] <- "Plotting is not possible: Bayes factor is infinite"
+								} else {
+									plottingError[variable] <- "Plotting is not possible: The Bayes factor is too small"
+								}
 							}
 						}
 
@@ -1029,32 +872,25 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 						index <- .addFootnote(footnotes, errorMessage)
 
-						errorFootnotes[rowNo] <- errorMessage
+						errorFootnotes[variable] <- errorMessage
 
 						result <- list(.variable=variable, BF=.clean(NaN), error="", .footnotes=list(BF=list(index)))
 
-						status[rowNo] <- "error"
+						status[variable] <- "error"
 					}
-
-					ttest.rows[[rowNo]] <- result
-
+					ttest.rows[[variable]] <- result
 				}
-
-				rowNo <- rowNo + 1
-				i <- i + 1
 			}
-		}
-
 		ttest[["status"]] <- "complete"
 	}
 
-	ttest[["footnotes"]] <- as.list(footnotes)
-	ttest[["data"]] <- ttest.rows
-
+	# drop the variable names
+	ttest[["footnotes"]] <- as.list(unname(footnotes))
+	ttest[["data"]] <- unname(ttest.rows)
 
 	list(ttest = ttest, status = status, g1 = g1, g2 = g2, BFH1H0 = BFH1H0, plottingError = plottingError,
 	     BF10post = BF10post, errorFootnotes = errorFootnotes, tValue = tValue, n_group2 = n_group2,
-	     n_group1 = n_group1, delta = delta)
+	     n_group1 = n_group1, delta = delta, ttestData = ttest.rows)
 }
 
 .base_breaks_x <- function(x) {
@@ -1368,4 +1204,30 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
   bf <- ifelse(oneSided == FALSE,  priorDensZeroPoint / densZeroPoint, 
                (priorDensZeroPoint / corFactorPrior) / (densZeroPoint / corFactorPosterior))
   return(bf)
+}
+
+.recodeBFtype <- function(bfOld, newBFtype, oldBFtype) {
+
+	if (oldBFtype == newBFtype)
+		return(bfOld)
+
+	if (oldBFtype == "BF10") {
+		if (newBFtype == "BF01") {
+			return(1 / bfOld)
+		} else {
+			return(log(bfOld))
+		}
+	} else if (oldBFtype == "BF01") {
+		if (newBFtype == "BF10") {
+			return(1 / bfOld)
+		} else {
+			return(log(1 / bfOld))
+		}
+	} else {
+		if (newBFtype == "BF10") {
+			return(exp(bfOld))
+		} else {
+			return(1 / exp(bfOld))
+		}
+	}
 }

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -17,11 +17,6 @@
 
 TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run", callback=function(...) 0, state = NULL, ...) {
   # 
-  print(perform)
-  print('str(state$descriptivesPlots, max.level = 3)')
-  print(str(state$descriptivesPlots, max.level = 3))
-  print('str(state, max.level = 3)')
-  print(str(state, max.level = 3))
 	dependents <- unlist(options$variables)
 	grouping   <- options$groupingVariable
 	options[["wilcoxTest"]] <- options$testStatistic ==  "Wilcoxon"
@@ -152,11 +147,16 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	}
 
 	plotGroups <- list()
-	plots.ttest <- list()
+	# plots.ttest <- list()
 	descriptPlotVariables <- list()
 	descriptivesPlots <- list()
-	plotTypes <- list()
-	plotVariables <- list()
+	# plotTypes <- list()
+	# plotVariables <- list()
+
+	descriptivesPlots <- state[["descriptivesPlots"]]
+	priorAndPosteriorPlots <- state[["priorAndPosteriorPlots"]]
+	robustnessPlots <- state[["robustnessPlots"]]
+	sequentialPlots <- state[["sequentialPlots"]]
 
 
 	if (options$plotPriorAndPosterior || options$plotSequentialAnalysis || options$plotBayesFactorRobustness || options$descriptivesPlots) {
@@ -176,114 +176,33 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 			}
 		}
 
-		# here make the booleans required for wether an analysis should be done or not.
-		# this code should be ported to Tim's state system.
-		boolDescriptivesPlots <- !is.null(state) && options$descriptivesPlots && (
-			identical(diff, FALSE) || 
-				(is.list(diff) && diff$groupingVariable == FALSE && diff$missingValues == FALSE && 
-				 	diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$descriptivesPlotsCredibleInterval == FALSE)
-			)
-		
-		boolPriorAndPosterior <- !is.null(state) && !is.null(diff) && 
-			(identical(diff, FALSE) || 
-			 	(is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE && diff$groupingVariable == FALSE && 
-			 					   	diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && 
-			 					   	diff$effectSizeStandardized == FALSE &&	diff$informativeStandardizedEffectSize == FALSE &&
-			 					   	diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE && 
-			 					   	diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && 
-			 					   	diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE
-			 ))) && diff$wilcoxTest == FALSE && diff$wilcoxonSamplesNumber == FALSE
-		
-		boolBayesFactorRobustness <- !is.null(state) && !is.null(diff) && 
-			(identical(diff, FALSE) || 
-			 	(is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE && BFtypeRequiresNewPlot == FALSE && 
-			 					   	diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && 
-			 					   	diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE && 
-			 					   	diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && 
-			 					   	diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE &&
-			 					   	diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE &&
-			 					   	diff$informativeNormalStd == FALSE
-			 )))
-		
-		boolSequentialRobustnessanalysis <- !is.null(state) && !is.null(diff) && 
-			(identical(diff, FALSE) || 
-			 	(is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE && BFtypeRequiresNewPlot == FALSE && 
-			 					   	diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && 
-			 					   	diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE && 
-			 					   	diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && 
-			 					   	diff$informativeCauchyScale == FALSE &&	diff$informativeTLocation == FALSE && 
-			 					   	diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && 
-			 					   	diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE
-		)))
-
-		iint <- 1
-		q <- 1
-		descriptInd <- 1
-
 		for (variable in options[["variables"]]){
 
-			plotGroups[[iint]] <- list()
-			plotGroups[[iint]][["title"]] <- variable
-			plotGroups[[iint]][["name"]] <- variable
+			plotGroups[[variable]] <- list()
+			plotGroups[[variable]][["title"]] <- variable
+			plotGroups[[variable]][["name"]] <- variable
 
-			if (options$descriptivesPlots) {
+			if (options[["descriptivesPlots"]]) {
 
-				if (boolDescriptivesPlots && variable %in% state$descriptPlotVariables) {
-
-
-					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-					# then, if the requested plot already exists, use it
-
-					index <- which(state$descriptPlotVariables == variable)
-
-					descriptivesPlots[[descriptInd]] <- state$descriptivesPlots[[index]]
-
-
-				} else {
+				# if the element is null it needs to be remade, otherwise it's useable!
+				if (is.null(descriptivesPlots[[variable]])) {
 					descriptivesPlot <- list()
 
 					descriptivesPlot[["title"]] <- variable
-					descriptivesPlot[["width"]] <- options$plotWidth
-					descriptivesPlot[["height"]] <- options$plotHeight
-					#descriptivesPlot[["custom"]] <- list(width="plotWidth", height="plotHeight")
+					descriptivesPlot[["width"]] <- options[["plotWidth"]]
+					descriptivesPlot[["height"]] <- options[["plotHeight"]]
 					descriptivesPlot[["status"]] <- "waiting"
 					descriptivesPlot[["data"]] <- ""
 
-					descriptivesPlots[[descriptInd]] <- descriptivesPlot
+					descriptivesPlots[[variable]] <- descriptivesPlot
+
 				}
 
-
-				descriptPlotVariables[[length(descriptPlotVariables)+1]] <- variable
-
-				descriptInd <- descriptInd + 1
 			}
 
 			if (options$plotPriorAndPosterior){
-
-				if (boolPriorAndPosterior && variable %in% state$plotVariables && 
-					options$plotPriorAndPosteriorAdditionalInfo && 
-					"posteriorPlotAddInfo" %in% state$plotTypes) {
-
-					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-					# then, if the requested plot already exists, use it
-
-					index <- which(state$plotVariables == variable & state$plotTypes == "posteriorPlotAddInfo")
-
-					plots.ttest[[q]] <- state$plotsTtest[[index]]
-
-				} else if (boolPriorAndPosterior && variable %in% state$plotVariables && 
-						   !options$plotPriorAndPosteriorAdditionalInfo &&
-						   "posteriorPlot" %in% state$plotTypes) {
-
-					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-					# if the requested plot already exists use it
-
-					index <- which(state$plotVariables == variable & state$plotTypes == "posteriorPlot")
-
-					plots.ttest[[q]] <- state$plotsTtest[[index]]
-
-				} else {
-
+				# if the element is null it needs to be remade, otherwise it's useable!
+				if (is.null(priorAndPosteriorPlots[[variable]])) {
 					plot <- list()
 
 					plot[["title"]] <- "Prior and Posterior"
@@ -300,51 +219,16 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					plot[["obj"]] <- content[["obj"]]
 					plot[["data"]] <- content[["png"]]
 
-					plots.ttest[[q]] <- plot
+					priorAndPosteriorPlots[[variable]] <- plot
 				}
 
 
-				if (options$plotPriorAndPosteriorAdditionalInfo) {
-
-					plotTypes[[length(plotTypes)+1]] <- "posteriorPlotAddInfo"
-
-				} else {
-
-					plotTypes[[length(plotTypes)+1]] <- "posteriorPlot"
-				}
-
-				plotGroups[[iint]][["PriorPosteriorPlot"]] <- plots.ttest[[q]]
-				plotVariables[[length(plotVariables)+1]] <- variable
-
-				q <- q + 1
-
+				plotGroups[[variable]][["PriorPosteriorPlot"]] <- priorAndPosteriorPlots[[variable]]
 			}
 
 			if (options$plotBayesFactorRobustness) {
-
-				if (boolBayesFactorRobustness && variable %in% state$plotVariables &&
-					options$plotBayesFactorRobustnessAdditionalInfo &&
-					"robustnessPlotAddInfo" %in% state$plotTypes) {
-
-					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-					# then, if the requested plot already exists, use it
-					index <- which(state$plotVariables == variable & state$plotTypes == "robustnessPlotAddInfo")
-
-					plots.ttest[[length(plots.ttest)+1]] <- state$plotsTtest[[index]]
-
-				} else if (boolBayesFactorRobustness && variable %in% state$plotVariables &&
-						   !options$plotBayesFactorRobustnessAdditionalInfo &&
-						   "robustnessPlot" %in% state$plotType) {
-
-					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-					# then, if the requested plot already exists, use it
-
-					index <- which(state$plotVariables == variable & state$plotTypes == "robustnessPlot")
-
-					plots.ttest[[q]] <- state$plotsTtest[[index]]
-
-				} else {
-
+				# if the element is null it needs to be remade, otherwise it's useable!
+				if (is.null(robustnessPlots[[variable]])) {
 					plot <- list()
 
 					plot[["title"]] <- "Bayes Factor Robustness Check"
@@ -360,48 +244,15 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					plot[["convertible"]] <- TRUE
 					plot[["obj"]] <- content[["obj"]]
 					plot[["data"]] <- content[["png"]]
+					robustnessPlots[[variable]] <- plot
 
-					plots.ttest[[q]] <- plot
 				}
-
-				if (options$plotBayesFactorRobustnessAdditionalInfo) {
-					plotTypes[[length(plotTypes)+1]] <- "robustnessPlotAddInfo"
-				} else {
-					plotTypes[[length(plotTypes)+1]] <- "robustnessPlot"
-				}
-
-				plotVariables[[length(plotVariables)+1]] <- variable
-				plotGroups[[iint]][["BFrobustnessPlot"]] <- plots.ttest[[q]]
-
-				q <- q + 1
+				plotGroups[[variable]][["BFrobustnessPlot"]] <- robustnessPlots[[variable]]
 			}
 
 			if (options$plotSequentialAnalysis) {
 
-				if (boolSequentialRobustnessanalysis && variable %in% state$plotVariables && 
-					options$plotSequentialAnalysisRobustness && 
-					"sequentialRobustnessPlot" %in% state$plotTypes) {
-
-					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-					# then, if the requested plot already exists, use it
-
-					index <- which(state$plotVariables == variable & state$plotTypes == "sequentialRobustnessPlot")
-
-					plots.ttest[[q]] <- state$plotsTtest[[index]]
-
-				} else if (boolSequentialRobustnessanalysis && variable %in% state$plotVariables &&
-						   !options$plotSequentialAnalysisRobustness && 
-						   "sequentialPlot" %in% state$plotTypes) {
-
-					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-					# then, if the requested plot already exists use it
-
-					index <- which(state$plotVariables == variable & state$plotTypes == "sequentialPlot")
-
-					plots.ttest[[q]] <- state$plotsTtest[[index]]
-
-				} else {
-
+				if (is.null(sequentialPlots[[variable]])) {
 					plot <- list()
 
 					plot[["title"]] <- "Sequential Analysis"
@@ -418,48 +269,31 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					plot[["obj"]] <- content[["obj"]]
 					plot[["data"]] <- content[["png"]]
 
-					plots.ttest[[q]] <- plot
+					sequentialPlots[[variable]] <- plot
 				}
-
-
-				if (options$plotSequentialAnalysisRobustness) {
-
-					plotTypes[[length(plotTypes)+1]] <- "sequentialRobustnessPlot"
-
-				} else {
-
-					plotTypes[[length(plotTypes)+1]] <- "sequentialPlot"
-				}
-
-				plotVariables[[length(plotVariables)+1]] <- variable
-				plotGroups[[iint]][["BFsequentialPlot"]] <- plots.ttest[[q]]
-
-				q <- q + 1
-
+				plotGroups[[variable]][["BFsequentialPlot"]] <- sequentialPlots[[variable]]
 			}
-
-			iint <- iint + 1
 
 		}
 
-
 		if (options$plotPriorAndPosterior || options$plotBayesFactorRobustness || options$plotSequentialAnalysis)
 			results[["inferentialPlots"]] <- list(title=ifelse(length(options[["variables"]]) > 1 || sum(c(options$plotPriorAndPosterior, options$plotBayesFactorRobustness, options$plotSequentialAnalysis)) > 1,
-				"Inferential Plots", "Inferential Plot"), collection=plotGroups)
+				"Inferential Plots", "Inferential Plot"), collection=stats::setNames(plotGroups, seq_along(dependents)))
 
 		if (options$descriptivesPlots)
-			results[["descriptives"]][["descriptivesPlots"]] <- list(title=ifelse(length(options[["variables"]]) > 1, "Descriptives Plots", "Descriptives Plot"), collection=descriptivesPlots)
+			results[["descriptives"]][["descriptivesPlots"]] <- list(title=ifelse(length(options[["variables"]]) > 1, "Descriptives Plots", "Descriptives Plot"),
+																															 collection=setNames(descriptivesPlots, seq_along(dependents)))
 
 
 		if (perform == "run" && length(options$variables) > 0 && !is.null(grouping)) {
 
+		# make everything indexable by name
+		names(tValue) <- names(n_group1) <- names(n_group2) <-
+		names(BF10post) <- names(deltaSamplesWilcox) <-
+			dependents
+
 			if ( ! .shouldContinue(callback(results)))
 				return()
-
-			statusInd <- 1
-			i <- 1
-			z <- 1
-			descriptInd <- 1
 
 			for (variable in options[["variables"]]) {
 
@@ -483,25 +317,19 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 				if (options$descriptivesPlots) {
 
+					# if the plot data is empty it wasn't obtained from state and needs to be remade
+					if (identical(descriptivesPlots[[variable]][["data"]], "")) {
 
-					if (boolDescriptivesPlots && variable %in% state$descriptPlotVariables) {
-
-						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-						# then, if the requested plot already exists, use it
-
-						index <- which(state$descriptPlotVariables == variable)
-
-						descriptivesPlots[[descriptInd]] <- state$descriptivesPlots[[index]]
-
-
-					} else {
-
-						results[["descriptives"]][["descriptivesPlots"]][["collection"]][[i]][["status"]] <- "running"
+						# JS sorts alphabetically, so we need to change to collection indices to 1, 2, ...
+						# there ought to be a better way to handle this. 
+						# the names are not reset because they persist in descriptivesPlots
+						results[["descriptives"]][["descriptivesPlots"]][["collection"]][[variable]][["status"]] <- "running"
+						names(results[["descriptives"]][["descriptivesPlots"]][["collection"]]) <- seq_along(dependents)
 
 						if ( ! .shouldContinue(callback(results)))
 							return()
 
-						plot <- descriptivesPlots[[descriptInd]]
+						plot <- descriptivesPlots[[variable]]
 
 						if (!is.null(errorMessage)) {
 
@@ -526,12 +354,17 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 						plot[["status"]] <- "complete"
 
-						descriptivesPlots[[descriptInd]] <- plot
+						descriptivesPlots[[variable]] <- plot
 					}
 
-					results[["descriptives"]][["descriptivesPlots"]][["collection"]] <- descriptivesPlots
+					print("before callback")
+					print(names(descriptivesPlots))
+					results[["descriptives"]][["descriptivesPlots"]][["collection"]] <- descriptivesPlots # also resets the
 
-					descriptInd <- descriptInd + 1
+					# JS sorts alphabetically, so we need to change to collection indices to 1, 2, ...
+					# there ought to be a better way to handle this.
+					names(results[["descriptives"]][["descriptivesPlots"]][["collection"]]) <- seq_along(dependents)
+					# descriptInd <- descriptInd + 1
 
 					if ( ! .shouldContinue(callback(results)))
 						return()
@@ -540,36 +373,15 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 				if (options$plotPriorAndPosterior) {
 
-					if (boolPriorAndPosterior && variable %in% state$plotVariables && 
-						options$plotPriorAndPosteriorAdditionalInfo &&
-						"posteriorPlotAddInfo" %in% state$plotTypes) {
+					if (identical(priorAndPosteriorPlots[[variable]][["status"]], "waiting")) {
 
-						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-						# then, if the requested plot already exists, use it
-
-						index <- which(state$plotVariables == variable & state$plotTypes == "posteriorPlotAddInfo")
-
-						plots.ttest[[z]] <- state$plotsTtest[[index]]
-
-					} else if (boolPriorAndPosterior && variable %in% state$plotVariables && 
-							   !options$plotPriorAndPosteriorAdditionalInfo &&
-							   "posteriorPlot" %in% state$plotTypes) {
-
-						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-						# if the requested plot already exists use it
-
-						index <- which(state$plotVariables == variable & state$plotTypes == "posteriorPlot")
-
-						plots.ttest[[z]] <- state$plotsTtest[[index]]
-
-					} else {
-
-						results[["inferentialPlots"]][["collection"]][[i]][["PriorPosteriorPlot"]][["status"]] <- "running"
+						results[["inferentialPlots"]][["collection"]][[variable]][["PriorPosteriorPlot"]][["status"]] <- "running"
+						names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
 
 						if ( ! .shouldContinue(callback(results)))
 							return()
 
-						plot <- plots.ttest[[z]]
+						plot <- priorAndPosteriorPlots[[variable]] # plots.ttest[[z]]
 
 						if (!is.null(errorMessage)) {
 
@@ -580,11 +392,11 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 						    p <- try(silent= FALSE, expr= {
 
 						        .plotFunc <- function() {
-						            .plotPosterior.summarystats.ttest(t = tValue[i], n1 = n_group2[i], n2 = n_group1[i],
-						                                              paired = FALSE, oneSided = oneSided, BF = BF10post[i],
+						            .plotPosterior.summarystats.ttest(t = tValue[variable], n1 = n_group2[variable], n2 = n_group1[variable],
+						                                              paired = FALSE, oneSided = oneSided, BF = BF10post[variable],
 						                                              BFH1H0 = BFH1H0, rscale = options$priorWidth,
 						                                              addInformation = options$plotPriorAndPosteriorAdditionalInfo,
-						                                              options = options, delta = deltaSamplesWilcox[[i]])
+						                                              options = options, delta = deltaSamplesWilcox[[variable]])
 						        }
 						        content <- .writeImage(width = 530, height = 400, plot = .plotFunc, obj = TRUE)
   
@@ -603,126 +415,84 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 						plot[["status"]] <- "complete"
 
-						plots.ttest[[z]] <- plot
+						priorAndPosteriorPlots[[variable]] <- plot
+
 					}
 
-					plotGroups[[i]][["PriorPosteriorPlot"]] <- plots.ttest[[z]]
+					plotGroups[[variable]][["PriorPosteriorPlot"]] <- priorAndPosteriorPlots[[variable]]#plots.ttest[[z]]
 
 
 					results[["inferentialPlots"]][["collection"]] <- plotGroups
-
-					z <- z + 1
+					names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
 
 					if ( ! .shouldContinue(callback(results)))
 						return()
+
 				}
 
 				if (options$plotBayesFactorRobustness) {
-					if (boolBayesFactorRobustness && variable %in% state$plotVariables && 
-						options$plotBayesFactorRobustnessAdditionalInfo && 
-						"robustnessPlotAddInfo" %in% state$plotTypes) {
 
-						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-						# then, if the requested plot already exists, use it
+					if (identical(robustnessPlots[[variable]][["status"]], "waiting")) {
 
-						index <- which(state$plotVariables == variable & state$plotTypes == "robustnessPlotAddInfo")
-
-						plots.ttest[[z]] <- state$plotsTtest[[index]]
-
-					} else if (boolBayesFactorRobustness && variable %in% state$plotVariables && 
-							   !options$plotBayesFactorRobustnessAdditionalInfo &&
-							   "robustnessPlot" %in% state$plotTypes) {
-
-						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-						# then, if the requested plot already exists, use it
-
-						index <- which(state$plotVariables == variable & state$plotTypes == "robustnessPlot")
-
-						plots.ttest[[z]] <- state$plotsTtest[[index]]
-
-					} else {
-
-						results[["inferentialPlots"]][["collection"]][[i]][["BFrobustnessPlot"]][["status"]] <- "running"
+						results[["inferentialPlots"]][["collection"]][[variable]][["BFrobustnessPlot"]][["status"]] <- "running"
+						names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
 
 						if ( ! .shouldContinue(callback(results)))
 							return()
 
-						plot <- plots.ttest[[z]]
+						plot <- robustnessPlots[[variable]]
 
 						if (options$effectSizeStandardized == "informative") {
-						  errorMessage="Bayes factor robustness check plot currently not supported for informed prior."
-						  plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
+							errorMessage="Bayes factor robustness check plot currently not supported for informed prior."
+							plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
 						}
 
 						if (!is.null(errorMessage)) {
 
-						    plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
+							plot[["error"]] <- list(error="badData", errorMessage=errorMessage)
 
 						} else {
 
 							p <- try(silent= FALSE, expr= {
 
-									.plotFunc <- function() {
-										.plotBF.robustnessCheck.ttest(x= group2, y= group1, BF10post=ifelse((options$bayesFactorType=="LogBF10"), exp(BF10post[i]), BF10post[i]), paired= FALSE, oneSided= oneSided,
-										                              rscale = options$priorWidth, BFH1H0= BFH1H0, additionalInformation=options$plotBayesFactorRobustnessAdditionalInfo)
-									}
-									content <- .writeImage(width = 530, height = 400, plot = .plotFunc, obj = TRUE)
+								.plotFunc <- function() {
+									.plotBF.robustnessCheck.ttest(x= group2, y= group1, BF10post=ifelse((options$bayesFactorType=="LogBF10"), exp(BF10post[variable]), BF10post[variable]), paired= FALSE, oneSided= oneSided,
+																								rscale = options$priorWidth, BFH1H0= BFH1H0, additionalInformation=options$plotBayesFactorRobustnessAdditionalInfo)
+								}
+								content <- .writeImage(width = 530, height = 400, plot = .plotFunc, obj = TRUE)
 
-									plot[["convertible"]] <- TRUE
-									plot[["obj"]] <- content[["obj"]]
-									plot[["data"]] <- content[["png"]]
+								plot[["convertible"]] <- TRUE
+								plot[["obj"]] <- content[["obj"]]
+								plot[["data"]] <- content[["png"]]
 
-								})
+							})
 
 						}
 
 						plot[["status"]] <- "complete"
+						robustnessPlots[[variable]] <- plot
 
-						plots.ttest[[z]] <- plot
 					}
 
-					plotGroups[[i]][["BFrobustnessPlot"]] <- plots.ttest[[z]]
-					results[["inferentialPlots"]][["collection"]] <- plotGroups # add plots without image object to results
-
-					z <- z + 1
+					plotGroups[[variable]][["BFrobustnessPlot"]] <- robustnessPlots[[variable]]
+					results[["inferentialPlots"]][["collection"]] <- plotGroups
+					names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
 
 					if ( ! .shouldContinue(callback(results)))
 						return()
+
 				}
 
 				if (options$plotSequentialAnalysis) {
+					if (identical(sequentialPlots[[variable]][["status"]], "waiting")) {
 
-					if (boolSequentialRobustnessanalysis && variable %in% state$plotVariables && 
-						options$plotSequentialAnalysisRobustness &&
-						"sequentialRobustnessPlot" %in% state$plotTypes) {
-
-						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-						# then, if the requested plot already exists, use it
-
-						index <- which(state$plotVariables == variable & state$plotTypes == "sequentialRobustnessPlot")
-
-						plots.ttest[[z]] <- state$plotsTtest[[index]]
-						results[["inferentialPlots"]][["collection"]][[i]][["BFsequentialPlot"]][["status"]] <- "complete"
-
-					} else if (boolSequentialRobustnessanalysis && variable %in% state$plotVariables &&
-							   !options$plotSequentialAnalysisRobustness && 
-							   "sequentialPlot" %in% state$plotTypes) {
-
-						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
-						# then, if the requested plot already exists use it
-
-						index <- which(state$plotVariables == variable & state$plotTypes == "sequentialPlot")
-
-						plots.ttest[[z]] <- state$plotsTtest[[index]]
-						results[["inferentialPlots"]][["collection"]][[i]][["BFsequentialPlot"]][["status"]] <- "complete"
-					} else {
-
-						results[["inferentialPlots"]][["collection"]][[i]][["BFsequentialPlot"]][["status"]] <- "running"
+						results[["inferentialPlots"]][["collection"]][[variable]][["BFsequentialPlot"]][["status"]] <- "running"
+						names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
 
 						if ( ! .shouldContinue(callback(results)))
 							return()
 
-						plot <- plots.ttest[[z]]
+						plot <- sequentialPlots[[variable]]
 
 						if (options$plotSequentialAnalysisRobustness && options$effectSizeStandardized == "informative") {
 						  plot[["error"]] <- list(error="badData", errorMessage="Sequential analysis robustness check plot currently not supported for informed prior.")
@@ -737,7 +507,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 							p <- try(silent= FALSE, expr= {
 
 									.plotFunc <- function() {
-										.plotSequentialBF.ttest(x= group2, y= group1, paired= FALSE, oneSided= oneSided, rscale = options$priorWidth, BFH1H0= BFH1H0, BF10post=BF10post[i],
+										.plotSequentialBF.ttest(x= group2, y= group1, paired= FALSE, oneSided= oneSided, rscale = options$priorWidth, BFH1H0= BFH1H0, BF10post=BF10post[variable],
 															plotDifferentPriors= options$plotSequentialAnalysisRobustness, subDataSet=subDataSet, level1=g1, level2=g2, options = options)
 									}
 									content <- .writeImage(width = 530, height = 400, plot = .plotFunc, obj = TRUE)
@@ -752,71 +522,91 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 						plot[["status"]] <- "complete"
 
-						plots.ttest[[z]] <- plot
+						sequentialPlots[[variable]] <- plot
 					}
 
-					plotGroups[[i]][["BFsequentialPlot"]] <- plots.ttest[[z]]
+					plotGroups[[variable]][["BFsequentialPlot"]] <- sequentialPlots[[variable]]
 					results[["inferentialPlots"]][["collection"]] <- plotGroups
+					names(results[["inferentialPlots"]][["collection"]]) <- seq_along(dependents)
 
-
-					z <- z + 1
 
 					if ( ! .shouldContinue(callback(results)))
 						return()
 				}
 
-				statusInd <- statusInd + 1
-				i <- i + 1
 			}
 		}
 	}
 
-
 	keep <- NULL
-
-	for (plot in plots.ttest)
-		keep <- c(keep, plot$data)
 
 	for (plot in descriptivesPlots)
 		keep <- c(keep, plot$data)
+	for (plot in priorAndPosteriorPlots)
+		keep <- c(keep, plot$data)
+	for (plot in robustnessPlots)
+		keep <- c(keep, plot$data)
+	for (plot in sequentialPlots)
+		keep <- c(keep, plot$data)
 
-	descriptivesPlots <- descriptivesPlots
-	plots.ttest <- plots.ttest
+	# plots.ttest <- plots.ttest
 
+	wilcoxExpr <- bquote(options[["testStatistic"]] == .(options[["testStatistic"]]))
 	stateKey <- list(
-	  descriptivesPlots = c("groupingVariable", "missingValues", "descriptivesPlotsCredibleInterval")
+		descriptivesPlots = c("groupingVariable", "missingValues", "descriptivesPlotsCredibleInterval"),
+		priorAndPosteriorPlots = list("priorWidth", "hypothesis", "groupingVariable", "missingValues", 
+															 "plotHeight", "plotWidth", "effectSizeStandardized", "informativeStandardizedEffectSize", 
+															 "informativeCauchyLocation", "informativeCauchyScale", "informativeTLocation", 
+															 "informativeTScale", "informativeTDf", "informativeNormalMean", 
+															 "informativeNormalStd", wilcoxExpr, "wilcoxonSamplesNumber"
+		),
+		robustnessPlots = c("priorWidth", "hypothesis", "groupingVariable", "missingValues", 
+												"plotHeight", "plotWidth", "effectSizeStandardized", "informativeStandardizedEffectSize", 
+												"informativeCauchyLocation", "informativeCauchyScale", "informativeTLocation", 
+												"informativeTScale", "informativeTDf", "informativeNormalMean", 
+												"informativeNormalStd"
+		),
+		sequentialPlots = c("priorWidth", "hypothesis", "groupingVariable", "missingValues", 
+												"plotHeight", "plotWidth", "effectSizeStandardized", "informativeStandardizedEffectSize", 
+												"informativeCauchyLocation", "informativeCauchyScale", "informativeTLocation", 
+												"informativeTScale", "informativeTDf", "informativeNormalMean", 
+												"informativeNormalStd"
+		)
 	)
 	
-	collectionKey <- .stateDependsOnVar(descriptPlotVariables)
+	collectionKey <- .stateDependsOnVar(dependents)
 	attr(stateKey[["descriptivesPlots"]], "collection") <- collectionKey
+	attr(stateKey[["priorAndPosteriorPlots"]], "collection") <- collectionKey
+	attr(stateKey[["robustnessPlots"]], "collection") <- collectionKey
+	attr(stateKey[["sequentialPlots"]], "collection") <- collectionKey
 
 	if (perform == "init") {
 
-	  print("after init")
-    str(state, max.level = 3)
-    if (!is.null(state) && is.null(attr(state, "key"))) {
-      print("init had no stateKey")
+    if (!is.null(state) && is.null(attr(state, "key")))
       attr(state, "key") <- stateKey
-    }
+
 		return(list(results=results, status="inited", state=state, keep=keep))
 
 	} else {
 
 		state <- list(
 			options = options, results = results, 
-			plotsTtest = plots.ttest, 
-			plotTypes = plotTypes, 
-			plotVariables = plotVariables,
+			# plotsTtest = plots.ttest,
+			# plotTypes = plotTypes,
+			# plotVariables = plotVariables,
 			descriptPlotVariables = descriptPlotVariables, 
 			descriptivesPlots = descriptivesPlots, 
+			priorAndPosteriorPlots = priorAndPosteriorPlots,
+			robustnessPlots = robustnessPlots,
+			sequentialPlots = sequentialPlots,
 			status = status, plottingError = plottingError, 
 			BF10post = BF10post, errorFootnotes = errorFootnotes,
 			tValue = tValue, n_group2 = n_group2, n_group1 = n_group1, 
 			delta = deltaSamplesWilcox
 		)
+		state <- state[lengths(state) > 0] # keep only non-NULL items in state
 		attr(state, "key") <- stateKey
-    print("after run")
-    str(state, max.level = 3)
+
 		return(list(results=results, status="complete", state = state, keep = keep))
 	}
 

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -536,7 +536,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 		priorAndPosteriorPlots = c(defaults, "plotHeight", "plotWidth", "plotPriorAndPosteriorAdditionalInfo"),
 		robustnessPlots = c(defaults, "plotHeight", "plotWidth", "plotBayesFactorRobustnessAdditionalInfo"),
 		sequentialPlots = c(defaults, "plotHeight", "plotWidth", "plotSequentialAnalysisRobustness"),
-		delta = c("hypothesis", "priorWidth", "groupingVariable", "missingValues", "wilcoxonSamplesNumber"),
+		delta = c("priorWidth", "groupingVariable", "missingValues", "wilcoxonSamplesNumber"),
 		descriptivesData = c("descriptives", "groupingVariable", "missingValues", "descriptivesPlotsCredibleInterval")
 	)
 	
@@ -1132,30 +1132,4 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
   bf <- ifelse(oneSided == FALSE,  priorDensZeroPoint / densZeroPoint, 
                (priorDensZeroPoint / corFactorPrior) / (densZeroPoint / corFactorPosterior))
   return(bf)
-}
-
-.recodeBFtype <- function(bfOld, newBFtype, oldBFtype) {
-
-	if (oldBFtype == newBFtype)
-		return(bfOld)
-
-	if (oldBFtype == "BF10") {
-		if (newBFtype == "BF01") {
-			return(1 / bfOld)
-		} else {
-			return(log(bfOld))
-		}
-	} else if (oldBFtype == "BF01") {
-		if (newBFtype == "BF10") {
-			return(1 / bfOld)
-		} else {
-			return(log(1 / bfOld))
-		}
-	} else {
-		if (newBFtype == "BF10") {
-			return(exp(bfOld))
-		} else {
-			return(1 / exp(bfOld))
-		}
-	}
 }

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -156,10 +156,6 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 	if (options$plotPriorAndPosterior || options$plotSequentialAnalysis || options$plotBayesFactorRobustness || options$descriptivesPlots) {
 
-		iint <- 1
-		q <- 1
-		descriptInd <- 1
-
 		BFtype <- options$bayesFactorType
 		BFtypeRequiresNewPlot <- TRUE
 
@@ -175,6 +171,50 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 			}
 		}
 
+		# here make the booleans required for wether an analysis should be done or not.
+		# this code should be ported to Tim's state system.
+		boolDescriptivesPlots <- !is.null(state) && options$descriptivesPlots && (
+			identical(diff, FALSE) || 
+				(is.list(diff) && diff$groupingVariable == FALSE && diff$missingValues == FALSE && 
+				 	diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$descriptivesPlotsCredibleInterval == FALSE)
+			)
+		
+		boolPriorAndPosterior <- !is.null(state) && !is.null(diff) && 
+			(identical(diff, FALSE) || 
+			 	(is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE && diff$groupingVariable == FALSE && 
+			 					   	diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && 
+			 					   	diff$effectSizeStandardized == FALSE &&	diff$informativeStandardizedEffectSize == FALSE &&
+			 					   	diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE && 
+			 					   	diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && 
+			 					   	diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE
+			 ))) && diff$wilcoxTest == FALSE && diff$wilcoxonSamplesNumber == FALSE
+		
+		boolBayesFactorRobustness <- !is.null(state) && !is.null(diff) && 
+			(identical(diff, FALSE) || 
+			 	(is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE && BFtypeRequiresNewPlot == FALSE && 
+			 					   	diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && 
+			 					   	diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE && 
+			 					   	diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && 
+			 					   	diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE &&
+			 					   	diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE &&
+			 					   	diff$informativeNormalStd == FALSE
+			 )))
+		
+		boolSequentialRobustnessanalysis <- !is.null(state) && !is.null(diff) && 
+			(identical(diff, FALSE) || 
+			 	(is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE && BFtypeRequiresNewPlot == FALSE && 
+			 					   	diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && 
+			 					   	diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE && 
+			 					   	diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && 
+			 					   	diff$informativeCauchyScale == FALSE &&	diff$informativeTLocation == FALSE && 
+			 					   	diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && 
+			 					   	diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE
+		)))
+
+		iint <- 1
+		q <- 1
+		descriptInd <- 1
+
 		for (variable in options[["variables"]]){
 
 			plotGroups[[iint]] <- list()
@@ -183,8 +223,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 			if (options$descriptivesPlots) {
 
-				if (!is.null(state) && variable %in% state$descriptPlotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$groupingVariable == FALSE &&
-					diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$descriptivesPlotsCredibleInterval == FALSE))) && options$descriptivesPlots) {
+				if (boolDescriptivesPlots && variable %in% state$descriptPlotVariables) {
 
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
@@ -216,11 +255,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 			if (options$plotPriorAndPosterior){
 
-				if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-					&& diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE &&
-					diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE &&
-					diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) && diff$wilcoxTest == FALSE && 
-					diff$wilcoxonSamplesNumber == FALSE && options$plotPriorAndPosteriorAdditionalInfo && "posteriorPlotAddInfo" %in% state$plotTypes) {
+				if (boolPriorAndPosterior && variable %in% state$plotVariables && 
+					options$plotPriorAndPosteriorAdditionalInfo && 
+					"posteriorPlotAddInfo" %in% state$plotTypes) {
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 					# then, if the requested plot already exists, use it
@@ -229,11 +266,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 					plots.ttest[[q]] <- state$plotsTtest[[index]]
 
-				} else if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-							&& diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE &&
-							diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE &&	diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE &&
-							diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) && diff$wilcoxTest == FALSE && 
-							diff$wilcoxonSamplesNumber == FALSE && !options$plotPriorAndPosteriorAdditionalInfo && "posteriorPlot" %in% state$plotTypes) {
+				} else if (boolPriorAndPosterior && variable %in% state$plotVariables && 
+						   !options$plotPriorAndPosteriorAdditionalInfo &&
+						   "posteriorPlot" %in% state$plotTypes) {
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 					# if the requested plot already exists use it
@@ -282,11 +317,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 			if (options$plotBayesFactorRobustness) {
 
-				if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-					&& BFtypeRequiresNewPlot == FALSE && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE &&
-					diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE &&
-					diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) &&
-					"robustnessPlotAddInfo" %in% state$plotTypes && options$plotBayesFactorRobustnessAdditionalInfo) {
+				if (boolBayesFactorRobustness && variable %in% state$plotVariables &&
+					options$plotBayesFactorRobustnessAdditionalInfo &&
+					"robustnessPlotAddInfo" %in% state$plotTypes) {
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 					# then, if the requested plot already exists, use it
@@ -294,11 +327,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 					plots.ttest[[length(plots.ttest)+1]] <- state$plotsTtest[[index]]
 
-				} else if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-					&& BFtypeRequiresNewPlot == FALSE && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE &&
-					diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE &&
-					diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) &&
-					"robustnessPlot" %in% state$plotTypes && !options$plotBayesFactorRobustnessAdditionalInfo) {
+				} else if (boolBayesFactorRobustness && variable %in% state$plotVariables &&
+						   !options$plotBayesFactorRobustnessAdditionalInfo &&
+						   "robustnessPlot" %in% state$plotType) {
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 					# then, if the requested plot already exists, use it
@@ -342,11 +373,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 			if (options$plotSequentialAnalysis) {
 
-				if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-					&& BFtypeRequiresNewPlot == FALSE && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE &&
-					diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE &&
-					diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) &&
-					options$plotSequentialAnalysisRobustness && "sequentialRobustnessPlot" %in% state$plotTypes) {
+				if (boolSequentialRobustnessanalysis && variable %in% state$plotVariables && 
+					options$plotSequentialAnalysisRobustness && 
+					"sequentialRobustnessPlot" %in% state$plotTypes) {
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 					# then, if the requested plot already exists, use it
@@ -355,11 +384,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 					plots.ttest[[q]] <- state$plotsTtest[[index]]
 
-				} else if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-							&& BFtypeRequiresNewPlot == FALSE && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE &&
-							diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE &&
-							diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) &&
-							!options$plotSequentialAnalysisRobustness && "sequentialPlot" %in% state$plotTypes) {
+				} else if (boolSequentialRobustnessanalysis && variable %in% state$plotVariables &&
+						   !options$plotSequentialAnalysisRobustness && 
+						   "sequentialPlot" %in% state$plotTypes) {
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 					# then, if the requested plot already exists use it
@@ -452,8 +479,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 				if (options$descriptivesPlots) {
 
 
-					if (!is.null(state) && variable %in% state$descriptPlotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$groupingVariable == FALSE &&
-						diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$descriptivesPlotsCredibleInterval == FALSE))) && options$descriptivesPlots) {
+					if (boolDescriptivesPlots && variable %in% state$descriptPlotVariables) {
 
 						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 						# then, if the requested plot already exists, use it
@@ -509,11 +535,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 				if (options$plotPriorAndPosterior) {
 
-					if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-						&& diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE &&
-						diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE &&	diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE &&
-						diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) && diff$wilcoxTest == FALSE && 
-						diff$wilcoxonSamplesNumber == FALSE && options$plotPriorAndPosteriorAdditionalInfo && "posteriorPlotAddInfo" %in% state$plotTypes) {
+					if (boolPriorAndPosterior && variable %in% state$plotVariables && 
+						options$plotPriorAndPosteriorAdditionalInfo &&
+						"posteriorPlotAddInfo" %in% state$plotTypes) {
 
 						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 						# then, if the requested plot already exists, use it
@@ -522,12 +546,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 						plots.ttest[[z]] <- state$plotsTtest[[index]]
 
-					} else if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE &&
-								diff$hypothesis == FALSE && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE &&
-								diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE &&
-								diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE &&
-								diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) && diff$wilcoxTest == FALSE && diff$wilcoxonSamplesNumber == FALSE &&
-								!options$plotPriorAndPosteriorAdditionalInfo && "posteriorPlot" %in% state$plotTypes) {
+					} else if (boolPriorAndPosterior && variable %in% state$plotVariables && 
+							   !options$plotPriorAndPosteriorAdditionalInfo &&
+							   "posteriorPlot" %in% state$plotTypes) {
 
 						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 						# if the requested plot already exists use it
@@ -592,11 +613,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 				}
 
 				if (options$plotBayesFactorRobustness) {
-					if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-						&& BFtypeRequiresNewPlot == FALSE && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE &&
-						diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE &&	diff$informativeCauchyScale == FALSE &&
-						diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) &&
-						"robustnessPlotAddInfo" %in% state$plotTypes && options$plotBayesFactorRobustnessAdditionalInfo) {
+					if (boolBayesFactorRobustness && variable %in% state$plotVariables && 
+						options$plotBayesFactorRobustnessAdditionalInfo && 
+						"robustnessPlotAddInfo" %in% state$plotTypes) {
 
 						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 						# then, if the requested plot already exists, use it
@@ -605,11 +624,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 						plots.ttest[[z]] <- state$plotsTtest[[index]]
 
-					} else if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-						&& BFtypeRequiresNewPlot == FALSE && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE &&
-						diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE &&	diff$informativeCauchyScale == FALSE &&
-						diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) &&
-						"robustnessPlot" %in% state$plotTypes && !options$plotBayesFactorRobustnessAdditionalInfo) {
+					} else if (boolBayesFactorRobustness && variable %in% state$plotVariables && 
+							   !options$plotBayesFactorRobustnessAdditionalInfo &&
+							   "robustnessPlot" %in% state$plotTypes) {
 
 						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 						# then, if the requested plot already exists, use it
@@ -670,11 +687,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 				if (options$plotSequentialAnalysis) {
 
-					if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE && diff$hypothesis == FALSE
-						&& BFtypeRequiresNewPlot == FALSE && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE &&
-						diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE &&
-						diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) &&
-						options$plotSequentialAnalysisRobustness && "sequentialRobustnessPlot" %in% state$plotTypes) {
+					if (boolSequentialRobustnessanalysis && variable %in% state$plotVariables && 
+						options$plotSequentialAnalysisRobustness &&
+						"sequentialRobustnessPlot" %in% state$plotTypes) {
 
 						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 						# then, if the requested plot already exists, use it
@@ -684,12 +699,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 						plots.ttest[[z]] <- state$plotsTtest[[index]]
 						results[["inferentialPlots"]][["collection"]][[i]][["BFsequentialPlot"]][["status"]] <- "complete"
 
-					} else if (!is.null(state) && variable %in% state$plotVariables && !is.null(diff) && ((is.logical(diff) && diff == FALSE) || (is.list(diff) && (diff$priorWidth == FALSE &&
-								diff$hypothesis == FALSE && BFtypeRequiresNewPlot == FALSE  && diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE &&
-								diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE && diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE &&
-								diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE && diff$informativeTScale == FALSE && diff$informativeTDf == FALSE &&
-								diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE)))
-								&& !options$plotSequentialAnalysisRobustness && "sequentialPlot" %in% state$plotTypes) {
+					} else if (boolSequentialRobustnessanalysis && variable %in% state$plotVariables &&
+							   !options$plotSequentialAnalysisRobustness && 
+							   "sequentialPlot" %in% state$plotTypes) {
 
 						# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 						# then, if the requested plot already exists use it
@@ -771,11 +783,16 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 		return(list(results=results, status="inited", state=state, keep=keep))
 
 	} else {
+		
+		state <- list(
+			options = options, results = results, plotsTtest = plots.ttest, 
+			plotTypes = plotTypes, plotVariables = plotVariables,
+			descriptPlotVariables = descriptPlotVariables, descriptivesPlots = descriptivesPlots, 
+			status = status, plottingError = plottingError, BF10post = BF10post, errorFootnotes = errorFootnotes,
+			tValue = tValue, n_group2 = n_group2, n_group1 = n_group1, delta = deltaSamplesWilcox
+		)
 
-		return(list(results=results, status="complete", state=list(options=options, results=results, plotsTtest=plots.ttest, plotTypes=plotTypes, plotVariables=plotVariables,
-		descriptPlotVariables=descriptPlotVariables, descriptivesPlots=descriptivesPlots, status=status, plottingError=plottingError, BF10post=BF10post, errorFootnotes=errorFootnotes,
-		tValue = tValue, n_group2 = n_group2, n_group1 = n_group1, delta = deltaSamplesWilcox),
-		keep=keep))
+		return(list(results=results, status="complete", state = state, keep = keep))
 	}
 
 }

--- a/JASP.pri
+++ b/JASP.pri
@@ -12,9 +12,12 @@ DEFINES += "CURRENT_R_VERSION=\"$$CURRENT_R_VERSION\""
 BUILDING_JASP_ENGINE=false
 
 
-macx | windows | exists(/app/lib/*) { DEFINES += JASP_LIBJSON_STATIC } else
-{
+macx | windows | exists(/app/lib/*) { 
+	message(using libjson static)
+	DEFINES += JASP_LIBJSON_STATIC 
+} else {
     linux {
+	message(using libjson from distro and pkgconfig)
         QT_CONFIG -= no-pkg-config
         CONFIG += link_pkgconfig
         PKGCONFIG += jsoncpp

--- a/R_HOME.pri
+++ b/R_HOME.pri
@@ -3,7 +3,7 @@ LINUX_SPECIAL_CASE = false
 _R_HOME = $$(R_HOME)
 
 linux {
-    $$LINUX_SPECIAL_CASE {
+    $$LINUX_SPECIAL_CASE | exists(/app/lib/*) {
         _R_HOME = /usr/lib64/R
         INCLUDEPATH += /usr/lib64/R/library/include
     } else {

--- a/R_HOME.pri
+++ b/R_HOME.pri
@@ -3,13 +3,18 @@ LINUX_SPECIAL_CASE = false
 _R_HOME = $$(R_HOME)
 
 linux {
-    $$LINUX_SPECIAL_CASE | exists(/app/lib/*) {
-        _R_HOME = /usr/lib64/R
-        INCLUDEPATH += /usr/lib64/R/library/include
+	exists(/app/lib/*) {
+        _R_HOME = /app/lib64/R
+        INCLUDEPATH += /app/lib64/R/library/include
     } else {
-        _R_HOME = /usr/lib/R
-        INCLUDEPATH += /usr/lib/R/library/include
-    }
+		$$LINUX_SPECIAL_CASE {
+			_R_HOME = /usr/lib64/R
+			INCLUDEPATH += /usr/lib64/R/library/include
+		} else {
+			_R_HOME = /usr/lib/R
+			INCLUDEPATH += /usr/lib/R/library/include
+		}
+	}
 
     QMAKE_CXXFLAGS += -D\'R_HOME=\"$$_R_HOME\"\'
     INCLUDEPATH += /usr/include/R/


### PR DESCRIPTION
(For the next release)
Implemented Tim's state system for the independent samples bayesian t-test. The main goal is to improve the legibility of this analysis and easy the transition to jaspResults. For now I focused on the state system, mainly to remove the giant if statements. The remainder should be cleaned when jaspResults is implemented. If this analysis goes well I plan to rewrite the Bayesian one sample and paired samples as well.

Changes to the state system:
- Elements of the statekey can now be lists containing expressions and options names.
- State can now be specified for collections (sublists), by adding a list to the attribute "collectionKey" of the specific element of the stateKey.

Together,  these changes allow for specifying "state$allPlots depends option1, option2", while also specifying "state$allPlots$contNormal depends on `'contNormal' %in% options[['variables']]`". This is particularly relevant for the T-tests, where removing one variable means most of the state is still useful. @vankesteren can you check whether the state changes make sense? And if the documentation about these changes is understandable by itself?

Changes to independent samples t-test:

- Removed legacy code (old checks for no. factor levels that are now handled by .hasErrors).
- Instead of using many different numeric indices, now uses variable names for indices.

@JohnnyDoorn since you added stuff to this analysis last, can you check if I didn't break anything?

All suggestions/ feedback are welcome!

