### PR TITLE
jaspObjects print nicer now

### DIFF
--- a/JASP-R-Interface/jaspResults/DESCRIPTION
+++ b/JASP-R-Interface/jaspResults/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: jaspResults
 Type: Package
 Title: Easy results for your JASP analysis
-Version: 1.0
-Date: 2018-02-23
+Version: 1.1
+Date: 2018-10-11
 Author: Joris Goosen
 Maintainer: JASP Team <info@jasp-stats.org>
 Description: This package helps you build your analysis for JASP (http://jasp-stats.org).

--- a/JASP-R-Interface/jaspResults/R/zzzWrappers.R
+++ b/JASP-R-Interface/jaspResults/R/zzzWrappers.R
@@ -147,29 +147,13 @@ createJaspPlot <- function(plot=NULL, title="", width=320, height=320, aspectRat
     jaspPlotObj$errorMessage  <- errorMessage
   }
 
-  if(!is.null(plot))
-	{
-		writtenImage <- tryCatch(
-			.writeImage(width=width, height=height, plot),
-			error	= function(e) { jaspPlotObj$errorMessage <- e$message; return(NULL) }
-		)
-
-		if(!is.null(writtenImage))
-		{
-			jaspPlotObj$filePathPng <- writtenImage[["png"]]
-      jaspPlotObj$plotObject <- plot
-		}
-  } 
-  else
-  {
-		jaspPlotObj$plotObject <- plot
-	}
+  jaspPlotObj$plotObject <- plot
 
   if(!is.null(dependencies))
     jaspPlotObj$dependOnTheseOptions(dependencies)
 
-	if(is.numeric(position))
-		jaspPlotObj$position = position
+  if(is.numeric(position))
+    jaspPlotObj$position = position
 
   return(jaspPlotObj)
 }
@@ -183,8 +167,8 @@ createJaspContainer <- function(title="", dependencies=NULL, position=NULL)
   if(!is.null(dependencies))
     container$dependOnTheseOptions(dependencies)
 
-	if(is.numeric(position))
-		container$position = position
+  if(is.numeric(position))
+    container$position = position
 
   return(container)
 }
@@ -194,7 +178,7 @@ createJaspTable <- function(title="", data=NULL, colNames=NULL, colTitles=NULL, 
   checkForJaspResultsInit()
 
   jaspObj <- create_cpp_jaspTable(title) # If we use R's constructor it will garbage collect our objects prematurely.. #new(jaspResultsModule$jaspTable, title)
-  jaspObj <- as(jaspObj, "jaspTableExtended") #We extend it so we may use addColumnInfo and addFootnote. Sadly enough this breaks for tables coming from a container.. This does however work in JASP and I cant get it to work in stand-alone. (This might be fixed by DvB)
+  jaspObj <- as(jaspObj, "jaspTableExtended") #We extend it so we may use addColumnInfo and addFootnote. Sadly enough this breaks for tables coming from a container.. This does however work in JASP but I cant get it to work in stand-alone. (This might be fixed by DvB)
 
   if(!is.null(data))
     jaspObj$setData(data)

--- a/JASP-R-Interface/jaspResults/src/jaspContainer.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspContainer.cpp
@@ -82,12 +82,25 @@ Rcpp::RObject jaspContainer::at(std::string field)
 std::string jaspContainer::dataToString(std::string prefix)
 {
 	std::stringstream out;
-	out << prefix << "{\n";
 
 	for(auto key : getSortedDataFields())
-		out << prefix << "\t\"" << key << "\": " << _data[key]->toString(prefix + "\t") << ",\n";
+		out << prefix << "\"" << key << "\":\n" << _data[key]->toString(prefix + "\t") << "\n";
 
-	out << prefix << "}";
+	return out.str();
+}
+
+std::string jaspContainer::toHtml()
+{
+	std::stringstream out;
+
+	out		<< "<div class=\"jaspHtml\">" "\n"
+			<< htmlTitle() << "\n"
+			<< "<ul>";
+
+	for(auto key : getSortedDataFields())
+		out << "<li><p><b>" << key << "</b></p>" << _data[key]->toHtml() << "</li>\n";
+
+	out << "</ul>" "\n" "</div>" "\n";
 
 	return out.str();
 }

--- a/JASP-R-Interface/jaspResults/src/jaspContainer.h
+++ b/JASP-R-Interface/jaspResults/src/jaspContainer.h
@@ -21,7 +21,8 @@ public:
 
 	jaspContainer(const jaspContainer& that) = delete;
 
-	std::string dataToString(std::string prefix = "") override;
+	std::string dataToString(std::string prefix = "")	override;
+	std::string toHtml()								override;
 
 	void			insert(std::string field, Rcpp::RObject value);
 	Rcpp::RObject	at(std::string field);

--- a/JASP-R-Interface/jaspResults/src/jaspHtml.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspHtml.cpp
@@ -33,6 +33,11 @@ std::string jaspHtml::convertTextToHtml(std::string text)
     return out.str();
 }
 
