### PR TITLE
CFA - changes to unicode arrows & remove "first-order" from table titles

### DIFF
--- a/JASP-Engine/JASP/R/cfa.R
+++ b/JASP-Engine/JASP/R/cfa.R
@@ -452,9 +452,9 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   fl1$addColumnInfo(name = "pvalue", title  = "p",          type = "number", format = "dp:3;p:.001")
 
   fl1$addColumnInfo(name = "ci.lower", title = "Lower", type = "number", format = "sf:4;dp:3",
-                    overtitle = "Confidence Interval")
+                    overtitle = "95% Confidence Interval")
   fl1$addColumnInfo(name = "ci.upper", title = "Upper", type = "number", format = "sf:4;dp:3",
-                    overtitle = "Confidence Interval")
+                    overtitle = "95% Confidence Interval")
 
   if (options$std != "none")
     fl1$addColumnInfo(name = paste0("std.", options$std), title = paste0("Std. Est. (", options$std, ")"),
@@ -483,9 +483,9 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     fl2$addColumnInfo(name = "pvalue", title  = "p",          type = "number", format = "dp:3;p:.001")
 
     fl2$addColumnInfo(name = "ci.lower", title = "Lower", type = "number", format = "sf:4;dp:3",
-                      overtitle = "Confidence Interval")
+                      overtitle = "95% Confidence Interval")
     fl2$addColumnInfo(name = "ci.upper", title = "Upper", type = "number", format = "sf:4;dp:3",
-                      overtitle = "Confidence Interval")
+                      overtitle = "95% Confidence Interval")
 
     if (options$std != "none")
       fl2$addColumnInfo(name = paste0("std.", options$std), title = paste0("Std. Est. (", options$std, ")"),
@@ -512,9 +512,9 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   fv$addColumnInfo(name = "pvalue", title = "p",          type = "number", format  = "dp:3;p:.001")
 
   fv$addColumnInfo(name = "ci.lower", title = "Lower", type = "number", format = "sf:4;dp:3",
-                   overtitle = "Confidence Interval")
+                   overtitle = "95% Confidence Interval")
   fv$addColumnInfo(name = "ci.upper", title = "Upper", type = "number", format = "sf:4;dp:3",
-                   overtitle = "Confidence Interval")
+                   overtitle = "95% Confidence Interval")
 
   if (options$std != "none")
     fv$addColumnInfo(name = paste0("std.", options$std), title = paste0("Std. Est. (", options$std, ")"),
@@ -542,9 +542,9 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     fc$addColumnInfo(name = "pvalue", title = "p",          type = "number", format  = "dp:3;p:.001")
 
     fc$addColumnInfo(name = "ci.lower", title = "Lower", type = "number", format = "sf:4;dp:3",
-                     overtitle = "Confidence Interval")
+                     overtitle = "95% Confidence Interval")
     fc$addColumnInfo(name = "ci.upper", title = "Upper", type = "number", format = "sf:4;dp:3",
-                     overtitle = "Confidence Interval")
+                     overtitle = "95% Confidence Interval")
 
     if (options$std != "none")
       fc$addColumnInfo(name   = paste0("std.", options$std),
@@ -572,9 +572,9 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   rv$addColumnInfo(name = "pvalue", title = "p",          type = "number", format  = "dp:3;p:.001")
 
   rv$addColumnInfo(name = "ci.lower", title = "Lower", type = "number", format = "sf:4;dp:3",
-                   overtitle = "Confidence Interval")
+                   overtitle = "95% Confidence Interval")
   rv$addColumnInfo(name = "ci.upper", title = "Upper", type = "number", format = "sf:4;dp:3",
-                   overtitle = "Confidence Interval")
+                   overtitle = "95% Confidence Interval")
 
   if (options$std != "none")
     rv$addColumnInfo(name   = paste0("std.", options$std),
@@ -603,9 +603,9 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     rescov$addColumnInfo(name = "pvalue", title = "p",          type = "number", format  = "dp:3;p:.001")
 
     rescov$addColumnInfo(name = "ci.lower", title = "Lower", type = "number", format = "sf:4;dp:3",
-                         overtitle = "Confidence Interval")
+                         overtitle = "95% Confidence Interval")
     rescov$addColumnInfo(name = "ci.upper", title = "Upper", type = "number", format = "sf:4;dp:3",
-                         overtitle = "Confidence Interval")
+                         overtitle = "95% Confidence Interval")
 
     rescov[["lhs"]]      <- .unv(rc$lhs)
     rescov[["op"]]       <- rep("\u2194", nrow(rc))
