### PR TITLE
JASPgraphs should check required-files for its dependencies

### DIFF
--- a/JASP-Engine/JASP-Engine.pro
+++ b/JASP-Engine/JASP-Engine.pro
@@ -84,7 +84,7 @@ exists(/app/lib/*) {
     InstallJASPgraphsRPackage.commands	= \"$$R_EXE\" CMD INSTALL --no-multiarch $$PWD/JASPgraphs
 } else {
     InstallJASPRPackage.commands        = \"$$R_EXE\" CMD INSTALL --no-multiarch --library=$$OUT_PWD/../R/library $$PWD/JASP
-    InstallJASPgraphsRPackage.commands  = \"$$R_EXE\" CMD INSTALL --no-multiarch --library=$$OUT_PWD/../R/library $$PWD/JASPgraphs
+    InstallJASPgraphsRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$_R_HOME/library\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
 }
 
 QMAKE_EXTRA_TARGETS += InstallJASPgraphsRPackage


### PR DESCRIPTION
In the current situation it checks the user library instead of required files.
If anyone knows of a prettier way to accomplish this, then by all means...