### PR TITLE
Preference changes, zoom notifier

### DIFF
--- a/JASP-Desktop/components/JASP/Theme/Theme.qml
+++ b/JASP-Desktop/components/JASP/Theme/Theme.qml
@@ -137,6 +137,12 @@ QtObject {
 	fontGroupTitle.pixelSize:	14 * uiScale
 	fontGroupTitle.family:		"SansSerif"
 
+	property font fontPrefOptionsGroupTitle
+	fontPrefOptionsGroupTitle.bold:			true
+	fontPrefOptionsGroupTitle.underline:	false
+	fontPrefOptionsGroupTitle.pixelSize:	13 * uiScale
+	fontPrefOptionsGroupTitle.family:		"SansSerif"
+
 	property font fontLabel
 	fontLabel.bold:			true
 	fontLabel.underline:	false

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -1,16 +1,14 @@
 import QtQuick			2.11
 import QtQuick.Controls 2.4
-import QtQuick.Layouts	1.3
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
 import JASP.Controls	1.0
-import JASP				1.0
 
 ScrollView
 {
 	id:						scrollPrefs
 	focus:					true
-	onActiveFocusChanged:	if(activeFocus) useDefaultPPICheckbox.forceActiveFocus();
+	onActiveFocusChanged:	if(activeFocus) uiScaleSpinBox.forceActiveFocus();
 	Keys.onLeftPressed:		resourceMenu.forceActiveFocus();
 
 	Column
@@ -31,83 +29,19 @@ ScrollView
 
 		PrefsGroupRect
 		{
-			title:				qsTr("Plot options")
-
-			CheckBox
-			{
-				id:					useDefaultPPICheckbox
-				label:				"Use PPI of screen in plots: " + preferencesModel.defaultPPI
-				checked:			preferencesModel.useDefaultPPI
-				onCheckedChanged:	preferencesModel.useDefaultPPI = checked
-				height:				implicitHeight * preferencesModel.uiScale
-				toolTip:			qsTr("Use the Pixels per Inch of your screen to render your plots")
-				focus:				true
-				KeyNavigation.tab:	customPPISpinBox
-				KeyNavigation.down:	customPPISpinBox
-			}
-
-			SpinBox
-			{
-				id:						customPPISpinBox
-				value:					preferencesModel.customPPI
-				onValueChanged:			preferencesModel.customPPI = value
-				from:					16
-				to:						2000
-				stepSize:				16
-
-				KeyNavigation.tab:		whiteBackgroundButton
-				KeyNavigation.down:		whiteBackgroundButton
-				text:					qsTr("Custom PPI: ")
-				enabled:				!preferencesModel.useDefaultPPI
-
-				x:						Theme.subOptionOffset
-			}
-
-
-
-			RadioButtonGroup
-			{
-				title:					qsTr("Image Background Color")
-
-				RadioButton
-				{
-					id:					whiteBackgroundButton
-					text:				qsTr("White")
-					checked:			preferencesModel.whiteBackground
-					onCheckedChanged:	preferencesModel.whiteBackground = checked
-					toolTip:			qsTr("This makes the background of all plots white, quite useful if you want to use it in LaTeX or submit it to a journal.")
-					KeyNavigation.tab:	transparentBackgroundButton
-					KeyNavigation.down:	transparentBackgroundButton
-				}
-
-				RadioButton
-				{
-					id:					transparentBackgroundButton
-					text:				qsTr("Transparent")
-					checked:			!preferencesModel.whiteBackground
-					onCheckedChanged:	preferencesModel.whiteBackground = !checked
-					toolTip:			qsTr("This makes the background of all plots transparent, quite useful if you want to use it seamlessly on any background that isn't white.")
-					KeyNavigation.tab:	uiScaleSpinBox
-					KeyNavigation.down:	uiScaleSpinBox
-				}
-			}
-		}
-
-		PrefsGroupRect
-		{
 			title:						qsTr("User interface options")
 
 			SpinBox
 			{
 				id:						uiScaleSpinBox
-				value:					preferencesModel.uiScale
-				onValueChanged:			if(value !== "") preferencesModel.uiScale = value
-				from:					0.01
-				to:						3
-				stepSize:				0.1
-				decimals:				2
-				text:					qsTr("Scaling: ")
-				toolTip:				qsTr("How big do you want the interface elements (text, buttons etc) to be?")
+				value:					Math.round(preferencesModel.uiScale * 100)
+				onEditingFinished:		preferencesModel.uiScale = value / 100
+				from:					20
+				to:						300
+				stepSize:				10
+				decimals:				0
+				text:					qsTr("Zoom (%): ")
+				toolTip:				qsTr("Increase or decrease the size of the interface elements (text, buttons, etc).")
 
 				KeyNavigation.tab:		uiMaxFlickVelocity
 				KeyNavigation.down:		uiMaxFlickVelocity
@@ -124,8 +58,8 @@ ScrollView
 				to:						3000
 				stepSize:				100
 				decimals:				0
-				text:					qsTr("Max Flick Velocity (pix/s): ")
-				toolTip:				qsTr("Flick velocity is how fast the scrolling can get in the options, dataviewer and other places.")
+				text:					qsTr("Scroll speed (pix/s): ")
+				toolTip:				qsTr("Set the speed with which you can scroll in the options, dataviewer and other places.")
 				widthLabel:				uiScaleSpinBox.widthLabel
 
 				KeyNavigation.tab:		developerMode
@@ -143,7 +77,7 @@ ScrollView
 				label:				qsTr("Developer mode (Beta version)")
 				checked:			preferencesModel.developerMode
 				onCheckedChanged:	preferencesModel.developerMode = checked
-				toolTip:			qsTr("To use JASP Modules enable this option")
+				toolTip:			qsTr("To use JASP Modules enable this option.")
 				KeyNavigation.tab:	browseDeveloperFolderButton
 				KeyNavigation.down:	browseDeveloperFolderButton
 			}
@@ -162,7 +96,7 @@ ScrollView
 					onClicked:			preferencesModel.browseDeveloperFolder()
 					anchors.left:		parent.left
 					anchors.leftMargin: Theme.subOptionOffset
-					toolTip:			qsTr("Browse to your JASP Module folder")
+					toolTip:			qsTr("Browse to your JASP Module folder.")
 					KeyNavigation.tab:	developerFolderText
 					KeyNavigation.down:	developerFolderText
 				}
@@ -289,8 +223,8 @@ ScrollView
 						margins:	Theme.generalAnchorMargin
 						left:		maxLogFilesSpinBox.right
 					}
-					KeyNavigation.tab:	useDefaultPPICheckbox
-					KeyNavigation.down:	useDefaultPPICheckbox
+					KeyNavigation.tab:	uiScaleSpinBox
+					KeyNavigation.down:	uiScaleSpinBox
 				}
 			}
 		}

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsGroupRect.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsGroupRect.qml
@@ -27,7 +27,7 @@ Rectangle
 	Text
 	{
 		id:					titleText
-		font:				Theme.fontGroupTitle
+		font:				Theme.fontPrefOptionsGroupTitle
 		anchors.margins:	text !== "" ? Theme.generalAnchorMargin : 0
 		anchors.top:		parent.top
 		anchors.left:		parent.left

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
@@ -4,34 +4,30 @@ import JASP.Widgets		1.0
 import JASP.Theme		1.0
 import JASP.Controls	1.0
 
-FocusScope
+ScrollView
 {
+	id:						scrollPrefs
 	focus:					true
 	onActiveFocusChanged:	if(activeFocus) displayExactPVals.forceActiveFocus();
+	Keys.onLeftPressed:		resourceMenu.forceActiveFocus();
 
-	MenuHeader
+	Column
 	{
-		id:			menuHeader
-		headertext:	"Results Preferences"
-		helpfile:	"preferences/prefsresults"
-	}
+		width:			scrollPrefs.width
+		spacing:		Theme.rowSpacing
 
-	ScrollView
-	{
-		id:					scrollPrefs
-		anchors.top:		menuHeader.bottom
-		anchors.left:		menuHeader.left
-		anchors.right:		menuHeader.right
-		anchors.bottom:		menuHeader.bottom
-		anchors.topMargin:	Theme.generalMenuMargin
-		focus:				true
-		Keys.onLeftPressed: resourceMenu.forceActiveFocus();
-		focusPolicy:		Qt.WheelFocus
+		MenuHeader
+		{
+			id:				menuHeader
+			headertext:		"Results Preferences"
+			helpfile:		"preferences/prefsresults"
+			anchorMe:		false
+			width:			scrollPrefs.width
+		}
 
 		PrefsGroupRect
 		{
-			spacing:		Theme.rowSpacing
-			implicitWidth:	scrollPrefs.width - (Theme.generalAnchorMargin * 2)
+			title:			qsTr("Table options")
 
 			CheckBox
 			{
@@ -40,7 +36,6 @@ FocusScope
 				checked:				preferencesModel.exactPValues
 				onCheckedChanged:		preferencesModel.exactPValues = checked
 				KeyNavigation.tab:		fixDecs
-				KeyNavigation.backtab:	numDecs
 				KeyNavigation.down:		fixDecs
 			}
 
@@ -56,7 +51,6 @@ FocusScope
 					checked:				preferencesModel.fixedDecimals
 					onCheckedChanged:		preferencesModel.fixedDecimals = checked
 					KeyNavigation.tab:		numDecs
-					KeyNavigation.backtab:	displayExactPVals
 					KeyNavigation.down:		numDecs
 				}
 
@@ -67,15 +61,76 @@ FocusScope
 					onValueChanged:			preferencesModel.numDecimals = value
 					visible:				preferencesModel.fixedDecimals
 
-					KeyNavigation.tab:		displayExactPVals
-					KeyNavigation.backtab:	fixDecs
-					KeyNavigation.down:		displayExactPVals
+					KeyNavigation.tab:		useDefaultPPICheckbox
+					KeyNavigation.down:		useDefaultPPICheckbox
 					anchors
 					{
 						left:				fixDecs.right
 						leftMargin:			Theme.generalAnchorMargin
 						verticalCenter:		parent.verticalCenter
 					}
+				}
+			}
+		}
+		
+		PrefsGroupRect
+		{
+			title:				qsTr("Plot options")
+
+			CheckBox
+			{
+				id:					useDefaultPPICheckbox
+				label:				"Use PPI of screen in plots: " + preferencesModel.defaultPPI
+				checked:			preferencesModel.useDefaultPPI
+				onCheckedChanged:	preferencesModel.useDefaultPPI = checked
+				height:				implicitHeight * preferencesModel.uiScale
+				toolTip:			qsTr("Use the Pixels Per Inch of your screen to render your plots.")
+				focus:				true
+				KeyNavigation.tab:	customPPISpinBox
+				KeyNavigation.down:	customPPISpinBox
+			}
+
+			SpinBox
+			{
+				id:						customPPISpinBox
+				value:					preferencesModel.customPPI
+				onValueChanged:			preferencesModel.customPPI = value
+				from:					16
+				to:						2000
+				stepSize:				16
+
+				KeyNavigation.tab:		whiteBackgroundButton
+				KeyNavigation.down:		whiteBackgroundButton
+				text:					qsTr("Custom PPI: ")
+				enabled:				!preferencesModel.useDefaultPPI
+
+				x:						Theme.subOptionOffset
+			}
+
+			RadioButtonGroup
+			{
+				title:					qsTr("Image background color")
+
+				RadioButton
+				{
+					id:					whiteBackgroundButton
+					text:				qsTr("White")
+					checked:			preferencesModel.whiteBackground
+					onCheckedChanged:	preferencesModel.whiteBackground = checked
+					toolTip:			qsTr("This makes the background of all plots white, quite useful if you want to use it in LaTeX or submit it to a journal.")
+					KeyNavigation.tab:	transparentBackgroundButton
+					KeyNavigation.down:	transparentBackgroundButton
+				}
+
+				RadioButton
+				{
+					id:					transparentBackgroundButton
+					text:				qsTr("Transparent")
+					checked:			!preferencesModel.whiteBackground
+					onCheckedChanged:	preferencesModel.whiteBackground = !checked
+					toolTip:			qsTr("This makes the background of all plots transparent, quite useful if you want to use it seamlessly on any background that isn't white.")
+					KeyNavigation.tab:	displayExactPVals
+					KeyNavigation.down:	displayExactPVals
 				}
 			}
 		}

