### PR TITLE
Missing 'Save As' dialog in OSF

### DIFF
--- a/JASP-Desktop/backstage/BackstageOSF.qml
+++ b/JASP-Desktop/backstage/BackstageOSF.qml
@@ -1,15 +1,18 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.2
+import JASP.Theme 1.0
 
 
 Rectangle
 {
 	id:rect
+	
 	objectName: "rect"
 	color: "#ececec"
 	
 	property bool loggedin : backstageosf.loggedin
 	property bool processing : backstageosf.processing
+	
 	
 	Label
 	{
@@ -75,10 +78,134 @@ Rectangle
 	}
 	
 	
+	/////////////////////////// File to save ////////////////////////////////////
+	
 	ToolSeparator
 	{
 		id: firstSeparator
 		anchors.top: osfbreadcrumbs.bottom
+		anchors.topMargin: 6
+		width: rect.width
+		orientation: Qt.Horizontal
+	}
+	
+	Label {
+		id : saveFilenameLabel
+		
+		width: 80
+		height: 30
+		anchors.top: firstSeparator.bottom
+		anchors.left: parent.left
+		anchors.leftMargin: 12
+		anchors.topMargin: 6
+		
+		text : "Filename"
+		font.family: "SansSerif"
+		font.pixelSize: 14
+		color: "black"
+		verticalAlignment: Text.AlignVCenter
+	}
+	
+	Rectangle{
+		
+		id: saveFilenameInput
+		
+		visible: true
+		
+		anchors.left: saveFilenameLabel.right
+		anchors.leftMargin: 6		
+		anchors.top: saveFilenameLabel.top			
+		anchors.right: parent.right
+		anchors.rightMargin: 12
+		height: saveFilenameLabel.height
+		clip: true
+		
+		color: "white"			
+		border.width: filenameText.activeFocus ? 5 : 1
+		border.color: filenameText.activeFocus ? Theme.focusBorderColor : "darkgray"
+		
+		TextInput {
+			
+			id: filenameText
+			
+			anchors.fill: parent
+			anchors.leftMargin: 10
+			selectByMouse: true
+			
+			text: backstageosf.savefilename
+			
+			verticalAlignment: Text.AlignVCenter			
+			font.pixelSize: 14
+						
+			onAccepted: {
+				backstageosf.saveFile(filenameText.text)
+			}
+		}		
+	}
+	
+	Button {
+		id: newDirectoryButton
+		
+		visible: true
+		
+		background: Rectangle {
+			anchors.fill: parent
+			gradient: Gradient {
+				GradientStop { position: 0 ; color:  "#e5e5e5" }
+				GradientStop { position: 1 ; color:  "white" }
+			}
+			border.color: "gray"
+			border.width: 1
+		}
+		
+		text: "New Folder"
+		width: 100
+		height: 20
+		anchors.right: saveFilenameButton.left
+		anchors.top: saveFilenameInput.bottom
+		anchors.rightMargin: 12
+		anchors.topMargin: 6
+		
+		onClicked: {
+			backstageosf.newFolderClicked()
+		}
+	}
+	
+	Button {
+		id: saveFilenameButton
+		
+		visible: true
+		
+		background: Rectangle {
+			anchors.fill: parent
+			gradient: Gradient {
+				GradientStop { position: 0 ; color:  "#e5e5e5" }
+				GradientStop { position: 1 ; color:  "white" }
+			}
+			border.color: "gray"
+			border.width: 1
+		}
+		
+		text: "Save"
+		width: 80
+		height: 20
+		anchors.right: parent.right
+		anchors.top: newDirectoryButton.top
+		anchors.rightMargin: 12
+		
+		onClicked: {
+			backstageosf.saveFile(filenameText.text)	
+		}
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////////
+	
+
+		
+	ToolSeparator
+	{
+		id: secondSeparator
+		anchors.top: saveFilenameButton.bottom
 		width: rect.width
 		orientation: Qt.Horizontal
 	}
@@ -105,8 +232,8 @@ Rectangle
 		
 		visible: loggedin && !processing
 		
-		anchors.top: firstSeparator.bottom
-		anchors.bottom: secondSeparator.top
+		anchors.top: secondSeparator.bottom
+		anchors.bottom: thirdSeparator.top
 		anchors.left: parent.left
 		anchors.right: parent.right
 		anchors.leftMargin: 12  //Position datalibrary items
@@ -132,7 +259,7 @@ Rectangle
 	
 	ToolSeparator
 	{
-		id: secondSeparator
+		id: thirdSeparator
 		
 		anchors.bottom: linkOSF.top
 		width: rect.width

--- a/JASP-Desktop/backstage/backstageosf.cpp
+++ b/JASP-Desktop/backstage/backstageosf.cpp
@@ -22,6 +22,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QQmlEngine>
+#include <QFileInfo>
 
 #include "settings.h"
 #include "qutils.h"
@@ -79,6 +80,16 @@ bool BackstageOSF::processing()
 	return _mProcessing;
 }
 
+bool BackstageOSF::showfiledialog()
+{
+	return _mShowFileDialog;
+}
+
+QString BackstageOSF::savefilename()
+{
+	return _mSaveFileName;
+}
+
 QString BackstageOSF::username()
 {
 	return _mUserName;
@@ -110,6 +121,18 @@ void BackstageOSF::setProcessing(const bool processing)
 {
 	_mProcessing = processing;
 	emit processingChanged();
+}
+
+void BackstageOSF::setSavefilename(const QString &savefilename)
+{
+	_mSaveFileName = savefilename;
+	emit savefilenameChanged();
+}
+
+void BackstageOSF::setShowfiledialog(const bool showdialog)
+{
+	_mShowFileDialog = showdialog;
+	emit showfiledialogChanged();
 }
 
 void BackstageOSF::setUsername(const QString &username)
@@ -162,6 +185,7 @@ void BackstageOSF::attemptToConnect()
 void BackstageOSF::setCurrentFileName(QString currentFileName)
 {
 	_currentFileName = currentFileName;
+	setSavefilename(currentFileName);
 }
 
 void BackstageOSF::setMode(FileEvent::FileMode mode)
@@ -174,6 +198,7 @@ void BackstageOSF::setMode(FileEvent::FileMode mode)
 void BackstageOSF::notifyDataSetSelected(QString path)
 {
 	//_fileNameTextBox->setText(QFileInfo(path).fileName());
+	setSavefilename(QFileInfo(path).fileName());
 }
 
 
@@ -199,7 +224,7 @@ void BackstageOSF::saveClicked()
 	}
 
 	///QString filename = _fileNameTextBox->text();
-	QString filename = "IMPLEMENT  ME!";
+	QString filename = _mSaveFileName;
 
 	if (checkEntryName(filename, "File", true) == false)
 		return;
@@ -222,7 +247,10 @@ void BackstageOSF::openSaveFile(const QString &nodePath, const QString &filename
 	{
 		if (storedata)
 		{
-				setProcessing(true);
+
+			setSavefilename(filename);
+			
+			setProcessing(true);
 
 			connect(event, SIGNAL(completed(FileEvent*)), this, SLOT(openSaveCompleted(FileEvent*)));
 		}
@@ -284,6 +312,8 @@ void BackstageOSF::newFolderCreated()
 		QMessageBox::warning(this, "", "An error occured and the folder could not be created.");
 	else
 		_model->refresh();
+	
+	setProcessing(false);
 }
 
 void BackstageOSF::newFolderClicked()
@@ -314,6 +344,8 @@ void BackstageOSF::newFolderClicked()
 
 	if (ok)
 	{
+		setProcessing(true);
+		
 		emit newFolderRequested(name);
 
 		if (_model->hasFolderEntry(name.toLower()) == false)
@@ -407,6 +439,13 @@ void BackstageOSF::loginRequested(const QString &username, const QString &passwo
 void BackstageOSF::openFile(const QString &path)
 {
 	emit openFileRequest(path);
+}
+
+void BackstageOSF::saveFile(const QString &name)
+{
+	_mSaveFileName = name;
+	saveClicked();
+	
 }
 
 void BackstageOSF::startProcessing()

--- a/JASP-Desktop/backstage/backstageosf.h
+++ b/JASP-Desktop/backstage/backstageosf.h
@@ -34,11 +34,13 @@ class BackstageOSF: public BackstagePage
 {
 	Q_OBJECT
 	
-	Q_PROPERTY(bool loggedin	READ loggedin	WRITE setLoggedin		NOTIFY loggedinChanged)
-	Q_PROPERTY(bool rememberme	READ rememberme WRITE setRememberme		NOTIFY remembermeChanged)
-	Q_PROPERTY(bool processing	READ processing WRITE setProcessing		NOTIFY processingChanged)
-	Q_PROPERTY(QString username	READ username	WRITE setUsername		NOTIFY usernameChanged)
-	Q_PROPERTY(QString password	READ password	WRITE setPassword		NOTIFY passwordChanged)
+	Q_PROPERTY(	bool	loggedin		READ loggedin		WRITE setLoggedin		NOTIFY loggedinChanged)
+	Q_PROPERTY(	bool	processing		READ processing		WRITE setProcessing		NOTIFY processingChanged)
+	Q_PROPERTY(	bool	showfiledialog	READ showfiledialog WRITE setShowfiledialog NOTIFY showfiledialogChanged)
+	Q_PROPERTY(	QString	savefilename	READ savefilename	WRITE setSavefilename	NOTIFY savefilenameChanged)	
+	Q_PROPERTY(	bool	rememberme		READ rememberme		WRITE setRememberme		NOTIFY remembermeChanged)
+	Q_PROPERTY(	QString	username		READ username		WRITE setUsername		NOTIFY usernameChanged)
+	Q_PROPERTY(	QString	password		READ password		WRITE setPassword		NOTIFY passwordChanged)
 	
 	
 public:
@@ -47,14 +49,18 @@ public:
 	bool loggedin();	
 	bool rememberme();
 	bool processing();
+	bool showfiledialog();
+	QString savefilename();
 	QString username();
 	QString password();
 	
 	void setLoggedin(const bool loggedin);	
 	void setRememberme(const bool rememberme);
-	void setProcessing(const bool processing);	
+	void setProcessing(const bool processing);
+	void setSavefilename(const QString &savefilename);	
+	void setShowfiledialog(const bool showdialog);
 	void setUsername(const QString &username);		
-	void setPassword(const QString &username);	
+	void setPassword(const QString &password);	
 		
 	void setOnlineDataManager(OnlineDataManager *odm);
 	void attemptToConnect();
@@ -67,6 +73,8 @@ signals:
 	void loggedinChanged();
 	void remembermeChanged();
 	void processingChanged();
+	void savefilenameChanged();
+	void showfiledialogChanged();
 	void usernameChanged();
 	void passwordChanged();
 	void openFileRequest(QString path);
@@ -80,7 +88,7 @@ private slots:
 	void openSaveCompleted(FileEvent* event);
 	void updateUserDetails();
 	void newFolderCreated();
-	void newFolderClicked();
+//	void newFolderClicked();
 	void authenticatedHandler();
 	void resetOSFListModel();
 	
@@ -93,8 +101,11 @@ public slots:
 	void updateLoginScreen();
 	void loginRequested(const QString &username, const QString &password);
 	void openFile(const QString &name);
+	void saveFile(const QString &name);
 	void startProcessing();
 	void stopProcessing();
+	void newFolderClicked();
+	
 	
 private:	
 	bool checkEntryName(QString name, QString entryTitle, bool allowFullStop);	
@@ -110,6 +121,8 @@ private:
 	bool _mLoggedin;
 	bool _mRememberMe;
 	bool _mProcessing;
+	bool _mShowFileDialog;
+	QString _mSaveFileName;
 	QString _mUserName;
 	QString _mPassword;
 		

--- a/JASP-Engine/JASP/R/anovarepeatedmeasuresbayesian.R
+++ b/JASP-Engine/JASP/R/anovarepeatedmeasuresbayesian.R
@@ -208,8 +208,8 @@ if (is.null(state)) {
 	new.state <- list(options = options, model = model, status = status, keep = keepDescriptivesPlot)
 
 	if (perform == "run" || ! status$ready || ! is.null(state)) {
-		return(list(results = results, status = "complete", state = new.state))
+		return(list(results = results, status = "complete", state = new.state, keep = keepDescriptivesPlot))
 	} else {
-		return(list(results = results, status = "inited"))
+		return(list(results = results, status = "inited", keep = keepDescriptivesPlot))
 	}
 }


### PR DESCRIPTION
Due to the QML integration the File dialog to save or export files in the OSF was disappeared. This has been fixed.