### PR TITLE
Add CIField for credible/confidence intervals

### DIFF
--- a/JASP-Desktop/analysis/jaspdoublevalidator.cpp
+++ b/JASP-Desktop/analysis/jaspdoublevalidator.cpp
@@ -26,6 +26,10 @@ QValidator::State JASPDoubleValidator::validate(QString& s, int& pos) const
 		// allow empty field or standalone minus sign
 		return QValidator::Intermediate;
 	}
+
+	if (s.contains("-") && bottom() >= 0)
+		return QValidator::Invalid; 
+	
 	// check length of decimal places
 	QChar point = locale().decimalPoint();
 	if (s.indexOf(point) != -1)

--- a/JASP-Desktop/components/JASP/Controls/CIField.qml
+++ b/JASP-Desktop/components/JASP/Controls/CIField.qml
@@ -21,20 +21,14 @@ import JASP.Controls 1.0
 import JASP.Theme 1.0
 import JASP 1.0
 
-TextField
+PercentField
 {
-	property int	defaultValue:	50
-	property bool	showPercent:	true
-	property int	decimals:		0
-	property int	min:			0
-	property int	max:			100
-    
-	id:					percentField
-	inputType:			"percent"
-	fieldWidth:			Theme.font.pixelSize * (percentField.decimals + 3)
-	validator:			JASPDoubleValidator { id: doubleValidator; bottom: min; top: max; decimals: percentField.decimals; notation: DoubleValidator.StandardNotation}
+	property int	defaultValue:	95
+	property int	decimals:		1
+      
+	id:					ciField
+	fieldWidth:			Theme.font.pixelSize * (ciField.decimals + 3)
+	validator:			JASPDoubleValidator { id: doubleValidator; bottom: 0 + 1E-10; top: 100 - 1E-10; decimals: ciField.decimals; notation: DoubleValidator.StandardNotation}
 
 	lastValidValue:		defaultValue
-	afterLabel:			showPercent ? "%" : ""
-	cursorShape:		Qt.IBeamCursor	
 }

--- a/JASP-Desktop/components/JASP/Controls/qmldir
+++ b/JASP-Desktop/components/JASP/Controls/qmldir
@@ -20,6 +20,7 @@ JASPDataView           1.0 JASPDataView.qml
 JASPScrollBar           1.0 JASPScrollBar.qml
 Label                    1.0 Label.qml
 PercentField              1.0 PercentField.qml
+CIField                   1.0 CIField.qml
 RadioButton                1.0 RadioButton.qml
 RadioButtonGroup            1.0 RadioButtonGroup.qml
 RepeatedMeasuresFactorsList 1.0 RepeatedMeasuresFactorsList.qml

--- a/JASP-Desktop/qml.qrc
+++ b/JASP-Desktop/qml.qrc
@@ -17,6 +17,7 @@
         <file>components/JASP/Controls/JASPControl.qml</file>
         <file>components/JASP/Controls/Label.qml</file>
         <file>components/JASP/Controls/PercentField.qml</file>
+        <file>components/JASP/Controls/CIField.qml</file>
         <file>components/JASP/Controls/RadioButton.qml</file>
         <file>components/JASP/Controls/TextField.qml</file>
         <file>components/JASP/Controls/VariablesList.qml</file>

--- a/Resources/ANOVA/qml/Ancova.qml
+++ b/Resources/ANOVA/qml/Ancova.qml
@@ -119,7 +119,7 @@ Form
 		{
 			name: "confidenceIntervalsContrast"; label: qsTr("Confidence intervals")
 			childrenOnSameRow: true
-			PercentField { name: "confidenceIntervalIntervalContrast"; defaultValue: 95 }
+			CIField { name: "confidenceIntervalIntervalContrast" }
 		}
 	}
 	
@@ -140,7 +140,7 @@ Form
             {
                 name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence Intervals")
                 childrenOnSameRow: true
-                PercentField {name: "confidenceIntervalIntervalPostHoc"; defaultValue: 95 }
+                CIField {name: "confidenceIntervalIntervalPostHoc" }
             }
             CheckBox
             {
@@ -206,7 +206,7 @@ Form
 					{
                         value: "confidenceInterval"; label: qsTr("Confidence Intervals"); checked: true
 						childrenOnSameRow: true
-                        PercentField { name: "confidenceIntervalInterval"; defaultValue: 95 }
+                        CIField { name: "confidenceIntervalInterval" }
 					}
 					RadioButton { value: "standardError"; label: qsTr("Standard error") }
 				}

