### PR TITLE
Change some property names in QML controls

### DIFF
--- a/Dynamic Modules/Descriptives Module/qml/Descriptives.qml
+++ b/Dynamic Modules/Descriptives Module/qml/Descriptives.qml
@@ -29,11 +29,11 @@ Form
 	VariablesForm
 	{
 		AssignedVariablesList { name: "variables";	title: qsTr("Variables") }
-		AssignedVariablesList { name: "splitby";	title: qsTr("Split"); singleItem: true; allowedColumns: ["ordinal", "nominal"] }
-		AssignedVariablesList { name: "test";	title: qsTr("Test"); singleItem: true; allowedColumns: ["ordinal", "nominal"] }
+		AssignedVariablesList { name: "splitby";	title: qsTr("Split"); singleVariable: true; allowedColumns: ["ordinal", "nominal"] }
+		AssignedVariablesList { name: "test";		title: qsTr("Test"); singleVariable: true; allowedColumns: ["ordinal", "nominal"] }
 	}
 
-	CheckBox { name: "frequencyTables"; text: qsTr("Frequency tables (nominal and ordinal variables)") }
+	CheckBox { name: "frequencyTables"; label: qsTr("Frequency tables (nominal and ordinal variables)") }
 
 	ExpanderButton
 	{
@@ -43,22 +43,22 @@ Form
 		{
 			CheckBox
 			{
-				name: "plotVariables"; text: qsTr("Distribution plots")
-				CheckBox { name: "distPlotDensity"; text: qsTr("Display density") }
+				name: "plotVariables"; label: qsTr("Distribution plots")
+				CheckBox { name: "distPlotDensity"; label: qsTr("Display density") }
 			}
-			CheckBox { name: "plotCorrelationMatrix"; text: qsTr("Correlation plots") }
+			CheckBox { name: "plotCorrelationMatrix"; label: qsTr("Correlation plots") }
 			CheckBox
 			{
-				name: "splitPlots"; text: qsTr("Boxplots")
-				CheckBox { name: "splitPlotOutlierLabel"; text: qsTr("Label Outliers") }
+				name: "splitPlots"; label: qsTr("Boxplots")
+				CheckBox { name: "splitPlotOutlierLabel"; label: qsTr("Label Outliers") }
 				CheckBox
 				{
-					name: "splitPlotColour"; text: qsTr("Color"); enableChildrenOnChecked: false
+					name: "splitPlotColour"; label: qsTr("Color"); enableChildrenOnChecked: false
 					Group
 					{
-						CheckBox { name: "splitPlotBoxplot";	text: qsTr("Boxplot Element"); checked: true	}
-						CheckBox { name: "splitPlotViolin";		text: qsTr("Violin Elem∂ent")					}
-						CheckBox { name: "splitPlotJitter";		text: qsTr("Jitter Element")					}
+						CheckBox { name: "splitPlotBoxplot";	label: qsTr("Boxplot Element"); checked: true	}
+						CheckBox { name: "splitPlotViolin";		label: qsTr("Violin Elem∂ent")					}
+						CheckBox { name: "splitPlotJitter";		label: qsTr("Jitter Element")					}
 					}
 				}
 			}
@@ -74,22 +74,22 @@ Form
 		{
 			title: qsTr("Percentile Values")
 
-			CheckBox { name: "percentileValuesQuartiles";	text: qsTr("Quartiles") }
+			CheckBox { name: "percentileValuesQuartiles";	label: qsTr("Quartiles") }
 			CheckBox
 			{
-				name: "percentileValuesEqualGroups"; text: qsTr("Cut points for: ")
+				name: "percentileValuesEqualGroups"; label: qsTr("Cut points for: ")
 				childrenOnSameRow: true
 				IntegerField
 				{
 					name: "percentileValuesEqualGroupsNo"
 					intValidator { bottom: 1; top: 1000 }
 					defaultValue: 4
-					afterLabel.text: qsTr(" equal groups")
+					afterLabel: qsTr(" equal groups")
 				}
 			}
 			CheckBox
 			{
-				name: "percentileValuesPercentiles"; text: qsTr("Percentiles:")
+				name: "percentileValuesPercentiles"; label: qsTr("Percentiles:")
 				childrenOnSameRow: true
 				TextField
 				{
@@ -104,31 +104,31 @@ Form
 		{
 			title: qsTr("Central Tendency")
 			implicitWidth: 200
-			CheckBox { name: "mean";			text: qsTr("Mean");		checked: true	}
-			CheckBox { name: "median";			text: qsTr("Median")					}
-			CheckBox { name: "mode";			text: qsTr("Mode");						}
-			CheckBox { name: "sum";				text: qsTr("Sum");						}
+			CheckBox { name: "mean";			label: qsTr("Mean");	checked: true	}
+			CheckBox { name: "median";			label: qsTr("Median")					}
+			CheckBox { name: "mode";			label: qsTr("Mode");					}
+			CheckBox { name: "sum";				label: qsTr("Sum");						}
 		}
 
 		Group
 		{
 			title: qsTr("Dispersion")
-			CheckBox { name: "standardDeviation";	text: qsTr("Std.deviation"); checked: true	}
-			CheckBox { name: "minimum";				text: qsTr("Minimum");		checked: true	}
-			CheckBox { name: "maximum";				text: qsTr("Maximum");		checked: true	}
-			CheckBox { name: "variance";			text: qsTr("Variance")						}
-			CheckBox { name: "range";				text: qsTr("Range")							}
-			CheckBox { name: "standardErrorMean";	text: qsTr("S. E. mean")					}
+			CheckBox { name: "standardDeviation";	label: qsTr("Std.deviation"); checked: true	}
+			CheckBox { name: "minimum";				label: qsTr("Minimum");		checked: true	}
+			CheckBox { name: "maximum";				label: qsTr("Maximum");		checked: true	}
+			CheckBox { name: "variance";			label: qsTr("Variance")						}
+			CheckBox { name: "range";				label: qsTr("Range")						}
+			CheckBox { name: "standardErrorMean";	label: qsTr("S. E. mean")					}
 		}
 
 		Group
 		{
 			title: qsTr("Distribution")
-			CheckBox { name: "skewness";			text: qsTr("Skewness")						}
-			CheckBox { name: "kurtosis";			text: qsTr("Kurtosis")						}
+			CheckBox { name: "skewness";			label: qsTr("Skewness")						}
+			CheckBox { name: "kurtosis";			label: qsTr("Kurtosis")						}
 		}
 
-		CheckBox { name: "statisticsValuesAreGroupMidpoints"; text: qsTr("Values are group midpoints"); debug: true }
+		CheckBox { name: "statisticsValuesAreGroupMidpoints"; label: qsTr("Values are group midpoints"); debug: true }
 	}
 
 	ExpanderButton
@@ -139,18 +139,18 @@ Form
 		{
 			name: "chartType";
 			title: qsTr("Chart Type")
-			RadioButton { value: "_1noCharts";		text: qsTr("None")			}
-			RadioButton { value: "_2barCharts";		text: qsTr("Bar charts")	}
-			RadioButton { value: "_3pieCharts";		text: qsTr("Pie Charts")	}
-			RadioButton { value: "_4histograms";	text: qsTr("Histograms")	}
+			RadioButton { value: "_1noCharts";		label: qsTr("None")			}
+			RadioButton { value: "_2barCharts";		label: qsTr("Bar charts")	}
+			RadioButton { value: "_3pieCharts";		label: qsTr("Pie Charts")	}
+			RadioButton { value: "_4histograms";	label: qsTr("Histograms")	}
 		}
 
 		RadioButtonGroup
 		{
 			name: "chartValues"
 			title: qsTr("Chart Values")
-			RadioButton { value: "_1frequencies";	text: qsTr("Frequencies")	}
-			RadioButton { value: "_2percentages";	text: qsTr("Percentages")	}
+			RadioButton { value: "_1frequencies";	label: qsTr("Frequencies")	}
+			RadioButton { value: "_2percentages";	label: qsTr("Percentages")	}
 		}
 	}
 }

--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -402,6 +402,13 @@ void Analyses::selectAnalysis(Analysis * analysis)
 		}
 }
 
