### PR TITLE
Fix for qpainter on windows

### DIFF
--- a/JASP-Desktop/utilities/resultsjsinterface.cpp
+++ b/JASP-Desktop/utilities/resultsjsinterface.cpp
@@ -21,6 +21,10 @@
 #include <QClipboard>
 #include <QStringBuilder>
 
+#ifdef __WIN32__
+#include <QPainter>
+#endif
+
 #include "utilities/qutils.h"
 #include "appinfo.h"
 #include "tempfiles.h"


### PR DESCRIPTION
Builds on windows were not possible without this fix