### PR TITLE
Strip comments from compute column code and filter code.

### DIFF
--- a/JASP-Common/computedcolumn.cpp
+++ b/JASP-Common/computedcolumn.cpp
@@ -1,12 +1,15 @@
 #include <regex>
 #include "computedcolumn.h"
 #include "analysis.h"
+#include "utils.h"
 
 bool ComputedColumn::setRCode(std::string rCode)
 {
 	if(_rCode != rCode)
 	{
-		_rCode = rCode;
+		_rCode			= rCode;
+		_rCodeStripped	= Utils::stripRComments(rCode);
+
 		findDependencies();
 		invalidate();
 		return true;
@@ -234,8 +237,8 @@ ComputedColumn::ComputedColumn(std::vector<ComputedColumn*> * allComputedColumns
 	_error				= json["error"].asString();
 	_name				= json["name"].asString();
 
+	_rCodeStripped		= Utils::stripRComments(_rCode);
 	_outputColumn		= &(*columns)[_name];
-
 }
 
 void ComputedColumn::findDependencies()

--- a/JASP-Common/computedcolumn.h
+++ b/JASP-Common/computedcolumn.h
@@ -21,11 +21,10 @@ public:
 			ComputedColumn(std::vector<ComputedColumn*> * allComputedColumns, Columns * columns, Json::Value json); //Conversion from JSON!
 
 
-			std::string				name()							const			{ return _name;					}
-			void					setColumn(Column * newPointer)					{ _outputColumn = newPointer;	}
-			Column					*column()										{ return _outputColumn;			}
-
-			Column::ColumnType		columnType()					const			{ return _outputColumn->columnType();	}
+			std::string				name()							const			{ return _name;								}
+			void					setColumn(Column * newPointer)					{ _outputColumn = newPointer;				}
+			Column					*column()										{ return _outputColumn;						}
+			Column::ColumnType		columnType()					const			{ return _outputColumn->columnType();		}
 
 			bool					setRCode(std::string rCode);
 			bool					setError(std::string error);
@@ -35,6 +34,7 @@ public:
 
 			int						analysisId()					const			{ return _analysisId;						}
 			std::string				rCode()							const			{ return _rCode;							}
+			std::string				rCodeCommentStripped()			const			{ return _rCodeStripped;					}
 			std::string				error()							const			{ return _error;							}
 			computedType			codeType()						const			{ return _codeType;							}
 			std::string				constructorJson()				const			{ return _constructorCode.toStyledString(); }
@@ -65,6 +65,7 @@ public:
 	static	computedType			computedTypeFromString(std::string type);
 
 			void					replaceChangedColumnNamesInRCode(std::map<std::string, std::string> changedNames);
+
 private:
 			void					_checkForLoopInDepenedencies(std::set<std::string> foundNames, std::list<std::string> loopList);
 
@@ -73,7 +74,8 @@ private:
 			computedType					_codeType;
 			std::string						_name,
 											_rCode				= "#Enter your R code here :)",
-											_error				= "";
+											_error				= "",
+											_rCodeStripped		= "";
 			Json::Value						_constructorCode	= Json::objectValue;
 			Analysis						*_analysis			= NULL;
 

--- a/JASP-Common/computedcolumns.cpp
+++ b/JASP-Common/computedcolumns.cpp
@@ -105,6 +105,16 @@ std::string ComputedColumns::getRCode(std::string name)
 	return "";
 }
 
+std::string ComputedColumns::getRCodeCommentStripped(std::string name)
+{
+	try
+	{
+		return (*this)[name].rCodeCommentStripped();
+	}
+	catch(...){}
+	return "";
+}
+
 bool ComputedColumns::usesRCode(std::string name)
 {
 	try

--- a/JASP-Common/computedcolumns.h
+++ b/JASP-Common/computedcolumns.h
@@ -27,6 +27,7 @@ public:
 
 	std::string			getConstructorJson(std::string name);
 	std::string			getRCode(std::string name);
+	std::string			getRCodeCommentStripped(std::string name);
 	std::string			getError(std::string name);
 
 	size_t				findIndexByName(std::string name)			const;

--- a/JASP-Common/utils.cpp
+++ b/JASP-Common/utils.cpp
@@ -317,3 +317,58 @@ bool Utils::getDoubleValue(const string &value, double &doubleValue)
 
 	return success;
 }
+
+std::string Utils::stripRComments(const std::string & rCode)
+{
+	std::stringstream out;
+
+	//Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/72
+	//Gotta do some rudimentary parsing here... A comment starts with # and ends with newline, but if a # is inside a string then it doesn't start a comment...
+	//String are started with ' or "
+
+	enum class status { R, Comment, SingleStr, DoubleStr };
+
+	status curStatus = status::R;
+
+	for(size_t r=0; r<rCode.size(); r++)
+	{
+		bool pushMe = true;
+
+		char kar = rCode[r];
+
+		switch(curStatus)
+		{
+		case status::R:
+			switch(kar)
+			{
+			case '\'':	curStatus = status::SingleStr;	break;
+			case '"':	curStatus = status::DoubleStr;	break;
+			case '#':
+				curStatus	= status::Comment;
+				pushMe		= false;
+				break;
+			}
+			break;
+
+		case status::Comment:
+			if(kar == '\n')	curStatus	= status::R;
+			else			pushMe		= false;
+			break;
+
+		case status::SingleStr:
+			if(kar == '\'' && rCode[r - 1] != '\\')
+				curStatus = status::R;
+			break;
+
+		case status::DoubleStr:
+			if(kar == '"' && rCode[r - 1] != '\\')
+				curStatus = status::R;
+			break;
+		}
+
+		if(pushMe)
+			out << kar;
+	}
+
+	return out.str();
+}

--- a/JASP-Common/utils.h
+++ b/JASP-Common/utils.h
@@ -56,6 +56,8 @@ public:
 	static bool getIntValue(const double& value, int& intValue);
 	static bool getDoubleValue(const std::string& value, double& doubleValue);
 
+	static std::string stripRComments(const std::string & rCode);
+
 private:
 	static std::vector<std::string> _currentEmptyValues;
 	static const std::vector<std::string> _defaultEmptyValues;

--- a/JASP-Desktop/application.h
+++ b/JASP-Desktop/application.h
@@ -29,7 +29,7 @@ class Application : public QApplication
 	Q_OBJECT
 public:
 	explicit Application(int &argc, char **argv, QString filePath, bool unitTest, int timeOut);
-	~Application();
+	~Application() override;
 
 	virtual bool notify(QObject *receiver, QEvent *event) OVERRIDE;
 	virtual bool event(QEvent *event) OVERRIDE;

--- a/JASP-Desktop/computedcolumnsmodel.cpp
+++ b/JASP-Desktop/computedcolumnsmodel.cpp
@@ -20,6 +20,14 @@ QString ComputedColumnsModel::computeColumnRCode()
 	return QString::fromStdString(_computedColumns->getRCode(_currentlySelectedName.toStdString()));
 }
 
