### PR TITLE
OSF progress indicator will not stop after failed login

### DIFF
--- a/JASP-Desktop/backstage/fsbmosf.cpp
+++ b/JASP-Desktop/backstage/fsbmosf.cpp
@@ -123,8 +123,9 @@ void FSBMOSF::setAuthenticated(bool value)
 	}
 	else
 	{
+		emit stopProcessing();
 		_isAuthenticated = false;
-		emit authenticationFail("Username and/or password are not correct. Please try again.");
+		emit authenticationFail("Username and/or password are not correct. Please try again.");		
 	}
 }
 


### PR DESCRIPTION
When a wrong user or password is entered in the OSF login the progressindicator keeps running. This has been fixed. Only a switch in the tab menu can solve this.