--- a/JASP-Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainWindow.qml
@@ -201,4 +201,72 @@ Window
 
 		}*/
 	}
+	
+	Item
+	{
+		id:					uiScaleNotifier
+		visible:			uiScaleRect.opacity !== 0
+		width:				100 * preferencesModel.uiScale
+		height:				50 * preferencesModel.uiScale
+		anchors.centerIn:	parent
+				 
+		property double	uiScale: preferencesModel.uiScale
+		
+		property bool	uiScaleIsLoadedFromSettings: false
+		
+		onUiScaleChanged: 
+		{ 
+			if (uiScaleIsLoadedFromSettings)
+			{
+				uiScaleRect.opacity = 0.8
+				uiScaleTimer.restart()
+			}
+			else 
+			{
+				uiScaleIsLoadedFromSettings = true
+			}
+		}
+		
+		Rectangle 
+		{
+			id:					uiScaleRect
+			width:				parent.width
+			height:				parent.height
+			radius:				20
+			color:				Theme.grayDarker
+			opacity:			0
+			z:					100
+			anchors.centerIn:	parent
+			
+			Timer
+			{
+				id:				uiScaleTimer
+				running:		false
+				repeat:			false
+				interval:		750
+				onTriggered:	uiScaleRect.opacity = 0
+			}
+			
+			Behavior on opacity
+			{
+				PropertyAnimation
+				{
+					duration: 50
+				}
+			}
+			
+			Text
+			{
+				color:				Theme.white
+				font:				Theme.fontLabel
+				anchors.centerIn:	parent
+				
+				text: Math.round(uiScaleNotifier.uiScale * 100) + "%"
+			}
+			
+		}
+			
+
+	}
+
 }

