### PR TITLE
Crash when closing

### DIFF
--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -140,6 +140,13 @@ void AnalysisForm::runRScript(QString script, QString controlName)
 	emit _analysis->sendRScript(_analysis, script, controlName);
 }
 
+void AnalysisForm::itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &value)
+{
+	if (change == ItemChange::ItemSceneChange)
+		_removed = value.window ? true : false;
+	QQuickItem::itemChange(change, value);
+}
+
 void AnalysisForm::runScriptRequestDone(const QString& result, const QString& controlName)
 {	
 	BoundQMLItem* item = dynamic_cast<BoundQMLItem*>(getControl(controlName));
@@ -520,8 +527,11 @@ void AnalysisForm::_formCompletedHandler()
 
 void AnalysisForm::dataSetChanged()
 {
-	_dataSet = _analysis->getDataSet();
-	_setAllAvailableVariablesModel(true);
+	if (_removed)
+	{
+		_dataSet = _analysis->getDataSet();
+		_setAllAvailableVariablesModel(true);
+	}
 }
 
 

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -58,6 +58,8 @@ public:
 				void			illegalValueHandler(Bound *source);
 
 				void			runRScript(QString script, QString controlName);
+				
+	virtual		void			itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &value) OVERRIDE;
 					
 public slots:
 				void			runScriptRequestDone(const QString& result, const QString& requestId);
@@ -102,10 +104,6 @@ protected:
 	QVector<QMLItem*>						_orderedControls;	
 	std::map<QMLListView*, ListModel* >		_relatedModelMap;
 	std::map<QString, ListModel* >			_modelMap;
-
-
-
-protected:
 	DataSet							*_dataSet;
 	Options							*_options;
 
@@ -116,6 +114,7 @@ protected:
 	std::list<Bound *>				_bounds;
 	bool							_hasIllegalValue;
 	QString							_illegalMessage;
+	bool							_removed = false;
 	
 private:
 	std::vector<ListModelTermsAvailable*>	_allAvailableVariablesModels;


### PR DESCRIPTION
When the analysis form is removed, the form object still exists, but
has references to main windows objects that might have been destroyed
(especially after a Close action).

