### PR TITLE
Prevent image adjustments if plot object is from an old file

### DIFF
--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -228,6 +228,19 @@ void Analyses::reload(Analysis *analysis)
 		Log::log() << "Analysis " << analysis->title() << " not found!" << std::endl << std::flush;
 }
 
+
+bool Analyses::allCreatedInCurrentVersion() const
+{
+	for (auto idAnalysis : _analysisMap)
+	{
+		Analysis* analysis = idAnalysis.second;
+		if (analysis->version() != AppInfo::version)
+			return false;
+	}
+	
+	return true;
+}
+
 void Analyses::_analysisQMLFileChanged(Analysis *analysis)
 {
 	emit emptyQMLCache();

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -63,6 +63,8 @@ public:
 	Analysis*	get(size_t id) const								{ return _analysisMap.count(id) > 0 ? _analysisMap.at(id) : nullptr;	}
 	void		clear();
 	void		reload(Analysis* analysis);
+	
+	bool		allCreatedInCurrentVersion() const;
 
 	void		setAnalysesUserData(Json::Value userData);
 	void		refreshAnalysesUsingColumns(std::vector<std::string> &changedColumns,	 std::vector<std::string> &missingColumns,	 std::map<std::string, std::string> &changeNameColumns,	 std::vector<std::string> &oldColumnNames);

--- a/JASP-Desktop/engine/enginerepresentation.cpp
+++ b/JASP-Desktop/engine/enginerepresentation.cpp
@@ -484,6 +484,7 @@ void EngineRepresentation::ppiChanged(int newPPI)
 void EngineRepresentation::imageBackgroundChanged(QString value)
 {
 	_imageBackground = value;
+	Log::log() << "image background for engineRep set to: " << _imageBackground.toStdString() << std::endl;
 
 	rerunRunningAnalysis();
 }

--- a/JASP-Desktop/engine/enginesync.cpp
+++ b/JASP-Desktop/engine/enginesync.cpp
@@ -103,7 +103,6 @@ void EngineSync::start(int ppi)
 			connect(_engines[i],	&EngineRepresentation::moduleUnloadingFinished,			this,			&EngineSync::moduleUnloadingFinishedHandler								);
 			connect(_engines[i],	&EngineRepresentation::moduleUninstallingFinished,		this,			&EngineSync::moduleUninstallingFinished									);
 			connect(_engines[i],	&EngineRepresentation::logCfgReplyReceived,				this,			&EngineSync::logCfgReplyReceived										);
-			connect(this,			&EngineSync::ppiChanged,								this,			&EngineSync::refreshAllPlots,					Qt::QueuedConnection	);
 			connect(this,			&EngineSync::ppiChanged,								_engines[i],	&EngineRepresentation::ppiChanged										);
 			connect(this,			&EngineSync::imageBackgroundChanged,					_engines[i],	&EngineRepresentation::imageBackgroundChanged							);
 			connect(_analyses,		&Analyses::analysisRemoved,								_engines[i],	&EngineRepresentation::analysisRemoved									);
@@ -622,7 +621,7 @@ void EngineSync::setModuleWideCastVars(Json::Value newVars)
 	_requestWideCastModuleJson			= newVars;
 }
 
-void EngineSync::refreshAllPlots(int)
+void EngineSync::refreshAllPlots()
 {
 	std::set<Analysis*> inProgress;
 	for(EngineRepresentation * engine : _engines)

--- a/JASP-Desktop/engine/enginesync.h
+++ b/JASP-Desktop/engine/enginesync.h
@@ -53,7 +53,7 @@ public slots:
 	void computeColumn(	const QString & columnName,			const QString & computeCode,	Column::ColumnType columnType);
 	void pause();
 	void resume();
-	void refreshAllPlots(int = 0);
+	void refreshAllPlots();
 	void stopEngines();
 	void logCfgRequest();
 	void logToFileChanged(bool logToFile) { logCfgRequest(); }

--- a/JASP-Desktop/gui/preferencesmodel.cpp
+++ b/JASP-Desktop/gui/preferencesmodel.cpp
@@ -217,7 +217,7 @@ void PreferencesModel::setUseDefaultPPI(bool newUseDefaultPPI)
 	emit useDefaultPPIChanged(newUseDefaultPPI);
 
 	if(customPPI() != defaultPPI())
-		emit plotPPIChanged(plotPPI());
+		emit plotPPIChanged(plotPPI(), true);
 	
 }
 
@@ -286,7 +286,7 @@ void PreferencesModel::setCustomPPI(int newCustomPPI)
 	emit customPPIChanged(newCustomPPI);
 
 	if(!useDefaultPPI())
-		emit plotPPIChanged(plotPPI());
+		emit plotPPIChanged(plotPPI(), true);
 }
 
 void PreferencesModel::setDefaultPPI(int defaultPPI)
