### PR TITLE
Change clicking behaviour in results panel

### DIFF
--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -33,6 +33,8 @@ $(document).ready(function () {
 
 	var $instructions = $("#instructions")
 	var showInstructions = false;
+	
+	var wasLastClickNote = false;
 
 	var analyses = new JASPWidgets.Analyses({ className: "jasp-report" });
 
@@ -401,8 +403,6 @@ $(document).ready(function () {
 		}
 	}
 
-	var wasLastClickNote = false;
-
 	var selectedHandler = function (event) {
 
 		var target = event.target || event.srcElement;
@@ -410,7 +410,10 @@ $(document).ready(function () {
 		var stacktraceClicked = $(target).is(".stack-trace-span, .stack-trace-arrow, .stack-trace-selector");
 		var noteClicked = $(target).is(".jasp-notes, .jasp-notes *");
 
-		var ignoreSelectionProcess = (wasLastClickNote === true && noteClicked === false) || stacktraceClicked === true;
+		var ignoreSelectionProcess = 
+									(wasLastClickNote === true && noteClicked === false) ||		// save the modified note
+									stacktraceClicked === true ||								// toggle the stack trace
+									(selectedAnalysisId === -1 && wasLastClickNote === true);	// click on a note when no analysis is selected
 
 		wasLastClickNote = noteClicked;
 
@@ -420,19 +423,14 @@ $(document).ready(function () {
 		var id = $(event.currentTarget).attr("id")
 		var idAsInt = parseInt(id.substring(3))
 
-		if (selectedAnalysisId == idAsInt && noteClicked === false) {
-				window.unselect()
-				jasp.analysisUnselected()
-		}
-		else if (selectedAnalysisId !== idAsInt && noteClicked === true) {
-			if (selectedAnalysisId !== -1) {
+		if (selectedAnalysisId !== idAsInt) {
+			if (wasLastClickNote !== true) {
+				window.select(idAsInt)
+				jasp.analysisSelected(idAsInt)
+			} else {
 				window.unselect()
 				jasp.analysisUnselected()
 			}
-		}
-		else {
-			window.select(idAsInt)
-			jasp.analysisSelected(idAsInt)
 		}
 	}
 


### PR DESCRIPTION
- Do not deselect an analysis by simply clicking on it (this does not make sense anymore with our new panel setup)
- Do not scroll to top when a notebox is clicked (it can scroll it out of view..)
- Select an analysis only if a different analysis is currently selected and the click is not on a notebox
- Deselect an analysis only if (1) a notebox of a different analysis (or the main results) is clicked or (2) a different part of the html body is clicked that is not analysis related