### PR TITLE
added .imageBackground

### DIFF
--- a/Tools/jasptools/DESCRIPTION
+++ b/Tools/jasptools/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jasptools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 0.5.5
+Version: 0.5.6
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/Tools/jasptools/R/rbridge.R
+++ b/Tools/jasptools/R/rbridge.R
@@ -48,3 +48,5 @@
 .callbackNative <- function(...) {
   list(status="ok")
 }
+
+.imageBackground <- function(...) return("white")


### PR DESCRIPTION
@JohnnyDoorn This should fix the error about a missing function `.imageBackground`! Don't forget to call `jasptools::develop()` after reinstalling.

This does not allow switching between white and transparent plot backgrounds within jasptools. I don't really see a use for allowing that right now (but feel free to convince me).