### PR TITLE
OSF breadcrumbs fix

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/BreadCrumbs.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/BreadCrumbs.qml
@@ -3,12 +3,33 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.2
 import JASP.Theme 1.0
 import JASP.Widgets 1.0
+import JASP.Controls 1.0
 
 ListView
 {
 	id : listView
 			
 	orientation: ListView.Horizontal
+	property alias scrollBarVisible: scrollBar.visible
+	property alias scrollBarHeight: scrollBar.height
+
+	clip: true
+
+	JASPScrollBar
+	{
+		id:				scrollBar
+		flickable:		listView
+		manualAnchor:	true
+		vertical:		false
+		height:			10 * preferencesModel.uiScale
+
+		anchors
+		{
+			left:			parent.left
+			right:			parent.right
+			bottom:			parent.bottom
+		}
+	}
 
 	signal crumbButtonClicked(int modelIndex)
 
@@ -22,8 +43,7 @@ ListView
 			Item
 			{
 				id :	rectArrow
-				//color:	Theme.grayMuchLighter
-				
+
 				height:		rect.height
 				width:		index > 0 ? height   : 0
 				visible:	index > 0

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/OSF.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/OSF.qml
@@ -67,8 +67,10 @@ Item
 		model	: fileMenuModel.osf.breadCrumbs
 		visible	: loggedin
 
+		anchors.rightMargin: Theme.generalMenuMargin * preferencesModel.uiScale
+
 		width	: rect.width
-		height	: (loggedin ? 40 : 0) * preferencesModel.uiScale
+		height	: loggedin ? (40 * preferencesModel.uiScale) + (scrollBarVisible ? scrollBarHeight : 0) : 0
 
 		anchors.top			: menuHeader.bottom
 		anchors.left		: menuHeader.left


### PR DESCRIPTION
- When  the bereadcrumbs button list  in the osf becomes very tall the latest button exceed the menu window so a clip is added.
- Moreover a Scrollbar is shown when required, because it is not quite intuitive that the breadcrumbs buttons itself can be  scrolled.

