### PR TITLE
don't unbase64 model components

### DIFF
--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -577,7 +577,7 @@ RegressionLinearBayesian <- function (
   # null model name
 	null.model <- "Null model"
 	if (sum(nuisanceTerms) > 0) {
-		null.model <- paste("Null model (incl. ", paste(.unvf(names(which(nuisanceTerms))), collapse = ", "), ")", sep = "")
+		null.model <- paste("Null model (incl. ", paste(names(which(nuisanceTerms)), collapse = ", "), ")", sep = "")
 	}
 
 	# generate all model names


### PR DESCRIPTION
This `.unvf` is already done on line 548, and doing it twice does bad things. 