### PR TITLE
Problem with extra controls

### DIFF
--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -442,12 +442,12 @@ void AnalysisForm::bindTo(Options *options, DataSet *dataSet, const Json::Value&
 						if (!boundControl->isJsonValid(optionValue))
 						{
 							std::string labelStr;
-							QVariant label = boundControl->getProperty("label");
+							QVariant label = boundControl->getItemProperty("label");
 							if (!label.isNull())
 								labelStr = label.toString().toStdString();
 							if (labelStr.empty())
 							{
-								label = boundControl->getProperty("title");
+								label = boundControl->getItemProperty("title");
 								labelStr = label.toString().toStdString();
 							}
 							if (labelStr.empty())

--- a/JASP-Desktop/analysis/boundqmlitem.cpp
+++ b/JASP-Desktop/analysis/boundqmlitem.cpp
@@ -19,15 +19,6 @@
 #include "boundqmlitem.h"
 #include "analysisform.h"
 
-BoundQMLItem::BoundQMLItem(QQuickItem *item, AnalysisForm* form)
-	: QMLItem(item, form)
-{
-}
-
-BoundQMLItem::~BoundQMLItem()
-{
-}
-
 void BoundQMLItem::runRScript(const QString &script)
 {
 	_form->runRScript(script, name());

--- a/JASP-Desktop/analysis/boundqmlitem.h
+++ b/JASP-Desktop/analysis/boundqmlitem.h
@@ -29,8 +29,8 @@ class BoundQMLItem : public virtual QMLItem, public Bound
 {
 
 public:
-	BoundQMLItem(QQuickItem* item, AnalysisForm* form);
-	virtual ~BoundQMLItem();
+	BoundQMLItem() {}
+	virtual ~BoundQMLItem() {}
 	
 	virtual Option* createOption() = 0;
 	virtual Option* boundTo() = 0;

--- a/JASP-Desktop/components/JASP/Controls/ExtraControlColumn.qml
+++ b/JASP-Desktop/components/JASP/Controls/ExtraControlColumn.qml
@@ -21,13 +21,14 @@ QtObject {
     property string type
     property string name
     property string title
-    property var model
-	property var values
-	property int width 
-    property string value
-	property bool checked
-	property string defaultValue
-	property int max
-	property int min
+	property var	model
+	property var	values
+	property int	width
+	property string value:			""
+	property bool	checked:		false
+	property string defaultValue:	""
+	property int	max:			2147483647
+	property int	min:			0
+	property int	currentIndex:	0
 	property string purpose
 }

--- a/JASP-Desktop/components/JASP/Controls/ExtraControlColumn.qml
+++ b/JASP-Desktop/components/JASP/Controls/ExtraControlColumn.qml
@@ -26,5 +26,8 @@ QtObject {
 	property int width 
     property string value
 	property bool checked
+	property string defaultValue
+	property int max
+	property int min
 	property string purpose
 }

--- a/JASP-Desktop/components/JASP/Controls/JASPControl.qml
+++ b/JASP-Desktop/components/JASP/Controls/JASPControl.qml
@@ -142,7 +142,6 @@ FocusScope
 	ToolTip.delay:				Theme.toolTipDelay
 	ToolTip.toolTip.font:		Theme.font
 	ToolTip.visible:			toolTip !== "" && controlMouseArea.containsMouse
-	ToolTip.toolTip.background: Rectangle { color:	Theme.tooltipBackgroundColor } //This does set it for ALL tooltips ever after
 
 	MouseArea
 	{

--- a/JASP-Desktop/components/JASP/Controls/RadioButton.qml
+++ b/JASP-Desktop/components/JASP/Controls/RadioButton.qml
@@ -49,7 +49,14 @@ JASPControl
 			property bool	indentChildren:			true
 			property alias	alignChildrenTopLeft:	childControlsArea.alignChildrenTopLeft
 	
-	function toggle() { control.toggle() }
+	function click()
+	{
+		if (!checked)
+		{
+			control.toggle();
+			control.clicked()
+		}
+	}
 	
 	RadioButton
 	{

--- a/JASP-Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/JASP-Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -24,6 +24,8 @@ Rectangle
 	property bool		expanded:			analysesModel.currentAnalysisIndex === myIndex
 	property bool		imploded:			height == loader.y
 
+    ToolTip.toolTip.background: Rectangle { color:	Theme.tooltipBackgroundColor } //This does set it for ALL tooltips ever after
+
 	function toggleExpander()
 	{
 		if(analysesModel.currentAnalysisIndex === myIndex)	analysesModel.unselectAnalysis()

--- a/JASP-Desktop/widgets/boundqmlcheckbox.cpp
+++ b/JASP-Desktop/widgets/boundqmlcheckbox.cpp
@@ -24,11 +24,19 @@
 BoundQMLCheckBox::BoundQMLCheckBox(QQuickItem* item, AnalysisForm* form) 
 	: QMLItem(item, form)
 	, QObject(form)
-	, BoundQMLItem(item, form)
+	, BoundQMLItem()
 {
-	_boundTo = nullptr;
-	_checked = false;
-	QQuickItem::connect(item, SIGNAL(clicked()), this, SLOT(checkBoxClickedSlot()));
+	if (item)
+		QQuickItem::connect(item, SIGNAL(clicked()), this, SLOT(checkBoxClickedSlot()));
+}
+
+BoundQMLCheckBox::BoundQMLCheckBox(QMap<QString, QVariant>& properties, AnalysisForm *form)
+	: QMLItem(properties, form)
+	, QObject(form)
+	, BoundQMLItem()
+
+{
+	_checked = getItemProperty("checked").toBool();
 }
 
 void BoundQMLCheckBox::bindTo(Option *option)
@@ -38,7 +46,7 @@ void BoundQMLCheckBox::bindTo(Option *option)
 	if (_boundTo != nullptr)
 	{
 		_checked = _boundTo->value();
-		_item->setProperty("checked", _checked);
+		setItemProperty("checked", _checked);
 	}
 	else
 		qDebug() << "could not bind to OptionBoolean in BoundQuickCheckBox.cpp";
@@ -56,7 +64,7 @@ bool BoundQMLCheckBox::isJsonValid(const Json::Value &optionValue)
 
 Option *BoundQMLCheckBox::createOption()
 {
-	QVariant checkedVariant = _item->property("checked");
+	QVariant checkedVariant = getItemProperty("checked");
 	if (!checkedVariant.isNull())
 		_checked = checkedVariant.toBool();
 	return new OptionBoolean(_checked);
@@ -65,14 +73,17 @@ Option *BoundQMLCheckBox::createOption()
 void BoundQMLCheckBox::resetQMLItem(QQuickItem *item)
 {
 	BoundQMLItem::resetQMLItem(item);
-	_item->setProperty("checked", _checked);
-	QQuickItem::connect(_item, SIGNAL(clicked()), this, SLOT(checkBoxClickedSlot()));
+	setItemProperty("checked", _checked);
+	if (_item)
+	{
+		QQuickItem::connect(_item, SIGNAL(clicked()), this, SLOT(checkBoxClickedSlot()));
+	}
 }
 
 void BoundQMLCheckBox::setQMLItemChecked(bool checked)
 {
 	_checked = checked;
-	_item->setProperty("checked", checked);
+	setItemProperty("checked", checked);
 }
 
 void BoundQMLCheckBox::checkBoxClickedSlot()

--- a/JASP-Desktop/widgets/boundqmlcheckbox.h
+++ b/JASP-Desktop/widgets/boundqmlcheckbox.h
@@ -29,6 +29,7 @@ class BoundQMLCheckBox : public QObject, public BoundQMLItem
 	
 public:
 	BoundQMLCheckBox(QQuickItem* item, AnalysisForm* form);
+	BoundQMLCheckBox(QMap<QString, QVariant>& properties,  AnalysisForm* form);
 	
 	void	bindTo(Option *option)						override;
 	Option* createOption()								override;
@@ -45,8 +46,8 @@ private slots:
 	void checkBoxClickedSlot();
     
 protected:
-	OptionBoolean *_boundTo;
-	bool _checked;
+	OptionBoolean *_boundTo = nullptr;
+	bool _checked = false;
 
 };
 

--- a/JASP-Desktop/widgets/boundqmlcombobox.h
+++ b/JASP-Desktop/widgets/boundqmlcombobox.h
@@ -31,6 +31,10 @@ class BoundQMLComboBox : public QMLListView, public BoundQMLItem
 	
 public:
 	BoundQMLComboBox(QQuickItem* item, AnalysisForm* form);
+	BoundQMLComboBox(QMap<QString, QVariant>& properties, AnalysisForm *form);
+
+	void		initComboBox();
+
 	void		bindTo(Option *option)						override;
 	void		resetQMLItem(QQuickItem *item)				override;
 	Option*		createOption()								override;
@@ -47,11 +51,11 @@ protected slots:
 	void comboBoxChangeValueSlot(int index);
 
 protected:
-	OptionList*				_boundTo;
-	int						_currentIndex;
+	OptionList*				_boundTo = nullptr;
+	int						_currentIndex = 0;
 	QString					_currentText;
 	QString					_currentColumnType;
-	ListModelTermsAvailable* _model;
+	ListModelTermsAvailable* _model = nullptr;
 	QMap<QString, QString>	_keyToValueMap;
 	QMap<QString, QString>	_valueToKeyMap;
 	

--- a/JASP-Desktop/widgets/boundqmlfactorsform.cpp
+++ b/JASP-Desktop/widgets/boundqmlfactorsform.cpp
@@ -31,7 +31,7 @@ using namespace std;
 BoundQMLFactorsForm::BoundQMLFactorsForm(QQuickItem *item, AnalysisForm *form)
 	: QMLItem(item, form)
 	, QMLListView(item, form)
-	, BoundQMLItem(item, form)
+	, BoundQMLItem()
 {
 	_factorsModel = new ListModelFactorsForm(this);
 	setTermsAreNotVariables();

--- a/JASP-Desktop/widgets/boundqmllistviewdraggable.cpp
+++ b/JASP-Desktop/widgets/boundqmllistviewdraggable.cpp
@@ -50,30 +50,18 @@ BoundQMLListViewDraggable::BoundQMLListViewDraggable(QQuickItem *item, AnalysisF
 			QMetaProperty property = meta->property(i);
 			QString key = QString::fromLatin1(property.name());
 			QVariant value = property.read(extraControlColumnObject);
-			bool addValue = true;
 			if (key == "purpose")
 			{
-				addValue = false;
 				if (value.toString() == "nuisance")
 					_hasNuisanceControl = true;
 			}
-			switch (QMetaType::Type(property.type()))
+			else if (key == "title")
 			{
-			case QMetaType::Int:
-				if (value.toInt() == 0) addValue = false;
-				break;
-			case QMetaType::QString:
-				if (value.toString().isEmpty()) addValue = false;
-				if (key == "title")
-				{
+				QString title = value.toString();
+				if (!title.isEmpty())
 					extraControlTitles.push_back(value.toString());
-					addValue = false;
-				}
-				break;
-			default:
-				addValue = true;
 			}
-			if (addValue)
+			else
 				properties[key] = value;
 		}
 

--- a/JASP-Desktop/widgets/boundqmllistviewdraggable.cpp
+++ b/JASP-Desktop/widgets/boundqmllistviewdraggable.cpp
@@ -33,7 +33,7 @@
 
 BoundQMLListViewDraggable::BoundQMLListViewDraggable(QQuickItem *item, AnalysisForm *form)
 	: QMLListViewDraggable(item, form)
-	, BoundQMLItem(item, form) 
+	, BoundQMLItem()
 {
 	QStringList extraControlTitles;
 	

--- a/JASP-Desktop/widgets/boundqmllistviewterms.cpp
+++ b/JASP-Desktop/widgets/boundqmllistviewterms.cpp
@@ -49,8 +49,8 @@ BoundQMLListViewTerms::BoundQMLListViewTerms(QQuickItem* item, AnalysisForm* for
 		_termsModel = new ListModelInteractionAssigned(this, addAvailableTermsToAssigned);
 	else
 		_termsModel = new ListModelTermsAssigned(this, _singleItem);
-	
-	connect(_termsModel, &ListModelAssignedInterface::allExtraControlsLoaded, this, &BoundQMLListViewTerms::bindExtraControlOptions);
+
+	connect(_termsModel, &ListModelAssignedInterface::extraControlsChanged, this, &BoundQMLListViewTerms::bindExtraControlOptions);
 }
 
 void BoundQMLListViewTerms::bindTo(Option *option)
@@ -83,7 +83,7 @@ void BoundQMLListViewTerms::bindTo(Option *option)
 		}
 		
 		// This will create the rows in QML, and if needed, this will create also their extra controls
-		// In that case, when all rows are loaded in QML, bindExtraControlOptions will be called.
+		// That will also call bindExtraControlOptions
 		_termsModel->initTerms(terms);
 	}
 	else

--- a/JASP-Desktop/widgets/boundqmllistviewterms.h
+++ b/JASP-Desktop/widgets/boundqmllistviewterms.h
@@ -62,6 +62,8 @@ private:
 	
 	void extraOptionsChangedSlot(Option *option);
 	void updateNuisances(bool checked);
+
+	void _fillOptionsMap(QMap<std::string, Options*>& optionsMap);
 };
 
 #endif // BOUNDQMLLISTVIEWTERMS_H

--- a/JASP-Desktop/widgets/boundqmlradiobuttons.cpp
+++ b/JASP-Desktop/widgets/boundqmlradiobuttons.cpp
@@ -25,7 +25,7 @@ using namespace std;
 
 BoundQMLRadioButtons::BoundQMLRadioButtons(QQuickItem* item, AnalysisForm* form)
 	: QMLItem(item, form)
-	, BoundQMLItem(item, form)
+	, BoundQMLItem()
 {
 	_boundTo = nullptr;
 	_checkedButton = nullptr;

--- a/JASP-Desktop/widgets/boundqmlrepeatedmeasuresfactors.cpp
+++ b/JASP-Desktop/widgets/boundqmlrepeatedmeasuresfactors.cpp
@@ -28,7 +28,7 @@ using namespace std;
 BoundQMLRepeatedMeasuresFactors::BoundQMLRepeatedMeasuresFactors(QQuickItem *item, AnalysisForm *form)
 	: QMLItem(item, form)
 	, QMLListView(item, form)
-	, BoundQMLItem(item, form)
+	, BoundQMLItem()
 {
 	_factorsModel = new ListModelRepeatedMeasuresFactors(this);
 	setTermsAreNotVariables();

--- a/JASP-Desktop/widgets/boundqmlslider.cpp
+++ b/JASP-Desktop/widgets/boundqmlslider.cpp
@@ -26,7 +26,7 @@
 BoundQMLSlider::BoundQMLSlider(QQuickItem* item, AnalysisForm* form) 
 	: QMLItem(item, form)
 	, QObject(form)
-	, BoundQMLItem(item, form)
+	, BoundQMLItem()
 {
 	QQuickItem::connect(item, SIGNAL(moved()), this, SLOT(sliderMovedSlot()));
 }

--- a/JASP-Desktop/widgets/boundqmltableview.cpp
+++ b/JASP-Desktop/widgets/boundqmltableview.cpp
@@ -29,7 +29,7 @@
 BoundQMLTableView::BoundQMLTableView(QQuickItem* item, AnalysisForm* form)
 	: QMLItem(item, form)
 	, QMLListView(item, form)
-	, BoundQMLItem(item, form)
+	, BoundQMLItem()
 {
 	_boundTo = nullptr;
 	QString modelType = _item->property("modelType").toString();

--- a/JASP-Desktop/widgets/boundqmltextarea.cpp
+++ b/JASP-Desktop/widgets/boundqmltextarea.cpp
@@ -28,7 +28,7 @@
 BoundQMLTextArea::BoundQMLTextArea(QQuickItem* item, AnalysisForm* form) 
 	: QMLItem(item, form)
 	, QObject(form)
-	, BoundQMLItem(item, form)
+	, BoundQMLItem()
 {
 	_boundTo = nullptr;
 	_lavaanHighlighter = nullptr;

--- a/JASP-Desktop/widgets/boundqmltextinput.cpp
+++ b/JASP-Desktop/widgets/boundqmltextinput.cpp
@@ -27,9 +27,22 @@ using namespace std;
 BoundQMLTextInput::BoundQMLTextInput(QQuickItem* item, AnalysisForm* form)
 	: QMLItem(item, form)
 	, QObject(form)
-	, BoundQMLItem(item, form)
+	, BoundQMLItem()
 {
-	QString type = QQmlProperty(item, "inputType").read().toString();
+	initTextInput();
+}
+
+BoundQMLTextInput::BoundQMLTextInput(QMap<QString, QVariant> &properties, AnalysisForm *form)
+	: QMLItem(properties, form)
+	, QObject(form)
+	, BoundQMLItem()
+{
+	initTextInput();
+}
+
+void BoundQMLTextInput::initTextInput()
+{
+	QString type = getItemProperty("inputType").toString();
 
 		 if (type == "integer")			_inputType = TextInputType::IntegerInputType;
 	else if (type == "number")			_inputType = TextInputType::NumberInputType;
@@ -38,8 +51,10 @@ BoundQMLTextInput::BoundQMLTextInput(QQuickItem* item, AnalysisForm* form)
 	else if (type == "computedColumn")	_inputType = TextInputType::ComputedColumnType;
 	else								_inputType = TextInputType::StringInputType;
 
-	QQuickItem::connect(item, SIGNAL(editingFinished()), this, SLOT(textChangedSlot()));
+	if (_item)
+		 QQuickItem::connect(_item, SIGNAL(editingFinished()), this, SLOT(textChangedSlot()));
 }
+
 
 QString BoundQMLTextInput::_getPercentValue()
 {
@@ -120,13 +135,13 @@ void BoundQMLTextInput::bindTo(Option *option)
 		break;
 	}
 
-	_item->setProperty("value", _value);
+	setItemProperty("value", _value);
 }
 
 Option *BoundQMLTextInput::createOption()
 {
 	Option* option = nullptr;
-	_value = QQmlProperty::read(_item, "value").toString();
+	_value = getItemProperty("value").toString();
 	switch (_inputType)
 	{
 	case TextInputType::IntegerInputType:		option = new OptionInteger();			break;
@@ -197,8 +212,9 @@ void BoundQMLTextInput::resetQMLItem(QQuickItem *item)
 {
 	BoundQMLItem::resetQMLItem(item);
 
-	_item->setProperty("value", _value);
-	QQuickItem::connect(_item, SIGNAL(editingFinished()), this, SLOT(textChangedSlot()));
+	setItemProperty("value", _value);
+	if (_item)
+		QQuickItem::connect(_item, SIGNAL(editingFinished()), this, SLOT(textChangedSlot()));
 }
 
 void BoundQMLTextInput::_setOptionValue(Option* option, QString& text)
@@ -246,7 +262,7 @@ void BoundQMLTextInput::_setOptionValue(Option* option, QString& text)
 
 void BoundQMLTextInput::textChangedSlot()
 {
-	_value = QQmlProperty::read(_item, "value").toString();
+	_value = getItemProperty("value").toString();
 	if (_option)
 		_setOptionValue(_option, _value);
 }

--- a/JASP-Desktop/widgets/boundqmltextinput.h
+++ b/JASP-Desktop/widgets/boundqmltextinput.h
@@ -37,6 +37,9 @@ public:
 	enum TextInputType { IntegerInputType = 0, StringInputType, NumberInputType, PercentIntputType, IntegerArrayInputType, ComputedColumnType };
 
 	BoundQMLTextInput(QQuickItem* item, AnalysisForm* form);
+	BoundQMLTextInput(QMap<QString, QVariant>& properties, AnalysisForm *form);
+	void initTextInput();
+
 	void bindTo(Option *option)			override;
 
 	Option* createOption()				override;

--- a/JASP-Desktop/widgets/listmodel.h
+++ b/JASP-Desktop/widgets/listmodel.h
@@ -58,6 +58,8 @@ public:
 	virtual void			refresh();
 	virtual void			initTerms(const Terms &terms);
 	virtual Terms			getSourceTerms();
+	virtual void			endResetModel()									{ return QAbstractTableModel::endResetModel(); } // Make endResetModel virtual
+
 
 signals:
 	void modelChanged(Terms* added = nullptr, Terms* removed = nullptr);

--- a/JASP-Desktop/widgets/listmodelassignedinterface.cpp
+++ b/JASP-Desktop/widgets/listmodelassignedinterface.cpp
@@ -23,7 +23,6 @@ ListModelAssignedInterface::ListModelAssignedInterface(QMLListView* listView)
 	: ListModelDraggable(listView)
   , _source(nullptr)
 {
-	connect(this, &QAbstractTableModel::modelReset, this, &ListModelAssignedInterface::modelResetHandler);
 }
 
 
@@ -39,30 +38,33 @@ QVariant ListModelAssignedInterface::data(const QModelIndex &index, int role) co
 	
 }
 
-void ListModelAssignedInterface::modelResetHandler()
+void ListModelAssignedInterface::endResetModel()
+{
+	addExtraControls();
+	ListModelDraggable::endResetModel();
+}
+
+void ListModelAssignedInterface::addExtraControls()
 {
 	if (!_extraControlsDefinitions.isEmpty())
 	{
-		QMapIterator<QString, ListModelExtraControls* > it(_extraControlsModels);
-		while(it.hasNext())
-		{
-			it.next();
-			_modelCache[it.key()] = it.value();
-		}
-		
-		_extraControlsLoadedIndicator.clear();
 		_extraControlsModels.clear();
 		_rowNames.clear();
 		for (int i = 0; i < rowCount(); i++)
 		{
 			QString colName = data(index(i, 0), ListModel::NameRole).toString();
-			_extraControlsLoadedIndicator[colName] = _extraControlsNames;
 			_rowNames[i] = colName;
 			if (_modelCache.contains(colName))
 				_extraControlsModels[colName] = _modelCache[colName];
 			else
-				_extraControlsModels[colName] = new ListModelExtraControls(this, colName, _extraControlsDefinitions);
+			{
+				ListModelExtraControls* extraControlsModel = new ListModelExtraControls(this, colName, _extraControlsDefinitions);
+				_extraControlsModels[colName] = extraControlsModel;
+				_modelCache[colName] = extraControlsModel;
+			}
 		}
+
+        emit extraControlsChanged();
 	}
 }
 
@@ -77,24 +79,4 @@ void ListModelAssignedInterface::addExtraControls(const QVector<QMap<QString, QV
 	
 	for (const QMap<QString, QVariant>& extraControlDefinition : _extraControlsDefinitions)
 		_extraControlsNames[extraControlDefinition["name"].toString()] = false;
-}
-
-void ListModelAssignedInterface::controlLoaded(const QString &colName, const QString &controlName)
-{
-	_extraControlsLoadedIndicator[colName][controlName] = true;
-	bool allControlsLoaded = true;
-	QMapIterator<QString, QMap<QString, bool> > it(_extraControlsLoadedIndicator);
-	while (it.hasNext())
-	{
-		it.next();
-		QMapIterator<QString, bool> it2(it.value());
-		while (it2.hasNext())
-		{
-			it2.next();
-			if (!it2.value())
-				allControlsLoaded = false;
-		}
-	}
-	if (allControlsLoaded)
-		emit allExtraControlsLoaded();
 }

--- a/JASP-Desktop/widgets/listmodelassignedinterface.cpp
+++ b/JASP-Desktop/widgets/listmodelassignedinterface.cpp
@@ -40,11 +40,11 @@ QVariant ListModelAssignedInterface::data(const QModelIndex &index, int role) co
 
 void ListModelAssignedInterface::endResetModel()
 {
-	addExtraControls();
+	addExtraControlModels();
 	ListModelDraggable::endResetModel();
 }
 
-void ListModelAssignedInterface::addExtraControls()
+void ListModelAssignedInterface::addExtraControlModels()
 {
 	if (!_extraControlsDefinitions.isEmpty())
 	{

--- a/JASP-Desktop/widgets/listmodelassignedinterface.h
+++ b/JASP-Desktop/widgets/listmodelassignedinterface.h
@@ -31,22 +31,22 @@ class ListModelAssignedInterface : public ListModelDraggable
 public:
 	ListModelAssignedInterface(QMLListView* listView);
 	
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;	
+	QVariant		data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	void			endResetModel() override;
 		
-	virtual void setAvailableModel(ListModelAvailableInterface *source);
+	virtual void	setAvailableModel(ListModelAvailableInterface *source);
 	ListModelAvailableInterface* source() const											{ return _source; }
 	void addExtraControls(const QVector<QMap<QString, QVariant> >& extraControlColumns);
 	ListModelExtraControls* getExtraControlModel(QString colName)						{ return _extraControlsModels[colName]; }
-	void controlLoaded(const QString& colName, const QString& controlName);
 	
 public slots:
 	virtual void availableTermsChanged(Terms *termsAdded, Terms *termsRemoved) {}
-	
+
 signals:
-	void allExtraControlsLoaded();
-	
+	void extraControlsChanged();
+
 protected:
-	void modelResetHandler();
+	void addExtraControls();
 	
 	ListModelAvailableInterface*			_source;
 	QVector<QMap<QString, QVariant> >		_extraControlsDefinitions;
@@ -54,7 +54,6 @@ protected:
 	QMap<QString, ListModelExtraControls* > _extraControlsModels;
 	QMap<int, QString>						_rowNames;
 	QMap<QString, ListModelExtraControls* > _modelCache;
-	QMap<QString, QMap<QString, bool> >		_extraControlsLoadedIndicator;
 };
 
 #endif // LISTMODELASSIGNEDINTERFACE_H

--- a/JASP-Desktop/widgets/listmodelassignedinterface.h
+++ b/JASP-Desktop/widgets/listmodelassignedinterface.h
@@ -46,7 +46,7 @@ signals:
 	void extraControlsChanged();
 
 protected:
-	void addExtraControls();
+	void addExtraControlModels();
 	
 	ListModelAvailableInterface*			_source;
 	QVector<QMap<QString, QVariant> >		_extraControlsDefinitions;

--- a/JASP-Desktop/widgets/listmodelextracontrols.cpp
+++ b/JASP-Desktop/widgets/listmodelextracontrols.cpp
@@ -45,6 +45,34 @@ ListModelExtraControls::ListModelExtraControls(ListModelAssignedInterface* paren
 			_extraColumns[name] = new ExtraColumnType(name, type, controlColumn);
 			_names.push_back(name);
 		}
+
+
+		BoundQMLItem* boundItem = nullptr;
+		if (type == "CheckBox" || type == "Switch")
+			boundItem = new BoundQMLCheckBox(controlColumn,	_assignedModel->listView()->form());
+		else if (type == "ComboBox" || type == "Dropdown")
+			boundItem = new BoundQMLComboBox(controlColumn,	_assignedModel->listView()->form());
+		else if (type == "TextField" || type == "IntegerField" || type == "DoubleField" || type == "PercentField")
+		{
+			QString inputType = "string";
+			if (type == "IntegerField")
+				inputType = "integer";
+			else if (type == "DoubleField")
+				inputType = "double";
+			else if (type == "PercentField")
+				inputType = "percent";
+
+			controlColumn["inputType"] = inputType;
+			boundItem = new BoundQMLTextInput(controlColumn,  _assignedModel->listView()->form());
+		}
+		else
+			std::cout << "Control type " << type.toStdString() << " not supported in TableView" << std::flush;
+
+		if (boundItem)
+		{
+			boundItem->setUp();
+			_boundItems[name] = boundItem;
+		}
 	}
 }
 
@@ -53,6 +81,9 @@ QHash<int, QByteArray> ListModelExtraControls::roleNames() const
 	QHash<int, QByteArray> roles;
 	roles[NameRole] = "name";
 	roles[PathRole] = "path";
+	roles[TypeRole] = "type";
+	roles[PropertiesRole] = "properties";
+
 	return roles;
 }
 
@@ -66,14 +97,14 @@ QVariant ListModelExtraControls::data(const QModelIndex &index, int role) const
 	int row = index.row();
 
 	if (role == Qt::DisplayRole || role == ListModelExtraControls::NameRole)
-	{
 		return QVariant(_extraColumns[_names[row]]->name);
-	}	
 	else if (role == ListModelExtraControls::PathRole)
-	{
 		return QVariant(_extraColumns[_names[row]]->path);
-	}
-	
+	else if (role == ListModelExtraControls::TypeRole)
+		return QVariant(_extraColumns[_names[row]]->type);
+	else if (role == ListModelExtraControls::PropertiesRole)
+		return QVariant(_extraColumns[_names[row]]->properties);
+
 	return QVariant();
 }
 
@@ -82,52 +113,29 @@ void ListModelExtraControls::controlLoaded(const QString& name, QVariant item)
 	QQuickItem *quickItem = qobject_cast<QQuickItem *>(item.value<QObject *>());
 	if (quickItem)
 	{
-		ExtraColumnType* extraColumn = _extraColumns[name];
-		if (extraColumn)
-		{			
-			if (_boundItems.contains(name))
-			{
-				BoundQMLItem* boundItem = _boundItems[name];
-				boundItem->resetQMLItem(quickItem);
-			}
-			else
-			{
-				QMapIterator<QString, QVariant> i(extraColumn->properties);
-				while (i.hasNext())
-				{
-					i.next();
-					quickItem->setProperty(i.key().toStdString().c_str(), i.value());
-				}
-				
-				qmlControlType controlType;
-				try						{ controlType	= qmlControlTypeFromQString(extraColumn->type);	}
-				catch(std::exception)	{ _assignedModel->addError(QString::fromLatin1("Unknown Control type: ") + extraColumn->type); controlType = qmlControlType::JASPControl; }
-				
-				BoundQMLItem* boundItem = nullptr;
-				switch(controlType)
-				{
-				case qmlControlType::CheckBox:		//fallthrough:
-				case qmlControlType::Switch:		boundItem = new BoundQMLCheckBox(quickItem,	_assignedModel->listView()->form());	break;
-				case qmlControlType::TextField:		boundItem = new BoundQMLTextInput(quickItem, _assignedModel->listView()->form());	break;
-				case qmlControlType::ComboBox:		boundItem = new BoundQMLComboBox(quickItem,	_assignedModel->listView()->form());	break;
-				default:
-					qDebug() << "Control type " << extraColumn->type << " not supported in TableView";
-				}
-				
-				if (boundItem)
-				{
-					boundItem->setUp();
-					_boundItems[name] = boundItem;
-				}
-	
-			}
-			
-			_assignedModel->controlLoaded(_colName, name);
+		if (_boundItems.contains(name))
+		{
+			BoundQMLItem* boundItem = _boundItems[name];
+			boundItem->resetQMLItem(quickItem);
 		}
 		else
-			_assignedModel->addError("Cannot find Extra column with name " + name);
+			std::cout << "controlLoaded: Cannot find bound item " << name.toStdString() << std::flush;
 	}
 	else
-		qDebug() << "Quick Item not found";
-	
+		std::cout << "Quick Item not found" << std::flush;
+
+}
+
+void ListModelExtraControls::controlDestroyed(const QString &name, QVariant item)
+{
+	QQuickItem *quickItem = qobject_cast<QQuickItem *>(item.value<QObject *>());
+	if (_boundItems.contains(name))
+	{
+		BoundQMLItem* boundItem = _boundItems[name];
+		if (boundItem->item() == quickItem)
+			boundItem->resetQMLItem(nullptr);
+	}
+	else
+		std::cout << "controlDestroyed: Cannot find bound item " << name.toStdString() << std::flush;
+
 }

--- a/JASP-Desktop/widgets/listmodelextracontrols.h
+++ b/JASP-Desktop/widgets/listmodelextracontrols.h
@@ -31,7 +31,9 @@ class ListModelExtraControls : public QAbstractTableModel
 public:
 	enum ListModelExtraControlsRoles {
         NameRole = Qt::UserRole + 1,
-		PathRole
+		PathRole,
+		TypeRole,
+		PropertiesRole
     };
 	
 	ListModelExtraControls(ListModelAssignedInterface* parent, const QString& colName, const QVector<QMap<QString, QVariant> >& controlColumns);
@@ -42,6 +44,7 @@ public:
 	QVariant				data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 	
 	Q_INVOKABLE	void controlLoaded(const QString& name, QVariant item);
+	Q_INVOKABLE void controlDestroyed(const QString& name, QVariant item);
 	const QMap<QString, BoundQMLItem*>&	getBoundItems() const { return _boundItems; } 
 
 private:

--- a/JASP-Desktop/widgets/qmlitem.cpp
+++ b/JASP-Desktop/widgets/qmlitem.cpp
@@ -24,7 +24,13 @@
 QMLItem::QMLItem(QQuickItem *item, AnalysisForm* form)
 	: _item(item), _form(form)
 {
-	_name = QQmlProperty(_item, "name").read().toString();
+	_name = getItemProperty("name").toString();
+}
+
+QMLItem::QMLItem(QMap<QString, QVariant> &properties, AnalysisForm *form)
+	: _item(nullptr), _properties(properties), _form(form)
+{
+	_name = getItemProperty("name").toString();
 }
 
 void QMLItem::cleanUp()
@@ -52,13 +58,19 @@ bool QMLItem::addDependency(QMLItem *item)
 	return true;
 }
 
-void QMLItem::setProperty(const QString& name, const QVariant& value)
+void QMLItem::setItemProperty(const QString& name, const QVariant& value)
 {
-	_item->setProperty(name.toStdString().c_str(), value);
+	if (_item)
+		_item->setProperty(name.toStdString().c_str(), value);
+	else
+		_properties[name] = value;
 }
 
-QVariant QMLItem::getProperty(const QString &name)
+QVariant QMLItem::getItemProperty(const QString &name)
 {
-	return _item->property(name.toStdString().c_str());
+	if (_item)
+		return _item->property(name.toStdString().c_str());
+	else
+		return _properties[name];
 }
 

--- a/JASP-Desktop/widgets/qmlitem.h
+++ b/JASP-Desktop/widgets/qmlitem.h
@@ -31,22 +31,25 @@ class QMLItem
 
 public:
 	QMLItem(QQuickItem* item, AnalysisForm* form);
+	QMLItem(QMap<QString, QVariant>& properties, AnalysisForm* form);
 	virtual ~QMLItem() {};
 	
 	virtual void				setUp() {}
 	virtual void				cleanUp();
 	const QString&				name() { return _name; }
 	AnalysisForm*				form() { return _form; }
+	QQuickItem*					item() { return _item; }
 	virtual void				resetQMLItem(QQuickItem* item);
 	void						addError(const QString& error);
 	bool						addDependency(QMLItem* item);
 	const QVector<QMLItem*>&	depends() { return _depends; }
-	void						setProperty(const QString& name, const QVariant& value);
-	QVariant					getProperty(const QString& name);
+	void						setItemProperty(const QString& name, const QVariant& value);
+	QVariant					getItemProperty(const QString& name);
 	
 protected:
 	
 	QQuickItem*			_item;
+	QMap<QString, QVariant>	_properties;
 	QString				_name;
 	AnalysisForm*		_form;
 	QVector<QMLItem*>	_depends;

--- a/JASP-Desktop/widgets/qmllistview.cpp
+++ b/JASP-Desktop/widgets/qmllistview.cpp
@@ -30,11 +30,11 @@ QMLListView::QMLListView(QQuickItem *item, AnalysisForm *form)
 	  
 {
 	_setAllowedVariables();	
-	QList<QVariant> sources = QQmlProperty(_item, "source").read().toList();
+	QList<QVariant> sources = getItemProperty("source").toList();
 	
 	if (sources.isEmpty())
 	{
-		QStringList stringSources = QQmlProperty(_item, "source").read().toStringList();
+		QStringList stringSources = getItemProperty("source").toStringList();
 		for (const QString& stringSource : stringSources)
 			sources.push_back(stringSource);
 	}
@@ -109,7 +109,7 @@ void QMLListView::setUp()
 	}
 
 	connect(listModel, &ListModel::modelChanged, this, &QMLListView::modelChangedHandler);
-	QQmlProperty(_item, "model").write(QVariant::fromValue(listModel));
+	setItemProperty("model", QVariant::fromValue(listModel));
 }
 
 void QMLListView::cleanUp()
@@ -123,7 +123,7 @@ void QMLListView::cleanUp()
 void QMLListView::setTermsAreNotVariables()
 {
 	model()->setTermsAreVariables(false);
-	QQmlProperty::write(_item, "showVariableTypeIcon", false);
+	setItemProperty("showVariableTypeIcon", false);
 }
 
 void QMLListView::setTermsAreInteractions()
@@ -135,10 +135,10 @@ int QMLListView::_getAllowedColumnsTypes()
 {
 	int allowedColumnsTypes = -1;
 	
-	QStringList allowedColumns = QQmlProperty(_item, "allowedColumns").read().toStringList();
+	QStringList allowedColumns = getItemProperty("allowedColumns").toStringList();
 	if (allowedColumns.isEmpty())
 	{
-		QString allowedColumn = QQmlProperty(_item, "allowedColumns").read().toString();
+		QString allowedColumn = getItemProperty("allowedColumns").toString();
 		if (!allowedColumn.isEmpty())
 			allowedColumns.append(allowedColumn);
 	}


### PR DESCRIPTION
When there are more variables that the GridView can show, then not all
variable Iten are created, and then also their Extra Controls (if
needed). So the Bound Items must be created even if the QuickItem is
not yet created.
This solves https://github.com/jasp-stats/INTERNAL-jasp/issues/165


