### PR TITLE
datasync and compcol fixes

### DIFF
--- a/JASP-Common/dataset.h
+++ b/JASP-Common/dataset.h
@@ -55,16 +55,18 @@ public:
 	std::vector<std::string> resetEmptyValues(emptyValsType emptyValuesMap);
 
 	void				setFilterVector(std::vector<bool> filterResult);
-	const BoolVector&	filterVector()		const { return _filterVector; }
-	int					filteredRowCount()	const { return _filteredRowCount; }
+	const BoolVector&	filterVector()		const	{ return _filterVector; }
+	int					filteredRowCount()	const	{ return _filteredRowCount; }
 
-	bool allColumnsPassFilter()						const;
-
+	bool allColumnsPassFilter()				const;
+	bool synchingData()						const	{ return _synchingData; }
+	void setSynchingData(bool newVal)				{ _synchingData = newVal; }
 
 private:
 	Columns			_columns;
 	int				_filteredRowCount = 0;
 	BoolVector		_filterVector;
+	bool			_synchingData;
 
 	boost::interprocess::managed_shared_memory *_mem;
 };

--- a/JASP-Common/datasetpackage.h
+++ b/JASP-Common/datasetpackage.h
@@ -92,8 +92,8 @@ public:
 
 			ComputedColumns	* computedColumnsPointer();
 
-			boost::signals2::signal<void (DataSetPackage *source)>																																					isModifiedChanged;
-			boost::signals2::signal<void (DataSetPackage *source, std::vector<std::string> &changedColumns, std::vector<std::string> &missingColumns, std::map<std::string, std::string> &changeNameColumns)>		dataChanged;
+			boost::signals2::signal<void (DataSetPackage *source)>																																									isModifiedChanged;
+			boost::signals2::signal<void (DataSetPackage *source, std::vector<std::string> &changedColumns, std::vector<std::string> &missingColumns, std::map<std::string, std::string> &changeNameColumns, bool rowCountChanged)>	dataChanged;
 
 private:
 
@@ -123,6 +123,7 @@ private:
 	uint				_dataFileTimestamp;
 
 	ComputedColumns		_computedColumns;
+	bool				_synchingData;
 };
 
 #endif // FILEPACKAGE_H

--- a/JASP-Common/sharedmemory.cpp
+++ b/JASP-Common/sharedmemory.cpp
@@ -64,6 +64,7 @@ DataSet *SharedMemory::retrieveDataSet(unsigned long parentPID)
 	}
 
 	DataSet * data = _memory->find<DataSet>(interprocess::unique_instance).first;
+
 	return data;
 }
 

--- a/JASP-Desktop/computedcolumnsmodel.cpp
+++ b/JASP-Desktop/computedcolumnsmodel.cpp
@@ -286,11 +286,11 @@ void ComputedColumnsModel::removeColumn()
 	setComputeColumnNameSelected("");
 }
 
