### PR TITLE
Fix error propogation and display of the error message

### DIFF
--- a/JASP-Common/enginedefinitions.h
+++ b/JASP-Common/enginedefinitions.h
@@ -5,7 +5,7 @@
 
 DECLARE_ENUM(engineState,			initializing, idle, analysis, filter, rCode, computeColumn, moduleRequest, pauseRequested, paused, resuming, stopRequested, stopped);
 DECLARE_ENUM(performType,			init, run, abort, saveImg, editImg, rewriteImgs);
-DECLARE_ENUM(analysisResultStatus,	error, exception, imageSaved, imageEdited, imagesRewritten, complete, inited, running, changed, waiting);
+DECLARE_ENUM(analysisResultStatus,	validationError, fatalError, imageSaved, imageEdited, imagesRewritten, complete, inited, running, changed, waiting);
 DECLARE_ENUM(moduleStatus,			uninitialized, installNeeded, loadingNeeded, unloadingNeeded, readyForUse, error);
 DECLARE_ENUM(engineAnalysisStatus,	empty, toInit, initing, inited, toRun, running, changed, complete, error, exception, aborted, stopped, saveImg, editImg, rewriteImgs, synchingData);
 

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -176,11 +176,11 @@ Analysis::Status Analysis::parseStatus(std::string name)
 	else if (name == "complete")		return Analysis::Complete;
 	else if (name == "initializing")	return Analysis::Initializing;
 	else if (name == "RewriteImgs")		return Analysis::RewriteImgs;
-	else if (name == "exception")		return Analysis::Exception;
+	else if (name == "validationError")	return Analysis::ValidationError;
 	else if (name == "aborted")			return Analysis::Aborted;
 	else if (name == "SaveImg")			return Analysis::SaveImg;
 	else if (name == "EditImg")			return Analysis::EditImg;
-	else								return Analysis::Error;
+	else								return Analysis::FatalError;
 }
 
 void Analysis::initialized(AnalysisForm* form, bool isNewAnalysis)
@@ -216,9 +216,9 @@ Json::Value Analysis::asJSON() const
 	case Analysis::SaveImg:			status = "SaveImg";			break;
 	case Analysis::EditImg:			status = "EditImg";			break;
 	case Analysis::RewriteImgs:		status = "RewriteImgs";		break;
-	case Analysis::Exception:		status = "exception";		break;
+	case Analysis::ValidationError:	status = "validationError";	break;
 	case Analysis::Initializing:	status = "initializing";	break;
-	default:						status = "error";			break;
+	default:						status = "fatalError";	break;
 	}
 
 	analysisAsJson["status"]	= status;

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -46,7 +46,7 @@ class Analysis : public QObject
 
 public:
 
-	enum Status { Empty, Initing, Inited, Running, Complete, Aborting, Aborted, Error, SaveImg, EditImg, RewriteImgs, Exception, Initializing };
+	enum Status { Empty, Initing, Inited, Running, Complete, Aborting, Aborted, ValidationError, SaveImg, EditImg, RewriteImgs, FatalError, Initializing };
 	void setStatus(Status status);
 
 	Analysis(Analyses* analyses, size_t id, std::string module, std::string name, std::string title, const Version &version, Json::Value *data);
@@ -140,7 +140,7 @@ public:
 	bool isRewriteImgs()	const { return status() == RewriteImgs;	}
 	bool isEditImg()		const { return status() == EditImg;		}
 	bool isInited()			const { return status() == Inited;		}
-	bool isFinished()		const { return status() == Complete || status() == Error || status() == Exception; }
+	bool isFinished()		const { return status() == Complete || status() == ValidationError || status() == FatalError; }
 
 
 	void initialized(AnalysisForm* form, bool isNewAnalysis);

