### PR TITLE
Set changed analysis title directly in JS

### DIFF
--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -161,6 +161,7 @@ void Analyses::bindAnalysisHandler(Analysis* analysis)
 	connect(analysis, &Analysis::optionsChanged,					this, &Analyses::analysisOptionsChanged				);
 	connect(analysis, &Analysis::sendRScript,						this, &Analyses::sendRScriptHandler					);
 	connect(analysis, &Analysis::toRefreshSignal,					this, &Analyses::analysisToRefresh					);
+	connect(analysis, &Analysis::titleChanged,						this, &Analyses::setChangedAnalysisTitle			);
 	connect(analysis, &Analysis::saveImageSignal,					this, &Analyses::analysisSaveImage					);
 	connect(analysis, &Analysis::editImageSignal,					this, &Analyses::analysisEditImage					);
 	connect(analysis, &Analysis::imageSavedSignal,					this, &Analyses::analysisImageSaved					);
@@ -551,10 +552,18 @@ void Analyses::setVisible(bool visible)
 		unselectAnalysis();
 }
 
-void Analyses::analysisTitleChanged(int id, QString title)
+void Analyses::analysisTitleChangedFromResults(int id, QString title)
 {
 	Analysis * analysis = get(id);
 
 	if(analysis != nullptr)
 		analysis->setTitleQ(title);
+}
+
+void Analyses::setChangedAnalysisTitle()
+{
+    Analysis * analysis = dynamic_cast<Analysis*>(QObject::sender());
+
+    if (analysis != nullptr)
+        emit analysisTitleChanged(analysis);
 }

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -107,7 +107,8 @@ public slots:
 	void removeAnalysesOfDynamicModule(Modules::DynamicModule * module);
 	void refreshAnalysesOfDynamicModule(Modules::DynamicModule * module);
 	void rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * module);
-	void analysisTitleChanged(int id, QString title);
+	void setChangedAnalysisTitle();
+	void analysisTitleChangedFromResults(int id, QString title);
 
 signals:
 	void analysesUnselected();
@@ -122,6 +123,7 @@ signals:
 	void analysisImageEdited(			Analysis *	source);
 	void analysisRewriteImages(			Analysis *	source);
 	void analysisResultsChanged(		Analysis *	source);
+	void analysisTitleChanged(			Analysis *  source);
 	void analysisOptionsChanged(		Analysis *	source);
 	void analysisNameSelected(			QString		name);
 	void sendRScript(					QString		script, int requestID);

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -364,13 +364,13 @@ void Analysis::setHelpFile(QString helpFile)
 void Analysis::setTitle(std::string title)
 {
 	if(title == "")
-		title = _name;
+		title = _title;
 
 	if (_title == title)
 		return;
 
+	_results["title"] = title;
 	_title = title;
+	
 	emit titleChanged();
-
-	optionsChangedHandler();
 }

--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -220,13 +220,13 @@ Item
 					// It would be much better to have resultsJsInterface be passed directly though..
 					// It also gives you an overview of the functions used in results html
 
-					function openFileTab()								{ resultsJsInterface.openFileTab()							}
-					function saveTextToFile(fileName, html)				{ resultsJsInterface.saveTextToFile(fileName, html)			}
-					function analysisUnselected()						{ resultsJsInterface.analysisUnselected()					}
-					function analysisSelected(id)						{ resultsJsInterface.analysisSelected(id)					}
-					function analysisChangedDownstream(id, model)		{ resultsJsInterface.analysisChangedDownstream(id, model)	}
-					function welcomeScreenIsCleared(callDelayedLoad)	{ resultsJsInterface.welcomeScreenIsCleared(callDelayedLoad)}
-					function analysisTitleChanged(id, title)			{ resultsJsInterface.analysisTitleChanged(id, title)		}
+					function openFileTab()								{ resultsJsInterface.openFileTab()                              }
+					function saveTextToFile(fileName, html)				{ resultsJsInterface.saveTextToFile(fileName, html)             }
+					function analysisUnselected()						{ resultsJsInterface.analysisUnselected()                       }
+					function analysisSelected(id)						{ resultsJsInterface.analysisSelected(id)                       }
+					function analysisChangedDownstream(id, model)		{ resultsJsInterface.analysisChangedDownstream(id, model)       }
+					function welcomeScreenIsCleared(callDelayedLoad)	{ resultsJsInterface.welcomeScreenIsCleared(callDelayedLoad)    }
+					function analysisTitleChangedFromResults(id, title)	{ resultsJsInterface.analysisTitleChangedFromResults(id, title) }
 
 
 					function showAnalysesMenu(options)

--- a/JASP-Desktop/html/js/analysis.js
+++ b/JASP-Desktop/html/js/analysis.js
@@ -578,7 +578,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 	editTitleClicked: function () {
 		var id = this.model.get("id");
-		this.toolbar.startEdit(function(title) { console.log("CALLBACK!"); jasp.analysisTitleChanged(id, title); } );
+		this.toolbar.startEdit(function(title) { console.log("CALLBACK!"); jasp.analysisTitleChangedFromResults(id, title); } );
 	},
 
 	createChild: function (result, status, metaEntry) {

--- a/JASP-Desktop/html/js/jaspwidgets.js
+++ b/JASP-Desktop/html/js/jaspwidgets.js
@@ -901,7 +901,7 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 
 		element.off("paste");
 
-		if (saveTitle)	this.title = element.text();
+		if (saveTitle)	this.setTitle(element.text());
 		else			element.html(this.title);
 
 		this._editEnding = false;
@@ -911,6 +911,10 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 			this["callback"](this.title);
 			this["callback"] = null;
 		}