--- a/Resources/ANOVA/qml/AncovaBayesian.qml
+++ b/Resources/ANOVA/qml/AncovaBayesian.qml
@@ -49,7 +49,7 @@ Form
 		}
         CheckBox { name: "posteriorEstimates"; label: qsTr("Estimates") }
         CheckBox { name: "descriptives";       label: qsTr("Descriptives") }
-        PercentField { name: "credibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
+        CIField { name: "credibleInterval";	label: qsTr("Credible interval") }
     }
 		
     RadioButtonGroup
@@ -191,7 +191,7 @@ Form
 			{
 				name: "plotCredibleInterval"; label: qsTr("Credible interval")
 				childrenOnSameRow: true
-				PercentField { name: "plotCredibleIntervalInterval"; defaultValue: 95 }
+				CIField { name: "plotCredibleIntervalInterval" }
 			}
 		}
 	}

--- a/Resources/ANOVA/qml/Anova.qml
+++ b/Resources/ANOVA/qml/Anova.qml
@@ -95,7 +95,7 @@ Form
 		{
 			name: "confidenceIntervalsContrast"; label: qsTr("Confidence intervals")
 			childrenOnSameRow: true
-			PercentField {	name: "confidenceIntervalIntervalContrast"; defaultValue: 95 }
+			CIField {	name: "confidenceIntervalIntervalContrast" }
 		}
 	}
 	
@@ -117,7 +117,7 @@ Form
             {
                 name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence Intervals")
                 childrenOnSameRow: true
-                PercentField {name: "confidenceIntervalIntervalPostHoc"; defaultValue: 95 }
+                CIField {name: "confidenceIntervalIntervalPostHoc" }
             }
             CheckBox
             {
@@ -182,7 +182,7 @@ Form
 					{
 						value: "confidenceInterval";		label: qsTr("Confidence Interval"); checked: true
 						childrenOnSameRow: true
-						PercentField { name: "confidenceIntervalInterval";	label: qsTr("Interval"); defaultValue: 95 }
+						CIField { name: "confidenceIntervalInterval";	label: qsTr("Interval") }
 					}
 					RadioButton { value: "standardError";	label: qsTr("Standard error") }
 				}

--- a/Resources/ANOVA/qml/AnovaBayesian.qml
+++ b/Resources/ANOVA/qml/AnovaBayesian.qml
@@ -48,7 +48,7 @@ Form
         }
         CheckBox { name: "posteriorEstimates"; label: qsTr("Estimates") }
         CheckBox { name: "descriptives";       label: qsTr("Descriptives") }
-        PercentField { name: "credibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
+        CIField { name: "credibleInterval";	label: qsTr("Credible interval") }
     }
 
     RadioButtonGroup
@@ -184,7 +184,7 @@ Form
 			{
 				name: "plotCredibleInterval"; label: qsTr("Credible interval")
 				childrenOnSameRow: true
-				PercentField { name: "plotCredibleIntervalInterval"; defaultValue: 95 }
+				CIField { name: "plotCredibleIntervalInterval" }
 			}
 		}
 	}

--- a/Resources/ANOVA/qml/AnovaRepeatedMeasures.qml
+++ b/Resources/ANOVA/qml/AnovaRepeatedMeasures.qml
@@ -140,7 +140,7 @@ Form
         {
             name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence Intervals")
             childrenOnSameRow: true
-            PercentField {name: "confidenceIntervalIntervalPostHoc"; defaultValue: 95 }
+            CIField {name: "confidenceIntervalIntervalPostHoc" }
         }
 
 		Group
@@ -189,7 +189,7 @@ Form
 					{
 						value: "confidenceInterval"; label: qsTr("Confidence Interval"); checked: true
 						childrenOnSameRow: true
-						PercentField { name: "confidenceIntervalInterval"; label: qsTr("Interval"); defaultValue: 95 }
+						CIField { name: "confidenceIntervalInterval"; label: qsTr("Interval") }
 					}
 					RadioButton { value: "standardError"; label: qsTr("Standard error") }
 				}

