### PR TITLE
Bayesian Contingency Tables has strange focus on startup

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/VariablesList.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesList.qml
@@ -268,7 +268,6 @@ JASPControl
 					if (itemWrapper)
 					{
 						var itemRectangle = itemWrapper.children[0];
-						itemWrapper.forceActiveFocus();
 						listView.clearSelectedItems(false);
 						listView.selectItem(itemRectangle, true);
 						listView.startShiftSelected = listView.currentIndex;


### PR DESCRIPTION
In the Bayesian Contingency Tables Test the 'Layers' window gets the focus for unclear reason.

Solves https://github.com/jasp-stats/jasp-test-release/issues/90