-void ComputedColumnsModel::packageSynchronized(const std::vector<std::string> & changedColumns, const std::vector<std::string> & missingColumns, const std::map<std::string, std::string> & changeNameColumns)
+void ComputedColumnsModel::packageSynchronized(const std::vector<std::string> & changedColumns, const std::vector<std::string> & missingColumns, const std::map<std::string, std::string> & changeNameColumns, bool rowCountChanged)
 {
 	for(ComputedColumn * col : *_computedColumns)
 	{
-		bool invalidateMe = false;
+		bool invalidateMe = rowCountChanged;
 
 		for(const std::string & changed : changedColumns)
 			if(col->dependsOn(changed, false))

--- a/JASP-Desktop/computedcolumnsmodel.h
+++ b/JASP-Desktop/computedcolumnsmodel.h
@@ -32,7 +32,7 @@ public:
 				void	setComputeColumnNameSelected(QString newName);
 				void	setComputeColumnJson(QString newJson);
 
-				void	packageSynchronized(const std::vector<std::string> & changedColumns, const std::vector<std::string> & missingColumns, const std::map<std::string, std::string> & changeNameColumns);
+				void	packageSynchronized(const std::vector<std::string> & changedColumns, const std::vector<std::string> & missingColumns, const std::map<std::string, std::string> & changeNameColumns, bool rowCountChanged);
 
 	Q_INVOKABLE	void	removeColumn();
 	Q_INVOKABLE void	sendCode(QString code);

--- a/JASP-Desktop/datasettablemodel.cpp
+++ b/JASP-Desktop/datasettablemodel.cpp
@@ -87,7 +87,7 @@ int DataSetTableModel::columnCount(const QModelIndex &parent) const
 
 QVariant DataSetTableModel::data(const QModelIndex &index, int role) const
 {
-	if (_dataSet == NULL)
+	if (_dataSet == NULL || _dataSet->synchingData())
 		return QVariant();
 
 	int column = index.column();

--- a/JASP-Desktop/importers/importer.cpp
+++ b/JASP-Desktop/importers/importer.cpp
@@ -246,6 +246,8 @@ void Importer::_syncPackage(
 		bool										rowCountChanged)
 
 {
+	_packageData->dataSet()->setSynchingData(true);
+
 	std::vector<std::string>			_changedColumns;
 	std::vector<std::string>			_missingColumns;
 	std::map<std::string, std::string>	_changeNameColumns;
@@ -304,6 +306,6 @@ void Importer::_syncPackage(
 		}
 	}
 
-	_packageData->dataChanged(_packageData, _changedColumns, _missingColumns, _changeNameColumns);
-
+	_packageData->dataSet()->setSynchingData(false);
+	_packageData->dataChanged(_packageData, _changedColumns, _missingColumns, _changeNameColumns, rowCountChanged);
 }

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -74,17 +74,10 @@ private:
 	void initQWidgetGUIParts();
 	void StartOnlineDataManager();
 
-	void refreshAnalysesUsingColumns(std::vector<std::string> &changedColumns
-									, std::vector<std::string> &missingColumns
-									, std::map<std::string, std::string> &changeNameColumns);
-
 
 	void packageChanged(DataSetPackage *package);
-	void packageDataChanged(DataSetPackage *package
-							, std::vector<std::string> &changedColumns
-							, std::vector<std::string> &missingColumns
-							, std::map<std::string, std::string> &changeNameColumns
-							);
+	void packageDataChanged(DataSetPackage *package, std::vector<std::string> &changedColumns, std::vector<std::string> &missingColumns, std::map<std::string, std::string> &changeNameColumns,	bool rowCountChanged);
+	void refreshAnalysesUsingColumns(std::vector<std::string> &changedColumns, std::vector<std::string> &missingColumns, std::map<std::string, std::string> &changeNameColumns, bool rowCountChanged);
 
 	void setDataSetAndPackageInModels(DataSetPackage *package);
 	bool closeRequestCheck(bool &isSaving);
@@ -129,6 +122,7 @@ private slots:
 	void removeAllAnalyses();
 	void refreshAllAnalyses();
 	void refreshAnalysesUsingColumn(QString col);
+	void updateShownVariablesModel();
 
 	void tabChanged(int index);
 	void helpToggled(bool on);

--- a/JASP-Desktop/variablespage/labelfiltergenerator.h
+++ b/JASP-Desktop/variablespage/labelfiltergenerator.h
@@ -14,6 +14,8 @@ public:
 	///Generates entire filter
 	std::string generateFilter();
 
+	void regenerateFilter() { emit setGeneratedFilter(QString::fromStdString(generateFilter())); }
+
 public slots:
 	void labelFilterChanged();
 	void easyFilterConstructorRCodeChanged(QString newRScript);

--- a/JASP-Engine/engine.h
+++ b/JASP-Engine/engine.h
@@ -76,6 +76,8 @@ private:
 	void runFilter();
 	void runComputeColumn();
 
+	void waitForDatasetSync();
+
 	void removeNonKeepFiles(Json::Value filesToKeepValue);
 	void saveImage();
     void editImage();

--- a/JASP-Engine/rbridge.cpp
+++ b/JASP-Engine/rbridge.cpp
@@ -231,12 +231,12 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 	if (resultCols)
 		freeRBridgeColumns(resultCols, lastColMax);
 	lastColMax = colMax;
-	resultCols = (RBridgeColumn*)calloc(colMax + 1, sizeof(RBridgeColumn));
+	resultCols = static_cast<RBridgeColumn*>(calloc(colMax + 1, sizeof(RBridgeColumn)));
 
 	int filteredRowCount = obeyFilter ? rbridge_dataSet->filteredRowCount() : rbridge_dataSet->rowCount();
 
 	// lets make some rownumbers/names for R that takes into account being filtered or not!
-	resultCols[colMax].ints		= (int*)calloc(filteredRowCount, sizeof(int));
+	resultCols[colMax].ints		= static_cast<int*>(calloc(filteredRowCount, sizeof(int)));
 	resultCols[colMax].nbRows	= filteredRowCount;
 	int filteredRow				= 0;
 
@@ -247,14 +247,14 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 
 	for (int colNo = 0; colNo < colMax; colNo++)
 	{
-		RBridgeColumnType& columnInfo = colHeaders[colNo];
-		RBridgeColumn& resultCol = resultCols[colNo];
+		RBridgeColumnType& columnInfo	= colHeaders[colNo];
+		RBridgeColumn& resultCol		= resultCols[colNo];
 
-		std::string columnName = columnInfo.name;
-		resultCol.name = strdup(Base64::encode("X", columnName, Base64::RVarEncoding).c_str());
+		std::string columnName			= columnInfo.name;
+		resultCol.name					= strdup(Base64::encode("X", columnName, Base64::RVarEncoding).c_str());
 
-		Column &column = columns.get(columnName);
-		Column::ColumnType columnType = column.columnType();
+		Column &column					= columns.get(columnName);
+		Column::ColumnType columnType	= column.columnType();
 
 		Column::ColumnType requestedType = (Column::ColumnType)columnInfo.type;
 		if (requestedType == Column::ColumnTypeUnknown)
@@ -560,10 +560,9 @@ void freeRBridgeColumns(RBridgeColumn *columns, int colMax)
 	{
 		RBridgeColumn& column = columns[i];
 		free(column.name);
-		if (column.isScale)
-			free(column.doubles);
-		else
-			free(column.ints);
+		if (column.isScale)	free(column.doubles);
+		else				free(column.ints);
+
 		if (column.hasLabels)
 			freeLabels(column.labels, column.nbLabels);
 	}


### PR DESCRIPTION
- fixed crashing on resizing data in synched data
- also preliminary change to make sure that jaspEngine doesn't start pulling in data that is in the midst of being synched. Not well-tested though.
- Make JASP crash less when synching large data from csv
- New computed columns are now also added to an opened analysisforms available variables model

