### PR TITLE
Fixed crash due to "collapse" option

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -40,7 +40,7 @@ Item
 		id:				panelSplit
 		orientation:	Qt.Horizontal
 		height:			parent.height
-		width:			parent.width + hackySplitHandlerHideWidth 
+		width:			parent.width + hackySplitHandlerHideWidth
 
 		//hackySplitHandlerHideWidth is there to create some extra space on the right side for the analysisforms I put inside the splithandle. https://github.com/jasp-stats/INTERNAL-jasp/issues/144
 		property int  hackySplitHandlerHideWidth:	(panelSplit.shouldShowInputOutput && analysesModel.visible ? Theme.formWidth + 3 + Theme.scrollbarBoxWidth : 0) + ( mainWindow.analysesAvailable ? Theme.splitHandleWidth : 0 )
@@ -227,7 +227,7 @@ Item
 						customMenu.showMenu(resultsView, props, optionsJSON['rXright'] + 10, optionsJSON['rY']);
 					}
 
-					function updateUserData(id, key)				{ resultsJsInterface.updateUserData(id, key)				}
+					function updateUserData()						{ resultsJsInterface.updateUserData()						}
 					function analysisSaveImage(id, options)			{ resultsJsInterface.analysisSaveImage(id, options)			}
 					function analysisEditImage(id, options)			{ resultsJsInterface.analysisEditImage(id, options)			}
 					function removeAnalysisRequest(id)				{ resultsJsInterface.removeAnalysisRequest(id)				}

--- a/JASP-Desktop/html/js/analyses.js
+++ b/JASP-Desktop/html/js/analyses.js
@@ -16,7 +16,7 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 		this.noteBox = new JASPWidgets.NoteBox({ className: "jasp-notes jasp-main-note jasp_top_level", model: this.note });
 
 		this.listenTo(this.noteBox, "NoteBox:textChanged", function () {
-			this.trigger("analyses:userDataChanged", 'first');
+			this.trigger("analyses:userDataChanged");
 		});
 
 		this.views.push(this.noteBox);

--- a/JASP-Desktop/html/js/analysis.js
+++ b/JASP-Desktop/html/js/analysis.js
@@ -57,7 +57,7 @@ JASPWidgets.DataDetails = function (dataKey, path) {
 		var extendedDetails = new JASPWidgets.DataDetails(dataKey, this.path)
 
 		var fullKey = this.GetFullKey();
-		if (fullKey === '') 
+		if (fullKey === '')
 			fullKey = dataKey;
 		else
 			fullKey = fullKey + '-' + dataKey;
@@ -77,7 +77,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		this.viewNotes = { list: [] };
 
 		this.toolbar = new JASPWidgets.Toolbar({ className: "jasp-toolbar" })
-		
+
 		this.progressbar = new JASPWidgets.Progressbar();
 
 		this.imageToEdit = null;
@@ -92,11 +92,11 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 		var firstNoteDetails = new JASPWidgets.DataDetails('firstNote');
 		var firstNoteBox = this.getNoteBox(firstNoteDetails);
-		
+
 		var lastNoteDetails = new JASPWidgets.DataDetails('lastNote');
 		var lastNoteBox = this.getNoteBox(lastNoteDetails);
 
-		this.toolbar.setParent(this);	
+		this.toolbar.setParent(this);
 
 		this.model.on("CustomOptions:changed", function (options) {
 			this.trigger("optionschanged", this.model.get("id"), options)
@@ -125,7 +125,8 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 				self.setData(details, pair.key, pair.value, self.userdata);
 			}
 		}
-		self.trigger("analysis:userDataChanged", self.model.get('id'));
+
+		self.trigger("analysis:userDataChanged");
 	},
 
 	_setTitle: function (title, format) {
@@ -140,14 +141,14 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		'mouseenter': '_hoveringStart',
 		'mouseleave': '_hoveringEnd',
 	},
-	
+
 	handleVisibilityProgressbar: function(statusProgress) {
 		if (statusProgress == "progress-complete") {
 			var id = this.model.get("id");
 			window.setTimeout(function() { $("#progressbar-" + id).fadeOut()}, 500);
 		}
 	},
