### PR TITLE
Make threshold between Scale or Nominal more clear

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -122,11 +122,13 @@ Item {
 				CheckBox
 				{
 					id:					customThreshold
-					label:				qsTr("Custom threshold between Scale or Nominal")
+					label:				qsTr("Import threshold between Nominal or Scale")
 					checked:			preferencesModel.customThresholdScale
 					onCheckedChanged:	preferencesModel.customThresholdScale = checked
-					//font:				Theme.font
-					toolTip:			qsTr("This will determine if, when importing new data, a column will be interpreted as a Scale column (When there are more unique integers then specified) or Nominal.")
+					ToolTip.delay:		500
+					ToolTip.timeout:	6000 //Some longer to read carefully
+					toolTip:			qsTr("Threshold number of unique integers before classifying a variable as 'scale'.\nYou need to reload your data to take effect! Check help for more info.")
+
 				}
 
 				SpinBox
@@ -143,7 +145,6 @@ Item {
 					editable:			true
 				}
 			}
-
 
 			PrefsMissingValues {} //Missing Value List
 		}

--- a/JASP-Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainWindow.qml
@@ -30,8 +30,8 @@ Window
 	height:		768
 
 
-	minimumWidth:	640
-	minimumHeight:	480
+	minimumWidth:	800
+	minimumHeight:	600
 
 	onVisibleChanged: if(!visible) helpModel.visible = false
 

--- a/Resources/Help/preferences/prefsdata.md
+++ b/Resources/Help/preferences/prefsdata.md
@@ -19,12 +19,13 @@ In JASP you can open the related datafile by double clicking the data pane.
 This opens your data file in your preferred editor which you can specify here
 or the default editor chosen by your operating system.
 
-### Custom threshold between Scale or Nominal.
+### Import threshold between Scale or Nominal.
 
 Importing data in JASP has a threshold value that determines if a column should be treated
 as a Scale type or as a Nominal type. The default value of this parameter is 10.
-This means the if you have less (or equal) than 10 different integers in the data, the column
-gets the Nominal type else it will get the Scale type. This threshold value can be influenced here.
+This means the if you have fewer (or equal) than 10 different integers in the data, the column
+gets the Nominal type else it will get the Scale type. Be aware that this value is used when
+importing the data, so data needs to be reloaded (or synchronized) to take effect!
 
 ### Missing Value List
 


### PR DESCRIPTION
It is quite unclear at the moment what the parameter 'Threshold between Scale or Nominal" means and how it takes effect. Label, Help and Tooltip are made more clear
See https://github.com/jasp-stats/jasp-test-release/issues/78