--- a/Resources/ANOVA/qml/AnovaRepeatedMeasuresBayesian.qml
+++ b/Resources/ANOVA/qml/AnovaRepeatedMeasuresBayesian.qml
@@ -73,7 +73,7 @@ Form
 		}
         CheckBox { name: "posteriorEstimates"; label: qsTr("Estimates") }
         CheckBox { name: "descriptives"; label: qsTr("Descriptives") }
-        PercentField { name: "credibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
+        CIField { name: "credibleInterval";	label: qsTr("Credible interval") }
     }
     RadioButtonGroup
     {
@@ -210,7 +210,7 @@ Form
 		{
 			name: "plotCredibleInterval"; label: qsTr("Credible interval")
 			childrenOnSameRow: true
-			PercentField { name: "plotCredibleIntervalInterval"; defaultValue: 95 }
+			CIField { name: "plotCredibleIntervalInterval" }
 		}
 	}
 

--- a/Resources/Descriptives/qml/ReliabilityAnalysis.qml
+++ b/Resources/Descriptives/qml/ReliabilityAnalysis.qml
@@ -93,7 +93,7 @@ Form
 			enabled: chronbach.checked
 			CheckBox {
 				name: "confAlpha"; label: qsTr("Cronbach's α analytical")
-				PercentField { name: "confAlphaLevel"; label: qsTr("Confidence"); defaultValue: 95; decimals: 1 }
+				CIField { name: "confAlphaLevel"; label: qsTr("Confidence"); decimals: 1 }
 			}
 		}
 	}

--- a/Resources/Frequencies/qml/BinomialTest.qml
+++ b/Resources/Frequencies/qml/BinomialTest.qml
@@ -46,7 +46,7 @@ Form
 		CheckBox
 		{
 			name: "confidenceInterval";	label: qsTr("Confidence interval")
-			PercentField { name: "confidenceIntervalInterval";	label: qsTr("Interval"); defaultValue: 95 }
+			CIField { name: "confidenceIntervalInterval";	label: qsTr("Interval") }
 		}
 		CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Sellke maximum p-ratio") }
 	}
@@ -57,7 +57,7 @@ Form
 		CheckBox
 		{
 			name: "descriptivesPlots";					label: qsTr("Descriptive plots")
-			PercentField { name: "descriptivesPlotsConfidenceInterval"; label: qsTr("Confidence Interval"); defaultValue: 95 }
+			CIField { name: "descriptivesPlotsConfidenceInterval"; label: qsTr("Confidence Interval") }
 		}
 	}
 		

--- a/Resources/Frequencies/qml/ContingencyTables.qml
+++ b/Resources/Frequencies/qml/ContingencyTables.qml
@@ -48,7 +48,7 @@ Form
 			CheckBox
 			{
 				name: "oddsRatio"; label: qsTr("Log odds ratio (2x2 only)")
-				PercentField { name: "oddsRatioConfidenceIntervalInterval"; label: qsTr("Confidence interval"); defaultValue: 95 }
+				CIField { name: "oddsRatioConfidenceIntervalInterval"; label: qsTr("Confidence interval") }
 			}
 			CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}

--- a/Resources/Frequencies/qml/ContingencyTablesBayesian.qml
+++ b/Resources/Frequencies/qml/ContingencyTablesBayesian.qml
@@ -70,12 +70,12 @@ Form
 			CheckBox
 			{
 				name: "oddsRatio";	label: qsTr("Log odds ratio (2x2 only)")
-				PercentField { name: "oddsRatioCredibleIntervalInterval"; label: qsTr("Credible interval"); defaultValue: 95 }
+				CIField { name: "oddsRatioCredibleIntervalInterval"; label: qsTr("Credible interval") }
 			}
 			CheckBox
 			{
 				name: "effectSize"; label: qsTr("Cramer's V"); debug: true
-				PercentField { name: "effectSizeCredibleIntervalInterval"; label: qsTr("Credible interval"); defaultValue: 95; debug: true }
+				CIField { name: "effectSizeCredibleIntervalInterval"; label: qsTr("Credible interval"); debug: true }
 			}
 		}
 