+void Analyses::setDataSet(DataSet *dataSet)
+{
+	_dataSet = dataSet;
+	
+	emit dataSetChanged();
+}
+
 
 void Analyses::setCurrentAnalysisIndex(int currentAnalysisIndex)
 {

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -76,7 +76,7 @@ public:
 
 	void		selectAnalysis(Analysis * analysis);
 	
-	void		setDataSet(DataSet* dataSet)	{ _dataSet = dataSet; }
+	void		setDataSet(DataSet* dataSet);
 	DataSet*	getDataSet() const				{ return _dataSet; }
 
 	int						rowCount(const QModelIndex & = QModelIndex())				const override	{ return int(count()); }
@@ -128,6 +128,7 @@ signals:
 	void currentFormHeightChanged(		double		currentFormHeight);
 	void visibleChanged(				bool		visible);
 	void emptyQMLCache();
+	void dataSetChanged();
 
 	ComputedColumn *	requestComputedColumnCreation(QString columnName, Analysis *source);
 	void				requestComputedColumnDestruction(QString columnName);

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -157,6 +157,8 @@ void Analysis::initialized(AnalysisForm* form, bool isNewAnalysis)
 {
 	_analysisForm	= form;
 	_status			= isNewAnalysis ? Empty : Complete;
+	
+	connect(_analyses, &Analyses::dataSetChanged, _analysisForm, &AnalysisForm::dataSetChanged);
 }
 
 Json::Value Analysis::asJSON() const

--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -252,9 +252,9 @@ void AnalysisForm::_parseQML()
 			switch(listViewType)
 			{
 			case qmlListViewType::AssignedVariables:	listView = new BoundQMLListViewTerms(quickItem, this);			break;
-			case qmlListViewType::AssignedPairs:		listView = new BoundQMLListViewPairs(quickItem,this);			break;
+			case qmlListViewType::Pairs:				listView = new BoundQMLListViewPairs(quickItem,this);			break;
 			case qmlListViewType::Interaction:			listView = new BoundQMLListViewInteraction(quickItem, this);	break;
-			case qmlListViewType::MeasuresCells:		listView = new BoundQMLListViewMeasuresCells(quickItem, this);	break;
+			case qmlListViewType::RepeatedMeasures:		listView = new BoundQMLListViewMeasuresCells(quickItem, this);	break;
 			case qmlListViewType::Layers:				listView = new BoundQMLListViewLayers(quickItem, this);			break;
 			case qmlListViewType::AvailableVariables:
 			{

--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -149,7 +149,7 @@ void AnalysisForm::runScriptRequestDone(const QString& result, const QString& co
 	else
 		std::cout << "Unknown item " << controlName.toStdString() << std::endl;
 #endif
-
+	
 }
 
 void AnalysisForm::_parseQML()
@@ -481,6 +481,14 @@ void AnalysisForm::_formCompletedHandler()
 		bool isNewAnalysis = _analysis->options()->size() == 0 && _analysis->optionsFromJASPFile().size() == 0;
 		bindTo(_analysis->options(), _analysis->getDataSet(), _analysis->optionsFromJASPFile());
 		_analysis->resetOptionsFromJASPFile();
-		_analysis->initialized(this, isNewAnalysis);	
+		_analysis->initialized(this, isNewAnalysis);
 	}
 }
+
+void AnalysisForm::dataSetChanged()
+{
+	_dataSet = _analysis->getDataSet();
+	_setAllAvailableVariablesModel();
+}
+
+

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -61,6 +61,7 @@ public:
 					
 public slots:
 				void			runScriptRequestDone(const QString& result, const QString& requestId);
+				void			dataSetChanged();
 
 signals:
 				void			illegalChanged(AnalysisForm * form);

--- a/JASP-Desktop/analysis/analysisqmldefines.h
+++ b/JASP-Desktop/analysis/analysisqmldefines.h
@@ -4,7 +4,7 @@
 #include "enumutilities.h"
 
 DECLARE_ENUM(qmlControlType, JASPControl, CheckBox, Switch, TextField, RadioButtonGroup, VariablesListView, ComboBox, RepeatedMeasuresFactorsList, TableView, Slider, TextArea, Button);
-DECLARE_ENUM(qmlListViewType, AssignedVariables, AssignedPairs, Interaction, AvailableVariables, MeasuresCells, Layers);
+DECLARE_ENUM(qmlListViewType, AssignedVariables, Pairs, Interaction, AvailableVariables, RepeatedMeasures, Layers);
 DECLARE_ENUM(qmlDropMode, None, Replace, Insert)
 
 #endif // ANALYSISQMLDEFINES_H

--- a/JASP-Desktop/components/JASP/Controls/CheckBox.qml
+++ b/JASP-Desktop/components/JASP/Controls/CheckBox.qml
@@ -38,6 +38,7 @@ JASPControl
 			property alias	control:				control
 			property alias	childrenArea:			childControlsArea
 			property alias	text:					control.text
+			property alias	label:					control.text
 			property alias	checked:				control.checked
 			property bool	childrenOnSameRow:	false
 			property alias	columns:				childControlsArea.columns

--- a/JASP-Desktop/components/JASP/Controls/ComboBox.qml
+++ b/JASP-Desktop/components/JASP/Controls/ComboBox.qml
@@ -7,20 +7,20 @@ JASPControl {
 	id:					comboBox
 	controlType:		"ComboBox"
 	implicitHeight:		control.height
-	implicitWidth:		control.implicitWidth + (label.visible ? labelSpacing + label.implicitWidth : 0)
+	implicitWidth:		control.implicitWidth + (controlLabel.visible ? labelSpacing + controlLabel.implicitWidth : 0)
 	width:				implicitWidth
     
 	property alias	control:				control
 	property int	labelSpacing:			4 * preferencesModel.uiScale
-	property alias	label:					label
-    property alias	text:					label.text
+	property alias	controlLabel:			controlLabel
+	property alias	label:					controlLabel.text
 	property string	currentText				//Am i empty or what?
 	property string	currentColumnType		//Same here
 	property alias	currentIndex:			control.currentIndex
 	property alias	indexDefaultValue:		control.currentIndex
 	property alias	model:					control.model
 	property alias	values:					control.model
-	property string	textRole:				"title"
+	property string	textRole:				"label"
 	property string	valueRole:				"value"
 	property bool	showVariableTypeIcon:	false
 	property var	source					//defaults would be nice
@@ -47,17 +47,17 @@ JASPControl {
     
 	RowLayout
 	{
-        spacing: label.visible ? labelSpacing : 0
+        spacing: controlLabel.visible ? labelSpacing : 0
         
 		Rectangle
 		{
-			implicitWidth: label.implicitWidth
+			implicitWidth: controlLabel.implicitWidth
 			implicitHeight: control.implicitHeight
 			color: debug ? Theme.debugBackgroundColor : "transparent"
 			Label
 			{
-				id:			label
-				visible:	label.text && comboBox.visible ? true : false
+				id:			controlLabel
+				visible:	controlLabel.text && comboBox.visible ? true : false
 				font:		Theme.font
 				anchors.verticalCenter: parent.verticalCenter				
 				color:		enabled ? Theme.textEnabled : Theme.textDisabled
@@ -73,7 +73,7 @@ JASPControl {
 			property int	modelWidth:		30 * preferencesModel.uiScale
 			property bool	isEmptyValue:	comboBox.addEmptyValue && currentIndex <= 0
 							
-			Layout.leftMargin: label.visible ? 0 : -labelSpacing
+			Layout.leftMargin: controlLabel.visible ? 0 : -labelSpacing
 							
             
 			TextMetrics { id: textMetrics }

--- a/JASP-Desktop/components/JASP/Controls/ExtraControlColumn.qml
+++ b/JASP-Desktop/components/JASP/Controls/ExtraControlColumn.qml
@@ -1,3 +1,20 @@
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
 import QtQuick 2.0
 
 QtObject {

--- a/JASP-Desktop/components/JASP/Controls/JASPControl.qml
+++ b/JASP-Desktop/components/JASP/Controls/JASPControl.qml
@@ -1,3 +1,20 @@
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
 import QtQuick				2.11
 import JASP.Theme			1.0
 import QtQuick.Controls		2.4

--- a/JASP-Desktop/components/JASP/Controls/PercentField.qml
+++ b/JASP-Desktop/components/JASP/Controls/PercentField.qml
@@ -34,6 +34,6 @@ TextField
 	control.width:		Theme.font.pixelSize * (with1Decimal ? 3 : 2)
 	validator:			with1Decimal ? doubleVal : intVal
 	value:				Number.parseInt(defaultValue);
-	afterLabel.text:	showPercent ? "%" : ""
+	afterLabel:			showPercent ? "%" : ""
 	cursorShape:		Qt.IBeamCursor
 }

--- a/JASP-Desktop/components/JASP/Controls/RadioButton.qml
+++ b/JASP-Desktop/components/JASP/Controls/RadioButton.qml
@@ -39,6 +39,7 @@ JASPControl
 
 			property alias	childrenArea:			childControlsArea
 			property alias	text:					control.text
+			property alias	label:					control.text
 			property alias	checked:				control.checked
 			property alias	value:					radioButton.name
 			property var	buttonGroup:			null

--- a/JASP-Desktop/components/JASP/Controls/Slider.qml
+++ b/JASP-Desktop/components/JASP/Controls/Slider.qml
@@ -8,16 +8,16 @@ JASPControl
 {
 	id:					slider
 	controlType:		"Slider"
-	implicitHeight:		control.height + (label.visible ? labelSpacing + label.implicitWidth : 0)
+	implicitHeight:		control.height + (controlLabel.visible ? labelSpacing + controlLabel.implicitWidth : 0)
 	implicitWidth:		control.width
     
 	property alias	control:		textField
 	property int	labelSpacing:	4 * preferencesModel.uiScale
 	property int	decimals:		2
 	property int	power:			Math.pow(10, decimals);
-	property alias	text:			label.text
-	property alias	title:			label.text
-	property alias	label:			label
+	property alias	label:			controlLabel.text
+	property alias	title:			controlLabel.text
+	property alias	controlLabel:	controlLabel
 	property alias	value:			control.value
 	property alias	orientation:	control.orientation
 	property alias	stepSize:		control.stepSize
@@ -32,12 +32,12 @@ JASPControl
 	ColumnLayout
 	{
 		id:			columnLayout;
-		spacing:	label.visible ? labelSpacing : 0
+		spacing:	controlLabel.visible ? labelSpacing : 0
         
 		Label
 		{
-			id:			label
-			visible:	label.text && slider.visible ? true : false
+			id:			controlLabel
+			visible:	controlLabel.text && slider.visible ? true : false
 			font:		Theme.font
 			color:		enabled ? Theme.textEnabled : Theme.textDisabled
         }

--- a/JASP-Desktop/components/JASP/Controls/Switch.qml
+++ b/JASP-Desktop/components/JASP/Controls/Switch.qml
@@ -27,7 +27,7 @@ JASPControl
 	implicitHeight:				control.height
 	
 	property alias control:		control
-	property alias text:		control.text
+	property alias label:		control.text
 	property alias checked:		control.checked
     signal clicked();
     
@@ -37,7 +37,7 @@ JASPControl
 	{
 		id:			control
 		height:		control.indicator.height + (4 * preferencesModel.uiScale)
-		width:		control.indicator.width + label.implicitWidth + control.spacing + (6 * preferencesModel.uiScale)
+		width:		control.indicator.width + controlLabel.implicitWidth + control.spacing + (6 * preferencesModel.uiScale)
 
 		indicator:	Rectangle
 		{
@@ -68,7 +68,7 @@ JASPControl
         
 		contentItem: Label
 		{
-			id:				label
+			id:				controlLabel
 			text:			control.text
 			font:			Theme.font
 			color:			enabled ? Theme.textEnabled : Theme.textDisabled

--- a/JASP-Desktop/components/JASP/Controls/TextField.qml
+++ b/JASP-Desktop/components/JASP/Controls/TextField.qml
@@ -32,6 +32,7 @@ JASPControl
 	cursorShape:		Qt.IBeamCursor
 	
 	property alias	control:			control	
+	property alias	label:				beforeLabel.text
 	property alias	text:				beforeLabel.text
 	property alias	value:				control.text
 	property int	fieldWidth:			Theme.textFieldWidth
@@ -40,9 +41,8 @@ JASPControl
 	property alias	placeholderText:	control.placeholderText
 	
 	property alias	validator:			control.validator
-	property alias	label:				beforeLabel
-	property alias	beforeLabel:		beforeLabel
-	property alias	afterLabel:			afterLabel
+	property alias	controlLabel:		beforeLabel
+	property alias	afterLabel:			afterLabel.text
 	property string	inputType:			"string"
 	property int	labelSpacing:		4
 	

--- a/JASP-Desktop/components/JASP/Controls/VariablesForm.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesForm.qml
@@ -75,7 +75,7 @@ Item
                 allAssignedVariablesList.push(control);
             if (i > 0)
                 minHeight += marginBetweenVariablesLists;
-            if (control.singleItem)
+            if (control.singleVariable)
                 minHeight += control.height;
             else if (control.height !== Theme.defaultListHeight)
                 // If the height of this List item was changed, don't change it
@@ -89,7 +89,7 @@ Item
             allJASPControls[i].parent = variablesForm;
         }
 
-        // Set the height of controls (that have not singleItem set or where the height is already specifically set)
+        // Set the height of controls (that have not singleVariable set or where the height is already specifically set)
         // so that the AssignedVariablesList column is as long as the AvailableVariablesList column.
 		// To Do: Should be a binding of some kind to avoid problems with resizing after changing preferencesModel.uiScale
         if (changeableHeightControls.length > 0) {

--- a/JASP-Desktop/components/JASP/Controls/VariablesList.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesList.qml
@@ -28,12 +28,13 @@ JASPControl
 	controlType:		"VariablesListView"
 	background:			rectangle
 	implicitWidth:		parent.width
-	height:				singleItem ? Theme.defaultSingleItemListHeight : Theme.defaultListHeight
+	height:				singleVariable ? Theme.defaultSingleItemListHeight : Theme.defaultListHeight
 	implicitHeight:		height
 	useControlMouseArea:	false
 	
 	property var	model
 	property string title
+	property alias	label:				variablesList.title
 	property alias	count:				listView.count	
 	property int	columns:			1
 	property string itemType:			"variables"
@@ -42,7 +43,7 @@ JASPControl
 	property bool	draggable:			true
 	property var	source
 	property alias	syncModels:			variablesList.source
-	property bool	singleItem:			false
+	property bool	singleVariable:			false
 	property string listViewType:		"AvailableVariables"
 	property var	allowedColumns:		[]
 	property bool	dropModeInsert:		dropMode === "Insert"
@@ -98,7 +99,7 @@ JASPControl
 		
 		onPositionChanged:
 		{
-			if (variablesList.singleItem || (!variablesList.dropModeInsert && !variablesList.dropModeReplace)) return;
+			if (variablesList.singleVariable || (!variablesList.dropModeInsert && !variablesList.dropModeReplace)) return;
 			var itemIndex = Math.floor((drag.y - text.height) / listView.cellHeight);
 			if (variablesList.columns > 1)
 			{
@@ -634,7 +635,7 @@ JASPControl
 							if (itemRectangle.Drag.target)
 							{
 								var dropTarget = itemRectangle.Drag.target.parent
-								if (dropTarget.singleItem && listView.selectedItems.length > 1)
+								if (dropTarget.singleVariable && listView.selectedItems.length > 1)
 									return;                                
 								
 								listView.clearSelectedItems(); // Must be before itemsDropped: listView does not exist anymore afterwards

--- a/JASP-Desktop/components/JASP/Widgets/BayesFactorType.qml
+++ b/JASP-Desktop/components/JASP/Widgets/BayesFactorType.qml
@@ -21,7 +21,8 @@ import QtQuick 2.8
 import JASP.Controls 1.0
 
 
-RadioButtonGroup {
+RadioButtonGroup
+{
     title: qsTr("Bayes Factor")                     ; name: "bayesFactorType"
 
     RadioButton { text: qsTr("BF\u2081\u2080")      ; name: "BF10"; checked: true }

--- a/JASP-Desktop/components/JASP/Widgets/Chi2TestTableView.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Chi2TestTableView.qml
@@ -2,7 +2,8 @@ import QtQuick 2.0
 import QtQuick.Layouts 1.11
 import JASP.Controls 1.0
 
-Item {
+Item
+{
     id: chi2TestTableView
     width: parent.width
     implicitWidth: width
@@ -13,9 +14,11 @@ Item {
     property alias source: tableView.source
     property alias tableView: tableView
         
-    RowLayout {
+    RowLayout
+	{
         id: layout
-        TableView {
+        TableView
+		{
             id: tableView
             implicitWidth: chi2TestTableView.width * 3/4 - layout.spacing
             implicitHeight: chi2TestTableView.height
@@ -23,22 +26,26 @@ Item {
             itemType: "double"
         }
     
-        GroupBox {
+        Group
+		{
             implicitWidth: chi2TestTableView.width * 1/4
             implicitHeight: chi2TestTableView.height            
-            Button { 
+            Button
+			{ 
                 text: qsTr("Add Column") ; name: "addButton" 
                 control.width: chi2TestTableView.width * 1/4
                 onClicked: tableView.addColumn()
                 enabled: tableView.columnCount > 0
             }
-            Button { 
+            Button
+			{ 
                 text: qsTr("Delete Column") ; name: "deleteButton"
                 control.width: chi2TestTableView.width * 1/4
                 onClicked: tableView.removeAColumn()
                 enabled: tableView.columnCount > 1
             }
-            Button { 
+            Button
+			{ 
                 text: qsTr("Reset") ; name: "resetButton"
                 control.width: chi2TestTableView.width * 1/4
                 onClicked: tableView.reset()

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
@@ -232,7 +232,7 @@ Rectangle
 			id: idRememberMe
 
 			checked: fileMenuModel.osf.rememberme
-			text   : qsTr("Remember me")
+			label   : qsTr("Remember me")
 
 			anchors.left  : parent.left
 			anchors.right : parent.right

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -20,7 +20,7 @@ Column
 		CheckBox
 		{
 			id:					useDefaultPPICheckbox
-			text:				"Use default PPI (Pixels per Inch) in plots: " + preferencesModel.defaultPPI
+			label:				"Use default PPI (Pixels per Inch) in plots: " + preferencesModel.defaultPPI
 			checked:			preferencesModel.useDefaultPPI
 			onCheckedChanged:	preferencesModel.useDefaultPPI = checked
 			//font:				Theme.font
@@ -141,7 +141,7 @@ Column
 		CheckBox
 		{
 			id:					developerMode
-			text:				qsTr("Developer mode")
+			label:				qsTr("Developer mode")
 			checked:			preferencesModel.developerMode
 			onCheckedChanged:	preferencesModel.developerMode = checked
 		}

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -17,7 +17,7 @@ ScrollView
 
 		CheckBox
 		{
-			text:				"Synchronize automatically on data file save"
+			label:				"Synchronize automatically on data file save"
 			checked:			preferencesModel.dataAutoSynchronization
 			onCheckedChanged:	preferencesModel.dataAutoSynchronization = checked
 			//font:				Theme.font
@@ -31,7 +31,7 @@ ScrollView
 			CheckBox
 			{
 				id:					useDefaultEditor
-				text:				"Use default spreadsheet editor"
+				label:				"Use default spreadsheet editor"
 				checked:			preferencesModel.useDefaultEditor
 				onCheckedChanged:	preferencesModel.useDefaultEditor = checked
 				//font:				Theme.font

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
@@ -12,7 +12,7 @@ Column
 
 	CheckBox
 	{
-		text:				"Display exact p-values"
+		label:				"Display exact p-values"
 		checked:			preferencesModel.exactPValues
 		onCheckedChanged:	preferencesModel.exactPValues = checked
 		//font:				Theme.font
@@ -26,7 +26,7 @@ Column
 		CheckBox
 		{
 			id:					fixDecs
-			text:				"Fix the number of decimals"
+			label:				"Fix the number of decimals"
 			checked:			preferencesModel.fixedDecimals
 			onCheckedChanged:	preferencesModel.fixedDecimals = checked
 			//font:				Theme.font

--- a/JASP-Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/JASP-Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -114,7 +114,7 @@ Item
 					CheckBox
 					{
 						id:					moduleButton
-						text:				displayText
+						label:				displayText
 						checked:			ribbonEnabled
 						onCheckedChanged:	ribbonModel.setModuleEnabled(index, checked)
 						enabled:			!isDynamic || !(dynamicModule.loading || dynamicModule.installing)

--- a/JASP-Desktop/components/JASP/Widgets/SubjectivePriors.qml
+++ b/JASP-Desktop/components/JASP/Widgets/SubjectivePriors.qml
@@ -24,28 +24,28 @@ import JASP.Controls 1.0
 
 ExpanderButton
 {
-    text: qsTr("Prior")
+    title: qsTr("Prior")
 
     RadioButtonGroup
 	{
         name: "effectSize"
         RadioButton
 		{
-			text: qsTr("Standardized effect size"); name: "standardized"; checked: true; debug: true
+			label: qsTr("Standardized effect size"); name: "standardized"; checked: true; debug: true
 			indentChildren: DEBUG_MODE
 			RadioButtonGroup
 			{
 				name: "effectSizeStandardized"
 				RadioButton
 				{
-					text: qsTr("Default"); name: "default"; checked: true
+					label: qsTr("Default"); name: "default"; checked: true
 					RadioButtonGroup
 					{
 						name: "defaultStandardizedEffectSize"
 						RadioButton
 						{
-							text: qsTr("Cauchy"); name: "cauchy"; checked: true; childrenOnSameRow: true
-							DoubleField { text: qsTr("scale"); name: "priorWidth"; defaultValue: 0.707; fieldWidth: 50; max: 2 }
+							label: qsTr("Cauchy"); name: "cauchy"; checked: true; childrenOnSameRow: true
+							DoubleField { label: qsTr("scale"); name: "priorWidth"; defaultValue: 0.707; fieldWidth: 50; max: 2 }
 						}
 					}
 				}
@@ -53,28 +53,28 @@ ExpanderButton
 
             RadioButton
 			{
-				text: qsTr("Informed"); name: "informative"
+				label: qsTr("Informed"); name: "informative"
 				RadioButtonGroup
 				{
 					name: "informativeStandardizedEffectSize"
 					RadioButton
 					{
-						text: qsTr("Cauchy"); name: "cauchy"; checked: true; childrenOnSameRow: true; id: cauchyInformative
-						DoubleField { text: qsTr("location:"); name: "informativeCauchyLocation"; visible: cauchyInformative.checked; defaultValue: 0; min: -3; max: -3 }
-						DoubleField { text: qsTr("scale:"); name: "informativeCauchyScale"; visible: cauchyInformative.checked; defaultValue: 0.707; fieldWidth: 50; max: 2 }
+						label: qsTr("Cauchy"); name: "cauchy"; checked: true; childrenOnSameRow: true; id: cauchyInformative
+						DoubleField { label: qsTr("location:"); name: "informativeCauchyLocation"; visible: cauchyInformative.checked; defaultValue: 0; min: -3; max: -3 }
+						DoubleField { label: qsTr("scale:"); name: "informativeCauchyScale"; visible: cauchyInformative.checked; defaultValue: 0.707; fieldWidth: 50; max: 2 }
 					}
 					RadioButton
 					{
-						text: qsTr("Normal"); name: "normal"; childrenOnSameRow: true; id: normalInformative
-						DoubleField { text: qsTr("mean:"); name: "informativeNormalMean"; visible: normalInformative.checked; defaultValue: 0; min: -3; max: -3 }
-						DoubleField { text: qsTr("std:"); name: "informativeNormalStd"; visible: normalInformative.checked; defaultValue: 0.707; fieldWidth: 50; max: 2 }
+						label: qsTr("Normal"); name: "normal"; childrenOnSameRow: true; id: normalInformative
+						DoubleField { label: qsTr("mean:"); name: "informativeNormalMean"; visible: normalInformative.checked; defaultValue: 0; min: -3; max: -3 }
+						DoubleField { label: qsTr("std:"); name: "informativeNormalStd"; visible: normalInformative.checked; defaultValue: 0.707; fieldWidth: 50; max: 2 }
 					}
 					RadioButton
 					{
-						text: qsTr("t"); name: "t"; childrenOnSameRow: true; id: tInformative
-						DoubleField { text: qsTr("location:"); name: "informativeTLocation"; visible: tInformative.checked; defaultValue: 0; min: -3; max: -3 }
-						DoubleField { text: qsTr("scale:"); name: "informativeTScale"; visible: tInformative.checked; defaultValue: 0.707; fieldWidth: 50; min: 0.001; max: 2 }
-						DoubleField { text: qsTr("df:"); name: "informativeTDf"; visible: tInformative.checked; inputType: "number"; value: "1"; min: 1; max: 100 }
+						label: qsTr("t"); name: "t"; childrenOnSameRow: true; id: tInformative
+						DoubleField { label: qsTr("location:"); name: "informativeTLocation"; visible: tInformative.checked; defaultValue: 0; min: -3; max: -3 }
+						DoubleField { label: qsTr("scale:"); name: "informativeTScale"; visible: tInformative.checked; defaultValue: 0.707; fieldWidth: 50; min: 0.001; max: 2 }
+						DoubleField { label: qsTr("df:"); name: "informativeTDf"; visible: tInformative.checked; inputType: "number"; value: "1"; min: 1; max: 100 }
 					}
 				}
 			}
@@ -82,27 +82,27 @@ ExpanderButton
 
         RadioButton
 		{
-			text: qsTr("Raw effect size (Dienes)"); name: "dienes"; debug: true
+			label: qsTr("Raw effect size (Dienes)"); name: "dienes"; debug: true
 			RadioButtonGroup
 			{
 				debug: true
 				name: "dienesEffectSize"
 				RadioButton
 				{
-					text: qsTr("Uniform"); name: "uniform"; checked: true; childrenOnSameRow: true; id: uniformDienes
-					DoubleField { text: qsTr("lower bound:"); name: "uniformDienesLowerBound"; visible: uniformDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
-					DoubleField { text: qsTr("upper bound:"); name: "uniformDienesUpperBound"; visible: uniformDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
+					label: qsTr("Uniform"); name: "uniform"; checked: true; childrenOnSameRow: true; id: uniformDienes
+					DoubleField { label: qsTr("lower bound:"); name: "uniformDienesLowerBound"; visible: uniformDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
+					DoubleField { label: qsTr("upper bound:"); name: "uniformDienesUpperBound"; visible: uniformDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
 				}
 				RadioButton
 				{
-					text: qsTr("Half-normal"); name: "half_normal"; childrenOnSameRow: true; id: halfNormalDienes
-					DoubleField { text: qsTr("std:"); name: "halfNormalDienesStd"; visible: halfNormalDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
+					label: qsTr("Half-normal"); name: "half_normal"; childrenOnSameRow: true; id: halfNormalDienes
+					DoubleField { label: qsTr("std:"); name: "halfNormalDienesStd"; visible: halfNormalDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
 				}
 				RadioButton
 				{
-					text: qsTr("Normal"); name: "normal"; childrenOnSameRow: true; id: normalDienes
-					DoubleField { text: qsTr("mean:"); name: "normalDienesMean"; visible: normalDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
-					DoubleField { text: qsTr("std:"); name: "normalDienesStd"; visible: normalDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
+					label: qsTr("Normal"); name: "normal"; childrenOnSameRow: true; id: normalDienes
+					DoubleField { label: qsTr("mean:"); name: "normalDienesMean"; visible: normalDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
+					DoubleField { label: qsTr("std:"); name: "normalDienesStd"; visible: normalDienes.checked; defaultValue: 0.707; fieldWidth: 50; min: 0; max: 2 }
 				}
 			}
 		}

--- a/JASP-Desktop/data/computedcolumnsmodel.cpp
+++ b/JASP-Desktop/data/computedcolumnsmodel.cpp
@@ -396,9 +396,9 @@ ComputedColumn * ComputedColumnsModel::createComputedColumn(QString name, int co
 	while (!success);
 
 	//if(theData != _package->dataSet())
-	emit dataSetChanged(_package->dataSet());
 
 	ComputedColumn  * createdColumn = computedColumnsPointer()->createComputedColumn(name.toStdString(), (Column::ColumnType)columnType, computeType);
+	emit dataSetChanged(_package->dataSet());
 	emit refreshData();
 
 	setLastCreatedColumn(name);

--- a/JASP-Desktop/widgets/boundqmlcombobox.cpp
+++ b/JASP-Desktop/widgets/boundqmlcombobox.cpp
@@ -50,13 +50,27 @@ BoundQMLComboBox::BoundQMLComboBox(QQuickItem* item, AnalysisForm* form)
 	}
 	else
 	{
+		QString textRole = QQmlProperty(item, "textRole").read().toString();
+		QString valueRole = QQmlProperty(item, "valueRole").read().toString();
 		_model->setTermsAreVariables(false);
 		Terms terms;
 		QList<QVariant> list = model.toList();
 		if (!list.isEmpty())
 		{
-			for (const QVariant& val : list)
-				terms.add(val.toString());
+			for (const QVariant& itemVariant : list)
+			{
+				QMap<QString, QVariant> labelValueMap = itemVariant.toMap();
+				if (labelValueMap.isEmpty())
+					terms.add(itemVariant.toString());
+				else
+				{
+					QString key = labelValueMap[textRole].toString();
+					QString value = labelValueMap[valueRole].toString();
+					terms.add(key);
+					_keyToValueMap[key] = value;
+					_valueToKeyMap[value] = key;					
+				}
+			}
 			_model->initTerms(terms);
 		}
 		else
@@ -64,12 +78,11 @@ BoundQMLComboBox::BoundQMLComboBox(QQuickItem* item, AnalysisForm* form)
 			QAbstractListModel *srcModel = qobject_cast<QAbstractListModel *>(model.value<QObject *>());
 			if (srcModel)
 			{
-				QMap<QString, int> roleMap;				
-				QString textRole = QQmlProperty(item, "textRole").read().toString();
-				QString valueRole = QQmlProperty(item, "valueRole").read().toString();
+				QMap<QString, int> roleMap;
 				QHash<int, QByteArray> roles = srcModel->roleNames();
 				QHashIterator<int, QByteArray> i(roles);
-				while (i.hasNext()) {
+				while (i.hasNext()) 
+				{
 					i.next();
 					QString valueStr = QString::fromStdString(i.value().toStdString());
 					roleMap[valueStr] = i.key();

--- a/JASP-Desktop/widgets/boundqmllistviewterms.cpp
+++ b/JASP-Desktop/widgets/boundqmllistviewterms.cpp
@@ -32,7 +32,7 @@ BoundQMLListViewTerms::BoundQMLListViewTerms(QQuickItem* item, AnalysisForm* for
 {
 	_optionsTable = nullptr;
 	_optionVariables = nullptr;
-	_singleItem = QQmlProperty(_item, "singleItem").read().toBool();
+	_singleItem = QQmlProperty(_item, "singleVariable").read().toBool();
 	_variablesModel = new ListModelTermsAssigned(this, _singleItem);
 	
 	connect(_variablesModel, &ListModelAssignedInterface::allExtraControlsLoaded, this, &BoundQMLListViewTerms::bindExtraControlOptions);

--- a/Resources/Common/qml/Ancova.qml
+++ b/Resources/Common/qml/Ancova.qml
@@ -38,7 +38,7 @@ Form
 		{
 			name: "dependent"
 			title: qsTr("Dependent Variable")
-			singleItem: true
+			singleVariable: true
 			allowedColumns: ["scale"]
 		}
 		AssignedVariablesList
@@ -64,7 +64,7 @@ Form
 		{
 			name: "wlsWeights"
 			title: qsTr("WLS Weights")
-			singleItem: true
+			singleVariable: true
 			allowedColumns: ["scale"]
 		}
 	}
@@ -85,13 +85,12 @@ Form
 		{
 			name: "sumOfSquares"
 			indexDefaultValue: 2
-			text: qsTr("Sum of squares")
-			model: ListModel
-			{
-				ListElement { title: "Type \u2160"; value: "type1" }
-				ListElement { title: "Type \u2161"; value: "type2" }
-				ListElement { title: "Type \u2162"; value: "type3" }
-			}
+			label: qsTr("Sum of squares")
+			values: [
+				{ label: "Type \u2160", value: "type1"},
+				{ label: "Type \u2161", value: "type2"},
+				{ label: "Type \u2162", value: "type3"}
+			]
 		}
 		
 	}
@@ -102,9 +101,9 @@ Form
 		
 		Group
 		{
-			CheckBox { name: "homogeneityTests";			text: qsTr("Homogeneity tests")									}
-			CheckBox { name: "qqPlot";						text: qsTr("Q-Q plot of residuals")								}
-			CheckBox { name: "factorCovariateIndependence";	text: qsTr("Factor covariate independence check"); debug: true	}
+			CheckBox { name: "homogeneityTests";			label: qsTr("Homogeneity tests")								}
+			CheckBox { name: "qqPlot";						label: qsTr("Q-Q plot of residuals")							}
+			CheckBox { name: "factorCovariateIndependence";	label: qsTr("Factor covariate independence check"); debug: true	}
 		}
 	}
 	
@@ -114,10 +113,10 @@ Form
 		
 		ContrastsList {}
 		
-		CheckBox { name: "contrastAssumeEqualVariance"; text: qsTr("Assume equal variances"); checked: true }
+		CheckBox { name: "contrastAssumeEqualVariance"; label: qsTr("Assume equal variances"); checked: true }
 		CheckBox
 		{
-			name: "confidenceIntervalsContrast"; text: qsTr("Confidence intervals")
+			name: "confidenceIntervalsContrast"; label: qsTr("Confidence intervals")
 			childrenOnSameRow: true
 			PercentField { name: "confidenceIntervalIntervalContrast"; defaultValue: 95 }
 		}
@@ -134,11 +133,11 @@ Form
 			AssignedVariablesList {  name: "postHocTestsVariables" }
 		}
 		
-		CheckBox { name: "postHocTestEffectSize";	text: qsTr("Effect Size") }
+		CheckBox { name: "postHocTestEffectSize";	label: qsTr("Effect Size") }
 
 		CheckBox
 		{
-			name: "confidenceIntervalsPostHoc"; text: qsTr("Confidence intervals")
+			name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence intervals")
 			childrenOnSameRow: true
 			PercentField {name: "confidenceIntervalIntervalPostHoc"; defaultValue: 95 }
 		}
@@ -146,19 +145,19 @@ Form
 		Group
 		{
 			title: qsTr("Correction")
-			CheckBox { name: "postHocTestsTukey";		text: qsTr("Tukey"); checked: true	}
-			CheckBox { name: "postHocTestsScheffe";		text: qsTr("Scheffe")				}
-			CheckBox { name: "postHocTestsBonferroni";	text: qsTr("Bonferroni")			}
-			CheckBox { name: "postHocTestsHolm";		text: qsTr("Holm")					}
+			CheckBox { name: "postHocTestsTukey";		label: qsTr("Tukey"); checked: true	}
+			CheckBox { name: "postHocTestsScheffe";		label: qsTr("Scheffe")				}
+			CheckBox { name: "postHocTestsBonferroni";	label: qsTr("Bonferroni")			}
+			CheckBox { name: "postHocTestsHolm";		label: qsTr("Holm")					}
 		}
 
 		Group
 		{
 			title: qsTr("Type")
-			CheckBox { name: "postHocTestsTypeStandard";	text: qsTr("Standard"); checked: true	}
-			CheckBox { name: "postHocTestsTypeGames";		text: qsTr("Games-Howell")				}
-			CheckBox { name: "postHocTestsTypeDunnett";		text: qsTr("Dunnett")					}
-			CheckBox { name: "postHocTestsTypeDunn";		text: qsTr("Dunn")						}
+			CheckBox { name: "postHocTestsTypeStandard";	label: qsTr("Standard"); checked: true	}
+			CheckBox { name: "postHocTestsTypeGames";		label: qsTr("Games-Howell")				}
+			CheckBox { name: "postHocTestsTypeDunnett";		label: qsTr("Dunnett")					}
+			CheckBox { name: "postHocTestsTypeDunn";		label: qsTr("Dunn")						}
 		}
 	}
 	
@@ -169,9 +168,9 @@ Form
 		VariablesForm {
 			height: 200
 			availableVariablesList { name: "descriptivePlotsVariables"; title: qsTr("Factors"); source: "fixedFactors"	}
-			AssignedVariablesList {	name: "plotHorizontalAxis";			title: qsTr("Horizontal axis"); singleItem: true	}
-			AssignedVariablesList {	name: "plotSeparateLines";			title: qsTr("Separate lines"); singleItem: true		}
-			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate plots"); singleItem: true		}
+			AssignedVariablesList {	name: "plotHorizontalAxis";			title: qsTr("Horizontal axis"); singleVariable: true	}
+			AssignedVariablesList {	name: "plotSeparateLines";			title: qsTr("Separate lines"); singleVariable: true		}
+			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate plots"); singleVariable: true		}
 		}
 		
 		Group
@@ -179,17 +178,17 @@ Form
 			title: qsTr("Display")
 			CheckBox
 			{
-				name: "plotErrorBars"; text: qsTr("Display error bars")
+				name: "plotErrorBars"; label: qsTr("Display error bars")
 				RadioButtonGroup
 				{
 					name: "errorBarType"
 					RadioButton
 					{
-						value: "confidenceInterval"; text: qsTr("Confidence Interval"); checked: true
+						value: "confidenceInterval"; label: qsTr("Confidence Interval"); checked: true
 						childrenOnSameRow: true
-						PercentField { name: "confidenceIntervalInterval";	text: qsTr("Interval"); defaultValue: 95 }
+						PercentField { name: "confidenceIntervalInterval";	label: qsTr("Interval"); defaultValue: 95 }
 					}
-					RadioButton { value: "standardError"; text: qsTr("Standard error") }
+					RadioButton { value: "standardError"; label: qsTr("Standard error") }
 				}
 			}
 		}
@@ -210,33 +209,32 @@ Form
 		
 		CheckBox
 		{
-			name: "marginalMeansCompareMainEffects"; text: qsTr("Compare marginal means to 0")
+			name: "marginalMeansCompareMainEffects"; label: qsTr("Compare marginal means to 0")
 			DropDown
 			{
 				name: "marginalMeansCIAdjustment"
-				text: qsTr("Confidence interval adjustment")
-				model: ListModel
-				{
-					ListElement { title: "None";		value: "none"		}
-					ListElement { title: "Bonferro";	value: "bonferroni"	}
-					ListElement { title: "Sidak";		value: "sidak"		}
-				}
+				label: qsTr("Confidence interval adjustment")
+				values: [
+					{ label: "None",		value: "none"},
+					{ label: "Bonferro",	value: "bonferroni"},
+					{ label: "Sidak",		value: "sidak"}
+				]
 			}
 		}
 		
 		Group
 		{
 			title: qsTr("Display")
-			CheckBox { name: "descriptives"; text: qsTr("Descriptive statistics") }
+			CheckBox { name: "descriptives"; label: qsTr("Descriptive statistics") }
 			CheckBox
 			{
-				name: "effectSizeEstimates"; text: qsTr("Estimates of effect size")
+				name: "effectSizeEstimates"; label: qsTr("Estimates of effect size")
 				columns: 3
-				CheckBox { name: "effectSizeEtaSquared";		text: qsTr("η²"); checked: true	}
-				CheckBox { name: "effectSizePartialEtaSquared";	text: qsTr("partial η²")		}
-				CheckBox { name: "effectSizeOmegaSquared";		text: qsTr("ω²")				}
+				CheckBox { name: "effectSizeEtaSquared";		label: qsTr("η²"); checked: true	}
+				CheckBox { name: "effectSizePartialEtaSquared";	label: qsTr("partial η²")		}
+				CheckBox { name: "effectSizeOmegaSquared";		label: qsTr("ω²")				}
 			}
-			CheckBox { name: "VovkSellkeMPR"; text: qsTr("Vovk-Sellke maximum p-ratio") }
+			CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}
 	}
 	
@@ -248,9 +246,9 @@ Form
 		{
 			height: 160
 			availableVariablesList { name: "effectsVariables";	title: qsTr("Factors");	source: "fixedFactors" }
-			AssignedVariablesList {	name: "simpleFactor";		title: qsTr("Simple effect factor"); singleItem: true }
-			AssignedVariablesList {	name: "moderatorFactorOne";	title: qsTr("Moderator factor 1"); singleItem: true }
-			AssignedVariablesList {	name: "moderatorFactorTwo";	title: qsTr("Moderator factor 2"); singleItem: true }
+			AssignedVariablesList {	name: "simpleFactor";		title: qsTr("Simple effect factor"); singleVariable: true }
+			AssignedVariablesList {	name: "moderatorFactorOne";	title: qsTr("Moderator factor 1"); singleVariable: true }
+			AssignedVariablesList {	name: "moderatorFactorTwo";	title: qsTr("Moderator factor 2"); singleVariable: true }
 		}
 	}
 	
@@ -270,7 +268,7 @@ Form
 			}
 		}
 		
-		CheckBox { name: "dunnTest"; text: qsTr("Dunn's post hoc test") }
+		CheckBox { name: "dunnTest"; label: qsTr("Dunn's post hoc test") }
 	}
 	
 }

--- a/Resources/Common/qml/AncovaBayesian.qml
+++ b/Resources/Common/qml/AncovaBayesian.qml
@@ -34,7 +34,7 @@ Form
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "dependent";		title: qsTr("Dependent Variable");	allowedColumns: ["scale"];  singleItem: true	}
+		AssignedVariablesList { name: "dependent";		title: qsTr("Dependent Variable");	allowedColumns: ["scale"];  singleVariable: true	}
 		AssignedVariablesList { name: "fixedFactors";	title: qsTr("Fixed Factors");		allowedColumns: ["ordinal", "nominal"]			}
 		AssignedVariablesList { name: "randomFactors";	title: qsTr("Random Factors");		allowedColumns: ["ordinal", "nominal"]			}
 		AssignedVariablesList { name: "covariates";		title: qsTr("Covariates");			allowedColumns: ["scale"]						}
@@ -47,23 +47,23 @@ Form
 		title: qsTr("Output")
 		CheckBox
 		{
-			name: "effects"; text: qsTr("Effects")
+			name: "effects"; label: qsTr("Effects")
 			RadioButtonGroup
 			{
 				name: "effectsType"
-				RadioButton { value: "allModels";		text: qsTr("Across all models"); checked: true	}
-				RadioButton { value: "matchedModels";	text: qsTr("Across matched models")				}
+				RadioButton { value: "allModels";		label: qsTr("Across all models"); checked: true	}
+				RadioButton { value: "matchedModels";	label: qsTr("Across matched models")			}
 			}
 		}
-		CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
+		CheckBox { name: "descriptives"; label: qsTr("Descriptives") }
 	}
 
 	RadioButtonGroup
 	{
 		title: qsTr("Order")
 		name: "bayesFactorOrder"
-		RadioButton { value: "nullModelTop"; text: qsTr("Compare to null model"); checked: true	}
-		RadioButton { value: "bestModelTop"; text: qsTr("Compare to best model")				}
+		RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model"); checked: true	}
+		RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model")					}
 	}
 	
 	ExpanderButton
@@ -113,7 +113,7 @@ Form
 		Group
 		{
 			title: qsTr("Correction")
-			CheckBox { name: "postHocTestsNullControl"; text: qsTr("Null control"); checked: true }
+			CheckBox { name: "postHocTestsNullControl"; label: qsTr("Null control"); checked: true }
 		}
 	}
 	
@@ -125,9 +125,9 @@ Form
 		{
 			height: 200
 			availableVariablesList { name: "descriptivePlotsVariables";	title: qsTr("Factors")          ; source: "fixedFactors" }
-			AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal axis")  ; singleItem: true }
-			AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate lines")	; singleItem: true }
-			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate plots")   ; singleItem: true }
+			AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal axis")  ; singleVariable: true }
+			AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate lines")	; singleVariable: true }
+			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate plots")   ; singleVariable: true }
 		}
 		
 		Group
@@ -135,7 +135,7 @@ Form
 			title: qsTr("Display")
 			CheckBox
 			{
-				name: "plotCredibleInterval"; text: qsTr("Credible interval")
+				name: "plotCredibleInterval"; label: qsTr("Credible interval")
 				childrenOnSameRow: true
 				PercentField { name: "plotCredibleIntervalInterval"; defaultValue: 95 }
 			}
@@ -149,23 +149,23 @@ Form
 		Group
 		{
 			title: qsTr("Prior")
-			DoubleField { name: "priorFixedEffects";		text: qsTr("r scale fixed effects");	defaultValue: 0.5;	fieldWidth: 50; max: 2; decimals: 1 }
-			DoubleField { name: "priorRandomEffects";		text: qsTr("r scale random effects");	defaultValue: 1;	fieldWidth: 50; max: 2; decimals: 1 }
-			DoubleField { name: "priorCovariatesEffects";	text: qsTr("r scale covariates");		defaultValue: 0.354; fieldWidth: 50; max: 2; decimals: 1 }
+			DoubleField { name: "priorFixedEffects";		label: qsTr("r scale fixed effects");	defaultValue: 0.5;	fieldWidth: 50; max: 2; decimals: 1 }
+			DoubleField { name: "priorRandomEffects";		label: qsTr("r scale random effects");	defaultValue: 1;	fieldWidth: 50; max: 2; decimals: 1 }
+			DoubleField { name: "priorCovariatesEffects";	label: qsTr("r scale covariates");		defaultValue: 0.354; fieldWidth: 50; max: 2; decimals: 1 }
 		}
 
 		RadioButtonGroup
 		{
 			name: "sampleMode"
-			text: qsTr("Samples")
+			title: qsTr("Samples")
 			RadioButton
 			{
-				value: "auto";		text: qsTr("Auto");	checked: true
+				value: "auto";		label: qsTr("Auto");	checked: true
 			}
 			RadioButton
 			{
-				value: "manual";	text: qsTr("Manual")
-				IntegerField { name: "fixedSamplesNumber"; text: qsTr("No. samples"); defaultValue: 10000; fieldWidth: 70 }
+				value: "manual";	label: qsTr("Manual")
+				IntegerField { name: "fixedSamplesNumber"; label: qsTr("No. samples"); defaultValue: 10000; fieldWidth: 70 }
 			}
 		}
 	}

--- a/Resources/Common/qml/Anova.qml
+++ b/Resources/Common/qml/Anova.qml
@@ -33,10 +33,10 @@ Form
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "dependent";		title: qsTr("Dependent Variable");	allowedColumns: ["scale"]; singleItem: true }
+		AssignedVariablesList { name: "dependent";		title: qsTr("Dependent Variable");	allowedColumns: ["scale"]; singleVariable: true }
 		AssignedVariablesList { name: "fixedFactors";	title: qsTr("Fixed Factors");		allowedColumns: ["ordinal", "nominal"]		}
 		AssignedVariablesList { name: "randomFactors";	title: qsTr("Random Factors");		allowedColumns: ["ordinal", "nominal"];	debug: true }
-		AssignedVariablesList { name: "wlsWeights";		title: qsTr("WLS Weights");			allowedColumns: ["scale"]; singleItem: true }
+		AssignedVariablesList { name: "wlsWeights";		title: qsTr("WLS Weights");			allowedColumns: ["scale"]; singleVariable: true }
 	}
 	
 	ExpanderButton
@@ -54,13 +54,12 @@ Form
 		{
 			name: "sumOfSquares"
 			indexDefaultValue: 2
-			text: qsTr("Sum of squares")
-			model: ListModel
-			{    
-				ListElement { title: "Type \u2160"; value: "type1"}
-				ListElement { title: "Type \u2161"; value: "type2"}
-				ListElement { title: "Type \u2162"; value: "type3"}
-			}
+			label: qsTr("Sum of squares")
+			values: [
+				{ label: "Type \u2160", value: "type1"},
+				{ label: "Type \u2161", value: "type2"},
+				{ label: "Type \u2162", value: "type3"}
+			]
 		}
 		
 	}
@@ -71,16 +70,16 @@ Form
 		
 		Group
 		{
-			CheckBox { name: "homogeneityTests";	text: qsTr("Homogeneity tests")			}
+			CheckBox { name: "homogeneityTests";	label: qsTr("Homogeneity tests")			}
 			CheckBox
 			{
-				name: "homogeneityCorrections";		text: qsTr("Homogeneity corrections")
+				name: "homogeneityCorrections";		label: qsTr("Homogeneity corrections")
 				columns: 3
-				CheckBox { name: "homogeneityNone";		text: qsTr("None")           ; checked: true }
-				CheckBox { name: "homogeneityBrown";	text: qsTr("Brown-Forsythe") ; checked: true }
-				CheckBox { name: "homogeneityWelch";	text: qsTr("Welch")          ; checked: true }
+				CheckBox { name: "homogeneityNone";		label: qsTr("None")           ; checked: true }
+				CheckBox { name: "homogeneityBrown";	label: qsTr("Brown-Forsythe") ; checked: true }
+				CheckBox { name: "homogeneityWelch";	label: qsTr("Welch")          ; checked: true }
 			}
-			CheckBox { name: "qqPlot"; text: qsTr("Q-Q plot of residuals") }
+			CheckBox { name: "qqPlot"; label: qsTr("Q-Q plot of residuals") }
 		}
 	}
 	
@@ -90,10 +89,10 @@ Form
 		
 		ContrastsList { source: ["fixedFactors", "randomFactors"] }
 		
-		CheckBox { name: "contrastAssumeEqualVariance"; text: qsTr("Assume equal variances"); checked: true }
+		CheckBox { name: "contrastAssumeEqualVariance"; label: qsTr("Assume equal variances"); checked: true }
 		CheckBox
 		{
-			name: "confidenceIntervalsContrast"; text: qsTr("Confidence intervals")
+			name: "confidenceIntervalsContrast"; label: qsTr("Confidence intervals")
 			childrenOnSameRow: true
 			PercentField {	name: "confidenceIntervalIntervalContrast"; defaultValue: 95 }
 		}
@@ -110,11 +109,11 @@ Form
 			AssignedVariablesList {  name: "postHocTestsVariables" }
 		}
 		
-		CheckBox { name: "postHocTestEffectSize"; text: qsTr("Effect Size") }
+		CheckBox { name: "postHocTestEffectSize"; label: qsTr("Effect Size") }
 
 		CheckBox
 		{
-			name: "confidenceIntervalsPostHoc"; text: qsTr("Confidence intervals")
+			name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence intervals")
 			childrenOnSameRow: true
 			PercentField {	name: "confidenceIntervalIntervalPostHoc"; defaultValue: 95 }
 		}
@@ -122,19 +121,19 @@ Form
 		Group
 		{
 			title: qsTr("Correction")
-			CheckBox { name: "postHocTestsTukey";		text: qsTr("Tukey"); checked: true	}
-			CheckBox { name: "postHocTestsScheffe";		text: qsTr("Scheffe")				}
-			CheckBox { name: "postHocTestsBonferroni";	text: qsTr("Bonferroni")			}
-			CheckBox { name: "postHocTestsHolm";		text: qsTr("Holm")					}
+			CheckBox { name: "postHocTestsTukey";		label: qsTr("Tukey"); checked: true	}
+			CheckBox { name: "postHocTestsScheffe";		label: qsTr("Scheffe")				}
+			CheckBox { name: "postHocTestsBonferroni";	label: qsTr("Bonferroni")			}
+			CheckBox { name: "postHocTestsHolm";		label: qsTr("Holm")					}
 		}
 
 		Group
 		{
 			title: qsTr("Type")
-			CheckBox { name: "postHocTestsTypeStandard";	text: qsTr("Standard"); checked: true	}
-			CheckBox { name: "postHocTestsTypeGames";		text: qsTr("Games-Howell")				}
-			CheckBox { name: "postHocTestsTypeDunnett";		text: qsTr("Dunnett")					}
-			CheckBox { name: "postHocTestsTypeDunn";		text: qsTr("Dunn")						}
+			CheckBox { name: "postHocTestsTypeStandard";	label: qsTr("Standard"); checked: true	}
+			CheckBox { name: "postHocTestsTypeGames";		label: qsTr("Games-Howell")				}
+			CheckBox { name: "postHocTestsTypeDunnett";		label: qsTr("Dunnett")					}
+			CheckBox { name: "postHocTestsTypeDunn";		label: qsTr("Dunn")						}
 		}
 	}
 	
@@ -146,9 +145,9 @@ Form
 		{
 			height: 150
 			availableVariablesList { name: "descriptivePlotsVariables"; title: qsTr("Factors"); source: ["fixedFactors", "randomFactors"] }
-			AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal axis"); singleItem: true }
-			AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate lines");	singleItem: true }
-			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate plots");	singleItem: true }
+			AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal axis"); singleVariable: true }
+			AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate lines");	singleVariable: true }
+			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate plots");	singleVariable: true }
 		}
 		
 		Group
@@ -156,17 +155,17 @@ Form
 			title: qsTr("Display")
 			CheckBox
 			{
-				name: "plotErrorBars"; text: qsTr("Display error bars")
+				name: "plotErrorBars"; label: qsTr("Display error bars")
 				RadioButtonGroup
 				{
 					name: "errorBarType"
 					RadioButton
 					{
-						value: "confidenceInterval";		text: qsTr("Confidence Interval"); checked: true
+						value: "confidenceInterval";		label: qsTr("Confidence Interval"); checked: true
 						childrenOnSameRow: true
-						PercentField { name: "confidenceIntervalInterval";	text: qsTr("Interval"); defaultValue: 95 }
+						PercentField { name: "confidenceIntervalInterval";	label: qsTr("Interval"); defaultValue: 95 }
 					}
-					RadioButton { value: "standardError";	text: qsTr("Standard error") }
+					RadioButton { value: "standardError";	label: qsTr("Standard error") }
 				}
 			}
 		}
@@ -187,32 +186,31 @@ Form
 		
 		CheckBox
 		{
-			name: "marginalMeansCompareMainEffects"; text: qsTr("Compare marginal means to 0")
+			name: "marginalMeansCompareMainEffects"; label: qsTr("Compare marginal means to 0")
 			DropDown
 			{
 				name: "marginalMeansCIAdjustment"
-				text: qsTr("Confidence interval adjustment")
-				model: ListModel
-				{
-					ListElement { title: "None";		value: "none"		}
-					ListElement { title: "Bonferro";	value: "bonferroni"	}
-					ListElement { title: "Sidak";		value: "sidak"		}
-				}
+				label: qsTr("Confidence interval adjustment")
+				values: [
+					{ label: "None",		value: "none"},
+					{ label: "Bonferro",	value: "bonferroni"},
+					{ label: "Sidak",		value: "sidak"}
+				]
 			}
 		}
 		
 		Group
 		{
 			title: qsTr("Display")
-			CheckBox { name: "descriptives";	text: qsTr("Descriptive statistics")	}
+			CheckBox { name: "descriptives";	label: qsTr("Descriptive statistics")	}
 			CheckBox {
-				name: "effectSizeEstimates";	text: qsTr("Estimates of effect size")
+				name: "effectSizeEstimates";	label: qsTr("Estimates of effect size")
 				columns: 3
-				CheckBox { name: "effectSizeEtaSquared";		text: qsTr("η²"); checked: true	}
-				CheckBox { name: "effectSizePartialEtaSquared";	text: qsTr("partial η²")		}
-				CheckBox { name: "effectSizeOmegaSquared";		text: qsTr("ω²")				}
+				CheckBox { name: "effectSizeEtaSquared";		label: qsTr("η²"); checked: true	}
+				CheckBox { name: "effectSizePartialEtaSquared";	label: qsTr("partial η²")		}
+				CheckBox { name: "effectSizeOmegaSquared";		label: qsTr("ω²")				}
 			}
-			CheckBox { name: "VovkSellkeMPR"; text: qsTr("Vovk-Sellke maximum p-ratio") }
+			CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}
 	}
 	
@@ -224,9 +222,9 @@ Form
 		{
 			height: 170
 			availableVariablesList { name: "effectsVariables";	title: qsTr("Factors")				; source:  ["fixedFactors", "randomFactors"] }
-			AssignedVariablesList {	name: "simpleFactor";		title: qsTr("Simple effect factor") ; singleItem: true }
-			AssignedVariablesList { name: "moderatorFactorOne";	title: qsTr("Moderator factor 1")	; singleItem: true }
-			AssignedVariablesList { name: "moderatorFactorTwo";	title: qsTr("Moderator factor 2")	; singleItem: true }
+			AssignedVariablesList {	name: "simpleFactor";		title: qsTr("Simple effect factor") ; singleVariable: true }
+			AssignedVariablesList { name: "moderatorFactorOne";	title: qsTr("Moderator factor 1")	; singleVariable: true }
+			AssignedVariablesList { name: "moderatorFactorTwo";	title: qsTr("Moderator factor 2")	; singleVariable: true }
 		}
 	}
 	

--- a/Resources/Common/qml/AnovaBayesian.qml
+++ b/Resources/Common/qml/AnovaBayesian.qml
@@ -35,7 +35,7 @@ Form
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "dependent";		title: qsTr("Dependent Variable");	allowedColumns: ["scale"]; singleItem: true	}
+		AssignedVariablesList { name: "dependent";		title: qsTr("Dependent Variable");	allowedColumns: ["scale"]; singleVariable: true	}
 		AssignedVariablesList { name: "fixedFactors";	title: qsTr("Fixed Factors");		allowedColumns: ["ordinal", "nominal"]		}
 		AssignedVariablesList { name: "randomFactors";	title: qsTr("Random Factors");		allowedColumns: ["ordinal", "nominal"]		}
 	}
@@ -47,23 +47,23 @@ Form
 		title: qsTr("Output")
 		CheckBox
 		{
-			name: "effects"; text: qsTr("Effects")
+			name: "effects"; label: qsTr("Effects")
 			RadioButtonGroup
 			{
 				name: "effectsType"
-				RadioButton { value: "allModels";		text: qsTr("Across all models"); checked: true	}
-				RadioButton { value: "matchedModels";	text: qsTr("Across matched models")				}
+				RadioButton { value: "allModels";		label: qsTr("Across all models"); checked: true	}
+				RadioButton { value: "matchedModels";	label: qsTr("Across matched models")				}
 			}
 		}
-		CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
+		CheckBox { name: "descriptives"; label: qsTr("Descriptives") }
 	}
 
 	RadioButtonGroup
 	{
 		title: qsTr("Order")
 		name: "bayesFactorOrder"
-		RadioButton { value: "nullModelTop"; text: qsTr("Compare to null model"); checked: true	}
-		RadioButton { value: "bestModelTop"; text: qsTr("Compare to best model")				}
+		RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model"); checked: true	}
+		RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model")				}
 	}
 	
 	ExpanderButton
@@ -107,7 +107,7 @@ Form
 		Group
 		{
 			title: qsTr("Correction")
-			CheckBox { name: "postHocTestsNullControl"; text: qsTr("Null control"); checked: true }
+			CheckBox { name: "postHocTestsNullControl"; label: qsTr("Null control"); checked: true }
 		}
 	}
 	
@@ -119,9 +119,9 @@ Form
 		{
 			height: 140
 			availableVariablesList { name: "descriptivePlotsVariables" ;	title: qsTr("Factors"); source: "fixedFactors" }
-			AssignedVariablesList { name: "plotHorizontalAxis";				title: qsTr("Horizontal axis");	singleItem: true }
-			AssignedVariablesList { name: "plotSeparateLines";				title: qsTr("Separate lines");	singleItem: true }
-			AssignedVariablesList { name: "plotSeparatePlots";				title: qsTr("Separate plots");	singleItem: true }
+			AssignedVariablesList { name: "plotHorizontalAxis";				title: qsTr("Horizontal axis");	singleVariable: true }
+			AssignedVariablesList { name: "plotSeparateLines";				title: qsTr("Separate lines");	singleVariable: true }
+			AssignedVariablesList { name: "plotSeparatePlots";				title: qsTr("Separate plots");	singleVariable: true }
 		}
 		
 		Group
@@ -129,7 +129,7 @@ Form
 			title: qsTr("Display")
 			CheckBox
 			{
-				name: "plotCredibleInterval"; text: qsTr("Credible interval")
+				name: "plotCredibleInterval"; label: qsTr("Credible interval")
 				childrenOnSameRow: true
 				PercentField { name: "plotCredibleIntervalInterval"; defaultValue: 95 }
 			}
@@ -143,22 +143,22 @@ Form
 		Group
 		{
 			title: qsTr("Prior")
-			DoubleField { name: "priorFixedEffects";	text: qsTr("r scale fixed effects"); defaultValue: 0.5; max: 2; decimals: 1 }
-			DoubleField { name: "priorRandomEffects";	text: qsTr("r scale random effects"); defaultValue: 1; max: 2; decimals: 1 }
+			DoubleField { name: "priorFixedEffects";	label: qsTr("r scale fixed effects"); defaultValue: 0.5; max: 2; decimals: 1 }
+			DoubleField { name: "priorRandomEffects";	label: qsTr("r scale random effects"); defaultValue: 1; max: 2; decimals: 1 }
 		}
 
 		RadioButtonGroup
 		{
 			name: "sampleMode"
 			title: qsTr("Samples")
-			RadioButton { value: "auto";	text: qsTr("Auto"); checked: true }
+			RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
 			RadioButton
 			{
-				value: "manual";	text: qsTr("Manual")
+				value: "manual";	label: qsTr("Manual")
 				IntegerField
 				{
 					name: "fixedSamplesNumber"
-					text: qsTr("No. samples")
+					label: qsTr("No. samples")
 					defaultValue: 10000
 					fieldWidth: 50
 				}

--- a/Resources/Common/qml/AnovaRepeatedMeasures.qml
+++ b/Resources/Common/qml/AnovaRepeatedMeasures.qml
@@ -39,7 +39,7 @@ Form
 			name: "repeatedMeasuresCells"
 			title: qsTr("Repeated Measures Cells")
 			allowedColumns: ["scale"]
-			listViewType: "MeasuresCells"
+			listViewType: "RepeatedMeasures"
 			source: "repeatedMeasuresFactors"
 			height: 140
 		}
@@ -81,13 +81,12 @@ Form
 		{
 			name: "sumOfSquares"
 			indexDefaultValue: 2
-			text: qsTr("Sum of squares")
-			model: ListModel
-			{
-				ListElement { title: "Type \u2160"; value: "type1" }
-				ListElement { title: "Type \u2161"; value: "type2" }
-				ListElement { title: "Type \u2162"; value: "type3" }
-			}
+			label: qsTr("Sum of squares")
+			values: [
+				{ label: "Type \u2160", value: "type1"},
+				{ label: "Type \u2161", value: "type2"},
+				{ label: "Type \u2162", value: "type3"}
+			]
 		}
 		
 	}
@@ -98,16 +97,16 @@ Form
 
 		Group
 		{
-			CheckBox { name: "sphericityTests";	text: qsTr("Sphericity tests") }
+			CheckBox { name: "sphericityTests";	label: qsTr("Sphericity tests") }
 			CheckBox
 			{
-				name: "sphericityCorrections";	text: qsTr("Sphericity corrections")
+				name: "sphericityCorrections";	label: qsTr("Sphericity corrections")
 				columns: 3
-				CheckBox { name: "sphericityNone";				text: qsTr("None");					checked: true }
-				CheckBox { name: "sphericityGreenhouseGeisser";	text: qsTr("Greenhouse-Geisser");	checked: true }
-				CheckBox { name: "sphericityHuynhFeldt";		text: qsTr("Huynth-Feidt");			checked: true }
+				CheckBox { name: "sphericityNone";				label: qsTr("None");					checked: true }
+				CheckBox { name: "sphericityGreenhouseGeisser";	label: qsTr("Greenhouse-Geisser");	checked: true }
+				CheckBox { name: "sphericityHuynhFeldt";		label: qsTr("Huynth-Feidt");			checked: true }
 			}
-			CheckBox { name: "homogeneityTests"; text: qsTr("Homogeneity Tests") }
+			CheckBox { name: "homogeneityTests"; label: qsTr("Homogeneity Tests") }
 		}
 	}
 	
@@ -132,17 +131,17 @@ Form
 		Group
 		{
 			columns: 2
-			CheckBox { name: "postHocTestEffectSize";	text: qsTr("Effect Size")						}
-			CheckBox { name: "postHocTestPooledError";	text: qsTr("Pool error term for RM factors")	}
+			CheckBox { name: "postHocTestEffectSize";	label: qsTr("Effect Size")						}
+			CheckBox { name: "postHocTestPooledError";	label: qsTr("Pool error term for RM factors")	}
 		}
 		
 		Group
 		{
 			title: qsTr("Correction")
-			CheckBox { name: "postHocTestsTukey";		text: qsTr("Tukey"); checked: true	}
-			CheckBox { name: "postHocTestsScheffe";		text: qsTr("Scheffe")				}
-			CheckBox { name: "postHocTestsBonferroni";	text: qsTr("Bonferroni")			}
-			CheckBox { name: "postHocTestsHolm";		text: qsTr("Holm")					}
+			CheckBox { name: "postHocTestsTukey";		label: qsTr("Tukey"); checked: true	}
+			CheckBox { name: "postHocTestsScheffe";		label: qsTr("Scheffe")				}
+			CheckBox { name: "postHocTestsBonferroni";	label: qsTr("Bonferroni")			}
+			CheckBox { name: "postHocTestsHolm";		label: qsTr("Holm")					}
 		}
 	}
 	
@@ -155,32 +154,32 @@ Form
 		{
 			height: 150
 			availableVariablesList { name: "descriptivePlotsVariables"; title: qsTr("Factors");			source: ["repeatedMeasuresFactors", "betweenSubjectFactors"] }
-			AssignedVariablesList {  name: "plotHorizontalAxis";		title: qsTr("Horizontal axis"); singleItem: true }
-			AssignedVariablesList {  name: "plotSeparateLines";			title: qsTr("Separate lines");	singleItem: true }
-			AssignedVariablesList {  name: "plotSeparatePlots";			title: qsTr("Separate plots");	singleItem: true }
+			AssignedVariablesList {  name: "plotHorizontalAxis";		title: qsTr("Horizontal axis"); singleVariable: true }
+			AssignedVariablesList {  name: "plotSeparateLines";			title: qsTr("Separate lines");	singleVariable: true }
+			AssignedVariablesList {  name: "plotSeparatePlots";			title: qsTr("Separate plots");	singleVariable: true }
 		}
 		
-		TextField { name: "labelYAxis"; text: qsTr("Label y-axis"); fieldWidth: 200 }
+		TextField { name: "labelYAxis"; label: qsTr("Label y-axis"); fieldWidth: 200 }
 		Group
 		{
 			title: qsTr("Display")
 			columns: 2
 			CheckBox
 			{
-				name: "plotErrorBars"; text: qsTr("Display error bars")
+				name: "plotErrorBars"; label: qsTr("Display error bars")
 				RadioButtonGroup
 				{
 					name: "errorBarType"
 					RadioButton
 					{
-						value: "confidenceInterval"; text: qsTr("Confidence Interval"); checked: true
+						value: "confidenceInterval"; label: qsTr("Confidence Interval"); checked: true
 						childrenOnSameRow: true
-						PercentField { name: "confidenceIntervalInterval"; text: qsTr("Interval"); defaultValue: 95 }
+						PercentField { name: "confidenceIntervalInterval"; label: qsTr("Interval"); defaultValue: 95 }
 					}
-					RadioButton { value: "standardError"; text: qsTr("Standard error") }
+					RadioButton { value: "standardError"; label: qsTr("Standard error") }
 				}
 			}
-			CheckBox { name: "usePooledStandErrorCI";	text: qsTr("Pool SE across RM factors")	}
+			CheckBox { name: "usePooledStandErrorCI";	label: qsTr("Pool SE across RM factors")	}
 			
 		}
 	}
@@ -204,17 +203,16 @@ Form
 			
 			CheckBox
 			{
-				name: "marginalMeansCompareMainEffects"; text: qsTr("Compare marginal means to 0")
+				name: "marginalMeansCompareMainEffects"; label: qsTr("Compare marginal means to 0")
 				DropDown
 				{
 					name: "marginalMeansCIAdjustment"
-					text: qsTr("Confidence interval adjustment")
-					model: ListModel
-					{
-						ListElement { title: "None";		value: "none"		}
-						ListElement { title: "Bonferro";	value: "bonferroni"	}
-						ListElement { title: "Sidak";		value: "sidak"		}
-					}
+					label: qsTr("Confidence interval adjustment")
+					values: [
+						{ label: "None",		value: "none"},
+						{ label: "Bonferro",	value: "bonferroni"},
+						{ label: "Sidak",		value: "sidak"}
+					]
 				}
 			}
 		}
@@ -222,16 +220,16 @@ Form
 		Group
 		{
 			title: qsTr("Display")
-			CheckBox { name: "descriptives";		text: qsTr("Descriptive statistics") }
+			CheckBox { name: "descriptives";		label: qsTr("Descriptive statistics") }
 			CheckBox
 			{
-				name: "effectSizeEstimates";	text: qsTr("Estimates of effect size")
+				name: "effectSizeEstimates";	label: qsTr("Estimates of effect size")
 				columns: 3
-				CheckBox { name: "effectSizeEtaSquared";		text: qsTr("η²")         ; checked: true	}
-				CheckBox { name: "effectSizePartialEtaSquared";	text: qsTr("partial η²")					}
-				CheckBox { name: "effectSizeOmegaSquared";		text: qsTr("ω²")							}
+				CheckBox { name: "effectSizeEtaSquared";		label: qsTr("η²")         ; checked: true	}
+				CheckBox { name: "effectSizePartialEtaSquared";	label: qsTr("partial η²")					}
+				CheckBox { name: "effectSizeOmegaSquared";		label: qsTr("ω²")							}
 			}
-			CheckBox { name: "VovkSellkeMPR";					text: qsTr("Vovk-Sellke maximum p-ratio")	}
+			CheckBox { name: "VovkSellkeMPR";					label: qsTr("Vovk-Sellke maximum p-ratio")	}
 		}
 	}
 	
@@ -243,12 +241,12 @@ Form
 		{
 			height: 150
 			availableVariablesList { name: "effectsVariables";	title: qsTr("Factors"); source: ["repeatedMeasuresFactors", "betweenSubjectFactors"] }
-			AssignedVariablesList {  name: "simpleFactor";		title: qsTr("Simple effect factor");	singleItem: true }
-			AssignedVariablesList { name: "moderatorFactorOne";	title: qsTr("Moderator factor 1");		singleItem: true }
-			AssignedVariablesList { name: "moderatorFactorTwo";	title: qsTr("Moderator factor 2");		singleItem: true }
+			AssignedVariablesList {  name: "simpleFactor";		title: qsTr("Simple effect factor");	singleVariable: true }
+			AssignedVariablesList { name: "moderatorFactorOne";	title: qsTr("Moderator factor 1");		singleVariable: true }
+			AssignedVariablesList { name: "moderatorFactorTwo";	title: qsTr("Moderator factor 2");		singleVariable: true }
 		}
 		
-		CheckBox { name: "poolErrorTermSimpleEffects"; text: qsTr("Pool error terms") }
+		CheckBox { name: "poolErrorTermSimpleEffects"; label: qsTr("Pool error terms") }
 	}
 	
 	ExpanderButton
@@ -260,9 +258,9 @@ Form
 			height: 150
 			availableVariablesList { name: "kruskalVariablesAvailable"; title: qsTr("Factors"); source: ["repeatedMeasuresFactors", "betweenSubjectFactors"] }
 			AssignedVariablesList {  name: "friedmanWithinFactor";		title: qsTr("RM Factor") }
-			AssignedVariablesList {  name: "friedmanBetweenFactor";		title: qsTr("Optional grouping factor"); singleItem: true }
+			AssignedVariablesList {  name: "friedmanBetweenFactor";		title: qsTr("Optional grouping factor"); singleVariable: true }
 		}
 		
-		CheckBox { name: "connoverTest"; text: qsTr("Connover's post hoc tests") }
+		CheckBox { name: "connoverTest"; label: qsTr("Connover's post hoc tests") }
 	}
 }

--- a/Resources/Common/qml/AnovaRepeatedMeasuresBayesian.qml
+++ b/Resources/Common/qml/AnovaRepeatedMeasuresBayesian.qml
@@ -47,7 +47,7 @@ Form
 			name: "repeatedMeasuresCells"
 			title: qsTr("Repeated Measures Cells")
 			allowedColumns: ["scale"]
-			listViewType: "MeasuresCells"
+			listViewType: "RepeatedMeasures"
 			source: "repeatedMeasuresFactors"
 			height: 140
 		}
@@ -73,23 +73,23 @@ Form
 		title: qsTr("Output")
 		CheckBox
 		{
-			name: "effects"; text: qsTr("Effects")
+			name: "effects"; label: qsTr("Effects")
 			RadioButtonGroup
 			{
 				name: "effectsType"
-				RadioButton { value: "allModels";		text: qsTr("Across all models"); checked: true	}
-				RadioButton { value: "matchedModels";	text: qsTr("Across matched models")				}
+				RadioButton { value: "allModels";		label: qsTr("Across all models"); checked: true	}
+				RadioButton { value: "matchedModels";	label: qsTr("Across matched models")			}
 			}
 		}
-		CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
+		CheckBox { name: "descriptives"; label: qsTr("Descriptives") }
 	}
 
 	RadioButtonGroup
 	{
 		title: qsTr("Order")
 		name: "bayesFactorOrder"
-		RadioButton { value: "nullModelTop";	text: qsTr("Compare to null model"); checked: true	}
-		RadioButton { value: "bestModelTop";	text: qsTr("Compare to best model")					}
+		RadioButton { value: "nullModelTop";	label: qsTr("Compare to null model"); checked: true	}
+		RadioButton { value: "bestModelTop";	label: qsTr("Compare to best model")					}
 	}
 
 	ExpanderButton
@@ -138,7 +138,7 @@ Form
 		Group
 		{
 			title: qsTr("Correction")
-			CheckBox { name: "postHocTestsNullControl"; text: qsTr("Null control"); checked: true }
+			CheckBox { name: "postHocTestsNullControl"; label: qsTr("Null control"); checked: true }
 		}
 	}
 
@@ -151,15 +151,15 @@ Form
 		{
 			height: 150
 			availableVariablesList { name: "descriptivePlotsVariables";	title: qsTr("Factors"); source: ["repeatedMeasuresFactors", "betweenSubjectFactors"] }
-			AssignedVariablesList {  name: "plotHorizontalAxis";		title: qsTr("Horizontal axis");	singleItem: true }
-			AssignedVariablesList {  name: "plotSeparateLines";			title: qsTr("Separate lines");	singleItem: true }
-			AssignedVariablesList {  name: "plotSeparatePlots";			title: qsTr("Separate plots");	singleItem: true }
+			AssignedVariablesList {  name: "plotHorizontalAxis";		title: qsTr("Horizontal axis");	singleVariable: true }
+			AssignedVariablesList {  name: "plotSeparateLines";			title: qsTr("Separate lines");	singleVariable: true }
+			AssignedVariablesList {  name: "plotSeparatePlots";			title: qsTr("Separate plots");	singleVariable: true }
 		}
 
-		TextField { name: "labelYAxis"; text: qsTr("Label y-axis"); fieldWidth: 200 }
+		TextField { name: "labelYAxis"; label: qsTr("Label y-axis"); fieldWidth: 200 }
 		CheckBox
 		{
-			name: "plotCredibleInterval"; text: qsTr("Credible interval")
+			name: "plotCredibleInterval"; label: qsTr("Credible interval")
 			childrenOnSameRow: true
 			PercentField { name: "plotCredibleIntervalInterval"; defaultValue: 95 }
 		}
@@ -172,23 +172,23 @@ Form
 		Group
 		{
 			title: qsTr("Prior")
-			DoubleField { name: "priorFixedEffects";	text: qsTr("r scale fixed effects"); defaultValue: 0.5; fieldWidth: 50; max: 2; decimals: 1 }
-			DoubleField { name: "priorRandomEffects";	text: qsTr("r scale random effects"); defaultValue: 1; fieldWidth: 50; max: 2; decimals: 1 }
-			DoubleField { name: "priorCovariates";		text: qsTr("r scale covariates"); defaultValue: 0.354; fieldWidth: 50; max: 2; decimals: 1 }
+			DoubleField { name: "priorFixedEffects";	label: qsTr("r scale fixed effects"); defaultValue: 0.5; fieldWidth: 50; max: 2; decimals: 1 }
+			DoubleField { name: "priorRandomEffects";	label: qsTr("r scale random effects"); defaultValue: 1; fieldWidth: 50; max: 2; decimals: 1 }
+			DoubleField { name: "priorCovariates";		label: qsTr("r scale covariates"); defaultValue: 0.354; fieldWidth: 50; max: 2; decimals: 1 }
 		}
 
 		RadioButtonGroup
 		{
 			name: "sampleMode"
-			text: qsTr("Samples")
+			title: qsTr("Samples")
 			RadioButton
 			{
-				value: "auto";		text: qsTr("Auto"); checked: true
+				value: "auto";		label: qsTr("Auto"); checked: true
 			}
 			RadioButton
 			{
-				value: "manual";	text: qsTr("Manual")
-				IntegerField { name: "fixedSamplesNumber"; text: qsTr("No. samples"); defaultValue: 10000; fieldWidth: 50 }
+				value: "manual";	label: qsTr("Manual")
+				IntegerField { name: "fixedSamplesNumber"; label: qsTr("No. samples"); defaultValue: 10000; fieldWidth: 50 }
 			}
 		}
 	}

--- a/Resources/Common/qml/BinomialTest.qml
+++ b/Resources/Common/qml/BinomialTest.qml
@@ -28,15 +28,15 @@ Form
 		AssignedVariablesList { name: "variables"; allowedColumns: ["ordinal", "nominal"] }
 	}
 	
-	DoubleField { name: "testValue"; text: qsTr("Test value: "); defaultValue: 0.5 ; max: 1; decimals: 2; Layout.columnSpan: 2 }
+	DoubleField { name: "testValue"; label: qsTr("Test value: "); defaultValue: 0.5 ; max: 1; decimals: 2; Layout.columnSpan: 2 }
 
 	RadioButtonGroup
 	{
 		title: qsTr("Hypothesis")
 		name: "hypothesis"
-		RadioButton { value: "notEqualToTestValue";		text: qsTr("≠ Test value"); checked: true	}
-		RadioButton { value: "greaterThanTestValue";	text: qsTr("> Test value")					}
-		RadioButton { value: "lessThanTestValue";		text: qsTr("< Test value")					}
+		RadioButton { value: "notEqualToTestValue";		label: qsTr("≠ Test value"); checked: true	}
+		RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value")					}
+		RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value")					}
 	}
 
 	Group
@@ -44,10 +44,10 @@ Form
 		title: qsTr("Additional Statisics")
 		CheckBox
 		{
-			name: "confidenceInterval";	text: qsTr("Confidence interval")
-			PercentField { name: "confidenceIntervalInterval";	text: qsTr("Interval"); defaultValue: 95 }
+			name: "confidenceInterval";	label: qsTr("Confidence interval")
+			PercentField { name: "confidenceIntervalInterval";	label: qsTr("Interval"); defaultValue: 95 }
 		}
-		CheckBox { name: "VovkSellkeMPR"; text: qsTr("Vovk-Sellke maximum p-ratio") }
+		CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Sellke maximum p-ratio") }
 	}
 
 	Group
@@ -55,8 +55,8 @@ Form
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "descriptivesPlots";					text: qsTr("Descriptive plots")
-			PercentField { name: "descriptivesPlotsConfidenceInterval"; text: qsTr("Confidence Interval"); defaultValue: 95 }
+			name: "descriptivesPlots";					label: qsTr("Descriptive plots")
+			PercentField { name: "descriptivesPlotsConfidenceInterval"; label: qsTr("Confidence Interval"); defaultValue: 95 }
 		}
 	}
 		

--- a/Resources/Common/qml/BinomialTestBayesian.qml
+++ b/Resources/Common/qml/BinomialTestBayesian.qml
@@ -29,25 +29,25 @@ Form
 		AssignedVariablesList { name: "variables"; allowedColumns: ["ordinal", "nominal"] }
 	}
 	
-	DoubleField { text: qsTr("Test value: "); name: "testValue"; defaultValue: 0.5 ; max: 1; decimals: 2; Layout.columnSpan: 2 }
+	DoubleField { label: qsTr("Test value: "); name: "testValue"; defaultValue: 0.5 ; max: 1; decimals: 2; Layout.columnSpan: 2 }
 	
 	RadioButtonGroup
 	{
 		title: qsTr("Hypothesis")
 		name: "hypothesis"
-		RadioButton { value: "notEqualToTestValue";		text: qsTr("≠ Test value"); checked: true	}
-		RadioButton { value: "greaterThanTestValue";	text: qsTr("> Test value")					}
-		RadioButton { value: "lessThanTestValue";		text: qsTr("< Test value")					}
+		RadioButton { value: "notEqualToTestValue";		label: qsTr("≠ Test value"); checked: true	}
+		RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value")					}
+		RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value")					}
 	}
 
 	Group {
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";				text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo"; text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";				label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo"; label: qsTr("Additional info"); checked: true }
 		}
-		CheckBox { name: "plotSequentialAnalysis";		text: qsTr("Sequential analysis") }
+		CheckBox { name: "plotSequentialAnalysis";		label: qsTr("Sequential analysis") }
 	}
 
 	BayesFactorType {}
@@ -55,7 +55,7 @@ Form
 	Group
 	{
 		title: qsTr("Prior")
-		DoubleField { name: "priorA"; text: qsTr("Beta prior: parameter a"); defaultValue: 1; min: 0.1; max: 9999; decimals: 1 }
-		DoubleField { name: "priorB"; text: qsTr("Beta prior: parameter b"); defaultValue: 1; min: 0.1; max: 9999; decimals: 1 }
+		DoubleField { name: "priorA"; label: qsTr("Beta prior: parameter a"); defaultValue: 1; min: 0.1; max: 9999; decimals: 1 }
+		DoubleField { name: "priorB"; label: qsTr("Beta prior: parameter b"); defaultValue: 1; min: 0.1; max: 9999; decimals: 1 }
 	}
 }

--- a/Resources/Common/qml/ContingencyTables.qml
+++ b/Resources/Common/qml/ContingencyTables.qml
@@ -27,7 +27,7 @@ Form
 	{
 		AssignedVariablesList { name: "rows";		title: qsTr("Rows");	allowedColumns: ["ordinal", "nominal"] }
 		AssignedVariablesList { name: "columns";	title: qsTr("Columns");	allowedColumns: ["ordinal", "nominal"] }
-		AssignedVariablesList { name: "counts";		title: qsTr("Counts");	allowedColumns: ["scale"]; singleItem: true }
+		AssignedVariablesList { name: "counts";		title: qsTr("Counts");	allowedColumns: ["scale"]; singleVariable: true }
 		AssignedVariablesList { name: "layers";		title: qsTr("Layers");	allowedColumns: ["ordinal", "nominal"]; listViewType: "Layers"; height: 120 }
 	}
 	
@@ -37,44 +37,44 @@ Form
 		
 		Group
 		{
-			CheckBox { name: "chiSquared";						text: qsTr("χ²"); checked: true			}
-			CheckBox { name: "chiSquaredContinuityCorrection";	text: qsTr("χ² continuity correction")	}
-			CheckBox { name: "likelihoodRatio";					text: qsTr("Likelihood ratio")			}
+			CheckBox { name: "chiSquared";						label: qsTr("χ²"); checked: true			}
+			CheckBox { name: "chiSquaredContinuityCorrection";	label: qsTr("χ² continuity correction")	}
+			CheckBox { name: "likelihoodRatio";					label: qsTr("Likelihood ratio")			}
 		}
 
 		Group
 		{
 			CheckBox
 			{
-				name: "oddsRatio"; text: qsTr("Log odds ratio (2x2 only)")
-				PercentField { name: "oddsRatioConfidenceIntervalInterval"; text: qsTr("Confidence interval"); defaultValue: 95 }
+				name: "oddsRatio"; label: qsTr("Log odds ratio (2x2 only)")
+				PercentField { name: "oddsRatioConfidenceIntervalInterval"; label: qsTr("Confidence interval"); defaultValue: 95 }
 			}
-			CheckBox { name: "VovkSellkeMPR";	text: qsTr("Vovk-Sellke maximum p-ratio") }
+			CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}
 
 		Group
 		{
 			title: qsTr("Nominal")
-			CheckBox { name: "contingencyCoefficient" ; text: qsTr("Contingency coefficient")				}
-			CheckBox { name: "phiAndCramersV";			text: qsTr("Phi and Cramer's V")					}
-			CheckBox { name: "lambda";					text: qsTr("Lambda");					debug: true }
-			CheckBox { name: "uncertaintyCoefficient";	text: qsTr("Uncertainty coefficient");	debug: true }
+			CheckBox { name: "contingencyCoefficient" ; label: qsTr("Contingency coefficient")				}
+			CheckBox { name: "phiAndCramersV";			label: qsTr("Phi and Cramer's V")					}
+			CheckBox { name: "lambda";					label: qsTr("Lambda");					debug: true }
+			CheckBox { name: "uncertaintyCoefficient";	label: qsTr("Uncertainty coefficient");	debug: true }
 		}
 
 		Group
 		{
 			title: qsTr("Ordinal")
-			CheckBox { name: "gamma";			text: qsTr("Gamma")						}
-			CheckBox { name: "somersD";			text: qsTr("Somers' d"); debug: true	}
-			CheckBox { name: "kendallsTauB";	text: qsTr("Kendall's tau-b")			}
-			CheckBox { name: "kendallsTauC";	text: qsTr("Kendall's tau-c"); debug: true }
+			CheckBox { name: "gamma";			label: qsTr("Gamma")						}
+			CheckBox { name: "somersD";			label: qsTr("Somers' d"); debug: true	}
+			CheckBox { name: "kendallsTauB";	label: qsTr("Kendall's tau-b")			}
+			CheckBox { name: "kendallsTauC";	label: qsTr("Kendall's tau-c"); debug: true }
 		}
 
 		Group
 		{
 			debug: true
 			title: qsTr("Nominal by interval")
-			CheckBox { name: "byIntervalEta"; text: qsTr("Eta") }
+			CheckBox { name: "byIntervalEta"; label: qsTr("Eta") }
 		}
 		
 		Group
@@ -83,8 +83,8 @@ Form
 			Layout.columnSpan: 2
 			CheckBox
 			{
-				name: "cochransAndMantel"; text: qsTr("Cochran's and Mantel-Haenszel statistics")
-				IntegerField { name: "testOddsRatioEquals"; text: qsTr("Test common odds ratio equals"); defaultValue: 1 }
+				name: "cochransAndMantel"; label: qsTr("Cochran's and Mantel-Haenszel statistics")
+				IntegerField { name: "testOddsRatioEquals"; label: qsTr("Test common odds ratio equals"); defaultValue: 1 }
 			}
 		}
 	}
@@ -96,11 +96,11 @@ Form
 		Group
 		{
 			title: qsTr("Counts")
-			CheckBox { name: "countsExpected";	text: qsTr("Expected") }
+			CheckBox { name: "countsExpected";	label: qsTr("Expected") }
 			CheckBox
 			{
-				name: "hideSmallCounts"; text: qsTr("Hide small counts"); debug: true
-				IntegerField { name: "hideSmallCountsLessThan"; text: qsTr("Less than"); defaultValue: 5; debug: true }
+				name: "hideSmallCounts"; label: qsTr("Hide small counts"); debug: true
+				IntegerField { name: "hideSmallCountsLessThan"; label: qsTr("Less than"); defaultValue: 5; debug: true }
 			}
 		}
 
@@ -110,26 +110,26 @@ Form
 			debug: true
 			CheckBox
 			{
-				name: "zTestCompareColumns"; text: qsTr("Compare column proportions")
-				CheckBox { name: "zTestAdjustPValues";	text: qsTr("Adjust p-values") }
+				name: "zTestCompareColumns"; label: qsTr("Compare column proportions")
+				CheckBox { name: "zTestAdjustPValues";	label: qsTr("Adjust p-values") }
 			}
 		}
 
 		Group
 		{
 			title: qsTr("Percentages")
-			CheckBox { name: "percentagesRow";		text: qsTr("Row")		}
-			CheckBox { name: "percentagesColumn";	text: qsTr("Column")	}
-			CheckBox { name: "percentagesTotal";	text: qsTr("Total")		}
+			CheckBox { name: "percentagesRow";		label: qsTr("Row")		}
+			CheckBox { name: "percentagesColumn";	label: qsTr("Column")	}
+			CheckBox { name: "percentagesTotal";	label: qsTr("Total")		}
 		}
 
 		Group
 		{
 			title: qsTr("Residuals")
 			debug: true
-			CheckBox { name: "residualsUnstandardized";			text: qsTr("Unstandardized")		}
-			CheckBox { name: "residualsStandardized";			text: qsTr("Standardized")			}
-			CheckBox { name: "residualsAdjustedStandardized";	text: qsTr("Adjusted Standardized")	}
+			CheckBox { name: "residualsUnstandardized";			label: qsTr("Unstandardized")		}
+			CheckBox { name: "residualsStandardized";			label: qsTr("Standardized")			}
+			CheckBox { name: "residualsAdjustedStandardized";	label: qsTr("Adjusted Standardized")	}
 		}
 	}
 	
@@ -141,15 +141,15 @@ Form
 		{
 			name: "rowOrder"
 			title: qsTr("Row Order")
-			RadioButton { value: "ascending";	text: qsTr("Ascending"); checked: true	}
-			RadioButton { value: "descending";	text: qsTr("Descending")				}
+			RadioButton { value: "ascending";	label: qsTr("Ascending"); checked: true	}
+			RadioButton { value: "descending";	label: qsTr("Descending")				}
 		}
 		RadioButtonGroup
 		{
 			name: "columnOrder"
 			title: qsTr("Column Order")
-			RadioButton { value: "ascending";	text: qsTr("Ascending"); checked: true	}
-			RadioButton { value: "descending";	text: qsTr("Descending")				}
+			RadioButton { value: "ascending";	label: qsTr("Ascending"); checked: true	}
+			RadioButton { value: "descending";	label: qsTr("Descending")				}
 		}
 	}
 }