@@ -634,9 +634,9 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
       fi$addColumnInfo(name = "pvalue", title = "p",          type = "number", format = "dp:3;p:.001")
 
       fi$addColumnInfo(name = "ci.lower", title = "Lower", type = "number", format = "sf:4;dp:3",
-                        overtitle = "Confidence Interval")
+                        overtitle = "95% Confidence Interval")
       fi$addColumnInfo(name = "ci.upper", title = "Upper", type = "number", format = "sf:4;dp:3",
-                        overtitle = "Confidence Interval")
+                        overtitle = "95% Confidence Interval")
 
       if (options$std != "none")
         fi$addColumnInfo(name = paste0("std.", options$std), title = paste0("Std. Est. (", options$std, ")"),
@@ -659,9 +659,9 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     vi$addColumnInfo(name = "pvalue", title  = "p",          type = "number", format = "dp:3;p:.001")
 
     vi$addColumnInfo(name = "ci.lower", title = "Lower", type = "number", format = "sf:4;dp:3",
-                     overtitle = "Confidence Interval")
+                     overtitle = "95% Confidence Interval")
     vi$addColumnInfo(name = "ci.upper", title = "Upper", type = "number", format = "sf:4;dp:3",
-                     overtitle = "Confidence Interval")
+                     overtitle = "95% Confidence Interval")
 
     if (options$std != "none")
       vi$addColumnInfo(name = paste0("std.", options$std), title = paste0("Std. Est. (", options$std, ")"),

--- a/JASP-Engine/JASP/R/cfa.R
+++ b/JASP-Engine/JASP/R/cfa.R
@@ -436,7 +436,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
 
   # First-order factor loadings ----
   # Set up table
-  jrobject[["fl1"]] <- fl1 <- createJaspTable(title = "First-order factor loadings")
+  jrobject[["fl1"]] <- fl1 <- createJaspTable(title = "Factor loadings")
 
   fl1$addColumnInfo(name = "lhs",   title = "Factor",    type = "string", combine = TRUE)
   fl1$addColumnInfo(name = "rhs",   title = "Indicator", type = "string")
@@ -701,7 +701,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   if (nrow(foc) > 0) {
     foc <- as.data.frame(foc)
     foc <- foc[order(foc$mi, decreasing = TRUE), ]
-    jrobject[["First-Order Cross-Loadings"]] <- focro <- createJaspTable("First-order cross-loadings")
+    jrobject[["Cross-Loadings"]] <- focro <- createJaspTable("Cross-loadings")
     focro$dependOn(optionsFromObject = jrobject)
 
     focro$addColumnInfo(name = "lhs", title = "",          type = "string")

--- a/JASP-Engine/JASP/R/cfa.R
+++ b/JASP-Engine/JASP/R/cfa.R
@@ -440,7 +440,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
 
   # First-order factor loadings ----
   # Set up table
-  jrobject[["fl1"]] <- fl1 <- createJaspTable(title = "First-order factor loadings")
+  jrobject[["fl1"]] <- fl1 <- createJaspTable(title = "Factor loadings")
 
   fl1$addColumnInfo(name = "lhs",   title = "Factor",    type = "string", combine = TRUE)
   fl1$addColumnInfo(name = "rhs",   title = "Indicator", type = "string")
@@ -555,7 +555,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     fcdat <- pei[pei$op == "~~" & pei$lhs %in% facNames & pei$lhs != pei$rhs, colSel[-c(3)]]
     fcdat$lhs <- .translateFactorNames(fcdat$lhs, options)
     fcdat$rhs <- .translateFactorNames(fcdat$rhs, options)
-    fcdat$op  <- rep("\u2B64", nrow(fcdat))
+    fcdat$op  <- rep("\u2194", nrow(fcdat))
 
     fc$setData(fcdat)
     fc$dependOn(optionsFromObject = jrobject)
@@ -608,7 +608,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
                          overtitle = "Confidence Interval")
 
     rescov[["lhs"]]      <- .unv(rc$lhs)
-    rescov[["op"]]       <- rep("\u2B64", nrow(rc))
+    rescov[["op"]]       <- rep("\u2194", nrow(rc))
     rescov[["rhs"]]      <- .unv(rc$rhs)
     rescov[["est"]]      <- rc$est
     rescov[["se"]]       <- rc$se
@@ -705,7 +705,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   if (nrow(foc) > 0) {
     foc <- as.data.frame(foc)
     foc <- foc[order(foc$mi, decreasing = TRUE), ]
-    jrobject[["First-Order Cross-Loadings"]] <- focro <- createJaspTable("First-order cross-loadings")
+    jrobject[["Cross-Loadings"]] <- focro <- createJaspTable("Cross-loadings")
     focro$dependOn(optionsFromObject = jrobject)
 
     focro$addColumnInfo(name = "lhs", title = "",          type = "string")
@@ -715,7 +715,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     focro$addColumnInfo(name = "epc", title  = "EPC",      type = "number", format = "sf:4;dp:3")
 
     focro[["lhs"]] <- .translateFactorNames(foc$lhs, options)
-    focro[["op"]]  <- rep("\u2B62", nrow(foc))
+    focro[["op"]]  <- rep("\u2192", nrow(foc))
     focro[["rhs"]] <- .unv(foc$rhs)
     focro[["mi"]]  <- foc$mi
     focro[["epc"]] <- foc$epc
@@ -742,7 +742,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
 
 
       socro[["lhs"]] <- soc$lhs
-      socro[["op"]]  <- rep("\u2B62", nrow(soc))
+      socro[["op"]]  <- rep("\u2192", nrow(soc))
       socro[["rhs"]] <- soc$rhs
       socro[["mi"]]  <- soc$mi
       socro[["epc"]] <- soc$epc
@@ -768,7 +768,7 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
     rec <- as.data.frame(rec)
     rec <- rec[order(rec$mi, decreasing = TRUE), ]
     rescov[["lhs"]] <- .unv(rec$lhs)
-    rescov[["op"]]  <- rep("\u2B64", nrow(rec))
+    rescov[["op"]]  <- rep("\u2194", nrow(rec))
     rescov[["rhs"]] <- .unv(rec$rhs)
     rescov[["mi"]]  <- rec$mi
     rescov[["epc"]] <- rec$epc

--- a/Resources/SEM/qml/ConfirmatoryFactorAnalysis.qml
+++ b/Resources/SEM/qml/ConfirmatoryFactorAnalysis.qml
@@ -210,7 +210,7 @@ Form
                             text: qsTr("Bootstrap samples")
                             name: "bootstrapNumber"
                             defaultValue: 1000
-                            min: 1
+                            min: 100
                             max: 1000000
                         }
                     }