--- a/Resources/Frequencies/qml/MultinomialTest.qml
+++ b/Resources/Frequencies/qml/MultinomialTest.qml
@@ -66,7 +66,7 @@ Form
 			{
 				name: "confidenceInterval"; label: qsTr("Confidence interval")
 				childrenOnSameRow: true
-				PercentField { name: "confidenceIntervalInterval"; defaultValue: 95	}
+				CIField { name: "confidenceIntervalInterval" }
 			}
 		}
 		CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Dellke maximum p-ratio")		}
@@ -88,7 +88,7 @@ Form
 			CheckBox
 			{
 				name: "descriptivesPlot"; label: qsTr("Descriptives plot")
-				PercentField { name: "descriptivesPlotConfidenceInterval"; label: qsTr("Confidence interval"); defaultValue: 95 }
+				CIField { name: "descriptivesPlotConfidenceInterval"; label: qsTr("Confidence interval") }
 			}
 		}
 	}

--- a/Resources/Frequencies/qml/MultinomialTestBayesian.qml
+++ b/Resources/Frequencies/qml/MultinomialTestBayesian.qml
@@ -69,7 +69,7 @@ Form
 				{
 					name				: "credibleInterval"; label: qsTr("Confidence interval")
 					childrenOnSameRow	: true
-					PercentField { name: "credibleIntervalInterval"; defaultValue: 95	}
+					CIField { name: "credibleIntervalInterval" }
 				}
 			}
 		}
@@ -92,7 +92,7 @@ Form
 			{
 				name	: "descriptivesPlot"
 				label	: qsTr("Descriptives plot")
-				PercentField { name: "descriptivesPlotCredibleInterval"; label: qsTr("Confidence interval"); defaultValue: 95 }
+				CIField { name: "descriptivesPlotCredibleInterval"; label: qsTr("Confidence interval") }
 			}
 		}
 	}

--- a/Resources/Frequencies/qml/RegressionLogLinear.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinear.qml
@@ -53,7 +53,7 @@ Form
 			CheckBox
 			{
 				name: "regressionCoefficientsConfidenceIntervals";	label: qsTr("Confidence intervals")
-				PercentField { name: "regressionCoefficientsConfidenceIntervalsInterval"; label: qsTr("Interval"); defaultValue: 95 }
+				CIField { name: "regressionCoefficientsConfidenceIntervalsInterval"; label: qsTr("Interval") }
 			}
 		}
 		CheckBox { name: "VovkSellkeMPR"; label: qsTr("Vovk-Sellke maximum p-ratio") }

--- a/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
@@ -72,12 +72,7 @@ Form
 			CheckBox
 			{
 				name: "regressionCoefficientsCredibleIntervals"; label: qsTr("Credible intervals")
-				PercentField
-				{
-					name: "regressionCoefficientsCredibleIntervalsInterval"
-					label: qsTr("Interval");
-					defaultValue: 95
-				}
+				CIField { name: "regressionCoefficientsCredibleIntervalsInterval"; label: qsTr("Interval") }
 			}
 		}
 
@@ -98,7 +93,7 @@ Form
 				CheckBox
 				{
 					name: "regressionCoefficientsSubmodelCredibleIntervals"; label: qsTr("Credible intervals")
-					PercentField { name: "regressionCoefficientsSubmodelCredibleIntervalsInterval"; label: qsTr("Interval"); defaultValue: 95 }
+					CIField { name: "regressionCoefficientsSubmodelCredibleIntervalsInterval"; label: qsTr("Interval") }
 				}
 			}
 		}