+std::string jaspHtml::toHtml()
+{
+	return "<div class=\"jaspHtml\">" "\n" + htmlTitle() + "\n" + dataToString() + "</div>" "\n";
+}
+
 Json::Value jaspHtml::dataEntry()
 {
 	Json::Value data(jaspObject::dataEntry());

--- a/JASP-R-Interface/jaspResults/src/jaspHtml.h
+++ b/JASP-R-Interface/jaspResults/src/jaspHtml.h
@@ -9,6 +9,7 @@ public:
 	~jaspHtml() {}
 
 	std::string dataToString(std::string prefix="") override;
+	std::string toHtml()							override;
 
 	Json::Value	metaEntry() override { return constructMetaEntry("htmlNode"); }
 	Json::Value	dataEntry() override;

--- a/JASP-R-Interface/jaspResults/src/jaspList.h
+++ b/JASP-R-Interface/jaspResults/src/jaspList.h
@@ -196,9 +196,6 @@ public:
 			else if(std::is_same<T, int>::value)	_field_to_val[memberName] = convertIntFromJson(fieldVal);
 			else if(std::is_same<T, bool>::value)	_field_to_val[memberName] = convertBoolFromJson(fieldVal);
 		}
-
-
-
 	}
 
 private:
@@ -223,9 +220,9 @@ class jaspList_Interface : public jaspObject_Interface
 public:
 	jaspList_Interface(jaspObject * dataObj) : jaspObject_Interface(dataObj) {}
 
-	void insert(Rcpp::RObject field, T value)	{ ((jaspList<T>*)myJaspObject)->insert(field, value); }
-	T at(Rcpp::RObject field)					{ return ((jaspList<T>*)myJaspObject)->at(field); }
-	void add(T value)							{ ((jaspList<T>*)myJaspObject)->add(value); }
+	void insert(Rcpp::RObject field, T value)	{			static_cast<jaspList<T>*>(myJaspObject)->insert(field, value);	}
+	T at(Rcpp::RObject field)					{ return	static_cast<jaspList<T>*>(myJaspObject)->at(field);				}
+	void add(T value)							{			static_cast<jaspList<T>*>(myJaspObject)->add(value);			}
 };
 
 typedef jaspList_Interface<std::string>	jaspStringlist_Interface;

--- a/JASP-R-Interface/jaspResults/src/jaspModuleRegistration.h
+++ b/JASP-R-Interface/jaspResults/src/jaspModuleRegistration.h
@@ -21,6 +21,8 @@ RCPP_MODULE(jaspResults)
 	Rcpp::class_<jaspObject_Interface>("jaspObject")
 
 		.method("print",							&jaspObject_Interface::print,											"Prints the contents of the jaspObject")
+		.method("toHtml",							&jaspObject_Interface::toHtml,											"gives a string with the contents of the jaspObject nicely formatted as html")
+		.method("printHtml",						&jaspObject_Interface::printHtml,										"Prints the contents of the jaspObject nicely formatted as html")
 
 		.method("addMessage",						&jaspObject_Interface::addMessage,										"Add a message to this object")
 		.method("addCitation",						&jaspObject_Interface::addCitation,										"Add a citation to this object")

--- a/JASP-R-Interface/jaspResults/src/jaspObject.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspObject.cpp
@@ -44,12 +44,42 @@ jaspObjectType jaspObjectTypeStringToObjectType(std::string type)
 
 }
 
-void JASPprint(std::string msg)
+std::string stringExtend(std::string & str, size_t len, char kar)
+{
+	if(str.size() < len)
+		str += std::string(len - str.size(), kar);
+
+	return str;
+}
+
+std::string stringRemove(std::string str, char kar)
+{
+	for(size_t removeMe = str.find_first_of(kar); removeMe != std::string::npos; removeMe = str.find_first_of(kar))
+		str.erase(removeMe, 1);
+	return str;
+}
+
+std::vector<std::string> stringSplit(std::string str, char kar)
+{
+	std::vector<std::string> strs;
+
+	strs.push_back("");
+	for(char k : str)
+		if(k == kar)
+			strs.push_back("");
+		else
+			strs[strs.size() - 1].push_back(k);
+
+	return strs;
+}
+
+void jaspPrint(std::string msg)
 {
 #ifdef JASP_R_INTERFACE_LIBRARY
 	std::cout << msg << std::endl << std::flush;
 #else
-	Rprintf(msg.c_str());
+	Rcpp::Rcout << msg << "\n";
+	//Rprintf(msg.c_str());
 #endif
 }
 
@@ -168,8 +198,8 @@ void jaspObject::childrenUpdatedCallback()
 
 std::string jaspObject::toString(std::string prefix)
 {
-	std::string dataString = dataToString(prefix);
-	return objectTitleString() + (dataString == "" ? "" : "\n" + dataString);
+	std::string dataString = dataToString(prefix + "\t");
+	return objectTitleString(prefix) + (dataString == "" ? "\n" : ":\n" + dataString);
 }
 
 Rcpp::DataFrame jaspObject::convertFactorsToCharacters(Rcpp::DataFrame df)

--- a/JASP-R-Interface/jaspResults/src/jaspObject.h
+++ b/JASP-R-Interface/jaspResults/src/jaspObject.h
@@ -9,7 +9,7 @@
 #include "lib_json/json.h"
 #endif
 