--- a/Resources/Common/qml/ContingencyTablesBayesian.qml
+++ b/Resources/Common/qml/ContingencyTablesBayesian.qml
@@ -44,7 +44,7 @@ Form
 	{
 		AssignedVariablesList { name: "rows";		title: qsTr("Rows");	allowedColumns: ["ordinal", "nominal"] }
 		AssignedVariablesList { name: "columns";	title: qsTr("Columns");	allowedColumns: ["ordinal", "nominal"] }
-		AssignedVariablesList { name: "counts";		title: qsTr("Counts");	allowedColumns: ["scale"]; singleItem: true }
+		AssignedVariablesList { name: "counts";		title: qsTr("Counts");	allowedColumns: ["scale"]; singleVariable: true }
 		AssignedVariablesList { name: "layers";		title: qsTr("Layers");	allowedColumns: ["ordinal", "nominal"]; listViewType: "Layers"; height: 120 }
 	}
 	
@@ -56,11 +56,11 @@ Form
 		{
 			name: "samplingModel"
 			title: qsTr("Sample")
-			RadioButton { value: "poisson";							text: qsTr("Poisson")										}
-			RadioButton { value: "jointMultinomial";				text: qsTr("Joint multinomial")								}
-			RadioButton { value: "independentMultinomialRowsFixed";	text: qsTr("Indep. multinomial, rows fixed"); checked: true	}
-			RadioButton { value: "independentMultinomialColumnsFixed"; text: qsTr("Indep. multinomial, columns fixed")			}
-			RadioButton { value: "hypergeometric";					text: qsTr("Hypergeometrics (2x2 only)"); id: hypergeometric }
+			RadioButton { value: "poisson";							label: qsTr("Poisson")											}
+			RadioButton { value: "jointMultinomial";				label: qsTr("Joint multinomial")								}
+			RadioButton { value: "independentMultinomialRowsFixed";	label: qsTr("Indep. multinomial, rows fixed"); checked: true	}
+			RadioButton { value: "independentMultinomialColumnsFixed"; label: qsTr("Indep. multinomial, columns fixed")				}
+			RadioButton { value: "hypergeometric";					label: qsTr("Hypergeometrics (2x2 only)"); id: hypergeometric	}
 		}
 
 		Group
