### PR TITLE
made JASPgraphs compatible with ggplot 3.0.0

### DIFF
--- a/JASP-Engine/JASPgraphs/R/compatability.R
+++ b/JASP-Engine/JASPgraphs/R/compatability.R
@@ -9,38 +9,35 @@ getMajorSource <- function(gb) {
 
     # gb: output from ggplot2::ggbuild(ggplot)
      return(
-        switch (graphOptions("ggVersion"),
-            "2.2.1.9000" = list(
-                x = gb$layout$panel_params[[1]]$x.major_source,
-                y = gb$layout$panel_params[[1]]$y.major_source
-            ),
-            list(
+        switch(graphOptions("ggVersion"),
+            "2.2.1" = list(
                 x = gb$layout$panel_ranges[[1]]$x.major_source,
                 y = gb$layout$panel_ranges[[1]]$y.major_source
+            ),
+            list(
+                x = gb$layout$panel_params[[1]]$x.major_source,  
+                y = gb$layout$panel_params[[1]]$y.major_source
             )
         )
     )
-
 }
 
 getRanges <- function(gb) {
 
     return(
-        switch (graphOptions("ggVersion"),
-            "2.2.1.9000" = list(
-                x = gb$layout$panel_params[[1]]$x.range,
-                y = gb$layout$panel_params[[1]]$y.range
-            ),
-            list(
+        switch(graphOptions("ggVersion"),
+            "2.2.1" = list(
                 x = gb$layout$panel_ranges[[1]]$x.range,
                 y = gb$layout$panel_ranges[[1]]$y.range
+            ),
+            list(
+                x = gb$layout$panel_params[[1]]$x.range,
+                y = gb$layout$panel_params[[1]]$y.range
             )
         )
     )
-
-
 }
 
 
-is.waive <- function (x) inherits(x, "waiver")
+is.waive <- function(x) inherits(x, "waiver")
 # waiver <- ggplot2::waiver


### PR DESCRIPTION
ggplot version 3.0.0 appeared and of course some of the objects had to change their structure. The minor changes below should fix this.