### PR TITLE
Textfield invalid values

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/DoubleField.qml
+++ b/JASP-Desktop/components/JASP/Controls/DoubleField.qml
@@ -32,6 +32,6 @@ TextField
     
 					inputType:			"number"
 					validator:			JASPDoubleValidator { id: doubleValidator; bottom: min; top: max ; decimals: decimals }
-					value:				Number.parseFloat(defaultValue);
+					lastValidValue:		defaultValue
 					fieldWidth:			Theme.numericFieldWidth
 }

--- a/JASP-Desktop/components/JASP/Controls/IntegerField.qml
+++ b/JASP-Desktop/components/JASP/Controls/IntegerField.qml
@@ -32,7 +32,7 @@ TextField
     
 					inputType:		"integer"
 					validator:		JASPDoubleValidator { id: intValidator; bottom: min; top: max; decimals: 0 }
-					value:			Number.parseInt(defaultValue);
+					lastValidValue:	defaultValue;
 					cursorShape:	Qt.IBeamCursor
 					fieldWidth:		Theme.numericFieldWidth
 }

--- a/JASP-Desktop/components/JASP/Controls/TextField.qml
+++ b/JASP-Desktop/components/JASP/Controls/TextField.qml
@@ -35,7 +35,8 @@ JASPControl
 	property alias	label:				beforeLabel.text
 	property alias	text:				beforeLabel.text
 	property alias	value:				control.text
-	property alias	defaultValue:		control.text
+	property string	defaultValue:		""
+	property string lastValidValue:		defaultValue
 	property int	fieldWidth:			Theme.textFieldWidth
 	property int	fieldHeight:		0
 	property bool	useExternalBorder:	true
@@ -60,6 +61,8 @@ JASPControl
 			if (KeyNavigation.tab)
 				KeyNavigation.tab.forceActiveFocus();
 		}
+		
+		lastValidValue = control.text
 		editingFinished();
 	}
 	
@@ -97,6 +100,7 @@ JASPControl
 		TextField
 		{
 			id:						control
+			text:					textField.lastValidValue
 			//text:					textField.value //Isn't this circular? control.text: textField.value == property alias value: control.text...
 			implicitWidth:			textField.fieldWidth
 			font:					Theme.font
@@ -121,12 +125,40 @@ JASPControl
 				height:				parent.implicitHeight + Theme.jaspControlHighlightWidth
 				width:				parent.implicitWidth + Theme.jaspControlHighlightWidth
 				color:				"transparent"
-				border.width: 2
+				border.width: 3
 				border.color: control.acceptableInput ? "transparent" : Theme.red
 				anchors.centerIn: parent
 				opacity: debug ? .3 : 1
 				visible: textField.useExternalBorder
 				radius: Theme.jaspControlHighlightWidth
+			}
+			
+			onActiveFocusChanged: {
+				if (!control.acceptableInput)
+					text = textField.lastValidValue
+			}
+			
+			PropertyAnimation
+			{
+				id: redToNormal
+				target: textField.background
+				property: "border.color"
+				to: Theme.focusBorderColor
+				duration: 350
+				onStopped: textField.background.border.color = control.activeFocus ? Theme.focusBorderColor : "transparent"
+			}
+			
+			Keys.onReturnPressed:
+			{
+				if (!control.acceptableInput)
+				{
+					textField.background.border.color = Theme.red;
+					redToNormal.start()
+				}
+				else
+				{
+					event.accepted = false;
+				}
 			}
 		}
 		


### PR DESCRIPTION
If you enter an invalid value and press enter the border flashes red. If you enter a wrong value and make the textfield go out of focus the last known valid value is restored and the border flashes red.

Fixes jasp-stats/INTERNAL-jasp#221