### PR TITLE
Computed Columns Factor Values Redux

### DIFF
--- a/JASP-Common/column.cpp
+++ b/JASP-Common/column.cpp
@@ -594,6 +594,8 @@ bool Column::changeColumnType(Column::ColumnType newColumnType)
 
 bool Column::overwriteDataWithScale(std::vector<double> scalarData)
 {
+	labels().clear();
+
 	size_t setVals = scalarData.size();
 
 	if(scalarData.size() != rowCount())
@@ -607,6 +609,8 @@ bool Column::overwriteDataWithScale(std::vector<double> scalarData)
 
 bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData, std::map<int, std::string> levels)
 {
+	labels().clear();
+
 	size_t setVals = ordinalData.size();
 
 	if(ordinalData.size() != rowCount())
@@ -620,6 +624,8 @@ bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData, std::map<int
 
 bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData)
 {
+	labels().clear();
+
 	size_t setVals = ordinalData.size();
 
 	if(ordinalData.size() != rowCount())
@@ -633,6 +639,8 @@ bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData)
 
 bool Column::overwriteDataWithNominal(std::vector<int> nominalData, std::map<int, std::string> levels)
 {
+	labels().clear();
+
 	size_t setVals = nominalData.size();
 
 	if(nominalData.size() != rowCount())
@@ -646,6 +654,8 @@ bool Column::overwriteDataWithNominal(std::vector<int> nominalData, std::map<int
 
 bool Column::overwriteDataWithNominal(std::vector<int> nominalData)
 {
+	labels().clear();
+
 	size_t setVals = nominalData.size();
 
 	if(nominalData.size() != rowCount())
@@ -659,6 +669,8 @@ bool Column::overwriteDataWithNominal(std::vector<int> nominalData)
 
 bool Column::overwriteDataWithNominal(std::vector<std::string> nominalData)
 {
+	labels().clear();
+
 	if(nominalData.size() != rowCount())
 		nominalData.resize(rowCount());
 
@@ -682,6 +694,13 @@ void Column::setDefaultValues(Column::ColumnType columnType)
 	case ColumnTypeUnknown:		throw std::runtime_error("Trying to set default values of a column with unknown column type...");
 	}
 	_labels.clear();
+}
+
+bool Column::setColumnAsNominalOrOrdinal(const std::vector<int> &values, bool is_ordinal)
+{
+	std::set<int> uniqueValues(values.begin(), values.end());
+	uniqueValues.erase(INT_MIN);
+	return setColumnAsNominalOrOrdinal(values, uniqueValues, is_ordinal);
 }
 
 bool Column::setColumnAsNominalOrOrdinal(const vector<int> &values, map<int, string> &uniqueValues, bool is_ordinal)
@@ -756,6 +775,11 @@ bool Column::setColumnAsScale(const std::vector<double> &values)
 	setColumnType(Column::ColumnTypeScale);
 
 	return changedSomething;
+}
+
+std::map<int, std::string> Column::setColumnAsNominalText(const std::vector<std::string> &values, bool * changedSomething)
+{
+	return setColumnAsNominalText(values, std::map<std::string, std::string>(), changedSomething);
 }
 
 std::map<int, std::string> Column::setColumnAsNominalText(const std::vector<std::string> &values, const std::map<std::string, std::string>&labels, bool * changedSomething)

--- a/JASP-Common/column.h
+++ b/JASP-Common/column.h
@@ -203,11 +203,11 @@ public:
 	bool						setColumnAsScale(const std::vector<double> &values);
 
 	std::map<int, std::string>	setColumnAsNominalText(const std::vector<std::string> &values,	const std::map<std::string, std::string> &labels, bool * changedSomething = NULL);
-	std::map<int, std::string>	setColumnAsNominalText(const std::vector<std::string> &values, bool * changedSomething = NULL)	{ return setColumnAsNominalText(values, std::map<std::string, std::string>(), changedSomething); }
+	std::map<int, std::string>	setColumnAsNominalText(const std::vector<std::string> &values, bool * changedSomething = NULL);
 
 	bool						setColumnAsNominalOrOrdinal(const std::vector<int> &values,		const std::set<int> &uniqueValues,			bool is_ordinal = false);
 	bool						setColumnAsNominalOrOrdinal(const std::vector<int> &values,		std::map<int, std::string> &uniqueValues,	bool is_ordinal = false);
-	bool						setColumnAsNominalOrOrdinal(const std::vector<int> &values,													bool is_ordinal = false)	{ return setColumnAsNominalOrOrdinal(values, std::set<int>(values.begin(), values.end()), is_ordinal); }
+	bool						setColumnAsNominalOrOrdinal(const std::vector<int> &values,													bool is_ordinal = false);
 
 	bool allLabelsPassFilter() const;
 

--- a/JASP-Desktop/computedcolumnsmodel.cpp
+++ b/JASP-Desktop/computedcolumnsmodel.cpp
@@ -240,6 +240,20 @@ void ComputedColumnsModel::clearColumn(std::string columnName)
 
 }
 
