### PR TITLE
Initialization of ANOVA forms

### DIFF
--- a/JASP-Desktop/widgets/listmodelavailableinterface.cpp
+++ b/JASP-Desktop/widgets/listmodelavailableinterface.cpp
@@ -44,7 +44,6 @@ void ListModelAvailableInterface::sourceTermsChanged(Terms* termsAdded, Terms* t
 	Q_UNUSED(termsRemoved);
 	
 	resetTermsFromSourceModels();
-	emit allAvailableTermsChanged(&_tempAddedTerms, &_tempRemovedTerms);
 }
 
 
@@ -85,11 +84,4 @@ void ListModelAvailableInterface::removeTermsInAssignedList()
 	
 	endResetModel();
 }
-
-void ListModelAvailableInterface::emitChangedTerms()
-{
-	emit modelChanged(&_tempAddedTerms, &_tempRemovedTerms);
-}
-
-
 

--- a/JASP-Desktop/widgets/listmodelavailableinterface.h
+++ b/JASP-Desktop/widgets/listmodelavailableinterface.h
@@ -33,9 +33,8 @@ public:
 	
 	virtual const Terms& allTerms() const { return _allTerms; }
 			void initTerms(const Terms &terms) override;
-	virtual void resetTermsFromSourceModels() = 0;
+	virtual void resetTermsFromSourceModels(bool updateAssigned = true) = 0;
 	virtual void removeTermsInAssignedList();
-			void emitChangedTerms();
 	
 			QVariant requestInfo(const Term &term, VariableInfo::InfoType info) const override;	
 

--- a/JASP-Desktop/widgets/listmodelinteractionassigned.cpp
+++ b/JASP-Desktop/widgets/listmodelinteractionassigned.cpp
@@ -86,13 +86,25 @@ void ListModelInteractionAssigned::_addTerms(const Terms& terms, bool combineWit
 	{
 		QString itemType = getItemType(term);
 		if (itemType == "fixedFactors")
-			fixedFactors.add(term);
+		{
+			if (!_fixedFactors.contains(term))
+				fixedFactors.add(term);
+		}
 		else if (itemType == "randomFactors")
-			randomFactors.add(term);
+		{
+			if (!_randomFactors.contains(term))
+				randomFactors.add(term);
+		}
 		else if (itemType == "covariates")
-			covariates.add(term);
+		{
+			if (!_covariates.contains(term))
+				covariates.add(term);
+		}
 		else
-			others.add(term);
+		{
+			if (!_interactionTerms.contains(term))
+				others.add(term);
+		}
 	}
 			
 	if (fixedFactors.size() > 0)

--- a/JASP-Desktop/widgets/listmodelinteractionavailable.cpp
+++ b/JASP-Desktop/widgets/listmodelinteractionavailable.cpp
@@ -26,7 +26,7 @@ ListModelInteractionAvailable::ListModelInteractionAvailable(QMLListView* listVi
 	_areTermsInteractions = true;
 }
 
-void ListModelInteractionAvailable::resetTermsFromSourceModels()
+void ListModelInteractionAvailable::resetTermsFromSourceModels(bool updateAssigned)
 {
 	const QList<QMLListView::SourceType*>& sourceItems = listView()->sourceModels();
 	if (sourceItems.size() == 0)
@@ -79,5 +79,9 @@ void ListModelInteractionAvailable::resetTermsFromSourceModels()
 	removeTermsInAssignedList();
 	
 	endResetModel();
+
+	if (updateAssigned)
+		emit allAvailableTermsChanged(&_tempAddedTerms, &_tempRemovedTerms);
+
 }
 

--- a/JASP-Desktop/widgets/listmodelinteractionavailable.h
+++ b/JASP-Desktop/widgets/listmodelinteractionavailable.h
@@ -29,7 +29,7 @@ class ListModelInteractionAvailable : public ListModelAvailableInterface, public
 public:
 	ListModelInteractionAvailable(QMLListView* listView);
 	
-	void resetTermsFromSourceModels() override;
+	void resetTermsFromSourceModels(bool updateAssigned = true) override;
 };
 
 #endif // LISTMODELINTERACTIONAVAILABLE_H

--- a/JASP-Desktop/widgets/listmodeltermsavailable.cpp
+++ b/JASP-Desktop/widgets/listmodeltermsavailable.cpp
@@ -61,7 +61,7 @@ void ListModelTermsAvailable::initTerms(const Terms &terms)
 	endResetModel();
 }
 
-void ListModelTermsAvailable::resetTermsFromSourceModels()
+void ListModelTermsAvailable::resetTermsFromSourceModels(bool updateAssigned)
 {
 	const QList<QMLListView::SourceType*>& sourceItems = listView()->sourceModels();
 	if (sourceItems.size() == 0)
@@ -87,6 +87,9 @@ void ListModelTermsAvailable::resetTermsFromSourceModels()
 	setChangedTerms(termsAvailable);
 	initTerms(termsAvailable);
 	endResetModel();
+
+	if (updateAssigned)
+		emit allAvailableTermsChanged(&_tempAddedTerms, &_tempRemovedTerms);
 }
 
 ListModel *ListModelTermsAvailable::getSourceModelOfTerm(const Term &term)

--- a/JASP-Desktop/widgets/listmodeltermsavailable.h
+++ b/JASP-Desktop/widgets/listmodeltermsavailable.h
@@ -28,8 +28,8 @@ class ListModelTermsAvailable : public ListModelAvailableInterface
 public:
 	ListModelTermsAvailable(QMLListView* listView);
 		
-	void		initTerms(const Terms& terms)		override;
-	void		resetTermsFromSourceModels()		override;
+	void		initTerms(const Terms& terms)							override;
+	void		resetTermsFromSourceModels(bool updateAssigned = true)	override;
 	
 	ListModel*	getSourceModelOfTerm(const Term& term);
 	void		addEmptyValue() { _addEmptyValue = true; }


### PR DESCRIPTION
The model terms should get the default factor when a new analysis is
created, and the right options of the JASP file when a JASP file is
opened.