+QString ComputedColumnsModel::computeColumnRCodeCommentStripped()
+{
+	if(_currentlySelectedName == "" || _computedColumns == NULL)
+		return "";
+
+	return QString::fromStdString(_computedColumns->getRCodeCommentStripped(_currentlySelectedName.toStdString()));
+}
+
 bool ComputedColumnsModel::computeColumnUsesRCode()
 {
 	if(_currentlySelectedName == "" || _computedColumns == NULL)
@@ -87,7 +95,7 @@ void ComputedColumnsModel::setComputeColumnNameSelected(QString newName)
 bool ComputedColumnsModel::areLoopDependenciesOk(std::string columnName)
 {
 
-	return areLoopDependenciesOk(columnName, (*_computedColumns)[columnName].analysis() != NULL ? "" : (*_computedColumns)[columnName].rCode());
+	return areLoopDependenciesOk(columnName, (*_computedColumns)[columnName].analysis() != NULL ? "" : (*_computedColumns)[columnName].rCodeCommentStripped());
 }
 
 bool ComputedColumnsModel::areLoopDependenciesOk(std::string columnName, std::string code)
@@ -131,7 +139,7 @@ void ComputedColumnsModel::sendCode(QString code)
 {
 	std::string columnName = _currentlySelectedName.toStdString();
 	setComputeColumnRCode(code);
-	emitSendComputeCode(_currentlySelectedName, code, (*_computedColumns)[columnName].columnType());
+	emitSendComputeCode(_currentlySelectedName, computeColumnRCodeCommentStripped(), (*_computedColumns)[columnName].columnType());
 }
 
 void ComputedColumnsModel::validate(QString columnName)
@@ -262,7 +270,7 @@ void ComputedColumnsModel::checkForDependentColumnsToBeSent(std::string columnNa
 
 	for(ComputedColumn * col : *_computedColumns)
 		if(col->iShouldBeSentAgain())
-			emitSendComputeCode(QString::fromStdString(col->name()), QString::fromStdString(col->rCode()), col->columnType());
+			emitSendComputeCode(QString::fromStdString(col->name()), QString::fromStdString(col->rCodeCommentStripped()), col->columnType());
 
 	checkForDependentAnalyses(columnName);
 }
@@ -358,7 +366,7 @@ void ComputedColumnsModel::packageSynchronized(const std::vector<std::string> & 
 		col->findDependencies(); //columnNames might have changed right? so check it again
 
 		if(col->iShouldBeSentAgain())
-			emitSendComputeCode(QString::fromStdString(col->name()), QString::fromStdString(col->rCode()), col->columnType());
+			emitSendComputeCode(QString::fromStdString(col->name()), QString::fromStdString(col->rCodeCommentStripped()), col->columnType());
 	}
 }
 

