### PR TITLE
Run VCREDIST silently during JASP install on Wndows

### DIFF
--- a/Tools/make-win-installer.nsi
+++ b/Tools/make-win-installer.nsi
@@ -180,8 +180,10 @@ SetOverwrite ifnewer
 
 ${If} ${RunningX64}
 	!include includeFiles64.nsi
+	ExecWait '"$INSTDIR\vcredist_x64.exe" /passive /norestart'
 ${else}
 	!include includeFiles32.nsi
+	ExecWait '"$INSTDIR\vcredist_x86.exe" /passive /norestart'
 ${EndIf}
 
 SectionEnd


### PR DESCRIPTION
Vcredist_x64 or vcredist_x86 is executed silently during JASP setup

