### PR TITLE
Types tweaking

### DIFF
--- a/Resources/ANOVA/qml/Ancova.qml
+++ b/Resources/ANOVA/qml/Ancova.qml
@@ -185,12 +185,10 @@ Form
 		
 		VariablesForm {
 			height: 200
-            AvailableVariablesList { name: "descriptivePlotsVariables"; title: qsTr("Factors");         source: ["fixedFactors", "covariates"]	}
-			AssignedVariablesList {	name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis"); singleVariable: true	}
-			AssignedVariablesList {	name: "plotSeparateLines";			title: qsTr("Separate Lines");  singleVariable: true
-									suggestedColumns: ["ordinal", "nominal"]		}
-			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate Plots");  singleVariable: true
-									suggestedColumns: ["ordinal", "nominal"]		}
+            AvailableVariablesList { name: "descriptivePlotsVariables"; source: ["fixedFactors", "covariates"]	}
+            AssignedVariablesList {	name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis"); singleVariable: true; suggestedColumns: "scale"}
+            AssignedVariablesList {	name: "plotSeparateLines";			title: qsTr("Separate Lines");  singleVariable: true; suggestedColumns: ["ordinal", "nominal"]		}
+            AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate Plots");  singleVariable: true; suggestedColumns: ["ordinal", "nominal"]		}
 		}
 		
 		Group

--- a/Resources/ANOVA/qml/Ancova.qml
+++ b/Resources/ANOVA/qml/Ancova.qml
@@ -186,7 +186,7 @@ Form
 		VariablesForm {
 			height: 200
             AvailableVariablesList { name: "descriptivePlotsVariables"; source: ["fixedFactors", "covariates"]	}
-            AssignedVariablesList {	name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis"); singleVariable: true; suggestedColumns: "scale"}
+            AssignedVariablesList {	name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis"); singleVariable: true}
             AssignedVariablesList {	name: "plotSeparateLines";			title: qsTr("Separate Lines");  singleVariable: true; suggestedColumns: ["ordinal", "nominal"]		}
             AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate Plots");  singleVariable: true; suggestedColumns: ["ordinal", "nominal"]		}
 		}

--- a/Resources/ANOVA/qml/AncovaBayesian.qml
+++ b/Resources/ANOVA/qml/AncovaBayesian.qml
@@ -180,7 +180,7 @@ Form
 		VariablesForm
 		{
             AvailableVariablesList { name: "descriptivePlotsVariables";	source: ["fixedFactors", "covariates"] }
-            AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis")  ; singleVariable: true; suggestedColumns: "scale"}
+            AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis")  ; singleVariable: true}
             AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate Lines")	; singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
             AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate Plots")   ; singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
 		}

--- a/Resources/ANOVA/qml/AncovaBayesian.qml
+++ b/Resources/ANOVA/qml/AncovaBayesian.qml
@@ -179,10 +179,10 @@ Form
 		
 		VariablesForm
 		{
-			AvailableVariablesList { name: "descriptivePlotsVariables";	title: qsTr("Factors")          ; source: "fixedFactors" }
-			AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis")  ; singleVariable: true }
-			AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate Lines")	; singleVariable: true }
-			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate Plots")   ; singleVariable: true }
+            AvailableVariablesList { name: "descriptivePlotsVariables";	source: ["fixedFactors", "covariates"] }
+            AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis")  ; singleVariable: true; suggestedColumns: "scale"}
+            AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate Lines")	; singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
+            AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate Plots")   ; singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
 		}
 		
 		Group

--- a/Resources/Frequencies/qml/ABTestBayesian.qml
+++ b/Resources/Frequencies/qml/ABTestBayesian.qml
@@ -32,10 +32,10 @@ Form
 		marginBetweenVariablesLists	: 15
 
 		AvailableVariablesList	{ name: "allVariablesList" }
-		AssignedVariablesList	{ name: "y1";	title: qsTr("Successes Group 1");	singleVariable: true;	suggestedColumns: ["ordinal", "scale"] }
-		AssignedVariablesList	{ name: "n1";	title: qsTr("Sample Size Group 1");	singleVariable: true;	suggestedColumns: ["ordinal", "scale"] }
-		AssignedVariablesList	{ name: "y2";	title: qsTr("Successes Group 2");	singleVariable: true;	suggestedColumns: ["ordinal", "scale"] }
-		AssignedVariablesList	{ name: "n2";	title: qsTr("Sample Size Group 2");	singleVariable: true;	suggestedColumns: ["ordinal", "scale"] }
+        AssignedVariablesList	{ name: "y1";	title: qsTr("Successes Group 1");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
+        AssignedVariablesList	{ name: "n1";	title: qsTr("Sample Size Group 1");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
+        AssignedVariablesList	{ name: "y2";	title: qsTr("Successes Group 2");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
+        AssignedVariablesList	{ name: "n2";	title: qsTr("Sample Size Group 2");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
 	}
 
 	ColumnLayout

--- a/Resources/Frequencies/qml/ContingencyTables.qml
+++ b/Resources/Frequencies/qml/ContingencyTables.qml
@@ -28,7 +28,7 @@ Form
 		AvailableVariablesList { name: "allVariablesList" }		
 		AssignedVariablesList { name: "rows";		title: qsTr("Rows");	suggestedColumns: ["ordinal", "nominal"] }
 		AssignedVariablesList { name: "columns";	title: qsTr("Columns");	suggestedColumns: ["ordinal", "nominal"] }
-		AssignedVariablesList { name: "counts";		title: qsTr("Counts");	suggestedColumns: ["scale"]; singleVariable: true }
+        AssignedVariablesList { name: "counts";		title: qsTr("Counts");	suggestedColumns: ["scale", "ordinal"]; singleVariable: true }
 		AssignedVariablesList { name: "layers";		title: qsTr("Layers");	suggestedColumns: ["ordinal", "nominal"]; listViewType: "Layers"; height: 120 }
 	}
 	

--- a/Resources/Frequencies/qml/ContingencyTablesBayesian.qml
+++ b/Resources/Frequencies/qml/ContingencyTablesBayesian.qml
@@ -45,7 +45,7 @@ Form
 		AvailableVariablesList { name: "allVariablesList" }		
 		AssignedVariablesList { name: "rows";		title: qsTr("Rows");	suggestedColumns: ["ordinal", "nominal"] }
 		AssignedVariablesList { name: "columns";	title: qsTr("Columns");	suggestedColumns: ["ordinal", "nominal"] }
-		AssignedVariablesList { name: "counts";		title: qsTr("Counts");	suggestedColumns: ["scale"]; singleVariable: true }
+        AssignedVariablesList { name: "counts";		title: qsTr("Counts");	suggestedColumns: ["scale", "ordinal"]; singleVariable: true }
 		AssignedVariablesList { name: "layers";		title: qsTr("Layers");	suggestedColumns: ["ordinal", "nominal"]; listViewType: "Layers"; height: 120 }
 	}
 	

--- a/Resources/Frequencies/qml/MultinomialTest.qml
+++ b/Resources/Frequencies/qml/MultinomialTest.qml
@@ -35,8 +35,8 @@ Form
 		marginBetweenVariablesLists: 15
 		AvailableVariablesList {				name: "allVariablesList" }
 		AssignedVariablesList {					name: "factor";		title: qsTr("Factor");			singleVariable: true; suggestedColumns: ["ordinal", "nominal"]	}
-		AssignedVariablesList {					name: "counts";		title: qsTr("Counts");			singleVariable: true; suggestedColumns: ["ordinal", "scale"]	}
-		AssignedVariablesList {	id: exProbVar;	name: "exProbVar";	title: qsTr("Expected Counts"); singleVariable: true; suggestedColumns: ["ordinal", "scale"]	}
+        AssignedVariablesList {					name: "counts";		title: qsTr("Counts");			singleVariable: true; suggestedColumns: ["scale", "ordinal"]	}
+        AssignedVariablesList {	id: exProbVar;	name: "exProbVar";	title: qsTr("Expected Counts"); singleVariable: true; suggestedColumns: ["scale", "ordinal"]	}
 	}
 
 	RadioButtonGroup

--- a/Resources/Frequencies/qml/MultinomialTestBayesian.qml
+++ b/Resources/Frequencies/qml/MultinomialTestBayesian.qml
@@ -31,8 +31,8 @@ Form
 		marginBetweenVariablesLists	: 15
 		AvailableVariablesList {				name: "allVariablesList" }
 		AssignedVariablesList {					name: "factor";		title: qsTr("Factor");			singleVariable: true; suggestedColumns: ["ordinal", "nominal"]	}
-		AssignedVariablesList {					name: "counts";		title: qsTr("Counts");			singleVariable: true; suggestedColumns: ["ordinal", "scale"]	}
-		AssignedVariablesList {	id: exProbVar;	name: "exProbVar";	title: qsTr("Expected Counts"); singleVariable: true; suggestedColumns: ["ordinal", "scale"]	}
+        AssignedVariablesList {					name: "counts";		title: qsTr("Counts");			singleVariable: true; suggestedColumns: ["scale", "ordinal"]	}
+        AssignedVariablesList {	id: exProbVar;	name: "exProbVar";	title: qsTr("Expected Counts"); singleVariable: true; suggestedColumns: ["scale", "ordinal"]	}
 	}
 
 	RadioButtonGroup

--- a/Resources/Frequencies/qml/RegressionLogLinear.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinear.qml
@@ -26,7 +26,7 @@ Form
 	VariablesForm
 	{
 		AvailableVariablesList { name: "allVariablesList" }		
-		AssignedVariablesList { name: "counts";		title: qsTr("Counts (optional)"); singleVariable: true; suggestedColumns: ["scale"]			}
+        AssignedVariablesList { name: "counts";		title: qsTr("Counts (optional)"); singleVariable: true; suggestedColumns: ["scale", "ordinal"]			}
 		AssignedVariablesList { name: "factors";	title: qsTr("Factors"); itemType: "fixedFactors"; suggestedColumns: ["ordinal", "nominal"]	}
 	}
 	

--- a/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
@@ -27,7 +27,7 @@ Form
 	VariablesForm
 	{
 		AvailableVariablesList { name: "allVariablesList" }		
-		AssignedVariablesList { name: "counts";	 title: qsTr("Counts (optional)");	singleVariable: true	}
+        AssignedVariablesList { name: "counts";	 title: qsTr("Counts (optional)");	singleVariable: true;	suggestedColumns:["scale", "ordinal"]}
 		AssignedVariablesList { name: "factors"; title: qsTr("Factors"); itemType: "fixedFactors"; suggestedColumns: ["ordinal", "nominal"] }
 	}
 	

--- a/Resources/Meta Analysis/qml/ClassicalMetaAnalysis.qml
+++ b/Resources/Meta Analysis/qml/ClassicalMetaAnalysis.qml
@@ -31,7 +31,7 @@ Form
 		AssignedVariablesList { name: "dependent";	title: qsTr("Effect Size"); singleVariable: true; suggestedColumns: ["scale"] }
 		AssignedVariablesList { name: "wlsWeights";	title: qsTr("Effect Size Standard Error"); singleVariable: true; suggestedColumns: ["scale"] }
 		DropDown { name: "method"; label: qsTr("Method"); currentIndex: 2; values: [ "Fixed Effects", "Maximum Likelihood", "Restricted ML", "DerSimonian-Laird", "Hedges", "Hunter-Schmidt", "Sidik-Jonkman", "Empirical Bayes", "Paule-Mandel"]; }
-		AssignedVariablesList { name: "studyLabels";	title: qsTr("Study Labels"); singleVariable: true; suggestedColumns: ["nominal","ordinal"] }
+        AssignedVariablesList { name: "studyLabels";	title: qsTr("Study Labels"); singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
 		AssignedVariablesList { name: "covariates";	title: qsTr("Covariates"); singleVariable: false; suggestedColumns: ["scale"] }
 		AssignedVariablesList { name: "factors";	title: qsTr("Factors"); singleVariable: false; suggestedColumns: ["ordinal", "nominal"] }
 	}

--- a/Resources/Network/qml/NetworkAnalysis.qml
+++ b/Resources/Network/qml/NetworkAnalysis.qml
@@ -41,7 +41,7 @@ Form
 	VariablesForm 
 	{
 		AvailableVariablesList { name: "allVariablesList" }		
-		AssignedVariablesList { name: "variables";			title: qsTr("Dependent Variables") }
+        AssignedVariablesList { name: "variables";			title: qsTr("Dependent Variables"); suggestedColumns: ["ordinal", "scale"]}
 		AssignedVariablesList { name: "groupingVariable";	title: qsTr("Split"); singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
 	}
 	
@@ -262,7 +262,7 @@ Form
 		{
 			height: 200
 			AvailableVariablesList { name: "variablesForColor"; title: qsTr("Nodes") }
-			AssignedVariablesList  { name: "colorNodesBy";		title: qsTr("Color Nodes By"); singleVariable: true }
+            AssignedVariablesList  { name: "colorNodesBy";		title: qsTr("Color Nodes By"); singleVariable: true; suggestedColumns: ["nominal"]}
 		}
 		
 		Group

--- a/Resources/Regression/qml/CorrelationBayesianPairs.qml
+++ b/Resources/Regression/qml/CorrelationBayesianPairs.qml
@@ -27,7 +27,7 @@ Form
 	VariablesForm
 	{
 		AvailableVariablesList { name: "allVariablesList" }		
-		AssignedVariablesList { name: "pairs"; suggestedColumns: ["scale"]; listViewType: "Pairs" }
+        AssignedVariablesList { name: "pairs"; suggestedColumns: ["ordinal", "scale"]; listViewType: "Pairs" }
 	}
 	
 	RadioButtonGroup

--- a/Resources/Regression/qml/RegressionLinear.qml
+++ b/Resources/Regression/qml/RegressionLinear.qml
@@ -40,7 +40,7 @@ Form
 			]			
 		}
 		AssignedVariablesList { name: "covariates";	title: qsTr("Covariates");			suggestedColumns: ["scale"]								}
-		AssignedVariablesList { name: "factors";	title: qsTr("Factors");				suggestedColumns: ["nominal", "ordinal"]; debug: true	}
+        AssignedVariablesList { name: "factors";	title: qsTr("Factors");				suggestedColumns: ["ordinal", "nominal"]; debug: true	}
 		AssignedVariablesList { name: "wlsWeights";	title: qsTr("WLS Weights (optional)"); suggestedColumns: ["scale"]; singleVariable: true	}
 	}
 	

