### PR TITLE
[do not merge] Add dependOn to jaspResults

### DIFF
--- a/Dynamic Modules/Descriptives Module/qml/Descriptives.qml
+++ b/Dynamic Modules/Descriptives Module/qml/Descriptives.qml
@@ -19,16 +19,14 @@
 import QtQuick 2.8
 import JASP.Controls 1.0
 import JASP.Widgets 1.0
-import JASP.Theme 1.0
 
 // All Analysis forms must be built with the From QML item
 Form
 {
-	usesJaspResults: true
-
+	columns: 1
 	VariablesForm
 	{
-		AvailableVariablesList { name: "allVariables" }
+		AvailableVariablesList { name: "allVariablesList" }
 		AssignedVariablesList { name: "variables";	title: qsTr("Variables") }
 		AssignedVariablesList { name: "splitby";	title: qsTr("Split"); singleVariable: true; allowedColumns: ["ordinal", "nominal"] }
 	}
@@ -68,7 +66,6 @@ Form
 	Section
 	{
 		title: qsTr("Statistics")
-		alignChildrenTopLeft: true
 
 		Group
 		{
@@ -82,7 +79,8 @@ Form
 				IntegerField
 				{
 					name: "percentileValuesEqualGroupsNo"
-					min: 1; max: 1000
+					min: 1
+					max: 1000
 					defaultValue: 4
 					afterLabel: qsTr(" equal groups")
 				}
@@ -103,7 +101,6 @@ Form
 		Group
 		{
 			title: qsTr("Central Tendency")
-			implicitWidth: 200
 			CheckBox { name: "mean";			label: qsTr("Mean");	checked: true	}
 			CheckBox { name: "median";			label: qsTr("Median")					}
 			CheckBox { name: "mode";			label: qsTr("Mode");					}
@@ -113,10 +110,11 @@ Form
 		Group
 		{
 			title: qsTr("Dispersion")
+			columns: 2
 			CheckBox { name: "standardDeviation";	label: qsTr("Std.deviation"); checked: true	}
 			CheckBox { name: "minimum";				label: qsTr("Minimum");		checked: true	}
-			CheckBox { name: "maximum";				label: qsTr("Maximum");		checked: true	}
 			CheckBox { name: "variance";			label: qsTr("Variance")						}
+			CheckBox { name: "maximum";				label: qsTr("Maximum");		checked: true	}
 			CheckBox { name: "range";				label: qsTr("Range")						}
 			CheckBox { name: "standardErrorMean";	label: qsTr("S. E. mean")					}
 		}
@@ -126,6 +124,7 @@ Form
 			title: qsTr("Distribution")
 			CheckBox { name: "skewness";			label: qsTr("Skewness")						}
 			CheckBox { name: "kurtosis";			label: qsTr("Kurtosis")						}
+			CheckBox { name: "shapiro";			label: qsTr("Shapiro-Wilk test")						}
 		}
 
 		CheckBox { name: "statisticsValuesAreGroupMidpoints"; label: qsTr("Values are group midpoints"); debug: true }
@@ -141,7 +140,7 @@ Form
 			title: qsTr("Chart Type")
 			RadioButton { value: "_1noCharts";		label: qsTr("None")			}
 			RadioButton { value: "_2barCharts";		label: qsTr("Bar charts")	}
-			RadioButton { value: "_3pieCharts";		label: qsTr("Pie Charts")	}
+			RadioButton { value: "_3pieCharts";		label: qsTr("Pie charts")	}
 			RadioButton { value: "_4histograms";	label: qsTr("Histograms")	}
 		}
 

--- a/JASP-Engine/JASP/R/binomialtest.R
+++ b/JASP-Engine/JASP/R/binomialtest.R
@@ -160,7 +160,7 @@ BinomialTest <- function(jaspResults, dataset, options, ...) {
 
   # Save results to state
   jaspResults[["stateBinomResults"]] <- createJaspState(results)
-  jaspResults[["stateBinomResults"]]$dependOnOptions(
+  jaspResults[["stateBinomResults"]]$dependOn(
     c("variables", "testValue", "hypothesis", "confidenceIntervalInterval", "descriptivesPlotsConfidenceInterval")
   )
 
@@ -200,7 +200,7 @@ BinomialTest <- function(jaspResults, dataset, options, ...) {
   # Create table
   binomialTable <- createJaspTable(title = "Binomial Test")
   jaspResults[["binomialTable"]] <- binomialTable
-  binomialTable$dependOnOptions(c("variables", "testValue", "hypothesis", "confidenceInterval",
+  binomialTable$dependOn(c("variables", "testValue", "hypothesis", "confidenceInterval",
                                   "confidenceIntervalInterval", "VovkSellkeMPR"))
 
   binomialTable$showSpecifiedColumnsOnly <- TRUE
@@ -257,7 +257,7 @@ BinomialTest <- function(jaspResults, dataset, options, ...) {
 
   if (is.null(jaspResults[["containerPlots"]])) {
     jaspResults[["containerPlots"]] <- createJaspContainer("Descriptives Plots")
-    jaspResults[["containerPlots"]]$dependOnOptions("descriptivesPlots")
+    jaspResults[["containerPlots"]]$dependOn("descriptivesPlots")
   }
 }
 
@@ -275,14 +275,13 @@ BinomialTest <- function(jaspResults, dataset, options, ...) {
     if (!is.null(pct[[variable]])) next
 
     pct[[variable]] <- createJaspContainer(variable)
-    pct[[variable]]$setOptionMustContainDependency("variables", variable)
-    pct[[variable]]$dependOnOptions(c("testValue", "descriptivesPlotsConfidenceInterval"))
+    pct[[variable]]$dependOn(options=c("testValue", "descriptivesPlotsConfidenceInterval"), optionContainsValue=list(variables=variable))
 
 
     for (level in binomResults[["spec"]][["levels"]][[variable]]) {
       descriptivesPlot <- .binomPlotHelper(binomResults[["binom"]][[variable]][[level]]$plotDat, options$testValue)
       pct[[variable]][[level]] <- createJaspPlot(plot = descriptivesPlot, title = level, width = 160, height = 320)
-      pct[[variable]][[level]]$dependOnOptions("descriptivesPlots")
+      pct[[variable]][[level]]$dependOn("descriptivesPlots")
     }
 
   }

--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -53,7 +53,7 @@ Descriptives <- function(jaspResults, dataset, options)
     if(is.null(jaspResults[["tables"]]))
     {
       jaspResults[["tables"]] <- createJaspContainer("Frequency Tables")
-      jaspResults[["tables"]]$dependOnOptions(c("frequencyTables", "splitby"))
+      jaspResults[["tables"]]$dependOn(c("frequencyTables", "splitby"))
       jaspResults[["tables"]]$position <- 3
     }
 
@@ -62,8 +62,7 @@ Descriptives <- function(jaspResults, dataset, options)
     if (jaspResults[["tables"]]$length > 0 && is.null(jaspResults[["frequenciesHeading"]]))
     {
       jaspResults[["frequenciesHeading"]] <- createJaspHtml("Frequencies", "h1")
-      jaspResults[["frequenciesHeading"]]$copyDependenciesFromJaspObject(jaspResults[["tables"]])
-      jaspResults[["frequenciesHeading"]]$dependOnOptions("variables")
+      jaspResults[["frequenciesHeading"]]$dependOn(options="variables", optionsFromObject=jaspResults[["tables"]])
       jaspResults[["frequenciesHeading"]]$position <- 2
     }
   }
@@ -77,7 +76,7 @@ Descriptives <- function(jaspResults, dataset, options)
       {
         jaspResults[["matrixPlot"]] <- createJaspContainer(title="Correlation plots")
         corrPlot <- jaspResults[["matrixPlot"]]
-        corrPlot$dependOnOptions(c("plotCorrelationMatrix", "splitby"))
+        corrPlot$dependOn(c("plotCorrelationMatrix", "splitby"))
 
         for (i in 1:length(splitLevels))
           corrPlot[[splitLevels[i]]] <- .descriptivesMatrixPlot(splitDat.factors[[i]], options, splitLevels[i])
@@ -95,7 +94,7 @@ Descriptives <- function(jaspResults, dataset, options)
     if(is.null(jaspResults[["distributionPlots"]]))
     {
       jaspResults[["distributionPlots"]] <- createJaspContainer("Distribution Plots")
-      jaspResults[["distributionPlots"]]$dependOnOptions(c("plotVariables", "splitby", "distPlotDensity"))
+      jaspResults[["distributionPlots"]]$dependOn(c("plotVariables", "splitby", "distPlotDensity"))
       jaspResults[["distributionPlots"]]$position <- 5
     }
 
@@ -119,7 +118,7 @@ Descriptives <- function(jaspResults, dataset, options)
     if(is.null(jaspResults[["splitPlots"]]))
     {
       jaspResults[["splitPlots"]] <- createJaspContainer("Boxplots")
-      jaspResults[["splitPlots"]]$dependOnOptions(c("splitPlots", "splitby"))
+      jaspResults[["splitPlots"]]$dependOn(c("splitPlots", "splitby"))
       jaspResults[["splitPlots"]]$position <- 7
     }
 
@@ -129,7 +128,7 @@ Descriptives <- function(jaspResults, dataset, options)
       if(is.null(splitPlots[[var]]))
       {
         splitPlots[[var]] <- .descriptivesSplitPlot(dataset = dataset, options = options, variable = var)
-        splitPlots[[var]]$setOptionMustContainDependency("variables", var)
+        splitPlots[[var]]$dependOn(optionContainsValue=list(variables=var))
       }
 
     if(splitPlots$length == 0)
@@ -151,7 +150,7 @@ Descriptives <- function(jaspResults, dataset, options)
   stats$transpose         <- TRUE
   stats$position          <- 1
 
-  stats$dependOnOptions(c("splitby", "variables", "percentileValuesEqualGroupsNo", "percentileValuesPercentilesPercentiles", "mean", "standardErrorMean",
+  stats$dependOn(c("splitby", "variables", "percentileValuesEqualGroupsNo", "percentileValuesPercentilesPercentiles", "mean", "standardErrorMean",
     "median", "mode", "standardDeviation", "variance", "skewness", "kurtosis", "shapiro", "range", "minimum", "maximum", "sum", "percentileValuesQuartiles", "percentileValuesEqualGroups", "percentileValuesPercentiles"))
 
   if (wantsSplit)
@@ -387,7 +386,7 @@ Descriptives <- function(jaspResults, dataset, options)
     freqTab <- createJaspTable(paste("Frequencies for", variable))
 
     freqTabs[[variable]] <- freqTab
-    freqTab$setOptionMustContainDependency("variables", variable)
+    freqTab$dependOn(optionContainsValue=list(variables=variable))
 
     if (wantsSplit) freqTab$addColumnInfo(name = "factor", title = splitName, type = "string", combine=TRUE)
 
@@ -737,12 +736,11 @@ Descriptives <- function(jaspResults, dataset, options)
     split <- names(dataset)
 
     plotResult <- createJaspContainer(title=variable)
-    plotResult$setOptionMustContainDependency("variables",  variable)
-    plotResult$setOptionMustBeDependency("splitby",         options$splitby)
+    plotResult$dependOn(options="splitby", optionContainsValue=list(variables=variable))
 
     for (l in split) {
       plotResult[[l]] <- .descriptivesFrequencyPlots_SubFunc(column=dataset[[l]][[.v(variable)]], variable=variable, width=options$plotWidth, height=options$plotHeight, displayDensity = options$distPlotDensity, title = l)
-      plotResult[[l]]$copyDependenciesFromJaspObject(plotResult)
+      plotResult[[l]]$dependOn(optionsFromObject=plotResult)
     }
 
     return(plotResult)
@@ -752,8 +750,7 @@ Descriptives <- function(jaspResults, dataset, options)
   {
     column <- dataset[[ .v(variable) ]]
     aPlot <- .descriptivesFrequencyPlots_SubFunc(column=column[!is.na(column)], variable=variable, width=options$plotWidth, height=options$plotHeight, displayDensity = options$distPlotDensity, title = variable)
-    aPlot$setOptionMustContainDependency("variables",  variable)
-    aPlot$setOptionMustBeDependency("splitby",         options$splitby)
+    aPlot$dependOn(options="splitby", optionContainsValue=list(variables=variable))
 
     return(aPlot)
   }

--- a/JASP-Engine/JASP/R/multinomialtestbayesian.R
+++ b/JASP-Engine/JASP/R/multinomialtestbayesian.R
@@ -160,7 +160,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   # Save results to state
   defaultOptions <- multinomialResults$specs$defaultOptions
   jaspResults[["stateMultinomialBayesianResults"]] <- createJaspState(multinomialResults)
-  jaspResults[["stateMultinomialBayesianResults"]]$dependOnOptions(defaultOptions)
+  jaspResults[["stateMultinomialBayesianResults"]]$dependOn(defaultOptions)
 
   return(multinomialResults)
 }
@@ -174,7 +174,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   defaultOptions                    <- multinomialResults$specs$defaultOptions
   multinomialTable                  <- createJaspTable(title = "Bayesian Multinomial Test")
   multinomialTable$position         <- 1
-  multinomialTable$dependOnOptions(c(defaultOptions, "bayesFactorType"))
+  multinomialTable$dependOn(c(defaultOptions, "bayesFactorType"))
 
   # Bayes factor type
   if (options$bayesFactorType == "BF01") {
@@ -226,7 +226,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
 
   # Create table
   descriptivesTable                          <- createJaspTable(title = "Descriptives")
-  descriptivesTable$dependOnOptions(c("countProp", "descriptives", "credibleIntervalInterval"))
+  descriptivesTable$dependOn(c("countProp", "descriptives", "credibleIntervalInterval"))
   descriptivesTable$showSpecifiedColumnsOnly <- TRUE
   descriptivesTable$position                 <- 2
 
@@ -305,7 +305,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   descriptivesPlot <- .multBayesPlotHelper(factorVariable, options, multinomialResults)
 
   jaspResults[["descriptivesPlot"]] <- createJaspPlot(plot = descriptivesPlot, title = "Descriptives plot", width = 480, height = 320)
-  jaspResults[["descriptivesPlot"]]$dependOnOptions(c("descriptivesPlot", "factor", "counts",
+  jaspResults[["descriptivesPlot"]]$dependOn(c("descriptivesPlot", "factor", "counts",
                                                       "descriptivesPlotsCredibleInterval"))
 
   descriptivesPlot$position <- 2


### PR DESCRIPTION
This PR merges four functions into one, namely `copyDependenciesFromJaspObject()`, `dependOnOptions()`, `setOptionMustBeDependency()` and `setOptionMustContainDependency()` become `dependOn()`.

It takes 3 optional arguments:
- `options`: a character vector
- `optionsFromObject`: a jaspObject or a vector of jaspObjects
- `optionContainsValue`: a named list (e.g., `list(variables="contBinom")`)

It is not backwards compatible as I removed the four old functions. I don't think we should care about backwards compatibility yet at this point.