--- a/JASP-Desktop/components/JASP/Widgets/SpinBox.qml
+++ b/JASP-Desktop/components/JASP/Widgets/SpinBox.qml
@@ -51,12 +51,17 @@ FocusScope
 					Keys.onReturnPressed:	valueField.focus = !valueField.focus;
 					Keys.onEscapePressed:	focus = false;
 
+	signal editingFinished()
+	
+	Component.onCompleted: valueField.onEditingFinished.connect(editingFinished);        
+	
 	function setValue(val)
 	{
 		var pow				= Math.pow(10, decimals);
 		val					= Math.round(val * pow) / pow;
 		val					= Math.min(root.max, Math.max(root.min, val));
 		valueField.text		= String(val);
+		editingFinished()
 		//valueField.focus	= false;
 	}
 
@@ -106,6 +111,7 @@ FocusScope
 		Keys.onEnterPressed:		valueField.processInput()
 		Keys.onEscapePressed:		{ text = root.lastValidValue; focus = false; }
 		onTextChanged:				if(acceptableInput) root.lastValidValue = text
+		selectByMouse:				true
 
 		function processInput()
 		{

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -423,7 +423,7 @@ $(document).ready(function () {
 
 		var target = event.target || event.srcElement;
 
-		if (ignoreSelectionProcess(target) || (selectedAnalysisId !== -1 && wasLastClickNote === true))
+		if (ignoreSelectionProcess(target) || (selectedAnalysisId === -1 && wasLastClickNote === true))
 			return;
 
 		var id = $(event.currentTarget).attr("id")

--- a/Resources/Help/preferences/prefsadvanced.md
+++ b/Resources/Help/preferences/prefsadvanced.md
@@ -5,31 +5,22 @@ Advanced Preferences
 With the advanced parameters in JASP you can specify the following options:
 (All these settings will remain after restarting JASP.)
 
-## Plotting options
-
-### Use PPI (Pixels pre inch) of screen in plots
-
-This is where you specify the number of pixels per inch of the screen
-to render your plots.
-
-### Image Background Colour
-
-The background colour of images in JASP results can be influenced with this option.
-This is especially important when copying and/or pasting plots.
-
-
 ## User interface options
 
-### Scaling
+### Zoom
 
 This number specifies how the JASP interface will be scaled.
 All menus and results are scaled by this factor.
-You can also use the keyboard shortcuts &#8984; with `+`, `-` or `0` (on MacOS) or Ctrl with `+`, `-` or `0` (on Windows & Linux) for
-this purpose. `-` decreases and `+` increases the scale while `0` resets the scaling for you.
+You can also use keyboard shortcuts instead:
 
-### Max Flick Velocity
+- OSX:  &#8984; with `+`, `-` or `0`
+- Windows and Linux: Ctrl with `+`, `-` or `0`
+
+`-` decreases and `+` increases the scale while `0` resets the scaling to its default value.
+
+### Scroll speed
 This speed determines, in pixels per second, what the maximum flick / scroll speed is of certain moving elements in JASP.
-Should you find that scrolling in the options goes to fast, or too slow, for your taste you can change this.
+Should you find that scrolling in the options goes too fast, or too slow, you can change this.
 
 
 ## Modules options
@@ -44,7 +35,12 @@ The checkbox decides if package metadata should be generated every time.
 Disable this option if you are transforming your R-package to a JASP Module
 or simply want to keep manual changes to DESCRIPTION and NAMESPACE.")
 
-### Logging
-You can check the box  "Log to file" and then JASP will start logging to files. You might need to restart JASP to have it fully applied.
-The number in the spinbox "Max logfiles to keep" defines how many logfiles will be kept at maximum to conserve diskspace. Any extra, older, logfiles will be removed.
-These files can be viewed by pressing "Show logs".
+
+## Logging options
+
+### Log to File
+When you check this JASP will start logging many of the actions it performs to logfiles. 
+Logging is especially useful when you are developing your own module, or run into a problem and wish to reach out to the development team.
+The logs might help us give insight in the nature of your problem. Note that you might need to restart JASP for the logging process to start.
+The number in the input field "Max logfiles to keep" defines how many logfiles will be kept at maximum to conserve diskspace. Any extra, older, logfiles will be removed.
+The files can be viewed by pressing "Show logs".

--- a/Resources/Help/preferences/prefsdata.md
+++ b/Resources/Help/preferences/prefsdata.md
@@ -5,31 +5,33 @@ Data Preferences
 Regarding data handling in JASP you can choose the following options:
 (All these settings will remain after restarting JASP.)
 
-### Synchronize automatically on data file save.
+### Synchronize automatically on data file save
 
 If you change a loaded data file in JASP from outside JASP
-(e.g. in your preferred editor see below), this checkbox determines
+(e.g., in your preferred editor, see below), this checkbox determines
 if results in JASP are automatically synchronized or not.
 You can also start the synchronization manually from the main menu
-or using the keyboard shortcuts &#8984; + Y (on MacOS) or Ctrl + Y (on Windows)
+or using keyboard shortcuts:
 
-### Use default spreadsheet editor.
+- OSX: &#8984; with Y
+- Windows and Linux: Ctrl with Y
 
-In JASP you can open the related datafile by double clicking the data pane.
+### Use default spreadsheet editor
+
+In JASP you can open the datafile by double clicking the data pane.
 This opens your data file in your preferred editor which you can specify here
 or the default editor chosen by your operating system.
 
-### Import threshold between Scale or Nominal.
+### Import threshold between Scale or Nominal
 
 Importing data in JASP has a threshold value that determines if a column should be treated
 as a Scale type or as a Nominal type. The default value of this parameter is 10.
 This means the if you have fewer (or equal) than 10 different integers in the data, the column
 gets the Nominal type else it will get the Scale type. Be aware that this value is used when
-importing the data, so data needs to be reloaded (or synchronized) to take effect!
+importing the data, so data needs to be reloaded (or synchronized) to take effect.
 
 ### Missing Value List
 
-In this list you can specify if your data should be treated as missing value or as real data.
-All the values in the 'Missing Value List' are treated as missing values.
+In this list you can specify when observations in your datafile should be treated as missing (e.g., if you coded missing observations to be 999, you can add this value here and JASP will treat all cells with the value 999 as missing).
 You can delete values from this list by selecting them and pressing the minus button.
-Reset will give you all the default values back.
+Clicking on "Reset" will restore all the default values.

--- a/Resources/Help/preferences/prefsresults.md
+++ b/Resources/Help/preferences/prefsresults.md
@@ -1,17 +1,27 @@
 
-Result Preferences
+Results Preferences
 =========
 
-Regarding analyses results in JASP you can choose the following options:
+Regarding analysis results in JASP you can choose the following options:
 (All these settings will remain after restarting JASP.)
+
+## Table options
 
 ### Display exact p-values
 
-This is where you specify to use exact p-values or not.
-This means that the result p-value is sometimes showed in scientific notation
-and sometimes as a rounded value.
+Here you can specify if p-values should be shown as "< .001" or if an exact value should be given.
 
 ### Fix the number of decimals
 
-The represents the number of decimals from a calculated value
-that JASP will show in the results pane.
+This represents the number of decimals JASP will show for numeric values.
+
+
+## Plot options
+
+### Use PPI (Pixels Per Inch) of screen in plots
+
+Here you can specify the number of pixels per inch your plots should have. By default it uses the value derived from your screen. This value can be increased to create higher quality images.
+
+### Image background colour
+
+This option let's you toggle the background colour of plots between white and transparant. You may find this especially useful when copying and/or pasting plots.


### PR DESCRIPTION
- moved the plotting options from advanced to results
- renamed some options
- touched up the helpfiles a little bit
- included a little rectangle that notifies you of the zoom level when you click cmd/ctrl +-
- deselect an analysis when a different analysis' note is clicked (I think it's all pretty consistent now)