@@ -68,13 +68,13 @@ Form
 			title: qsTr("Additional Statistics")
 			CheckBox
 			{
-				name: "oddsRatio";	text: qsTr("Log odds ratio (2x2 only)")
-				PercentField { name: "oddsRatioCredibleIntervalInterval"; text: qsTr("Credible interval"); defaultValue: 95 }
+				name: "oddsRatio";	label: qsTr("Log odds ratio (2x2 only)")
+				PercentField { name: "oddsRatioCredibleIntervalInterval"; label: qsTr("Credible interval"); defaultValue: 95 }
 			}
 			CheckBox
 			{
-				name: "effectSize"; text: qsTr("Cramer's V"); debug: true
-				PercentField { name: "effectSizeCredibleIntervalInterval"; text: qsTr("Credible interval"); defaultValue: 95; debug: true }
+				name: "effectSize"; label: qsTr("Cramer's V"); debug: true
+				PercentField { name: "effectSizeCredibleIntervalInterval"; label: qsTr("Credible interval"); defaultValue: 95; debug: true }
 			}
 		}
 
@@ -83,9 +83,9 @@ Form
 			title: qsTr("Hypothesis")
 			name: "hypothesis"
 			enabled: !hypergeometric.checked
-			RadioButton { value: "groupsNotEqual";	text: qsTr("Group one ≠ Group two"); checked: true	}
-			RadioButton { value: "groupOneGreater";	text: qsTr("Group one > Group two")					}
-			RadioButton { value: "groupTwoGreater";	text: qsTr("Group one < Group two")					}
+			RadioButton { value: "groupsNotEqual";	label: qsTr("Group one ≠ Group two"); checked: true	}
+			RadioButton { value: "groupOneGreater";	label: qsTr("Group one > Group two")					}
+			RadioButton { value: "groupTwoGreater";	label: qsTr("Group one < Group two")					}
 		}
 
 		Group
@@ -93,10 +93,10 @@ Form
 			title: qsTr("Plots")
 			CheckBox
 			{
-				name: "plotPosteriorOddsRatio";			text: qsTr("Log odds ratio (2x2 only)")
-				CheckBox { name: "plotPosteriorOddsRatioAdditionalInfo"; text: qsTr("Additional info"); checked: true }
+				name: "plotPosteriorOddsRatio";			label: qsTr("Log odds ratio (2x2 only)")
+				CheckBox { name: "plotPosteriorOddsRatioAdditionalInfo"; label: qsTr("Additional info"); checked: true }
 			}
-			CheckBox { name: "plotPosteriorEffectSize";	text: qsTr("Cramer's V"); debug: true }
+			CheckBox { name: "plotPosteriorEffectSize";	label: qsTr("Cramer's V"); debug: true }
 		}
 
 		BayesFactorType {}
@@ -104,7 +104,7 @@ Form
 		Group
 		{
 			title: qsTr("Prior")
-			DoubleField { name: "priorConcentration"; text: qsTr("Prior concentration"); defaultValue: 1; min: 1; decimals: 1 }
+			DoubleField { name: "priorConcentration"; label: qsTr("Prior concentration"); defaultValue: 1; min: 1; decimals: 1 }
 		}
 	}
 	
@@ -116,15 +116,15 @@ Form
 		{
 			name: "rowOrder"
 			title: qsTr("Row Order")
-			RadioButton { value: "ascending";	text: qsTr("Ascending"); checked: true	}
-			RadioButton { value: "descending";	text: qsTr("Descending")				}
+			RadioButton { value: "ascending";	label: qsTr("Ascending"); checked: true	}
+			RadioButton { value: "descending";	label: qsTr("Descending")				}
 		}
 		RadioButtonGroup
 		{
 			name: "columnOrder"
 			title: qsTr("Column Order")
-			RadioButton { value: "ascending";	text: qsTr("Ascending"); checked: true	}
-			RadioButton { value: "descending";	text: qsTr("Descending")				}
+			RadioButton { value: "ascending";	label: qsTr("Ascending"); checked: true	}
+			RadioButton { value: "descending";	label: qsTr("Descending")				}
 		}
 	}
 }

--- a/Resources/Common/qml/Correlation.qml
+++ b/Resources/Common/qml/Correlation.qml
@@ -32,31 +32,31 @@ Form
 	Group
 	{
 		title: qsTr("Correlation Coefficients")
-		CheckBox { name: "pearson";			text: qsTr("Pearson"); checked: true	}
-		CheckBox { name: "spearman";		text: qsTr("Spearman")					}
-		CheckBox { name: "kendallsTauB";	text: qsTr("Kendall's tau-b")			}
+		CheckBox { name: "pearson";			label: qsTr("Pearson"); checked: true	}
+		CheckBox { name: "spearman";		label: qsTr("Spearman")					}
+		CheckBox { name: "kendallsTauB";	label: qsTr("Kendall's tau-b")			}
 	}
 
 	Group
 	{
-		CheckBox { name: "displayPairwise";		text: qsTr("Display pairwise table")				}
-		CheckBox { name: "reportSignificance";	text: qsTr("Report significance"); checked: true	}
-		CheckBox { name: "flagSignificant";		text: qsTr("Flag significant correlations")			}
+		CheckBox { name: "displayPairwise";		label: qsTr("Display pairwise table")				}
+		CheckBox { name: "reportSignificance";	label: qsTr("Report significance"); checked: true	}
+		CheckBox { name: "flagSignificant";		label: qsTr("Flag significant correlations")			}
 		CheckBox
 		{
-			name: "confidenceIntervals";		text: qsTr("Confidence intervals")
-			PercentField { name: "confidenceIntervalsInterval"; text: qsTr("Interval"); defaultValue: 95 }
+			name: "confidenceIntervals";		label: qsTr("Confidence intervals")
+			PercentField { name: "confidenceIntervalsInterval"; label: qsTr("Interval"); defaultValue: 95 }
 		}
-		CheckBox { name: "VovkSellkeMPR";		text: qsTr("Vovk-Sellke maximum p-ratio")			}
+		CheckBox { name: "VovkSellkeMPR";		label: qsTr("Vovk-Sellke maximum p-ratio")			}
 	}
 	
 	RadioButtonGroup
 	{
 		title: qsTr("Hypothesis")
 		name: "hypothesis"
-		RadioButton { value: "correlated";				text: qsTr("Correlated"); checked: true	}
-		RadioButton { value: "correlatedPositively";	text: qsTr("Correlated positively")		}
-		RadioButton { value: "correlatedNegatively";	text: qsTr("Correlated negatively")		}
+		RadioButton { value: "correlated";				label: qsTr("Correlated"); checked: true	}
+		RadioButton { value: "correlatedPositively";	label: qsTr("Correlated positively")		}
+		RadioButton { value: "correlatedNegatively";	label: qsTr("Correlated negatively")		}
 	}
 
 	Group
@@ -64,9 +64,9 @@ Form
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotCorrelationMatrix"; text: qsTr("Display pairwise table")
-			CheckBox { name: "plotDensities";		text: qsTr("Densities for variables")	}
-			CheckBox { name: "plotStatistics";		text: qsTr("Statistics")				}
+			name: "plotCorrelationMatrix"; label: qsTr("Display pairwise table")
+			CheckBox { name: "plotDensities";		label: qsTr("Densities for variables")	}
+			CheckBox { name: "plotStatistics";		label: qsTr("Statistics")				}
 		}
 
 	}
@@ -79,16 +79,16 @@ Form
 		Group
 		{
 			title: qsTr("Statistics")
-			CheckBox { name: "meansAndStdDev";	text: qsTr("Means and standard deviations")				}
-			CheckBox { name: "crossProducts";	text: qsTr("Cross-product deviations and covariances")	}
+			CheckBox { name: "meansAndStdDev";	label: qsTr("Means and standard deviations")				}
+			CheckBox { name: "crossProducts";	label: qsTr("Cross-product deviations and covariances")		}
 		}
 		
 		RadioButtonGroup
 		{
 			name: "missingValues"
 			title: qsTr("Missing Values")
-			RadioButton { value: "excludePairwise"; text: qsTr("Exclude cases pairwise"); checked: true	}
-			RadioButton { value: "excludeListwise"; text: qsTr("Exclude cases listwise")				}
+			RadioButton { value: "excludePairwise"; label: qsTr("Exclude cases pairwise"); checked: true	}
+			RadioButton { value: "excludeListwise"; label: qsTr("Exclude cases listwise")					}
 		}
 	}
 }

--- a/Resources/Common/qml/CorrelationBayesian.qml
+++ b/Resources/Common/qml/CorrelationBayesian.qml
@@ -33,19 +33,19 @@ Form
 	Group
 	{
 		title: qsTr("Correlation Coefficients")
-		CheckBox { name: "pearson";			text: qsTr("Pearson's rho"); checked: true	}
-		CheckBox { name: "spearman";		text: qsTr("Spearman"); debug: true			}
-		CheckBox { name: "kendallsTauB";	text: qsTr("Kendall's tau-b")				}
+		CheckBox { name: "pearson";			label: qsTr("Pearson's rho"); checked: true	}
+		CheckBox { name: "spearman";		label: qsTr("Spearman"); debug: true		}
+		CheckBox { name: "kendallsTauB";	label: qsTr("Kendall's tau-b")				}
 	}
 
 	Group
 	{
-		CheckBox { name: "reportBayesFactors";	text: qsTr("Report Bayes factors"); checked: true		}
-		CheckBox { name: "flagSupported";		text: qsTr("Flag supported correlations")				}
+		CheckBox { name: "reportBayesFactors";	label: qsTr("Report Bayes factors"); checked: true		}
+		CheckBox { name: "flagSupported";		label: qsTr("Flag supported correlations")				}
 		CheckBox
 		{
-			name: "credibleInterval"; text: qsTr("Credible intervals")
-			PercentField { name: "ciValue";	text: qsTr("Interval"); defaultValue: 95; debug: true }
+			name: "credibleInterval"; label: qsTr("Credible intervals")
+			PercentField { name: "ciValue";	label: qsTr("Interval"); defaultValue: 95; debug: true }
 		}
 	}
 	
@@ -53,9 +53,9 @@ Form
 	{
 		name: "hypothesis"
 		title: qsTr("Hypothesis")
-		RadioButton { value: "correlated";				text: qsTr("Correlated"); checked: true	}
-		RadioButton { value: "correlatedPositively";	text: qsTr("Correlated positively")		}
-		RadioButton { value: "correlatedNegatively";	text: qsTr("Correlated negatively")		}
+		RadioButton { value: "correlated";				label: qsTr("Correlated"); checked: true	}
+		RadioButton { value: "correlatedPositively";	label: qsTr("Correlated positively")		}
+		RadioButton { value: "correlatedNegatively";	label: qsTr("Correlated negatively")		}
 	}
 
 	Group
@@ -63,9 +63,9 @@ Form
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotCorrelationMatrix"; text: qsTr("Correlation matrix")
-			CheckBox { name: "plotDensitiesForVariables";	text: qsTr("Densities for variables")	}
-			CheckBox { name: "plotPosteriors";				text: qsTr("Posteriors under H\u2081")	}
+			name: "plotCorrelationMatrix"; label: qsTr("Correlation matrix")
+			CheckBox { name: "plotDensitiesForVariables";	label: qsTr("Densities for variables")	}
+			CheckBox { name: "plotPosteriors";				label: qsTr("Posteriors under H\u2081")	}
 		}
 	}
 
@@ -74,7 +74,7 @@ Form
 	Group
 	{
 		title: qsTr("Prior")
-		DoubleField { name: "priorWidth"; text: qsTr("Stretched beta prior width"); defaultValue: 1.0; max: 2; decimals: 1 }
+		DoubleField { name: "priorWidth"; label: qsTr("Stretched beta prior width"); defaultValue: 1.0; max: 2; decimals: 1 }
 	}
 
 	ExpanderButton
@@ -85,8 +85,8 @@ Form
 		{
 			name: "missingValues"
 			title: qsTr("Missing Values")
-			RadioButton { value: "excludePairwise"; text: qsTr("Exclude cases pairwise"); checked: true	}
-			RadioButton { value: "excludeListwise"; text: qsTr("Exclude cases listwise")				}
+			RadioButton { value: "excludePairwise"; label: qsTr("Exclude cases pairwise"); checked: true	}
+			RadioButton { value: "excludeListwise"; label: qsTr("Exclude cases listwise")				}
 		}
 	}
 }

--- a/Resources/Common/qml/CorrelationBayesianPairs.qml
+++ b/Resources/Common/qml/CorrelationBayesianPairs.qml
@@ -26,51 +26,51 @@ Form
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "pairs"; allowedColumns: ["scale"]; listViewType: "AssignedPairs" }
+		AssignedVariablesList { name: "pairs"; allowedColumns: ["scale"]; listViewType: "Pairs" }
 	}
 	
 	RadioButtonGroup
 	{
 		name: "corcoefficient"
 		title: qsTr("Correlation Coefficients")
-		RadioButton { value: "Pearson";	text: qsTr("Pearson's rho"); checked: true	}
-		RadioButton { value: "Kendall";	text: qsTr("Kendall's tau-b")				}
+		RadioButton { value: "Pearson";	label: qsTr("Pearson's rho"); checked: true	}
+		RadioButton { value: "Kendall";	label: qsTr("Kendall's tau-b")				}
 	}
 
 	CheckBox
 	{
-		name: "credibleInterval"; text: qsTr("Credible intervals")
-		PercentField { name: "ciValue";	text: qsTr("Interval"); defaultValue: 95; debug: true }
+		name: "credibleInterval"; label: qsTr("Credible intervals")
+		PercentField { name: "ciValue";	label: qsTr("Interval"); defaultValue: 95; debug: true }
 	}
 
 	RadioButtonGroup
 	{
 		name: "hypothesis"
 		title: qsTr("Hypothesis")
-		RadioButton { value: "correlated";				text: qsTr("Correlated"); checked: true	}
-		RadioButton { value: "correlatedPositively";	text: qsTr("Correlated positively")		}
-		RadioButton { value: "correlatedNegatively";	text: qsTr("Correlated negatively")		}
+		RadioButton { value: "correlated";				label: qsTr("Correlated"); checked: true	}
+		RadioButton { value: "correlatedPositively";	label: qsTr("Correlated positively")		}
+		RadioButton { value: "correlatedNegatively";	label: qsTr("Correlated negatively")		}
 	}
 
 	Group
 	{
 		title: qsTr("Plots")
 		Layout.rowSpan: 2
-		CheckBox { name: "plotScatter";				text: qsTr("Scatterplot") }
+		CheckBox { name: "plotScatter";				label: qsTr("Scatterplot") }
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";			text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";	text: qsTr("Additional info") }
+			name: "plotPriorAndPosterior";			label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";	label: qsTr("Additional info") }
 		}
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness";		text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo"; text: qsTr("Additional info") }
+			name: "plotBayesFactorRobustness";		label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo"; label: qsTr("Additional info") }
 		}
 		CheckBox
 		{
-			name: "plotSequentialAnalysis";			text: qsTr("Sequential analysis")
-			CheckBox { name: "plotSequentialAnalysisRobustness"; text: qsTr("Robustness check"); debug: true }
+			name: "plotSequentialAnalysis";			label: qsTr("Sequential analysis")
+			CheckBox { name: "plotSequentialAnalysisRobustness"; label: qsTr("Robustness check"); debug: true }
 		}
 	}
 
@@ -79,14 +79,14 @@ Form
 	Group
 	{
 		title: qsTr("Prior")
-		DoubleField { name: "priorWidth"; text: qsTr("Stretched beta prior width"); defaultValue: 1.0; max: 2; decimals: 1 }
+		DoubleField { name: "priorWidth"; label: qsTr("Stretched beta prior width"); defaultValue: 1.0; max: 2; decimals: 1 }
 	}
 
 	RadioButtonGroup
 	{
 		name: "missingValues"
 		title: qsTr("Missing Values")
-		RadioButton { value: "excludeAnalysisByAnalysis";	text: qsTr("Exclude cases analysis by analysis"); checked: true	}
-		RadioButton { value: "excludeListwise";				text: qsTr("Exclude cases listwise")							}
+		RadioButton { value: "excludeAnalysisByAnalysis";	label: qsTr("Exclude cases analysis by analysis"); checked: true	}
+		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")							}
 	}
 }

--- a/Resources/Common/qml/Descriptives.qml
+++ b/Resources/Common/qml/Descriptives.qml
@@ -27,10 +27,10 @@ Form
 	VariablesForm
 	{
 		AssignedVariablesList { name: "variables";	title: qsTr("Variables") }
-		AssignedVariablesList { name: "splitby";	title: qsTr("Split"); singleItem: true; allowedColumns: ["ordinal", "nominal"] }
+		AssignedVariablesList { name: "splitby";	title: qsTr("Split"); singleVariable: true; allowedColumns: ["ordinal", "nominal"] }
 	}
 
-	CheckBox { name: "frequencyTables"; text: qsTr("Frequency tables (nominal and ordinal variables)") }
+	CheckBox { name: "frequencyTables"; label: qsTr("Frequency tables (nominal and ordinal variables)") }
 
 	ExpanderButton
 	{
@@ -40,22 +40,22 @@ Form
 		{
 			CheckBox
 			{
-				name: "plotVariables"; text: qsTr("Distribution plots")
-				CheckBox { name: "distPlotDensity"; text: qsTr("Display density") }
+				name: "plotVariables"; label: qsTr("Distribution plots")
+				CheckBox { name: "distPlotDensity"; label: qsTr("Display density") }
 			}
-			CheckBox { name: "plotCorrelationMatrix"; text: qsTr("Correlation plots") }
+			CheckBox { name: "plotCorrelationMatrix"; label: qsTr("Correlation plots") }
 			CheckBox
 			{
-				name: "splitPlots"; text: qsTr("Boxplots")
-				CheckBox { name: "splitPlotOutlierLabel"; text: qsTr("Label Outliers") }
+				name: "splitPlots"; label: qsTr("Boxplots")
+				CheckBox { name: "splitPlotOutlierLabel"; label: qsTr("Label Outliers") }
 				CheckBox
 				{
-					name: "splitPlotColour"; text: qsTr("Color"); enableChildrenOnChecked: false
+					name: "splitPlotColour"; label: qsTr("Color"); enableChildrenOnChecked: false
 					Group
 					{
-						CheckBox { name: "splitPlotBoxplot";	text: qsTr("Boxplot Element"); checked: true	}
-						CheckBox { name: "splitPlotViolin";		text: qsTr("Violin Elem∂ent")					}
-						CheckBox { name: "splitPlotJitter";		text: qsTr("Jitter Element")					}
+						CheckBox { name: "splitPlotBoxplot";	label: qsTr("Boxplot Element"); checked: true	}
+						CheckBox { name: "splitPlotViolin";		label: qsTr("Violin Elem∂ent")					}
+						CheckBox { name: "splitPlotJitter";		label: qsTr("Jitter Element")					}
 					}
 				}
 			}
@@ -70,10 +70,10 @@ Form
 		{
 			title: qsTr("Percentile Values")
 
-			CheckBox { name: "percentileValuesQuartiles";	text: qsTr("Quartiles") }
+			CheckBox { name: "percentileValuesQuartiles";	label: qsTr("Quartiles") }
 			CheckBox
 			{
-				name: "percentileValuesEqualGroups"; text: qsTr("Cut points for: ")
+				name: "percentileValuesEqualGroups"; label: qsTr("Cut points for: ")
 				childrenOnSameRow: true
 				IntegerField
 				{
@@ -81,12 +81,12 @@ Form
 					min: 1
 					max: 1000
 					defaultValue: 4
-					afterLabel.text: qsTr(" equal groups")
+					afterLabel: qsTr(" equal groups")
 				}
 			}
 			CheckBox
 			{
-				name: "percentileValuesPercentiles"; text: qsTr("Percentiles:")
+				name: "percentileValuesPercentiles"; label: qsTr("Percentiles:")
 				childrenOnSameRow: true
 				TextField
 				{
@@ -100,32 +100,32 @@ Form
 		Group
 		{
 			title: qsTr("Central Tendency")
-			CheckBox { name: "mean";			text: qsTr("Mean");		checked: true	}
-			CheckBox { name: "median";			text: qsTr("Median")					}
-			CheckBox { name: "mode";			text: qsTr("Mode");						}
-			CheckBox { name: "sum";				text: qsTr("Sum");						}
+			CheckBox { name: "mean";			label: qsTr("Mean");	checked: true	}
+			CheckBox { name: "median";			label: qsTr("Median")					}
+			CheckBox { name: "mode";			label: qsTr("Mode");					}
+			CheckBox { name: "sum";				label: qsTr("Sum");						}
 		}
 
 		Group
 		{
 			title: qsTr("Dispersion")
 			columns: 2
-			CheckBox { name: "standardDeviation";	text: qsTr("Std.deviation"); checked: true	}
-			CheckBox { name: "minimum";				text: qsTr("Minimum");		checked: true	}
-			CheckBox { name: "variance";			text: qsTr("Variance")						}
-			CheckBox { name: "maximum";				text: qsTr("Maximum");		checked: true	}
-			CheckBox { name: "range";				text: qsTr("Range")							}
-			CheckBox { name: "standardErrorMean";	text: qsTr("S. E. mean")					}
+			CheckBox { name: "standardDeviation";	label: qsTr("Std.deviation"); checked: true	}
+			CheckBox { name: "minimum";				label: qsTr("Minimum");		checked: true	}
+			CheckBox { name: "variance";			label: qsTr("Variance")						}
+			CheckBox { name: "maximum";				label: qsTr("Maximum");		checked: true	}
+			CheckBox { name: "range";				label: qsTr("Range")						}
+			CheckBox { name: "standardErrorMean";	label: qsTr("S. E. mean")					}
 		}
 
 		Group
 		{
 			title: qsTr("Distribution")
-			CheckBox { name: "skewness";			text: qsTr("Skewness")						}
-			CheckBox { name: "kurtosis";			text: qsTr("Kurtosis")						}
+			CheckBox { name: "skewness";			label: qsTr("Skewness")						}
+			CheckBox { name: "kurtosis";			label: qsTr("Kurtosis")						}
 		}
 
-		CheckBox { name: "statisticsValuesAreGroupMidpoints"; text: qsTr("Values are group midpoints"); debug: true }
+		CheckBox { name: "statisticsValuesAreGroupMidpoints"; label: qsTr("Values are group midpoints"); debug: true }
 	}
 
 	ExpanderButton
@@ -136,18 +136,18 @@ Form
 		{
 			name: "chartType";
 			title: qsTr("Chart Type")
-			RadioButton { value: "_1noCharts";		text: qsTr("None")			}
-			RadioButton { value: "_2barCharts";		text: qsTr("Bar charts")	}
-			RadioButton { value: "_3pieCharts";		text: qsTr("Pie Charts")	}
-			RadioButton { value: "_4histograms";	text: qsTr("Histograms")	}
+			RadioButton { value: "_1noCharts";		label: qsTr("None")			}
+			RadioButton { value: "_2barCharts";		label: qsTr("Bar charts")	}
+			RadioButton { value: "_3pieCharts";		label: qsTr("Pie Charts")	}
+			RadioButton { value: "_4histograms";	label: qsTr("Histograms")	}
 		}
 
 		RadioButtonGroup
 		{
 			name: "chartValues"
 			title: qsTr("Chart Values")
-			RadioButton { value: "_1frequencies";	text: qsTr("Frequencies")	}
-			RadioButton { value: "_2percentages";	text: qsTr("Percentages")	}
+			RadioButton { value: "_1frequencies";	label: qsTr("Frequencies")	}
+			RadioButton { value: "_2percentages";	label: qsTr("Percentages")	}
 		}
 	}
 }

--- a/Resources/Common/qml/ExploratoryFactorAnalysis.qml
+++ b/Resources/Common/qml/ExploratoryFactorAnalysis.qml
@@ -39,16 +39,16 @@ Form
 	{
 		name: "factorMethod"
 		title: qsTr("Number of Factors")
-		RadioButton { value: "parallelAnalysis";	text: qsTr("Parallel Analysis");  checked: true	}
+		RadioButton { value: "parallelAnalysis";	label: qsTr("Parallel Analysis");  checked: true	}
 		RadioButton
 		{
-			value: "eigenValues";					text: qsTr("Eigenvalues")
-			DoubleField { name: "eigenValuesBox"; text: qsTr("Eigenvalues above"); defaultValue: 0; decimals: 1 }
+			value: "eigenValues";					label: qsTr("Eigenvalues")
+			DoubleField { name: "eigenValuesBox"; label: qsTr("Eigenvalues above"); defaultValue: 0; decimals: 1 }
 		}
 		RadioButton
 		{
-			value: "manual";						text: qsTr("Manual")
-			IntegerField { name: "numberOfFactors"; text: qsTr("Number of Factors"); defaultValue: 1; min: 1 }
+			value: "manual";						label: qsTr("Manual")
+			IntegerField { name: "numberOfFactors"; label: qsTr("Number of Factors"); defaultValue: 1; min: 1 }
 		}
 	}
 
@@ -58,12 +58,12 @@ Form
 		title: qsTr("Rotation")
 		RadioButton
 		{
-			value: "orthogonal";	text: qsTr("Orthogonal")
+			value: "orthogonal";	label: qsTr("Orthogonal")
 			DropDown { name: "orthogonalSelector"; values: ["none", "varimax", "quartimax","bentlerT","equamax","varimin"] }
 		}
 		RadioButton
 		{
-			value: "oblique";		text: qsTr("Oblique"); checked: true
+			value: "oblique";		label: qsTr("Oblique"); checked: true
 			DropDown { name: "obliqueSelector"; values: [ "promax", "oblimin", "simplimax", "bentlerQ", "biquartimin", "cluster" ] }
 		}
 	}
@@ -84,18 +84,18 @@ Form
 		Group
 		{
 			title: qsTr("Includes tables")
-			CheckBox { name: "incl_correlations";	text: qsTr("Factor correlations")		}
-			CheckBox { name: "incl_fitIndices";		text: qsTr("Additional fit indices")	}
-			CheckBox { name: "incl_pathDiagram";	text: qsTr("Path diagram")				}
-			CheckBox { name: "incl_screePlot";		text: qsTr("Scree plot")				}
+			CheckBox { name: "incl_correlations";	label: qsTr("Factor correlations")		}
+			CheckBox { name: "incl_fitIndices";		label: qsTr("Additional fit indices")	}
+			CheckBox { name: "incl_pathDiagram";	label: qsTr("Path diagram")				}
+			CheckBox { name: "incl_screePlot";		label: qsTr("Scree plot")				}
 		}
 
 		RadioButtonGroup
 		{
 			name: "missingValues"
 			title: qsTr("Missing values")
-			RadioButton { value: "pairwise";	text: qsTr("Exclude cases pairwise"); checked: true	}
-			RadioButton { value: "listwise";	text: qsTr("Exclude cases listwise")				}
+			RadioButton { value: "pairwise";	label: qsTr("Exclude cases pairwise"); checked: true	}
+			RadioButton { value: "listwise";	label: qsTr("Exclude cases listwise")					}
 		}
 	}
 }

