### PR TITLE
fixed initialization bug

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2906,8 +2906,7 @@ createJaspState <- function(object=NULL, title="", dependencies=NULL, position=N
 {
   stateObj <- jaspResultsModule$create_cpp_jaspState(title) # If we use R's constructor it will garbage collect our objects prematurely.. #
 
-  if(!is.null(object))
-    stateObj$object <- object
+  stateObj$object <- object
 
   if(!is.null(dependencies))
       stateObj$dependOnTheseOptions(dependencies)

--- a/JASP-R-Interface/jaspResults/R/zzzWrappers.R
+++ b/JASP-R-Interface/jaspResults/R/zzzWrappers.R
@@ -159,6 +159,10 @@ createJaspPlot <- function(plot=NULL, title="", width=320, height=320, aspectRat
 			jaspPlotObj$filePathPng <- writtenImage[["png"]]
       jaspPlotObj$plotObject <- plot
 		}
+  } 
+  else
+  {
+		jaspPlotObj$plotObject <- plot
 	}
 
   if(!is.null(dependencies))
@@ -245,8 +249,7 @@ createJaspState <- function(object=NULL, title="", dependencies=NULL, position=N
 
   stateObj <- create_cpp_jaspState(title) # If we use R's constructor it will garbage collect our objects prematurely.. #
 
-  if(!is.null(object))
-    stateObj$object <- object
+  stateObj$object <- object
 
   if(!is.null(dependencies))
     stateObj$dependOnTheseOptions(dependencies)


### PR DESCRIPTION
if a `jaspPlot` or `jaspState` was initialized with `NULL`, the `NULL` wasn't actually stored. As a consequence, R bugs out when trying to access the object. Example:

```
library(jaspResults)
p <- createJaspPlot()
s <- createJaspState()

# previously crashed R
p$plotObject
s$object

# as a consequence, these also crashed R
str(s)
str(p)
```

The wrapper for `createJaspPlot()` in `common.R` already did this correctly.