### PR TITLE
Fix ANOVA labels & Dunnet's CI

### DIFF
--- a/JASP-Engine/JASP/R/ancova.R
+++ b/JASP-Engine/JASP/R/ancova.R
@@ -714,28 +714,8 @@ Ancova <- function(dataset=NULL, options, perform="run", callback=function(...) 
     list(name="F", type="number", format="sf:4;dp:3"),
     list(name="p", type="number", format="dp:3;p:.001"))
   
-  if (options$homogeneityCorrections && !is.null(corrections)) {
-    fields <- list(
-      list(name="Cases", type="string"),
-      list(name="cor", type="string", title="Homogeneity Correction"),
-      list(name="Sum of Squares", type="number", format="sf:4;dp:3"),
-      list(name="df", type="number", format="sf:4;dp:3"),
-      list(name="Mean Square", type="number", format="sf:4;dp:3"),
-      list(name="F", type="number", format="sf:4;dp:3"),
-      list(name="p", type="number", format="dp:3;p:.001"))
-  }
-  
-  
-  if (options$homogeneityCorrections && !is.null(corrections)) {
-    fields <- list(
-      list(name="Cases", type="string"),
-      list(name="cor", type="string", title="Homogeneity Correction"),
-      list(name="Sum of Squares", type="number", format="sf:4;dp:3"),
-      list(name="df", type="number", format="sf:4;dp:3"),
-      list(name="Mean Square", type="number", format="sf:4;dp:3"),
-      list(name="F", type="number", format="sf:4;dp:3"),
-      list(name="p", type="number", format="dp:3;p:.001"))
-  }
+  if (options$homogeneityCorrections && !is.null(corrections))
+    fields <- append(fields, list(list(name="cor", type="string", title="Homogeneity Correction")), 1)
   
   
   if (options$VovkSellkeMPR) {
@@ -2710,7 +2690,7 @@ Ancova <- function(dataset=NULL, options, perform="run", callback=function(...) 
       list(name="p", title="p<sub>dunnett</sub>", type="number", format="dp:3;p:.001"))
     
     if (options$confidenceIntervalsPostHoc) {
-      thisOverTitle <- paste(options$confidenceIntervalIntervalContrast*100, "% CI for Mean Difference", sep = "")
+      thisOverTitle <- paste(options$confidenceIntervalIntervalPostHoc*100, "% CI for Mean Difference", sep = "")
       fields <- list(
         list(name="Comparison",title="", type="string"),
         list(name="Mean Difference", type="number", format="sf:4;dp:3"),
@@ -2736,7 +2716,7 @@ Ancova <- function(dataset=NULL, options, perform="run", callback=function(...) 
       
       dunnettFit <- multcomp::glht(dunAOV, linfct=multcomp::mcp(Group="Dunnett"))
       dunnettResult <- summary(dunnettFit)[["test"]]
-      dunnettConfInt <- confint(dunnettFit, level = options$confidenceIntervalIntervalContrast)
+      dunnettConfInt <- confint(dunnettFit, level = options$confidenceIntervalIntervalPostHoc)
       
       for (i in 1:(nLevels-1)) {
         

--- a/Resources/ANOVA/qml/Ancova.qml
+++ b/Resources/ANOVA/qml/Ancova.qml
@@ -138,7 +138,7 @@ Form
         {
             CheckBox
             {
-                name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence Intervals")
+                name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence intervals")
                 childrenOnSameRow: true
                 CIField {name: "confidenceIntervalIntervalPostHoc" }
             }
@@ -219,11 +219,10 @@ Form
 		title: qsTr("Additional Options")
 		columns: 1
 		
-		Label { text: qsTr("Marginal means") }
 		VariablesForm
 		{
 			height: 200
-			AvailableVariablesList { name: "marginalMeansTermsAvailable" ; source: [{ name: "modelTerms", discard: "covariates" }] }
+			AvailableVariablesList { name: "marginalMeansTermsAvailable"; title: qsTr("Marginal Means"); source: [{ name: "modelTerms", discard: "covariates" }] }
 			AssignedVariablesList {	 name: "marginalMeansTerms" }
 		}
 		
@@ -250,8 +249,8 @@ Form
 				label: qsTr("Confidence interval adjustment")
 				values: [
 					{ label: "None",		value: "none"},
-					{ label: "Bonferro",	value: "bonferroni"},
-					{ label: "Sidak",		value: "sidak"}
+					{ label: "Bonferroni",	value: "bonferroni"},
+					{ label: "Šidák",		value: "sidak"}
 				]
 			}
 		}
@@ -293,11 +292,10 @@ Form
 		
 		Group
 		{
-			Label { text: qsTr("Kruskal-Wallis test") }
 			VariablesForm
 			{
 				height: 200
-				AvailableVariablesList { name: "kruskalVariablesAvailable"; source: "fixedFactors" }
+				AvailableVariablesList { name: "kruskalVariablesAvailable"; title: qsTr("Kruskal-Wallis Test"); source: "fixedFactors" }
 				AssignedVariablesList {	name: "kruskalVariablesAssigned" }
 			}
 		}

--- a/Resources/ANOVA/qml/Anova.qml
+++ b/Resources/ANOVA/qml/Anova.qml
@@ -115,7 +115,7 @@ Form
         {
             CheckBox
             {
-                name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence Intervals")
+                name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence intervals")
                 childrenOnSameRow: true
                 CIField {name: "confidenceIntervalIntervalPostHoc" }
             }
@@ -182,7 +182,7 @@ Form
 					{
 						value: "confidenceInterval";		label: qsTr("Confidence interval"); checked: true
 						childrenOnSameRow: true
-						CIField { name: "confidenceIntervalInterval";	label: qsTr("Interval") }
+						CIField { name: "confidenceIntervalInterval" }
 					}
 					RadioButton { value: "standardError";	label: qsTr("Standard error") }
 				}
@@ -195,11 +195,10 @@ Form
 		title: qsTr("Additional Options")
 		columns: 1
 		
-		Label { text: qsTr("Marginal means") }
 		VariablesForm
 		{
 			height: 200
-			AvailableVariablesList { name: "marginalMeansTermsAvailable" ; source: "modelTerms"; showVariableTypeIcon: false }
+			AvailableVariablesList { name: "marginalMeansTermsAvailable"; title: qsTr("Marginal Means"); source: "modelTerms"; showVariableTypeIcon: false }
 			AssignedVariablesList {  name: "marginalMeansTerms"; showVariableTypeIcon: false }
 		}
 
@@ -226,8 +225,8 @@ Form
 				label: qsTr("Confidence interval adjustment")
 				values: [
 					{ label: "None",		value: "none"},
-					{ label: "Bonferro",	value: "bonferroni"},
-					{ label: "Sidak",		value: "sidak"}
+					{ label: "Bonferroni",	value: "bonferroni"},
+					{ label: "Šidák",		value: "sidak"}
 				]
 			}
 		}
@@ -265,11 +264,10 @@ Form
 	{
 		title: qsTr("Nonparametrics")
 		
-		Label { text: qsTr("Kruskal-Wallis test") }
 		VariablesForm
 		{
 			height: 170
-			AvailableVariablesList { name: "kruskalVariablesAvailable" ; source:  ["fixedFactors", "randomFactors"] }
+			AvailableVariablesList { name: "kruskalVariablesAvailable"; title: qsTr("Kruskal-Wallis Test"); source:  ["fixedFactors", "randomFactors"] }
 			AssignedVariablesList {  name: "kruskalVariablesAssigned" }
 		}
 	}	

--- a/Resources/ANOVA/qml/AnovaRepeatedMeasures.qml
+++ b/Resources/ANOVA/qml/AnovaRepeatedMeasures.qml
@@ -112,7 +112,7 @@ Form
 				columns: 3
 				CheckBox { name: "sphericityNone";				label: qsTr("None");					checked: true }
 				CheckBox { name: "sphericityGreenhouseGeisser";	label: qsTr("Greenhouse-Geisser");	checked: true }
-				CheckBox { name: "sphericityHuynhFeldt";		label: qsTr("Huynth-Feidt");			checked: true }
+				CheckBox { name: "sphericityHuynhFeldt";		label: qsTr("Huynh-Feldt");			checked: true }
 			}
 			CheckBox { name: "homogeneityTests"; label: qsTr("Homogeneity tests") }
 		}
@@ -189,7 +189,7 @@ Form
 					{
 						value: "confidenceInterval"; label: qsTr("Confidence interval"); checked: true
 						childrenOnSameRow: true
-						CIField { name: "confidenceIntervalInterval"; label: qsTr("Interval") }
+						CIField { name: "confidenceIntervalInterval" }
 					}
 					RadioButton { value: "standardError"; label: qsTr("Standard error") }
 				}


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#104 and all the low hanging fruit I saw as I went through the ANOVA.

- Post hoc -> Dunnett's used the *contrast* confidence interval level
- Additional Options -> Sidak & Bonferroni labels were incorrect
- Assumption Checks -> ticking homogeneityCorrections changed the decimals of the degrees of freedom
- Generally -> fixed caps and removed redundant labels