+	},
+	
+	setTitle: function(title) {
+		this.title = title;
 	},
 
 	_looseFocus: function () {

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -76,6 +76,14 @@ $(document).ready(function () {
 		}
 	}
 
+	window.changeTitle = function(id, title) {
+		var selectedAnalysis = analyses.getAnalysis(id);
+		if (selectedAnalysis !== undefined) {
+			selectedAnalysis.toolbar.setTitle(title);
+			selectedAnalysis.toolbar.render();
+		}
+	}
+
 	window.setAppVersion = function (version) {
 		$(".app-version").text("Version " + version);
 	}

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -229,8 +229,8 @@ void MainWindow::makeConnections()
 	connect(_resultsJsInterface,	&ResultsJsInterface::removeAnalysisRequest,			_analyses,				&Analyses::removeAnalysisById								);
 	connect(_resultsJsInterface,	&ResultsJsInterface::analysisSelected,				_analyses,				&Analyses::analysisIdSelectedInResults						);
 	connect(_resultsJsInterface,	&ResultsJsInterface::analysisUnselected,			_analyses,				&Analyses::analysesUnselectedInResults						);
-	connect(_resultsJsInterface,	&ResultsJsInterface::analysisTitleChanged,			_analyses,				&Analyses::analysisTitleChanged								);
-	connect(_resultsJsInterface,	&ResultsJsInterface::openFileTab,					_fileMenu,				&FileMenu::showFileOpenMenu										);
+	connect(_resultsJsInterface,	&ResultsJsInterface::analysisTitleChangedFromResults,_analyses,				&Analyses::analysisTitleChangedFromResults					);
+	connect(_resultsJsInterface,	&ResultsJsInterface::openFileTab,					_fileMenu,				&FileMenu::showFileOpenMenu									);
 	connect(_resultsJsInterface,	&ResultsJsInterface::refreshAllAnalyses,			this,					&MainWindow::refreshKeyPressed								);
 	connect(_resultsJsInterface,	&ResultsJsInterface::removeAllAnalyses,				this,					&MainWindow::removeAllAnalyses								);
 	connect(_resultsJsInterface,	&ResultsJsInterface::welcomeScreenIsCleared,		this,					&MainWindow::welcomeScreenIsCleared							);
@@ -241,6 +241,7 @@ void MainWindow::makeConnections()
 	connect(_analyses,				&Analyses::emptyQMLCache,							this,					&MainWindow::resetQmlCache									);
 	connect(_analyses,				&Analyses::analysisAdded,							this,					&MainWindow::analysisAdded									);
 	connect(_analyses,				&Analyses::analysisAdded,							_fileMenu,				&FileMenu::analysisAdded									);
+	connect(_analyses,              &Analyses::analysisTitleChanged,                    _resultsJsInterface,    &ResultsJsInterface::changeTitle							);
 	connect(_analyses,				&Analyses::showAnalysisInResults,					_resultsJsInterface,	&ResultsJsInterface::showAnalysis							);
 	connect(_analyses,				&Analyses::unselectAnalysisInResults,				_resultsJsInterface,	&ResultsJsInterface::unselect								);
 	connect(_analyses,				&Analyses::analysisImageEdited,						_resultsJsInterface,	&ResultsJsInterface::analysisImageEditedHandler				);

--- a/JASP-Desktop/utilities/resultsjsinterface.cpp
+++ b/JASP-Desktop/utilities/resultsjsinterface.cpp
@@ -205,6 +205,14 @@ void ResultsJsInterface::displayMessageFromResults(QString msg)
 	MessageForwarder::showWarning("Results Warning", msg);
 }
 
+void ResultsJsInterface::changeTitle(Analysis *analysis)
+{
+    int id = analysis->id();
+    QString title = analysis->titleQ();
+
+    emit runJavaScript("window.changeTitle(" + QString::number(id) + ", '" + title + "')");
+}
+
 void ResultsJsInterface::showAnalysis(int id)
 {
 	emit runJavaScript("window.select(" % QString::number(id) % ")");

--- a/JASP-Desktop/utilities/resultsjsinterface.h
+++ b/JASP-Desktop/utilities/resultsjsinterface.h
@@ -39,6 +39,7 @@ public:
 	explicit ResultsJsInterface(QObject *parent = 0);
 
 
+	void changeTitle(Analysis *analyses);
 	void showAnalysis(int id);
 	void analysisChanged(Analysis *analysis);
 	void setResultsMeta(QString str);
@@ -68,7 +69,7 @@ signals:
 	Q_INVOKABLE void analysisSaveImage(int id, QString options);
 	Q_INVOKABLE void analysisEditImage(int id, QString options);
 	Q_INVOKABLE void analysisSelected(int id);
-	Q_INVOKABLE void analysisTitleChanged(int id, QString title);
+	Q_INVOKABLE void analysisTitleChangedFromResults(int id, QString title);
 	Q_INVOKABLE void removeAnalysisRequest(int id);
 	Q_INVOKABLE void packageModified();
 	Q_INVOKABLE void refreshAllAnalyses();


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#107

For the time being I changed the analysis name fallback (after providing `""` to the title) to be the last correct title, but the default title thing still needs to be implemented. I suppose we'd need a `defaultTitle` field in `analyses.json` stored in the JASP file?