### PR TITLE
Fix jasp-stats/jasp-test-release#177

### DIFF
--- a/JASP-Engine/JASP/R/multinomialtest.R
+++ b/JASP-Engine/JASP/R/multinomialtest.R
@@ -588,12 +588,9 @@ MultinomialTest <- function (dataset = NULL, options, perform = "run",
     }
     # use only exProbVar
     fact <- dataset[[.v(options$factor)]]
-    eProps <- data.frame(dataset[[.v(options$exProbVar)]])
-
-    # Reorder to match factor levels
-    eProps           <- data.frame(eProps[levels(fact),])
+    eProps <- dataset[.v(options$exProbVar)]
     colnames(eProps) <- options$exProbVar
-    rownames(eProps) <- levels(fact)
+    rownames(eProps) <- fact
 
     # Exclude missing values
     eProps           <- na.omit(eProps)


### PR DESCRIPTION
Seems to work nicely now. @ASarafoglou: are the column names of the eprops table used anywhere? Because they are no longer base64 encoded once they leave `.generateExpectedProps`