@@ -298,7 +298,7 @@ void PreferencesModel::setDefaultPPI(int defaultPPI)
 	emit defaultPPIChanged(_defaultPPI);
 
 	if(useDefaultPPI())
-		emit plotPPIChanged(plotPPI());
+		emit plotPPIChanged(plotPPI(), false);
 }
 
 void PreferencesModel::removeMissingValue(QString value)

--- a/JASP-Desktop/gui/preferencesmodel.h
+++ b/JASP-Desktop/gui/preferencesmodel.h
@@ -21,7 +21,6 @@ class PreferencesModel : public QObject
 	Q_PROPERTY(double		uiScale					READ uiScale					WRITE setUiScale					NOTIFY uiScaleChanged					)
 	Q_PROPERTY(QStringList	missingValues			READ missingValues													NOTIFY missingValuesChanged				)
 	Q_PROPERTY(int			defaultPPI				READ defaultPPI					WRITE setDefaultPPI					NOTIFY defaultPPIChanged				)
-	Q_PROPERTY(int			plotPPI					READ plotPPI														NOTIFY plotPPIChanged					)
 	Q_PROPERTY(bool			developerMode			READ developerMode				WRITE setDeveloperMode				NOTIFY developerModeChanged				)
 	Q_PROPERTY(QString		developerFolder			READ developerFolder			WRITE setDeveloperFolder			NOTIFY developerFolderChanged			)
 	Q_PROPERTY(bool			customThresholdScale	READ customThresholdScale		WRITE setCustomThresholdScale		NOTIFY customThresholdScaleChanged		)
@@ -114,7 +113,7 @@ signals:
 	void missingValuesChanged();
 	void developerModeChanged(			bool		developerMode);
 	void developerFolderChanged(		QString		developerFolder);
-	void plotPPIChanged(				int			ppiForPlot);
+	void plotPPIChanged(				int			ppiForPlot,			bool	wasUserAction);
 	void plotBackgroundChanged(			QString		background);
 	void customThresholdScaleChanged(	bool		customThresholdScale);
 	void thresholdScaleChanged(			int			thresholdScale);

--- a/JASP-Desktop/html/js/analysis.js
+++ b/JASP-Desktop/html/js/analysis.js
@@ -80,10 +80,9 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 		this.progressbar = new JASPWidgets.Progressbar();
 
-		this.imageToEdit = null;
-		this.ctxImage = null;
+		this.imageBeingEdited = null;
 		this.model.on("analysis:resizeStarted", function (image) {
-			this.ctxImage = image
+			this.imageBeingEdited = image
 		}, this);
 
 		this.userdata = this.model.get('userdata');
@@ -149,26 +148,14 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		}
 	},
 