--- a/Resources/Regression/qml/RegressionLinearBayesian.qml
+++ b/Resources/Regression/qml/RegressionLinearBayesian.qml
@@ -27,8 +27,8 @@ Form {
 	VariablesForm
 	{
 		AvailableVariablesList	{ name: "allVariablesList" }
-		AssignedVariablesList	{ name: "dependent";	title: qsTr("Dependent Variable");		suggestedColumns: ["scale"];	singleVariable: true	}
-		AssignedVariablesList	{ name: "covariates";	title: qsTr("Covariates");				suggestedColumns: ["scale"]								}
+        AssignedVariablesList	{ name: "dependent";	title: qsTr("Dependent Variable");		suggestedColumns: ["scale"];	singleVariable: true	}
+        AssignedVariablesList	{ name: "covariates";	title: qsTr("Covariates");				suggestedColumns: ["scale"];    allowedColumns: ["scale"]   }
 		AssignedVariablesList	{ name: "wlsWeights";	title: qsTr("WLS Weights (optional)");	suggestedColumns: ["scale"];	singleVariable: true	}
 	}
 	

--- a/Resources/Regression/qml/RegressionLogistic.qml
+++ b/Resources/Regression/qml/RegressionLogistic.qml
@@ -28,7 +28,7 @@ Form
 	VariablesForm
 	{
 		AvailableVariablesList { name: "allVariablesList" }		
-		AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable");	suggestedColumns: ["nominal", "ordinal"]; singleVariable: true	}
+        AssignedVariablesList { name: "dependent";	title: qsTr("Dependent Variable");	suggestedColumns: ["ordinal", "nominal"]; singleVariable: true	}
 		DropDown
 		{
 			name: "method"
@@ -41,7 +41,7 @@ Form
 			]
 		}
 		AssignedVariablesList { name: "covariates";	title: qsTr("Covariates");			suggestedColumns: ["scale"]											}
-		AssignedVariablesList { name: "factors";	title: qsTr("Factors");				suggestedColumns: ["nominal", "ordinal"];itemType: "fixedFactors"	}
+        AssignedVariablesList { name: "factors";	title: qsTr("Factors");				suggestedColumns: ["ordinal", "nominal"];itemType: "fixedFactors"	}
 		AssignedVariablesList { name: "wlsWeights";	title: qsTr("WLS Weights (optional)"); suggestedColumns: ["scale"]; singleVariable: true; debug: true	}
 	}
 	

--- a/Resources/SEM/qml/FactorsForm.qml
+++ b/Resources/SEM/qml/FactorsForm.qml
@@ -66,6 +66,7 @@ JASPControl
 					editableTitle:      factorTitle
 					dropMode:			"Replace"
 					suggestedColumns:	allowAll ? [] : ["scale"]
+                    allowedColumns:     ["scale"]
                     implicitWidth:      listWidth
 					height:             factorsForm.factorListHeight
 


### PR DESCRIPTION
- ANCOVAs - Descriptives Plots: Allow covariates on the horizontal axis based on Simon's work: https://github.com/jasp-stats/jasp-desktop/pull/3127
- Restrict: Bayesian linear regression: Covariates to only take scale
- Restrict: CFA: Factors only take scale
- Reorder some symbols. For frequency analyses the ordinals are shown before scale in the counts

Continues:
https://github.com/jasp-stats/jasp-desktop/pull/3304

Discussion:
https://github.com/jasp-stats/INTERNAL-jasp/issues/278