--- a/Resources/Common/qml/LinearMixedModels.qml
+++ b/Resources/Common/qml/LinearMixedModels.qml
@@ -31,7 +31,7 @@ Form
 		{
 			name: "dependent"
 			title: qsTr("Dependent Variable")
-			singleItem: true
+			singleVariable: true
 			allowedColumns: ["scale"]
 		}
 
@@ -61,7 +61,7 @@ Form
 	{
 		name: "estimation"
 		currentIndex: 2
-		text: qsTr("Estimation method")
+		label: qsTr("Estimation method")
 
 		model: ListModel
 		{
@@ -75,7 +75,7 @@ Form
 
 	ExpanderButton
 	{
-		text: qsTr("Fixed Effects")
+		title: qsTr("Fixed Effects")
 
 		VariablesForm
 		{
@@ -94,12 +94,12 @@ Form
 			}
 		}
 
-		CheckBox { text: qsTr("Test intercept"); name: "testIntercept" }
+		CheckBox { label: qsTr("Test intercept"); name: "testIntercept" }
 	}
 
 	ExpanderButton
 	{
-		text: qsTr("Random Effects")
+		title: qsTr("Random Effects")
 
 		// TODO: Widget similar to repeated measures anova
 
@@ -121,7 +121,7 @@ Form
 
 	ExpanderButton
 	{
-		text: qsTr("Post Hoc Tests")
+		title: qsTr("Post Hoc Tests")
 
 		VariablesForm
 		{
@@ -140,58 +140,58 @@ Form
 		Group
 		{
 			title: qsTr("Correction")
-			CheckBox { text: qsTr("No correction"); name: "postHocNoCorrection"   ; checked: true }
-			CheckBox { text: qsTr("Bonferroni")   ; name: "postHocTestsBonferroni"				}
-			CheckBox { text: qsTr("Holm")		 ; name: "postHocTestsHolm"					  }
+			CheckBox { label: qsTr("No correction"); name: "postHocNoCorrection"   ; checked: true }
+			CheckBox { label: qsTr("Bonferroni")   ; name: "postHocTestsBonferroni"				}
+			CheckBox { label: qsTr("Holm")		 ; name: "postHocTestsHolm"					  }
 		}
 	}
 
 	ExpanderButton
 	{
-		text: qsTr("Descriptives Plots")
+		title: qsTr("Descriptives Plots")
 
 		VariablesForm
 		{
 			height: 170
 			availableVariablesList {		title: qsTr("Factors")		  ; name: "descriptivePlotsVariables" ; source: ["fixedFactors", "randomFactors"] }
-			AssignedVariablesList {  title: qsTr("Horizontal axis")  ; name: "plotHorizontalAxis"	; singleItem: true }
-			AssignedVariablesList {		 title: qsTr("Separate lines")   ; name: "plotSeparateLines"	 ; singleItem: true }
-			AssignedVariablesList {		 title: qsTr("Separate plots")   ; name: "plotSeparatePlots"	 ; singleItem: true }
+			AssignedVariablesList {  title: qsTr("Horizontal axis")  ; name: "plotHorizontalAxis"	; singleVariable: true }
+			AssignedVariablesList {		 title: qsTr("Separate lines")   ; name: "plotSeparateLines"	 ; singleVariable: true }
+			AssignedVariablesList {		 title: qsTr("Separate plots")   ; name: "plotSeparatePlots"	 ; singleVariable: true }
 		}
 	}
 
 	ExpanderButton
 	{
-		text: qsTr("Assumption Checks")
+		title: qsTr("Assumption Checks")
 
 		Group
 		{
-			CheckBox { text: qsTr("Homogeneity tests"); name: "homogeneityTests" }
+			CheckBox { label: qsTr("Homogeneity tests"); name: "homogeneityTests" }
 			CheckBox
 			{
-				text: qsTr("Homogeneity corrections"); name: "homogeneityCorrections"
+				label: qsTr("Homogeneity corrections"); name: "homogeneityCorrections"
 				columns: 3
-				CheckBox { text: qsTr("None")		   ; name: "homogeneityNone" ; checked: true }
-				CheckBox { text: qsTr("Brown-Forsythe") ; name: "homogeneityBrown" ; checked: true }
-				CheckBox { text: qsTr("Welch")		  ; name: "homogeneityWelch" ; checked: true }
+				CheckBox { label: qsTr("None")		   ; name: "homogeneityNone" ; checked: true }
+				CheckBox { label: qsTr("Brown-Forsythe") ; name: "homogeneityBrown" ; checked: true }
+				CheckBox { label: qsTr("Welch")		  ; name: "homogeneityWelch" ; checked: true }
 			}
-			CheckBox { text: qsTr("Q-Q plot of residuals") ; name: "qqPlot" }
+			CheckBox { label: qsTr("Q-Q plot of residuals") ; name: "qqPlot" }
 		}
 	}
 
 	ExpanderButton
 	{
-		text: qsTr("Contrasts")
+		title: qsTr("Contrasts")
 
 		ContrastsList
 		{
 			source: ["fixedFactors", "randomFactors"]
 		}
 
-		CheckBox { text: qsTr("Assume equal variances") ; name: "contrastAssumeEqualVariance" ; checked: true }
+		CheckBox { label: qsTr("Assume equal variances") ; name: "contrastAssumeEqualVariance" ; checked: true }
 		CheckBox
 		{
-			text: qsTr("Confidence intervals"); name: "confidenceIntervalsContrast"
+			label: qsTr("Confidence intervals"); name: "confidenceIntervalsContrast"
 			childrenOnSameRow: true
 			PercentField { name: "confidenceIntervalIntervalContrast"; defaultValue: 95 }
 		}
@@ -199,7 +199,7 @@ Form
 
 	ExpanderButton
 	{
-		text: qsTr("Additional Options")
+		title: qsTr("Additional Options")
 		columns: 1
 
 		Label { text: qsTr("Marginal means") }
@@ -212,11 +212,11 @@ Form
 
 		CheckBox
 		{
-			text: qsTr("Compare marginal means to 0")	; name: "marginalMeansCompareMainEffects"
+			label: qsTr("Compare marginal means to 0")	; name: "marginalMeansCompareMainEffects"
 			ComboBox
 			{
 				name: "marginalMeansCIAdjustment";
-				text: qsTr("Confidence interval adjustment");
+				label: qsTr("Confidence interval adjustment");
 
 				model: ListModel
 				{
@@ -230,36 +230,36 @@ Form
 		Group
 		{
 			title: qsTr("Display")
-			CheckBox { text: qsTr("Descriptive statistics")	 ; name: "descriptives" }
+			CheckBox { label: qsTr("Descriptive statistics")	 ; name: "descriptives" }
 			CheckBox
 			{
-				text: qsTr("Estimates of effect size")   ; name: "effectSizeEstimates"
+				label: qsTr("Estimates of effect size")   ; name: "effectSizeEstimates"
 				columns: 3
-				CheckBox { text: qsTr("η²")		 ; name: "effectSizeEtaSquared"; checked: true }
-				CheckBox { text: qsTr("partial η²") ; name: "effectSizePartialEtaSquared" }
-				CheckBox { text: qsTr("ω²")		 ; name: "effectSizeOmegaSquared" }
+				CheckBox { label: qsTr("η²")		 ; name: "effectSizeEtaSquared"; checked: true }
+				CheckBox { label: qsTr("partial η²") ; name: "effectSizePartialEtaSquared" }
+				CheckBox { label: qsTr("ω²")		 ; name: "effectSizeOmegaSquared" }
 			}
-			CheckBox { text: qsTr("Vovk-Sellke maximum p-ratio"); name: "VovkSellkeMPR" }
+			CheckBox { label: qsTr("Vovk-Sellke maximum p-ratio"); name: "VovkSellkeMPR" }
 		}
 	}
 
 	ExpanderButton
 	{
-		text: qsTr("Simple Main Effects")
+		title: qsTr("Simple Main Effects")
 
 		VariablesForm
 		{
 			height: 170
 			availableVariablesList {		title: qsTr("Factors")			  ; name: "effectsVariables"	  ; source:  ["fixedFactors", "randomFactors"] }
-			AssignedVariablesList {  title: qsTr("Simple effect factor") ; name: "simpleFactor"		  ; singleItem: true }
-			AssignedVariablesList {		 title: qsTr("Moderator factor 1")   ; name: "moderatorFactorOne"	; singleItem: true }
-			AssignedVariablesList {		 title: qsTr("Moderator factor 2")   ; name: "moderatorFactorTwo"	; singleItem: true }
+			AssignedVariablesList {  title: qsTr("Simple effect factor") ; name: "simpleFactor"		  ; singleVariable: true }
+			AssignedVariablesList {		 title: qsTr("Moderator factor 1")   ; name: "moderatorFactorOne"	; singleVariable: true }
+			AssignedVariablesList {		 title: qsTr("Moderator factor 2")   ; name: "moderatorFactorTwo"	; singleVariable: true }
 		}
 	}
 
 	ExpanderButton
 	{
-		text: qsTr("Non parametrics")
+		title: qsTr("Non parametrics")
 
 		VariablesForm
 		{

--- a/Resources/Common/qml/MultinomialTest.qml
+++ b/Resources/Common/qml/MultinomialTest.qml
@@ -32,9 +32,9 @@ Form
 	{
 		height: 170
 		marginBetweenVariablesLists: 15
-		AssignedVariablesList { name: "factor";		title: qsTr("Factor");			singleItem: true; allowedColumns: ["ordinal", "nominal"] }
-		AssignedVariablesList { name: "counts";		title: qsTr("Counts");			singleItem: true; allowedColumns: ["ordinal", "scale"] }
-		AssignedVariablesList { name: "exProbVar";	title: qsTr("Expected Counts"); singleItem: true; allowedColumns: ["ordinal", "scale"] }
+		AssignedVariablesList { name: "factor";		title: qsTr("Factor");			singleVariable: true; allowedColumns: ["ordinal", "nominal"] }
+		AssignedVariablesList { name: "counts";		title: qsTr("Counts");			singleVariable: true; allowedColumns: ["ordinal", "scale"] }
+		AssignedVariablesList { name: "exProbVar";	title: qsTr("Expected Counts"); singleVariable: true; allowedColumns: ["ordinal", "scale"] }
 	}
 	
 	RadioButtonGroup
@@ -43,8 +43,8 @@ Form
 		name: "hypothesis"
 		title: qsTr("Alt. Hypothesis")
 		Layout.columnSpan: 2
-		RadioButton { value: "multinomialTest";	text: qsTr("Multinomial test");	 checked: true	}
-		RadioButton { value: "expectedProbs";	text: qsTr("χ² test"); id: expectedProbs			}
+		RadioButton { value: "multinomialTest";	label: qsTr("Multinomial test");	 checked: true	}
+		RadioButton { value: "expectedProbs";	label: qsTr("χ² test"); id: expectedProbs			}
 		
 		Chi2TestTableView
 		{
@@ -60,15 +60,15 @@ Form
 		title: qsTr("Additional Statistics")
 		CheckBox
 		{
-			name: "descriptives"; text: qsTr("Descriptives")
+			name: "descriptives"; label: qsTr("Descriptives")
 			CheckBox
 			{
-				name: "confidenceInterval"; text: qsTr("Confidence interval")
+				name: "confidenceInterval"; label: qsTr("Confidence interval")
 				childrenOnSameRow: true
 				PercentField { name: "confidenceIntervalInterval"; defaultValue: 95	}
 			}
 		}
-		CheckBox { name: "VovkSellkeMPR"; text: qsTr("Vovk-Dellke maximum p-ratio")		}
+		CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Dellke maximum p-ratio")		}
 	}
 
 	ColumnLayout
@@ -77,8 +77,8 @@ Form
 		{
 			name: "countProp"
 			title: qsTr("Display")
-			RadioButton { value: "descCounts";	text: qsTr("Counts"); checked: true		}
-			RadioButton { value: "descProps";	text: qsTr("Proportions")				}
+			RadioButton { value: "descCounts";	label: qsTr("Counts"); checked: true		}
+			RadioButton { value: "descProps";	label: qsTr("Proportions")				}
 		}
 
 		Group
@@ -86,8 +86,8 @@ Form
 			title: qsTr("Plots")
 			CheckBox
 			{
-				name: "descriptivesPlot"; text: qsTr("Descriptives plot")
-				PercentField { name: "descriptivesPlotConfidenceInterval"; text: qsTr("Confidence interval"); defaultValue: 95 }
+				name: "descriptivesPlot"; label: qsTr("Descriptives plot")
+				PercentField { name: "descriptivesPlotConfidenceInterval"; label: qsTr("Confidence interval"); defaultValue: 95 }
 			}
 		}
 	}

--- a/Resources/Common/qml/PrincipalComponentAnalysis.qml
+++ b/Resources/Common/qml/PrincipalComponentAnalysis.qml
@@ -43,17 +43,17 @@ Form
 		title: qsTr("Number of Factors")
 		RadioButton
 		{
-			value: "parallelAnalysis"; text: qsTr("Parallel Analysis"); checked: true
+			value: "parallelAnalysis"; label: qsTr("Parallel Analysis"); checked: true
 		}
 		RadioButton
 		{
-			value: "eigenValues"; text: qsTr("Eigenvalues")
-			DoubleField { name: "eigenValuesBox"; text: qsTr("Eigenvalues above"); defaultValue: 1; decimals: 1 }
+			value: "eigenValues"; label: qsTr("Eigenvalues")
+			DoubleField { name: "eigenValuesBox"; label: qsTr("Eigenvalues above"); defaultValue: 1; decimals: 1 }
 		}
 		RadioButton
 		{
-			value: "manual"; text: qsTr("Manual")
-			IntegerField { name: "numberOfFactors"; text: qsTr("Number of Factors"); defaultValue: 1; min: 1 }
+			value: "manual"; label: qsTr("Manual")
+			IntegerField { name: "numberOfFactors"; label: qsTr("Number of Factors"); defaultValue: 1; min: 1 }
 		}
 	}
 
@@ -63,12 +63,12 @@ Form
 		title: qsTr("Rotation")
 		RadioButton
 		{
-			value: "orthogonal";	text: qsTr("Orthogonal")
+			value: "orthogonal";	label: qsTr("Orthogonal")
 			DropDown { name: "orthogonalSelector"; values: ["none", "varimax", "quartimax","bentlerT","equamax","varimin"] }
 		}
 		RadioButton
 		{
-			value: "oblique";		text: qsTr("Oblique");  checked: true
+			value: "oblique";		label: qsTr("Oblique");  checked: true
 			DropDown { name: "obliqueSelector"; values: [ "promax", "oblimin", "simplimax", "bentlerQ", "biquartimin", "cluster" ] }
 		}
 	}
@@ -90,17 +90,17 @@ Form
 		Group
 		{
 			title: qsTr("Includes tables")
-			CheckBox { name: "incl_correlations";	text: qsTr("Factor correlations")	}
-			CheckBox { name: "incl_pathDiagram";	text: qsTr("Path diagram")			}
-			CheckBox { name: "incl_screePlot";		text: qsTr("Scree plot")			}
+			CheckBox { name: "incl_correlations";	label: qsTr("Factor correlations")	}
+			CheckBox { name: "incl_pathDiagram";	label: qsTr("Path diagram")			}
+			CheckBox { name: "incl_screePlot";		label: qsTr("Scree plot")			}
 		}
 
 		RadioButtonGroup
 		{
 			name: "missingValues"
 			title: qsTr("Missing values")
-			RadioButton { value: "pairwise";		text: qsTr("Exclude cases pairwise"); checked: true	}
-			RadioButton { value: "listwise";		text: qsTr("Exclude cases listwise")				}
+			RadioButton { value: "pairwise";		label: qsTr("Exclude cases pairwise"); checked: true	}
+			RadioButton { value: "listwise";		label: qsTr("Exclude cases listwise")				}
 		}
 	}
 }

--- a/Resources/Common/qml/RegressionLinear.qml
+++ b/Resources/Common/qml/RegressionLinear.qml
@@ -26,22 +26,21 @@ Form
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable");	allowedColumns: ["scale"]; singleItem: true;		}
+		AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable");	allowedColumns: ["scale"]; singleVariable: true;		}
 		DropDown
 		{
 			name: "method"
-			text: qsTr("Method")
-			model: ListModel
-			{
-				ListElement { title: "Enter";		value: "enter"		}
-				ListElement { title: "Backward";	value: "backward"	}
-				ListElement { title: "Forward";		value: "forward"	}
-				ListElement { title: "Stepwise";	value: "stepwise"	}
-			}
+			label: qsTr("Method")
+			values: [
+				{ label: "Enter",		value: "enter"},
+				{ label: "Backward",	value: "backward"},
+				{ label: "Forward",		value: "forward"},
+				{ label: "Stepwise",	value: "stepwise"}
+			]			
 		}
 		AssignedVariablesList { name: "covariates";	title: qsTr("Covariates");			allowedColumns: ["scale"]							}
 		AssignedVariablesList { name: "factors";	title: qsTr("Factors");				allowedColumns: ["nominal", "ordinal"]; debug: true	}
-		AssignedVariablesList { name: "wlsWeights";	title: qsTr("WLS Weights (optional)"); allowedColumns: ["scale"]; singleItem: true		}
+		AssignedVariablesList { name: "wlsWeights";	title: qsTr("WLS Weights (optional)"); allowedColumns: ["scale"]; singleVariable: true		}
 	}
 	
 	
@@ -89,10 +88,10 @@ Form
 			{
 				CheckBox
 				{
-					name: "regressionCoefficientsEstimates"; text: qsTr("Estimates"); checked: true
+					name: "regressionCoefficientsEstimates"; label: qsTr("Estimates"); checked: true
 					CheckBox
 					{
-						name: "regressionCoefficientsBootstrapping"; text: qsTr("From")
+						name: "regressionCoefficientsBootstrapping"; label: qsTr("From")
 						childrenOnSameRow: true
 						IntegerField
 						{
@@ -100,53 +99,53 @@ Form
 							defaultValue: 5000
 							fieldWidth: 50
 							min: 100
-							afterLabel.text: qsTr("bootstraps")
+							afterLabel: qsTr("bootstraps")
 						}
 					}
 				}
 
 				CheckBox
 				{
-					name: "regressionCoefficientsConfidenceIntervals"; text: qsTr("Confidence intervals")
+					name: "regressionCoefficientsConfidenceIntervals"; label: qsTr("Confidence intervals")
 					childrenOnSameRow: true
 					PercentField { name: "regressionCoefficientsConfidenceIntervalsInterval"; defaultValue: 95 }
 				}
-				CheckBox { name: "regressionCoefficientsCovarianceMatrix"; text: qsTr("Covariance matrix") }
+				CheckBox { name: "regressionCoefficientsCovarianceMatrix"; label: qsTr("Covariance matrix") }
 			}
 
 			Group
 			{
-				CheckBox { name: "modelFit";					text: qsTr("Model fit");  checked: true		}
-				CheckBox { name: "rSquaredChange";				text: qsTr("R squared change")				}
-				CheckBox { name: "descriptives";				text: qsTr("Descriptives")					}
-				CheckBox { name: "partAndPartialCorrelations";	text: qsTr("Part and partial correlations")	}
-				CheckBox { name: "collinearityDiagnostics";		text: qsTr("Collinearity diagnostics")		}
+				CheckBox { name: "modelFit";					label: qsTr("Model fit");  checked: true		}
+				CheckBox { name: "rSquaredChange";				label: qsTr("R squared change")				}
+				CheckBox { name: "descriptives";				label: qsTr("Descriptives")					}
+				CheckBox { name: "partAndPartialCorrelations";	label: qsTr("Part and partial correlations")	}
+				CheckBox { name: "collinearityDiagnostics";		label: qsTr("Collinearity diagnostics")		}
 			}
 		}
 		
 		Group
 		{
 			title: qsTr("Residuals")
-			CheckBox { name: "residualsDurbinWatson";	text: qsTr("Dublin-Watson") }
+			CheckBox { name: "residualsDurbinWatson";	label: qsTr("Dublin-Watson") }
 			CheckBox
 			{
-				name: "residualsCasewiseDiagnostics";	text: qsTr("Casewise diagnostics")
+				name: "residualsCasewiseDiagnostics";	label: qsTr("Casewise diagnostics")
 				RadioButtonGroup
 				{
 					name: "residualsCasewiseDiagnosticsType"
 					RadioButton
 					{
-						value: "outliersOutside"; text: qsTr("Standard residual >"); checked: true
+						value: "outliersOutside"; label: qsTr("Standard residual >"); checked: true
 						childrenOnSameRow: true
 						IntegerField { name: "residualsCasewiseDiagnosticsOutliersOutside"; defaultValue: 3	}
 					}
 					RadioButton
 					{
-						value: "cooksDistance";	text: qsTr("Cook's distance >")
+						value: "cooksDistance";	label: qsTr("Cook's distance >")
 						childrenOnSameRow: true
 						IntegerField { name: "residualsCasewiseDiagnosticsCooksDistance";	defaultValue: 0	}
 					}
-					RadioButton { value: "allCases"; text: qsTr("All")										}
+					RadioButton { value: "allCases"; label: qsTr("All")										}
 				}
 			}
 		}
@@ -164,24 +163,24 @@ Form
 			title: qsTr("Stepping Method Criteria")
 			RadioButton
 			{
-				value: "usePValue"; text: qsTr("Use p value"); checked: true
+				value: "usePValue"; label: qsTr("Use p value"); checked: true
 				columns: 2
-				DoubleField { name: "steppingMethodCriteriaPEntry";		text: qsTr("Entry");	fieldWidth: 60; defaultValue: 0.05; max: 1; decimals: 3 }
-				DoubleField { name: "steppingMethodCriteriaPRemoval";	text: qsTr("Removal");	fieldWidth: 60; defaultValue: 0.1; max: 1; decimals: 3	}
+				DoubleField { name: "steppingMethodCriteriaPEntry";		label: qsTr("Entry");	fieldWidth: 60; defaultValue: 0.05; max: 1; decimals: 3 }
+				DoubleField { name: "steppingMethodCriteriaPRemoval";	label: qsTr("Removal");	fieldWidth: 60; defaultValue: 0.1; max: 1; decimals: 3	}
 			}
 			RadioButton
 			{
-				value: "useFValue"; text: qsTr("Use F value")
+				value: "useFValue"; label: qsTr("Use F value")
 				columns: 2
-				DoubleField { name: "steppingMethodCriteriaFEntry";		text: qsTr("Entry");	fieldWidth: 60; defaultValue: 3.84; decimals: 3 }
-				DoubleField { name: "steppingMethodCriteriaFRemoval";	text: qsTr("Removal");	fieldWidth: 60; defaultValue: 2.71; decimals: 3 }
+				DoubleField { name: "steppingMethodCriteriaFEntry";		label: qsTr("Entry");	fieldWidth: 60; defaultValue: 3.84; decimals: 3 }
+				DoubleField { name: "steppingMethodCriteriaFRemoval";	label: qsTr("Removal");	fieldWidth: 60; defaultValue: 2.71; decimals: 3 }
 			}
 		}
 		
 		Group
 		{
-			CheckBox { name: "includeConstant";	text: qsTr("Include constant in equation"); checked: true }
-			CheckBox { name: "VovkSellkeMPR"; text: qsTr("Vovk-Sellke maximum p-ratio") }
+			CheckBox { name: "includeConstant";	label: qsTr("Include constant in equation"); checked: true }
+			CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}
 
 
@@ -190,8 +189,8 @@ Form
 			name: "missingValues"
 			title: qsTr("Missing Values")
 			debug: true
-			RadioButton { value: "excludeCasesListwise"; text: qsTr("Exclude cases listwise"); checked: true	}
-			RadioButton { value: "excludeCasesPairwise"; text: qsTr("Exclude cases pairwise")					}
+			RadioButton { value: "excludeCasesListwise"; label: qsTr("Exclude cases listwise"); checked: true	}
+			RadioButton { value: "excludeCasesPairwise"; label: qsTr("Exclude cases pairwise")					}
 		}
 	}
 	
@@ -202,16 +201,16 @@ Form
 		Group
 		{
 			title: qsTr("Residuals Plots")
-			CheckBox { name: "plotResidualsDependent";	text: qsTr("Residuals vs. dependent")					}
-			CheckBox { name: "plotResidualsCovariates";	text: qsTr("Residuals vs. covariates")					}
-			CheckBox { name: "plotResidualsPredicted";	text: qsTr("Residuals vs. predicted")					}
+			CheckBox { name: "plotResidualsDependent";	label: qsTr("Residuals vs. dependent")					}
+			CheckBox { name: "plotResidualsCovariates";	label: qsTr("Residuals vs. covariates")					}
+			CheckBox { name: "plotResidualsPredicted";	label: qsTr("Residuals vs. predicted")					}
 			CheckBox
 			{
-				name: "plotResidualsHistogram";	text: qsTr("Residuals vs. histogram")
-				CheckBox { name: "plotResidualsHistogramStandardized";	text: qsTr("Standardized residuals")	}
+				name: "plotResidualsHistogram";	label: qsTr("Residuals vs. histogram")
+				CheckBox { name: "plotResidualsHistogramStandardized";	label: qsTr("Standardized residuals")	}
 			}
-			CheckBox { name: "plotResidualsQQ";			text: qsTr("Q-Q plot standardized residuals")			}
-			CheckBox { name: "plotsPartialRegression";	text: qsTr("Partial plots")								}
+			CheckBox { name: "plotResidualsQQ";			label: qsTr("Q-Q plot standardized residuals")			}
+			CheckBox { name: "plotsPartialRegression";	label: qsTr("Partial plots")								}
 		}
 	}
 }

--- a/Resources/Common/qml/RegressionLinearBayesian.qml
+++ b/Resources/Common/qml/RegressionLinearBayesian.qml
@@ -26,9 +26,9 @@ Form {
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable");	allowedColumns: ["scale"]; singleItem: true	}	
+		AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable");	allowedColumns: ["scale"]; singleVariable: true	}	
 		AssignedVariablesList { name: "covariates";	title: qsTr("Covariates");			allowedColumns: ["scale"]					}
-		AssignedVariablesList { name: "wlsWeights";	title: qsTr("WLS Weights (optional)"); allowedColumns: ["scale"]; singleItem: true }
+		AssignedVariablesList { name: "wlsWeights";	title: qsTr("WLS Weights (optional)"); allowedColumns: ["scale"]; singleVariable: true }
 	}
 	
 	BayesFactorType {}
@@ -40,26 +40,25 @@ Form {
 
 		CheckBox
 		{
-			name: "postSummaryTable"; text: qsTr("Posterior summary")
+			name: "postSummaryTable"; label: qsTr("Posterior summary")
 			DropDown
 			{
 				name: "summaryType"
 				indexDefaultValue: 3
-				model: ListModel
-				{
-					ListElement { title: "Best model";			value: "best"		}
-					ListElement { title: "Most complex model";	value: "complex"	}
-					ListElement { title: "Median model";		value: "median"		}
-					ListElement { title: "Model averaged";		value: "averaged"	}
-				}
+				values: [
+					{ label: "Best model",			value: "best"	},
+					{ label: "Most complex model",	value: "complex"},
+					{ label: "Median model",		value: "median"	},
+					{ label: "Model averaged",		value: "averaged"}
+				]				
 			}
 		}
 
 		CheckBox
 		{
-			name: "postSummaryPlot"; text: qsTr("Plot of coefficients")
-			CheckBox { name: "omitIntercept"; text: qsTr("Omit intercept") }
-			PercentField { name: "posteriorSummaryPlotCredibleIntervalValue"; text: qsTr("Credible interval"); defaultValue: 95 }
+			name: "postSummaryPlot"; label: qsTr("Plot of coefficients")
+			CheckBox { name: "omitIntercept"; label: qsTr("Omit intercept") }
+			PercentField { name: "posteriorSummaryPlotCredibleIntervalValue"; label: qsTr("Credible interval"); defaultValue: 95 }
 		}
 	}
 
