### PR TITLE
ReliabilityAnalysis - fix reverse scaled items

### DIFF
--- a/JASP-Engine/JASP/R/reliabilityanalysis.R
+++ b/JASP-Engine/JASP/R/reliabilityanalysis.R
@@ -130,7 +130,7 @@ ReliabilityAnalysis <- function(dataset = NULL, options, perform = "run",
 			key[match(.v(unlist(options[["reverseScaledItems"]])), colnames(dataset))] <- -1
 
 		}
-browser()
+
 		# calculate chronbach alpha, gutmanns lambda6, and average inter item corrrelation
 		relyFit <- .quietDuringUnitTest(psych::alpha(dataList[["covariance"]], 
 		                                             key = .v(unlist(options[["reverseScaledItems"]]))))

--- a/JASP-Engine/JASP/R/reliabilityanalysis.R
+++ b/JASP-Engine/JASP/R/reliabilityanalysis.R
@@ -130,9 +130,10 @@ ReliabilityAnalysis <- function(dataset = NULL, options, perform = "run",
 			key[match(.v(unlist(options[["reverseScaledItems"]])), colnames(dataset))] <- -1
 
 		}
-
+browser()
 		# calculate chronbach alpha, gutmanns lambda6, and average inter item corrrelation
-		relyFit <- .quietDuringUnitTest(psych::alpha(dataList[["covariance"]], key = key))
+		relyFit <- .quietDuringUnitTest(psych::alpha(dataList[["covariance"]], 
+		                                             key = .v(unlist(options[["reverseScaledItems"]]))))
 
 		# because we supply a correlation matrix and not raw data, we have to add these ourselves
 		relyFit[["total"]][["mean"]] <- mean(dataList[["itemMeans"]])

--- a/JASP-Tests/R/tests/testthat/test-reliabilityanalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-reliabilityanalysis.R
@@ -18,9 +18,9 @@ test_that("Main table results match", {
   results <- jasptools::run("ReliabilityAnalysis", "test.csv", options)
   table <- results[["results"]][["reliabilityScale"]][["data"]]
   expect_equal_tables(table,
-    list("scale", 0.535041083185576, 0.558313196445623, 0.667932535083157,
-         0.622700230679449, 0.283327270506343, -0.02217061461, 0.144515070286093,
-         0.351394015923524, 0.673229304903445)
+    list("scale", -0.757822989578577, -0.0677657928415725, 0.667932535083157,
+         0.622700230679449, -0.175972651899464, -0.02217061461, 0.144515070286093,
+         -1.45211881901153, -0.235388804018903)
   )
 })
 
@@ -59,13 +59,11 @@ test_that("Reverse scaled items match", {
   options$meanScale <- TRUE
   options$sdScale <- TRUE
   
-  datapath <- file.path(jasptools:::.pkgOptions$data.dir, "Data Library", "1. Descriptives", "Fear of Statistics.csv")
-  data <- read.table(datapath, header = TRUE)
-  results <- jasptools::run("ReliabilityAnalysis", data, options)
+  results <- jasptools::run("ReliabilityAnalysis", "Fear of Statistics.csv", options)
   table <- results[["results"]][["reliabilityScale"]][["data"]]
   expect_equal_tables(table,
-    list("scale", 0.535041083185576, 0.558313196445623, 0.667932535083157,
-         0.622700230679449, 0.283327270506343, -0.02217061461, 0.144515070286093,
-         0.351394015923524, 0.673229304903445)
+    list("scale", 0.820836210468446, 0.813045844410605, 0.724966918842779,
+         0.708529526625945, 0.368244389782582, 3.08727148969273, 0.393585959365817,
+         0.81017314606981, 0.831119838017159)
   )
 })

--- a/JASP-Tests/R/tests/testthat/test-reliabilityanalysis.R
+++ b/JASP-Tests/R/tests/testthat/test-reliabilityanalysis.R
@@ -45,3 +45,27 @@ test_that("Item Statistics table matches", {
          1.05841360919316)
   )
 })
+
+test_that("Reverse scaled items match", {
+  options <- jasptools::analysisOptions("ReliabilityAnalysis")
+  options$variables <- c("Q01", "Q03", "Q04", "Q05", "Q12", "Q16", "Q20", "Q21")
+  options$reverseScaledItems <- "Q03"
+  options$alphaScale <- TRUE
+  options$averageInterItemCor <- TRUE
+  options$confAlpha <- TRUE
+  options$glbScale <- TRUE
+  options$gutmannScale <- TRUE
+  options$mcDonaldScale <- TRUE
+  options$meanScale <- TRUE
+  options$sdScale <- TRUE
+  
+  datapath <- file.path(jasptools:::.pkgOptions$data.dir, "Data Library", "1. Descriptives", "Fear of Statistics.csv")
+  data <- read.table(datapath, header = TRUE)
+  results <- jasptools::run("ReliabilityAnalysis", data, options)
+  table <- results[["results"]][["reliabilityScale"]][["data"]]
+  expect_equal_tables(table,
+    list("scale", 0.535041083185576, 0.558313196445623, 0.667932535083157,
+         0.622700230679449, 0.283327270506343, -0.02217061461, 0.144515070286093,
+         0.351394015923524, 0.673229304903445)
+  )
+})


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/52

@TimKDJ I added a unit test specifically for the data set where the results changed. I load this data set via 
```r
  datapath <- file.path(jasptools:::.pkgOptions$data.dir, "Data Library", "1. Descriptives", "Fear of Statistics.csv")
  data <- read.table(datapath, header = TRUE)
```
but it looks a bit hacky. Is there a better way? Copying the data set to `github/jasp-desktop/JASP-Tests/R/tests/datasets/` looks a bit weird because then we get copies of data sets.

