### PR TITLE
Compile error on Windows

### DIFF
--- a/JASP-Desktop/exporters/jaspexporter.cpp
+++ b/JASP-Desktop/exporters/jaspexporter.cpp
@@ -274,8 +274,8 @@ void JASPExporter::saveDataArchive(archive *a, DataSetPackage *package, boost::f
 	archive_entry_set_perm(entry, 0644); // Not sure what this does
 	archive_write_header(a, entry);
 
-	ssize_t ws = archive_write_data(a, html.c_str(), htmlSize);
-	if (ws != ssize_t(htmlSize))
+	size_t ws = archive_write_data(a, html.c_str(), htmlSize);
+	if (ws != size_t(htmlSize))
 		throw std::runtime_error("Can't save jasp archive writing ERROR");
 
 	archive_entry_free(entry);


### PR DESCRIPTION
In jaspexporter.cpp:
ssize_t is not defined on Windows by default  (unless a _SSIZE_T_DEFINED is used)