@@ -67,18 +66,18 @@ Form {
 	{
 		name: "bayesFactorOrder"
 		title: qsTr("Order")
-		RadioButton { value: "bestModelTop"; text: qsTr("Compare to best model"); checked: true	}
-		RadioButton { value: "nullModelTop"; text: qsTr("Compare to null model")				}
+		RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model"); checked: true	}
+		RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model")				}
 	}
 
 	RadioButtonGroup
 	{
 		name: "shownModels"
 		title: qsTr("Limit no. models shown")
-		RadioButton { value: "limited"; text: qsTr("No") }
+		RadioButton { value: "limited"; label: qsTr("No") }
 		RowLayout
 		{
-			RadioButton { value: "unlimited"; text: qsTr("Yes, show best"); checked: true }
+			RadioButton { value: "unlimited"; label: qsTr("Yes, show best"); checked: true }
 			IntegerField { name: "numShownModels"; defaultValue: 10; min: 1 }
 		}
 	}
@@ -86,7 +85,7 @@ Form {
 	Group
 	{
 		title: qsTr("Data")
-		CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
+		CheckBox { name: "descriptives"; label: qsTr("Descriptives") }
 	}
 	
 	ExpanderButton
@@ -127,23 +126,23 @@ Form {
 		Group
 		{
 			title: qsTr("Coefficients")
-			CheckBox { name: "plotInclusionProbabilities";	text: qsTr("Inclusion probabilities")			}
-			CheckBox { name: "plotCoefficientsPosterior";	text: qsTr("Marginal posterior distributions")	}
+			CheckBox { name: "plotInclusionProbabilities";	label: qsTr("Inclusion probabilities")			}
+			CheckBox { name: "plotCoefficientsPosterior";	label: qsTr("Marginal posterior distributions")	}
 		}
 
 		Group
 		{
 			title: qsTr("Models")
-			CheckBox { name: "plotLogPosteriorOdds";	text: qsTr("Log posterior odds")				}
-			CheckBox { name: "plotModelComplexity";		text: qsTr("Log(P(data)M)) vs. model size")		}
-			CheckBox { name: "plotModelProbabilities";	text: qsTr("Model probabilities")				}
+			CheckBox { name: "plotLogPosteriorOdds";	label: qsTr("Log posterior odds")				}
+			CheckBox { name: "plotModelComplexity";		label: qsTr("Log(P(data)M)) vs. model size")		}
+			CheckBox { name: "plotModelProbabilities";	label: qsTr("Model probabilities")				}
 		}
 
 		Group
 		{
 			title: qsTr("Residuals")
-			CheckBox { name: "plotResidualsVsFitted";	text: qsTr("Residuals vs. fitted")				  }
-			CheckBox { name: "plotQQplot";	            text: qsTr("Q-Q plot of model averaged residuals")}
+			CheckBox { name: "plotResidualsVsFitted";	label: qsTr("Residuals vs. fitted")				  }
+			CheckBox { name: "plotQQplot";	            label: qsTr("Q-Q plot of model averaged residuals")}
 		}
 	}
 	
@@ -156,32 +155,33 @@ Form {
 			name: "priorRegressionCoefficients"
 			title: qsTr("Prior")
 
-			RadioButton { value: "AIC";			text: qsTr("AIC")		}
-			RadioButton { value: "BIC";			text: qsTr("BIC")		}
-			RadioButton { value: "EB-global";	text: qsTr("EB-global")	}
-			RadioButton { value: "EB-local";	text: qsTr("EB-local")	}
-			RadioButton { value: "g-prior";		text: qsTr("g-prior")	}
+			RadioButton { value: "AIC";			label: qsTr("AIC")		}
+			RadioButton { value: "BIC";			label: qsTr("BIC")		}
+			RadioButton { value: "EB-global";	label: qsTr("EB-global")	}
+			RadioButton { value: "EB-local";	label: qsTr("EB-local")	}
+			RadioButton { value: "g-prior";		label: qsTr("g-prior")	}
 			GridLayout
 			{
 				rowSpacing: Theme.rowGroupSpacing
+				columnSpacing: 0
 				Group
 				{
-					RadioButton { value: "hyper-g";			text: qsTr("Hyper-g");			id: hyperg			}
-					RadioButton { value: "hyper-g-laplace";	text: qsTr("Hyper-g-Laplace");	id: hyperglaplace	}
-					RadioButton { value: "hyper-g-n";		text: qsTr("Hyper-g-n");		id: hypergn			}
+					RadioButton { value: "hyper-g";			label: qsTr("Hyper-g!");			id: hyperg			}
+					RadioButton { value: "hyper-g-laplace";	label: qsTr("Hyper-g-Laplace");	id: hyperglaplace	}
+					RadioButton { value: "hyper-g-n";		label: qsTr("Hyper-g-n");		id: hypergn			}
 				}
 				IntegerField
 				{
 					name: "alpha";
-					text: qsTr("alpha");
+					label: qsTr("alpha");
 					enabled: hyperg.checked || hyperglaplace.checked || hypergn.checked
 					defaultValue: 3
 				}
-				RadioButton { value: "JZS"; text: qsTr("JZS"); checked: true; id: jzs }
+				RadioButton { value: "JZS"; label: qsTr("JZS"); checked: true; id: jzs }
 				DoubleField
 				{
 					name: "rScale"
-					text: qsTr("r scale")
+					label: qsTr("r scale")
 					enabled: jzs.checked
 					fieldWidth: 50
 					defaultValue: 0.354
@@ -198,18 +198,19 @@ Form {
 				title: qsTr("Model prior")
 				RadioButton
 				{
-					value: "beta.binomial"; text: qsTr("Beta binomial"); checked: true
+					value: "beta.binomial"; label: qsTr("Beta binomial"); checked: true
 					childrenOnSameRow: true
-					DoubleField { name: "betaBinomialParamA"; text: qsTr("a");  defaultValue: 1 }
-					DoubleField { name: "betaBinomialParamB"; text: qsTr("b");  defaultValue: 1 }
+					childrenArea.columnSpacing: 1
+					DoubleField { name: "betaBinomialParamA"; label: qsTr("a");  defaultValue: 1 }
+					DoubleField { name: "betaBinomialParamB"; label: qsTr("b");  defaultValue: 1 }
 				}
 				RadioButton
 				{
-					value: "Bernoulli"; text: qsTr("Bernouilli")
+					value: "Bernoulli"; label: qsTr("Bernouilli")
 					childrenOnSameRow: true
-					DoubleField { name: "bernoulliParam"; text: qsTr("p"); defaultValue: 0.5; max: 1; decimals: 2 }
+					DoubleField { name: "bernoulliParam"; label: qsTr("p"); defaultValue: 0.5; max: 1; decimals: 2 }
 				}
-				RadioButton { value: "uniform"; text: qsTr("Uniform") }
+				RadioButton { value: "uniform"; label: qsTr("Uniform") }
 			}
 
 			RadioButtonGroup
@@ -218,22 +219,30 @@ Form {
 				title: qsTr("Sampling method")
 				RadioButton
 				{
-					value: "BAS"; text: qsTr("BAS"); checked: true
+					value: "BAS"; label: qsTr("BAS"); checked: true
 					childrenOnSameRow: true
-					IntegerField { name: "numberOfModels"; text: qsTr("No. models"); defaultValue: 0; max: 100000000 }
+					IntegerField { name: "numberOfModels"; label: qsTr("No. models"); defaultValue: 0; max: 100000000 }
 				}
 				RadioButton
 				{
-					value: "MCMC"; text: qsTr("MCMC")
+					value: "MCMC"; label: qsTr("MCMC")
 					childrenOnSameRow: true
-					IntegerField { name: "iterationsMCMC"; text: qsTr("No. samples"); defaultValue: 0; max: 100000000 }
+					IntegerField { name: "iterationsMCMC"; label: qsTr("No. samples"); defaultValue: 0; max: 100000000 }
 				}
 			}
 
 			Group
 			{
 				title: qsTr("Numerical accuracy")
-				IntegerField { name: "nSimForCRI"; text: qsTr("No. samples for credible interval"); defaultValue: 1000; min: 100; max: 1000000 }
+				IntegerField
+				{
+					name: "nSimForCRI"
+					label: qsTr("No. samples for credible interval")
+					defaultValue: 1000
+					fieldWidth: 50
+					min: 100
+					max: 1000000
+				}
 			}
 		}
 	}

--- a/Resources/Common/qml/RegressionLogLinear.qml
+++ b/Resources/Common/qml/RegressionLogLinear.qml
@@ -25,7 +25,7 @@ Form
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "counts";		title: qsTr("Counts (optional)"); singleItem: true	}
+		AssignedVariablesList { name: "counts";		title: qsTr("Counts (optional)"); singleVariable: true	}
 		AssignedVariablesList { name: "factors";	title: qsTr("Factors"); itemType: "fixedFactors"; allowedColumns: ["ordinal", "nominal"] }			
 	}
 	
@@ -49,13 +49,13 @@ Form
 		Group
 		{
 			title: qsTr("Regression Coefficient")
-			CheckBox { name: "regressionCoefficientsEstimates";		text: qsTr("Estimates") }
+			CheckBox { name: "regressionCoefficientsEstimates";		label: qsTr("Estimates") }
 			CheckBox
 			{
-				name: "regressionCoefficientsConfidenceIntervals";	text: qsTr("Confidence intervals")
-				PercentField { name: "regressionCoefficientsConfidenceIntervalsInterval"; text: qsTr("Interval"); defaultValue: 95 }
+				name: "regressionCoefficientsConfidenceIntervals";	label: qsTr("Confidence intervals")
+				PercentField { name: "regressionCoefficientsConfidenceIntervalsInterval"; label: qsTr("Interval"); defaultValue: 95 }
 			}
 		}
-		CheckBox { name: "VovkSellkeMPR"; text: qsTr("Vovk-Sellke maximum p-ratio") }
+		CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Sellke maximum p-ratio") }
 	}
 }

--- a/Resources/Common/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Common/qml/RegressionLogLinearBayesian.qml
@@ -26,7 +26,7 @@ Form
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "counts";	 title: qsTr("Counts (optional)");	singleItem: true	}
+		AssignedVariablesList { name: "counts";	 title: qsTr("Counts (optional)");	singleVariable: true	}
 		AssignedVariablesList { name: "factors"; title: qsTr("Factors"); itemType: "fixedFactors"; allowedColumns: ["ordinal", "nominal"] }
 	}
 	
@@ -36,15 +36,15 @@ Form
 	Group
 	{
 		title: qsTr("Prior")
-		DoubleField { name: "priorShape"; text: qsTr("Shape"); defaultValue: -1 ; min: -1 }
-		DoubleField { name: "priorScale"; text: qsTr("Scale"); defaultValue: 0 }
+		DoubleField { name: "priorShape"; label: qsTr("Shape"); defaultValue: -1 ; min: -1 }
+		DoubleField { name: "priorScale"; label: qsTr("Scale"); defaultValue: 0 }
 	}
 
 	Group
 	{
 		title: qsTr("Model cut-offs")
-		IntegerField { name: "maxModels";					text: qsTr("Display best") ;  defaultValue: 2; afterLabel.text: qsTr("models"); min: 2 }
-		DoubleField { name: "posteriorProbabilityCutOff";	text: qsTr("Posterior prob."); defaultValue: 0.1 ; max: 0.5 }
+		IntegerField { name: "maxModels";					label: qsTr("Display best") ;  defaultValue: 2; afterLabel: qsTr("models"); min: 2 }
+		DoubleField { name: "posteriorProbabilityCutOff";	label: qsTr("Posterior prob."); defaultValue: 0.1 ; max: 0.5 }
 	}
 	
 	ExpanderButton
@@ -68,14 +68,14 @@ Form
 		Group
 		{
 			title: qsTr("Regression Coefficients")
-			CheckBox { name: "regressionCoefficientsEstimates";	text: qsTr("Estimates") }
+			CheckBox { name: "regressionCoefficientsEstimates";	label: qsTr("Estimates") }
 			CheckBox
 			{
-				name: "regressionCoefficientsCredibleIntervals"; text: qsTr("Credible intervals")
+				name: "regressionCoefficientsCredibleIntervals"; label: qsTr("Credible intervals")
 				PercentField
 				{
 					name: "regressionCoefficientsCredibleIntervalsInterval"
-					text: qsTr("Interval");
+					label: qsTr("Interval");
 					defaultValue: 95
 				}
 			}
@@ -85,7 +85,7 @@ Form
 		{
 			CheckBox
 			{
-				name: "regressionCoefficientsSubmodel"; text: qsTr("Submodel"); id: regressionCoefficientsSubmodel
+				name: "regressionCoefficientsSubmodel"; label: qsTr("Submodel"); id: regressionCoefficientsSubmodel
 				childrenOnSameRow: true
 				IntegerField { name: "regressionCoefficientsSubmodelNo"; defaultValue: 1 ; min: 1 }
 			}
@@ -94,11 +94,11 @@ Form
 			{
 				indent: true;
 				enabled: regressionCoefficientsSubmodel.checked
-				CheckBox { name: "regressionCoefficientsSubmodelEstimates"; text: qsTr("Estimates") }
+				CheckBox { name: "regressionCoefficientsSubmodelEstimates"; label: qsTr("Estimates") }
 				CheckBox
 				{
-					name: "regressionCoefficientsSubmodelCredibleIntervals"; text: qsTr("Credible intervals")
-					PercentField { name: "regressionCoefficientsSubmodelCredibleIntervalsInterval"; text: qsTr("Interval"); defaultValue: 95 }
+					name: "regressionCoefficientsSubmodelCredibleIntervals"; label: qsTr("Credible intervals")
+					PercentField { name: "regressionCoefficientsSubmodelCredibleIntervalsInterval"; label: qsTr("Interval"); defaultValue: 95 }
 				}
 			}
 		}
@@ -112,11 +112,11 @@ Form
 		{
 			title: qsTr("Samples")
 			name: "sampleMode"
-			RadioButton { value: "auto";	text: qsTr("Auto");  checked: true	}
+			RadioButton { value: "auto";	label: qsTr("Auto");  checked: true	}
 			RadioButton
 			{
-				value: "manual";			text: qsTr("Manual")
-				IntegerField { name: "fixedSamplesNumber"; text: qsTr("No. samples"); defaultValue: 10000; fieldWidth: 60 }
+				value: "manual";			label: qsTr("Manual")
+				IntegerField { name: "fixedSamplesNumber"; label: qsTr("No. samples"); defaultValue: 10000; fieldWidth: 60 }
 			}
 		}
 	}

--- a/Resources/Common/qml/RegressionLogistic.qml
+++ b/Resources/Common/qml/RegressionLogistic.qml
@@ -27,29 +27,28 @@ Form
 	
 	VariablesForm
 	{
-		AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable");	allowedColumns: ["nominal", "ordinal"]; singleItem: true	}
+		AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable");	allowedColumns: ["nominal", "ordinal"]; singleVariable: true	}
 		DropDown
 		{
 			name: "method"
-			text: qsTr("Method")
-			model: ListModel
-			{
-				ListElement { title: "Enter";		value: "enter"		}
-				ListElement { title: "Backward";	value: "backward"	}
-				ListElement { title: "Forward";		value: "forward"	}
-				ListElement { title: "Stepwise";	value: "stepwise"	}
-			}
+			label: qsTr("Method")
+			values: [
+				{ label: "Enter",		value: "enter"},
+				{ label: "Backward",	value: "backward"},
+				{ label: "Forward",		value: "forward"},
+				{ label: "Stepwise",	value: "stepwise"}
+			]
 		}
 		AssignedVariablesList { name: "covariates";	title: qsTr("Covariates");			allowedColumns: ["scale"]									}
 		AssignedVariablesList { name: "factors";	title: qsTr("Factors");				allowedColumns: ["nominal", "ordinal"];itemType: "fixedFactors" }
-		AssignedVariablesList { name: "wlsWeights";	title: qsTr("WLS Weights (optional)"); allowedColumns: ["scale"]; singleItem: true; debug: true	}
+		AssignedVariablesList { name: "wlsWeights";	title: qsTr("WLS Weights (optional)"); allowedColumns: ["scale"]; singleVariable: true; debug: true	}
 	}
 	
 	ExpanderButton
 	{
 		title: qsTr("Model")
 		
-		CheckBox { name: "includeIntercept"; text: qsTr("Include intercept"); checked: true }
+		CheckBox { name: "includeIntercept"; label: qsTr("Include intercept"); checked: true }
 		
 		VariablesForm
 		{
@@ -87,7 +86,7 @@ Form
 		Group
 		{
 			title: qsTr("Descriptives")
-			CheckBox { name: "factorDescriptivesOpt"; text: qsTr("Factor descriptives") }
+			CheckBox { name: "factorDescriptivesOpt"; label: qsTr("Factor descriptives") }
 		}
 
 		Group
@@ -95,37 +94,37 @@ Form
 			title: qsTr("Performance Diagnostics")
 			CheckBox
 			{
-				name: "confusionMatrixOpt";	text: qsTr("Confusion matrix")
-				CheckBox { name: "confusionMatrixProportions";	text: qsTr("Proportions") }
+				name: "confusionMatrixOpt";	label: qsTr("Confusion matrix")
+				CheckBox { name: "confusionMatrixProportions";	label: qsTr("Proportions") }
 			}
 		}
 
 		Group
 		{
 			title: qsTr("Regression Coefficients")
-			CheckBox { name: "coeffEstimates";	text: qsTr("Estimates"); checked: true			}
-			CheckBox { name: "stdCoeff";		text: qsTr("Standardized coefficients")			}
-			CheckBox { name: "oddsRatios";		text: qsTr("Odds ratios")						}
+			CheckBox { name: "coeffEstimates";	label: qsTr("Estimates"); checked: true			}
+			CheckBox { name: "stdCoeff";		label: qsTr("Standardized coefficients")			}
+			CheckBox { name: "oddsRatios";		label: qsTr("Odds ratios")						}
 			CheckBox
 			{
-				name: "coeffCI";				text: qsTr("Confidence intervals")
-				PercentField {	name: "coeffCIInterval"; text: "Interval"; defaultValue: 95	}
-				CheckBox {		name: "coeffCIOR";		text: qsTr("Odds ratio scale")		}
+				name: "coeffCI";				label: qsTr("Confidence intervals")
+				PercentField {	name: "coeffCIInterval"; label: "Interval"; defaultValue: 95	}
+				CheckBox {		name: "coeffCIOR";		label: qsTr("Odds ratio scale")		}
 			}
-			CheckBox { name: "robustSEOpt";		text: qsTr("Robust standard errors")		}
-			CheckBox { name: "VovkSellkeMPR";	text: qsTr("Vovk-Sellke maximum p-ratio")	}
+			CheckBox { name: "robustSEOpt";		label: qsTr("Robust standard errors")		}
+			CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke maximum p-ratio")	}
 		}
 
 		Group
 		{
 			title: qsTr("Performance metrics")
-			CheckBox { name: "AUC";			text: qsTr("AUC")					}
-			CheckBox { name: "Sens";		text: qsTr("Sensitivity / Recall")	}
-			CheckBox { name: "Spec";		text: qsTr("Specificity")			}
-			CheckBox { name: "Prec";		text: qsTr("Precision")				}
-			CheckBox { name: "Fmsr";		text: qsTr("F-measure")				}
-			CheckBox { name: "BrierScr";	text: qsTr("Brier score")			}
-			CheckBox { name: "Hmsr";		text: qsTr("H-measure")				}
+			CheckBox { name: "AUC";			label: qsTr("AUC")					}
+			CheckBox { name: "Sens";		label: qsTr("Sensitivity / Recall")	}
+			CheckBox { name: "Spec";		label: qsTr("Specificity")			}
+			CheckBox { name: "Prec";		label: qsTr("Precision")				}
+			CheckBox { name: "Fmsr";		label: qsTr("F-measure")				}
+			CheckBox { name: "BrierScr";	label: qsTr("Brier score")			}
+			CheckBox { name: "Hmsr";		label: qsTr("H-measure")				}
 		}
 	}
 	
@@ -138,26 +137,26 @@ Form
 			title: qsTr("Inferential plots")
 			CheckBox
 			{
-				name: "estimatesPlotsOpt"; text: qsTr("Display conditional estimates plots")
-				PercentField {	name: "estimatesPlotsCI";	text: qsTr("Confidence interval"); defaultValue: 95 }
-				CheckBox {		name: "showPoints";			text: qsTr("Show data points")						}
+				name: "estimatesPlotsOpt"; label: qsTr("Display conditional estimates plots")
+				PercentField {	name: "estimatesPlotsCI";	label: qsTr("Confidence interval"); defaultValue: 95 }
+				CheckBox {		name: "showPoints";			label: qsTr("Show data points")						}
 			}
 		}
 
 		Group
 		{
 			title: qsTr("Residual plots")
-			CheckBox { name: "predictedPlotOpt";		text: qsTr("Predicted - residual plot")			}
-			CheckBox { name: "predictorPlotsOpt";		text: qsTr("Predictor - residual plots")		}
-			CheckBox { name: "squaredPearsonPlotOpt";	text: qsTr("Squared Pearson residuals plot")	}
+			CheckBox { name: "predictedPlotOpt";		label: qsTr("Predicted - residual plot")			}
+			CheckBox { name: "predictorPlotsOpt";		label: qsTr("Predictor - residual plots")		}
+			CheckBox { name: "squaredPearsonPlotOpt";	label: qsTr("Squared Pearson residuals plot")	}
 		}
 
 		RadioButtonGroup
 		{
 			name: "residualType"
 			title: qsTr("Residual type")
-			RadioButton { value: "deviance";	text: qsTr("Deviance");	checked: true   }
-			RadioButton { value: "pearson";		text: qsTr("Pearson")					}
+			RadioButton { value: "deviance";	label: qsTr("Deviance");	checked: true   }
+			RadioButton { value: "pearson";		label: qsTr("Pearson")					}
 		}
 	}
 }

--- a/Resources/Common/qml/ReliabilityAnalysis.qml
+++ b/Resources/Common/qml/ReliabilityAnalysis.qml
@@ -33,34 +33,34 @@ Form
 	Group
 	{
 		title: qsTr("Scale Statistics")
-		CheckBox { name: "mcDonaldScale";					text: qsTr("McDonald's ω");	checked: true	}
+		CheckBox { name: "mcDonaldScale";					label: qsTr("McDonald's ω");	checked: true	}
 		CheckBox
 		{
 			id: chronbach
-			name: "alphaScale";								text: qsTr("Cronbach's α")
+			name: "alphaScale";								label: qsTr("Cronbach's α")
 			RadioButtonGroup
 			{
 				name: "alphaScaleStandardized"
-				RadioButton { value: "_1unstandardized";	text: qsTr("Unstandardized"); checked: true }
-				RadioButton { value: "_2standardized";		text: qsTr("Standardized")					}
+				RadioButton { value: "_1unstandardized";	label: qsTr("Unstandardized"); checked: true }
+				RadioButton { value: "_2standardized";		label: qsTr("Standardized")					}
 			}
 		}
-		CheckBox { name: "gutmannScale";					text: qsTr("Gutmann's λ6")					}
-		CheckBox { name: "glbScale";						text: qsTr("Greatest lower bound")			}
-		CheckBox { name: "averageInterItemCor";				text: qsTr("Average interitem correlation")	}
-		CheckBox { name: "meanScale";						text: qsTr("Mean")							}
-		CheckBox { name: "sdScale";							text: qsTr("Standard deviation")			}
+		CheckBox { name: "gutmannScale";					label: qsTr("Gutmann's λ6")					}
+		CheckBox { name: "glbScale";						label: qsTr("Greatest lower bound")			}
+		CheckBox { name: "averageInterItemCor";				label: qsTr("Average interitem correlation")	}
+		CheckBox { name: "meanScale";						label: qsTr("Mean")							}
+		CheckBox { name: "sdScale";							label: qsTr("Standard deviation")			}
 	}
 
 	Group
 	{
 		title: qsTr("Individual Item Statistics")
-		CheckBox { name: "mcDonaldItem";					text: qsTr("McDonald's ω  (if item dropped)")	}
-		CheckBox { name: "alphaItem";						text: qsTr("Cronbach's α (if item dropped)")	}
-		CheckBox { name: "gutmannItem";						text: qsTr("Gutmann's λ6 (if item dropped)")	}
-		CheckBox { name: "meanItem";						text: qsTr("Mean")								}
-		CheckBox { name: "sdItem";							text: qsTr("Standard deviation")				}
-		CheckBox { name: "itemRestCor";						text: qsTr("Item-rest correlation")				}
+		CheckBox { name: "mcDonaldItem";					label: qsTr("McDonald's ω  (if item dropped)")	}
+		CheckBox { name: "alphaItem";						label: qsTr("Cronbach's α (if item dropped)")	}
+		CheckBox { name: "gutmannItem";						label: qsTr("Gutmann's λ6 (if item dropped)")	}
+		CheckBox { name: "meanItem";						label: qsTr("Mean")								}
+		CheckBox { name: "sdItem";							label: qsTr("Standard deviation")				}
+		CheckBox { name: "itemRestCor";						label: qsTr("Item-rest correlation")				}
 	}
 
 	ExpanderButton
@@ -82,8 +82,8 @@ Form
 		RadioButtonGroup {
 			title: qsTr("Missing Values")
 			name: "missingValues"
-			RadioButton { value: "excludeCasesListwise"; text: qsTr("Exclude cases listwise"); checked: true	}
-			RadioButton { value: "excludeCasesPairwise"; text: qsTr("Exclude cases pairwise")					}
+			RadioButton { value: "excludeCasesListwise"; label: qsTr("Exclude cases listwise"); checked: true	}
+			RadioButton { value: "excludeCasesPairwise"; label: qsTr("Exclude cases pairwise")					}
 		}
 
 		Group
@@ -91,8 +91,8 @@ Form
 			title: qsTr("Confidence Interval")
 			enabled: chronbach.checked
 			CheckBox {
-				name: "confAlpha"; text: qsTr("Cronbach's α analytical")
-				PercentField { name: "confAlphaLevel"; text: qsTr("Confidence"); defaultValue: 95; with1Decimal: true }
+				name: "confAlpha"; label: qsTr("Cronbach's α analytical")
+				PercentField { name: "confAlphaLevel"; label: qsTr("Confidence"); defaultValue: 95; with1Decimal: true }
 			}
 		}
 	}

--- a/Resources/Common/qml/TTestBayesianIndependentSamples.qml
+++ b/Resources/Common/qml/TTestBayesianIndependentSamples.qml
@@ -30,16 +30,16 @@ Form {
 	{
 		height: 200
 		AssignedVariablesList { name: "variables"; title: qsTr("Dependent Variables"); allowedColumns: ["scale"] }
-		AssignedVariablesList { name: "groupingVariable"; title: qsTr("Grouping Variable"); allowedColumns: ["ordinal", "nominal"]; singleItem: true }
+		AssignedVariablesList { name: "groupingVariable"; title: qsTr("Grouping Variable"); allowedColumns: ["ordinal", "nominal"]; singleVariable: true }
 	}
 	
 	RadioButtonGroup
 	{
 		name: "hypothesis"
 		title: qsTr("Hypothesis")
-		RadioButton { value: "groupsNotEqual";	text: qsTr("Group 1 ≠ Group 2"); checked: true	}
-		RadioButton { value: "groupOneGreater";	text: qsTr("Group 1 > Group 2")					}
-		RadioButton { value: "groupTwoGreater";	text: qsTr("Group 1 < Group 2")					}
+		RadioButton { value: "groupsNotEqual";	label: qsTr("Group 1 ≠ Group 2"); checked: true	}
+		RadioButton { value: "groupOneGreater";	label: qsTr("Group 1 > Group 2")					}
+		RadioButton { value: "groupTwoGreater";	label: qsTr("Group 1 < Group 2")					}
 	}
 
 	Group
@@ -49,26 +49,26 @@ Form {
 
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";		text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";		label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness";	text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	text: qsTr("Additional info"); checked: true }
+			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			name: "plotSequentialAnalysis";		text: qsTr("Sequential analysis")
-			CheckBox { name: "plotSequentialAnalysisRobustness";		text: qsTr("Robustness check") }
+			name: "plotSequentialAnalysis";		label: qsTr("Sequential analysis")
+			CheckBox { name: "plotSequentialAnalysisRobustness";		label: qsTr("Robustness check") }
 		}
 
 		CheckBox
 		{
-			name: "descriptivesPlots";			text: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsCredibleInterval";	text: qsTr("Credible interval"); defaultValue: 95 }
+			name: "descriptivesPlots";			label: qsTr("Descriptives plots")
+			PercentField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
 		}
 	}
 
@@ -80,11 +80,11 @@ Form {
 		title: qsTr("Tests")
 		RadioButton
 		{
-			value: "Student";	text: qsTr("Student"); checked: true }
+			value: "Student";	label: qsTr("Student"); checked: true }
 		RadioButton
 		{
-			value: "Wilcoxon";	text: qsTr("Mann-Whitney");
-			IntegerField { name: "wilcoxonSamplesNumber"; text: qsTr("No. samples"); defaultValue: 1000; min: 100; max: 10000; fieldWidth: 60 }
+			value: "Wilcoxon";	label: qsTr("Mann-Whitney");
+			IntegerField { name: "wilcoxonSamplesNumber"; label: qsTr("No. samples"); defaultValue: 1000; min: 100; max: 10000; fieldWidth: 60 }
 		}
 	}
 
@@ -92,14 +92,14 @@ Form {
 	{
 		name: "missingValues"
 		title: qsTr("Missing Values")
-		RadioButton { value: "excludeAnalysisByAnalysis";	text: qsTr("Exclude cases analysis by analysis"); checked: true }
-		RadioButton { value: "excludeListwise";				text: qsTr("Exclude cases listwise")							}
+		RadioButton { value: "excludeAnalysisByAnalysis";	label: qsTr("Exclude cases analysis by analysis"); checked: true }
+		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")							}
 	}
 
 	Group
 	{
 		title: qsTr("Additional Statistics")
-		CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
+		CheckBox { name: "descriptives"; label: qsTr("Descriptives") }
 	}
 
 	SubjectivePriors { }

--- a/Resources/Common/qml/TTestBayesianOneSample.qml
+++ b/Resources/Common/qml/TTestBayesianOneSample.qml
@@ -35,7 +35,7 @@ Form
 		AssignedVariablesList { name: "variables"; title: qsTr("Variables"); allowedColumns: ["scale"] }
 	}
 	
-	DoubleField { name: "testValue"; text: qsTr("Test value:"); defaultValue: 0; validation: false }
+	DoubleField { name: "testValue"; label: qsTr("Test value:"); defaultValue: 0; validation: false }
 
 	Group
 	{
@@ -44,26 +44,26 @@ Form
 
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";		text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";		label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness";	text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	text: qsTr("Additional info"); checked: true }
+			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			name: "plotSequentialAnalysis";		text: qsTr("Sequential analysis")
-			CheckBox { name: "plotSequentialAnalysisRobustness";		text: qsTr("Robustness check") }
+			name: "plotSequentialAnalysis";		label: qsTr("Sequential analysis")
+			CheckBox { name: "plotSequentialAnalysisRobustness";		label: qsTr("Robustness check") }
 		}
 
 		CheckBox
 		{
-			name: "descriptivesPlots";			text: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsCredibleInterval";	text: qsTr("Credible interval"); defaultValue: 95 }
+			name: "descriptivesPlots";			label: qsTr("Descriptives plots")
+			PercentField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
 		}
 	}
 
@@ -72,9 +72,9 @@ Form
 	{
 		name: "hypothesis"
 		title: qsTr("Hypothesis")
-		RadioButton { value: "notEqualToTestValue";		text: qsTr("≠ Test value"); checked: true	}
-		RadioButton { value: "greaterThanTestValue";	text: qsTr("> Test value");					}
-		RadioButton { value: "lessThanTestValue";		text: qsTr("< Test value");					}
+		RadioButton { value: "notEqualToTestValue";		label: qsTr("≠ Test value"); checked: true	}
+		RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value");					}
+		RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value");					}
 	}
 
 	BayesFactorType { }
@@ -82,15 +82,15 @@ Form
 	Group
 	{
 		title: qsTr("Additional Statistics")
-		CheckBox { name: "descriptives";	text: qsTr("Descriptives") }
+		CheckBox { name: "descriptives";	label: qsTr("Descriptives") }
 	}
 
 	RadioButtonGroup
 	{
 		name: "missingValues"
 		title: qsTr("Missing Values")
-		RadioButton { value: "excludeAnalysisByAnalysis";	text: qsTr("Exclude cases analysis by analysis"); checked: true	}
-		RadioButton { value: "excludeListwise";				text: qsTr("Exclude cases listwise")							}
+		RadioButton { value: "excludeAnalysisByAnalysis";	label: qsTr("Exclude cases analysis by analysis"); checked: true	}
+		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")							}
 	}
 	
 	SubjectivePriors { }

