### PR TITLE
Fix Minor Bugs in Linear Regression, AN(C)OVA, and RM ANOVA

### DIFF
--- a/JASP-Engine/JASP/R/ancova.R
+++ b/JASP-Engine/JASP/R/ancova.R
@@ -535,7 +535,7 @@ Ancova <- function(dataset=NULL, options, perform="run", callback=function(...) 
 
 		for (component in components) {
 
-			nLevels <- length(levels(dataset[[ .v(component) ]]))
+		  nLevels <- nrow(plyr::count(dataset[[ .v(component) ]]))
 
 			if (nLevels < 2)
 				independentsWithLessThanTwoLevels <- c(independentsWithLessThanTwoLevels, component)
@@ -908,9 +908,9 @@ Ancova <- function(dataset=NULL, options, perform="run", callback=function(...) 
 			errorMessage <- .extractErrorMessage(anova.rows)
 
 			if (errorMessage == "U[1,1] = 0" || errorMessage == "NA/NaN/Inf in foreign function call (arg 1)" || errorMessage == "undefined columns selected" ||
-				errorMessage == "ANOVA F-tests on an essentially perfect fit are unreliable") {
+				errorMessage == "ANOVA F-tests on an essentially perfect fit are unreliable" || errorMessage == "residual df = 0") {
 
-				errorMessage <- "Residual sums of squares and/or residual degrees of freedom are equal to zero indicating perfect fit.<br><br>(ANOVA F-tests on an essentially perfect fit are unreliable)"
+				errorMessage <- "Residual sums of squares and/or residual degrees of freedom are equal to zero indicating perfect fit.<br><br>(ANOVA F-tests on an essentially perfect fit are unreliable.) <br><br> Potential reasons for this to occur are a very small number of observations or a large number of missing values."
 
 			}
 

--- a/JASP-Engine/JASP/R/anovarepeatedmeasures.R
+++ b/JASP-Engine/JASP/R/anovarepeatedmeasures.R
@@ -400,7 +400,7 @@ AnovaRepeatedMeasures <- function(dataset=NULL, options, perform="run", callback
 
 		for (component in components) {
 
-			nLevels <- length(levels(dataset[[ .v(component) ]]))
+			nLevels <- nrow(plyr::count(dataset[[ .v(component) ]]))
 
 			if (nLevels < 2)
 				independentsWithLessThanTwoLevels <- c(independentsWithLessThanTwoLevels, component)

--- a/JASP-Engine/JASP/R/commonerrorcheck.R
+++ b/JASP-Engine/JASP/R/commonerrorcheck.R
@@ -511,6 +511,11 @@
     return(list(error=TRUE,reason="Matrix is not symmetrical"))
   }
   
+  # Covariance matrix contains infinity
+  if (any(dataset == Inf)) {
+    return(list(error=TRUE,reason="Matrix contains infinity"))
+  }
+  
   # Positive-definite?
   if (posdef && any(round(eigen(dataset)$values,10) <= 0)){
     vars <- .checkForPerfectCorrelations(dataset)

--- a/JASP-Engine/JASP/R/regressionlinear.R
+++ b/JASP-Engine/JASP/R/regressionlinear.R
@@ -288,7 +288,7 @@ RegressionLinear <- function(dataset=NULL, options, perform="run", callback=func
 		}
 
 
-		if (perform == "run" && (options$method == "backward" || options$method == "forward" || options$method == "stepwise")) {
+		if (perform == "run" && (options$method == "backward" || options$method == "forward" || options$method == "stepwise") && length(list.of.errors) == 0) {
 
 			if (length(options$modelTerm) > 0) {
 


### PR DESCRIPTION
Fix for the following bugs:

1. Linear Regression (debug dataset): DV: contNormal. Covariates: debInf with method != Enter.

-> Change: JASP now gives the same error as when method == Enter (see change in regressionlinear.R).

2. Linear Regression (debug dataset): DV: contNormal. Covariates: debMiss80; Weights: contExpon.

-> Change: JASP now gives a proper error message (see change in commonerrorcheck.R).

3. ANOVA/ANCOVA (debug dataset): If debMiss99 is used as DV, covariate or wlsweights

-> Change: JASP now gives a proper error message (see change in ancova.R).

4. RM ANOVA (debug dataset): If debMiss99 is used as RM Cell or covariate and a between subjects factor is specified

-> Change: JASP now gives a proper error message (see change in anovarepeatedmeasures.R).
