### PR TITLE
Impossible to build JASP on some Qt 5.12.3 environments

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/qmldir
+++ b/JASP-Desktop/components/JASP/Widgets/qmldir
@@ -33,3 +33,6 @@ CustomMenu                  1.0 CustomMenu.qml
 ColumntypeModel             1.0 ColumnTypeModel
 SplitHandle                 1.0 SplitHandle.qml
 SpinBox                     1.0 SpinBox.qml
+WelcomePage                 1.0 WelcomePage.qml
+UIScaleNotifier             1.0 UIScaleNotifier.qml
+ModulesMenu                 1.0 ModulesMenu.qml


### PR DESCRIPTION
After upgrade to Qt 5.12.3 some types could not be found in MainWindow.qml.