--- a/Resources/Common/qml/TTestBayesianPairedSamples.qml
+++ b/Resources/Common/qml/TTestBayesianPairedSamples.qml
@@ -29,16 +29,16 @@ Form {
 	VariablesForm
 	{
 		height: 200
-		AssignedVariablesList { name: "pairs"; title: qsTr("Variables"); allowedColumns: ["scale"]; listViewType: "AssignedPairs" }
+		AssignedVariablesList { name: "pairs"; title: qsTr("Variables"); allowedColumns: ["scale"]; listViewType: "Pairs" }
 	}
 	
 	RadioButtonGroup
 	{
 		name: "hypothesis"
 		title: qsTr("Hypothesis")
-		RadioButton { value: "groupsNotEqual";	text: qsTr("Measure 1 ≠ Measure 2"); checked: true	}
-		RadioButton { value: "groupOneGreater";	text: qsTr("Measure 1 > Measure 2");				}
-		RadioButton { value: "groupTwoGreater";	text: qsTr("Measure 1 < Measure 2");				}
+		RadioButton { value: "groupsNotEqual";	label: qsTr("Measure 1 ≠ Measure 2"); checked: true	}
+		RadioButton { value: "groupOneGreater";	label: qsTr("Measure 1 > Measure 2");				}
+		RadioButton { value: "groupTwoGreater";	label: qsTr("Measure 1 < Measure 2");				}
 	}
 
 	Group
@@ -48,26 +48,26 @@ Form {
 
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";		text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";		label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness";	text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	text: qsTr("Additional info"); checked: true }
+			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			name: "plotSequentialAnalysis";		text: qsTr("Sequential analysis")
-			CheckBox { name: "plotSequentialAnalysisRobustness";		text: qsTr("Robustness check") }
+			name: "plotSequentialAnalysis";		label: qsTr("Sequential analysis")
+			CheckBox { name: "plotSequentialAnalysisRobustness";		label: qsTr("Robustness check") }
 		}
 
 		CheckBox
 		{
-			name: "descriptivesPlots";			text: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsCredibleInterval";	text: qsTr("Credible interval"); defaultValue: 95 }
+			name: "descriptivesPlots";			label: qsTr("Descriptives plots")
+			PercentField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
 		}
 	}
 
@@ -76,15 +76,15 @@ Form {
 	Group
 	{
 		title: qsTr("Additional Statistics")
-		CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
+		CheckBox { name: "descriptives"; label: qsTr("Descriptives") }
 	}
 
 	RadioButtonGroup
 	{
 		name: "missingValues"
 		title: qsTr("Missing Values")
-		RadioButton { value: "excludeAnalysisByAnalysis";	text: qsTr("Exclude cases analysis by analysis"); checked: true	}
-		RadioButton { value: "excludeListwise";				text: qsTr("Exclude cases listwise")							}
+		RadioButton { value: "excludeAnalysisByAnalysis";	label: qsTr("Exclude cases analysis by analysis"); checked: true	}
+		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")							}
 	}
 
 	SubjectivePriors { }

--- a/Resources/Common/qml/TTestIndependentSamples.qml
+++ b/Resources/Common/qml/TTestIndependentSamples.qml
@@ -30,15 +30,15 @@ Form
 	{
 		height: 200
 		AssignedVariablesList { name: "variables";			title: qsTr("Variables");			allowedColumns: ["scale"]	}
-		AssignedVariablesList { name: "groupingVariable";	title: qsTr("Grouping Variable");	allowedColumns: ["ordinal", "nominal"]; singleItem: true }
+		AssignedVariablesList { name: "groupingVariable";	title: qsTr("Grouping Variable");	allowedColumns: ["ordinal", "nominal"]; singleVariable: true }
 	}
 	
 	Group
 	{
 		title: qsTr("Tests")
-		CheckBox { name: "students";		text: qsTr("Student"); checked: true	}
-		CheckBox { name: "welchs";			text: qsTr("Welch")						}
-		CheckBox { name: "mannWhitneyU";	text: qsTr("Mann-Whitney")				}
+		CheckBox { name: "students";		label: qsTr("Student"); checked: true	}
+		CheckBox { name: "welchs";			label: qsTr("Welch")					}
+		CheckBox { name: "mannWhitneyU";	label: qsTr("Mann-Whitney")				}
 	}
 
 	Group
@@ -47,54 +47,54 @@ Form
 		Layout.rowSpan: 2
 		CheckBox
 		{
-			name: "meanDifference"; text: qsTr("Location parameter")
+			name: "meanDifference"; label: qsTr("Location parameter")
 			CheckBox
 			{
-				name: "meanDiffConfidenceIntervalCheckbox"; text: qsTr("Confidence interval")
+				name: "meanDiffConfidenceIntervalCheckbox"; label: qsTr("Confidence interval")
 				childrenOnSameRow: true
 				PercentField { name: "descriptivesMeanDiffConfidenceIntervalPercent"; defaultValue: 95 }
 			}
 		}
 		CheckBox
 		{
-			name: "effectSize"; text: qsTr("Effect Size")
+			name: "effectSize"; label: qsTr("Effect Size")
 			CheckBox
 			{
-				name: "effSizeConfidenceIntervalCheckbox"; text: qsTr("Confidence interval")
+				name: "effSizeConfidenceIntervalCheckbox"; label: qsTr("Confidence interval")
 				childrenOnSameRow: true
 				PercentField { name: "descriptivesEffectSizeConfidenceIntervalPercent"; defaultValue: 95 }
 			}
 		}
-		CheckBox { name: "descriptives";	text: qsTr("Descriptives")								}
+		CheckBox { name: "descriptives";	label: qsTr("Descriptives")								}
 		CheckBox
 		{
-			name: "descriptivesPlots";		text: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsConfidenceInterval"; text: qsTr("Confidence interval"); defaultValue: 95 }
+			name: "descriptivesPlots";		label: qsTr("Descriptives plots")
+			PercentField { name: "descriptivesPlotsConfidenceInterval"; label: qsTr("Confidence interval"); defaultValue: 95 }
 		}
-		CheckBox { name: "VovkSellkeMPR";	text: qsTr("Vovk-Sellke mazimum p-ratio")				}
+		CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke mazimum p-ratio")				}
 	}
 
 	RadioButtonGroup
 	{
 		name: "hypothesis"
 		title: qsTr("Alt. Hypothesis")
-		RadioButton { value: "groupsNotEqual";	text: qsTr("Group 1 ≠ Group 2"); checked: true	}
-		RadioButton { value: "groupOneGreater";	text: qsTr("Group 1 > Group 2")					}
-		RadioButton { value: "groupTwoGreater";	text: qsTr("Group 1 < Group 2")					}
+		RadioButton { value: "groupsNotEqual";	label: qsTr("Group 1 ≠ Group 2"); checked: true	}
+		RadioButton { value: "groupOneGreater";	label: qsTr("Group 1 > Group 2")					}
+		RadioButton { value: "groupTwoGreater";	label: qsTr("Group 1 < Group 2")					}
 	}
 
 	Group
 	{
 		title: qsTr("Assumption checks")
-		CheckBox { name: "normalityTests";				text: qsTr("Normality")					}
-		CheckBox { name: "equalityOfVariancesTests";	text: qsTr("Equality of variances")		}
+		CheckBox { name: "normalityTests";				label: qsTr("Normality")					}
+		CheckBox { name: "equalityOfVariancesTests";	label: qsTr("Equality of variances")		}
 	}
 
 	RadioButtonGroup
 	{
 		name: "missingValues"
 		title: qsTr("Missing Values")
-		RadioButton { value: "excludeAnalysisByAnalysis";	text: qsTr("Exclude cases analysis by analysis"); checked: true	}
-		RadioButton { value: "excludeListwise";				text: qsTr("Exclude cases listwise")							}
+		RadioButton { value: "excludeAnalysisByAnalysis";	label: qsTr("Exclude cases analysis by analysis"); checked: true	}
+		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")							}
 	}
 }

--- a/Resources/Common/qml/TTestOneSample.qml
+++ b/Resources/Common/qml/TTestOneSample.qml
@@ -32,11 +32,11 @@ Form
 	Group
 	{
 		title: qsTr("Tests")
-		CheckBox { name: "students";		text: qsTr("Student"); checked: true	}
-		CheckBox { name: "mannWhitneyU";	text: qsTr("Wilcoxon signed-rank")		}
-		CheckBox { name: "zTest";			text: qsTr("Z Test"); id: zTest			}
-		DoubleField { name: "testValue";	text: qsTr("Test value:");		defaultValue: 0;	validation: false }
-		DoubleField { name: "stddev";		text: qsTr("Std. deviation:");	defaultValue: 1.0;  enabled: zTest.checked }
+		CheckBox { name: "students";		label: qsTr("Student"); checked: true	}
+		CheckBox { name: "mannWhitneyU";	label: qsTr("Wilcoxon signed-rank")		}
+		CheckBox { name: "zTest";			label: qsTr("Z Test"); id: zTest		}
+		DoubleField { name: "testValue";	label: qsTr("Test value:");		defaultValue: 0;	validation: false }
+		DoubleField { name: "stddev";		label: qsTr("Std. deviation:");	defaultValue: 1.0;  enabled: zTest.checked }
 	}
 
 	Group
@@ -45,10 +45,10 @@ Form
 		Layout.rowSpan: 2
 		CheckBox
 		{
-			name: "meanDifference";			text: qsTr("Location parameter")
+			name: "meanDifference";			label: qsTr("Location parameter")
 			CheckBox
 			{
-				name: "meanDiffConfidenceIntervalCheckbox";	text: qsTr("Confidence interval")
+				name: "meanDiffConfidenceIntervalCheckbox";	label: qsTr("Confidence interval")
 				childrenOnSameRow: true
 				PercentField { name: "meanDiffConfidenceIntervalPercent"; defaultValue: 95 }
 			}
@@ -56,43 +56,43 @@ Form
 
 		CheckBox
 		{
-			name: "effectSize";				text: qsTr("Effect Size")
+			name: "effectSize";				label: qsTr("Effect Size")
 			CheckBox
 			{
-				name: "effSizeConfidenceIntervalCheckbox"; text: qsTr("Confidence interval")
+				name: "effSizeConfidenceIntervalCheckbox"; label: qsTr("Confidence interval")
 				childrenOnSameRow: true
 				PercentField { name: "effSizeConfidenceIntervalPercent"; defaultValue: 95 }
 			}
 		}
-		CheckBox { name: "descriptives";	text: qsTr("Descriptives") }
+		CheckBox { name: "descriptives";	label: qsTr("Descriptives") }
 		CheckBox
 		{
-			name: "descriptivesPlots";		text: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsConfidenceInterval";	text: qsTr("Confidence interval"); defaultValue: 95 }
+			name: "descriptivesPlots";		label: qsTr("Descriptives plots")
+			PercentField { name: "descriptivesPlotsConfidenceInterval";	label: qsTr("Confidence interval"); defaultValue: 95 }
 		}
-		CheckBox { name: "VovkSellkeMPR";	text: qsTr("Vovk-Sellke mazimum p-ratio") }
+		CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke mazimum p-ratio") }
 	}
 
 	RadioButtonGroup
 	{
 		name: "hypothesis"
 		title: qsTr("Alt. Hypothesis")
-		RadioButton { value: "notEqualToTestValue";		text: qsTr("≠ Test value"); checked: true	}
-		RadioButton { value: "greaterThanTestValue";	text: qsTr("> Test value")					}
-		RadioButton { value: "lessThanTestValue";		text: qsTr("< Test value")					}
+		RadioButton { value: "notEqualToTestValue";		label: qsTr("≠ Test value"); checked: true	}
+		RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value")					}
+		RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value")					}
 	}
 
 	Group
 	{
 		title: qsTr("Assumption checks")
-		CheckBox { name: "normalityTests"; text: qsTr("Normality") }
+		CheckBox { name: "normalityTests"; label: qsTr("Normality") }
 	}
 
 	RadioButtonGroup
 	{
 		name: "missingValues"
 		title: qsTr("Missing Values")
-		RadioButton { value: "excludeAnalysisByAnalysis";	text: qsTr("Exclude cases analysis by analysis"); checked: true }
-		RadioButton { value: "excludeListwise";				text: qsTr("Exclude cases listwise")							}
+		RadioButton { value: "excludeAnalysisByAnalysis";	label: qsTr("Exclude cases analysis by analysis"); checked: true	}
+		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")								}
 	}
 }

--- a/Resources/Common/qml/TTestPairedSamples.qml
+++ b/Resources/Common/qml/TTestPairedSamples.qml
@@ -31,14 +31,14 @@ Form
 	VariablesForm
 	{
 		height: 200
-		AssignedVariablesList { name: "pairs"; title: qsTr("Variables"); allowedColumns: ["scale"]; listViewType: "AssignedPairs" }
+		AssignedVariablesList { name: "pairs"; title: qsTr("Variables"); allowedColumns: ["scale"]; listViewType: "Pairs" }
 	}
 	
 	Group
 	{
 		title: qsTr("Tests")
-		CheckBox { name: "students";			text: qsTr("Student"); checked: true	}
-		CheckBox { name: "wilcoxonSignedRank";	text: qsTr("Wilcoxon signed-rank")		}
+		CheckBox { name: "students";			label: qsTr("Student"); checked: true	}
+		CheckBox { name: "wilcoxonSignedRank";	label: qsTr("Wilcoxon signed-rank")		}
 	}
 
 	Group
@@ -47,10 +47,10 @@ Form
 		Layout.rowSpan: 2
 		CheckBox
 		{
-			name: "meanDifference";	text: qsTr("Location parameter")
+			name: "meanDifference";	label: qsTr("Location parameter")
 			CheckBox
 			{
-				name: "meanDiffConfidenceIntervalCheckbox";	text: qsTr("Confidence interval")
+				name: "meanDiffConfidenceIntervalCheckbox";	label: qsTr("Confidence interval")
 				childrenOnSameRow: true
 				PercentField { name: "meanDiffConfidenceIntervalPercent"; defaultValue: 95 }
 			}
@@ -58,44 +58,44 @@ Form
 
 		CheckBox
 		{
-			name: "effectSize";	text: qsTr("Effect Size")
+			name: "effectSize";	label: qsTr("Effect Size")
 			CheckBox
 			{
-				name: "effSizeConfidenceIntervalCheckbox";	text: qsTr("Confidence interval")
+				name: "effSizeConfidenceIntervalCheckbox";	label: qsTr("Confidence interval")
 				childrenOnSameRow: true
 				PercentField { name: "effSizeConfidenceIntervalPercent"; defaultValue: 95 }
 			}
 		}
-		CheckBox { name: "descriptives";					text: qsTr("Descriptives")											}
+		CheckBox { name: "descriptives";					label: qsTr("Descriptives")											}
 		CheckBox
 		{
-			name: "descriptivesPlots";						text: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsConfidenceInterval";	text: qsTr("Confidence interval"); defaultValue: 95 }
+			name: "descriptivesPlots";						label: qsTr("Descriptives plots")
+			PercentField { name: "descriptivesPlotsConfidenceInterval";	label: qsTr("Confidence interval"); defaultValue: 95 }
 		}
-		CheckBox { name: "VovkSellkeMPR";					text: qsTr("Vovk-Sellke mazimum p-ratio")						}
+		CheckBox { name: "VovkSellkeMPR";					label: qsTr("Vovk-Sellke mazimum p-ratio")						}
 	}
 
 	RadioButtonGroup
 	{
 		name: "hypothesis"
 		title: qsTr("Alt. Hypothesis")
-		RadioButton { value: "groupsNotEqual";	text: qsTr("Measure 1 ≠ Measure 2"); checked: true	}
-		RadioButton { value: "groupOneGreater";	text: qsTr("Measure 1 > Measure 2");				}
-		RadioButton { value: "groupTwoGreater";	text: qsTr("Measure 1 < Measure 2");				}
+		RadioButton { value: "groupsNotEqual";	label: qsTr("Measure 1 ≠ Measure 2"); checked: true	}
+		RadioButton { value: "groupOneGreater";	label: qsTr("Measure 1 > Measure 2");				}
+		RadioButton { value: "groupTwoGreater";	label: qsTr("Measure 1 < Measure 2");				}
 	}
 
 	Group
 	{
 		title: qsTr("Assumption checks")
-		CheckBox { name: "normalityTests";		text: qsTr("Normality") }
+		CheckBox { name: "normalityTests";		label: qsTr("Normality") }
 	}
 
 	RadioButtonGroup
 	{
 		name: "missingValues"
 		title: qsTr("Missing Values")
-		RadioButton { value: "excludeAnalysisByAnalysis";			text: qsTr("Exclude cases analysis by analysis"); checked: true		}
-		RadioButton { value: "excludeListwise";						text: qsTr("Exclude cases listwise")								}
+		RadioButton { value: "excludeAnalysisByAnalysis";			label: qsTr("Exclude cases analysis by analysis"); checked: true		}
+		RadioButton { value: "excludeListwise";						label: qsTr("Exclude cases listwise")								}
 	}
 
 }

--- a/Resources/Network/qml/NetworkAnalysis.qml
+++ b/Resources/Network/qml/NetworkAnalysis.qml
@@ -41,14 +41,14 @@ Form
 	VariablesForm 
 	{
 		AssignedVariablesList { name: "variables";			title: qsTr("Dependent Variables") }
-		AssignedVariablesList { name: "groupingVariable";	title: qsTr("Split"); singleItem: true; allowedColumns: ["ordinal", "nominal"] }
+		AssignedVariablesList { name: "groupingVariable";	title: qsTr("Split"); singleVariable: true; allowedColumns: ["ordinal", "nominal"] }
 	}
 	
 	DropDown
 	{
 		id: estimator
 		name: "estimator"
-		text: qsTr("Estimator")
+		label: qsTr("Estimator")
 		Layout.columnSpan: 2
 		values: ["EBICglasso", "cor", "pcor", "IsingFit", "IsingSampler", "huge", "adalasso", "mgm"]
 	}
@@ -56,21 +56,21 @@ Form
 	Group
 	{
 		title: qsTr("Plots")
-		CheckBox { name: "plotNetwork";		text: qsTr("Network plot")		}
-		CheckBox { name: "plotCentrality";	text: qsTr("Centrality plot")	}
-		CheckBox { name: "plotClustering";	text: qsTr("Clustering plot")	}
+		CheckBox { name: "plotNetwork";		label: qsTr("Network plot")		}
+		CheckBox { name: "plotCentrality";	label: qsTr("Centrality plot")	}
+		CheckBox { name: "plotClustering";	label: qsTr("Clustering plot")	}
 	}
 
 	Group
 	{
 		title: qsTr("Tables")
-		CheckBox { name: "tableCentrality";			text: qsTr("Centrality tabel")					}
-		CheckBox { name: "tableClustering";			text: qsTr("Clustering tabel")					}
-		CheckBox { name: "tableWeightsMatrix";		text: qsTr("Weights matrix")					}
+		CheckBox { name: "tableCentrality";			label: qsTr("Centrality tabel")					}
+		CheckBox { name: "tableClustering";			label: qsTr("Clustering tabel")					}
+		CheckBox { name: "tableWeightsMatrix";		label: qsTr("Weights matrix")					}
 		CheckBox
 		{
-			name: "tableLayout"; text: qsTr("Layout matrix")
-			CheckBox { name: "tableLayoutValuesOnly"; text: qsTr("Show variable names") }
+			name: "tableLayout"; label: qsTr("Layout matrix")
+			CheckBox { name: "tableLayoutValuesOnly"; label: qsTr("Show variable names") }
 		}
 	}
 
@@ -83,10 +83,10 @@ Form
 			name: "correlationMethod"
 			title: qsTr("Correlation method")
 			visible: [0, 1, 2].includes(estimator.currentIndex)
-			RadioButton { value: "auto";	text: qsTr("Auto");	checked: true	}
-			RadioButton { value: "cor";		text: qsTr("Cor")					}
-			RadioButton { value: "cov";		text: qsTr("Cov")					}
-			RadioButton { value: "npn";		text: qsTr("Npn")					}
+			RadioButton { value: "auto";	label: qsTr("Auto"); checked: true	}
+			RadioButton { value: "cor";		label: qsTr("Cor")					}
+			RadioButton { value: "cov";		label: qsTr("Cov")					}
+			RadioButton { value: "npn";		label: qsTr("Npn")					}
 		}
 
 		RadioButtonGroup
@@ -94,17 +94,17 @@ Form
 			name: "normalizeCentrality"
 			title: qsTr("Centrality measures")
 			visible: estimator.currentIndex === 0
-			RadioButton { value: "normalized";	text: qsTr("Normalized"); checked: true	}
-			RadioButton { value: "relative" ;	text: qsTr("Relative")					}
-			RadioButton { value: "raw";			text: qsTr("Raw")						}
+			RadioButton { value: "normalized";	label: qsTr("Normalized"); checked: true }
+			RadioButton { value: "relative" ;	label: qsTr("Relative")					}
+			RadioButton { value: "raw";			label: qsTr("Raw")						}
 		}
 
 		Group
 		{
 			title: qsTr("Network")
 			visible: estimator.currentIndex === 0
-			CheckBox { name: "weightedNetwork"; text: qsTr("Weighted");	checked: true }
-			CheckBox { name: "signedNetwork";	text: qsTr("Signed");	checked: true }
+			CheckBox { name: "weightedNetwork"; label: qsTr("Weighted"); checked: true	}
+			CheckBox { name: "signedNetwork";	label: qsTr("Signed");	checked: true	}
 		}
 
 		RadioButtonGroup
@@ -112,8 +112,8 @@ Form
 			name: "missingValues"
 			title: qsTr("Missing values")
 			visible: [0, 1, 2].includes(estimator.currentIndex)
-			RadioButton { value: "pairwise";	text: qsTr("Exclude pairwise"); checked: true	}
-			RadioButton { value: "listwise";	text: qsTr("Exclude listwise")					}
+			RadioButton { value: "pairwise";	label: qsTr("Exclude pairwise"); checked: true	}
+			RadioButton { value: "listwise";	label: qsTr("Exclude listwise")					}
 		}
 
 		RadioButtonGroup
@@ -121,8 +121,8 @@ Form
 			name: "sampleSize"
 			title: qsTr("Sample size")
 			visible: estimator.currentIndex === 0
-			RadioButton { value: "maximum";	text: qsTr("Maximum"); checked: true	}
-			RadioButton { value: "minimim";	text: qsTr("Minimum")					}
+			RadioButton { value: "maximum";	label: qsTr("Maximum"); checked: true	}
+			RadioButton { value: "minimim";	label: qsTr("Minimum")					}
 		}
 
 		RadioButtonGroup
@@ -130,10 +130,10 @@ Form
 			name: "isingEstimator"
 			title: qsTr("Ising Estimator")
 			visible: estimator.currentIndex === 4
-			RadioButton { value: "pseudoLikelihood";		text: qsTr("Pseudo-likelihood"); checked: true	}
-			RadioButton { value: "univariateRegressions";	text: qsTr("Univariate regressions")			}
-			RadioButton { value: "bivariateRegressions";	text: qsTr("Bivariate regressions")				}
-			RadioButton { value: "logLinear";				text: qsTr("Loglinear")							}
+			RadioButton { value: "pseudoLikelihood";		label: qsTr("Pseudo-likelihood"); checked: true	}
+			RadioButton { value: "univariateRegressions";	label: qsTr("Univariate regressions")			}
+			RadioButton { value: "bivariateRegressions";	label: qsTr("Bivariate regressions")			}
+			RadioButton { value: "logLinear";				label: qsTr("Loglinear")						}
 		}
 
 		RadioButtonGroup
@@ -141,10 +141,10 @@ Form
 			name: "criterion"
 			title: qsTr("Criterion")
 			visible: [5, 7].includes(estimator.currentIndex)
-			RadioButton { value: "ebic";	text: qsTr("EBIC"); checked: true	}
-			RadioButton { value: "ric";	text: qsTr("RIC")						}
-			RadioButton { value: "stars";	text: qsTr("STARS")					}
-			RadioButton { value: "cv";	text: qsTr("CV")						}
+			RadioButton { value: "ebic";	label: qsTr("EBIC"); checked: true	}
+			RadioButton { value: "ric";		label: qsTr("RIC")					}
+			RadioButton { value: "stars";	label: qsTr("STARS")				}
+			RadioButton { value: "cv";		label: qsTr("CV")					}
 		}
 
 		RadioButtonGroup
@@ -152,8 +152,8 @@ Form
 			name: "rule"
 			title: qsTr("Rule")
 			visible: [3, 7].includes(estimator.currentIndex)
-			RadioButton { value: "and";	text: qsTr("AND"); checked: true	}
-			RadioButton { value: "or";	text: qsTr("OR")					}
+			RadioButton { value: "and";	label: qsTr("AND"); checked: true	}
+			RadioButton { value: "or";	label: qsTr("OR")					}
 		}
 
 		RadioButtonGroup
@@ -161,15 +161,15 @@ Form
 			name: "split"
 			title: qsTr("Split")
 			visible: [3, 4].includes(estimator.currentIndex)
-			RadioButton { value: "median";	text: qsTr("Median"); checked: true	}
-			RadioButton { value: "mean";	text: qsTr("Mean")					}
+			RadioButton { value: "median";	label: qsTr("Median"); checked: true	}
+			RadioButton { value: "mean";	label: qsTr("Mean")						}
 		}
 
 		Group
 		{
 			title: qsTr("Tuning parameters")
 			visible: [0, 3, 5, 7].includes(estimator.currentIndex)
-			DoubleField { name: "tuningParameter"; text: qsTr("value"); defaultValue: 0.5; max: 1 }
+			DoubleField { name: "tuningParameter"; label: qsTr("value"); defaultValue: 0.5; max: 1 }
 		}
 
 		RadioButtonGroup
@@ -179,29 +179,28 @@ Form
 			visible: [1, 2].includes(estimator.currentIndex)
 			RadioButton
 			{
-				value: "value";	text: qsTr("Value"); checked: true
+				value: "value";	label: qsTr("Value"); checked: true
 				childrenOnSameRow: true
 				DoubleField { name: "thresholdValue"; defaultValue: 0; max: 1000000000 }
 			}
 			RadioButton
 			{
-				value: "method"; text: qsTr("Method")
+				value: "method"; label: qsTr("Method")
 				childrenOnSameRow: true
 				DropDown
 				{
 					name: "thresholdMethod"
-					model: ListModel
-					{
-						ListElement { title: "Significant"; value: "sig" }
-						ListElement { title: "Bonferroni"; value: "bonferroni" }
-						ListElement { title: "locfdr"; value: "locfdr" }
-						ListElement { title: "Holm"; value: "holm" }
-						ListElement { title: "Hochberg"; value: "hochberg" }
-						ListElement { title: "Hommel"; value: "hommel" }
-						ListElement { title: "BH"; value: "BH" }
-						ListElement { title: "BY"; value: "BY" }
-						ListElement { title: "fdr"; value: "fdr" }
-					}
+					values: [
+						{ label: "Significant", value: "sig"		},
+						{ label: "Bonferroni",	value: "bonferroni"	},
+						{ label: "locfdr",		value: "locfdr"		},
+						{ label: "Holm",		value: "holm"		},
+						{ label: "Hochberg",	value: "hochberg"	},
+						{ label: "Hommel",		value: "hommel"		},
+						{ label: "BH",			value: "BH"			},
+						{ label: "BY",			value: "BY"			},
+						{ label: "fdr",			value: "fdr"		}
+					]
 				}
 			}
 		}
@@ -210,7 +209,7 @@ Form
 		{
 			title: qsTr("Cross-validation")
 			visible: [6].includes(estimator.currentIndex)
-			IntegerField { name: "nFolds"; text: qsTr("nFolds"); min: 3; max: 100000; fieldWidth: 60 }
+			IntegerField { name: "nFolds"; label: qsTr("nFolds"); min: 3; max: 100000; fieldWidth: 60 }
 		}
 
 		VariablesForm
@@ -218,7 +217,7 @@ Form
 			visible: [7].includes(estimator.currentIndex)
 			height: 150
 			availableVariablesList.name: "variablesTypeAvailable"
-			AssignedVariablesList { name: "mgmVariableType";	title: qsTr("Variable Type"); singleItem: true; allowedColumns: ["nominal"] }
+			AssignedVariablesList { name: "mgmVariableType";	title: qsTr("Variable Type"); singleVariable: true; allowedColumns: ["nominal"] }
 		}
 	}
 
@@ -229,8 +228,8 @@ Form
 		Group
 		{
 			title: qsTr("Settings")
-			CheckBox	 { name: "bootstrapOnOff";		text: qsTr("Bootstrap network")	}
-			IntegerField { name: "numberOfBootstraps";	text: qsTr("Number of bootstraps"); defaultValue: 0; max: 100000 }
+			CheckBox	 { name: "bootstrapOnOff";		label: qsTr("Bootstrap network")	}
+			IntegerField { name: "numberOfBootstraps";	label: qsTr("Number of bootstraps"); defaultValue: 0; max: 100000 }
 		}
 
 		RadioButtonGroup
@@ -238,19 +237,19 @@ Form
 			name: "BootstrapType"
 			title: qsTr("Bootstrap type")
 			Layout.rowSpan: 2
-			RadioButton { value: "nonparametric";	text: qsTr("Nonparametic");	 checked: true	}
-			RadioButton { value: "case";			text: qsTr("Case")							}
-			RadioButton { value: "node";			text: qsTr("Node")							}
-			RadioButton { value: "parametric";		text: qsTr("Parametric")					}
-			RadioButton { value: "person";			text: qsTr("Person")						}
-			RadioButton { value: "jackknife";		text: qsTr("Jackknife")						}
+			RadioButton { value: "nonparametric";	label: qsTr("Nonparametic"); checked: true	}
+			RadioButton { value: "case";			label: qsTr("Case")							}
+			RadioButton { value: "node";			label: qsTr("Node")							}
+			RadioButton { value: "parametric";		label: qsTr("Parametric")					}
+			RadioButton { value: "person";			label: qsTr("Person")						}
+			RadioButton { value: "jackknife";		label: qsTr("Jackknife")					}
 		}
 
 		Group
 		{
 			title: qsTr("Statistics")
-			CheckBox { name: "StatisticsEdges";			text: qsTr("Edges");		checked: true }
-			CheckBox { name: "StatisticsCentrality";	text: qsTr("Centrality");	checked: true }
+			CheckBox { name: "StatisticsEdges";			label: qsTr("Edges");		checked: true }
+			CheckBox { name: "StatisticsCentrality";	label: qsTr("Centrality");	checked: true }
 		}
 	}
 	
