### PR TITLE
[Requires review] - Classical MetaAnalysis: Handle 'NA' when reading dataset

### DIFF
--- a/JASP-Engine/JASP/R/classicalmetaanalysis.R
+++ b/JASP-Engine/JASP/R/classicalmetaanalysis.R
@@ -120,7 +120,7 @@ ClassicalMetaAnalysis <- function(dataset=NULL, options, perform="run", callback
     dataset <- .readDS(
       columns.as.factor  = factor.variables,
       columns.as.numeric = numeric.variables,
-      exclude.na.listwise = c()	# let metafor::rma deal with NA's
+      exclude.na.listwise = numeric.variables
     )
     
     .hasErrors(dataset, perform, type=c("infinity", "observations"),


### PR DESCRIPTION
`metafor::rma` doesn't deal with the NA's in the dataset. (Attempt to fix issue #2373)

I think we need to let jasp's `.readDatasetToEnd` function handle NAs (and the custom "NA"s in the missing values list).