### PR TITLE
Redo gglot minimum version to 3.0.0

### DIFF
--- a/JASP-Engine/JASPgraphs/DESCRIPTION
+++ b/JASP-Engine/JASPgraphs/DESCRIPTION
@@ -10,4 +10,4 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
 Suggests: testthat
-Imports: ggplot2, scales
+Imports: ggplot2 (>= 3.0.0), scales


### PR DESCRIPTION
This was removed per accident in PR: Change ExtraControlColumn handling
#3017

