### PR TITLE
Prevent the plot placeholder from taking on ridiculous sizes

### DIFF
--- a/JASP-Desktop/html/css/theme-jasp.css
+++ b/JASP-Desktop/html/css/theme-jasp.css
@@ -367,6 +367,9 @@ div.jasp-image-image.no-data {
 	background-image: url('images/empty-plot.png') ;
 	background-repeat: no-repeat;
 	background-size: contain;
+	position: relative;
+	max-height: 480px;
+	max-width: 480px;
 }
 
 .error-state {
@@ -399,7 +402,7 @@ div.jasp-image-image.no-data {
 	z-index: 100 ;
 }
 
-.jasp-image-holder .error-message-positioner {
+.jasp-image-image .error-message-positioner {
 
 	position: absolute ;
 	top: 25% ;

--- a/JASP-Desktop/html/js/image.js
+++ b/JASP-Desktop/html/js/image.js
@@ -163,7 +163,8 @@ JASPWidgets.imagePrimitive= JASPWidgets.View.extend({
 			html += 'background-image : url(\'' + url + '?x=' + Math.random() + '\'); '
 			html += 'background-size : 100% 100%">'
 		} else {
-			html += '<div class="jasp-image-image no-data">';
+			if (height > 100 && width > 100)
+				html += '<div class="jasp-image-image no-data">';
 		}
 
 		if (error && error.errorMessage) {
@@ -191,7 +192,9 @@ JASPWidgets.imagePrimitive= JASPWidgets.View.extend({
 			width: width,
 			height: height
 		});
-		this.resizer.render();
+		
+		if (data)
+			this.resizer.render();
 
 		return this;
 	},

--- a/JASP-Engine/JASP/R/principalcomponentanalysis.R
+++ b/JASP-Engine/JASP/R/principalcomponentanalysis.R
@@ -418,9 +418,10 @@ mainFunctionPCAEFA <- function(type, dataset = NULL, options, perform = "run",
 
 	xName <- ifelse(Rotation == "none", "PC", "RC")
 
-	pathDiagram$width <- options$plotWidthPathDiagram
-	pathDiagram$height <- options$plotHeightPathDiagram
-	if (pathDiagram$height==0) {
+	pathDiagram$width <- 480
+	if (length(options$variables) < 2) {
+		pathDiagram$height <- 300
+	} else {
 		pathDiagram$height <- 1 + 299 * (length(options$variables)/5)
 	}
 	pathDiagram$custom <- list(width="plotWidthPathDiagram", height="plotHeightPathDiagram")


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#129 and jasp-stats/jasp-test-release#113

Maybe the placeholder plot should just be fixed to a single size, I'm not too sure.