### PR TITLE
Added R support for rewriting images

### DIFF
--- a/JASP-R-Interface/jaspResults/src/jaspResults.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspResults.cpp
@@ -229,7 +229,13 @@ void jaspResults::addSerializedPlotObjsForStateFromJaspObject(jaspObject * obj, 
 	{
 		jaspPlot * plot = (jaspPlot*)obj;
 		if(plot->_filePathPng != "")
-			pngImgObj[plot->_filePathPng] = plot->getPlotObject();
+		{
+			Rcpp::List pngImg;
+			pngImg["obj"] = plot->getPlotObject();
+			pngImg["width"] = plot->_width;
+			pngImg["height"] = plot->_height;
+			pngImgObj[plot->_filePathPng] = pngImg;
+		}
 	}
 
 	for(auto c : obj->getChildren())


### PR DESCRIPTION
Width and height weren't previously stored in the `state[["figures"]]` object, so I had to edit some R functions and jaspResults as well. 

See also [this issue](https://github.com/jasp-stats/INTERNAL-jasp/issues/100).