+void ComputedColumnsModel::recomputeColumn(std::string columnName)
+{
+	clearColumn(columnName);
+	_computedColumns->findAllColumnNames();
+	try
+	{
+		ComputedColumn * col = &((*_computedColumns)[columnName]);
+		col->findDependencies();
+	}
+	catch(columnNotFound e){}
+
+	checkForDependentColumnsToBeSent(columnName, true);
+}
+
 void ComputedColumnsModel::checkForDependentColumnsToBeSent(std::string columnName, bool refreshMe)
 {
 	for(ComputedColumn * col : *_computedColumns)

--- a/JASP-Desktop/computedcolumnsmodel.h
+++ b/JASP-Desktop/computedcolumnsmodel.h
@@ -79,9 +79,9 @@ public slots:
 				void				computeColumnSucceeded(std::string columnName, std::string warning, bool dataChanged);
 				void				computeColumnFailed(std::string columnName, std::string error);
 				void				checkForDependentColumnsToBeSentSlot(std::string columnName)					{ checkForDependentColumnsToBeSent(columnName, false); }
-				void				checkForDependentColumnsAndMeToBeSentSlot(std::string columnName)				{ checkForDependentColumnsToBeSent(columnName, true); }
 				ComputedColumn *	requestComputedColumnCreation(std::string columnName, Analysis * analysis);
 				void				requestComputedColumnDestruction(std::string columnName);
+				void				recomputeColumn(std::string columnName);
 
 private:
 

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -189,7 +189,7 @@ void MainWindow::makeConnections()
 	connect(_tableModel,			&DataSetTableModel::modelReset,						_levelsTableModel,		&LevelsTableModel::refresh,									Qt::QueuedConnection);
 	connect(_tableModel,			&DataSetTableModel::headerDataChanged,				_columnsModel,			&ColumnsModel::datasetHeaderDataChanged						);
 	connect(_tableModel,			&DataSetTableModel::modelReset,						_columnsModel,			&ColumnsModel::refresh										);
-	connect(_tableModel,			&DataSetTableModel::columnDataTypeChanged,			_computedColumnsModel,	&ComputedColumnsModel::checkForDependentColumnsAndMeToBeSentSlot	);
+	connect(_tableModel,			&DataSetTableModel::columnDataTypeChanged,			_computedColumnsModel,	&ComputedColumnsModel::recomputeColumn						);
 
 	connect(_engineSync,			&EngineSync::computeColumnSucceeded,				_computedColumnsModel,	&ComputedColumnsModel::computeColumnSucceeded				);
 	connect(_engineSync,			&EngineSync::computeColumnFailed,					_computedColumnsModel,	&ComputedColumnsModel::computeColumnFailed					);

--- a/JASP-Desktop/resources/CreateComputeColumnDialog.qml
+++ b/JASP-Desktop/resources/CreateComputeColumnDialog.qml
@@ -212,7 +212,7 @@ Popup {
 
 			Repeater{
 				id: iconRepeater
-				model: [columnTypeScale, columnTypeOrdinal, columnTypeNominal] //, columnTypeNominalText] //these are set in the rootcontext in mainwindow!
+				model: [columnTypeScale, columnTypeOrdinal, columnTypeNominal, columnTypeNominalText] //these are set in the rootcontext in mainwindow!
 
 				Rectangle
 				{

--- a/JASP-Desktop/resources/DataTableView.qml
+++ b/JASP-Desktop/resources/DataTableView.qml
@@ -189,7 +189,7 @@ FocusScope
 
 							Repeater{
 								id: iconRepeater
-								model: //columnIsComputed ? [columnTypeScale, columnTypeOrdinal, columnTypeNominal, columnTypeNominalText] :
+								model: columnIsComputed ? [columnTypeScale, columnTypeOrdinal, columnTypeNominal, columnTypeNominalText] :
 														  [columnTypeScale, columnTypeOrdinal, columnTypeNominal] //these are set in the rootcontext in mainwindow!
 
 								Rectangle

--- a/JASP-Engine/engine.cpp
+++ b/JASP-Engine/engine.cpp
@@ -571,3 +571,36 @@ void Engine::waitForDatasetSync()
 		Utils::sleep(10);
 
 }
+
+bool Engine::setColumnDataAsNominalOrOrdinal(bool isOrdinal, std::string columnName, std::vector<int> data, std::map<int, std::string> levels)
+{
+	std::map<int, int> uniqueInts;
+
+	for(auto keyval : levels)
+	{
+		size_t convertedChars;
+
+		try {
+			int asInt = std::stoi(keyval.second, &convertedChars);
+
+			if(convertedChars == keyval.second.size()) //It was a number!
+				uniqueInts[keyval.first] = asInt;
+		}
+		catch(std::invalid_argument e) {}
+	}
+
+	if(uniqueInts.size() == levels.size()) //everything was an int!
+	{
+		for(auto & dat : data)
+			if(dat != INT_MIN)
+				dat = uniqueInts[dat];
+
+		if(isOrdinal)	return	provideDataSet()->columns()[columnName].overwriteDataWithOrdinal(data);
+		else			return	provideDataSet()->columns()[columnName].overwriteDataWithNominal(data);
+	}
+	else
+	{
+		if(isOrdinal)	return	provideDataSet()->columns()[columnName].overwriteDataWithOrdinal(data, levels);
+		else			return	provideDataSet()->columns()[columnName].overwriteDataWithNominal(data, levels);
+	}
+}

--- a/JASP-Engine/engine.h
+++ b/JASP-Engine/engine.h
@@ -58,9 +58,11 @@ public:
 
 	//return true if changed:
 	bool setColumnDataAsScale(std::string columnName, std::vector<double> scalarData)										{	return provideDataSet()->columns()[columnName].overwriteDataWithScale(scalarData);				}
-	bool setColumnDataAsOrdinal(std::string columnName, std::vector<int> ordinalData, std::map<int, std::string> levels)	{	return provideDataSet()->columns()[columnName].overwriteDataWithOrdinal(ordinalData, levels);	}
-	bool setColumnDataAsNominal(std::string columnName, std::vector<int> nominalData, std::map<int, std::string> levels)	{	return provideDataSet()->columns()[columnName].overwriteDataWithNominal(nominalData, levels);	}
+	bool setColumnDataAsOrdinal(std::string columnName, std::vector<int> ordinalData, std::map<int, std::string> levels)	{	return setColumnDataAsNominalOrOrdinal(true,  columnName, ordinalData, levels);					}
+	bool setColumnDataAsNominal(std::string columnName, std::vector<int> nominalData, std::map<int, std::string> levels)	{	return setColumnDataAsNominalOrOrdinal(false, columnName, nominalData, levels);					}
 	bool setColumnDataAsNominalText(std::string columnName, std::vector<std::string> nominalData)							{	return provideDataSet()->columns()[columnName].overwriteDataWithNominal(nominalData);			}
+
+	bool setColumnDataAsNominalOrOrdinal(bool isOrdinal, std::string columnName, std::vector<int> data, std::map<int, std::string> levels);
 
 	int dataSetRowCount()	{ return static_cast<int>(provideDataSet()->rowCount()); }
 


### PR DESCRIPTION
Made sure ordinal and nominal (number) columns get the integer values they are as "value" in JASP.

Also enabled nominal text again as I've worked out the kinks in the overwriting of strings.
Also made sure INT_MIN (-2......... number) doesnt show up anymore in label-editwindow

