### PR TITLE
Clean up file menu and modules window after opened

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
@@ -45,6 +45,7 @@ FocusScope
 		{
 			customMenu.visible		= false;
 			fileMenuModel.visible	= !fileMenuModel.visible;
+			modulesMenu.opened = false;
 		}
 
 		anchors
@@ -66,6 +67,17 @@ FocusScope
 			right	: modulesPlusButton.left
 			left	: fileMenuOpenButton.right
 		}
+
+		MouseArea
+		{
+			anchors.fill: parent
+			enabled:  fileMenuModel.visible  || modulesMenu.opened
+
+			onClicked: {
+				fileMenuModel.visible =false;
+				modulesMenu.opened = false;
+			}
+		}
 	}
 
 	MenuArrowButton
@@ -77,6 +89,7 @@ FocusScope
 		{
 			customMenu.visible	= false;
 			modulesMenu.opened	= !modulesMenu.opened;
+			fileMenuModel.visible = false;
 		}
 
 		showArrow	: modulesMenu.opened


### PR DESCRIPTION
Solves INTERNAL #127
File menu should close after choosing the add module button and vice versa #127

