### PR TITLE
Prevent progress bar from showing after completion

### DIFF
--- a/JASP-R-Interface/jaspResults/src/jaspResults.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspResults.cpp
@@ -409,8 +409,24 @@ void jaspResults::progressbarTick()
 	if(curTime - _progressbarLastUpdateTime > _progressbarBetweenUpdatesTime || progress == 100)
 	{
 		send();
-		_progressbarLastUpdateTime = curTime;
+		
+		if (progress == 100)
+			resetProgressbar();
+		else
+			_progressbarLastUpdateTime = curTime;
 	}
+}
+
+void jaspResults::resetProgressbar()
+{
+	_progressbarExpectedTicks      = 100;
+	_progressbarLastUpdateTime     = -1;
+	_progressbarTicks              = 0;
+	_progressbarBetweenUpdatesTime = 500;
+	_sendingFeedbackLastTime       = -1;
+	_sendingFeedbackInterval       = 500;
+	
+	_response["progress"] = -1;
 }
 
 //implementation here in jaspResults.cpp to make sure we have access to all constructors

--- a/JASP-R-Interface/jaspResults/src/jaspResults.h
+++ b/JASP-R-Interface/jaspResults/src/jaspResults.h
@@ -57,6 +57,7 @@ public:
 
 	void startProgressbar(int expectedTicks, int timeBetweenUpdatesInMs = 500);
 	void progressbarTick();
+	void resetProgressbar();
 
 	static Rcpp::RObject	getObjectFromEnv(std::string envName);
 	static void				setObjectInEnv(std::string envName, Rcpp::RObject obj);


### PR DESCRIPTION
If it's not reset once it reaches 100 it will keep sending this value to js.

I figured we might as well reset all values to their respective defaults to accomodate analyses that want to use progressbars multiple times per analysis (e.g., Bayesian ANOVA's).