-	modifyImage: function(image, ctx) {
-		var id = '#' + image.name.replace(/[^A-Za-z0-9]/g, '-');
-		if (image.error && image.resized) {
-			ctx.restoreSize(); // sets the properties of the model
-			this.resizeImageContainer(id, ctx.model.get("preResizeHeight"), ctx.model.get("preResizeWidth"));
-		} else if (image.resized) {
-			this.resizeImageContainer(id, image.height, image.width)
-			this.insertNewImage(id, image.name);
-		} else {
-			this.insertNewImage(id, image.name);
-		}
+	undoImageResize: function() {
+		if (this.imageBeingEdited !== null)
+			this.imageBeingEdited.restoreSize();
 	},
-
-	resizeImageContainer: function(id, height, width) {
-		this.$el.find(id).parent().height(height + 'px');
-		this.$el.find(id).parent().width(width + 'px');
-	},
-
-	insertNewImage: function(id, name) {
-		this.$el.find(id).css('background-image', 'url(\'' + window.globSet.tempFolder + name + '?x=' + Math.random() + '\')');
+	
+	insertNewImage: function() {
+		if (this.imageBeingEdited !== null)
+			this.imageBeingEdited.reRender();
 	},
 
 	detachNotes: function() {
@@ -621,13 +608,6 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 	render: function () {
 
-		if (this.imageToEdit != null) { // we only want to re-render adjusted images
-			this.modifyImage(this.imageToEdit, this.ctxImage);
-			this.imageToEdit = null;
-			this.ctxImage = null;
-			return this;
-		}
-
 		var results = this.model.get("results");
 		if (results == "" || results == null) {
 			var progress = this.model.get("progress");
@@ -638,6 +618,8 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 			}
 			return this;
 		}
+
+		this.imageBeingEdited = null;
 
 		this.toolbar.$el.detach();
 		this.detachNotes();

--- a/JASP-Desktop/html/js/image.js
+++ b/JASP-Desktop/html/js/image.js
@@ -141,6 +141,11 @@ JASPWidgets.imagePrimitive= JASPWidgets.View.extend({
 	_hoveringEndImage: function (e) {
 		this.resizer.setVisibility(false);
 	},
+	
+	reRender: function () {
+		this.$el.find(".jasp-image-image").remove();
+		this.render();
+	},
 
 	render: function () {
 		var html	= ''

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -44,10 +44,20 @@ $(document).ready(function () {
 		analyses.reRender();
 	}
 
-	window.modifySelectedImage = function(id, image) {
-		var jaspWidget = analyses.getAnalysis(id);
-		jaspWidget.imageToEdit = image;
-		jaspWidget.render();
+	window.refreshEditedImage = function(id, results) {
+		var analysis = analyses.getAnalysis(id);
+		if (analysis !== undefined) {
+			if (results.error && results.resized)
+				analysis.undoImageResize();
+			else
+				analysis.insertNewImage();
+		}
+	}
+	
+	window.cancelImageEdit = function(id) {
+		var analysis = analyses.getAnalysis(id);
+		if (analysis !== undefined)
+			analysis.undoImageResize();
 	}
 
 	window.select = function (id) {
@@ -68,10 +78,10 @@ $(document).ready(function () {
 	}
 
 	window.changeTitle = function(id, title) {
-		var selectedAnalysis = analyses.getAnalysis(id);
-		if (selectedAnalysis !== undefined) {
-			selectedAnalysis.toolbar.setTitle(title);
-			selectedAnalysis.toolbar.render();
+		var analysis = analyses.getAnalysis(id);
+		if (analysis !== undefined) {
+			analysis.toolbar.setTitle(title);
+			analysis.toolbar.render();
 		}
 	}
 

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -89,6 +89,7 @@ public:
 
 public slots:
 	void setImageBackgroundHandler(QString value);
+	void plotPPIChangedHandler(int ppi, bool wasUserAction);
 	void setProgressBarProgress(int progressBarProgress);
 	void setProgressBarVisible(bool progressBarVisible);
 	void setWelcomePageVisible(bool welcomePageVisible);
@@ -166,6 +167,8 @@ private:
 signals:
 	void saveJaspFile();
 	void imageBackgroundChanged(QString value);
+	void editImageCancelled(int id);
+	void ppiChanged(int ppi);
 	void updateAnalysesUserData(QString userData);
 	void runButtonTextChanged(QString runButtonText);
 	void runButtonEnabledChanged(bool runButtonEnabled);

--- a/JASP-Desktop/utilities/resultsjsinterface.cpp
+++ b/JASP-Desktop/utilities/resultsjsinterface.cpp
@@ -127,10 +127,15 @@ void ResultsJsInterface::analysisImageEditedHandler(Analysis *analysis)
 	Json::Value imgJson = analysis->getImgResults();
 	QString	results = tq(imgJson.toStyledString());
 	results = escapeJavascriptString(results);
-	results = "window.modifySelectedImage(" + QString::number(analysis->id()) + ", JSON.parse('" + results + "'));";
+	results = "window.refreshEditedImage(" + QString::number(analysis->id()) + ", JSON.parse('" + results + "'));";
 	emit runJavaScript(results);
 
     return;
+}
+
+void ResultsJsInterface::cancelImageEdit(int id)
+{
+	emit runJavaScript("window.cancelImageEdit(" + QString::number(id) + ");");
 }
 
 void ResultsJsInterface::menuHidding()

--- a/JASP-Desktop/utilities/resultsjsinterface.h
+++ b/JASP-Desktop/utilities/resultsjsinterface.h
@@ -102,6 +102,7 @@ public slots:
 	void setExactPValuesHandler(bool exact);
 	void setFixDecimalsHandler(QString numDecimals);
 	void analysisImageEditedHandler(Analysis *analysis);
+	void cancelImageEdit(int id);
 	void exportSelected(const QString &filename);
 	void setResultsPageUrl(QString resultsPageUrl);
 	void resultsPageLoaded(bool success);

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2768,8 +2768,9 @@ editImage <- function(plotName, type, height, width) {
     state[["figures"]][[plotName]][["width"]]  <- width
     state[["figures"]][[plotName]][["height"]] <- height
 		
-    key                <- attr(x = state, which = "key")
-    attr(state, "key") <- key
+    key                 <- attr(x = state, which = "key")
+    state               <- .modifyStateFigures(state, identifier=plotName, replacement=list(width=width, height=height), completeObject = FALSE)
+    attr(state, "key")  <- key
 		
     .saveState(state)
 		


### PR DESCRIPTION
If you have an old JASP file you should not be able to change ppi, background color, size or save it.
Usually this will break, so analyses must be recomputed first.

With this PR the user is asked if he wants to refresh the analysis/analyses, except when simply moving JASP between different dpi screens.
As the user isn't specifically requesting a ppi change I think that behaviour would be weird otherwise.