### PR TITLE
Fix error retrieval from state in jaspcontainers

### DIFF
--- a/JASP-R-Interface/jaspResults/src/jaspObject.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspObject.cpp
@@ -242,9 +242,10 @@ Json::Value jaspObject::convertToJSON()
 	obj["title"]		= _title;
 	obj["type"]			= jaspObjectTypeToString(_type);
 	obj["error"]        = _error;
+	obj["errorMessage"] = _errorMessage;
 	obj["warning"]		= _warning;
-	obj["position"]		= _position;
 	obj["warningSet"]	= _warningSet;
+	obj["position"]		= _position;
 	obj["citations"]	= _citations;
 	obj["messages"]		= Json::arrayValue;
 
@@ -265,12 +266,14 @@ Json::Value jaspObject::convertToJSON()
 
 void jaspObject::convertFromJSON_SetFields(Json::Value in)
 {
-	_name		= in.get("name",		"null").asString();
-	_title		= in.get("title",		"null").asString();
-	_warning	= in.get("warning",		"null").asString();
-	_warningSet	= in.get("warningSet",	false).asBool();
-	_position	= in.get("position",	JASPOBJECT_DEFAULT_POSITION).asInt();
-	_citations	= in.get("citations",	Json::arrayValue);
+	_name			= in.get("name",			"null").asString();
+	_title			= in.get("title",			"null").asString();
+	_error			= in.get("error",			false).asBool();
+	_errorMessage	= in.get("errorMessage",	"").asString();
+	_warning		= in.get("warning",			"null").asString();
+	_warningSet		= in.get("warningSet",		false).asBool();
+	_position		= in.get("position",		JASPOBJECT_DEFAULT_POSITION).asInt();
+	_citations		= in.get("citations",		Json::arrayValue);
 
 	_messages.clear();
 

--- a/JASP-R-Interface/jaspResults/src/jaspPlot.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspPlot.cpp
@@ -122,7 +122,6 @@ Json::Value jaspPlot::convertToJSON()
 	obj["width"]				= _width;
 	obj["height"]				= _height;
 	obj["status"]				= _status;
-	obj["errorMessage"]			= _errorMessage;
 	obj["filePathPng"]			= _filePathPng;
 	obj["environmentName"]		= _envName;
 
@@ -136,9 +135,7 @@ void jaspPlot::convertFromJSON_SetFields(Json::Value in)
 	_aspectRatio	= in.get("aspectRatio",		0.0f).asDouble();
 	_width			= in.get("width",			-1).asInt();
 	_height			= in.get("height",			-1).asInt();
-	_error			= in.get("error",			"false").asBool();
 	_status			= in.get("status",			"complete").asString();
-	_errorMessage	= in.get("errorMessage",	"null").asString();
 	_filePathPng	= in.get("filePathPng",		"null").asString();
 	_envName		= in.get("environmentName",	_envName).asString();
 	

--- a/JASP-R-Interface/jaspResults/src/jaspTable.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspTable.cpp
@@ -1211,7 +1211,6 @@ Json::Value jaspTable::convertToJSON()
 	Json::Value obj		= jaspObject::convertToJSON();
 
 	obj["status"]					= _status;
-	obj["errorMessage"]				= _errorMessage;
 	obj["transposeTable"]			= _transposeTable;
 	obj["transposeWithOvertitle"]	= _transposeWithOvertitle;
 	obj["showSpecifiedColumnsOnly"]	= _showSpecifiedColumnsOnly;
@@ -1261,8 +1260,6 @@ void jaspTable::convertFromJSON_SetFields(Json::Value in)
 	jaspObject::convertFromJSON_SetFields(in);
 
 	_status						= in.get("status",						"null").asString();
-	_error						= in.get("error",						"false").asBool();
-	_errorMessage				= in.get("errorMessage",				"null").asString();
 	_transposeTable				= in.get("transposeTable",				false).asBool();
 	_transposeWithOvertitle		= in.get("transposeWithOvertitle",		false).asBool();
 	_showSpecifiedColumnsOnly	= in.get("showSpecifiedColumnsOnly",	false).asBool();


### PR DESCRIPTION
After performing a $setError() on a jaspcontainer, the container would lose its error status when it was retrieved on analysis rerun.