### PR TITLE
Make jasptools more compatible with modules

### DIFF
--- a/JASP-Tests/R/tests/testthat/helper-plots.R
+++ b/JASP-Tests/R/tests/testthat/helper-plots.R
@@ -1,3 +1,8 @@
 expect_equal_plots <- function(test, name, dir) {
+  if (length(test) == 0) {
+    errorMsg <- jasptools:::.getErrorMsgFromLastResults()
+    if (! is.null(errorMsg))
+        stop(paste("Tried retrieving plot from results, but last run of jasptools exited with an error:", errorMsg), call.=FALSE)
+  }
   vdiffr::expect_doppelganger(paste(dir, name, sep="-"), test, path=dir)
 }

--- a/JASP-Tests/R/tests/testthat/helper-tables.R
+++ b/JASP-Tests/R/tests/testthat/helper-tables.R
@@ -1,4 +1,9 @@
 expect_equal_tables <- function(test, ref, ...) {
+  if (length(test) == 0) {
+    errorMsg <- jasptools:::.getErrorMsgFromLastResults()
+    if (! is.null(errorMsg))
+        stop(paste("Tried retrieving table data from results, but last run of jasptools exited with an error:", errorMsg), call.=FALSE)
+  }
   test <- jasptools:::collapseTable(test)
   expect_equal(test, ref, tolerance=1e-4, ...)
 }

