### PR TITLE
AN(C)OVA Post hoc tests for interactions and some small fixes

### DIFF
--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -91,7 +91,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	    
 	    optsForSampling <- c(
 	      "variables", "groupingVariable", "wilcoxTest", "wilcoxonSamplesNumber",
-	      "missingValues", "priorWidth"
+	      "missingValues", "priorWidth", "wilcoxonChainsNumber"
 	    )
 	    
 	    change <- .diff(env[["options"]], response[["options"]])
@@ -122,7 +122,9 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	n_group2 <- ttest.results[["n_group2"]]
 	n_group1 <- ttest.results[["n_group1"]]
 	deltaSamplesWilcox <- ttest.results[["delta"]]
-
+	rHat <- ttest.results[["rHat"]]
+	
+	
 	if(is.null(options()$BFMaxModels)) options(BFMaxModels = 50000)
 	if(is.null(options()$BFpretestIterations)) options(BFpretestIterations = 100)
 	if(is.null(options()$BFapproxOptimizer)) options(BFapproxOptimizer = "optim")
@@ -220,7 +222,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					&& diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE &&
 					diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE && diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE &&
 					diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) && diff$wilcoxTest == FALSE && 
-					diff$wilcoxonSamplesNumber == FALSE && options$plotPriorAndPosteriorAdditionalInfo && "posteriorPlotAddInfo" %in% state$plotTypes) {
+					diff$wilcoxonSamplesNumber == FALSE && diff$wilcoxonChainsNumber == FALSE && options$plotPriorAndPosteriorAdditionalInfo && "posteriorPlotAddInfo" %in% state$plotTypes) {
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 					# then, if the requested plot already exists, use it
@@ -233,7 +235,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 							&& diff$groupingVariable == FALSE && diff$missingValues == FALSE && diff$plotHeight == FALSE && diff$plotWidth == FALSE && diff$effectSizeStandardized == FALSE &&
 							diff$informativeStandardizedEffectSize == FALSE && diff$informativeCauchyLocation == FALSE &&	diff$informativeCauchyScale == FALSE && diff$informativeTLocation == FALSE &&
 							diff$informativeTScale == FALSE && diff$informativeTDf == FALSE && diff$informativeNormalMean == FALSE && diff$informativeNormalStd == FALSE))) && diff$wilcoxTest == FALSE && 
-							diff$wilcoxonSamplesNumber == FALSE && !options$plotPriorAndPosteriorAdditionalInfo && "posteriorPlot" %in% state$plotTypes) {
+							diff$wilcoxonSamplesNumber == FALSE && diff$wilcoxonChainsNumber == FALSE && !options$plotPriorAndPosteriorAdditionalInfo && "posteriorPlot" %in% state$plotTypes) {
 
 					# if there is state and the variable has been plotted before and there is either no difference or only the variables or requested plot types have changed
 					# if the requested plot already exists use it
@@ -774,7 +776,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 		return(list(results=results, status="complete", state=list(options=options, results=results, plotsTtest=plots.ttest, plotTypes=plotTypes, plotVariables=plotVariables,
 		descriptPlotVariables=descriptPlotVariables, descriptivesPlots=descriptivesPlots, status=status, plottingError=plottingError, BF10post=BF10post, errorFootnotes=errorFootnotes,
-		tValue = tValue, n_group2 = n_group2, n_group1 = n_group1, delta = deltaSamplesWilcox),
+		tValue = tValue, n_group2 = n_group2, n_group1 = n_group1, delta = deltaSamplesWilcox, rHat = rHat),
 		keep=keep))
 	}
 
@@ -861,7 +863,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	} else if (options$wilcoxTest) {
 	  # display Wilcoxon statistic instead of error % 
 	  fields[[length(fields)+1]] <- list(name="error", type="number", format="sf:4;dp:3;", title="W")
-    
+	  fields[[length(fields)+1]] <- list(name="rHat", type="number", format="sf:4;dp:3", title="R^")
 	}
 
 	ttest[["schema"]] <- list(fields=fields)
