### PR TITLE
Add dots when a table has no data

### DIFF
--- a/JASP-Desktop/html/js/table.js
+++ b/JASP-Desktop/html/js/table.js
@@ -63,7 +63,7 @@ JASPWidgets.tableView = JASPWidgets.objectView.extend({
 		let columnDefs = optSchema.fields;
 		let columnCount = columnDefs.length;
 
-		let rowCount = optData ? optData.length : 0;
+		let rowCount = optData.length > 1 ? optData.length : 1;
 		let cells = Array(columnCount);
 
 		for (let colNo = 0; colNo < columnCount; colNo++) {
@@ -434,7 +434,7 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 		var columnCount = columnDefs.length
 
 		let rowData = optData;
-		let rowCount = rowData ? rowData.length : 0
+		let rowCount = rowData.length > 1 ? rowData.length : 1;
 
 		let columnsDict = createColumns(columnDefs, rowData, optFootnotes);
 		let columnHeaders = columnsDict['columnHeaders'];

--- a/JASP-Desktop/html/js/utils.js
+++ b/JASP-Desktop/html/js/utils.js
@@ -500,7 +500,8 @@ function createColumns(columnDefs, rowData, modelFootnotes) {
     let columnCount = columnDefs.length;
     let columns = Array(columnCount);
     let columnHeaders = Array(columnCount);
-    let rowCount = rowData ? rowData.length : 0;
+    let tableDataExists = rowData.length > 0;
+    let rowCount = tableDataExists ? rowData.length : 1;
 
     for (let colNo = 0; colNo < columnCount; colNo++) {
 
@@ -538,8 +539,14 @@ function createColumns(columnDefs, rowData, modelFootnotes) {
 
         for (let rowNo = 0; rowNo < rowCount; rowNo++) {
 
-            let row = rowData[rowNo];
-			let content = row[columnName] === null ? '' : row[columnName];
+            let row = [];
+            let content = '.';
+
+            if (tableDataExists) {
+                row = rowData[rowNo];
+                content = row[columnName] === null ? '' : row[columnName];
+            }          
+
             let cell = { content: content };
 
             if (row['.footnotes'] && row['.footnotes'][columnName])


### PR DESCRIPTION
This removes the need to use `$setExpectedRows(1)` when an analysis is not ready to compute. Also fixes current analyses which only show a header row.