-	
+
 	modifyImage: function(image, ctx) {
 		var id = '#' + image.name.replace(/[^A-Za-z0-9]/g, '-');
 		if (image.error && image.resized) {
@@ -224,7 +225,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 				else {
 					rootDataNode = rootDataNode[keyPath[i]];
 					if (rootDataNode === undefined)
-						break;	
+						break;
 				}
 			}
 		}
@@ -253,7 +254,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 			this.viewNotes.list.push({ noteDetails: noteDetails, widget: widget, note: noteData });
 
 			this.listenTo(widget, "NoteBox:textChanged", function () {
-				this.trigger("analysis:userDataChanged", this.model.get('id'), key);
+				this.trigger("analysis:userDataChanged");
 			});
 		}
 
@@ -414,7 +415,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 				var name = subView.model.get('name');
 				if (name !== null)
 					this.passUserDataToView(path.concat([name]), subView);
-				else 
+				else
 					throw "there must be a name parameter."
 			}
 		}
@@ -470,7 +471,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 	},
 
 	copyMenuClicked: function () {
-		
+
 		var exportParams = new JASPWidgets.Exporter.params();
 		exportParams.format = JASPWidgets.ExportProperties.format.html;
 		exportParams.process = JASPWidgets.ExportProperties.process.copy;
@@ -525,7 +526,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 			if (!_.has(results, name))
 				continue
 			let data = results[name];
-			
+
 			if (meta.type == 'collection' && data.title == "") {  // remove collections without a title from view
 				let collectionMeta = meta.meta;
 				if (Array.isArray(collectionMeta)) { // the meta comes from a jaspResult analysis
@@ -564,7 +565,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		else if (metaEntry.type == "h2")
 			this.labelRequest = { title: result, titleFormat: 'h4' };
 		else {
-		
+
 			if (_.isArray(result)) {
 
 				result = { collection: result };
@@ -607,7 +608,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 			}
 			return this;
 		}
-		
+
 		this.toolbar.$el.detach();
 		this.detachNotes();
 
@@ -658,7 +659,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		var $progressbar = this.progressbar.init(this.model.get("progress"), this.model.get("id"), this.model.get("status"));
 		$innerElement.prepend($progressbar);
 		this.handleVisibilityProgressbar(this.progressbar.status());
-		
+
 		this.viewNotes.lastNoteNoteBox.render();
 		$innerElement.append(this.viewNotes.lastNoteNoteBox.$el);
 
@@ -672,7 +673,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 		$tempClone.replaceWith($innerElement);
 		$tempClone.empty();
-		
+
 		var errorBoxHeight = $innerElement.find(".analysis-error").outerHeight(true);
 		var $selectedAnalysis = $innerElement.find(".jasp-analysis");
 		if ($selectedAnalysis.height() < errorBoxHeight) {

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -461,8 +461,8 @@ $(document).ready(function () {
 				window.menuObject = obj;
 			});
 
-			analyses.on("analyses:userDataChanged", function (key) {
-				jasp.updateUserData(-1, key);
+			analyses.on("analyses:userDataChanged", function () {
+				jasp.updateUserData();
 			});
 
 			analyses.render();
@@ -520,8 +520,9 @@ $(document).ready(function () {
 				jasp.removeAnalysisRequest(id);
 			});
 
-			jaspWidget.on("analysis:userDataChanged", function (id, key) {
-				jasp.updateUserData(id, key);
+			jaspWidget.on("analysis:userDataChanged", function () {
+
+				jasp.updateUserData();
 			});
 		}
 		else

--- a/JASP-Desktop/utilities/resultsjsinterface.h
+++ b/JASP-Desktop/utilities/resultsjsinterface.h
@@ -76,7 +76,7 @@ signals:
 public slots:
 	void setZoom(double zoom);
 	void resultsDocumentChanged()				{ emit packageModified(); }
-	void updateUserData(int id, QString key)	{ emit packageModified(); }
+	void updateUserData()						{ emit packageModified(); }
 	void simulatedMouseClick(int x, int y, int count);
 	void saveTempImage(int id, QString path, QByteArray data);
 	void pushImageToClipboard(const QByteArray &base64, const QString &html);


### PR DESCRIPTION
`collapse` option on the result page leads to a crash since `key` param is `undefined` (should be QString ideally).