### PR TITLE
Add space between adjacent overtitles

### DIFF
--- a/JASP-Desktop/html/js/table.js
+++ b/JASP-Desktop/html/js/table.js
@@ -584,35 +584,32 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 		}
 
 		if (columnHeaders.length > 0) {
-
-			var overTitles = false;
-			var overTitleSpace = false;
-			var overTitlesArray = [];
-			// Find the overTitles
+			
+			var hasOvertitles = false;
+			var hasAdjacentOvertitles = false;
+			
+			// If we have multiple adjacent overtitles, we should make small
+			// breaks in the line under the overTitle to indicate end of old and
+			// start of new overTitle. NB: with this option, the line is not copied
+			// to text processor.
+			var lastOvertitle = "";
 			for (var i = 0; i < columnHeaders.length; i++) {
 				if (typeof columnHeaders[i].overTitle != "undefined") {
-					overTitles = true
-					break;
+					hasOvertitles = true;
+					var overtitle = columnHeaders[i].overTitle;
+					if (lastOvertitle != "" && lastOvertitle != overtitle) {
+						hasAdjacentOvertitles = true;
+						break;
+					}
+					lastOvertitle = overtitle;
+				} else {
+					lastOvertitle = "";
 				}
 			}
 
-			if (overTitlesArray.length > 0) {
-				// If we have an overTitle, we should make it
-				overTitles = true;
-			}
+			if (hasOvertitles) {
 
-			var uniqueOverTitles = $.unique(overTitlesArray)
-			if (uniqueOverTitles.length > 1) {
-				// If we have more than one unique overTitle, we should make small
-				// breaks in the line under the overTitle to indicate end of old and
-				// start of new overTitle. NB: with this option, the line is not copied
-				// to text processor.
-				overTitleSpace = true;
-			}
-
-			if (overTitles) {
-
-				if (overTitleSpace) {
+				if (hasAdjacentOvertitles) {
 					chunks.push('<tr class="over-title-space">')
 				} else {
 					chunks.push('<tr class="over-title">')
@@ -637,7 +634,7 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 						span++
 					}
 					else {
-						if (overTitleSpace) {
+						if (hasAdjacentOvertitles) {
 							chunks.push('<th colspan="' + (2 * span) + '"><div class="over-title-space">' + oldTitle + '</div></th>');
 						} else {
 							chunks.push('<th colspan="' + (2 * span) + '">' + oldTitle + '</th>');
@@ -648,7 +645,7 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 				}
 
 				if (newTitle == oldTitle) {
-					if (overTitleSpace) {
+					if (hasAdjacentOvertitles) {
 						chunks.push('<th colspan="' + (2 * span) + '"><div class="over-title-space">' + newTitle + '</div></th>')
 					} else {
 						chunks.push('<th colspan="' + (2 * span) + '">' + newTitle + '</th>')


### PR DESCRIPTION
So apparently we had the functionality to add spacing between consecutive lines already.
There is a problem with this approach though, the overtitle line is not copied to word processors.

It'd also be possible to solve this purely through css, but again no line after copying:
```
thead tr.over-title th {
  position: relative
}

thead tr.over-title th:not(:empty):before {
  content: "";
  display: block;
  height: 1px;
  overflow: hidden;
  background: black;
  position: absolute;
  left: 1px;
  right: 1px;
  bottom: 0;
  border-bottom: none;
}

thead tr:not(.over-title) th {
  border-bottom: thin solid ;
}
```