### PR TITLE
Do not show collections without a title

### DIFF
--- a/JASP-Desktop/html/js/collection.js
+++ b/JASP-Desktop/html/js/collection.js
@@ -156,51 +156,38 @@ JASPWidgets.collectionView = JASPWidgets.View.extend({
 
 
 	constructChildren: function (constructor, data) {
-
-		this.collection = this.model.get('collection');
-		var metaData = data.meta //remember for later
-
-		if(Array.isArray(metaData))  //from jaspResults
-		{
-			_.each(
-				metaData,
-				function (meta)
-				{
-					var itemResults = this.collection[meta.name]
-					data.meta = meta
-
-					var itemView = constructor.call(this, itemResults, data, true);
-					if (itemView !== null) {
-						itemView.inCollection = true;
-
-						if (itemView.resizer)
-							this.listenTo(itemView.resizer, "ResizeableView:resizeStart", this.onResizingStart);
-
-						this.listenTo(itemView, "all", this.eventEcho)
-						this.views.push(itemView);
-						this.localViews.push(itemView);
-					}
-				},
-				this);
-
-			data.meta = metaData //and put it back again..
-		}
-		else
-		{
-
-			_.each(this.collection, function (itemResults) {
-				var itemView = constructor.call(this, itemResults, data, true);
-				if (itemView !== null) {
-					itemView.inCollection = true;
-
-					if (itemView.resizer)
-						this.listenTo(itemView.resizer, "ResizeableView:resizeStart", this.onResizingStart);
-
-					this.listenTo(itemView, "all", this.eventEcho)
-					this.views.push(itemView);
-					this.localViews.push(itemView);
+		if (Array.isArray(data.meta)) { // the meta comes from a jaspResult analysis
+			_.each(data.meta, function (meta) {
+				if (meta.type == "collection" && data.collection[meta.name].title == "") { // remove collections without a title from view
+					var dataWithSkip = jQuery.extend(true, {}, data);
+					dataWithSkip.collection = dataWithSkip.collection[meta.name]["collection"];
+					dataWithSkip.meta = meta.meta;
+					this.constructChildren(constructor, dataWithSkip);
+				} else {
+					var itemResults = data.collection[meta.name];
+					data.meta = meta;
+					let itemView = constructor.call(this, itemResults, data, true);
+					this.pushViews(itemView);
 				}
 			}, this);
+		} else {
+			_.each(data.collection, function (itemResults) {
+				var itemView = constructor.call(this, itemResults, data, true);
+				this.pushViews(itemView);
+			}, this);
+		}
+	},
+
+	pushViews: function(itemView) {
+		if (itemView !== null) {
+			itemView.inCollection = true;
+
+			if (itemView.resizer)
+				this.listenTo(itemView.resizer, "ResizeableView:resizeStart", this.onResizingStart);
+
+			this.listenTo(itemView, "all", this.eventEcho)
+			this.views.push(itemView);
+			this.localViews.push(itemView);
 		}
 	},
 

--- a/JASP-Desktop/html/js/object.js
+++ b/JASP-Desktop/html/js/object.js
@@ -89,7 +89,7 @@ JASPWidgets.objectConstructor = function (results, params, ignoreEvents) {
 
 	if (itemView.constructChildren) {
 		var indentChildren = itemView.indentChildren === undefined ? false : itemView.indentChildren;
-		itemView.constructChildren(JASPWidgets.objectConstructor, { meta: metaData.meta, status: results.status, namespace: newNamespace, childOfCollection: results.collection !== undefined, embeddedLevel: embeddedLevel + 1, indent: indentChildren });
+		itemView.constructChildren(JASPWidgets.objectConstructor, { meta: metaData.meta, status: results.status, namespace: newNamespace, collection: results.collection, childOfCollection: results.collection !== undefined, embeddedLevel: embeddedLevel + 1, indent: indentChildren });
 		if (itemView.hasViews() === false) {
 			itemView.close();
 			return null;

--- a/JASP-R-Interface/jaspResults/src/jaspContainer.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspContainer.cpp
@@ -29,9 +29,6 @@ void jaspContainer::insert(std::string field, Rcpp::RObject value)
 
 	_data[field] = obj; //If we overwrite anything: deletion will be taken care of by jaspObject::destroyAllAllocatedObjects()
 
-	if(obj->_title == "")
-		obj->_title = field;
-
 	obj->setName(field);
 	if (_passErrorMessageToNextChild)
 	{


### PR DESCRIPTION
This allows containers to be used in the R analyses to group items without this grouping showing in the output.

e.g.,
```
      jaspResults[["1"]] <- createJaspContainer()  
      jaspResults[["1"]][["image"]] <- createJaspPlot(title="Plot of Container 1", plot=ggplot2::ggplot(iris))
      jaspResults[["1"]][["2"]] <- createJaspContainer()

      jaspResults[["1"]][["2"]][["image"]] <- createJaspPlot(title="Plot of Container 2", plot=ggplot2::ggplot(iris))
      jaspResults[["1"]][["2"]][["3"]] <- createJaspContainer(title = "Container 3")

      jaspResults[["1"]][["2"]][["3"]][["4"]] <- createJaspContainer()

      jaspResults[["1"]][["2"]][["3"]][["4"]][["5"]] <- createJaspContainer(title = "Container 5")
      jaspResults[["1"]][["2"]][["3"]][["4"]][["5"]][["image"]] <- createJaspPlot(title="Plot of Container 5", plot=ggplot2::ggplot(iris))
      jaspResults[["1"]][["2"]][["3"]][["4"]][["5"]][["6"]] <- createJaspContainer(title = "Container 6")
      jaspResults[["1"]][["2"]][["3"]][["4"]][["5"]][["6"]][["7"]] <- createJaspContainer(title = "Container 7")
      jaspResults[["1"]][["2"]][["3"]][["4"]][["5"]][["6"]][["7"]][["8"]] <- createJaspContainer()
      jaspResults[["1"]][["2"]][["3"]][["4"]][["5"]][["6"]][["7"]][["8"]][["9"]] <- createJaspContainer()
      jaspResults[["1"]][["2"]][["3"]][["4"]][["5"]][["6"]][["7"]][["8"]][["9"]][["image"]] <- createJaspPlot(title="Plot of Container 9", plot=ggplot2::ggplot(iris))

```

gives (the partial output):
<img width="376" alt="containers" src="https://user-images.githubusercontent.com/18737241/53649096-c0ff2c00-3c41-11e9-930e-364bc8c11aa9.png">