--- a/JASP-Desktop/engine/enginerepresentation.cpp
+++ b/JASP-Desktop/engine/enginerepresentation.cpp
@@ -237,8 +237,8 @@ Analysis::Status EngineRepresentation::analysisResultStatusToAnalysStatus(analys
 {
 	switch(result)
 	{
-	case analysisResultStatus::error:			return Analysis::Error;
-	case analysisResultStatus::exception:		return Analysis::Exception;
+	case analysisResultStatus::validationError:		return Analysis::ValidationError;
+	case analysisResultStatus::fatalError:		return Analysis::FatalError;
 	case analysisResultStatus::imageSaved:
 	case analysisResultStatus::imageEdited:
 	case analysisResultStatus::imagesRewritten:
@@ -309,7 +309,7 @@ void EngineRepresentation::processAnalysisReply(Json::Value & json)
 		clearAnalysisInProgress();
 		break;
 
-	case analysisResultStatus::error:
+	case analysisResultStatus::validationError:
 		analysis->setResults(results);
 		clearAnalysisInProgress();
 
@@ -317,7 +317,7 @@ void EngineRepresentation::processAnalysisReply(Json::Value & json)
 			emit computeColumnFailed(QString::fromStdString(col), "Analysis had an error..");
 		break;
 
-	case analysisResultStatus::exception:
+	case analysisResultStatus::fatalError:
 	case analysisResultStatus::inited:
 	case analysisResultStatus::complete:
 		analysis->setResults(results);

--- a/JASP-Desktop/html/css/theme-jasp.css
+++ b/JASP-Desktop/html/css/theme-jasp.css
@@ -286,7 +286,7 @@ svg > text
 	margin-right: 1.7em ;
 }
 
-.jasp-analysis {
+:not(.error-state) > .jasp-analysis {
 
 	margin: 0 .7em .7em .7em ;
 	padding: 0 1em 1em 1em ;
@@ -370,25 +370,23 @@ div.jasp-image-image.no-data {
 }
 
 .error-state {
-	color: silver ;
+	color: silver;
+	min-height: 200px;
+	min-width: 500px;
 }
 
-.exception .error-message-box {
+.fatalError.error-message-box {
 	border-width: 3px;
 	border-style: double;
 }
 
-.analysis-error {
+.analysis-error-message {
+	min-width: 400px;
+	max-width: 1000px;
 	position: absolute;
 	top: 60px;
-	left: 40px;
-	right: 40px;
-	margin-left: auto;
-	margin-right: auto;
-}
-
-.analysis-error.analysis-error-top-max {
-	top: 200px;
+	left: 50px;
+	margin-right: 50px;
 }
 
 .error-message-positioner {
@@ -400,8 +398,6 @@ div.jasp-image-image.no-data {
 	float: left ;
 	z-index: 100 ;
 }
-
-
 
 .jasp-image-holder .error-message-positioner {
 
@@ -422,10 +418,6 @@ div.jasp-image-image.no-data {
 	border-radius: .4em ;
 	min-width: 300px ;
 	white-space: normal;
-}
-
-.error-message-message {
-
 }
 
 .stack-trace-selector div,

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -534,7 +534,7 @@ $(document).ready(function () {
 	$("#results").on("click", ".stack-trace-selector", function() {
 		$(this).next(".stack-trace").slideToggle(function() {
 			var $selectedInner = $(this).parent().siblings(".jasp-analysis");
-			var errorBoxHeight = $(this).parent(".analysis-error").outerHeight(true);
+			var errorBoxHeight = $(this).parent(".analysis-error-message").outerHeight();
 			if ($(this).next(".stack-trace").is(":hidden")) {
 				$selectedInner.css("height", "");
 			}

--- a/JASP-Engine/JASP/R/commonerrorcheck.R
+++ b/JASP-Engine/JASP/R/commonerrorcheck.R
@@ -17,10 +17,10 @@
 
 .quitAnalysis <- function(message) {
   # Function to gracefully exit an analysis when continuing to run is nonsensical.
-  # Comparable to stop(message), except this does not raise an exception.
+  # Comparable to stop(message), except this raises an validationError.
   # Arg message: String with the reason why the analysis has ended.
   
-  e <- structure(class = c('expectedError', 'error', 'condition'),
+  e <- structure(class = c('validationError', 'error', 'condition'),
                  list(message=message, call=sys.call(-1)))
   stop(e)
 }

--- a/JASP-Engine/JASP/R/commonmessages.R
+++ b/JASP-Engine/JASP/R/commonmessages.R
@@ -23,7 +23,7 @@
   "The following problem(s) occurred while running the analysis:"
   m$error$grouping <- 
   "after grouping on {{grouping}}"
-  m$error$exception <- 
+  m$error$fatalError <- 
   "This analysis terminated unexpectedly.<br><br>{{error}}<br><div class=stack-trace-selector><span>Stack trace</span><div class=stack-trace-arrow></div></div><div class=stack-trace>{{stackTrace}}</div><br>To receive assistance with this problem, please report the message above at: https://jasp-stats.org/bug-reports"
   
   ### Error checks

--- a/JASP-Engine/engine.cpp
+++ b/JASP-Engine/engine.cpp
@@ -531,7 +531,7 @@ analysisResultStatus Engine::getStatusToAnalysisStatus()
 	case Status::running:
 	case Status::changed:	return analysisResultStatus::running;
 	case Status::complete:	return analysisResultStatus::complete;
-	default:				return analysisResultStatus::error;
+	default:				return analysisResultStatus::fatalError;
 	}
 }
 

--- a/JASP-R-Interface/jaspResults/src/jaspResults.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspResults.cpp
@@ -241,13 +241,13 @@ Json::Value jaspResults::dataEntry()
 
 
 
-void jaspResults::setErrorMessage(std::string msg)
+void jaspResults::setErrorMessage(std::string msg, std::string errorStatus)
 {
 	if(msg.find(analysisChangedErrorMessage) != std::string::npos)
 		return; //we do not wanna report analysis changed as an error I think
 
 	errorMessage = msg;
-	setStatus("error");
+	setStatus(errorStatus);
 }
 
 Rcpp::List jaspResults::getPlotObjectsForState()

--- a/JASP-R-Interface/jaspResults/src/jaspResults.h
+++ b/JASP-R-Interface/jaspResults/src/jaspResults.h
@@ -39,7 +39,7 @@ public:
 	void saveResults();
 
 	void loadResults();
-	void setErrorMessage(std::string msg);
+	void setErrorMessage(std::string msg, std::string errorStatus);
 	void changeOptions(std::string opts);
 	void setOptions(std::string opts);
 	void pruneInvalidatedData();
@@ -104,15 +104,16 @@ public:
 
 	void		send()								{ ((jaspResults*)myJaspObject)->send();								}
 	void		complete()							{ ((jaspResults*)myJaspObject)->complete();							}
-	void		setErrorMessage(std::string msg)	{ ((jaspResults*)myJaspObject)->setErrorMessage(msg);				}
 	Rcpp::List	getOtherObjectsForState()			{ return ((jaspResults*)myJaspObject)->getOtherObjectsForState();	}
 	Rcpp::List	getPlotObjectsForState()			{ return ((jaspResults*)myJaspObject)->getPlotObjectsForState();	}
 	Rcpp::List	getKeepList()						{ return ((jaspResults*)myJaspObject)->getKeepList();				}
 	void		progressbarTick()					{ ((jaspResults*)myJaspObject)->progressbarTick();					}
 	std::string getResults()						{ return ((jaspResults*)myJaspObject)->getResults();				}
-
-	void		startProgressbar(int expectedTicks)									{ ((jaspResults*)myJaspObject)->startProgressbar(expectedTicks); }
-	void		startProgressbarMs(int expectedTicks, int timeBetweenUpdatesInMs)	{ ((jaspResults*)myJaspObject)->startProgressbar(expectedTicks, timeBetweenUpdatesInMs); }
+	
+	void		setErrorMessage(std::string msg, std::string errorStatus)			{ ((jaspResults*)myJaspObject)->setErrorMessage(msg, errorStatus);							}
+	
+	void		startProgressbar(int expectedTicks)									{ ((jaspResults*)myJaspObject)->startProgressbar(expectedTicks);							}
+	void		startProgressbarMs(int expectedTicks, int timeBetweenUpdatesInMs)	{ ((jaspResults*)myJaspObject)->startProgressbar(expectedTicks, timeBetweenUpdatesInMs);	}
 
 	void		setOptions(std::string opts)		{ ((jaspResults*)myJaspObject)->setOptions(opts); }
 	void		changeOptions(std::string opts)		{ ((jaspResults*)myJaspObject)->changeOptions(opts); }

--- a/JASP-Tests/R/tests/testthat/test-regressionlinear.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionlinear.R
@@ -250,59 +250,59 @@ test_that("Analysis handles errors", {
   options$covariates <- "contGamma"
   options$modelTerms <- list(list(components="contGamma", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="Inf dependent check")
+  expect_identical(results[["status"]], "validationError", label="Inf dependent check")
 
   options$dependent <- "contNormal"
   options$covariates <- "debInf"
   options$modelTerms <- list(list(components="debInf", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="Inf covariate check")
+  expect_identical(results[["status"]], "validationError", label="Inf covariate check")
 
   options$covariates <- "contGamma"
   options$wlsWeights <- "debInf"
   options$modelTerms <- list(list(components="contGamma", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="Inf wlsWeights check")
+  expect_identical(results[["status"]], "validationError", label="Inf wlsWeights check")
 
   options$dependent <- "debSame"
   options$covariates <- "contGamma"
   options$wlsWeights <- ""
   options$modelTerms <- list(list(components="contGamma", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="No variance dependent check")
+  expect_identical(results[["status"]], "validationError", label="No variance dependent check")
 
   options$dependent <- "contNormal"
   options$covariates <- "debSame"
   options$modelTerms <- list(list(components="debSame", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="No variance covariate check")
+  expect_identical(results[["status"]], "validationError", label="No variance covariate check")
 
   options$dependent <- "contGamma"
   options$covariates <- "contcor1"
   options$wlsWeights <- "contNormal"
   options$modelTerms <- list(list(components="contcor1", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="Negative wlsWeights check")
+  expect_identical(results[["status"]], "validationError", label="Negative wlsWeights check")
 
   options$dependent <- "debNaN"
   options$covariates <- "contcor1"
   options$wlsWeights <- ""
   options$modelTerms <- list(list(components="contcor1", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="Too few obs dependent check")
+  expect_identical(results[["status"]], "validationError", label="Too few obs dependent check")
 
   options$dependent <- "contGamma"
   options$covariates <- "debNaN"
   options$modelTerms <- list(list(components="debNaN", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="Too few obs covariate check")
+  expect_identical(results[["status"]], "validationError", label="Too few obs covariate check")
 
   options$dependent <- "contGamma"
   options$covariates <- "contNormal"
   options$wlsWeights <- "debNaN"
   options$modelTerms <- list(list(components="contNormal", isNuisance=FALSE))
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  expect_identical(results[["status"]], "error", label="Too few obs wlsWeights check")
+  expect_identical(results[["status"]], "validationError", label="Too few obs wlsWeights check")
   
   options <- jasptools::analysisOptions("RegressionLinear")
   options$dependent <- "contNormal"
@@ -313,7 +313,7 @@ test_that("Analysis handles errors", {
   )
   results <- jasptools::run("RegressionLinear", "test.csv", options)
   results$results$errorMessage
-  expect_identical(results[["status"]], "error", label="Perfect correlation check")
+  expect_identical(results[["status"]], "validationError", label="Perfect correlation check")
 })
 
 # Below are the unit tests for Andy Field's book

--- a/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
@@ -95,7 +95,7 @@ test_that("Analysis handles errors", {
   obj <- results
   obj$results$errorMessage <- NULL # error message can change and shouldn't tested.
   expect_equal(object = obj, expected = structure(list(
-  	status = "error", results = structure(list(title = "error", error = 1L), .Names = c("title", "error"))),
+  	status = "validationError", results = structure(list(title = "error", error = 1L), .Names = c("title", "error"))),
   	.Names = c("status", "results")),
   	label = "Variance check"
   )


### PR DESCRIPTION
This prevents the errored analysis from doing a little shuffle to the right when multiple errors occur. It also makes jaspResults propogate the correct error status (fatalError & validationError).