--- a/Resources/Meta Analysis/qml/ClassicalMetaAnalysis.qml
+++ b/Resources/Meta Analysis/qml/ClassicalMetaAnalysis.qml
@@ -59,11 +59,7 @@ Form
 			CheckBox
 			{
 				name: "regressionCoefficientsConfidenceIntervals"; text: qsTr("Confidence intervals")
-				PercentField
-				{
-					name: "regressionCoefficientsConfidenceIntervalsInterval"; label: qsTr("Interval");
-					defaultValue: 95
-				}
+				CIField { name: "regressionCoefficientsConfidenceIntervalsInterval"; label: qsTr("Interval") }
 				DropDown { name: "test"; label: qsTr("Test"); values: [ "z", "knha"]; }
 			}
 			CheckBox { name: "regressionCoefficientsCovarianceMatrix"; text: qsTr("Covariance matrix") }

--- a/Resources/MixedModels/qml/LinearMixedModels.qml
+++ b/Resources/MixedModels/qml/LinearMixedModels.qml
@@ -194,7 +194,7 @@ Form
 		{
 			label: qsTr("Confidence intervals"); name: "confidenceIntervalsContrast"
 			childrenOnSameRow: true
-			PercentField { name: "confidenceIntervalIntervalContrast"; defaultValue: 95 }
+			CIField { name: "confidenceIntervalIntervalContrast" }
 		}
 	}
 

--- a/Resources/Regression/qml/Correlation.qml
+++ b/Resources/Regression/qml/Correlation.qml
@@ -46,7 +46,7 @@ Form
 		CheckBox
 		{
 			name: "confidenceIntervals";		label: qsTr("Confidence intervals")
-			PercentField { name: "confidenceIntervalsInterval"; label: qsTr("Interval"); defaultValue: 95 }
+			CIField { name: "confidenceIntervalsInterval"; label: qsTr("Interval") }
 		}
 		CheckBox { name: "VovkSellkeMPR";		label: qsTr("Vovk-Sellke maximum p-ratio")			}
 	}

--- a/Resources/Regression/qml/CorrelationBayesian.qml
+++ b/Resources/Regression/qml/CorrelationBayesian.qml
@@ -46,7 +46,7 @@ Form
 		CheckBox
 		{
 			name: "credibleInterval"; label: qsTr("Credible intervals")
-			PercentField { name: "ciValue";	label: qsTr("Interval"); defaultValue: 95; debug: true }
+			CIField { name: "ciValue";	label: qsTr("Interval"); debug: true }
 		}
 	}
 	

--- a/Resources/Regression/qml/CorrelationBayesianPairs.qml
+++ b/Resources/Regression/qml/CorrelationBayesianPairs.qml
@@ -41,7 +41,7 @@ Form
 	CheckBox
 	{
 		name: "credibleInterval"; label: qsTr("Credible intervals")
-		PercentField { name: "ciValue";	label: qsTr("Interval"); defaultValue: 95; debug: true }
+		CIField { name: "ciValue";	label: qsTr("Interval"); debug: true }
 	}
 
 	RadioButtonGroup

--- a/Resources/Regression/qml/RegressionLinear.qml
+++ b/Resources/Regression/qml/RegressionLinear.qml
@@ -110,7 +110,7 @@ Form
 				{
 					name: "regressionCoefficientsConfidenceIntervals"; label: qsTr("Confidence intervals")
 					childrenOnSameRow: true
-					PercentField { name: "regressionCoefficientsConfidenceIntervalsInterval"; defaultValue: 95 }
+					CIField { name: "regressionCoefficientsConfidenceIntervalsInterval" }
 				}
 				CheckBox { name: "regressionCoefficientsCovarianceMatrix"; label: qsTr("Covariance matrix") }
 			}

--- a/Resources/Regression/qml/RegressionLinearBayesian.qml
+++ b/Resources/Regression/qml/RegressionLinearBayesian.qml
@@ -63,12 +63,11 @@ Form {
 
 		}
 
-		PercentField
+		CIField
 		{
 			name: "posteriorSummaryPlotCredibleIntervalValue"
 			label: qsTr("Credible interval")
 			enabled: postSummaryTable.checked || postSummaryPlot.checked
-			defaultValue: 95
 		}
 	}
 

