### PR TITLE
travisChanges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ matrix:
         "sudo apt-get install r-cran-rcppeigen",
         "sudo apt-get install r-cran-plogr"
       ]
-      install: Rscript -e 'install.packages("testthat"); install.packages("JASP-R-Interface/jaspResults/", repos=NULL, type="source")'
+      install: Rscript Tools/requiredPackages.R JASP-Engine/JASP/R true true
       script:
-        - Rscript Tools/requiredPackages.R JASP-Engine/JASP/R true
         - cd JASP-Tests/R/tests/
         - R < testthat.R --no-save


### PR DESCRIPTION
Some more changes to travis:

All R packages are now installed from:

`install: Rscript Tools/requiredPackages.R JASP-Engine/JASP/R true true`

`requiredPackages.R` now accepts a third argument that is intended to mean: is this run on Travis? If yes, it will for instance check if `BH` or `jaspResults` are installed and if not install them. If the third argument is false these checks are not executed. 
