### PR TITLE
Bayesian RM ANOVA: input field

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/RepeatedMeasuresFactorsList.qml
+++ b/JASP-Desktop/components/JASP/Controls/RepeatedMeasuresFactorsList.qml
@@ -63,10 +63,26 @@ JASPControl
 		border.width:	1
 		border.color:	Theme.borderColor
 
+		JASPScrollBar
+		{
+			id:				scrollBar
+			flickable:		listView
+			manualAnchor:	true
+			vertical:		true
+
+			anchors
+			{
+				top:		parent.top
+				right:		parent.right
+				bottom:		parent.bottom
+			}
+		}
+
+
 		GridView
 		{
 			id:					listView
-			cellHeight:			23 * preferencesModel.uiScale
+			cellHeight:			22 * preferencesModel.uiScale
 			cellWidth:			width
 			clip:				true
 
@@ -85,7 +101,7 @@ JASPControl
 		{
 			id:		itemWrapper
 			height: listView.cellHeight
-			width:	listView.cellWidth
+			width:	scrollBar.visible ?  listView.cellWidth - scrollBar.width : listView.cellWidth
 
 			Rectangle
 			{
@@ -105,7 +121,7 @@ JASPControl
 					value:							itemRectangle.isVirtual ? "" : model.name
 					placeholderText:				itemRectangle.isVirtual ? model.name : ""
 					anchors.verticalCenter:			parent.verticalCenter
-					fieldWidth:						parent.width - (6 * preferencesModel.uiScale)
+					fieldWidth:						parent.width
 					useExternalBorder:				false
 					control.horizontalAlignment:	itemRectangle.isLevel ? TextInput.AlignLeft : TextInput.AlignHCenter
 					onEditingFinished:				itemChanged(index, value)

--- a/JASP-Desktop/widgets/listmodelrepeatedmeasuresfactors.cpp
+++ b/JASP-Desktop/widgets/listmodelrepeatedmeasuresfactors.cpp
@@ -142,6 +142,16 @@ const Terms &ListModelRepeatedMeasuresFactors::getLevels() const
 	return _allLevelsCombinations;
 }
 
+void ListModelRepeatedMeasuresFactors::updateLatestLevelIndex(int currentindex)
+{
+	int index, lastlevel, countlevels = 0;
+	for (index=currentindex ;  _factors[index].isLevel && index<_factors.size(); index++) countlevels ++;
+	lastlevel=index-1;
+	for (index=currentindex ;  _factors[index].isLevel && index>0; index--) countlevels ++;
+	_factors[lastlevel].value=tq("Level %1").arg(countlevels-1);
+}
+
+
 void ListModelRepeatedMeasuresFactors::_setAllLevelsCombinations()
 {
 	vector<vector<string> > allLevelsCombinations;
@@ -213,7 +223,7 @@ void ListModelRepeatedMeasuresFactors::itemChanged(int row, QVariant value)
 			if (factor.index > 2 && !factor.isVirtual)
 			{
 				setValue = false;
-				_factors.removeAt(row);
+				_factors.removeAt(row);				
 			}
 			else
 				val = tq("Level %1").arg(factor.index);
@@ -263,6 +273,7 @@ void ListModelRepeatedMeasuresFactors::itemChanged(int row, QVariant value)
 			{
 				Factor newLevel(tq("Level ") + QString::number(factor.index + 1), true, true, factor.index + 1, factor.headFactor);
 				_factors.insert(row + 1, newLevel);
+				updateLatestLevelIndex(row);
 			}
 			else
 			{
@@ -271,7 +282,7 @@ void ListModelRepeatedMeasuresFactors::itemChanged(int row, QVariant value)
 				_factors.push_back(newLevel1);
 				Factor newLevel2(tq("Level 2"), false, true, 2, &factor);
 				_factors.push_back(newLevel2);
-				Factor newVirtualLevel(tq("Level"), true, true, 3, &factor);
+				Factor newVirtualLevel(tq("Level 3"), true, true, 3, &factor);
 				_factors.push_back(newVirtualLevel);
 				Factor newVirtualFactor(tq("Factor ") + QString::number(factor.index + 1), true, false, factor.index + 1);
 				_factors.push_back(newVirtualFactor);
@@ -306,6 +317,7 @@ void ListModelRepeatedMeasuresFactors::itemRemoved(int row)
 		{
 			if (factor.index > 2)
 				_factors.removeAt(row);
+			updateLatestLevelIndex(row-1);
 		}
 		else
 		{

--- a/JASP-Desktop/widgets/listmodelrepeatedmeasuresfactors.h
+++ b/JASP-Desktop/widgets/listmodelrepeatedmeasuresfactors.h
@@ -34,6 +34,9 @@ public:
 	void initFactors(const std::vector<std::pair<std::string, std::vector<std::string> > > &factors);
 	std::vector<std::pair<std::string, std::vector<std::string> > > getFactors() const;
 	const Terms& getLevels() const;
+
+private:
+	void updateLatestLevelIndex(int startindex);
 	
 public slots:
 	void itemChanged(int row, QVariant value);


### PR DESCRIPTION
The 'Repeated Measures Factors' input field shows values partially.
Size is slightly changed to avoid and a scroll bar is added.
Moreover values of the default Levels strings are improved.

Solves https://github.com/jasp-stats/jasp-test-release/issues/134

