### PR TITLE
Fixes Descriptives issues #304 and #309

### DIFF
--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -31,11 +31,14 @@ Descriptives <- function(jaspResults, dataset, options)
     }
   }
 
-  # If user requests split, create a list of datasets, one for each level
   if (makeSplit)
   {
     splitFactor      <- dataset[[.v(splitName)]]
     splitLevels      <- levels(splitFactor)
+    # remove missing values from the grouping variable
+    dataset <- dataset[!is.na(splitFactor), ]
+    dataset.factors <- dataset.factors[!is.na(splitFactor), ]
+    # create a list of datasets, one for each level
     splitDat         <- split(dataset[.v(variables)],         splitFactor)
     splitDat.factors <- split(dataset.factors[.v(variables)], splitFactor)
   }

--- a/JASP-Engine/rbridge.cpp
+++ b/JASP-Engine/rbridge.cpp
@@ -256,9 +256,9 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 	datasetStatic[colMax].nbRows	= filteredRowCount;
 	int filteredRow					= 0;
 
-	for(size_t i=0; i<rbridge_dataSet->rowCount() && i<datasetStatic[colMax].nbRows; i++)
+	for(size_t i=0; i<rbridge_dataSet->rowCount() && filteredRow < datasetStatic[colMax].nbRows; i++)
 		if(!obeyFilter || (rbridge_dataSet->filterVector().size() > i && rbridge_dataSet->filterVector()[i]))
-			datasetStatic[colMax].ints[filteredRow++] = int(i + 1); //R needs 1-based index
+			datasetStatic[colMax].ints[filteredRow++] = int(filteredRow + 1); //R needs 1-based index
 
 
 	for (int colNo = 0; colNo < colMax; colNo++)


### PR DESCRIPTION
The row.names returned from .readDataSetToEnd() were incorrect after a filter was applied and missing values were not omitted in the grouping variable in Descriptives.