### PR TITLE
Bayesian Linear Regression - matched models

### DIFF
--- a/JASP-Engine/JASP/R/commonAnovaBayesian.R
+++ b/JASP-Engine/JASP/R/commonAnovaBayesian.R
@@ -440,12 +440,12 @@
     
     # get all higher order interactions of which this effect is a component
     # e.g., V1 is a component of V1:V2
-    idx1 <- which(interactions.matrix[effect, ])
+    idx1 <- interactions.matrix[effect, ]
     
     # get all models that exclude the predictor, but that always include the lower order main effects
     # e.g., V1:V2 is compared against models that always include V1 and V2
-    idx2 <- which(interactions.matrix[, effect]) # if effect is V1:V2, idx3 contains c(V1, V2)
-    
+    idx2 <- interactions.matrix[, effect] # if effect is V1:V2, idx2 contains c(V1, V2)
+
     # idx3 is FALSE if a model contains higher order interactions of effect, TRUE otherwise
     idx3 <- !matrixStats::rowAnys(effects.matrix[, idx1, drop = FALSE])
     

--- a/JASP-Engine/JASP/R/commonAnovaBayesian.R
+++ b/JASP-Engine/JASP/R/commonAnovaBayesian.R
@@ -405,6 +405,10 @@
     priorInclProb <- tmp[["priorInclProb"]]
     postInclProb  <- tmp[["postInclProb"]]
     bfIncl        <- tmp[["bfIncl"]]
+    
+    # show BFinclusion for nuisance predictors as 1, rather than NaN
+    priorInclIs1 <- is.nan(bfIncl) & abs(1 - priorInclProb) <= sqrt(.Machine$double.eps)
+    bfIncl[priorInclIs1] <- 1
 
   }
   

--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -826,10 +826,10 @@ RegressionLinearBayesian <- function (
       
       priorModelProbs <- bas_obj$priorprobs
       postModelProbs  <- bas_obj$postprobs
-      terms <- attr(bas_obj$terms, "factors")[-1, ]
+      terms <- attr(bas_obj$terms, "factors")[-1, , drop = FALSE]
       rownames(terms) <- .unvf(rownames(terms))
       colnames(terms) <- .unvf(colnames(terms))
-      inclMat <- BAS:::list2matrix.which(bas_obj)[, -1]
+      inclMat <- BAS:::list2matrix.which(bas_obj)[, -1, drop = FALSE]
       terms <- rbind(terms, matrix(FALSE, nrow = ncol(terms) - nrow(terms), ncol = ncol(terms)))
       diag(terms) <- FALSE
       storage.mode(terms) <- "logical"

--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -836,13 +836,16 @@ RegressionLinearBayesian <- function (
       storage.mode(inclMat) <- "logical"
       rownames(terms) <- colnames(terms)
       effectNames <- colnames(terms)
-      
+
       tmp <- .BANOVAcomputMatchedInclusion(
         effectNames, inclMat, terms, priorModelProbs, postModelProbs
       )
       probne0     <- c(1 ,tmp[["postInclProb"]])
       priorProbs  <- c(1, tmp[["priorInclProb"]])
       BFinclusion <- c(1, tmp[["bfIncl"]])
+      # show BFinclusion for nuisance predictors as 1, rather than NaN
+      priorInclIs1 <- is.nan(BFinclusion) & abs(1 - priorProbs) <= sqrt(.Machine$double.eps)
+      BFinclusion[priorInclIs1] <- 1
       
     }
     

--- a/Resources/Regression/qml/RegressionLinearBayesian.qml
+++ b/Resources/Regression/qml/RegressionLinearBayesian.qml
@@ -39,7 +39,14 @@ Form {
 		title: qsTr("Output")
 		columns: 2
 
-		CheckBox{ name: "postSummaryTable"; label: qsTr("Posterior summary"); id: postSummaryTable }
+		CheckBox{ name: "postSummaryTable"; label: qsTr("Posterior summary"); id: postSummaryTable
+            RadioButtonGroup
+            {
+                name: "effectsType"
+                RadioButton { value: "allModels";		label: qsTr("Across all models");   checked: true	}
+                RadioButton { value: "matchedModels";	label: qsTr("Across matched models")				}
+            }
+        }
 
 		DropDown
 		{


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/151

- Adds a function to compute inclusion probabilities for matched models from the code in `commonAnovaBayesian.R`, called `.BANOVAcomputMatchedInclusion`. 
- Added option to select matched models in Bayesian linear regression.

The changes are minimal and could also easily be added to https://github.com/jasp-stats/jasp-desktop/pull/3028.

Note: for some reason the analysis used tabs and not spaces, add `?w=1` to the url to remove whitespace changes.