--- a/Resources/SEM/qml/ConfirmatoryFactorAnalysis.qml
+++ b/Resources/SEM/qml/ConfirmatoryFactorAnalysis.qml
@@ -192,24 +192,34 @@ Form
                 }
             }
 
-            RadioButtonGroup {
-                title: qsTr("Error Calculation")
-                name: "se"
-                RadioButton { text: qsTr("Standard")  ; name: "standard" ; checked: true }
-                RadioButton { text: qsTr("Robust")    ; name: "robust" }
-                RadioButton { 
-                    text: qsTr("Bootstrap") 
-                    name: "bootstrap" 
-                    IntegerField {
-                        text: qsTr("Bootstrap samples")
-                        name: "bootstrapNumber"
-                        defaultValue: 1000
-                        min: 1
-                        max: 1000000
+            GroupBox {
+                title: qsTr("Error calculation")
+                CIField {
+                    text: qsTr("CI width")
+                    name: "ciWidth"
+                }
+                RadioButtonGroup {
+                    title: qsTr("Method")
+                    name: "se"
+                    RadioButton { text: qsTr("Standard")  ; name: "standard" ; checked: true }
+                    RadioButton { text: qsTr("Robust")    ; name: "robust" }
+                    RadioButton {
+                        text: qsTr("Bootstrap CI")
+                        name: "bootstrap"
+                        IntegerField {
+                            text: qsTr("Bootstrap samples")
+                            name: "bootstrapNumber"
+                            defaultValue: 1000
+                            min: 1
+                            max: 1000000
+                        }
                     }
                 }
-                
             }
+
+
+
+
 
             RadioButtonGroup {
                 title: qsTr("Estimator")


### PR DESCRIPTION
Fixes [#137](https://github.com/jasp-stats/jasp-test-release/issues/137)

Also apparently OSX does not support full unicode. We should use `\u2192` (→) and `\u2194` (↔) because those do work, even though there are better-looking options

