### PR TITLE
"Recent File" list ends with an extra slash, sometimes

### DIFF
--- a/JASP-Desktop/widgets/filemenu/filemenubasiclistmodel.cpp
+++ b/JASP-Desktop/widgets/filemenu/filemenubasiclistmodel.cpp
@@ -39,10 +39,17 @@ QVariant FileMenuBasicListModel::data(const QModelIndex &index, int role) const
 	case AssociatedDataFileRole:	return QFileInfo(item.associatedDataFile).fileName();
 	case IconSourceRole:			return FileSystemEntry::sourcesIcons()[item.entryType];
 	case DataIconSourceRole:		return FileSystemEntry::sourcesIcons()[FileSystemEntry::CSV];
-	case DirRole:					if (QFileInfo(item.path).path().toLower().startsWith("http:") || QFileInfo(item.path).path().toLower().startsWith("https:"))
-										return QFileInfo (item.path).path();
-									else
-										return QDir::toNativeSeparators(QFileInfo (item.path).path()) + QDir::separator() ;
+	case DirRole:
+	{
+		if (QFileInfo(item.path).path().toLower().startsWith("http:") || QFileInfo(item.path).path().toLower().startsWith("https:"))
+			return QFileInfo (item.path).path();
+		else
+		{
+			QString location = QDir::toNativeSeparators(QFileInfo (item.path).path()) ;
+			while (location.endsWith(QDir::separator())) location.chop(1);
+			return location + QDir::separator();
+		}
+	}
 	case ActionRole:				return _openFileWhenClicked ? "open" : "sync";
 	default:						return QStringLiteral("Me know nothing");
 	}


### PR DESCRIPTION
On windows the recent file list folder sometimes show double back slashes at the end.
Fixes https://github.com/jasp-stats/jasp-test-release/issues/173

