### PR TITLE
Make table unit tests less stringent

### DIFF
--- a/JASP-Tests/R/tests/testthat/helper-tables.R
+++ b/JASP-Tests/R/tests/testthat/helper-tables.R
@@ -1,9 +1,54 @@
-expect_equal_tables <- function(test, ref, ...) {
+  roundToPrecision <- function(x) {
+    if (is.numeric(x))  signif(round(x, digits=4), digits=4)
+    else                x
+  }
+  
+  getTableMismatches <- function(testTable, lookupTable, nRows, nCells) {
+    
+    namesTestTable <- unlist(testTable)
+    testTable <- unlist(lapply(testTable, roundToPrecision))
+    names(testTable) <- namesTestTable
+    
+    namesLookupTable <- unlist(lookupTable)
+    lookupTable <- unlist(lapply(lookupTable, roundToPrecision))
+    names(lookupTable) <- namesLookupTable
+    
+    errors <- character(0)
+    for (row in 1:nRows) {
+      cellRange <- (1 + (row - 1) * nCells):(row * nCells)
+      lookupRow <- lookupTable[cellRange]
+      for (cell in cellRange) {
+        indicesMatch <- which(lookupRow %in% testTable[cell])
+        if (length(indicesMatch) > 0)
+          lookupRow <- lookupRow[-min(indicesMatch)]
+        else
+          errors <- c(errors, paste0("Value `", names(testTable)[cell], "` in test table (row ", row, ")", " cannot be located in reference table"))
+      }
+      if (length(lookupRow) > 0)
+        errors <- c(errors, paste0("Value(s) `", paste0(names(lookupRow), collapse="`, `"), "` not matched in reference table"))
+    }
+    return(errors)
+  }
+
+expect_equal_tables <- function(test, ref, label=NULL) {
   if (length(test) == 0) {
     errorMsg <- jasptools:::.getErrorMsgFromLastResults()
     if (! is.null(errorMsg))
         stop(paste("Tried retrieving table data from results, but last run of jasptools exited with an error:", errorMsg), call.=FALSE)
   }
+  
+  if (is.null(label))
+    label <- "Test table"
+  
+  nRows <- length(test)
+  nCells <- length(test[[1]])
+  
   test <- jasptools:::collapseTable(test)
-  expect_equal(test, ref, tolerance=1e-4, ...)
+
+  if (length(test) == length(ref)) {
+    mismatches <- getTableMismatches(test, ref, nRows, nCells)
+    expect(length(mismatches) == 0, paste0(label, " is not equal to reference table:\n", paste0(mismatches, collapse="\n")))
+  } else {
+    expect(FALSE, paste(label, "and reference table are not of equal length, check if the number of columns/rows is still the same"))
+  }
 }

--- a/Tools/jasptools/DESCRIPTION
+++ b/Tools/jasptools/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jasptools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 0.6.6
+Version: 0.6.7
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/Tools/jasptools/R/test.R
+++ b/Tools/jasptools/R/test.R
@@ -62,8 +62,15 @@ manageTestPlots <- function(analysis = NULL) {
     analysis <- .validateAnalysis(analysis)
     analysis <- paste0("^", analysis, "$")
   }
+  
+  oldLibPaths <- .libPaths()
+  .libPaths(c(.getPkgOption("pkgs.dir"), .libPaths()))
+  on.exit({
+    .libPaths(oldLibPaths)
+    unloadNamespace("SomePkg") # unload fake pkg in JASP unit tests, which is needed to run vdiffr
+  }) 
+
   testDir <- .getPkgOption("tests.dir")
-  on.exit(unloadNamespace("SomePkg")) # unload fake pkg in JASP unit tests, which is needed to run vdiffr
   vdiffr::manage_cases(testDir, analysis)
 }
 


### PR DESCRIPTION
Now it will only check if all values of a row are present in both test and reference. Positions are allowed to shift. Easier for the jaspResults rewrite.