-void JASPprint(std::string msg);
+void jaspPrint(std::string msg);
 
 enum class jaspObjectType { unknown, container, table, plot, json, list, results, html, state };
 
@@ -18,6 +18,10 @@ enum class jaspObjectType { unknown, container, table, plot, json, list, results
 
 std::string		jaspObjectTypeToString(jaspObjectType type);
 jaspObjectType	jaspObjectTypeStringToObjectType(std::string type);
+
+std::string					stringExtend(std::string & str, size_t len, char kar = ' ');
+std::string					stringRemove(std::string str, char kar = ' ');
+std::vector<std::string>	stringSplit(std::string str, char kar = ';');
 
 //Simple base-class for all JASP-objects, containing things like a title or a warning and stuff like that
 class jaspObject
@@ -29,14 +33,17 @@ public:
 						jaspObject(const jaspObject& that) = delete;
 	virtual				~jaspObject();
 
-			std::string objectTitleString()					{ return jaspObjectTypeToString(_type) + "(\"" + _title + "\")"; }
-	virtual	std::string dataToString(std::string prefix)	{ return ""; }
+			std::string objectTitleString(std::string prefix)	{ return prefix + jaspObjectTypeToString(_type) + " " + _title; }
+	virtual	std::string dataToString(std::string)				{ return ""; }
 			std::string toString(std::string prefix = "");
+
+	virtual std::string toHtml() { return ""; }
+			std::string htmlTitle() { return "<h2>" + _title + "</h2>"; }
 
 			std::string	getWarning()						{ return _warning; }
 			void		setWarning(std::string warning)		{ _warning = warning; _warningSet = true; }
 
-			void		print()								{ try { JASPprint(toString()); } catch(std::exception e) { JASPprint(std::string("toString failed because of: ") + e.what()); } }
+			void		print()								{ try { jaspPrint(toString()); } catch(std::exception e) { jaspPrint(std::string("toString failed because of: ") + e.what()); } }
 			void		addMessage(std::string msg)			{ _messages.push_back(msg); }
 	virtual void		childrenUpdatedCallbackHandler()	{} ///Can be caugt by jaspResults to send changes and stuff like that.
 
@@ -164,6 +171,8 @@ public:
 
 	void		print()								{ myJaspObject->print(); }
 	void		addMessage(std::string msg)			{ myJaspObject->addMessage(msg); }
+	std::string	toHtml()							{ return myJaspObject->toHtml(); }
+	void		printHtml()							{ jaspPrint(myJaspObject->toHtml()); }
 
 	void		setOptionMustBeDependency(std::string optionName, Rcpp::RObject mustBeThis)				{ myJaspObject->setOptionMustBeDependency(optionName, mustBeThis);				}
 	void		setOptionMustContainDependency(std::string optionName, Rcpp::RObject mustContainThis)	{ myJaspObject->setOptionMustContainDependency(optionName, mustContainThis);	}

--- a/JASP-R-Interface/jaspResults/src/jaspPlot.h
+++ b/JASP-R-Interface/jaspResults/src/jaspPlot.h
@@ -22,6 +22,7 @@ public:
 
 	Json::Value	metaEntry() override { return constructMetaEntry("image"); }
 	Json::Value	dataEntry() override;
+	std::string toHtml()	override;
 
 	Json::Value convertToJSON() override;
 	void		convertFromJSON_SetFields(Json::Value in) override;

--- a/JASP-R-Interface/jaspResults/src/jaspResults.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspResults.cpp
@@ -63,7 +63,7 @@ void jaspResults::saveResults()
 {
 	if(_saveResultsHere == "")
 	{
-		JASPprint("Did not store jaspResults");
+		jaspPrint("Did not store jaspResults");
 		return;
 	}
 

--- a/JASP-R-Interface/jaspResults/src/jaspState.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspState.cpp
@@ -34,3 +34,13 @@ Rcpp::RObject jaspState::getObject()
 	Rcpp::Function unserialize("unserialize");
 	return unserialize(_stateObjectSerialized);
 }
+
+
+std::string jaspState::dataToString(std::string prefix)
+{
+	std::stringstream out;
+
+	out << prefix << "object stored: "	<< ( _stateObjectSerialized.size() == 0 ? "no" : "yes") << "\n";
+
+	return out.str();
+}

--- a/JASP-R-Interface/jaspResults/src/jaspState.h
+++ b/JASP-R-Interface/jaspResults/src/jaspState.h
@@ -12,6 +12,7 @@ public:
 
 	Json::Value convertToJSON() override;
 	void		convertFromJSON_SetFields(Json::Value in) override;
+	std::string dataToString(std::string prefix) override;
 
 private:
 	Rcpp::Vector<RAWSXP> _stateObjectSerialized;


### PR DESCRIPTION
Made the print functions of the jaspObjects more alike and showing all of their properties.

overtitles are now taken into account and table is formatted nicely in ascii-art. Also makes sure columns are only shown when specified when required etc etc

All jaspObjects should now be able to print nicely to html, which still needs some css magic to make it look not-horrible though.

