### PR TITLE
force pkg installs from binaries in unit tests

### DIFF
--- a/JASP-Tests/R/tests/install.R
+++ b/JASP-Tests/R/tests/install.R
@@ -3,17 +3,18 @@
 repos <- getOption("repos")
 repos["CRAN"] <- "https://cloud.r-project.org"
 options(repos = repos)
+options(pkgType="binary")
 
 install.packages("devtools")
 
 jaspResultsPath <- file.path("..", "..", "..", "JASP-R-Interface", "jaspResults")
-devtools::install_deps(jaspResultsPath, upgrade="never")
+devtools::install_deps(jaspResultsPath, upgrade=FALSE)
 install.packages(jaspResultsPath, type="source", repos=NULL)
 
 jasptoolsPath <- file.path("..", "..", "..", "Tools", "jasptools")
-devtools::install_deps(jasptoolsPath, upgrade="never")
+devtools::install_deps(jasptoolsPath, upgrade=FALSE)
 install.packages(jasptoolsPath, type="source", repos=NULL)
 
 JASPgraphsPath <- file.path("..", "..", "..", "JASP-Engine", "JASPgraphs")
-devtools::install_deps(JASPgraphsPath, upgrade="never")
+devtools::install_deps(JASPgraphsPath, upgrade=FALSE)
 install.packages(JASPgraphsPath, type="source", repos=NULL)


### PR DESCRIPTION
This reduces the chance of the unit tests breaking when package dependencies are updated (e.g., gdtools breaks the tests at the moment because the source installation fails)