--- a/JASP-Desktop/computedcolumnsmodel.h
+++ b/JASP-Desktop/computedcolumnsmodel.h
@@ -22,6 +22,7 @@ public:
 
 				bool	datasetLoaded()					{ return _package != NULL; }
 				QString	computeColumnRCode();
+				QString computeColumnRCodeCommentStripped();
 				QString computeColumnError();
 				QString computeColumnNameSelected();
 				QString computeColumnJson();

--- a/JASP-Desktop/main.cpp
+++ b/JASP-Desktop/main.cpp
@@ -143,7 +143,7 @@ void recursiveFileOpener(QFileInfo file, int & failures, int & total, int & time
 #ifdef SEPARATE_PROCESS
 				QProcess subJasp;
 				subJasp.setProgram(argv[0]);
-				subJasp.setArguments({file.absoluteFilePath(), "--unitTest", QString::fromStdString("--timeOut="+std::to_string(timeOut)) });
+				subJasp.setArguments({file.absoluteFilePath(), "--unitTest", QString::fromStdString("--timeOut="+std::to_string(timeOut)), "-platform", "minimal" });
 				subJasp.start();
 
 				subJasp.waitForFinished((timeOut * 60000) + 10000);
@@ -179,13 +179,6 @@ int main(int argc, char *argv[])
 	// qputenv("QT_QUICK_BACKEND", "software");
 	QCoreApplication::setAttribute(Qt::AA_UseOpenGLES); //might fix weirdlooking QML on Windows when using not-so-goo drivers? ( https://github.com/jasp-stats/jasp-desktop/issues/2669 )
 #endif
-	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-	QCoreApplication::setAttribute(Qt::AA_SynthesizeTouchForUnhandledMouseEvents, false); //To avoid weird splitterbehaviour with QML and a touchscreen
-	QCoreApplication::setOrganizationName("JASP");
-	QCoreApplication::setOrganizationDomain("jasp-stats.org");
-	QCoreApplication::setApplicationName("JASP");
-
-	QLocale::setDefault(QLocale(QLocale::English)); // make decimal points == .
 
 	std::string filePath;
 	bool		unitTest,
@@ -199,6 +192,14 @@ int main(int argc, char *argv[])
 	if(!dirTest)
 		try
 		{
+			QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+			QCoreApplication::setAttribute(Qt::AA_SynthesizeTouchForUnhandledMouseEvents, false); //To avoid weird splitterbehaviour with QML and a touchscreen
+			QCoreApplication::setOrganizationName("JASP");
+			QCoreApplication::setOrganizationDomain("jasp-stats.org");
+			QCoreApplication::setApplicationName("JASP");
+
+			QLocale::setDefault(QLocale(QLocale::English)); // make decimal points == .
+
 			Application a(argc, argv, filePathQ, unitTest, timeOut);
 			return a.exec();
 		}

--- a/JASP-Engine/r_functionwhitelist.cpp
+++ b/JASP-Engine/r_functionwhitelist.cpp
@@ -1,4 +1,5 @@
 #include "r_functionwhitelist.h"
+#include "utils.h"
 
 	//The following functions (and keywords that can be followed by a '(') will be allowed in user-entered R-code, such as filters or computed columns. This is for security because otherwise JASP-files could become a vector of attack and that doesn't refer to an R-datatype.
 const std::set<std::string> R_FunctionWhiteList::functionWhiteList {
@@ -278,9 +279,11 @@ std::set<std::string> R_FunctionWhiteList::findIllegalFunctionsAliases(std::stri
 
 void R_FunctionWhiteList::scriptIsSafe(const std::string &script)
 {
+	std::string commentFree = Utils::stripRComments(script);
+
 	static std::string errorMsg;
 
-	std::set<std::string> blackListedFunctions = findIllegalFunctions(script);
+	std::set<std::string> blackListedFunctions = findIllegalFunctions(commentFree);
 
 	if(blackListedFunctions.size() > 0)
 	{
@@ -294,7 +297,7 @@ void R_FunctionWhiteList::scriptIsSafe(const std::string &script)
 		throw filterException(errorMsg);
 	}
 
-	std::set<std::string> illegalAliasesFound = findIllegalFunctionsAliases(script);
+	std::set<std::string> illegalAliasesFound = findIllegalFunctionsAliases(commentFree);
 
 	if(illegalAliasesFound.size() > 0)
 	{


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp/issues/#72

Also disables the GUI for JASP when running unit-tests on a jasp-file recursively