@@ -262,65 +261,64 @@ Form
 		{
 			height: 200
 			availableVariablesList { name: "variablesForColor"; title: qsTr("Nodes") }
-			AssignedVariablesList  { name: "colorNodesBy";		title: qsTr("Color nodes by"); singleItem: true }
+			AssignedVariablesList  { name: "colorNodesBy";		title: qsTr("Color nodes by"); singleVariable: true }
 		}
 		
 		Group
 		{
 			Layout.columnSpan: 2
-			DoubleField { name: "nodeSize"; text: qsTr("Node size"); defaultValue: 1; max: 10 }
+			DoubleField { name: "nodeSize"; label: qsTr("Node size"); defaultValue: 1; max: 10 }
 			DropDown
 			{
 				name: "nodeColors"
-				text: qsTr("Node palette")
+				label: qsTr("Node palette")
 				indexDefaultValue: 1
-				model: ListModel {
-					ListElement { title: qsTr("Rainbow");		value: "rainbow"	}
-					ListElement { title: qsTr("Colorblind");	value: "colorblind" }
-					ListElement { title: qsTr("Pastel");		value: "pastel"		}
-					ListElement { title: qsTr("Gray");			value: "gray"		}
-					ListElement { title: qsTr("R");				value: "R"			}
-					ListElement { title: qsTr("ggplot2");		value: "ggplot2"	}
-				}
+				values: [
+					{ label: qsTr("Rainbow"),		value: "rainbow"	},
+					{ label: qsTr("Colorblind"),	value: "colorblind" },
+					{ label: qsTr("Pastel"),		value: "pastel"		},
+					{ label: qsTr("Gray"),			value: "gray"		},
+					{ label: qsTr("R"),				value: "R"			},
+					{ label: qsTr("ggplot2"),		value: "ggplot2"	}
+				]
 			}
 		}
 
 		Group
 		{
 			title: qsTr("Edges")
-			DoubleField { name: "edgeSize";			text: qsTr("Edge size");			defaultValue: 1 }
-			DoubleField { name: "maxEdgeStrength";	text: qsTr("Max edge strength");	defaultValue: 0; max: 10 }
-			DoubleField { name: "minEdgeStrength";	text: qsTr("Min edge strength");	defaultValue: 0; max: 10 }
-			DoubleField { name: "cut";				text: qsTr("Cut");					defaultValue: 0; max: 10 }
-			CheckBox	{ name: "showDetails";		text: qsTr("Show details") }
+			DoubleField { name: "edgeSize";			label: qsTr("Edge size");			defaultValue: 1 }
+			DoubleField { name: "maxEdgeStrength";	label: qsTr("Max edge strength");	defaultValue: 0; max: 10 }
+			DoubleField { name: "minEdgeStrength";	label: qsTr("Min edge strength");	defaultValue: 0; max: 10 }
+			DoubleField { name: "cut";				label: qsTr("Cut");					defaultValue: 0; max: 10 }
+			CheckBox	{ name: "showDetails";		label: qsTr("Show details") }
 			DropDown
 			{
 				name: "edgeColors"
-				text: qsTr("Edge palette")
+				label: qsTr("Edge palette")
 				indexDefaultValue: 1
-				model: ListModel
-				{
-					ListElement { title: qsTr("Classic");		value: "classic"	}
-					ListElement { title: qsTr("Colorblind");	value: "colorblind" }
-					ListElement { title: qsTr("Gray");			value: "gray"		}
-					ListElement { title: qsTr("Hollywood");		value: "Hollywood"	}
-					ListElement { title: qsTr("Borkulo");		value: "Borkulo"	}
-					ListElement { title: qsTr("TeamFortress");	value: "TeamFortress" }
-					ListElement { title: qsTr("Reddit");		value: "Reddit"		}
-					ListElement { title: qsTr("Fried");			value: "Fried"		}
-				}
-
+				values:
+				[
+					{ label: qsTr("Classic"),		value: "classic"	},
+					{ label: qsTr("Colorblind"),	value: "colorblind" },
+					{ label: qsTr("Gray"),			value: "gray"		},
+					{ label: qsTr("Hollywood"),		value: "Hollywood"	},
+					{ label: qsTr("Borkulo"),		value: "Borkulo"	},
+					{ label: qsTr("TeamFortress"),	value: "TeamFortress" },
+					{ label: qsTr("Reddit"),		value: "Reddit"		},
+					{ label: qsTr("Fried"),			value: "Fried"		}
+				]
 			}
 		}
 
 		Group
 		{
 			title: qsTr("Labels")
-			DoubleField { name: "labelSize";	text: qsTr("Label size");		defaultValue: 1; max: 10 }
-			CheckBox	{ name: "scaleLabels";	text: qsTr("Scale label size");	checked: true }
+			DoubleField { name: "labelSize";	label: qsTr("Label size");		defaultValue: 1; max: 10 }
+			CheckBox	{ name: "scaleLabels";	label: qsTr("Scale label size");	checked: true }
 			CheckBox
 			{
-				name: "abbreviateLabels"; text: qsTr("Abbreviate labels to ")
+				name: "abbreviateLabels"; label: qsTr("Abbreviate labels to ")
 				childrenOnSameRow: true
 				IntegerField { name: "abbreviateNoChars"; defaultValue: 4; max: 100000 }
 			}
@@ -331,16 +329,16 @@ Form
 		{
 			name: "graphSize";
 			title: qsTr("Network size")
-			RadioButton { value: "graphSizeFixed";	text: qsTr("Fixed ratio"); checked: true	}
-			RadioButton { value: "graphSizeFree";	text: qsTr("Free")							}
+			RadioButton { value: "graphSizeFixed";	label: qsTr("Fixed ratio"); checked: true	}
+			RadioButton { value: "graphSizeFree";	label: qsTr("Free")							}
 		}
 
 		RadioButtonGroup
 		{
 			name: "showVariableNames";
 			title: qsTr("Show variable names")
-			RadioButton { value: "In nodes";		text: qsTr("In nodes");	 checked: true	}
-			RadioButton { value: "In legend";		text: qsTr("In legend")					}
+			RadioButton { value: "In nodes";		label: qsTr("In nodes");	 checked: true	}
+			RadioButton { value: "In legend";		label: qsTr("In legend")					}
 		}
 
 		RadioButtonGroup
@@ -348,20 +346,20 @@ Form
 			name: "showMgmVariableType";
 			title: qsTr("Show variable type")
 			visible: [7].includes(estimator.currentIndex)
-			RadioButton { value: "mgmNoShow";		text: qsTr("Don't show")						}
-			RadioButton { value: "mgmNodeColor";	text: qsTr("Using node color")					}
-			RadioButton { value: "mgmNodeShape";	text: qsTr("Using node shape"); checked: true	}
+			RadioButton { value: "mgmNoShow";		label: qsTr("Don't show")						}
+			RadioButton { value: "mgmNodeColor";	label: qsTr("Using node color")					}
+			RadioButton { value: "mgmNodeShape";	label: qsTr("Using node shape"); checked: true	}
 		}
 
 		RadioButtonGroup
 		{
 			name: "showLegend"
 			title: qsTr("Legend")
-			RadioButton { value: "No legend";		text: qsTr("No legend")					}
-			RadioButton { value: "All plots";		text: qsTr("All plots"); checked: true	}
+			RadioButton { value: "No legend";		label: qsTr("No legend")					}
+			RadioButton { value: "All plots";		label: qsTr("All plots"); checked: true	}
 			RadioButton
 			{
-				value: "In plot number: "; text: qsTr("In plot number: ")
+				value: "In plot number: "; label: qsTr("In plot number: ")
 				childrenOnSameRow: true
 				IntegerField { name: "legendNumber"; defaultValue: 1 }
 			}
@@ -371,15 +369,15 @@ Form
 		{
 			name: "layout"
 			title: qsTr("Layout")
-			CheckBox { name: "keepLayoutTheSame"; text: qsTr("Do not update layout") }
+			CheckBox { name: "keepLayoutTheSame"; label: qsTr("Do not update layout") }
 			RadioButton
 			{
-				value: "spring"; text: qsTr("Spring"); checked: true
+				value: "spring"; label: qsTr("Spring"); checked: true
 				childrenOnSameRow: true
-				DoubleField { name: "repulsion"; text: qsTr("Repulsion"); defaultValue: 1; max: 10 }
+				DoubleField { name: "repulsion"; label: qsTr("Repulsion"); defaultValue: 1; max: 10 }
 			}
-			RadioButton { value: "circle";	text: qsTr("Circle")	}
-			RadioButton { value: "data";	text: qsTr("Data")		}
+			RadioButton { value: "circle";	label: qsTr("Circle")	}
+			RadioButton { value: "data";	label: qsTr("Data")		}
 		}
 	}
 }

--- a/Resources/SEM/qml/SEMSimple.qml
+++ b/Resources/SEM/qml/SEMSimple.qml
@@ -35,11 +35,11 @@ Form
 		title: qsTr("Data")
 		name: "Data"
 		columns: 2
-		RadioButton { value: "raw"; text: qsTr("raw"); checked: true }
+		RadioButton { value: "raw"; label: qsTr("raw"); checked: true }
 		RadioButton
 		{
-			value: "varcov"; text: qsTr("Variance-covariance matrix")
-			IntegerField { name: "SampleSize"; text: qsTr("Sample Size"); defaultValue: 0 }
+			value: "varcov"; label: qsTr("Variance-covariance matrix")
+			IntegerField { name: "SampleSize"; label: qsTr("Sample Size"); defaultValue: 0 }
 		}
 	}
 	
@@ -52,15 +52,15 @@ Form
 		{
 			title: qsTr("Error Calculation")
 			name: "errorCalculation"
-			RadioButton { value: "standard";	text: qsTr("Standard"); checked: true		}
-			RadioButton { value: "robust";		text: qsTr("Robust")						}
+			RadioButton { value: "standard";	label: qsTr("Standard"); checked: true		}
+			RadioButton { value: "robust";		label: qsTr("Robust")						}
 			RadioButton
 			{
-				value: "bootstrap";	text: qsTr("Bootstrap")
+				value: "bootstrap";	label: qsTr("Bootstrap")
 				IntegerField
 				{
 					name: "errorCalculationBootstrapSamples"
-					text: qsTr("Bootstrap samples")
+					label: qsTr("Bootstrap samples")
 					fieldWidth: 60
 					defaultValue: 1000
 					min: 1
@@ -68,20 +68,20 @@ Form
 			}
 		}
 
-		GroupBox
+		Group
 		{
-			CheckBox { name: "outputAdditionalFitMeasures";				text: qsTr("Additional fit measures")				}
-			CheckBox { name: "outputFittedCovarianceCorrelations";		text: qsTr("Fitted covariances / correlations")		}
-			CheckBox { name: "outputObservedCovarianceCorrelations";	text: qsTr("Observed covariances / correlations")	}
-			CheckBox { name: "outputResidualCovarianceCorrelations";	text: qsTr("Residual covariances / correlations")	}
-			CheckBox { name: "outputMardiasCoefficients";				text: qsTr("Mardia's coefficient")					}
+			CheckBox { name: "outputAdditionalFitMeasures";				label: qsTr("Additional fit measures")				}
+			CheckBox { name: "outputFittedCovarianceCorrelations";		label: qsTr("Fitted covariances / correlations")	}
+			CheckBox { name: "outputObservedCovarianceCorrelations";	label: qsTr("Observed covariances / correlations")	}
+			CheckBox { name: "outputResidualCovarianceCorrelations";	label: qsTr("Residual covariances / correlations")	}
+			CheckBox { name: "outputMardiasCoefficients";				label: qsTr("Mardia's coefficient")					}
 			CheckBox
 			{
-				name: "outputModificationIndices";						text: qsTr("Modification indices")
+				name: "outputModificationIndices";						label: qsTr("Modification indices")
 				CheckBox
 				{
-					name: "outputModificationIndicesHideLowIndices";	text: qsTr("Hide low indices")
-					IntegerField { name: "outputModificationIndicesHideLowIndicesThreshold"; text: qsTr("Threshold"); defaultValue: 10 }
+					name: "outputModificationIndicesHideLowIndices";	label: qsTr("Hide low indices")
+					IntegerField { name: "outputModificationIndicesHideLowIndicesThreshold"; label: qsTr("Threshold"); defaultValue: 10 }
 				}
 			}
 		}
@@ -92,22 +92,22 @@ Form
 		title: qsTr("Options")
 		columns: 3
 
-		GroupBox
+		Group
 		{
 			title: qsTr("Grouping variable")
 			DropDown { name: "groupingVariable"; showVariableTypeIcon: true; addEmptyValue: true} // No model or source: it takes all variables per default
-			GroupBox
+			Group
 			{
 				title: qsTr("Equality Constraits")
-				CheckBox { name: "eq_loadings";				text: qsTr("Loadings")				}
-				CheckBox { name: "eq_intercepts";			text: qsTr("Intercepts")			}
-				CheckBox { name: "eq_residuals";			text: qsTr("Residuals")				}
-				CheckBox { name: "eq_residualcovariances";	text: qsTr("Residual covariances")	}
-				CheckBox { name: "eq_means";				text: qsTr("Means")					}
-				CheckBox { name: "eq_thresholds";			text: qsTr("Threashold")			}
-				CheckBox { name: "eq_regressions";			text: qsTr("Regressions")			}
-				CheckBox { name: "eq_variances";			text: qsTr("Latent Variances")		}
-				CheckBox { name: "eq_lvcovariances";		text: qsTr("Latent Covariances")	}
+				CheckBox { name: "eq_loadings";				label: qsTr("Loadings")				}
+				CheckBox { name: "eq_intercepts";			label: qsTr("Intercepts")			}
+				CheckBox { name: "eq_residuals";			label: qsTr("Residuals")			}
+				CheckBox { name: "eq_residualcovariances";	label: qsTr("Residual covariances")	}
+				CheckBox { name: "eq_means";				label: qsTr("Means")				}
+				CheckBox { name: "eq_thresholds";			label: qsTr("Threashold")			}
+				CheckBox { name: "eq_regressions";			label: qsTr("Regressions")			}
+				CheckBox { name: "eq_variances";			label: qsTr("Latent Variances")		}
+				CheckBox { name: "eq_lvcovariances";		label: qsTr("Latent Covariances")	}
 			}
 		}
 
@@ -115,31 +115,31 @@ Form
 		{
 			name: "estimator"
 			title: qsTr("Estimator")
-			RadioButton { value: "automatic";	text: qsTr("Auto"); checked: true	}
-			RadioButton { value: "ML";			text: qsTr("ML")					}
-			RadioButton { value: "GLS";			text: qsTr("GLS")					}
-			RadioButton { value: "WLS";			text: qsTr("WLS")					}
-			RadioButton { value: "ULS";			text: qsTr("ULS")					}
-			RadioButton { value: "DWLS";		text: qsTr("DWLS")					}
+			RadioButton { value: "automatic";	label: qsTr("Auto"); checked: true	}
+			RadioButton { value: "ML";			label: qsTr("ML")					}
+			RadioButton { value: "GLS";			label: qsTr("GLS")					}
+			RadioButton { value: "WLS";			label: qsTr("WLS")					}
+			RadioButton { value: "ULS";			label: qsTr("ULS")					}
+			RadioButton { value: "DWLS";		label: qsTr("DWLS")					}
 		}
 
-		GroupBox
+		Group
 		{
 			title: qsTr("Model Options")
-			CheckBox { name: "includeMeanStructure";		text: qsTr("Include mean structure")					}
-			CheckBox { name: "assumeFactorsUncorrelated";	text: qsTr("Assume factors uncorrelated")				}
-			CheckBox { name: "fixExogenousCovariates";		text: qsTr("Fix exogenous covariates"); checked: true	}
+			CheckBox { name: "includeMeanStructure";		label: qsTr("Include mean structure")					}
+			CheckBox { name: "assumeFactorsUncorrelated";	label: qsTr("Assume factors uncorrelated")				}
+			CheckBox { name: "fixExogenousCovariates";		label: qsTr("Fix exogenous covariates"); checked: true	}
 
 			DropDown
 			{
 				name: "factorStandardisation"
-				text: qsTr("Factor Scaling")
-				model: ListModel
-				{
-					ListElement { title: "Factor Loadings"    ; value: "factorLoadings"		}
-					ListElement { title: "Residual Variance"  ; value: "residualVariance"	}
-					ListElement { title: "None"               ; value: "none"				}
-				}
+				label: qsTr("Factor Scaling")
+				values:
+				[
+					{ label: "Factor Loadings"    , value: "factorLoadings"		},
+					{ label: "Residual Variance"  , value: "residualVariance"	},
+					{ label: "None"               , value: "none"				}
+				]
 			}
 		}
 	}
@@ -147,28 +147,28 @@ Form
 	ExpanderButton
 	{
 		title: qsTr("Advanced")
-		GroupBox
+		Group
 		{
 			title: qsTr("Options")
 			columns: 2
 			Layout.columnSpan: 2
-			CheckBox { name: "fixManifestInterceptsToZero";	text: qsTr("Fix manifest intercepts to zero")					}
-			CheckBox { name: "fixLatentInterceptsToZero";	text: qsTr("Fix latent intercepts to zero");	checked: true	}
-			CheckBox { name: "omitResidualSingleIndicator";	text: qsTr("Omit residual single indicator");	checked: true	}
-			CheckBox { name: "residualVariances";			text: qsTr("Residual variances");				checked: true	}
-			CheckBox { name: "correlateExogenousLatents";	text: qsTr("Correlate exogenous latents");		checked: true	}
-			CheckBox { name: "addThresholds";				text: qsTr("Add thresholdds");					checked: true	}
-			CheckBox { name: "addScalingParameters";		text: qsTr("Add scalings parameters");			checked: true	}
-			CheckBox { name: "correlateDependentVariables";	text: qsTr("Correlate dependent variables");	checked: true	}
+			CheckBox { name: "fixManifestInterceptsToZero";	label: qsTr("Fix manifest intercepts to zero")					}
+			CheckBox { name: "fixLatentInterceptsToZero";	label: qsTr("Fix latent intercepts to zero");	checked: true	}
+			CheckBox { name: "omitResidualSingleIndicator";	label: qsTr("Omit residual single indicator");	checked: true	}
+			CheckBox { name: "residualVariances";			label: qsTr("Residual variances");				checked: true	}
+			CheckBox { name: "correlateExogenousLatents";	label: qsTr("Correlate exogenous latents");		checked: true	}
+			CheckBox { name: "addThresholds";				label: qsTr("Add thresholdds");					checked: true	}
+			CheckBox { name: "addScalingParameters";		label: qsTr("Add scalings parameters");			checked: true	}
+			CheckBox { name: "correlateDependentVariables";	label: qsTr("Correlate dependent variables");	checked: true	}
 		}
 
 		RadioButtonGroup
 		{
 			name: "emulation"
 			title: qsTr("Emulation")
-			RadioButton { value: "none";	text: qsTr("None");	checked: true	}
-			RadioButton { value: "Mplus";	text: qsTr("Mplus")					}
-			RadioButton { value: "EQS";		text: qsTr("EQS")					}
+			RadioButton { value: "none";	label: qsTr("None"); checked: true	}
+			RadioButton { value: "Mplus";	label: qsTr("Mplus")				}
+			RadioButton { value: "EQS";		label: qsTr("EQS")					}
 		}
 
 		Group

--- a/Resources/Summary Statistics/qml/SummaryStatsBinomialTestBayesian.qml
+++ b/Resources/Summary Statistics/qml/SummaryStatsBinomialTestBayesian.qml
@@ -28,9 +28,9 @@ Form
 
 	Group
 	{
-		IntegerField { name: "successes";	text: qsTr("Successes")	}
-		IntegerField { name: "failures";	text: qsTr("Failures")	}
-		DoubleField  { name: "testValue";	text: qsTr("Test value"); defaultValue: 0.5 ; max: 1 }
+		IntegerField { name: "successes";	label: qsTr("Successes")	}
+		IntegerField { name: "failures";	label: qsTr("Failures")		}
+		DoubleField  { name: "testValue";	label: qsTr("Test value"); defaultValue: 0.5 ; max: 1 }
     }
 
     Divider { }
@@ -39,9 +39,9 @@ Form
 	{
 		title: qsTr("Hypothesis")
 		name: "hypothesis"
-		RadioButton { value: "notEqualToTestValue";		text: qsTr("\u2260 Test value"); checked: true	}
-		RadioButton { value: "greaterThanTestValue";	text: qsTr("> Test value")						}
-		RadioButton { value: "lessThanTestValue";		text: qsTr("< Test value")						}
+		RadioButton { value: "notEqualToTestValue";		label: qsTr("\u2260 Test value"); checked: true	}
+		RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value")						}
+		RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value")						}
 	}
 
 	Group
@@ -49,8 +49,8 @@ Form
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";		text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo"; text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";		label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo"; label: qsTr("Additional info"); checked: true }
 		}
 	}
 
@@ -60,7 +60,7 @@ Form
 	Group
 	{
 		title: qsTr("Prior")
-		DoubleField { name: "betaPriorParamA"; text: qsTr("Beta prior: parameter a"); defaultValue: 1 }
-		DoubleField { name: "betaPriorParamB"; text: qsTr("Beta prior: parameter b"); defaultValue: 1 }
+		DoubleField { name: "betaPriorParamA"; label: qsTr("Beta prior: parameter a"); defaultValue: 1 }
+		DoubleField { name: "betaPriorParamB"; label: qsTr("Beta prior: parameter b"); defaultValue: 1 }
 	}
 }

--- a/Resources/Summary Statistics/qml/SummaryStatsCorrelationBayesianPairs.qml
+++ b/Resources/Summary Statistics/qml/SummaryStatsCorrelationBayesianPairs.qml
@@ -26,7 +26,7 @@ Form
 {
 	usesJaspResults: false
 
-	IntegerField { name: "sampleSize"; text: qsTr("Sample size"); intValidator.bottom: 2 }
+	IntegerField { name: "sampleSize"; label: qsTr("Sample size"); intValidator.bottom: 2 }
 
     Divider { }
 
@@ -37,12 +37,12 @@ Form
 		Layout.columnSpan: 2
 		RadioButton
 		{
-			value: "pearsonRho"; text: qsTr("Pearson's rho"); childrenOnSameRow: true
+			value: "pearsonRho"; label: qsTr("Pearson's rho"); childrenOnSameRow: true
 			DoubleField { name: "pearsonRhoValue"; defaultValue: 0; min: -1; max: 1 }
 		}
 		RadioButton
 		{
-			value: "kendallTau"; text: qsTr("Kendall's tau-b"); childrenOnSameRow: true
+			value: "kendallTau"; label: qsTr("Kendall's tau-b"); childrenOnSameRow: true
 			DoubleField { name: "kendallTauValue"; defaultValue: 0; min: -1; max: 1 }
 		}
 	}
@@ -51,31 +51,31 @@ Form
 	{
 		title: qsTr("Hypothesis")
 		name: "hypothesis"
-		RadioButton { value: "correlated";				text: qsTr("Correlated"); checked: true	}
-		RadioButton { value: "correlatedPositively";	text: qsTr("Correlated positively")		}
-		RadioButton { value: "correlatedNegatively";	text: qsTr("Correlated negatively")		}
+		RadioButton { value: "correlated";				label: qsTr("Correlated"); checked: true	}
+		RadioButton { value: "correlatedPositively";	label: qsTr("Correlated positively")		}
+		RadioButton { value: "correlatedNegatively";	label: qsTr("Correlated negatively")		}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";				text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";				label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		label: qsTr("Additional info"); checked: true }
 		}
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness";			text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	text: qsTr("Additional info"); checked: true }
+			name: "plotBayesFactorRobustness";			label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 	}
 
 	BayesFactorType { }
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Prior")
-		DoubleField { name: "priorWidth"; text: qsTr("Stretched beta prior width"); defaultValue: 1; min: 0; max: 2 }
+		DoubleField { name: "priorWidth"; label: qsTr("Stretched beta prior width"); defaultValue: 1; min: 0; max: 2 }
 	}
 }

--- a/Resources/Summary Statistics/qml/SummaryStatsRegressionLinearBayesian.qml
+++ b/Resources/Summary Statistics/qml/SummaryStatsRegressionLinearBayesian.qml
@@ -26,33 +26,33 @@ Form
 {
 	usesJaspResults: false
 
-	IntegerField { text: qsTr("Sample size"); name: "sampleSize" ; min: 3; Layout.columnSpan: 2 }
+	IntegerField { label: qsTr("Sample size"); name: "sampleSize" ; min: 3; Layout.columnSpan: 2 }
 
 	Group
 	{
 		title: qsTr("Null model")
-		IntegerField {	text: qsTr("Number of covariates"); name: "numberOfCovariatesNull" }
-		DoubleField {	text: qsTr("R-squared");			name: "unadjustedRSquaredNull" ; max: 0.9999 }
+		IntegerField {	label: qsTr("Number of covariates"); name: "numberOfCovariatesNull" }
+		DoubleField {	label: qsTr("R-squared");			name: "unadjustedRSquaredNull" ; max: 0.9999 }
 	}
 
 	Group
 	{
 		title: qsTr("Alternative model")
-		IntegerField {	text: qsTr("Number of covariates"); name: "numberOfCovariatesAlternative" ; min: 1 }
-		DoubleField {	text: qsTr("R-squared");			name: "unadjustedRSquaredAlternative" ; max: 0.9999 }
+		IntegerField {	label: qsTr("Number of covariates"); name: "numberOfCovariatesAlternative" ; min: 1 }
+		DoubleField {	label: qsTr("R-squared");			name: "unadjustedRSquaredAlternative" ; max: 0.9999 }
 	}
 
 	Divider { }
 
 	BayesFactorType { }
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness"; text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo"; text: qsTr("Additional info"); checked: true }
+			name: "plotBayesFactorRobustness"; label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo"; label: qsTr("Additional info"); checked: true }
 		}
 	}
 
@@ -60,10 +60,10 @@ Form
 	{
         title: qsTr("Advanced Options")
 
-        GroupBox 
+        Group
 		{
             title: qsTr("Prior")
-			DoubleField { text: qsTr("r scale covariates"); defaultValue: 0.3536 ; name: "priorWidth" ; fieldWidth: 80; max: 2 }
+			DoubleField { label: qsTr("r scale covariates"); defaultValue: 0.3536 ; name: "priorWidth" ; fieldWidth: 80; max: 2 }
         }
     }
 }

--- a/Resources/Summary Statistics/qml/SummaryStatsTTestBayesianIndependentSamples.qml
+++ b/Resources/Summary Statistics/qml/SummaryStatsTTestBayesianIndependentSamples.qml
@@ -29,9 +29,9 @@ Form
 
 	Group
 	{
-		DoubleField  { name: "tStatistic";	text: qsTr("t"); validation: false	}
-		IntegerField { name: "n1Size";		text: qsTr("Group 1 size")			}
-		IntegerField { name: "n2Size";		text: qsTr("Group 2 size")			}
+		DoubleField  { name: "tStatistic";	label: qsTr("t"); validation: false	}
+		IntegerField { name: "n1Size";		label: qsTr("Group 1 size")			}
+		IntegerField { name: "n2Size";		label: qsTr("Group 2 size")			}
     }
 
     Divider { }
@@ -40,23 +40,23 @@ Form
 	{
 		title: qsTr("Hypothesis")
 		name: "hypothesis"
-		RadioButton { value: "groupsNotEqual";	text: qsTr("Group 1 \u2260 Group 2"); checked: true	}
-		RadioButton { value: "groupOneGreater";	text: qsTr("Group 1 > Group 2")						}
-		RadioButton { value: "groupTwoGreater";	text: qsTr("Group 1 < Group 2")						}
+		RadioButton { value: "groupsNotEqual";	label: qsTr("Group 1 \u2260 Group 2"); checked: true	}
+		RadioButton { value: "groupOneGreater";	label: qsTr("Group 1 > Group 2")						}
+		RadioButton { value: "groupTwoGreater";	label: qsTr("Group 1 < Group 2")						}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";		text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";		label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		label: qsTr("Additional info"); checked: true }
 		}
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness";	text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	text: qsTr("Additional info"); checked: true }
+			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 	}
 

--- a/Resources/Summary Statistics/qml/SummaryStatsTTestBayesianOneSample.qml
+++ b/Resources/Summary Statistics/qml/SummaryStatsTTestBayesianOneSample.qml
@@ -27,10 +27,10 @@ Form
 {
 	usesJaspResults: false
 
-	GroupBox 
+	Group
 	{
-		DoubleField  { name: "tStatistic";	text: qsTr("t"); validation: false  }
-		IntegerField { name: "n1Size";		text: qsTr("Group size")			}
+		DoubleField  { name: "tStatistic";	label: qsTr("t"); validation: false  }
+		IntegerField { name: "n1Size";		label: qsTr("Group size")			}
 	}
 
     Divider { }
@@ -39,23 +39,23 @@ Form
 	{
 		title: qsTr("Hypothesis")
 		name: "hypothesis"
-		RadioButton { value: "notEqualToTestValue";		text: qsTr("\u2260 Test value"); checked: true	}
-		RadioButton { value: "greaterThanTestValue";	text: qsTr("> Test value")						}
-		RadioButton { value: "lessThanTestValue";		text: qsTr("< Test value")						}
+		RadioButton { value: "notEqualToTestValue";		label: qsTr("\u2260 Test value"); checked: true	}
+		RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value")						}
+		RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value")						}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";		text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";		label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		label: qsTr("Additional info"); checked: true }
 		}
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness";	text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	text: qsTr("Additional info"); checked: true }
+			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 	}
 

--- a/Resources/Summary Statistics/qml/SummaryStatsTTestBayesianPairedSamples.qml
+++ b/Resources/Summary Statistics/qml/SummaryStatsTTestBayesianPairedSamples.qml
@@ -27,10 +27,10 @@ Form
 {
 	usesJaspResults: false
 
-	GroupBox 
+	Group
 	{
-		DoubleField  { text: qsTr("t");				name: "tStatistic" ; validation: false  }
-		IntegerField { text: qsTr("Group size");	name: "n1Size" }
+		DoubleField  { label: qsTr("t");				name: "tStatistic" ; validation: false  }
+		IntegerField { label: qsTr("Group size");	name: "n1Size" }
 	}
 	
     Divider { }
@@ -39,23 +39,23 @@ Form
 	{
 		name: "hypothesis"
 		title: qsTr("Hypothesis")
-		RadioButton { value: "groupsNotEqual";	text: qsTr("Measure 1 \u2260 Measure 2"); checked: true }
-		RadioButton { value: "groupOneGreater";	text: qsTr("Measure 1 > Measure 2")						}
-		RadioButton { value: "groupTwoGreater";	text: qsTr("Measure 1 < Measure 2")						}
+		RadioButton { value: "groupsNotEqual";	label: qsTr("Measure 1 \u2260 Measure 2"); checked: true }
+		RadioButton { value: "groupOneGreater";	label: qsTr("Measure 1 > Measure 2")					}
+		RadioButton { value: "groupTwoGreater";	label: qsTr("Measure 1 < Measure 2")					}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Plots")
 		CheckBox
 		{
-			name: "plotPriorAndPosterior";		text: qsTr("Prior and posterior")
-			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		text: qsTr("Additional info"); checked: true }
+			name: "plotPriorAndPosterior";		label: qsTr("Prior and posterior")
+			CheckBox { name: "plotPriorAndPosteriorAdditionalInfo";		label: qsTr("Additional info"); checked: true }
 		}
 		CheckBox
 		{
-			name: "plotBayesFactorRobustness";	text: qsTr("Bayes factor robustness check")
-			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	text: qsTr("Additional info"); checked: true }
+			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
+			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 	}
 

--- a/Tools/jasptools/R/optionsParserQML.R
+++ b/Tools/jasptools/R/optionsParserQML.R
@@ -139,7 +139,7 @@ extractData.AssignedVariablesList <- function(element) {
   }
 
   result <- list()
-  regSingleItem <- "singleItem:true"
+  regSingleItem <- "singleVariable:true"
   isSingleItem <- grepl(regSingleItem, element)
   if (isSingleItem) {
     result[[name]] <- ""


### PR DESCRIPTION
Change text to label in CheckBox, RadioButton, ComboBox, TextField
singleItem to singleVariable
MeasuresCells to RepeatedMeasures
AssignedPairs to Pairs
Add possibility to have a list of label - value for dropdown values