--- a/Tools/jasptools/DESCRIPTION
+++ b/Tools/jasptools/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jasptools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 0.6.2
+Version: 0.6.3
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/Tools/jasptools/R/initPackage.R
+++ b/Tools/jasptools/R/initPackage.R
@@ -128,10 +128,9 @@ isJaspDesktopDir <- function(path) {
     
     # set locations of all required resources (json, analyses, html, packages)
     relativePaths <- list(
-      r.dirs = c(file.path("JASP-Engine", "JASP", "R"), file.path("Dynamic Modules")),
+      common.r.dir = file.path("JASP-Engine", "JASP", "R"),
       html.dir = file.path("JASP-Desktop", "html"),
-      json.dir = file.path("Resources", "Library"),
-      qml.dirs = c(file.path("Resources"), file.path("Dynamic Modules")),
+      common.qml.dir = file.path("Resources"),
       data.dir = file.path("Resources", "Data Sets"),
       tests.dir = file.path("JASP-Tests", "R", "tests", "testthat"),
       tests.data.dir = file.path("JASP-Tests", "R", "tests", "datasets")

--- a/Tools/jasptools/R/main.R
+++ b/Tools/jasptools/R/main.R
@@ -143,6 +143,8 @@ view <- function(results) {
   insertedJS <- paste0(
     "<script>
       $(document).ready(function() {
+        window.jasp = { welcomeScreenIsCleared: function() {} }
+        window.clearWelcomeScreen()
         window.analysisChanged(", content, ")
       })
     </script></body>")
@@ -226,7 +228,7 @@ view <- function(results) {
 #' # If we want R functions sourced to the global env
 #' jasptools::run("BinomialTest", "debug.csv", options, sideEffects="globalEnv")
 #'
-#' # Or additionally have the .libPaths() set to JASP<e2><80><99>s R packages
+#' # Or additionally have the .libPaths() set to the JASP R packages
 #' jasptools::run("BinomialTest", "debug.csv", options, sideEffects=c("globalEnv", "libPaths"))
 #'
 #' @export run
@@ -274,8 +276,11 @@ run <- function(name, dataset, options, perform = "run", view = TRUE, quiet = FA
     })
   }
   
-  usesJaspResults <- .usesJaspResults(name)
   .initRunEnvironment(envir = envir, dataset = dataset, perform = perform)
+
+  if (! name %in% names(envir))
+    stop("Could not find the R analysis function ", name, ".\n",
+         "If you're trying to run the R script of an analysis from a module you have to set the module directory with setPkgOption(\"module.dir\", dir/to/module)")
   
   possibleArgs <- list(
     name = name,
@@ -292,9 +297,9 @@ run <- function(name, dataset, options, perform = "run", view = TRUE, quiet = FA
   if (usesJaspResults) {
     
     if (! "jaspResults" %in% .packages())
-      library(jaspResults)
-    
-    jaspResults::initJaspResults()
+      suppressMessages(library(jaspResults))
+    else
+      suppressMessages(jaspResults::initJaspResults())
     
     runFun <- "runJaspResults"
 

--- a/Tools/jasptools/R/optionsParserJSON.R
+++ b/Tools/jasptools/R/optionsParserJSON.R
@@ -1,38 +1,17 @@
 .analysisOptionsFromJSONString <- function(x) {
-  json <- try(jsonlite::fromJSON(x, simplifyVector=FALSE), silent = TRUE)
+  json <- try(jsonlite::fromJSON(x, simplifyVector=FALSE))
   
   if (inherits(json, "try-error")) {
-    stop("Your json is invalid, please copy the entire message
-         including the outer braces { } that was send to R in the Qt terminal.
-         Remember to use single quotes around the message.")
+    stop("There was a problem parsing the JSON string, cannot create the options list")
   }
   
   if ("options" %in% names(json)) {
     return(json[["options"]])
   } else {
-    stop("The JSON file appears to be invalid")
+    stop("There is no \"options\" field in your JSON string, cannot create options list")
   }
   
 }
-
-
-.analysisOptionsFromJSONFile <- function(file) {
-  
-  analysisOptsRaw <- try(jsonlite::read_json(file), silent = TRUE)
-  
-  if (inherits(analysisOptsRaw, "try-error")) {
-    stop("The file for the analysis you supplied could not be found.
-         Please ensure that (1) its name matches the main R function.")
-  }
-  
-  if (!"options" %in% names(analysisOptsRaw)) {
-    stop("The JSON file was found, but it appears to be invalid")
-  }
-
-  analysisOpts <- .fillOptions(analysisOptsRaw[["options"]])
-  return(analysisOpts)
-}
-
 
 .fillOptions <- function(options) {
   output <- list()

--- a/Tools/jasptools/R/optionsParserQML.R
+++ b/Tools/jasptools/R/optionsParserQML.R
@@ -1,4 +1,8 @@
-.analysisOptionsFromQMLFile <- function(file) {
+.analysisOptionsFromQMLFile <- function(analysis) {
+  file <- .getQMLFile(analysis)
+  if (is.null(file))
+    stop("Could not find the options file for analysis ", analysis, ".\n",
+         "If you're trying to obtain options for an analysis from a module you have to set the module directory with setPkgOption(\"module.dir\", dir/to/module)")
   options <- .readQML(file)
   return(options)
 }

--- a/Tools/jasptools/R/pkg-settings.R
+++ b/Tools/jasptools/R/pkg-settings.R
@@ -1,9 +1,9 @@
 # first the externally accessible options
 .pkgOptions <- list2env(list(
-  r.dirs = c(file.path("..", "JASP-Engine", "JASP", "R"), file.path("..", "Dynamic Modules")),
+  common.r.dir = file.path("..", "JASP-Engine", "JASP", "R"),
   html.dir = file.path("..", "JASP-Desktop", "html"),
-  json.dir = file.path("..", "Resources", "Library"),
-  qml.dirs = c(file.path("..", "Resources"), file.path("..", "Dynamic Modules")),
+  common.qml.dir = file.path("..", "Resources"),
+  module.dir = "",
   data.dir = file.path("..", "Resources", "Data Sets"),
   pkgs.dir = "",
   tests.dir = file.path("..", "JASP-Tests", "R", "tests", "testthat"),
@@ -66,7 +66,7 @@ setPkgOption <- function(name, value) {
       warning("jasptools is not configured correctly. It will not find the needed resources.
               Please set your working directory to %path%/to%jasp%jasp-desktop/Tools.")
     }
-    }
+  }
   return(get(name, envir = .pkgOptions))
 }
 

--- a/Tools/jasptools/R/test.R
+++ b/Tools/jasptools/R/test.R
@@ -15,7 +15,7 @@ testAnalysis <- function(analysis) {
   root <- .getPkgOption("tests.dir")
   file <- file.path(root, paste0("test-", analysis, ".R"))
   envirValue <- Sys.getenv("NOT_CRAN")
-  Sys.setenv("NOT_CRAN" = "true")
+  Sys.setenv("NOT_CRAN" = "true") # this is to prevent vdiffr from skipping plots
   on.exit(Sys.setenv("NOT_CRAN" = envirValue))
   testthat::test_file(file)
 }


### PR DESCRIPTION
Analyses from dynamic modules are no longer included by default, so no more problems with duplicate analysis names (solves jasp-stats/INTERNAL-jasp#169). If you want to run an analysis from a module you can `setPkgOption("module.dir", "path/to/module/dir")`; this also means that modules in any location on your pc will work. 