### PR TITLE
Add addAvailableVariablesToAssigned property to VariablesList

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/VariablesList.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesList.qml
@@ -57,6 +57,7 @@ JASPControl
 	property bool	showVariableTypeIcon:	true
 	property bool	setWidthInForm:		false
 	property bool	setHeightInForm:	false
+	property bool	addAvailableVariablesToAssigned: listViewType === "Interaction"
 	
 	
 	property var	extraControlColumns:		[]

--- a/JASP-Desktop/widgets/boundqmllistviewterms.cpp
+++ b/JASP-Desktop/widgets/boundqmllistviewterms.cpp
@@ -37,7 +37,8 @@ BoundQMLListViewTerms::BoundQMLListViewTerms(QQuickItem* item, AnalysisForm* for
 	_optionsTable = nullptr;
 	_optionVariables = nullptr;
 	_singleItem = QQmlProperty(_item, "singleVariable").read().toBool();
-	QString extraControlOptionName = QQmlProperty(_item, "extraControlOptionName").read().toString();
+	QString extraControlOptionName = _item->property("extraControlOptionName").toString();
+	bool addAvailableTermsToAssigned = _item->property("addAvailableVariablesToAssigned").toBool();
 	
 	if (extraControlOptionName.isEmpty())
 		_extraControlOptionName = interaction ? "components" : "variable";
@@ -45,7 +46,7 @@ BoundQMLListViewTerms::BoundQMLListViewTerms(QQuickItem* item, AnalysisForm* for
 		_extraControlOptionName = extraControlOptionName.toStdString();
 	
 	if (interaction)
-		_termsModel = new ListModelInteractionAssigned(this);
+		_termsModel = new ListModelInteractionAssigned(this, addAvailableTermsToAssigned);
 	else
 		_termsModel = new ListModelTermsAssigned(this, _singleItem);
 	

--- a/JASP-Desktop/widgets/listmodelinteractionassigned.cpp
+++ b/JASP-Desktop/widgets/listmodelinteractionassigned.cpp
@@ -25,12 +25,12 @@
 
 using namespace std;
 
-ListModelInteractionAssigned::ListModelInteractionAssigned(QMLListView* listView)
+ListModelInteractionAssigned::ListModelInteractionAssigned(QMLListView* listView, bool addAvailableTermsToAssigned)
 	: ListModelAssignedInterface(listView), InteractionModel ()
 {
 	_areTermsInteractions = true;
 	_copyTermsWhenDropped = true;
-	_addNewAvailableTermsToAssignedModel = true;
+	_addNewAvailableTermsToAssignedModel = addAvailableTermsToAssigned;
 }
 
 void ListModelInteractionAssigned::initTerms(const Terms &terms)

--- a/JASP-Desktop/widgets/listmodelinteractionassigned.h
+++ b/JASP-Desktop/widgets/listmodelinteractionassigned.h
@@ -32,7 +32,7 @@ class ListModelInteractionAssigned : public ListModelAssignedInterface, public I
 	enum AssignType { Cross = 0, MainEffects, Interaction, All2Way, All3Way, All4Way, All5Way };
 	
 public:
-	ListModelInteractionAssigned(QMLListView* listView);
+	ListModelInteractionAssigned(QMLListView* listView, bool addAvailableTermsToAssigned);
 
 	virtual void initTerms(const Terms &terms) OVERRIDE;
 	


### PR DESCRIPTION
This is for Interaction VariablesList: per default it adds new variables from the Available List. This behaviour can be changed by using the addAvailableVariablesToAssigned property