### PR TITLE
Do not mix / and \ on windows filemenu

### DIFF
--- a/JASP-Desktop/widgets/filemenu/filemenubasiclistmodel.cpp
+++ b/JASP-Desktop/widgets/filemenu/filemenubasiclistmodel.cpp
@@ -39,7 +39,7 @@ QVariant FileMenuBasicListModel::data(const QModelIndex &index, int role) const
 	case IconSourceRole:			return FileSystemEntry::sourcesIcons()[item.entryType];
 	case DataIconSourceRole:		return FileSystemEntry::sourcesIcons()[FileSystemEntry::CSV];
 	//case DirRole:					return QFileInfo (item.associated_datafile).path() + QDir::separator();
-	case DirRole:					return QFileInfo (item.path).path() + QDir::separator();
+	case DirRole:					return QDir::toNativeSeparators(QFileInfo (item.path).path()) + QDir::separator();
 	case ActionRole:				return _openFileWhenClicked ? "open" : "sync";
 	default:						return QStringLiteral("Me know nothing");
 	}


### PR DESCRIPTION
In the menu folders on windows different pathes are shown on file menu

