### PR TITLE
Fix bayes factor comparison plot in bain ttest

### DIFF
--- a/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
@@ -386,7 +386,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
   bainResult <- jaspResults[["bainResult"]]$object
   if(options[["bayesFactorPlot"]] && ready){
       if(is.null(jaspResults[["BFplots"]])){
-      jaspResults[["BFplots"]]                    <- createJaspContainer("Bayes Factor Comparison", height = 400, width = 600)
+      jaspResults[["BFplots"]]                    <- createJaspContainer("Bayes Factor Comparison")
       jaspResults[["BFplots"]]                    $dependOn(options =c("variables", "testValue", "hypothesis", "bayesFactorPlot"))
       jaspResults[["BFplots"]]					          $position <- 3
       }


### PR DESCRIPTION
@koenderks the bayes factor comparison plots in paired samples ttest do not function in 0.10.
This PR fixes that problem, but it won't be included in the current version as we're literally 10 minutes away from releasing.