### PR TITLE
added aliases

### DIFF
--- a/JASP-R-Interface/jaspResults/man/jaspContainer.Rd
+++ b/JASP-R-Interface/jaspResults/man/jaspContainer.Rd
@@ -2,6 +2,7 @@
 \Rdversion{1.1}
 \docType{class}
 \alias{jaspContainer}
+\alias{createJaspContainer}
 
 \title{Class "jaspContainer"}
 \description{

--- a/JASP-R-Interface/jaspResults/man/jaspHtml.Rd
+++ b/JASP-R-Interface/jaspResults/man/jaspHtml.Rd
@@ -2,6 +2,7 @@
 \Rdversion{1.1}
 \docType{class}
 \alias{jaspHtml}
+\alias{createJaspHtml}
 
 \title{Class "jaspHtml"}
 \description{

--- a/JASP-R-Interface/jaspResults/man/jaspPlot.Rd
+++ b/JASP-R-Interface/jaspResults/man/jaspPlot.Rd
@@ -2,6 +2,7 @@
 \Rdversion{1.1}
 \docType{class}
 \alias{jaspPlot}
+\alias{createJaspPlot}
 
 \title{Class "jaspPlot"}
 \description{

--- a/JASP-R-Interface/jaspResults/man/jaspState.Rd
+++ b/JASP-R-Interface/jaspResults/man/jaspState.Rd
@@ -2,6 +2,7 @@
 \Rdversion{1.1}
 \docType{class}
 \alias{jaspState}
+\alias{createJaspState}
 
 \title{Class "jaspState"}
 \description{

--- a/JASP-R-Interface/jaspResults/man/jaspTable.Rd
+++ b/JASP-R-Interface/jaspResults/man/jaspTable.Rd
@@ -2,6 +2,7 @@
 \Rdversion{1.1}
 \docType{class}
 \alias{jaspTable}
+\alias{createJaspTable}
 
 \title{Class "jaspTable"}
 \description{


### PR DESCRIPTION
In Rstudio, only `?jaspContainer` shows the helpfile. Since people usually call `createJaspContainer`, they might get confused that `?createJaspContainer` does not exists. This PR redirects 
`?createJaspContainer` to `?jaspContainer`.

idem for `jaspState`, `jaspPlot`, `jaspTable`, and `jaspHtml`.