--- a/Resources/Regression/qml/RegressionLogistic.qml
+++ b/Resources/Regression/qml/RegressionLogistic.qml
@@ -125,7 +125,7 @@ Form
 			CheckBox
 			{
 				name: "coeffCI";				label: qsTr("Confidence intervals")
-				PercentField {	name: "coeffCIInterval"; label: "Interval"; defaultValue: 95	}
+				CIField {	name: "coeffCIInterval"; label: "Interval" }
 				CheckBox {		name: "coeffCIOR";		label: qsTr("Odds ratio scale")		}
 			}
 			CheckBox { name: "robustSEOpt";		label: qsTr("Robust standard errors")		}
@@ -181,7 +181,7 @@ Form
 			CheckBox
 			{
 				name: "estimatesPlotsOpt"; label: qsTr("Display conditional estimates plots")
-				PercentField {	name: "estimatesPlotsCI";	label: qsTr("Confidence interval"); defaultValue: 95 }
+				CIField {	name: "estimatesPlotsCI";	label: qsTr("Confidence interval") }
 				CheckBox {		name: "showPoints";			label: qsTr("Show data points")						}
 			}
 		}

--- a/Resources/T-Tests/qml/TTestBayesianIndependentSamples.qml
+++ b/Resources/T-Tests/qml/TTestBayesianIndependentSamples.qml
@@ -69,7 +69,7 @@ Form {
 		CheckBox
 		{
 			name: "descriptivesPlots";			label: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
+			CIField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval") }
 		}
 	}
 

--- a/Resources/T-Tests/qml/TTestBayesianOneSample.qml
+++ b/Resources/T-Tests/qml/TTestBayesianOneSample.qml
@@ -64,7 +64,7 @@ Form
 		CheckBox
 		{
 			name: "descriptivesPlots";			label: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
+			CIField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval") }
 		}
 	}
 

--- a/Resources/T-Tests/qml/TTestBayesianPairedSamples.qml
+++ b/Resources/T-Tests/qml/TTestBayesianPairedSamples.qml
@@ -68,7 +68,7 @@ Form {
 		CheckBox
 		{
 			name: "descriptivesPlots";			label: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval"); defaultValue: 95 }
+			CIField { name: "descriptivesPlotsCredibleInterval";	label: qsTr("Credible interval") }
 		}
 	}
 

--- a/Resources/T-Tests/qml/TTestIndependentSamples.qml
+++ b/Resources/T-Tests/qml/TTestIndependentSamples.qml
@@ -53,7 +53,7 @@ Form
 			{
 				name: "meanDiffConfidenceIntervalCheckbox"; label: qsTr("Confidence interval")
 				childrenOnSameRow: true
-				PercentField { name: "descriptivesMeanDiffConfidenceIntervalPercent"; defaultValue: 95 }
+				CIField { name: "descriptivesMeanDiffConfidenceIntervalPercent" }
 			}
 		}
 		CheckBox
@@ -63,14 +63,14 @@ Form
 			{
 				name: "effSizeConfidenceIntervalCheckbox"; label: qsTr("Confidence interval")
 				childrenOnSameRow: true
-				PercentField { name: "descriptivesEffectSizeConfidenceIntervalPercent"; defaultValue: 95 }
+				CIField { name: "descriptivesEffectSizeConfidenceIntervalPercent" }
 			}
 		}
 		CheckBox { name: "descriptives";	label: qsTr("Descriptives")								}
 		CheckBox
 		{
 			name: "descriptivesPlots";		label: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsConfidenceInterval"; label: qsTr("Confidence interval"); defaultValue: 95 }
+			CIField { name: "descriptivesPlotsConfidenceInterval"; label: qsTr("Confidence interval") }
 		}
 		CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke maximum p-ratio")				}
 	}

--- a/Resources/T-Tests/qml/TTestOneSample.qml
+++ b/Resources/T-Tests/qml/TTestOneSample.qml
@@ -51,7 +51,7 @@ Form
 			{
 				name: "meanDiffConfidenceIntervalCheckbox";	label: qsTr("Confidence interval")
 				childrenOnSameRow: true
-				PercentField { name: "meanDiffConfidenceIntervalPercent"; defaultValue: 95 }
+				CIField { name: "meanDiffConfidenceIntervalPercent" }
 			}
 		}
 
