### PR TITLE
Couple of Fixes

### DIFF
--- a/JASP-Desktop/analysisforms/Common/multinomialtestform.cpp
+++ b/JASP-Desktop/analysisforms/Common/multinomialtestform.cpp
@@ -218,7 +218,7 @@ void MultinomialTestForm::addColumnToTable() {
 	int rowCount = ui->tableWidget->rowCount();
 
 	// Add column labels (Hypotheses labels)
-	
+
 	horizontalLabels = QStringList();
 	QString letters[5] = {"a", "b", "c", "d", "e"};
 	for (int col = 1; col <= columnCount; ++col) {
@@ -256,7 +256,7 @@ bool MultinomialTestForm::deleteColumnFromTable() {
 	// Assign the new hypothesis labels
 	QString letters[5] = {"a", "b", "c", "d", "e"};
 	for (int i = 0; i < columns; ++i) {
-		horizontalLabels << "H₀ (" + letters[i] + ")";
+		horizontalLabels << QString::fromUtf8("H\u2080 (") + letters[i] + QString::fromUtf8(")");
 	}
 
 	ui->tableWidget->setHorizontalHeaderLabels(horizontalLabels);

--- a/JASP-Engine/JASP/R/commonsummarystatsttestbayesian.R
+++ b/JASP-Engine/JASP/R/commonsummarystatsttestbayesian.R
@@ -300,7 +300,11 @@
 			errorMessage <- .extractErrorMessage(p)
 
 			if (errorMessage == "'from' cannot be NA, NaN or infinite") {
-				errorMessage <- "The Bayes factor is infinite"
+				errorMessage <- "The Bayes factor is infinite."
+			} else if (errorMessage == "Infinite value encountered.") {
+				if (options$effectSizeStandardized == 'informative') {
+					errorMessage <- "Posterior too peaked."
+				}
 			} else if (!is.null(bayesFactorObject)) {
 				if (.clean(exp(bayesFactorObject$bf)) == "\u221E") {
 					errorMessage <- "The Bayes factor is infinite"

--- a/JASP-Engine/JASP/R/multinomialtest.R
+++ b/JASP-Engine/JASP/R/multinomialtest.R
@@ -628,7 +628,7 @@ MultinomialTest <- function (dataset = NULL, options, perform = "run",
       }
     })
 
-    colnames(eProps) <- sapply(options$tableWidget, function(x) x$name)
+    colnames(eProps) <- sapply(seq_along(options$tableWidget), function(x) paste0("H\u2080 (", letters[x], ")"))
     rownames(eProps) <- options$tableWidget[[1]]$levels
 
     return(as.data.frame(eProps))

--- a/JASP-Tests/R/tests/testthat/test-multinomialtest.R
+++ b/JASP-Tests/R/tests/testthat/test-multinomialtest.R
@@ -19,8 +19,15 @@ test_that("Main table results match", {
                             quiet=TRUE)
   maintable <- results[["results"]][["chisq"]][["data"]]
   desctable <- results[["results"]][["descriptivesTable"]][["data"]]
-  expect_equal_tables(maintable,
-                      list("H1", 5.72, 3, 0.126056548007017, 1.40914224189199))
+
+  expected <- jasptools:::collapseTable(
+      list(list(case = "H\u2080 (a)",
+                chisquare = 5.72,
+                df = 3,
+                p = 0.126056548007017,
+                VovkSellkeMPR = 1.40914224189199)))
+
+  expect_equal_tables(maintable, expected)
   expect_equal_tables(desctable,
                       list("f1", 0.49, 0.5,
                            "f2", 0.49, 0.42,


### PR DESCRIPTION
1. Weird characters appear in the Multinomial headers [`H_0(a)`]. Forcefully rename the headers in R. This is a temporary fix.
2. Change the error message in #1944. 