### PR TITLE
Fixed saving with computed column

### DIFF
--- a/JASP-Common/computedcolumns.cpp
+++ b/JASP-Common/computedcolumns.cpp
@@ -6,6 +6,13 @@ Columns& ComputedColumns::columns()
 	return _package->dataSet()->columns();
 }
 
+
+void ComputedColumns::setPackageModified()
+{
+	if(_package != NULL)
+		_package->setModified(true);
+}
+
 ComputedColumn * ComputedColumns::createComputedColumn(std::string name, Column::ColumnType type, ComputedColumn::computedType desiredType)
 {
 	Column			* column			= columns().createColumn(name);
@@ -15,6 +22,7 @@ ComputedColumn * ComputedColumns::createComputedColumn(std::string name, Column:
 	column->setDefaultValues(type);
 
 	refreshColumnPointers();
+	setPackageModified();
 
 	return newComputedColumn;
 }
@@ -28,6 +36,8 @@ void ComputedColumns::removeComputedColumn(std::string name)
 			_computedColumns.erase(it);
 			break;
 		}
+
+	setPackageModified();
 
 	columns().removeColumn(name);  //This moves the columns, meaning the pointers in the other computeColumns are now no longer valid..
 	refreshColumnPointers();
@@ -53,7 +63,9 @@ bool ComputedColumns::setRCode(std::string name, std::string rCode)
 {
 	try
 	{
-		return (*this)[name].setRCode(rCode);
+		bool changed = (*this)[name].setRCode(rCode);
+		if(changed) setPackageModified();
+		return changed;
 	}
 	catch(...){}
 	return false;
@@ -63,7 +75,9 @@ bool ComputedColumns::setConstructorJson(std::string name, std::string json)
 {
 	try
 	{
-		return (*this)[name].setConstructorJson(json);
+		bool changed = (*this)[name].setConstructorJson(json);
+		if(changed) setPackageModified();
+		return changed;
 	}
 	catch(...){}
 	return false;
@@ -73,7 +87,9 @@ bool ComputedColumns::setError(std::string name, std::string error)
 {
 	try
 	{
-		return (*this)[name].setError(error);
+		bool changed = (*this)[name].setError(error);
+		if(changed) setPackageModified();
+		return changed;
 	}
 	catch(...){}
 	return false;

--- a/JASP-Common/computedcolumns.h
+++ b/JASP-Common/computedcolumns.h
@@ -35,6 +35,8 @@ public:
 	iterator			end()			{ return _computedColumns.end();	}
 	size_t				columnCount()	{ return _computedColumns.size();	}
 
+	void setPackageModified();
+
 			ComputedColumn & operator[](size_t i)					{ return *_computedColumns[i]; }
 	const	ComputedColumn & operator[](size_t i)			const	{ return *_computedColumns[i]; }
 			ComputedColumn & operator[](std::string name)			{ return *_computedColumns[findIndexByName(name)]; }

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -1069,7 +1069,6 @@ void MainWindow::dataSetIORequest(FileEvent *event)
 	}
 	else if (event->operation() == FileEvent::FileClose)
 	{
-		
 		if (_package->isModified())
 		{
 			QString title = windowTitle();
@@ -1187,8 +1186,6 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 	}
 	else if (event->operation() == FileEvent::FileClose)
 	{
-		std::cout << "else if (event->operation() == FileEvent::FileClose)"<< std::endl;
-
 		if (event->successful())
 		{
 			closeCurrentOptionsWidget();
@@ -1749,7 +1746,7 @@ void MainWindow::refreshAnalysesUsingColumn(QString col)
 	changedColumns.push_back(col.toStdString());
 	refreshAnalysesUsingColumns(changedColumns, missingColumns, changeNameColumns, false);
 
-	_package->setModified(false);
+	//_package->setModified(false); //Why would we do this?
 }
 
 void MainWindow::removeAnalysisRequestHandler(int id)


### PR DESCRIPTION
Saving a jasp-file could be short-circuited by closing it fast. This was possible because the computed columns didn't notify the datasetpackage that it was modified..