@@ -62,14 +62,14 @@ Form
 			{
 				name: "effSizeConfidenceIntervalCheckbox"; label: qsTr("Confidence interval")
 				childrenOnSameRow: true
-				PercentField { name: "effSizeConfidenceIntervalPercent"; defaultValue: 95 }
+				CIField { name: "effSizeConfidenceIntervalPercent" }
 			}
 		}
 		CheckBox { name: "descriptives";	label: qsTr("Descriptives") }
 		CheckBox
 		{
 			name: "descriptivesPlots";		label: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsConfidenceInterval";	label: qsTr("Confidence interval"); defaultValue: 95 }
+			CIField { name: "descriptivesPlotsConfidenceInterval";	label: qsTr("Confidence interval") }
 		}
 		CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke maximum p-ratio") }
 	}

--- a/Resources/T-Tests/qml/TTestPairedSamples.qml
+++ b/Resources/T-Tests/qml/TTestPairedSamples.qml
@@ -53,7 +53,7 @@ Form
 			{
 				name: "meanDiffConfidenceIntervalCheckbox";	label: qsTr("Confidence interval")
 				childrenOnSameRow: true
-				PercentField { name: "meanDiffConfidenceIntervalPercent"; defaultValue: 95 }
+				CIField { name: "meanDiffConfidenceIntervalPercent" }
 			}
 		}
 
@@ -64,14 +64,14 @@ Form
 			{
 				name: "effSizeConfidenceIntervalCheckbox";	label: qsTr("Confidence interval")
 				childrenOnSameRow: true
-				PercentField { name: "effSizeConfidenceIntervalPercent"; defaultValue: 95 }
+				CIField { name: "effSizeConfidenceIntervalPercent" }
 			}
 		}
 		CheckBox { name: "descriptives";					label: qsTr("Descriptives")											}
 		CheckBox
 		{
 			name: "descriptivesPlots";						label: qsTr("Descriptives plots")
-			PercentField { name: "descriptivesPlotsConfidenceInterval";	label: qsTr("Confidence interval"); defaultValue: 95 }
+			CIField { name: "descriptivesPlotsConfidenceInterval";	label: qsTr("Confidence interval") }
 		}
 		CheckBox { name: "VovkSellkeMPR";					label: qsTr("Vovk-Sellke maximum p-ratio")						}
 	}

--- a/Tools/jasptools/R/optionsParserQML.R
+++ b/Tools/jasptools/R/optionsParserQML.R
@@ -13,6 +13,7 @@
     "IntegerField",
     "DoubleField",
     "PercentField",
+    "CIField",
     "TextField",
     "CheckBox",
     "Slider",
@@ -120,24 +121,36 @@ extractData <- function (element, ...) {
 }
 
 
-extractData.IntegerField <- function(element) {
+extractData.IntegerField <- function(element, defaultValue = 0) {
   regMatch <- "default.*?:([+-]?([0-9]*[.])?[0-9]+)"
   matchTable <- stringr::str_match(element, regMatch)
   default <- as.numeric(matchTable[2])
+  if (is.na(default)) {
+    default <- defaultValue
+  }
   extractData.default(element, default)
 }
 
 
-extractData.DoubleField <- function(element) {
-  extractData.IntegerField(element)
+extractData.DoubleField <- function(element, defaultValue = 0) {
+  extractData.IntegerField(element, defaultValue)
 }
 
 
-extractData.PercentField <- function(element) {
+extractData.PercentField <- function(element, defaultValue = 50) {
   regMatch <- "default.*?:([+-]?([0-9]*[.])?[0-9]+)"
   matchTable <- stringr::str_match(element, regMatch)
-  default <- as.numeric(matchTable[2]) / 100
+  default <- as.numeric(matchTable[2])
+  if (is.na(default)) {
+    default <- defaultValue
+  }
+  default <- default / 100
   extractData.default(element, default)
+}
+
+
+extractData.CIField <- function(element, defaultValue = 95) {
+  extractData.PercentField(element, defaultValue)
 }
 
 


### PR DESCRIPTION
I hope this name isn't too cryptic.. Otherwise we should just name it ConfidenceIntervalField and let users figure out these will also work for credible intervals.

This PR also ensures that minus in positive value fields are not allowed and it adds `min` and `max` to the regular `PercentField`

Solves jasp-stats/jasp-test-release#80