@@ -892,7 +894,12 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 		.addFootnote(footnotes, symbol="<em>Note.</em>", text=message)
 	}
 
-
+  if (options$wilcoxTest) {
+    
+    message <- paste("Result based on data augmentation algorithm with 5 chains of ", options$wilcoxonSamplesNumber, " iterations.", sep="")
+    .addFootnote(footnotes, symbol="<em>Note.</em>", text=message)
+  }
+	
 	ttest.rows <- list()
 
 	status <- rep("ok", length(options$variables))
@@ -903,6 +910,8 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 	plottingError <- rep("error", length(options$variables))
 	errorFootnotes <- rep("no", length(options$variables))
 	delta <- list()
+	rHat <- list()
+	
 	
 	for (variable in options[["variables"]]) {
 
@@ -983,7 +992,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 			i <- 1
 			
 			if (options$wilcoxTest) {
-			  progressbar <- .newProgressbar(ticks=length(options[["variables"]]) * round(options$wilcoxonSamplesNumber / 1e2, 0), 
+			  progressbar <- .newProgressbar(ticks=length(options[["variables"]]) * round(5 * options$wilcoxonSamplesNumber / 1e2, 0), 
 			                                                 callback = callBackWilcoxonMCMC, response=TRUE)
 			}
 			
@@ -1075,7 +1084,8 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					status[rowNo] <- state$status[index]
 					plottingError[rowNo] <- state$plottingError[index]
 					delta[[rowNo]] <- state$delta[[index]]
-
+					rHat[[rowNo]] <- state$rHat[[index]]
+					
 				} else {
 
 				    errors <- .hasErrors(dataset, perform, message = 'short', type = c('observations', 'variance', 'infinity'),
@@ -1101,6 +1111,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
   					  error <- .clean(r[["error"]])
   					  tValue[i] <- r[["tValue"]]
   					  delta[[i]] <- NA
+  					  rHat[[i]] <- NA
   					  
   					  
 					  } else if (options$wilcoxTest) {
@@ -1110,14 +1121,16 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 					        diff$missingValues == FALSE && diff$wilcoxonSamplesNumber == FALSE) {
                 
                 delta[[i]] <- state$delta[[i]]
+                rHat[[i]] <- state$rHat[[i]]
                 bf.raw <- .computeBayesFactorWilcoxon(deltaSamples = delta[[i]], cauchyPriorParameter = options$priorWidth, oneSided = oneSided)
-                
+
               } else {
                 
-                r <- .rankSumGibbsSampler(x = group2, y = group1, nSamples = options$wilcoxonSamplesNumber, nBurnin = 0,
+                r <- .rankSumGibbsSampler(x = group2, y = group1, nSamples = options$wilcoxonSamplesNumber, nBurnin = 1,
                                           cauchyPriorParameter = options$priorWidth, progressbar = progressbar)
                 if(is.null(r)) return() # Return null if settings are changed
                 delta[[i]] <- r[["deltaSamples"]]
+                rHat[[i]] <- r[["rHat"]]
                 bf.raw <- .computeBayesFactorWilcoxon(deltaSamples = r[["deltaSamples"]], cauchyPriorParameter = options$priorWidth, oneSided = oneSided)
                 
               }
@@ -1187,7 +1200,10 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 							index <- .addFootnote(footnotes, errorMessage)
 							list(.variable=variable, BF=BF, error=error, .footnotes=list(BF=list(index)))
-						} else {
+						} else if (!is.null(rHat)) {
+
+						  list(.variable=variable, BF=BF, error=error, rHat=rHat[[i]])
+						}	else {
 
 							list(.variable=variable, BF=BF, error=error)
 						}
@@ -1222,7 +1238,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 	list(ttest = ttest, status = status, g1 = g1, g2 = g2, BFH1H0 = BFH1H0, plottingError = plottingError,
 	     BF10post = BF10post, errorFootnotes = errorFootnotes, tValue = tValue, n_group2 = n_group2,
-	     n_group1 = n_group1, delta = delta)
+	     n_group1 = n_group1, delta = delta, rHat = rHat)
 }
 
 .base_breaks_x <- function(x) {
@@ -1432,53 +1448,71 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
 
 
 .rankSumGibbsSampler <- function(xVals, yVals, nSamples = 1e3, cauchyPriorParameter = 1/sqrt(2),
-                                 nBurnin = 0, nGibbsIterations = 10, progressbar){
+                                 nBurnin = 0, nGibbsIterations = 10, nChains = 5, progressbar){
   n1 <- length(xVals)
   n2 <- length(yVals)
+  
   allRanks <- rank(c(xVals,yVals))
   xRanks <- allRanks[1:n1]
   yRanks <- allRanks[(n1+1):(n1+n2)]
   
-  allVals <- sort(rnorm((n1+n2)))[allRanks] # initial values
-  nSamples <- nSamples + nBurnin
-  deltaSamples <- gSamples <- muSamples <- numeric(nSamples)
+  deltaSamples <- numeric(nSamples)
+  deltaSamplesMatrix <- matrix(ncol = nChains, nrow = nSamples-nBurnin)
+  totalIterCount <- 0
   
-  oldMuProp <- oldDeltaProp <- 0
-  
-  for (j in 1:nSamples) {
-
-    if (j %% 1e2 == 0 ) { 
-      response <- progressbar()
-      if (response[["status"]] != "ok")
-        return()
-    }
+  for(thisChain in 1:nChains) {
     
-    for (i in sample(1:(n1+n2))) {
-      underx <- allVals[allRanks < allRanks[i]][order(allVals[allRanks < allRanks[i]], decreasing = T)][1]
-      upperx <- allVals[allRanks > allRanks[i]][order(allVals[allRanks > allRanks[i]], decreasing = F)][1]
-      if (is.na(underx)) {underx <- -Inf}
-      if (is.na(upperx)) {upperx <- Inf}
+  
+    currentVals <- sort(rnorm((n1+n2)))[allRanks] # initial values
+    
+    
+    oldDeltaProp <- 0
+    
+    for (j in 1:nSamples) {
       
-      if (i <= n1) {
-        allVals[i] <- .truncNormSample(mu = (-0.5*oldMuProp), sd = 1, lBound = underx, uBound = upperx)
-      } else if (i > n1) {
-        allVals[i] <- .truncNormSample(mu = (0.5*oldMuProp), sd = 1, lBound = underx, uBound = upperx)
+      totalIterCount <-   totalIterCount + 1
+      
+      if (totalIterCount %% 1e2 == 0 ) { 
+        response <- progressbar()
+        if (response[["status"]] != "ok")
+          return()
       }
+      
+      for (i in sample(1:(n1+n2))) {
+        
+        currentRank <- allRanks[i]
+        
+        currentBounds <- .upperLowerTruncation(ranks=allRanks, values=currentVals, currentRank=currentRank)
+        if (i <= n1) {
+          oldDeltaProp <- -0.5*oldDeltaProp
+        } else if (i > n1) {
+          oldDeltaProp <- 0.5*oldDeltaProp
+        }
+        
+        currentVals[i] <- .truncNormSample(currentBounds[["under"]], currentBounds[["upper"]], mu=oldDeltaProp, sd=1)
+        
+      }
+      
+      xVals <- currentVals[1:n1]
+      yVals <- currentVals[(n1+1):(n1+n2)]
+      
+      gibbsResult <- .sampleGibbsTwoSampleWilcoxon(x = xVals, y = yVals, n1 = n1, n2 = n2, nIter = nGibbsIterations,
+                                          rscale = cauchyPriorParameter)
+      
+      deltaSamples[j] <- oldDeltaProp <- gibbsResult
+  
     }
-    
-    xVals <- allVals[1:n1]
-    yVals <- allVals[(n1+1):(n1+n2)]
-    
-    gibbsResult <- .sampleGibbsTwoSampleWilcoxon(x = xVals, y = yVals, n1 = n1, n2 = n2, nIter = nGibbsIterations,
-                                                 rscale = cauchyPriorParameter)
-    
-    muSamples[j] <- oldMuProp <- gibbsResult[3]
-    deltaSamples[j] <- oldDeltaProp <- gibbsResult[1]
+    deltaSamples <- -1 * deltaSamples[-(1:nBurnin)]
+    deltaSamplesMatrix[, thisChain] <- deltaSamples
   }
   
-  deltaSamples <- -1 * deltaSamples[-(1:nBurnin)]
+  betweenChainVar <- (nSamples / (nChains - 1)) * sum((apply(deltaSamplesMatrix, 2, mean)  - mean(deltaSamplesMatrix))^2)
+  withinChainVar <- (1/ nChains) * sum(apply(deltaSamplesMatrix, 2, var)) 
+  
+  fullVar <- ((nSamples - 1) / nSamples) * withinChainVar + (betweenChainVar / nSamples)
+  rHat <- sqrt(fullVar/withinChainVar)
 
-  return(list(deltaSamples = deltaSamples))
+  return(list(deltaSamples = as.vector(deltaSamplesMatrix), rHat = rHat))
 }
 
 .sampleGibbsTwoSampleWilcoxon <- function(x, y, n1, n2, nIter = 10, rscale = 1/sqrt(2)) {
@@ -1499,7 +1533,7 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
     # convert to delta
     delta <- mu / sqrt(sigmaSq)
   }
-  return(c(delta, sigmaSq, mu, g))
+  return(delta)
 }
 
 .truncNormSample <- function(lBound = -Inf, uBound = Inf, mu = 0, sd = 1) {
@@ -1509,6 +1543,23 @@ TTestBayesianIndependentSamples <- function(dataset=NULL, options, perform="run"
   mySample <- qnorm(runif(1, lBoundUni, uBoundUni), mean = mu, sd = sd)
   
   return(mySample)
+}
+
+.upperLowerTruncation <- function(ranks, values, currentRank, n, ranksAreIndices = FALSE) {
+  
+  if (currentRank == min(ranks)) {
+    under <- -Inf
+  } else {
+    under <- max(values[ranks < currentRank])
+  }
+  
+  if (currentRank == max(ranks)) {
+    upper <- Inf
+  } else {
+    upper <- min(values[ranks > currentRank])
+  }
+  
+  return(list(under=under, upper=upper))
 }
 
 .computeBayesFactorWilcoxon <- function(deltaSamples, cauchyPriorParameter, oneSided) {

--- a/JASP-Engine/JASP/R/ttestindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestindependentsamples.R
@@ -337,26 +337,32 @@ TTestIndependentSamples <- function(dataset = NULL, options, perform = "run",
 							sed <-  .clean((as.numeric(r$estimate[1]) - as.numeric(r$estimate[2]))/stat)
 							confIntEffSize <- c(0,0)
 							if (wantsConfidenceEffSize){
+							  # Taken from effsize package by Marco Torchiano, v0.7.4
+							  # Using the non-central t distributions for computing the confidence interval.
+							  # https://cran.r-project.org/web/packages/effsize/index.html
+							  # Same result as MBESS package by Ken Kelley, v4.4.3
 							  alphaLevels <- sort( c( (1-ciEffSize), ciEffSize ) )
 							  
 							  if (direction == "two.sided") {
 							    alphaLevels[1] <- (1-ciEffSize) / 2
 							    alphaLevels[2] <- (ciEffSize + 1) / 2
 							  } 
-							  
-							  end1 <- abs(stat)
+							  st = max(0.1,abs(stat))
+							  df <- sum(ns) -2
+							  end1 <- stat
 							  while( pt(q=stat,df=df,ncp=end1) > alphaLevels[1]){
-							    end1 = end1 * 2
+							    end1 <- end1 + st
 							  }
 							  ncp1 <- uniroot(function(x) alphaLevels[1] - pt(q=stat, df=df, ncp=x),
 							                  c(2*stat-end1,end1))$root
 				
-							  end2 = -abs(stat)
+							  end2 <- stat
 							  while( pt(q=stat,df=df,ncp=end2) < alphaLevels[2]){
-							    end2 = end2 * 2
+							    end2 <- end2 - st
 							  }
 							  ncp2 <- uniroot(function(x) alphaLevels[2] - pt(q=stat, df=df, ncp=x),
 							                  c(end2,2*stat-end2))$root
+							  
 							  
 							  confIntEffSize = sort(c(ncp1*sqrt(1/ns[1]+1/ns[2]),  ncp2*sqrt(1/ns[1]+1/ns[2]) ))[order(c(1-ciEffSize, ciEffSize ))]
 							  if (direction == "greater") {

--- a/JASP-Tests/R/tests/testthat/test-ancova.R
+++ b/JASP-Tests/R/tests/testthat/test-ancova.R
@@ -142,14 +142,14 @@ test_that("Post Hoc table results match", {
   options$postHocTestsHolm <- TRUE
   options$postHocTestsScheffe <- TRUE
   options$postHocTestsTukey <- TRUE
-  options$postHocTestsVariables <- "facExperim"
+  options$postHocTestsVariables <- list("facExperim")
   options$postHocTestsTypeStandard <- TRUE
   results <- jasptools::run("Ancova", "test.csv", options)
   table <- results[["results"]][["posthoc"]][["collection"]][[1]][["data"]]
   expect_equal_tables(table,
     list("control", "experimental", -0.0830902357515323, 0.21391801479091,
          -0.388420937024623, -0.078154288522293197, 0.698555762823947,
-         0.927393971055831, 0.698555762823947, 0.698555762823947, -0.4966168, 0.3501177, "TRUE")
+         0.698555762823947, 0.698555762823947, 0.698555762823947, -0.5076582796131340, 0.3414778081100690, "TRUE")
   )
 })
 

--- a/Resources/Common/qml/Ancova.qml
+++ b/Resources/Common/qml/Ancova.qml
@@ -131,7 +131,7 @@ Form
 		{
 			height: 200
 			AvailableVariablesList { name: "postHocTestsAvailable"; source: "fixedFactors" }
-			AssignedVariablesList {  name: "postHocTestsVariables" }
+			AssignedVariablesList {  name: "postHocTestsVariables"; listViewType: "Interaction"; addAvailableVariablesToAssigned: false}
 		}
 		
 		CheckBox { name: "postHocTestEffectSize";	label: qsTr("Effect Size") }
@@ -269,7 +269,6 @@ Form
 			}
 		}
 		
-		CheckBox { name: "dunnTest"; label: qsTr("Dunn's post hoc test") }
 	}
 	
 }

--- a/Resources/Common/qml/Anova.qml
+++ b/Resources/Common/qml/Anova.qml
@@ -107,7 +107,8 @@ Form
 		{
 			height: 200
 			AvailableVariablesList { name: "postHocTestsAvailable"; source: "fixedFactors" }
-			AssignedVariablesList {  name: "postHocTestsVariables" }
+			AssignedVariablesList {  name: "postHocTestsVariables"; listViewType: "Interaction"; addAvailableVariablesToAssigned: false}
+
 		}
 		
 		CheckBox { name: "postHocTestEffectSize"; label: qsTr("Effect Size") }

--- a/Resources/Library/TTestBayesianIndependentSamples.json
+++ b/Resources/Library/TTestBayesianIndependentSamples.json
@@ -27,7 +27,7 @@
 			"name": "wilcoxonSamplesNumber",
 			"type": "Integer",
 			"min": 100,
-			"max": 10000
+			"max": 100000
 		},
 		{
 			"name": "hypothesis",


### PR DESCRIPTION
Now allows post hoc tests for interactions in AN(C)OVA (Fix  #215, #113)
Also
- Increased stability of Bayesian Wilcoxon test, and footnote to indicate that it is based on sampling
- Informative message when singular fit is encountered in ANOVA type 3 SS (set singular.ok to false) - Fix  #312
- Removed reDunndant Dunn's test for ANOVA, as it is now featured in the post hoc menu
Maybe squash commits because I had some merge conflicts.
- Improved cohen d confidence itnterval, added reference to package
- Changed "Pool sd across rm factors" option text in RM ANOVA to make it clearer what is meant.
