### PR TITLE
Fix webengineview resizing problem

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -152,7 +152,10 @@ Item
 
 			onWidthChanged:
 			{
-				resizeTimer.resizer(giveResultsSomeSpace.width);
+				// removed the timer as it isn't necessary any longer after a fix to the dataview (see df7a6eb29a66cc9b201818bf0f6bc86ba8e747ca)
+				// the timer creates a lag in resizing which isn't very nice, we should only activate this if we have hard data that we should
+				//resizeTimer.resizer(giveResultsSomeSpace.width);
+				
 				//data.wasMaximized = data.width === data.maxWidth;
 			}
 
@@ -168,7 +171,7 @@ Item
 					bottom:				parent.bottom
 				}
 
-				width: resizeTimer.currentWidth - panelSplit.hackySplitHandlerHideWidth
+				width: giveResultsSomeSpace.width - panelSplit.hackySplitHandlerHideWidth
 
 				Timer
 				{

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -1033,9 +1033,15 @@ void MainWindow::resultsPageLoaded()
 
 	if (_openOnLoadFilename != "")
 	{
-		_fileMenu->open(_openOnLoadFilename);
-		_openOnLoadFilename = "";
+		// this timer solves a resizing issue with the webengineview (https://github.com/jasp-stats/jasp-test-release/issues/70)
+        QTimer::singleShot(500, this, &MainWindow::_openFile);
 	}
+}
+
+void MainWindow::_openFile()
+{
+    _fileMenu->open(_openOnLoadFilename);
+    _openOnLoadFilename = "";
 }
 
 

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -159,6 +159,8 @@ private:
 	void pauseEngines();
 	void resumeEngines();
 
+    void _openFile();
+
 signals:
 	void saveJaspFile();
 	void imageBackgroundChanged(QString value);


### PR DESCRIPTION
Or more of a remedy, really. The cause of the resizing issue is still unknown.

@AlexanderLyNL and @quentingronau you both encountered this bug, so it would be awesome if you could verify the solution. It should be in the next nightly.

Fixes jasp-stats/jasp-test-release#70