### PR TITLE
Fixes to bain module

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/TextArea.qml
+++ b/JASP-Desktop/components/JASP/Controls/TextArea.qml
@@ -24,6 +24,12 @@ JASPControl
     
     signal applyRequest()
     
+	function userEnteredInput() {
+		if (textArea.trim)
+			textArea.text = textArea.text.trim();
+
+		applyRequest();
+	}
 
 	Text
 	{
@@ -63,7 +69,7 @@ JASPControl
 					if (event.modifiers & Qt.ControlModifier)
 					{
 						if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
-							applyRequest();
+							userEnteredInput();
 					}
 					else if ( event.key === Qt.Key_Tab)
 					{

--- a/JASP-Desktop/components/JASP/Controls/TextArea.qml
+++ b/JASP-Desktop/components/JASP/Controls/TextArea.qml
@@ -20,6 +20,7 @@ JASPControl
 	property alias	font:				control.font
 	property alias	textDocument:		control.textDocument
 	property alias	title:				textAreaTitle.text
+	property bool	trim:				false
     
     signal applyRequest()
     

--- a/JASP-Desktop/html/js/utils.js
+++ b/JASP-Desktop/html/js/utils.js
@@ -544,7 +544,7 @@ function createColumns(columnDefs, rowData, modelFootnotes) {
 
             if (tableDataExists) {
                 row = rowData[rowNo];
-                content = row[columnName] === null ? '' : row[columnName];
+                content = row[columnName] == null ? '' : row[columnName];
             }          
 
             let cell = { content: content };

--- a/JASP-Desktop/widgets/boundqmltextarea.cpp
+++ b/JASP-Desktop/widgets/boundqmltextarea.cpp
@@ -88,8 +88,6 @@ BoundQMLTextArea::BoundQMLTextArea(QQuickItem* item, AnalysisForm* form)
 	}
 	else
 		_textType = TextType::Default;
-	
-	_trim = _item->property("trim").toBool();
 
 	QQuickItem::connect(item, SIGNAL(applyRequest()), this, SLOT(checkSyntax()));
 	
@@ -134,10 +132,6 @@ void BoundQMLTextArea::resetQMLItem(QQuickItem *item)
 void BoundQMLTextArea::checkSyntax()
 {
 	_text = _item->property("text").toString();
-
-	if (_trim)
-		_text = _text.trimmed();
-
 	if (_textType == TextType::Lavaan)
 	{
 		// create an R vector of available column names

--- a/JASP-Desktop/widgets/boundqmltextarea.cpp
+++ b/JASP-Desktop/widgets/boundqmltextarea.cpp
@@ -89,6 +89,8 @@ BoundQMLTextArea::BoundQMLTextArea(QQuickItem* item, AnalysisForm* form)
 	else
 		_textType = TextType::Default;
 	
+	_trim = _item->property("trim").toBool();
+
 	QQuickItem::connect(item, SIGNAL(applyRequest()), this, SLOT(checkSyntax()));
 	
 }
@@ -132,6 +134,10 @@ void BoundQMLTextArea::resetQMLItem(QQuickItem *item)
 void BoundQMLTextArea::checkSyntax()
 {
 	_text = _item->property("text").toString();
+
+	if (_trim)
+		_text = _text.trimmed();
+
 	if (_textType == TextType::Lavaan)
 	{
 		// create an R vector of available column names

--- a/JASP-Desktop/widgets/boundqmltextarea.h
+++ b/JASP-Desktop/widgets/boundqmltextarea.h
@@ -55,6 +55,7 @@ protected:
 	QString						_text;
 	TextType					_textType;
 	QString						_applyScriptInfo;
+	bool						_trim = false;
 	
 	LavaanSyntaxHighlighter*	_lavaanHighlighter = nullptr;
 	ListModelTermsAvailable*	_allVariablesModel = nullptr;

--- a/JASP-Desktop/widgets/boundqmltextarea.h
+++ b/JASP-Desktop/widgets/boundqmltextarea.h
@@ -55,7 +55,6 @@ protected:
 	QString						_text;
 	TextType					_textType;
 	QString						_applyScriptInfo;
-	bool						_trim = false;
 	
 	LavaanSyntaxHighlighter*	_lavaanHighlighter = nullptr;
 	ListModelTermsAvailable*	_allVariablesModel = nullptr;

--- a/JASP-Engine/JASP/R/bainancovabayesian.R
+++ b/JASP-Engine/JASP/R/bainancovabayesian.R
@@ -25,47 +25,47 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 	dataset <- readList[["dataset"]]
 	missingValuesIndicator <- readList[["missingValuesIndicator"]]
 	
+	bainContainer <- .bainGetContainer(jaspResults, deps=c("dependent", "fixedFactors", "covariates", "model"))
+	
 	### LEGEND ###
 	.bainLegendAncova(dataset, options, jaspResults)
 	
 	### RESULTS ###
-	.bainAncovaResultsTable(dataset, options, jaspResults, missingValuesIndicator, ready)
+	.bainAncovaResultsTable(dataset, options, bainContainer, missingValuesIndicator, ready)
 	
 	### BAYES FACTOR MATRIX ###
-	.bainBayesFactorMatrix(dataset, options, jaspResults, ready, type = "anova")
+	.bainBayesFactorMatrix(dataset, options, bainContainer, ready, type = "ancova")
 	
 	### COEFFICIENTS ###
-	.bainAncovaCoefficientsTable(dataset, options, jaspResults, ready)
+	.bainAncovaCoefficientsTable(dataset, options, bainContainer, ready)
 	
 	### BAYES FACTOR PLOT ###
-	.bainAnovaBayesFactorPlots(dataset, options, jaspResults, ready)
+	.bainAnovaBayesFactorPlots(dataset, options, bainContainer, ready)
 	
 	### DESCRIPTIVES PLOT ###
-	.bainAnovaDescriptivesPlot(dataset, options, jaspResults, ready, type = "ancova")
+	.bainAnovaDescriptivesPlot(dataset, options, bainContainer, ready, type = "ancova")
 }
 
-.bainAncovaResultsTable <- function(dataset, options, jaspResults, missingValuesIndicator, ready){
+.bainAncovaResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready){
 
-	if(!is.null(jaspResults[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+	if(!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
-	variables 											<- c(options$dependent, options$fixedFactors, unlist(options$covariates))
-	bainTable                      	<- createJaspTable("Bain ANCOVA Result")
-	jaspResults[["bainTable"]]     	<- bainTable
-	bainTable$dependOn(options =c("dependent", "fixedFactors", "covariates", "model"))
+	variables <- c(options$dependent, options$fixedFactors, unlist(options$covariates))
+	bainTable <- createJaspTable("Bain ANCOVA Result")
 
-	bainTable$addColumnInfo(name="hypotheses", 				type="string", title="")
-	bainTable$addColumnInfo(name="BF", 						type="number", format="sf:4;dp:3", title= "BF.c")
-	bainTable$addColumnInfo(name="PMP1", 					type="number", format="sf:4;dp:3", title= "PMP a")
-	bainTable$addColumnInfo(name="PMP2", 					type="number", format="sf:4;dp:3", title= "PMP b")
+	bainTable$addColumnInfo(name="hypotheses", 		type="string", title="")
+	bainTable$addColumnInfo(name="BF", 						type="number", title= "BF.c")
+	bainTable$addColumnInfo(name="PMP1", 					type="number", title= "PMP a")
+	bainTable$addColumnInfo(name="PMP2", 					type="number", title= "PMP b")
 	bainTable$position <- 1
 
 	message <-  "BF.c denotes the Bayes factor of the hypothesis in the row versus its complement.
 				Posterior model probabilities (a: excluding the unconstrained hypothesis, b: including the unconstrained hypothesis) are based on equal prior model probabilities."
-	bainTable$addFootnote(message=message, symbol="<i>Note.</i>")
+	bainTable$addFootnote(message=message)
 
-	bainTable$addCitation("Gu, X., Mulder, J., and Hoijtink, H. (2017). Approximate adjusted fractional Bayes factors: A general method for testing informative hypotheses. British Journal of Mathematical and Statistical Psychology. DOI:10.1111/bmsp.12110")
-	bainTable$addCitation("Hoijtink, H., Mulder, J., van Lissa, C., and Gu, X. (2018). A Tutorial on testing hypotheses using the Bayes factor. Psychological Methods.")
-	bainTable$addCitation("Hoijtink, H., Gu, X., and Mulder, J. (2018). Bayesian evaluation of informative hypotheses for multiple populations. Britisch Journal of Mathematical and Statistical Psychology. DOI: 10.1111/bmsp.12145")
+	bainTable$addCitation(.bainGetCitations())
+	
+	bainContainer[["bainTable"]] <- bainTable
 
 	if(!ready)
 		return()
@@ -100,17 +100,12 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 
 		p <- try({
 			bainResult <- Bain::Bain_ancova(X = dataset, dep_var = .v(options[["dependent"]]), covariates = .v(options[["covariates"]]), group = .v(options[["fixedFactors"]]), ERr, IRr)
-			jaspResults[["bainResult"]] <- createJaspState(bainResult)
-			jaspResults[["bainResult"]]$dependOn(options =c("dependent", "fixedFactors", "covariates", "model"))
+			bainContainer[["bainResult"]] <- createJaspState(bainResult)
 		})
 
 	} else {
 
-		jaspResults$startProgressbar(3)
-		jaspResults$progressbarTick()
-		rest.string <- options$model
-		rest.string <- gsub("\n", ";", rest.string)
-		jaspResults$progressbarTick()
+		rest.string <- .bainCleanModelInput(options$model)
 
 		inpt <- list()
 		names(dataset) <- .unv(names(dataset))
@@ -122,155 +117,140 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 
 		p <- try({
 			bainResult <- Bain::Bain_ancova_cm(X = inpt[[1]], dep_var = inpt[[2]], covariates = inpt[[3]], group = inpt[[4]], hyp = inpt[[5]])
-			jaspResults[["bainResult"]] <- createJaspState(bainResult)
-			jaspResults[["bainResult"]]$dependOn(options =c("dependent", "fixedFactors", "covariates", "model"))
+			bainContainer[["bainResult"]] <- createJaspState(bainResult)
 		})
 	}
 
-	if(class(p) == "try-error"){
-		bainTable$setError("An error occurred in the analysis. Please double check your variables.")
+	if (inherits(p, "try-error")) {
+		bainContainer$setError(paste0("An error occurred in the analysis:<br>", .extractErrorMessage(p), "<br><br>Please double check your variables and model constraints."))
 		return()
-	} else {
-		jaspResults$progressbarTick()
-		BF <- bainResult$BF
-		for(i in 1:length(BF)){
-			row <- data.frame(hypotheses = paste0("H",i), BF = .clean(BF[i]), PMP1 = .clean(bainResult$PMPa[i]), PMP2 = .clean(bainResult$PMPb[i]))
-			bainTable$addRows(row)
-		}
-		row <- data.frame(hypotheses = "Hu", BF = "", PMP1 = "", PMP2 = .clean(1-sum(bainResult$PMPb)))
+	}
+
+	BF <- bainResult$BF
+	for(i in 1:length(BF)){
+		row <- data.frame(hypotheses = paste0("H",i), BF = BF[i], PMP1 = bainResult$PMPa[i], PMP2 = bainResult$PMPb[i])
 		bainTable$addRows(row)
+	}
+	row <- data.frame(hypotheses = "Hu", BF = "", PMP1 = "", PMP2 = 1-sum(bainResult$PMPb))
+	bainTable$addRows(row)
+}
+
+.bainBayesFactorMatrix <- function(dataset, options, bainContainer, ready, type) {
+
+	if(!is.null(bainContainer[["bayesFactorMatrix"]]) || !options[["bayesFactorMatrix"]]) return() #The options for this table didn't change so we don't need to rebuild it
+
+	bayesFactorMatrix <- createJaspTable("Bayes Factor Matrix")
+	bayesFactorMatrix$position <- 3
+
+	if(type == "regression")
+		bayesFactorMatrix$dependOn(options = c("bayesFactorMatrix", "covariates", "standardized"))
+	if(type == "ancova")
+		bayesFactorMatrix$dependOn(options = c("bayesFactorMatrix", "fixedFactors", "covariates"))
+	if(type == "anova")
+		bayesFactorMatrix$dependOn(options = c("bayesFactorMatrix", "fixedFactors"))
+		
+	bayesFactorMatrix$addColumnInfo(name = "hypothesis", title = "", type = "string")
+	bayesFactorMatrix$addColumnInfo(name = "H1", type = "number")
+	
+	bainContainer[["bayesFactorMatrix"]] <- bayesFactorMatrix
+
+	if(!ready || bainContainer$getError()){
+		row <- data.frame(hypothesis = "H1", H1 = ".")
+		bayesFactorMatrix$addRows(row)
+		return()
+	}
+
+	bainResult <- bainContainer[["bainResult"]]$object
+
+	BFmatrix <- diag(1, length(bainResult$BF))
+	for (h1 in 1:length(bainResult$BF)) {
+		for (h2 in 1:length(bainResult$BF)) {
+			BFmatrix[h1, h2] <- bainResult$fit[h1]/bainResult$fit[h2]/(bainResult$complexity[h1]/bainResult$complexity[h2])
+		}
+	}
+
+	if (nrow(BFmatrix) > 1) {
+		for (i in 2:nrow(BFmatrix))
+			bayesFactorMatrix$addColumnInfo(name = paste0("H", i), type = "number")
+	}
+
+	for(i in 1:nrow(BFmatrix)){
+		tmp <- list(hypothesis = paste0("H", i))
+		for(j in 1:ncol(BFmatrix)){
+			tmp[[paste0("H", j)]] <- BFmatrix[i,j]
+		}
+		row <- tmp
+		bayesFactorMatrix$addRows(row)
 	}
 }
 
-.bainBayesFactorMatrix <- function(dataset, options, jaspResults, ready, type){
+.bainAncovaCoefficientsTable <- function(dataset, options, bainContainer, ready) {
 
-	if(!is.null(jaspResults[["bayesFactorMatrix"]])) return() #The options for this table didn't change so we don't need to rebuild it
-		if(options[["bayesFactorMatrix"]]){
+	if(!is.null(bainContainer[["coefficientsTable"]]) || !options[["coefficients"]]) return()
+	
+	coefficientsTable <- createJaspTable("Coefficients for Groups plus Covariates")
+	coefficientsTable$dependOn(options="coefficients")
+	coefficientsTable$position <- 2
 
-			bayesFactorMatrix                                            <- createJaspTable("Bayes Factor Matrix")
-			jaspResults[["bayesFactorMatrix"]]                           <- bayesFactorMatrix
-			bayesFactorMatrix$position <- 3
+	coefficientsTable$addColumnInfo(name="v",				title="Covariate",		type="string")
+	coefficientsTable$addColumnInfo(name="N",				title="N",						type="integer")
+	coefficientsTable$addColumnInfo(name="mean",		title="Coefficient",	type="number")
+	coefficientsTable$addColumnInfo(name="SE",			title="SE",						type="number")
+	coefficientsTable$addColumnInfo(name="CiLower",	title="lowerCI",			type="number", overtitle="95% Credible Interval")
+	coefficientsTable$addColumnInfo(name="CiUpper",	title="upperCI",			type="number", overtitle="95% Credible Interval")
 
-			if(type == "regression")
-				bayesFactorMatrix$dependOn(options =c("dependent", "covariates", "model", "bayesFactorMatrix", "standardized"))
-			if(type == "ancova")
-				bayesFactorMatrix$dependOn(options =c("dependent", "fixedFactors", "covariates", "model", "bayesFactorMatrix"))
-			if(type == "anova")
-				bayesFactorMatrix$dependOn(options =c("dependent", "fixedFactors", "model", "bayesFactorMatrix"))
+	bainContainer[["coefficientsTable"]] <- coefficientsTable
+	
+	if(!ready || bainContainer$getError())
+		return()
 
-			if(!ready){
-				bayesFactorMatrix$addColumnInfo(name = "hypothesis", title = "", type = "string")
-				bayesFactorMatrix$addColumnInfo(name = "h1", title = "H1", type = "number", format="sf:4;dp:3")
-				bayesFactorMatrix$addColumnInfo(name = "h2", title = "H2", type = "number", format="sf:4;dp:3")
-				row <- data.frame(hypothesis = c("H1", "H2"), h1 = c(".", "."), h2 = c(".", "."))
-				bayesFactorMatrix$addRows(row)
-				return()
-			}
+	bainResult <- bainContainer[["bainResult"]]$object
 
-			bainResult <- jaspResults[["bainResult"]]$object
-			if(!is.null(bainResult)) {
-				BFmatrix <- diag(1, length(bainResult$BF))
-				for (h1 in 1:length(bainResult$BF)) {
-					for (h2 in 1:length(bainResult$BF)) {
-						BFmatrix[h1, h2] <- bainResult$fit[h1]/bainResult$fit[h2]/(bainResult$complexity[h1]/bainResult$complexity[h2])
-					}
-				}
-			}
+	sum_model <- bainResult$estimate_res
+	covcoef <- data.frame(sum_model$coefficients)
+	SEs <- summary(sum_model)$coefficients[, 2]
 
-			bayesFactorMatrix$addColumnInfo(name = "hypothesis", title = "", type = "string")
-			for(i in 1:nrow(BFmatrix)){
-				bayesFactorMatrix$addColumnInfo(name = paste0("H", i), title = paste0("H", i), type = "number", format="sf:4;dp:3")
-			}
+	rownames(covcoef) <- gsub("groupf", "", rownames(covcoef))
+	x <- rownames(covcoef)
+	x <- sapply(regmatches(x, gregexpr("covars", x)), length)
+	x <- sum(x)
+	if(x > 1){
+			rownames(covcoef)[(length(rownames(covcoef)) - (x-1)):length(rownames(covcoef))] <- options$covariates
+	} else {
+			rownames(covcoef) <- gsub("covars", options$covariates, rownames(covcoef))
+	}
+	# mucho fixo
 
-			if(is.null(bainResult)){
-				for(i in 1:nrow(BFmatrix)){
-					tmp <- list(hypothesis = paste0("H", i))
-					for(j in 1:ncol(BFmatrix)){
-						tmp[[paste0("H", j)]] <- "."
-					}
-					row <- tmp
-					bayesFactorMatrix$addRows(row)
-				}
-			} else {
-				for(i in 1:nrow(BFmatrix)){
-					tmp <- list(hypothesis = paste0("H", i))
-					for(j in 1:ncol(BFmatrix)){
-						tmp[[paste0("H", j)]] <- .clean(BFmatrix[i,j])
-					}
-					row <- tmp
-					bayesFactorMatrix$addRows(row)
-				}
-			}
-		}
-}
+	groups <- rownames(covcoef)
+	estim <- covcoef[, 1]
+	CiLower <- estim - 1.96 * SEs
+	CiUpper <- estim + 1.96 * SEs
 
-.bainAncovaCoefficientsTable <- function(dataset, options, jaspResults, ready){
+	groupCol <- dataset[ , .v(options[["fixedFactors"]])]
+	varLevels <- levels(groupCol)
+	varLevels <- levels(groupCol)
 
-	if(!is.null(jaspResults[["coefficientsTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
-		if(options[["coefficients"]]){
-			coefficientsTable                      	<- createJaspTable("Coefficients for Groups plus Covariates")
-			jaspResults[["coefficientsTable"]]     	<- coefficientsTable
-			coefficientsTable$dependOn(options =c("dependent", "fixedFactors", "covariates", "coefficients", "model"))
-			coefficientsTable$position <- 2
+	N <- NULL
 
-			coefficientsTable$addColumnInfo(name="v",    				title="Covariate",   type="string")
-			coefficientsTable$addColumnInfo(name="N",					title = "N", type = "integer")
-			coefficientsTable$addColumnInfo(name="mean", 				title="Coefficient", type="number", format="sf:4;dp:3")
-			coefficientsTable$addColumnInfo(name = "SE", 				title = "SE", type = "number", format = "sf:4;dp:3")
-			coefficientsTable$addColumnInfo(name="CiLower",              title = "lowerCI", type="number", format="sf:4;dp:3", overtitle = "95% Credible Interval")
-			coefficientsTable$addColumnInfo(name="CiUpper",              title = "upperCI", type="number", format="sf:4;dp:3", overtitle = "95% Credible Interval")
+	for(variable in varLevels){
+		column <- dataset[ , .v(options$dependent)]
+		column <- column[which(groupCol == variable)]
+		N <- c(N,length(column))
+	}
 
-			if(!ready)
-				return()
+	covVars <- options$covariates
+	covVars <- unlist(covVars)
 
-			bainResult <- jaspResults[["bainResult"]]$object
+	for(var in covVars){
+		col <- dataset[ , .v(var)]
+		col <- na.omit(col)
+		N <- c(N, length(col))
+	}
 
-			sum_model <- bainResult$estimate_res
-			covcoef <- data.frame(sum_model$coefficients)
-			SEs <- summary(sum_model)$coefficients[, 2]
-
-			rownames(covcoef) <- gsub("groupf", "", rownames(covcoef))
-			x <- rownames(covcoef)
-			x <- sapply(regmatches(x, gregexpr("covars", x)), length)
-			x <- sum(x)
-			if(x > 1){
-					rownames(covcoef)[(length(rownames(covcoef)) - (x-1)):length(rownames(covcoef))] <- options$covariates
-			} else {
-					rownames(covcoef) <- gsub("covars", options$covariates, rownames(covcoef))
-			}
-			# mucho fixo
-
-			groups <- rownames(covcoef)
-			estim <- covcoef[, 1]
-			CiLower <- estim - 1.96 * SEs
-			CiUpper <- estim + 1.96 * SEs
-
-			groupCol <- dataset[ , .v(options[["fixedFactors"]])]
-			varLevels <- levels(groupCol)
-			varLevels <- levels(groupCol)
-
-			N <- NULL
-
-			for(variable in varLevels){
-				column <- dataset[ , .v(options$dependent)]
-				column <- column[which(groupCol == variable)]
-				N <- c(N,length(column))
-			}
-
-			covVars <- options$covariates
-			covVars <- unlist(covVars)
-
-			for(var in covVars){
-				col <- dataset[ , .v(var)]
-				col <- na.omit(col)
-				N <- c(N, length(col))
-			}
-
-			for(i in 1:length(groups)){
-				row <- data.frame(v = groups[i], mean = .clean(estim[i]), N = N[i], SE = .clean(SEs[i]), CiLower = .clean(CiLower[i]), CiUpper = .clean(CiUpper[i]))
-				coefficientsTable$addRows(row)
-			}
-		}
+	for(i in 1:length(groups)){
+		row <- data.frame(v = groups[i], mean = estim[i], N = N[i], SE = SEs[i], CiLower = CiLower[i], CiUpper = CiUpper[i])
+		coefficientsTable$addRows(row)
+	}
 }
 
 .readDataBainAncova <- function(options, dataset){
@@ -287,7 +267,7 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 		dataset 							<- .vdf(dataset, columns.as.numeric=numeric.variables, columns.as.factor=factor.variables)
 	}
 	.hasErrors(dataset, perform, type=c("infinity", "variance", "observations"),
-				all.target=all.variables, message="short", observations.amount="< 3",
+				all.target=all.variables, observations.amount="< 3",
 				exitAnalysisIfErrors = TRUE)
 	readList <- list()
   readList[["dataset"]] <- dataset
@@ -299,17 +279,17 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 
 	if(!is.null(jaspResults[["legendTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
-		legendTable                      	<- createJaspTable("Hypothesis Legend")
-		jaspResults[["legendTable"]]     	<- legendTable
+		legendTable <- createJaspTable("Hypothesis Legend")
 		legendTable$dependOn(options =c("model", "fixedFactors"))
 		legendTable$position <- 0
 
 		legendTable$addColumnInfo(name="number", type="string", title="Abbreviation")
 		legendTable$addColumnInfo(name="hypothesis", type="string", title="Hypothesis")
+		
+		jaspResults[["legendTable"]] <- legendTable
 
 		if(options$model != ""){
-			rest.string <- options$model
-			rest.string <- gsub("\n", ";", rest.string)
+			rest.string <- .bainCleanModelInput(options$model)
 			hyp.vector <- unlist(strsplit(rest.string, "[;]"))
 				for(i in 1:length(hyp.vector)){
 					row <- list(number = paste0("H",i), hypothesis = hyp.vector[i])

--- a/JASP-Engine/JASP/R/bainancovabayesian.R
+++ b/JASP-Engine/JASP/R/bainancovabayesian.R
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
+BainAncovaBayesian	 <- function(jaspResults, dataset, options, ...) {
 
 	### READY ###
 	ready <- options[["dependent"]] != "" && options[["fixedFactors"]] != ""  && !is.null(unlist(options[["covariates"]]))
@@ -46,9 +46,9 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 	.bainAnovaDescriptivesPlot(dataset, options, bainContainer, ready, type = "ancova")
 }
 
-.bainAncovaResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready){
+.bainAncovaResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready) {
 
-	if(!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+	if (!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
 	variables <- c(options$dependent, options$fixedFactors, unlist(options$covariates))
 	bainTable <- createJaspTable("Bain ANCOVA Result")
@@ -67,14 +67,14 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 	
 	bainContainer[["bainTable"]] <- bainTable
 
-	if(!ready)
+	if (!ready)
 		return()
 
-	if(any(variables %in% missingValuesIndicator)){
+	if (any(variables %in% missingValuesIndicator)) {
 		i <- which(variables %in% missingValuesIndicator)
-		if(length(i) > 1){
+		if (length(i) > 1) {
 			bainTable$addFootnote(message= paste0("The variables ", paste(variables[i], collapse = ", "), " contain missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-		} else if (length(i) == 1){
+		} else if (length(i) == 1) {
 			bainTable$addFootnote(message= paste0("The variable ", variables[i], " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
 		}
 	}
@@ -82,12 +82,12 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 	groupCol <- dataset[ , .v(options[["fixedFactors"]])]
 	varLevels <- levels(groupCol)
 
-	if(length(varLevels) > 15){
+	if (length(varLevels) > 15) {
 		bainTable$setError("The fixed factor has too many levels for a Bain analysis.")
 		return()
 	}
 
-	if(options$model == ""){
+	if (options$model == "") {
 		# We have to make a default matrix depending on the levels of the grouping variable...meh
 		# The default hypothesis is that all groups are equal (e.g., 3 groups, "p1=p2=p3")
 		len <- length(varLevels)
@@ -127,7 +127,7 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 	}
 
 	BF <- bainResult$BF
-	for(i in 1:length(BF)){
+	for (i in 1:length(BF)) {
 		row <- data.frame(hypotheses = paste0("H",i), BF = BF[i], PMP1 = bainResult$PMPa[i], PMP2 = bainResult$PMPb[i])
 		bainTable$addRows(row)
 	}
@@ -137,16 +137,16 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 
 .bainBayesFactorMatrix <- function(dataset, options, bainContainer, ready, type) {
 
-	if(!is.null(bainContainer[["bayesFactorMatrix"]]) || !options[["bayesFactorMatrix"]]) return() #The options for this table didn't change so we don't need to rebuild it
+	if (!is.null(bainContainer[["bayesFactorMatrix"]]) || !options[["bayesFactorMatrix"]]) return() #The options for this table didn't change so we don't need to rebuild it
 
 	bayesFactorMatrix <- createJaspTable("Bayes Factor Matrix")
 	bayesFactorMatrix$position <- 3
 
-	if(type == "regression")
+	if (type == "regression")
 		bayesFactorMatrix$dependOn(options = c("bayesFactorMatrix", "covariates", "standardized"))
-	if(type == "ancova")
+	if (type == "ancova")
 		bayesFactorMatrix$dependOn(options = c("bayesFactorMatrix", "fixedFactors", "covariates"))
-	if(type == "anova")
+	if (type == "anova")
 		bayesFactorMatrix$dependOn(options = c("bayesFactorMatrix", "fixedFactors"))
 		
 	bayesFactorMatrix$addColumnInfo(name = "hypothesis", title = "", type = "string")
@@ -154,7 +154,7 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 	
 	bainContainer[["bayesFactorMatrix"]] <- bayesFactorMatrix
 
-	if(!ready || bainContainer$getError()){
+	if (!ready || bainContainer$getError()) {
 		row <- data.frame(hypothesis = "H1", H1 = ".")
 		bayesFactorMatrix$addRows(row)
 		return()
@@ -174,9 +174,9 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 			bayesFactorMatrix$addColumnInfo(name = paste0("H", i), type = "number")
 	}
 
-	for(i in 1:nrow(BFmatrix)){
+	for (i in 1:nrow(BFmatrix)) {
 		tmp <- list(hypothesis = paste0("H", i))
-		for(j in 1:ncol(BFmatrix)){
+		for (j in 1:ncol(BFmatrix)) {
 			tmp[[paste0("H", j)]] <- BFmatrix[i,j]
 		}
 		row <- tmp
@@ -186,7 +186,7 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 
 .bainAncovaCoefficientsTable <- function(dataset, options, bainContainer, ready) {
 
-	if(!is.null(bainContainer[["coefficientsTable"]]) || !options[["coefficients"]]) return()
+	if (!is.null(bainContainer[["coefficientsTable"]]) || !options[["coefficients"]]) return()
 	
 	coefficientsTable <- createJaspTable("Coefficients for Groups plus Covariates")
 	coefficientsTable$dependOn(options="coefficients")
@@ -201,7 +201,7 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 
 	bainContainer[["coefficientsTable"]] <- coefficientsTable
 	
-	if(!ready || bainContainer$getError())
+	if (!ready || bainContainer$getError())
 		return()
 
 	bainResult <- bainContainer[["bainResult"]]$object
@@ -214,7 +214,7 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 	x <- rownames(covcoef)
 	x <- sapply(regmatches(x, gregexpr("covars", x)), length)
 	x <- sum(x)
-	if(x > 1){
+	if (x > 1) {
 			rownames(covcoef)[(length(rownames(covcoef)) - (x-1)):length(rownames(covcoef))] <- options$covariates
 	} else {
 			rownames(covcoef) <- gsub("covars", options$covariates, rownames(covcoef))
@@ -232,7 +232,7 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 
 	N <- NULL
 
-	for(variable in varLevels){
+	for (variable in varLevels) {
 		column <- dataset[ , .v(options$dependent)]
 		column <- column[which(groupCol == variable)]
 		N <- c(N,length(column))
@@ -241,30 +241,30 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 	covVars <- options$covariates
 	covVars <- unlist(covVars)
 
-	for(var in covVars){
+	for (var in covVars) {
 		col <- dataset[ , .v(var)]
 		col <- na.omit(col)
 		N <- c(N, length(col))
 	}
 
-	for(i in 1:length(groups)){
+	for (i in 1:length(groups)) {
 		row <- data.frame(v = groups[i], mean = estim[i], N = N[i], SE = SEs[i], CiLower = CiLower[i], CiUpper = CiUpper[i])
 		coefficientsTable$addRows(row)
 	}
 }
 
-.readDataBainAncova <- function(options, dataset){
-	numeric.variables 						<- c(unlist(options$dependent),unlist(options$covariates))
-	numeric.variables 						<- numeric.variables[numeric.variables != ""]
-	factor.variables 						<- unlist(options$fixedFactors)
-	factor.variables 						<- factor.variables[factor.variables != ""]
-	all.variables							<- c(numeric.variables, factor.variables)
+.readDataBainAncova <- function(options, dataset) {
+	numeric.variables	<- c(unlist(options$dependent),unlist(options$covariates))
+	numeric.variables	<- numeric.variables[numeric.variables != ""]
+	factor.variables	<- unlist(options$fixedFactors)
+	factor.variables	<- factor.variables[factor.variables != ""]
+	all.variables			<- c(numeric.variables, factor.variables)
 	if (is.null(dataset)) {
-		trydata                                 <- .readDataSetToEnd(columns.as.numeric=all.variables)
-		missingValuesIndicator                  <- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
-		dataset 							<- .readDataSetToEnd(columns.as.numeric=numeric.variables, columns.as.factor=factor.variables, exclude.na.listwise=all.variables)
+		trydata									<- .readDataSetToEnd(columns.as.numeric=all.variables)
+		missingValuesIndicator	<- .unv(names(which(apply(trydata, 2, function(x) { any(is.na(x))} ))))
+		dataset									<- .readDataSetToEnd(columns.as.numeric=numeric.variables, columns.as.factor=factor.variables, exclude.na.listwise=all.variables)
 	} else {
-		dataset 							<- .vdf(dataset, columns.as.numeric=numeric.variables, columns.as.factor=factor.variables)
+		dataset									<- .vdf(dataset, columns.as.numeric=numeric.variables, columns.as.factor=factor.variables)
 	}
 	.hasErrors(dataset, perform, type=c("infinity", "variance", "observations"),
 				all.target=all.variables, observations.amount="< 3",
@@ -275,9 +275,9 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
   return(readList)
 }
 
-.bainLegendAncova <- function(dataset, options, jaspResults){
+.bainLegendAncova <- function(dataset, options, jaspResults) {
 
-	if(!is.null(jaspResults[["legendTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+	if (!is.null(jaspResults[["legendTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
 		legendTable <- createJaspTable("Hypothesis Legend")
 		legendTable$dependOn(options =c("model", "fixedFactors"))
@@ -288,14 +288,14 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 		
 		jaspResults[["legendTable"]] <- legendTable
 
-		if(options$model != ""){
+		if (options$model != "") {
 			rest.string <- .bainCleanModelInput(options$model)
 			hyp.vector <- unlist(strsplit(rest.string, "[;]"))
-				for(i in 1:length(hyp.vector)){
+				for (i in 1:length(hyp.vector)) {
 					row <- list(number = paste0("H",i), hypothesis = hyp.vector[i])
 					legendTable$addRows(row)
 				}
-		} else if (options$fixedFactors != ""){
+		} else if (options$fixedFactors != "") {
 			factor <- options$fixedFactors
 			fact <- dataset[, .v(factor)]
 			levels <- levels(fact)
@@ -305,7 +305,7 @@ BainAncovaBayesian	 <- function (jaspResults, dataset, options, ...) {
 		}
 }
 
-.plot.BainA <- function (x, y, ...)
+.plot.BainA <- function(x, y, ...)
 {
     PMPa <- x$PMPa
     PMPb <- c(x$PMPb, 1 - sum(x$PMPb))

--- a/JASP-Engine/JASP/R/bainancovabayesian.R
+++ b/JASP-Engine/JASP/R/bainancovabayesian.R
@@ -196,8 +196,8 @@ BainAncovaBayesian	 <- function(jaspResults, dataset, options, ...) {
 	coefficientsTable$addColumnInfo(name="N",				title="N",						type="integer")
 	coefficientsTable$addColumnInfo(name="mean",		title="Coefficient",	type="number")
 	coefficientsTable$addColumnInfo(name="SE",			title="SE",						type="number")
-	coefficientsTable$addColumnInfo(name="CiLower",	title="lowerCI",			type="number", overtitle="95% Credible Interval")
-	coefficientsTable$addColumnInfo(name="CiUpper",	title="upperCI",			type="number", overtitle="95% Credible Interval")
+	coefficientsTable$addColumnInfo(name="CiLower",	title="lower",			type="number", overtitle="95% Credible Interval")
+	coefficientsTable$addColumnInfo(name="CiUpper",	title="upper",			type="number", overtitle="95% Credible Interval")
 
 	bainContainer[["coefficientsTable"]] <- coefficientsTable
 	

--- a/JASP-Engine/JASP/R/bainancovabayesian.R
+++ b/JASP-Engine/JASP/R/bainancovabayesian.R
@@ -121,7 +121,7 @@ BainAncovaBayesian	 <- function(jaspResults, dataset, options, ...) {
 		})
 	}
 
-	if (inherits(p, "try-error")) {
+	if (isTryError(p)) {
 		bainContainer$setError(paste0("An error occurred in the analysis:<br>", .extractErrorMessage(p), "<br><br>Please double check your variables and model constraints."))
 		return()
 	}

--- a/JASP-Engine/JASP/R/bainanovabayesian.R
+++ b/JASP-Engine/JASP/R/bainanovabayesian.R
@@ -123,7 +123,7 @@ BainAnovaBayesian <- function(jaspResults, dataset, options, ...) {
 			})
 	}
 
-	if (inherits(p, "try-error")) {
+	if (isTryError(p)) {
 		bainContainer$setError(paste0("An error occurred in the analysis:<br>", .extractErrorMessage(p), "<br><br>Please double check your variables and model constraints."))
 		return()
 	}

--- a/JASP-Engine/JASP/R/bainanovabayesian.R
+++ b/JASP-Engine/JASP/R/bainanovabayesian.R
@@ -148,13 +148,13 @@ BainAnovaBayesian <- function(jaspResults, dataset, options, ...) {
 	descriptivesTable$addColumnInfo(name="v",    		title="Level",	type="string")
 	descriptivesTable$addColumnInfo(name="N",    		title="N",			type="integer")
 	descriptivesTable$addColumnInfo(name="mean", 		title="Mean",		type="number")
-	descriptivesTable$addColumnInfo(name="sd",   		title="sd", 		type="number")
-	descriptivesTable$addColumnInfo(name="se",   		title="se", 		type="number")
+	descriptivesTable$addColumnInfo(name="sd",   		title="SD", 		type="number")
+	descriptivesTable$addColumnInfo(name="se",   		title="SE", 		type="number")
 
 	interval <- options$CredibleInterval * 100
 	overTitle <- paste0(interval, "% Credible Interval")
-	descriptivesTable$addColumnInfo(name="lowerCI",      title = "lowerCI", type="number", overtitle = overTitle)
-	descriptivesTable$addColumnInfo(name="upperCI",      title = "upperCI", type="number", overtitle = overTitle)
+	descriptivesTable$addColumnInfo(name="lowerCI",      title = "Lower", type="number", overtitle = overTitle)
+	descriptivesTable$addColumnInfo(name="upperCI",      title = "Upper", type="number", overtitle = overTitle)
 	
 	jaspResults[["descriptivesTable"]] <- descriptivesTable
 

--- a/JASP-Engine/JASP/R/bainanovabayesian.R
+++ b/JASP-Engine/JASP/R/bainanovabayesian.R
@@ -297,7 +297,7 @@ BainAnovaBayesian <- function(jaspResults, dataset, options, ...) {
   citations <- c(
 		"Gu, X., Mulder, J., and Hoijtink, H. (2017). Approximate adjusted fractional Bayes factors: A general method for testing informative hypotheses. British Journal of Mathematical and Statistical Psychology. DOI:10.1111/bmsp.12110",
 		"Hoijtink, H., Mulder, J., van Lissa, C., and Gu, X. (2018). A Tutorial on testing hypotheses using the Bayes factor. Psychological Methods.",
-		"Hoijtink, H., Gu, X., and Mulder, J. (2018). Bayesian evaluation of informative hypotheses for multiple populations. Britisch Journal of Mathematical and Statistical Psychology. DOI: 10.1111/bmsp.12145"
+		"Hoijtink, H., Gu, X., and Mulder, J. (2018). Bayesian evaluation of informative hypotheses for multiple populations. British Journal of Mathematical and Statistical Psychology. DOI: 10.1111/bmsp.12145"
 	)
   return(citations)
 }

--- a/JASP-Engine/JASP/R/bainanovabayesian.R
+++ b/JASP-Engine/JASP/R/bainanovabayesian.R
@@ -25,47 +25,47 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	dataset <- readList[["dataset"]]
 	missingValuesIndicator <- readList[["missingValuesIndicator"]]
 	
+	bainContainer <- .bainGetContainer(jaspResults, deps=c("dependent", "fixedFactors", "model"))
+	
 	### LEGEND ###
 	.bainLegendAncova(dataset, options, jaspResults)
 	
 	### RESULTS ###
-	.bainAnovaResultsTable(dataset, options, jaspResults, missingValuesIndicator, ready)
+	.bainAnovaResultsTable(dataset, options, bainContainer, missingValuesIndicator, ready)
 	
 	### BAYES FACTOR MATRIX ###
-	.bainBayesFactorMatrix(dataset, options, jaspResults, ready, type = "anova")
+	.bainBayesFactorMatrix(dataset, options, bainContainer, ready, type = "anova")
 	
 	### DESCRIPTIVES ###
 	.bainAnovaDescriptivesTable(dataset, options, jaspResults, ready)
 	
 	### BAYES FACTOR PLOT ###
-	.bainAnovaBayesFactorPlots(dataset, options, jaspResults, ready)
+	.bainAnovaBayesFactorPlots(dataset, options, bainContainer, ready)
 	
 	### DESCRIPTIVES PLOT ###
-	.bainAnovaDescriptivesPlot(dataset, options, jaspResults, ready)
+	.bainAnovaDescriptivesPlot(dataset, options, bainContainer, ready)
 }
 
-.bainAnovaResultsTable <- function(dataset, options, jaspResults, missingValuesIndicator, ready){
+.bainAnovaResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready){
 
-	if(!is.null(jaspResults[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+	if(!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
-	variables 											<- c(options$dependent, options$fixedFactors)
-	bainTable                      	<- createJaspTable("Bain ANOVA Result")
-	jaspResults[["bainTable"]]     	<- bainTable
-	bainTable$dependOn(options =c("dependent", "fixedFactors", "model"))
+	variables <- c(options$dependent, options$fixedFactors)
+	bainTable <- createJaspTable("Bain ANOVA Result")
 	bainTable$position <- 1
 
-	bainTable$addColumnInfo(name="hypotheses", 				type="string", title="")
-	bainTable$addColumnInfo(name="BF", 						type="number", format="sf:4;dp:3", title= "BF.c")
-	bainTable$addColumnInfo(name="PMP1", 					type="number", format="sf:4;dp:3", title= "PMP a")
-	bainTable$addColumnInfo(name="PMP2", 					type="number", format="sf:4;dp:3", title= "PMP b")
+	bainContainer[["bainTable"]] <- bainTable
+
+	bainTable$addColumnInfo(name="hypotheses", 		type="string", title="")
+	bainTable$addColumnInfo(name="BF", 						type="number", title="BF.c")
+	bainTable$addColumnInfo(name="PMP1", 					type="number", title="PMP a")
+	bainTable$addColumnInfo(name="PMP2", 					type="number", title="PMP b")
 
 	message <- "BF.c denotes the Bayes factor of the hypothesis in the row versus its complement.
 				Posterior model probabilities (a: excluding the unconstrained hypothesis, b: including the unconstrained hypothesis) are based on equal prior model probabilities."
-	bainTable$addFootnote(message=message, symbol="<i>Note.</i>")
+	bainTable$addFootnote(message=message)
 
-	bainTable$addCitation("Gu, X., Mulder, J., and Hoijtink, H. (2017). Approximate adjusted fractional Bayes factors: A general method for testing informative hypotheses. British Journal of Mathematical and Statistical Psychology. DOI:10.1111/bmsp.12110")
-	bainTable$addCitation("Hoijtink, H., Mulder, J., van Lissa, C., and Gu, X. (2018). A Tutorial on testing hypotheses using the Bayes factor. Psychological Methods.")
-	bainTable$addCitation("Hoijtink, H., Gu, X., and Mulder, J. (2018). Bayesian evaluation of informative hypotheses for multiple populations. Britisch Journal of Mathematical and Statistical Psychology. DOI: 10.1111/bmsp.12145")
+	bainTable$addCitation(.bainGetCitations())
 
 	if(!ready)
 		return()
@@ -83,7 +83,7 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	varLevels <- levels(groupCol)
 
 	if(length(varLevels) > 15){
-		bainTable$setError("The fixed factor has too many levels for a Bain analysis.")
+		bainContainer$setError("The fixed factor has too many levels for a Bain analysis.")
 		return()
 	}
 
@@ -103,18 +103,12 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 
 		p <- try(silent= FALSE, expr= {
 			bainResult <- Bain::Bain_anova(X = dataset, dep_var = .v(options[["dependent"]]), group = .v(options[["fixedFactors"]]), ERr, IRr)
-			jaspResults[["bainResult"]] <- createJaspState(bainResult)
-			jaspResults[["bainResult"]]$dependOn(options =c("dependent", "fixedFactors", "model"))
+			bainContainer[["bainResult"]] <- createJaspState(bainResult)
 		})
 
 	} else {
 
-			jaspResults$startProgressbar(3)
-			jaspResults$progressbarTick()
-
-			rest.string <- options$model
-			rest.string <- gsub("\n", ";", rest.string)
-			jaspResults$progressbarTick()
+			rest.string <- .bainCleanModelInput(options$model)
 
 			inpt <- list()
 			names(dataset) <- .unv(names(dataset))
@@ -125,159 +119,150 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 
 			p <- try(silent= FALSE, expr= {
 				bainResult <- Bain::Bain_anova_cm(X = inpt[[1]], dep_var = inpt[[2]], group = inpt[[3]], hyp = inpt[[4]])
-				jaspResults[["bainResult"]] <- createJaspState(bainResult)
-				jaspResults[["bainResult"]]$dependOn(options =c("dependent", "fixedFactors", "model"))
+				bainContainer[["bainResult"]] <- createJaspState(bainResult)
 			})
-		}
+	}
 
-		if(class(p) == "try-error"){
-			bainTable$setError("An error occurred in the analysis. Please double check your variables.")
-			return()
-		} else {
+	if (inherits(p, "try-error")) {
+		bainContainer$setError(paste0("An error occurred in the analysis:<br>", .extractErrorMessage(p), "<br><br>Please double check your variables and model constraints."))
+		return()
+	}
 
-			jaspResults$progressbarTick()
-			BF <- bainResult$BF
-			for(i in 1:length(BF)){
-				row <- list(hypotheses = paste0("H",i), BF = .clean(BF[i]), PMP1 = .clean(bainResult$PMPa[i]), PMP2 = .clean(bainResult$PMPb[i]))
-				bainTable$addRows(row)
-			}
-			row <- list(hypotheses = "Hu", BF = "", PMP1 = "", PMP2 = .clean(1-sum(bainResult$PMPb)))
-			bainTable$addRows(row)
-		}
+	BF <- bainResult$BF
+	for(i in 1:length(BF)){
+		row <- list(hypotheses = paste0("H",i), BF = BF[i], PMP1 = bainResult$PMPa[i], PMP2 = bainResult$PMPb[i])
+		bainTable$addRows(row)
+	}
+	row <- list(hypotheses = "Hu", BF = "", PMP1 = "", PMP2 = 1-sum(bainResult$PMPb))
+	bainTable$addRows(row)
 }
 
 .bainAnovaDescriptivesTable <- function(dataset, options, jaspResults, ready){
 
-	if(!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
-		if(options[["descriptives"]]){
+	if (!is.null(jaspResults[["descriptivesTable"]]) || !options[["descriptives"]]) return()
 
-			descriptivesTable                      	<- createJaspTable("Descriptive Statistics")
-			jaspResults[["descriptivesTable"]]     	<- descriptivesTable
-			descriptivesTable$dependOn(options =c("dependent", "fixedFactors", "descriptives", "CredibleInterval"))
-			descriptivesTable$position <- 2
+	descriptivesTable <- createJaspTable("Descriptive Statistics")
+	descriptivesTable$dependOn(options =c("dependent", "fixedFactors", "descriptives", "CredibleInterval"))
+	descriptivesTable$position <- 2
 
-			descriptivesTable$addColumnInfo(name="v",    		title="Level",   type="string")
-			descriptivesTable$addColumnInfo(name="N",    		title="N",  type="integer")
-			descriptivesTable$addColumnInfo(name="mean", 		title="Mean", type="number", format="sf:4;dp:3")
-			descriptivesTable$addColumnInfo(name="sd",   		title="sd", type="number",   format="sf:4;dp:3")
-			descriptivesTable$addColumnInfo(name="se",   		title="se", type="number",   format="sf:4;dp:3")
+	descriptivesTable$addColumnInfo(name="v",    		title="Level",	type="string")
+	descriptivesTable$addColumnInfo(name="N",    		title="N",			type="integer")
+	descriptivesTable$addColumnInfo(name="mean", 		title="Mean",		type="number")
+	descriptivesTable$addColumnInfo(name="sd",   		title="sd", 		type="number")
+	descriptivesTable$addColumnInfo(name="se",   		title="se", 		type="number")
 
-			interval <- options$CredibleInterval * 100
-			overTitle <- paste0(interval, "% Credible Interval")
-			descriptivesTable$addColumnInfo(name="lowerCI",      title = "lowerCI", type="number", format="sf:4;dp:3", overtitle = overTitle)
-    	descriptivesTable$addColumnInfo(name="upperCI",      title = "upperCI", type="number", format="sf:4;dp:3", overtitle = overTitle)
+	interval <- options$CredibleInterval * 100
+	overTitle <- paste0(interval, "% Credible Interval")
+	descriptivesTable$addColumnInfo(name="lowerCI",      title = "lowerCI", type="number", overtitle = overTitle)
+	descriptivesTable$addColumnInfo(name="upperCI",      title = "upperCI", type="number", overtitle = overTitle)
+	
+	jaspResults[["descriptivesTable"]] <- descriptivesTable
 
-			if(!ready)
-				return()
+	if(!ready)
+		return()
 
-			groupCol <- dataset[ , .v(options[["fixedFactors"]])]
-			varLevels <- levels(groupCol)
+	groupCol <- dataset[ , .v(options[["fixedFactors"]])]
+	varLevels <- levels(groupCol)
 
-			for(variable in varLevels){
+	for(variable in varLevels){
 
-					column <- dataset[ , .v(options$dependent)]
-					column <- column[which(groupCol == variable)]
+			column <- dataset[ , .v(options$dependent)]
+			column <- column[which(groupCol == variable)]
 
-					posteriorSummary <- .posteriorSummaryGroupMean(variable=column, descriptivesPlotsCredibleInterval=options$CredibleInterval/100)
-                    ciLower <- .clean(posteriorSummary$ciLower)
-                    ciUpper <- .clean(posteriorSummary$ciUpper)
+			posteriorSummary <- .posteriorSummaryGroupMean(variable=column, descriptivesPlotsCredibleInterval=options$CredibleInterval/100)
+								ciLower <- posteriorSummary$ciLower
+								ciUpper <- posteriorSummary$ciUpper
 
-					row <- data.frame(v = variable, N = .clean(length(column)), mean = .clean(mean(column)), sd = .clean(round(sd(column),3)),
-													se = .clean(sd(column)/sqrt(length(column))), lowerCI = ciLower, upperCI = ciUpper)
-					descriptivesTable$addRows(row)
-			}
+			row <- data.frame(v = variable, N = length(column), mean = mean(column), sd = round(sd(column),3),
+											se = sd(column)/sqrt(length(column)), lowerCI = ciLower, upperCI = ciUpper)
+			descriptivesTable$addRows(row)
 	}
 }
 
-.bainAnovaBayesFactorPlots <- function(dataset, options, jaspResults, ready){
-	if(options[["bayesFactorPlot"]] && ready){
-	  if(is.null(jaspResults[["bayesFactorPlot"]])){
-			bainResult <- jaspResults[["bainResult"]]$object
-				png(tempfile())
-				p <- .plot.BainA(bainResult)
-				dev.off()
-	      jaspResults[["bayesFactorPlot"]] <- createJaspPlot(plot = p, title = "Bayes Factor Comparison", height = 400, width = 600)
-	      jaspResults[["bayesFactorPlot"]]$dependOn(options =c("bayesFactorPlot", "fixedFactors", "dependent", "model"))
-				jaspResults[["bayesFactorPlot"]]$position <- 4
-		}
-	} else if(options[["bayesFactorPlot"]]){
-			errorPlot <- createJaspPlot(plot = NULL, title = "Bayes Factor Comparison", height = 400, width = 600)
-			errorPlot$setError("Plotting not possible: No analysis has been run.")
-			jaspResults[["bayesFactorPlot"]] <- errorPlot
-			jaspResults[["bayesFactorPlot"]]$dependOn(options =c("bayesFactorPlot", "fixedFactors", "dependent", "model"))
-			jaspResults[["bayesFactorPlot"]]$position <- 4
-	}
+.bainAnovaBayesFactorPlots <- function(dataset, options, bainContainer, ready) {
+	if (!is.null(bainContainer[["bayesFactorPlot"]]) || !options[["bayesFactorPlot"]]) return()
+
+	bayesFactorPlot <- createJaspPlot(plot = NULL, title = "Bayes Factor Comparison", height = 400, width = 600)
+	bayesFactorPlot$dependOn(options="bayesFactorPlot")
+	bayesFactorPlot$position <- 4
+	
+	bainContainer[["bayesFactorPlot"]] <- bayesFactorPlot
+
+	if (!ready || bainContainer$getError())
+		return()
+		
+	bainResult <- bainContainer[["bainResult"]]$object
+	bayesFactorPlot$plotObject <- .suppressGrDevice(.plot.BainA(bainResult))
 }
 
-.bainAnovaDescriptivesPlot <- function(dataset, options, jaspResults, ready, type = "anova") {
-	if(options[["descriptivesPlot"]] && ready){
-		if(is.null(jaspResults[["descriptivesPlot"]])){
-			bainResult <- jaspResults[["bainResult"]]$object
-			base_breaks_y <- function(x, plotErrorBars = TRUE){
-					ci.pos <- c(x[,"dependent"], x[,"ciLower"], x[,"ciUpper"])
-					b <- pretty(ci.pos)
-					d <- data.frame(x=-Inf, xend=-Inf, y=min(b), yend=max(b))
-					list(ggplot2::geom_segment(data=d, ggplot2::aes(x=x, y=y, xend=xend, yend=yend), inherit.aes=FALSE, size = 1),
-						 ggplot2::scale_y_continuous(breaks=c(min(b),max(b))))
-					 }
-			groupVars <- options$fixedFactors
-			groupVars <- unlist(groupVars)
+.bainAnovaDescriptivesPlot <- function(dataset, options, bainContainer, ready, type = "anova") {
+	if (!is.null(bainContainer[["descriptivesPlot"]]) || !options[["descriptivesPlot"]]) return()
+	
+	descriptivesPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plot")
+	descriptivesPlot$dependOn(options=c("descriptivesPlot", "fixedFactors", "dependent", "model"))
+	descriptivesPlot$position <- 4
 
-			groupVarsV <- .v(groupVars)
-			dependentV <- .v(options$dependent)
+	bainContainer[["descriptivesPlot"]] <- descriptivesPlot
 
-			sum_model <- bainResult$estimate_res
-			summaryStat <- summary(sum_model)$coefficients
-
-			if(type == "ancova"){
-				summaryStat <- summaryStat[-(nrow(summaryStat) - 0:(length(options[["covariates"]])-1)), ] # Remove covars rows
-			}
-
-			summaryStat <- cbind(summaryStat, 1:nrow(summaryStat))
-			colnames(summaryStat)[length(colnames(summaryStat))] <- "plotHorizontalAxis"
-			colnames(summaryStat)[which(colnames(summaryStat) == "Estimate")] <- "dependent"
-			summaryStatSubset <- as.data.frame(summaryStat)
-
-			groupCol <- dataset[ , .v(options[["fixedFactors"]])]
-			varLevels <- levels(groupCol)
-			ciLower <- summaryStatSubset[, 1] - 1.96*summaryStatSubset[, 2]
-			ciUpper <- summaryStatSubset[, 1] + 1.96*summaryStatSubset[, 2]
-			summaryStatSubset$ciLower <- ciLower
-			summaryStatSubset$ciUpper <- ciUpper
-			summaryStat <- summaryStatSubset
-
-				p <- ggplot2::ggplot(summaryStatSubset, ggplot2::aes(x=plotHorizontalAxis,
-											y=dependent,
-											group=1))
-
-
-				pd <- ggplot2::position_dodge(.2)
-				p = p + ggplot2::geom_errorbar(ggplot2::aes(ymin=ciLower,
-															ymax=ciUpper),
-															colour="black", width=.2, position=pd)
-
-
-			p <- p + ggplot2::geom_line(position=pd, size = .7) +
-				ggplot2::geom_point(position=pd, size=4) +
-				ggplot2::scale_fill_manual(values = c(rep(c("white","black"),5),rep("grey",100)), guide=ggplot2::guide_legend(nrow=10)) +
-				ggplot2::scale_shape_manual(values = c(rep(c(21:25),each=2),21:25,7:14,33:112), guide=ggplot2::guide_legend(nrow=10)) +
-				ggplot2::scale_color_manual(values = rep("black",200),guide=ggplot2::guide_legend(nrow=10)) +
-				ggplot2::ylab(options$dependent) +
-				ggplot2::xlab(groupVars) +
-				base_breaks_y(summaryStat, TRUE)
-			p <- JASPgraphs::themeJasp(p)
-
-				jaspResults[["descriptivesPlot"]] <- createJaspPlot(plot = p, title = "Descriptives Plot")
-				jaspResults[["descriptivesPlot"]]$dependOn(options =c("descriptivesPlot", "fixedFactors", "dependent", "model"))
-				jaspResults[["descriptivesPlot"]]$position <- 4
-		}
-	} else if(options[["descriptivesPlot"]]){
-			errorPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plot")
-			errorPlot$setError("Plotting not possible: No analysis has been run.")
-			jaspResults[["descriptivesPlot"]] <- errorPlot
-			jaspResults[["descriptivesPlot"]]$dependOn(options =c("descriptivesPlot", "fixedFactors", "dependent", "model"))
-			jaspResults[["descriptivesPlot"]]$position <- 4
+	if (!ready || bainContainer$getError())
+		return()
+	
+	bainResult <- bainContainer[["bainResult"]]$object
+	
+	base_breaks_y <- function(x, plotErrorBars = TRUE) {
+			ci.pos <- c(x[,"dependent"], x[,"ciLower"], x[,"ciUpper"])
+			b <- pretty(ci.pos)
+			d <- data.frame(x=-Inf, xend=-Inf, y=min(b), yend=max(b))
+			list(ggplot2::geom_segment(data=d, ggplot2::aes(x=x, y=y, xend=xend, yend=yend), inherit.aes=FALSE, size = 1),
+					ggplot2::scale_y_continuous(breaks=c(min(b),max(b))))
 	}
+	groupVars <- options$fixedFactors
+	groupVars <- unlist(groupVars)
+
+	groupVarsV <- .v(groupVars)
+	dependentV <- .v(options$dependent)
+
+	sum_model <- bainResult$estimate_res
+	summaryStat <- summary(sum_model)$coefficients
+
+	if(type == "ancova"){
+		summaryStat <- summaryStat[-(nrow(summaryStat) - 0:(length(options[["covariates"]])-1)), ] # Remove covars rows
+	}
+
+	summaryStat <- cbind(summaryStat, 1:nrow(summaryStat))
+	colnames(summaryStat)[length(colnames(summaryStat))] <- "plotHorizontalAxis"
+	colnames(summaryStat)[which(colnames(summaryStat) == "Estimate")] <- "dependent"
+	summaryStatSubset <- as.data.frame(summaryStat)
+
+	groupCol <- dataset[ , .v(options[["fixedFactors"]])]
+	varLevels <- levels(groupCol)
+	ciLower <- summaryStatSubset[, 1] - 1.96*summaryStatSubset[, 2]
+	ciUpper <- summaryStatSubset[, 1] + 1.96*summaryStatSubset[, 2]
+	summaryStatSubset$ciLower <- ciLower
+	summaryStatSubset$ciUpper <- ciUpper
+	summaryStat <- summaryStatSubset
+
+	p <- ggplot2::ggplot(summaryStatSubset, ggplot2::aes(x=plotHorizontalAxis,
+								y=dependent,
+								group=1))
+
+	pd <- ggplot2::position_dodge(.2)
+	p = p + ggplot2::geom_errorbar(ggplot2::aes(ymin=ciLower,
+												ymax=ciUpper),
+												colour="black", width=.2, position=pd)
+
+	p <- p + ggplot2::geom_line(position=pd, size = .7) +
+		ggplot2::geom_point(position=pd, size=4) +
+		ggplot2::scale_fill_manual(values = c(rep(c("white","black"),5),rep("grey",100)), guide=ggplot2::guide_legend(nrow=10)) +
+		ggplot2::scale_shape_manual(values = c(rep(c(21:25),each=2),21:25,7:14,33:112), guide=ggplot2::guide_legend(nrow=10)) +
+		ggplot2::scale_color_manual(values = rep("black",200),guide=ggplot2::guide_legend(nrow=10)) +
+		ggplot2::ylab(options$dependent) +
+		ggplot2::xlab(groupVars) +
+		base_breaks_y(summaryStat, TRUE)
+
+	p <- JASPgraphs::themeJasp(p)
+
+	descriptivesPlot$plotObject <- p
 }
 
 .readDataBainAnova <- function(options, dataset){
@@ -296,10 +281,31 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	}
 
 	.hasErrors(dataset, perform, type=c("infinity", "variance", "observations"),
-				all.target=all.variables, message="short", observations.amount="< 3",
+				all.target=all.variables, observations.amount="< 3",
 				exitAnalysisIfErrors = TRUE)
 	readList <- list()
   readList[["dataset"]] <- dataset
   readList[["missingValuesIndicator"]] <- missingValuesIndicator
   return(readList)
+}
+
+.bainCleanModelInput <- function(input) {
+  return(gsub("\n+", ";", input))
+}
+
+.bainGetCitations <- function() {
+  citations <- c(
+		"Gu, X., Mulder, J., and Hoijtink, H. (2017). Approximate adjusted fractional Bayes factors: A general method for testing informative hypotheses. British Journal of Mathematical and Statistical Psychology. DOI:10.1111/bmsp.12110",
+		"Hoijtink, H., Mulder, J., van Lissa, C., and Gu, X. (2018). A Tutorial on testing hypotheses using the Bayes factor. Psychological Methods.",
+		"Hoijtink, H., Gu, X., and Mulder, J. (2018). Bayesian evaluation of informative hypotheses for multiple populations. Britisch Journal of Mathematical and Statistical Psychology. DOI: 10.1111/bmsp.12145"
+	)
+  return(citations)
+}
+
+.bainGetContainer <- function(jaspResults, deps) {
+	if (is.null(jaspResults[["bainContainer"]])) {
+		jaspResults[["bainContainer"]] <- createJaspContainer()
+		jaspResults[["bainContainer"]]$dependOn(options=deps)
+	}
+	invisible(jaspResults[["bainContainer"]])
 }

--- a/JASP-Engine/JASP/R/bainanovabayesian.R
+++ b/JASP-Engine/JASP/R/bainanovabayesian.R
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
+BainAnovaBayesian <- function(jaspResults, dataset, options, ...) {
 
 	### READY ###
 	ready <- options[["fixedFactors"]] != "" && options[["dependent"]] != ""
@@ -46,9 +46,9 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	.bainAnovaDescriptivesPlot(dataset, options, bainContainer, ready)
 }
 
-.bainAnovaResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready){
+.bainAnovaResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready) {
 
-	if(!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+	if (!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
 	variables <- c(options$dependent, options$fixedFactors)
 	bainTable <- createJaspTable("Bain ANOVA Result")
@@ -67,14 +67,14 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 
 	bainTable$addCitation(.bainGetCitations())
 
-	if(!ready)
+	if (!ready)
 		return()
 
-	if(any(variables %in% missingValuesIndicator)){
+	if (any(variables %in% missingValuesIndicator)) {
 		i <- which(variables %in% missingValuesIndicator)
-		if(length(i) > 1){
+		if (length(i) > 1) {
 			bainTable$addFootnote(message= paste0("The variables ", variables[1], " and ", variables[2], " contain missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-		} else if (length(i) == 1){
+		} else if (length(i) == 1) {
 			bainTable$addFootnote(message= paste0("The variable ", variables[i], " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
 		}
 	}
@@ -82,12 +82,12 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	groupCol <- dataset[ , .v(options[["fixedFactors"]])]
 	varLevels <- levels(groupCol)
 
-	if(length(varLevels) > 15){
+	if (length(varLevels) > 15) {
 		bainContainer$setError("The fixed factor has too many levels for a Bain analysis.")
 		return()
 	}
 
-	if(options$model == ""){
+	if (options$model == "") {
 
 		# We have to make a default matrix depending on the levels of the grouping variable...meh
 		# The default hypothesis is that all groups are equal (e.g., 3 groups, "p1=p2=p3")
@@ -129,7 +129,7 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	}
 
 	BF <- bainResult$BF
-	for(i in 1:length(BF)){
+	for (i in 1:length(BF)) {
 		row <- list(hypotheses = paste0("H",i), BF = BF[i], PMP1 = bainResult$PMPa[i], PMP2 = bainResult$PMPb[i])
 		bainTable$addRows(row)
 	}
@@ -137,7 +137,7 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	bainTable$addRows(row)
 }
 
-.bainAnovaDescriptivesTable <- function(dataset, options, jaspResults, ready){
+.bainAnovaDescriptivesTable <- function(dataset, options, jaspResults, ready) {
 
 	if (!is.null(jaspResults[["descriptivesTable"]]) || !options[["descriptives"]]) return()
 
@@ -158,13 +158,13 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	
 	jaspResults[["descriptivesTable"]] <- descriptivesTable
 
-	if(!ready)
+	if (!ready)
 		return()
 
 	groupCol <- dataset[ , .v(options[["fixedFactors"]])]
 	varLevels <- levels(groupCol)
 
-	for(variable in varLevels){
+	for (variable in varLevels) {
 
 			column <- dataset[ , .v(options$dependent)]
 			column <- column[which(groupCol == variable)]
@@ -225,7 +225,7 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	sum_model <- bainResult$estimate_res
 	summaryStat <- summary(sum_model)$coefficients
 
-	if(type == "ancova"){
+	if (type == "ancova") {
 		summaryStat <- summaryStat[-(nrow(summaryStat) - 0:(length(options[["covariates"]])-1)), ] # Remove covars rows
 	}
 
@@ -265,16 +265,16 @@ BainAnovaBayesian <- function (jaspResults, dataset, options, ...) {
 	descriptivesPlot$plotObject <- p
 }
 
-.readDataBainAnova <- function(options, dataset){
-	numeric.variables 							<- c(unlist(options$dependent))
-	numeric.variables 							<- numeric.variables[numeric.variables != ""]
-	factor.variables 							<- unlist(options$fixedFactors)
-	factor.variables 							<- factor.variables[factor.variables != ""]
-	all.variables 								<- c(numeric.variables, factor.variables)
+.readDataBainAnova <- function(options, dataset) {
+	numeric.variables	<- c(unlist(options$dependent))
+	numeric.variables	<- numeric.variables[numeric.variables != ""]
+	factor.variables	<- unlist(options$fixedFactors)
+	factor.variables	<- factor.variables[factor.variables != ""]
+	all.variables			<- c(numeric.variables, factor.variables)
 
 	if (is.null(dataset)) {
-		trydata                                 <- .readDataSetToEnd(columns.as.numeric=all.variables)
-		missingValuesIndicator                  <- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
+		trydata									<- .readDataSetToEnd(columns.as.numeric=all.variables)
+		missingValuesIndicator	<- .unv(names(which(apply(trydata, 2, function(x) { any(is.na(x))} ))))
 		dataset 								<- .readDataSetToEnd(columns.as.numeric=numeric.variables, columns.as.factor=factor.variables, exclude.na.listwise=all.variables)
 	} else {
 		dataset 								<- .vdf(dataset, columns.as.numeric=numeric.variables, columns.as.factor=factor.variables)

--- a/JASP-Engine/JASP/R/bainregressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/bainregressionlinearbayesian.R
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
+BainRegressionLinearBayesian <- function(jaspResults, dataset, options, ...) {
 
 	### READY ###
 	ready <- (options[["dependent"]] != "" && unlist(options[["covariates"]]) != "" && !is.null(unlist(options[["covariates"]])))
@@ -44,9 +44,9 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 
 }
 
-.bainLinearRegressionResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready){
+.bainLinearRegressionResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready) {
 
-	if(!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+	if (!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
 	variables <- c(options[["dependent"]], unlist(options[["covariates"]]))
 
@@ -65,19 +65,19 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 
 	bainTable$addCitation(.bainGetCitations())
 
-	if(!ready)
+	if (!ready)
 		return()
 
-	if(any(variables %in% missingValuesIndicator)){
+	if (any(variables %in% missingValuesIndicator)) {
 		i <- which(variables %in% missingValuesIndicator)
-		if(length(i) > 1){
+		if (length(i) > 1) {
 			bainTable$addFootnote(message= paste0("The variables ", paste(variables[i], collapse = ", "), " contain missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-		} else if (length(i) == 1){
+		} else if (length(i) == 1) {
 			bainTable$addFootnote(message= paste0("The variable ", variables[i], " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
 		}
 	}
 
-	if(options$model == ""){
+	if (options$model == "") {
 		formula <- paste(options[["dependent"]], "~", paste(options[["covariates"]], collapse=' + '))
 		rest.string <- paste0(paste0(options[["covariates"]], " = 0"), collapse = " & ")
 		rest.string <- .bainCleanModelInput(rest.string)
@@ -118,7 +118,7 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 	}
 
 	BF <- bainResult$BF
-	for(i in 1:length(BF)){
+	for (i in 1:length(BF)) {
 		row <- data.frame(hypotheses = paste0("H",i), BF = BF[i], PMP1 = bainResult$PMPa[i], PMP2 = bainResult$PMPb[i])
 		bainTable$addRows(row)
 	}
@@ -126,7 +126,7 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 	bainTable$addRows(row)
 }
 
-.bainLinearRegressionBayesFactorPlots <- function(dataset, options, bainContainer, ready){
+.bainLinearRegressionBayesFactorPlots <- function(dataset, options, bainContainer, ready) {
 	if (!is.null(bainContainer[["bayesFactorPlot"]]) || !options[["bayesFactorPlot"]]) return()
 
 	bayesFactorPlot <- createJaspPlot(plot = NULL, title = "Bayes Factor Comparison", height = 400, width = 600)
@@ -142,8 +142,8 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 	bayesFactorPlot$plotObject <- .suppressGrDevice(.plot.BainR(bainResult))
 }
 
-.bainLinearRegressionCoefficientsTable <- function(dataset, options, bainContainer, ready){
-	if(!is.null(bainContainer[["coefficientsTable"]]) || !options[["coefficients"]]) return()
+.bainLinearRegressionCoefficientsTable <- function(dataset, options, bainContainer, ready) {
+	if (!is.null(bainContainer[["coefficientsTable"]]) || !options[["coefficients"]]) return()
 
 	coefficientsTable <- createJaspTable("Coefficients")
 	coefficientsTable$dependOn(options = "coefficients")
@@ -159,13 +159,13 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 
 	bainContainer[["coefficientsTable"]] <- coefficientsTable
 
-	if(!ready || bainContainer$getError())
+	if (!ready || bainContainer$getError())
 		return()
 
 	bainResult <- bainContainer[["bainResult"]]$object
 	sum_model <- bainResult[["estimate_res"]]
 
-	if(!options[["standardized"]]){
+	if (!options[["standardized"]]) {
 		covcoef <- data.frame(sum_model[["coefficients"]])
 		groups <- rownames(covcoef)
 		estim <- summary(sum_model)$coefficients[, 1]
@@ -180,8 +180,8 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 		CiLower <- covcoef[, 1]
 		CiUpper <- covcoef[, 3]
 	}
-	for(i in 1:length(estim)){
-		if(i == 1 && !options$standardized){
+	for (i in 1:length(estim)) {
+		if (i == 1 && !options$standardized) {
 			row <- data.frame(v = groups[i], mean = estim[i], SE = SE[i], CiLower = CiLower[i], CiUpper = CiUpper[i])
 			coefficientsTable$addRows(row)
 		} else {
@@ -191,12 +191,12 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 	}
 }
 
-.readDataBainLinearRegression <- function(options, dataset){
+.readDataBainLinearRegression <- function(options, dataset) {
 	all.variables <- c(options$dependent, unlist(options$covariates))
 	all.variables <- all.variables[all.variables != ""]
 	if (is.null(dataset)) {
 		trydata <- .readDataSetToEnd(columns.as.numeric=all.variables)
-		missingValuesIndicator <- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
+		missingValuesIndicator <- .unv(names(which(apply(trydata, 2, function(x) { any(is.na(x))} ))))
 		dataset <- .readDataSetToEnd(columns.as.numeric=all.variables, exclude.na.listwise=all.variables)
 	} else {
 		dataset <- .vdf(dataset, columns.as.numeric=all.variables)
@@ -210,8 +210,8 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
   return(readList)
 }
 
-.bainLegendRegression <- function(dataset, options, jaspResults){
-	if(!is.null(jaspResults[["legendTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+.bainLegendRegression <- function(dataset, options, jaspResults) {
+	if (!is.null(jaspResults[["legendTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
 	legendTable <- createJaspTable("Hypothesis Legend")
 	legendTable$dependOn(options =c("model", "covariates"))
@@ -221,21 +221,21 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 
 	jaspResults[["legendTable"]] <- legendTable
 
-	if(options$model != ""){
+	if (options$model != "") {
 		rest.string <- .bainCleanModelInput(options$model)
 		hyp.vector <- unlist(strsplit(rest.string, "[;]"))
 
-			for(i in 1:length(hyp.vector)){
+			for (i in 1:length(hyp.vector)) {
 				row <- list(number = paste0("H",i), hypothesis = hyp.vector[i])
 				legendTable$addRows(row)
 			}
 	} else {
 		variables <- options$covariates
-		if(length(variables) == 0){
+		if (length(variables) == 0) {
 			string <- ""
 			row <- list(number = "H1", hypothesis = string)
 			legendTable$addRows(row)
-		} else if(length(variables) == 1){
+		} else if (length(variables) == 1) {
 			string <- paste(variables, "= 0")
 			row <- list(number = "H1", hypothesis = string)
 			legendTable$addRows(row)
@@ -247,7 +247,7 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 	}
 }
 
-.plot.BainR <- function (x, y, ...)
+.plot.BainR <- function(x, y, ...)
 {
     PMPa <- x$PMPa
     PMPb <- c(x$PMPb, 1 - sum(x$PMPb))

--- a/JASP-Engine/JASP/R/bainregressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/bainregressionlinearbayesian.R
@@ -112,7 +112,7 @@ BainRegressionLinearBayesian <- function(jaspResults, dataset, options, ...) {
 		})
 	}
 
-	if (inherits(p, "try-error")) {
+	if (isTryError(p)) {
 		bainContainer$setError(paste0("An error occurred in the analysis:<br>", .extractErrorMessage(p), "<br><br>Please double check your variables and model constraints."))
 		return()
 	}

--- a/JASP-Engine/JASP/R/bainregressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/bainregressionlinearbayesian.R
@@ -25,45 +25,45 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 	dataset <- readList[["dataset"]]
 	missingValuesIndicator <- readList[["missingValuesIndicator"]]
 	
+	bainContainer <- .bainGetContainer(jaspResults, deps=c("dependent", "covariates", "model", "standardized"))
+
 	### LEGEND ###
 	.bainLegendRegression(dataset, options, jaspResults)
 	
 	### RESULTS ###
-	.bainLinearRegressionResultsTable(dataset, options, jaspResults, missingValuesIndicator, ready)
+	.bainLinearRegressionResultsTable(dataset, options, bainContainer, missingValuesIndicator, ready)
 	
 	### COEFFICIENTS ###
-	.bainLinearRegressionCoefficientsTable(dataset, options, jaspResults, ready)
+	.bainLinearRegressionCoefficientsTable(dataset, options, bainContainer, ready)
 	
 	### BAYES FACTOR MATRIX ###
-	.bainBayesFactorMatrix(dataset, options, jaspResults, ready, type = "regression")
+	.bainBayesFactorMatrix(dataset, options, bainContainer, ready, type = "regression")
 	
 	### BAYES FACTOR PLOT ###
-	.bainLinearRegressionBayesFactorPlots(dataset, options, jaspResults, ready)
+	.bainLinearRegressionBayesFactorPlots(dataset, options, bainContainer, ready)
+
 }
 
-.bainLinearRegressionResultsTable <- function(dataset, options, jaspResults, missingValuesIndicator, ready){
+.bainLinearRegressionResultsTable <- function(dataset, options, bainContainer, missingValuesIndicator, ready){
 
-	if(!is.null(jaspResults[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+	if(!is.null(bainContainer[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
 	variables <- c(options[["dependent"]], unlist(options[["covariates"]]))
 
-	bainTable                      	<- createJaspTable("Bain Linear Regression Result")
-	jaspResults[["bainTable"]]     	<- bainTable
-	bainTable$dependOn(options =c("dependent", "covariates", "model", "standardized"))
+	bainTable <- createJaspTable("Bain Linear Regression Result")
+	bainContainer[["bainTable"]] <- bainTable
 	bainTable$position <- 1
 
 	bainTable$addColumnInfo(name="hypotheses", type="string", title="")
-	bainTable$addColumnInfo(name="BF", type="number", format="sf:4;dp:3", title= "BF.c")
-	bainTable$addColumnInfo(name="PMP1", type="number", format="sf:4;dp:3", title="PMP a")
-	bainTable$addColumnInfo(name="PMP2", type="number", format="sf:4;dp:3", title="PMP b")
+	bainTable$addColumnInfo(name="BF", type="number", title= "BF.c")
+	bainTable$addColumnInfo(name="PMP1", type="number", title="PMP a")
+	bainTable$addColumnInfo(name="PMP2", type="number", title="PMP b")
 
 	message <- "BF.c denotes the Bayes factor of the hypothesis in the row versus its complement.
 				Posterior model probabilities (a: excluding the unconstrained hypothesis, b: including the unconstrained hypothesis) are based on equal prior model probabilities."
-	bainTable$addFootnote(message=message, symbol="<i>Note.</i>")
+	bainTable$addFootnote(message=message)
 
-	bainTable$addCitation("Gu, X., Mulder, J., and Hoijtink, H. (2017). Approximate adjusted fractional Bayes factors: A general method for testing informative hypotheses. British Journal of Mathematical and Statistical Psychology. DOI:10.1111/bmsp.12110")
-	bainTable$addCitation("Hoijtink, H., Mulder, J., van Lissa, C., and Gu, X. (2018). A Tutorial on testing hypotheses using the Bayes factor. Psychological Methods.")
-	bainTable$addCitation("Hoijtink, H., Gu, X., and Mulder, J. (2018). Bayesian evaluation of informative hypotheses for multiple populations. Britisch Journal of Mathematical and Statistical Psychology. DOI: 10.1111/bmsp.12145")
+	bainTable$addCitation(.bainGetCitations())
 
 	if(!ready)
 		return()
@@ -78,13 +78,10 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 	}
 
 	if(options$model == ""){
-		jaspResults$startProgressbar(3)
-		jaspResults$progressbarTick()
 		formula <- paste(options[["dependent"]], "~", paste(options[["covariates"]], collapse=' + '))
 		rest.string <- paste0(paste0(options[["covariates"]], " = 0"), collapse = " & ")
-		rest.string <- gsub("\n", ";", rest.string)
+		rest.string <- .bainCleanModelInput(rest.string)
 
-		jaspResults$progressbarTick()
 		inpt <- list()
 		inpt[[1]] <- formula
 		names(dataset) <- .unv(names(dataset))
@@ -94,19 +91,14 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 
 		p <- try({
 			bainResult <- Bain::Bain_regression_cm(formula = inpt[[1]], data = inpt[[2]], hyp = inpt[[3]], standardize = inpt[[4]])
-			jaspResults[["bainResult"]] <- createJaspState(bainResult)
-			jaspResults[["bainResult"]]$dependOn(options =c("dependent", "covariates", "model", "standardized"))
+			bainContainer[["bainResult"]] <- createJaspState(bainResult)
 		})
 
 	} else {
 
-		jaspResults$startProgressbar(3)
-		jaspResults$progressbarTick()
 		formula <- paste(options[["dependent"]], "~", paste(options[["covariates"]], collapse=' + '))
-		rest.string <- options$model
-		rest.string <- gsub("\n", ";", rest.string)
+		rest.string <- .bainCleanModelInput(options$model)
 
-		jaspResults$progressbarTick()
 		inpt <- list()
 		inpt[[1]] <- formula
 		names(dataset) <- .unv(names(dataset))
@@ -116,110 +108,101 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 
 		p <- try({
 			bainResult <- Bain::Bain_regression_cm(formula = inpt[[1]], data = inpt[[2]], hyp = inpt[[3]], standardize = inpt[[4]])
-			jaspResults[["bainResult"]] <- createJaspState(bainResult)
-			jaspResults[["bainResult"]]$dependOn(options =c("dependent", "covariates", "model", "standardized"))
-
+			bainContainer[["bainResult"]] <- createJaspState(bainResult)
 		})
 	}
 
-	if(class(p) == "try-error"){
-		bainTable$setError("An error occurred in the analysis. Please double check your variables.")
+	if (inherits(p, "try-error")) {
+		bainContainer$setError(paste0("An error occurred in the analysis:<br>", .extractErrorMessage(p), "<br><br>Please double check your variables and model constraints."))
 		return()
-	} else {
-
-		jaspResults$progressbarTick()
-		BF <- bainResult$BF
-		for(i in 1:length(BF)){
-			row <- data.frame(hypotheses = paste0("H",i), BF = .clean(BF[i]), PMP1 = .clean(bainResult$PMPa[i]), PMP2 = .clean(bainResult$PMPb[i]))
-			bainTable$addRows(row)
-		}
-		row <- data.frame(hypotheses = "Hu", BF = "", PMP1 = "", PMP2 = .clean(1-sum(bainResult$PMPb)))
-		bainTable$addRows(row)
-		}
-}
-
-.bainLinearRegressionBayesFactorPlots <- function(dataset, options, jaspResults, ready){
-	if(options[["bayesFactorPlot"]] && ready){
-	  if(is.null(jaspResults[["bayesFactorPlot"]])){
-			bainResult <- jaspResults[["bainResult"]]$object
-				png(tempfile())
-				p <- .plot.BainR(bainResult)
-				dev.off()
-	      jaspResults[["bayesFactorPlot"]] 		<- createJaspPlot(plot = p, title = "Bayes Factor Comparison", height = 400, width = 600)
-	      jaspResults[["bayesFactorPlot"]]			$dependOn(options =c("bayesFactorPlot", "covariates", "dependent", "model", "standardized"))
-				jaspResults[["bayesFactorPlot"]] 		$position <- 4
-		}
-	} else if(options[["bayesFactorPlot"]]){
-			errorPlot <- createJaspPlot(plot = NULL, title = "Bayes Factor Comparison", height = 400, width = 600)
-			errorPlot$setError("Plotting not possible: No analysis has been run.")
-			jaspResults[["bayesFactorPlot"]] <- errorPlot
-			jaspResults[["bayesFactorPlot"]]			$dependOn(options =c("bayesFactorPlot", "covariates", "dependent", "model", "standardized"))
-			jaspResults[["bayesFactorPlot"]] 		$position <- 4
 	}
+
+	BF <- bainResult$BF
+	for(i in 1:length(BF)){
+		row <- data.frame(hypotheses = paste0("H",i), BF = BF[i], PMP1 = bainResult$PMPa[i], PMP2 = bainResult$PMPb[i])
+		bainTable$addRows(row)
+	}
+	row <- data.frame(hypotheses = "Hu", BF = "", PMP1 = "", PMP2 = 1-sum(bainResult$PMPb))
+	bainTable$addRows(row)
 }
 
-.bainLinearRegressionCoefficientsTable <- function(dataset, options, jaspResults, ready){
-	if(!is.null(jaspResults[["coefficientsTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
-		if(options[["coefficients"]]){
+.bainLinearRegressionBayesFactorPlots <- function(dataset, options, bainContainer, ready){
+	if (!is.null(bainContainer[["bayesFactorPlot"]]) || !options[["bayesFactorPlot"]]) return()
 
-			coefficientsTable                                            <- createJaspTable("Coefficients")
-			jaspResults[["coefficientsTable"]]                           <- coefficientsTable
-			coefficientsTable$dependOn(options =c("dependent", "covariates", "model", "standardized", "coefficients"))
-			coefficientsTable$position <- 2
+	bayesFactorPlot <- createJaspPlot(plot = NULL, title = "Bayes Factor Comparison", height = 400, width = 600)
+	bayesFactorPlot$dependOn(options = "bayesFactorPlot")
+	bayesFactorPlot$position <- 4
 
-			overTitle <- title <- "95% Credible Interval"
+	bainContainer[["bayesFactorPlot"]] <- bayesFactorPlot
 
-			coefficientsTable$addColumnInfo(name="v",    				title="Covariate",   type="string")
-			coefficientsTable$addColumnInfo(name="mean", 				title="Coefficient", type="number", format="sf:4;dp:3")
-			coefficientsTable$addColumnInfo(name = "SE", 				title = "se", type = "number", format="sf:4;dp:3")
-			coefficientsTable$addColumnInfo(name="CiLower",     title = "lowerCI", type="number", format="sf:4;dp:3", overtitle = overTitle)
-		  coefficientsTable$addColumnInfo(name="CiUpper",     title = "upperCI", type="number", format="sf:4;dp:3", overtitle = overTitle)
+	if (!ready || bainContainer$getError())
+		return()
 
-			bainResult <- jaspResults[["bainResult"]]$object
-			if(!ready || is.null(bainResult))
-				return()
+	bainResult <- bainContainer[["bainResult"]]$object
+	bayesFactorPlot$plotObject <- .suppressGrDevice(.plot.BainR(bainResult))
+}
 
-			sum_model <- bainResult[["estimate_res"]]
+.bainLinearRegressionCoefficientsTable <- function(dataset, options, bainContainer, ready){
+	if(!is.null(bainContainer[["coefficientsTable"]]) || !options[["coefficients"]]) return()
 
-			if(!options[["standardized"]]){
-				covcoef <- data.frame(sum_model[["coefficients"]])
-				groups <- rownames(covcoef)
-				estim <- summary(sum_model)$coefficients[, 1]
-				SE <- summary(sum_model)$coefficients[, 2]
-				CiLower <- estim - (1.96 * SE)
-				CiUpper <- estim + (1.96 * SE)
-			} else {
-				covcoef <- data.frame(sum_model$CIs)
-				groups <- .v(options$covariates)
-				estim <- covcoef[, 2]
-				SE <- sum_model$SEs
-				CiLower <- covcoef[, 1]
-				CiUpper <- covcoef[, 3]
-			}
-			for(i in 1:length(estim)){
-				if(i == 1 && !options$standardized){
-					row <- data.frame(v = groups[i], mean = .clean(estim[i]), SE = .clean(SE[i]), CiLower = .clean(CiLower[i]), CiUpper = .clean(CiUpper[i]))
-					coefficientsTable$addRows(row)
-				} else {
-					row <- data.frame(v = .unv(groups[i]), mean = .clean(estim[i]), SE = .clean(SE[i]), CiLower = .clean(CiLower[i]), CiUpper = .clean(CiUpper[i]))
-					coefficientsTable$addRows(row)
-				}
-			}
-	 }
+	coefficientsTable <- createJaspTable("Coefficients")
+	coefficientsTable$dependOn(options = "coefficients")
+	coefficientsTable$position <- 2
+
+	overTitle <- "95% Credible Interval"
+
+	coefficientsTable$addColumnInfo(name="v",       title="Covariate",   type="string")
+	coefficientsTable$addColumnInfo(name="mean",    title="Coefficient", type="number")
+	coefficientsTable$addColumnInfo(name="SE",      title="se",          type="number")
+	coefficientsTable$addColumnInfo(name="CiLower", title="lowerCI",     type="number", overtitle=overTitle)
+	coefficientsTable$addColumnInfo(name="CiUpper", title="upperCI",     type="number", overtitle=overTitle)
+
+	bainContainer[["coefficientsTable"]] <- coefficientsTable
+
+	if(!ready || bainContainer$getError())
+		return()
+
+	bainResult <- bainContainer[["bainResult"]]$object
+	sum_model <- bainResult[["estimate_res"]]
+
+	if(!options[["standardized"]]){
+		covcoef <- data.frame(sum_model[["coefficients"]])
+		groups <- rownames(covcoef)
+		estim <- summary(sum_model)$coefficients[, 1]
+		SE <- summary(sum_model)$coefficients[, 2]
+		CiLower <- estim - (1.96 * SE)
+		CiUpper <- estim + (1.96 * SE)
+	} else {
+		covcoef <- data.frame(sum_model$CIs)
+		groups <- .v(options$covariates)
+		estim <- covcoef[, 2]
+		SE <- sum_model$SEs
+		CiLower <- covcoef[, 1]
+		CiUpper <- covcoef[, 3]
+	}
+	for(i in 1:length(estim)){
+		if(i == 1 && !options$standardized){
+			row <- data.frame(v = groups[i], mean = estim[i], SE = SE[i], CiLower = CiLower[i], CiUpper = CiUpper[i])
+			coefficientsTable$addRows(row)
+		} else {
+			row <- data.frame(v = .unv(groups[i]), mean = estim[i], SE = SE[i], CiLower = CiLower[i], CiUpper = CiUpper[i])
+			coefficientsTable$addRows(row)
+		}
+	}
 }
 
 .readDataBainLinearRegression <- function(options, dataset){
-	all.variables 						<- c(options$dependent, unlist(options$covariates))
-	all.variables 						<- all.variables[all.variables != ""]
+	all.variables <- c(options$dependent, unlist(options$covariates))
+	all.variables <- all.variables[all.variables != ""]
 	if (is.null(dataset)) {
-		trydata                                 <- .readDataSetToEnd(columns.as.numeric=all.variables)
-		missingValuesIndicator                  <- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
-		dataset 						<- .readDataSetToEnd(columns.as.numeric=all.variables, exclude.na.listwise=all.variables)
+		trydata <- .readDataSetToEnd(columns.as.numeric=all.variables)
+		missingValuesIndicator <- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
+		dataset <- .readDataSetToEnd(columns.as.numeric=all.variables, exclude.na.listwise=all.variables)
 	} else {
-		dataset 						<- .vdf(dataset, columns.as.numeric=all.variables)
+		dataset <- .vdf(dataset, columns.as.numeric=all.variables)
 	}
 	.hasErrors(dataset, perform, type=c("infinity", "variance", "observations"),
-				all.target=all.variables, message="short", observations.amount="< 3",
+				all.target=all.variables, observations.amount="< 3",
 				exitAnalysisIfErrors = TRUE)
 	readList <- list()
   readList[["dataset"]] <- dataset
@@ -230,16 +213,16 @@ BainRegressionLinearBayesian <- function (jaspResults, dataset, options, ...) {
 .bainLegendRegression <- function(dataset, options, jaspResults){
 	if(!is.null(jaspResults[["legendTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
-	legendTable                      	<- createJaspTable("Hypothesis Legend")
-	jaspResults[["legendTable"]]     	<- legendTable
+	legendTable <- createJaspTable("Hypothesis Legend")
 	legendTable$dependOn(options =c("model", "covariates"))
 	legendTable$position <- 0
 	legendTable$addColumnInfo(name="number", type="string", title="Abbreviation")
 	legendTable$addColumnInfo(name="hypothesis", type="string", title="Hypothesis")
 
+	jaspResults[["legendTable"]] <- legendTable
+
 	if(options$model != ""){
-		rest.string <- options$model
-		rest.string <- gsub("\n", ";", rest.string)
+		rest.string <- .bainCleanModelInput(options$model)
 		hyp.vector <- unlist(strsplit(rest.string, "[;]"))
 
 			for(i in 1:length(hyp.vector)){

--- a/JASP-Engine/JASP/R/bainregressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/bainregressionlinearbayesian.R
@@ -153,9 +153,9 @@ BainRegressionLinearBayesian <- function(jaspResults, dataset, options, ...) {
 
 	coefficientsTable$addColumnInfo(name="v",       title="Covariate",   type="string")
 	coefficientsTable$addColumnInfo(name="mean",    title="Coefficient", type="number")
-	coefficientsTable$addColumnInfo(name="SE",      title="se",          type="number")
-	coefficientsTable$addColumnInfo(name="CiLower", title="lowerCI",     type="number", overtitle=overTitle)
-	coefficientsTable$addColumnInfo(name="CiUpper", title="upperCI",     type="number", overtitle=overTitle)
+	coefficientsTable$addColumnInfo(name="SE",      title="SE",          type="number")
+	coefficientsTable$addColumnInfo(name="CiLower", title="Lower",     type="number", overtitle=overTitle)
+	coefficientsTable$addColumnInfo(name="CiUpper", title="Upper",     type="number", overtitle=overTitle)
 
 	bainContainer[["coefficientsTable"]] <- coefficientsTable
 

--- a/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
@@ -21,9 +21,9 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 		ready <- length(options[["variables"]][options[["variables"]] != ""] > 0) && options[["groupingVariable"]] != ""
 		
 		### READ DATA ###
-		readList											<- .readDataBainTwoSample(options, dataset)
-		dataset                       <- readList[["dataset"]]
-		missingValuesIndicator        <- readList[["missingValuesIndicator"]]
+		readList								<- .readDataBainTwoSample(options, dataset)
+		dataset									<- readList[["dataset"]]
+		missingValuesIndicator	<- readList[["missingValuesIndicator"]]
     
 		### RESULTS ###
     .bainIndependentSamplesResultsTable(dataset, options, jaspResults, missingValuesIndicator, ready)
@@ -40,7 +40,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 
 .bainIndependentSamplesResultsTable <- function(dataset, options, jaspResults, missingValuesIndicator, ready) {
 
-  if(!is.null(jaspResults[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+  if (!is.null(jaspResults[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
   bainTable <- createJaspTable("Bain Independent Samples Welch's T-Test Result")
   bainTable$dependOn(options =c("variables", "hypothesis", "bayesFactorType", "groupingVariable"))
@@ -50,7 +50,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
   BFH1H0 <- FALSE
   bf.title <- "BF"
 
-  if(options$hypothesis == "allTypes"){
+  if (options$hypothesis == "allTypes") {
           bainTable$addColumnInfo(name="Variable", type="string", title="")
           bainTable$addColumnInfo(name = "type[equal]", type = "string", title = "Hypothesis")
           bainTable$addColumnInfo(name="BF[equal]", type="number", title=bf.title)
@@ -89,7 +89,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 	
 	jaspResults[["bainTable"]] <- bainTable
 
-	if(!ready)
+	if (!ready)
 		return()
 
   jaspResults$startProgressbar(length(options[["variables"]]))
@@ -103,9 +103,9 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 	  g2 <- levels[2]
   }
 
-  for (variable in options[["variables"]]){
+  for (variable in options[["variables"]]) {
 
-		if(variable %in% missingValuesIndicator){
+		if (variable %in% missingValuesIndicator) {
 			bainTable$addFootnote(message= paste0("The variable ", variable, " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
 		}
 
@@ -127,42 +127,42 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 		next
 	}
 
-    if(type == 1){
+    if (type == 1) {
         BF_0u <- bainAnalysis$BF_0u
         PMP_u <- bainAnalysis$PMP_u
         PMP_0 <- bainAnalysis$PMP_0
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
           BF_0u <- 1/BF_0u
     }
-    if(type == 2){
+    if (type == 2) {
         BF_01 <- bainAnalysis$BF_01
         PMP_1 <- bainAnalysis$PMP_1
         PMP_0 <- bainAnalysis$PMP_0
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
             BF_01 <- 1/BF_01
     }
-    if(type == 3){
+    if (type == 3) {
         BF_01 <- bainAnalysis$BF_01
         PMP_0 <- bainAnalysis$PMP_0
         PMP_1 <- bainAnalysis$PMP_1
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
             BF_01 <- 1/BF_01
     }
-     if (type == 4){
+     if (type == 4) {
         BF_01 <- bainAnalysis$BF_12
         PMP_0 <- bainAnalysis$PMP_1
         PMP_1 <- bainAnalysis$PMP_2
-        if(options$bayesFactorType == "BF01")
+        if (options$bayesFactorType == "BF01")
             BF_01 <- 1/BF_01
     }
-     if (type == 5){
+     if (type == 5) {
         BF_01 <- bainAnalysis$BF_01
         BF_02 <- bainAnalysis$BF_02
         BF_12 <- bainAnalysis$BF_12
         PMP_0 <- bainAnalysis$PMP_0
         PMP_1 <- bainAnalysis$PMP_1
         PMP_2 <- bainAnalysis$PMP_2
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
         {
             BF_01 <- 1/BF_01
             BF_02 <- 1/BF_02
@@ -170,20 +170,20 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
         }
     }
 
-    if(options$bayesFactorType == "BF01"){
-        if(options$hypothesis == "groupsNotEqual"){
+    if (options$bayesFactorType == "BF01") {
+        if (options$hypothesis == "groupsNotEqual") {
             row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_0u, "pmp[type1]" = PMP_0,
                                 "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = "", "pmp[type2]" = PMP_u)
-        } else if(options$hypothesis == "groupOneGreater"){
+        } else if (options$hypothesis == "groupOneGreater") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
                                "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = "", "pmp[type2]" = PMP_1)
-        } else if(options$hypothesis == "groupTwoGreater"){
+        } else if (options$hypothesis == "groupTwoGreater") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
                                "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_1)
-        } else if (options$hypothesis == "_4type"){
+        } else if (options$hypothesis == "_4type") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"=BF_01, "pmp[type1]" = PMP_1,
                                "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_0)
-        } else if (options$hypothesis == "allTypes"){
+        } else if (options$hypothesis == "allTypes") {
             row <-list(Variable=variable,
                                "type[equal]" = "H0: Equal",
                                "BF[equal]"= "",
@@ -195,20 +195,20 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
                                "BF[less]" = BF_01,
                                "pmp[less]" = PMP_1)
         }
-    } else if (options$bayesFactorType == "BF10"){
-        if(options$hypothesis == "groupsNotEqual"){
+    } else if (options$bayesFactorType == "BF10") {
+        if (options$hypothesis == "groupsNotEqual") {
             row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
                                 "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = BF_0u, "pmp[type2]" = PMP_u)
-        } else if(options$hypothesis == "groupOneGreater"){
+        } else if (options$hypothesis == "groupOneGreater") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
                                "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
-        } else if(options$hypothesis == "groupTwoGreater"){
+        } else if (options$hypothesis == "groupTwoGreater") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"="", "pmp[type1]" = PMP_0,
                                "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
-        } else if (options$hypothesis == "_4type"){
+        } else if (options$hypothesis == "_4type") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"= "", "pmp[type1]" = PMP_1,
                                "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_0)
-        } else if (options$hypothesis == "allTypes"){
+        } else if (options$hypothesis == "allTypes") {
             row <-list(Variable=variable,
                                "type[equal]" = "H0: Equal",
                                "BF[equal]"= "",
@@ -230,8 +230,8 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 
 .bainIndependentSamplesDescriptivesTable <- function(dataset, options, jaspResults, ready) {
 
-  if(!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
-		if(options[["descriptives"]]){
+  if (!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+		if (options[["descriptives"]]) {
 
 	  descriptivesTable <- createJaspTable("Descriptive Statistics")
 	  descriptivesTable$dependOn(options =c("variables", "descriptives", "descriptivesPlotsCredibleInterval", "groupingVariable"))
@@ -251,7 +251,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 		
 		jaspResults[["descriptivesTable"]] <- descriptivesTable
 
-		if(!ready)
+		if (!ready)
 			return()
 
 		levels <- base::levels(dataset[[ .v(options$groupingVariable) ]])
@@ -263,7 +263,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 			g2 <- levels[2]
 		}
 
-	for(variable in options[["variables"]]){
+	for (variable in options[["variables"]]) {
 		for (i in 1:2) {
 
 	  	level <- levels[i]
@@ -280,9 +280,9 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 		  	mean <- mean(groupDataOm)
 		  	std <- sd(groupDataOm)
 		  	sem <- sd(groupDataOm) / sqrt(length(groupDataOm))
-				if(i == 1)
+				if (i == 1)
 					row <- data.frame(v = variable, group = level, N = n, mean = mean, sd = std, se = sem, lowerCI = ciLower, upperCI = ciUpper)
-				if(i == 2)
+				if (i == 2)
 					row <- data.frame(v = "", group = level, N = n, mean = mean, sd = std, se = sem, lowerCI = ciLower, upperCI = ciUpper)
 
 				} else {
@@ -295,15 +295,15 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 	}
 }
 
-.bainIndependentSamplesDescriptivesPlots <- function(dataset, options, jaspResults, ready){
-	if(options[["descriptivesPlots"]] && ready){
-			if(is.null(jaspResults[["descriptivesPlots"]])){
-			jaspResults[["descriptivesPlots"]]          <- createJaspContainer("Descriptive Plots")
-			jaspResults[["descriptivesPlots"]]          $dependOn(options =c("descriptivesPlots", "descriptivesPlotsCredibleInterval", "groupingVariable"))
-			jaspResults[["descriptivesPlots"]]			    $position <- 4
+.bainIndependentSamplesDescriptivesPlots <- function(dataset, options, jaspResults, ready) {
+	if (options[["descriptivesPlots"]] && ready) {
+			if (is.null(jaspResults[["descriptivesPlots"]])) {
+				jaspResults[["descriptivesPlots"]] <- createJaspContainer("Descriptive Plots")
+				jaspResults[["descriptivesPlots"]]$dependOn(options =c("descriptivesPlots", "descriptivesPlotsCredibleInterval", "groupingVariable"))
+				jaspResults[["descriptivesPlots"]]$position <- 4
 			}
-			for (variable in unlist(options[["variables"]])){
-					if(is.null(jaspResults[["descriptivesPlots"]][[variable]]))
+			for (variable in unlist(options[["variables"]])) {
+					if (is.null(jaspResults[["descriptivesPlots"]][[variable]]))
 					{
 						levels <- base::levels(dataset[[ .v(options$groupingVariable) ]])
 						if (length(levels) != 2) {
@@ -325,7 +325,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 						jaspResults[["descriptivesPlots"]][[variable]]        $dependOn(optionContainsValue=list("variables" = variable))
 					}
 			}
-	} else if(options[["descriptivesPlots"]]){
+	} else if (options[["descriptivesPlots"]]) {
 		emptyPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plots")
 		jaspResults[["descriptivesPlots"]] <- emptyPlot
 		jaspResults[["descriptivesPlots"]]$dependOn(options =c("variables", "descriptivesPlots","groupingVariable"))
@@ -333,7 +333,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 	}	
 }
 
-.readDataBainTwoSample <- function(options, dataset){
+.readDataBainTwoSample <- function(options, dataset) {
 
 	all.variables 									<- unlist(options$variables)
 	grouping   										<- options$groupingVariable
@@ -341,9 +341,9 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 	if (options[["groupingVariable"]] == "")
 		grouping <- NULL
 
-	if (is.null(dataset)){
+	if (is.null(dataset)) {
 						trydata                	<- .readDataSetToEnd(columns.as.numeric=all.variables)
-						missingValuesIndicator 	<- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
+						missingValuesIndicator 	<- .unv(names(which(apply(trydata, 2, function(x) { any(is.na(x))} ))))
             dataset 								<- .readDataSetToEnd(columns.as.numeric=all.variables, columns.as.factor=grouping, exclude.na.listwise=read.variables)
     }
 	.hasErrors(dataset, type="factorLevels",

--- a/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
@@ -32,7 +32,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 		.bainIndependentSamplesDescriptivesTable(dataset, options, jaspResults, ready)
 		
 		### BAYES FACTOR PLOTS ###
-		.bainOneSampleBayesFactorPlots(dataset, options, jaspResults, ready)
+		.bainTTestFactorPlots(dataset, options, jaspResults, ready, "independentSamples")
 		
 		### DESCRIPTIVES PLOTS ###
 		.bainIndependentSamplesDescriptivesPlots(dataset, options, jaspResults, ready)
@@ -42,8 +42,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 
   if(!is.null(jaspResults[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
-  bainTable                      <- createJaspTable("Bain Independent Samples Welch's T-Test Result")
-  jaspResults[["bainTable"]]     <- bainTable
+  bainTable <- createJaspTable("Bain Independent Samples Welch's T-Test Result")
   bainTable$dependOn(options =c("variables", "hypothesis", "bayesFactorType", "groupingVariable"))
 	bainTable$position <- 1
 
@@ -54,21 +53,21 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
   if(options$hypothesis == "allTypes"){
           bainTable$addColumnInfo(name="Variable", type="string", title="")
           bainTable$addColumnInfo(name = "type[equal]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name="BF[equal]", type="number", format="sf:4;dp:3", title=bf.title)
+          bainTable$addColumnInfo(name="BF[equal]", type="number", title=bf.title)
           bainTable$addColumnInfo(name="pmp[equal]", type="number", format="dp:3", title="Posterior probability")
           bainTable$addColumnInfo(name = "type[greater]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name="BF[greater]", type="number", format="sf:4;dp:3", title="bf.title")
+          bainTable$addColumnInfo(name="BF[greater]", type="number", title="bf.title")
           bainTable$addColumnInfo(name="pmp[greater]", type="number", format="dp:3", title="Posterior probability")
           bainTable$addColumnInfo(name = "type[less]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name = "BF[less]", type = "number", format="sf:4;dp:3", title = bf.title)
+          bainTable$addColumnInfo(name = "BF[less]", type = "number", title = bf.title)
           bainTable$addColumnInfo(name="pmp[less]", type="number", format="dp:3", title="Posterior probability")
   } else {
           bainTable$addColumnInfo(name="Variable", type="string", title="")
           bainTable$addColumnInfo(name = "hypothesis[type1]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name="BF[type1]", type="number", format="sf:4;dp:3", title=bf.title)
+          bainTable$addColumnInfo(name="BF[type1]", type="number", title=bf.title)
           bainTable$addColumnInfo(name="pmp[type1]", type="number", format="dp:3", title="Posterior probability")
           bainTable$addColumnInfo(name = "hypothesis[type2]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name="BF[type2]", type="number", format="sf:4;dp:3", title=bf.title)
+          bainTable$addColumnInfo(name="BF[type2]", type="number", title=bf.title)
           bainTable$addColumnInfo(name="pmp[type2]", type="number", format="dp:3", title="Posterior probability")
   }
 	
@@ -84,11 +83,11 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 														"groupOneGreater"		= "The alternative hypothesis H1 specifies that mean of group 1 is bigger than the mean of group 2. The posterior probabilities are based on equal prior probabilities.",
 														"_4type"						= "The hypothesis H1 specifies that the mean of group 1 is bigger than the mean of group 2. The hypothesis H2 specifies that the mean in group 1 is smaller than the mean in group 2. The posterior probabilities are based on equal prior probabilities.",
 														"allTypes"					= "The null hypothesis H0 (equal group means) is tested against H1 (first mean larger than second mean) and H2 (first mean smaller than second mean). The posterior probabilities are based on equal prior probabilities.")
-  bainTable$addFootnote(message=message, symbol="<i>Note.</i>")
+  bainTable$addFootnote(message=message)
 
-	bainTable$addCitation("Gu, X., Mulder, J., and Hoijtink, H. (2017). Approximate adjusted fractional Bayes factors: A general method for testing informative hypotheses. British Journal of Mathematical and Statistical Psychology. DOI:10.1111/bmsp.12110")
-	bainTable$addCitation("Hoijtink, H., Mulder, J., van Lissa, C., and Gu, X. (2018). A Tutorial on testing hypotheses using the Bayes factor. Psychological Methods.")
-	bainTable$addCitation("Hoijtink, H., Gu, X., and Mulder, J. (2018). Bayesian evaluation of informative hypotheses for multiple populations. Britisch Journal of Mathematical and Statistical Psychology. DOI: 10.1111/bmsp.12145")
+	bainTable$addCitation(.bainGetCitations())
+	
+	jaspResults[["bainTable"]] <- bainTable
 
 	if(!ready)
 		return()
@@ -122,9 +121,10 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 
 	})
 
-	if(class(p) == "try-error"){
-		bainTable$setError("An error occurred in the analysis. Please double check your variables.")
-		return()
+	if (inherits(p, "try-error")) {
+		bainTable$addFootnote(message=paste0("Results for ", variable, " not computed: ", .extractErrorMessage(p)), symbol="<b>Error.</b>")
+		jaspResults$progressbarTick()
+		next
 	}
 
     if(type == 1){
@@ -172,53 +172,53 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 
     if(options$bayesFactorType == "BF01"){
         if(options$hypothesis == "groupsNotEqual"){
-            row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=.clean(BF_0u), "pmp[type1]" = .clean(PMP_0),
-                                "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = "", "pmp[type2]" = .clean(PMP_u))
+            row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_0u, "pmp[type1]" = PMP_0,
+                                "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = "", "pmp[type2]" = PMP_u)
         } else if(options$hypothesis == "groupOneGreater"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=.clean(BF_01), "pmp[type1]" = .clean(PMP_0),
-                               "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = "", "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
+                               "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = "", "pmp[type2]" = PMP_1)
         } else if(options$hypothesis == "groupTwoGreater"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"=.clean(BF_01), "pmp[type1]" = .clean(PMP_0),
-                               "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = "", "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
+                               "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_1)
         } else if (options$hypothesis == "_4type"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"=.clean(BF_01), "pmp[type1]" = .clean(PMP_1),
-                               "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = "", "pmp[type2]" = .clean(PMP_0))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"=BF_01, "pmp[type1]" = PMP_1,
+                               "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_0)
         } else if (options$hypothesis == "allTypes"){
             row <-list(Variable=variable,
                                "type[equal]" = "H0: Equal",
                                "BF[equal]"= "",
-                               "pmp[equal]" = .clean(PMP_0),
+                               "pmp[equal]" = PMP_0,
                                "type[greater]" = "H1: Bigger",
-                               "BF[greater]" = .clean(BF_02),
-                               "pmp[greater]" = .clean(PMP_2),
+                               "BF[greater]" = BF_02,
+                               "pmp[greater]" = PMP_2,
                                "type[less]" = "H2: Smaller",
-                               "BF[less]" = .clean(BF_01),
-                               "pmp[less]" = .clean(PMP_1))
+                               "BF[less]" = BF_01,
+                               "pmp[less]" = PMP_1)
         }
     } else if (options$bayesFactorType == "BF10"){
         if(options$hypothesis == "groupsNotEqual"){
-            row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = .clean(PMP_0),
-                                "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = .clean(BF_0u), "pmp[type2]" = PMP_u)
+            row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
+                                "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = BF_0u, "pmp[type2]" = PMP_u)
         } else if(options$hypothesis == "groupOneGreater"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = .clean(PMP_0),
-                               "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = .clean(BF_01), "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
+                               "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
         } else if(options$hypothesis == "groupTwoGreater"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"="", "pmp[type1]" = .clean(PMP_0),
-                               "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = .clean(BF_01), "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"="", "pmp[type1]" = PMP_0,
+                               "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
         } else if (options$hypothesis == "_4type"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"= "", "pmp[type1]" = .clean(PMP_1),
-                               "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = .clean(BF_01), "pmp[type2]" = .clean(PMP_0))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"= "", "pmp[type1]" = PMP_1,
+                               "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_0)
         } else if (options$hypothesis == "allTypes"){
             row <-list(Variable=variable,
                                "type[equal]" = "H0: Equal",
                                "BF[equal]"= "",
-                               "pmp[equal]" = .clean(PMP_0),
+                               "pmp[equal]" = PMP_0,
                                "type[greater]"= "H1: Bigger",
-                               "BF[greater]" = .clean(BF_02),
-                               "pmp[greater]" = .clean(PMP_2),
+                               "BF[greater]" = BF_02,
+                               "pmp[greater]" = PMP_2,
                                "type[less]" = "H2: Smaller",
-                               "BF[less]" = .clean(BF_01),
-                               "pmp[less]" = .clean(PMP_1))
+                               "BF[less]" = BF_01,
+                               "pmp[less]" = PMP_1)
         }
     }
     bainTable$addRows(row)
@@ -233,22 +233,23 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
   if(!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 		if(options[["descriptives"]]){
 
-	  descriptivesTable                                            <- createJaspTable("Descriptive Statistics")
-	  jaspResults[["descriptivesTable"]]                           <- descriptivesTable
+	  descriptivesTable <- createJaspTable("Descriptive Statistics")
 	  descriptivesTable$dependOn(options =c("variables", "descriptives", "descriptivesPlotsCredibleInterval", "groupingVariable"))
 		descriptivesTable$position <- 2
 
 	  descriptivesTable$addColumnInfo(name="v",                    title = "", type="string")
 		descriptivesTable$addColumnInfo(name="group",                title = "Group", type="string")
 	  descriptivesTable$addColumnInfo(name="N",                    title = "N", type="integer")
-	  descriptivesTable$addColumnInfo(name="mean",                 title = "Mean", type="number", format="sf:4;dp:3")
-	  descriptivesTable$addColumnInfo(name="sd",                   title = "sd", type="number", format="sf:4;dp:3")
-	  descriptivesTable$addColumnInfo(name="se",                   title = "se", type="number", format="sf:4;dp:3")
+	  descriptivesTable$addColumnInfo(name="mean",                 title = "Mean", type="number")
+	  descriptivesTable$addColumnInfo(name="sd",                   title = "sd", type="number")
+	  descriptivesTable$addColumnInfo(name="se",                   title = "se", type="number")
 
 		interval <- 100 * options[["descriptivesPlotsCredibleInterval"]]
 		overTitle <- paste0(interval, "% Credible Interval")
-		descriptivesTable$addColumnInfo(name="lowerCI",              title = "lowerCI", type="number", format="sf:4;dp:3", overtitle = overTitle)
-	  descriptivesTable$addColumnInfo(name="upperCI",              title = "upperCI", type="number", format="sf:4;dp:3", overtitle = overTitle)
+		descriptivesTable$addColumnInfo(name="lowerCI",              title = "lowerCI", type="number", overtitle = overTitle)
+	  descriptivesTable$addColumnInfo(name="upperCI",              title = "upperCI", type="number", overtitle = overTitle)
+		
+		jaspResults[["descriptivesTable"]] <- descriptivesTable
 
 		if(!ready)
 			return()
@@ -273,19 +274,19 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 
 			if (class(groupDataOm) != "factor") { # TODO: Fix this...
 				posteriorSummary <- .posteriorSummaryGroupMean(variable=groupDataOm, descriptivesPlotsCredibleInterval=options$descriptivesPlotsCredibleInterval)
-				ciLower <- .clean(round(posteriorSummary$ciLower,3))
-				ciUpper <- .clean(round(posteriorSummary$ciUpper,3))
-				n <- .clean(length(groupDataOm))
-		  	mean <- .clean(mean(groupDataOm))
-		  	std <- .clean(sd(groupDataOm))
-		  	sem <- .clean(sd(groupDataOm) / sqrt(length(groupDataOm)))
+				ciLower <- round(posteriorSummary$ciLower,3)
+				ciUpper <- round(posteriorSummary$ciUpper,3)
+				n <- length(groupDataOm)
+		  	mean <- mean(groupDataOm)
+		  	std <- sd(groupDataOm)
+		  	sem <- sd(groupDataOm) / sqrt(length(groupDataOm))
 				if(i == 1)
 					row <- data.frame(v = variable, group = level, N = n, mean = mean, sd = std, se = sem, lowerCI = ciLower, upperCI = ciUpper)
 				if(i == 2)
 					row <- data.frame(v = "", group = level, N = n, mean = mean, sd = std, se = sem, lowerCI = ciLower, upperCI = ciUpper)
 
 				} else {
-						n <- .clean(length(groupDataOm))
+						n <- length(groupDataOm)
 						row <- data.frame(v = variable, group = "", N = n, mean = "", sd = "", se = "", lowerCI = "", upperCI = "")
 				}
 				descriptivesTable$addRows(row)
@@ -298,7 +299,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 	if(options[["descriptivesPlots"]] && ready){
 			if(is.null(jaspResults[["descriptivesPlots"]])){
 			jaspResults[["descriptivesPlots"]]          <- createJaspContainer("Descriptive Plots")
-			jaspResults[["descriptivesPlots"]]          $dependOn(options =c("variables", "testValue", "descriptivesPlots", "descriptivesPlotsCredibleInterval", "groupingVariable"))
+			jaspResults[["descriptivesPlots"]]          $dependOn(options =c("descriptivesPlots", "descriptivesPlotsCredibleInterval", "groupingVariable"))
 			jaspResults[["descriptivesPlots"]]			    $position <- 4
 			}
 			for (variable in unlist(options[["variables"]])){
@@ -325,9 +326,8 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 					}
 			}
 	} else if(options[["descriptivesPlots"]]){
-		errorPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plots")
-		errorPlot$setError("Plotting not possible: No analysis has been run.")
-		jaspResults[["descriptivesPlots"]] <- errorPlot
+		emptyPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plots")
+		jaspResults[["descriptivesPlots"]] <- emptyPlot
 		jaspResults[["descriptivesPlots"]]$dependOn(options =c("variables", "descriptivesPlots","groupingVariable"))
 		jaspResults[["descriptivesPlots"]]$position <- 4
 	}	
@@ -346,11 +346,11 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 						missingValuesIndicator 	<- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
             dataset 								<- .readDataSetToEnd(columns.as.numeric=all.variables, columns.as.factor=grouping, exclude.na.listwise=read.variables)
     }
-	.hasErrors(dataset=dataset, perform=perform, type="factorLevels",
+	.hasErrors(dataset, type="factorLevels",
 			   factorLevels.target=grouping, factorLevels.amount = "!= 2",
 			   exitAnalysisIfErrors = TRUE)
-	.hasErrors(dataset, perform, type=c("infinity", "variance", "observations"),
-				all.target=all.variables, message="short", observations.amount="< 3",
+	.hasErrors(dataset, type=c("infinity", "variance", "observations"),
+				all.target=all.variables, observations.amount="< 3",
 				exitAnalysisIfErrors = TRUE)
 	readList <- list()
   readList[["dataset"]] <- dataset

--- a/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
@@ -117,7 +117,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 
 		})
 
-		if (inherits(p, "try-error")) {
+		if (isTryError(p)) {
 			bainTable$addRows(list(Variable=variable), rowNames=variable)
 			bainTable$addFootnote(message=paste0("Results not computed: ", .extractErrorMessage(p)), colNames="Variable", rowNames=variable)
 			jaspResults$progressbarTick()

--- a/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
@@ -242,13 +242,13 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 		descriptivesTable$addColumnInfo(name="group",                title = "Group", type="string")
 	  descriptivesTable$addColumnInfo(name="N",                    title = "N", type="integer")
 	  descriptivesTable$addColumnInfo(name="mean",                 title = "Mean", type="number")
-	  descriptivesTable$addColumnInfo(name="sd",                   title = "sd", type="number")
-	  descriptivesTable$addColumnInfo(name="se",                   title = "se", type="number")
+	  descriptivesTable$addColumnInfo(name="sd",                   title = "SD", type="number")
+	  descriptivesTable$addColumnInfo(name="se",                   title = "SE", type="number")
 
 		interval <- 100 * options[["descriptivesPlotsCredibleInterval"]]
 		overTitle <- paste0(interval, "% Credible Interval")
-		descriptivesTable$addColumnInfo(name="lowerCI",              title = "lowerCI", type="number", overtitle = overTitle)
-	  descriptivesTable$addColumnInfo(name="upperCI",              title = "upperCI", type="number", overtitle = overTitle)
+		descriptivesTable$addColumnInfo(name="lowerCI",              title = "Lower", type="number", overtitle = overTitle)
+	  descriptivesTable$addColumnInfo(name="upperCI",              title = "Upper", type="number", overtitle = overTitle)
 		
 		jaspResults[["descriptivesTable"]] <- descriptivesTable
 

--- a/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianindependentsamples.R
@@ -105,10 +105,6 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
 
   for (variable in options[["variables"]]) {
 
-		if (variable %in% missingValuesIndicator) {
-			bainTable$addFootnote(message= paste0("The variable ", variable, " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-		}
-
 	  subDataSet <- dataset[, c(.v(variable), .v(options[["groupingVariable"]]))]
 	  subDataSet <- na.omit(subDataSet)
 	  group2 <- subDataSet[subDataSet[[.v(options[["groupingVariable"]])]]== g1,.v(variable)]
@@ -119,13 +115,18 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
       	bainAnalysis <- Bain::Bain_ttestData(group1, group2, type = type)
       	bainResult[[variable]] <- bainAnalysis
 
-	})
+		})
 
-	if (inherits(p, "try-error")) {
-		bainTable$addFootnote(message=paste0("Results for ", variable, " not computed: ", .extractErrorMessage(p)), symbol="<b>Error.</b>")
-		jaspResults$progressbarTick()
-		next
-	}
+		if (inherits(p, "try-error")) {
+			bainTable$addRows(list(Variable=variable), rowNames=variable)
+			bainTable$addFootnote(message=paste0("Results not computed: ", .extractErrorMessage(p)), colNames="Variable", rowNames=variable)
+			jaspResults$progressbarTick()
+			next
+		}
+		
+		if (variable %in% missingValuesIndicator) {
+			bainTable$addFootnote(message= paste0("Variable contains missing values, the rows containing these values are removed in the analysis."), colNames="Variable", rowNames=variable)
+		}
 
     if (type == 1) {
         BF_0u <- bainAnalysis$BF_0u
@@ -221,7 +222,7 @@ BainTTestBayesianIndependentSamples <- function(jaspResults, dataset, options, .
                                "pmp[less]" = PMP_1)
         }
     }
-    bainTable$addRows(row)
+    bainTable$addRows(row, rowNames=variable)
 	  jaspResults$progressbarTick()
   }
   jaspResults[["bainResult"]] <- createJaspState(bainResult)

--- a/JASP-Engine/JASP/R/bainttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianonesample.R
@@ -21,9 +21,9 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   ready <- length(options[["variables"]][options[["variables"]] != ""] > 0)
   
   ### READ DATA ###
-  readList                                        <- .readDataBainOneSample(options, dataset)
-  dataset                                         <- readList[["dataset"]]
-  missingValuesIndicator                          <- readList[["missingValuesIndicator"]]
+  readList								<- .readDataBainOneSample(options, dataset)
+  dataset									<- readList[["dataset"]]
+  missingValuesIndicator	<- readList[["missingValuesIndicator"]]
   
   ### RESULTS ###
   .bainOneSampleResultsTable(dataset, options, jaspResults, missingValuesIndicator, ready)
@@ -38,11 +38,11 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   .bainOneSampleDescriptivesPlot(dataset, options, jaspResults, ready)
 }
 
-.readDataBainOneSample <- function(options, dataset){
-    if (is.null(dataset)){
-            trydata                                 <- .readDataSetToEnd(columns.as.numeric = options[["variables"]])
-            missingValuesIndicator                  <- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
-            dataset                                 <- .readDataSetToEnd(columns.as.numeric = options[["variables"]], exclude.na.listwise = options[["variables"]])
+.readDataBainOneSample <- function(options, dataset) {
+    if (is.null(dataset)) {
+            trydata									<- .readDataSetToEnd(columns.as.numeric = options[["variables"]])
+            missingValuesIndicator	<- .unv(names(which(apply(trydata, 2, function(x) { any(is.na(x))} ))))
+            dataset									<- .readDataSetToEnd(columns.as.numeric = options[["variables"]], exclude.na.listwise = options[["variables"]])
     }
     .hasErrors(dataset, perform, type=c("infinity", "variance", "observations"),
                 all.target = options[["variables"]], observations.amount="< 3",
@@ -55,7 +55,7 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
 
 .bainOneSampleResultsTable <- function(dataset, options, jaspResults, missingValuesIndicator, ready) {
 
-  if(!is.null(jaspResults[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+  if (!is.null(jaspResults[["bainTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
 
   bainTable                      <- createJaspTable("Bain One Sample T-test Result")
   jaspResults[["bainTable"]]     <- bainTable
@@ -66,7 +66,7 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   BFH1H0 <- FALSE
   bf.title <- "BF"
 
-  if(options$hypothesis == "allTypes"){
+  if (options$hypothesis == "allTypes") {
     bainTable$addColumnInfo(name="Variable",      type="string", title="")
     bainTable$addColumnInfo(name="type[equal]",   type="string", title="Hypothesis")
     bainTable$addColumnInfo(name="BF[equal]",     type="number", title=bf.title)
@@ -109,15 +109,15 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
 
   bainTable$addCitation(.bainGetCitations())
 
-  if(!ready)
+  if (!ready)
     return()
 
   jaspResults$startProgressbar(length(options[["variables"]]))
   bainResult <- list()
   
-  for (variable in options[["variables"]]){
+  for (variable in options[["variables"]]) {
 
-    if(variable %in% missingValuesIndicator){
+    if (variable %in% missingValuesIndicator) {
       bainTable$addFootnote(message= paste0("The variable ", variable, " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
     }
 
@@ -136,42 +136,42 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
       next
     }
 
-    if(type == 1){
+    if (type == 1) {
         BF_0u <- bainAnalysis$BF_0u
         PMP_u <- bainAnalysis$PMP_u
         PMP_0 <- bainAnalysis$PMP_0
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
           BF_0u <- 1/BF_0u
     }
-    if(type == 2){
+    if (type == 2) {
         BF_01 <- bainAnalysis$BF_01
         PMP_1 <- bainAnalysis$PMP_1
         PMP_0 <- bainAnalysis$PMP_0
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
             BF_01 <- 1/BF_01
     }
-    if(type == 3){
+    if (type == 3) {
         BF_01 <- bainAnalysis$BF_01
         PMP_0 <- bainAnalysis$PMP_0
         PMP_1 <- bainAnalysis$PMP_1
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
             BF_01 <- 1/BF_01
     }
-     if (type == 4){
+     if (type == 4) {
         BF_01 <- bainAnalysis$BF_12
         PMP_0 <- bainAnalysis$PMP_1
         PMP_1 <- bainAnalysis$PMP_2
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
             BF_01 <- 1/BF_01
     }
-     if (type == 5){
+     if (type == 5) {
         BF_01 <- bainAnalysis$BF_01
         BF_02 <- bainAnalysis$BF_02
         BF_12 <- bainAnalysis$BF_12
         PMP_0 <- bainAnalysis$PMP_0
         PMP_1 <- bainAnalysis$PMP_1
         PMP_2 <- bainAnalysis$PMP_2
-        if(options$bayesFactorType == "BF10")
+        if (options$bayesFactorType == "BF10")
         {
             BF_01 <- 1/BF_01
             BF_02 <- 1/BF_02
@@ -179,38 +179,38 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
         }
     }
 
-    if(options$bayesFactorType == "BF01"){
-        if(options$hypothesis == "notEqualToTestValue"){
+    if (options$bayesFactorType == "BF01") {
+        if (options$hypothesis == "notEqualToTestValue") {
             row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_0u, "pmp[type1]" = PMP_0,
                                             "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = "", "pmp[type2]" = PMP_u)
-        } else if(options$hypothesis == "greaterThanTestValue"){
+        } else if (options$hypothesis == "greaterThanTestValue") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
                                             "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = "", "pmp[type2]" = PMP_1)
-        } else if(options$hypothesis == "lessThanTestValue"){
+        } else if (options$hypothesis == "lessThanTestValue") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
                                             "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_1)
-        } else if (options$hypothesis == "_4type"){
+        } else if (options$hypothesis == "_4type") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
                                             "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_1)
-        } else if (options$hypothesis == "allTypes"){
+        } else if (options$hypothesis == "allTypes") {
             row <-list(Variable=variable, "type[equal]" = "H0: Equal", "BF[equal]"= "", "pmp[equal]" = PMP_0, 
                                             "type[greater]" = "H1: Bigger", "BF[greater]" = BF_01, "pmp[greater]" = PMP_1,
                                             "type[less]" = "H2: Smaller", "BF[less]" = BF_02, "pmp[less]" = PMP_2)
         }
-    } else if (options$bayesFactorType == "BF10"){
-        if(options$hypothesis == "notEqualToTestValue"){
+    } else if (options$bayesFactorType == "BF10") {
+        if (options$hypothesis == "notEqualToTestValue") {
             row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
                                               "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = BF_0u, "pmp[type2]" = PMP_u)
-        } else if(options$hypothesis == "greaterThanTestValue"){
+        } else if (options$hypothesis == "greaterThanTestValue") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
                                             "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
-        } else if(options$hypothesis == "lessThanTestValue"){
+        } else if (options$hypothesis == "lessThanTestValue") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"="", "pmp[type1]" = PMP_0,
                                             "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
-        } else if (options$hypothesis == "_4type"){
+        } else if (options$hypothesis == "_4type") {
             row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"= "", "pmp[type1]" = PMP_0,
                                             "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
-        } else if (options$hypothesis == "allTypes"){
+        } else if (options$hypothesis == "allTypes") {
             row <-list(Variable=variable, "type[equal]" = "H0: Equal", "BF[equal]"= "", "pmp[equal]" = PMP_0,
                                             "type[greater]"= "H1: Bigger", "BF[greater]" = BF_01, "pmp[greater]" = PMP_1,
                                             "type[less]" = "H2: Smaller", "BF[less]" = BF_02, "pmp[less]" = PMP_2)
@@ -225,8 +225,8 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
 
 .bainOneSampleDescriptivesTable <- function(dataset, options, jaspResults, ready) {
 
-  if(!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
-    if(options[["descriptives"]]){
+  if (!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
+    if (options[["descriptives"]]) {
       
       descriptivesTable <- createJaspTable("Descriptive Statistics")
       descriptivesTable$dependOn(options =c("variables", "descriptives", "descriptivesPlotsCredibleInterval"))
@@ -245,12 +245,12 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
       
       jaspResults[["descriptivesTable"]] <- descriptivesTable
 
-      if(!ready)
+      if (!ready)
         return()
 
-      for(variable in options[["variables"]]){
+      for (variable in options[["variables"]]) {
           data <- na.omit(dataset[[ .v(variable) ]])
-          if (class(data) != "factor"){ # TODO: Fix this...
+          if (class(data) != "factor") { # TODO: Fix this...
             posteriorSummary <- .posteriorSummaryGroupMean(variable=data, descriptivesPlotsCredibleInterval=options$descriptivesPlotsCredibleInterval)
             ciLower <- round(posteriorSummary$ciLower,3)
             ciUpper <- round(posteriorSummary$ciUpper,3)
@@ -268,15 +268,15 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
     }
 }
 
-.bainOneSampleDescriptivesPlot <- function(dataset, options, jaspResults, ready){
-  if(options[["descriptivesPlots"]] && ready){
-      if(is.null(jaspResults[["descriptivesPlots"]])){
-      jaspResults[["descriptivesPlots"]]          <- createJaspContainer("Descriptive Plots")
-      jaspResults[["descriptivesPlots"]]          $dependOn(options =c("descriptivesPlots", "descriptivesPlotsCredibleInterval"))
-      jaspResults[["descriptivesPlots"]]			    $position <- 4
+.bainOneSampleDescriptivesPlot <- function(dataset, options, jaspResults, ready) {
+  if (options[["descriptivesPlots"]] && ready) {
+      if (is.null(jaspResults[["descriptivesPlots"]])) {
+      jaspResults[["descriptivesPlots"]] <- createJaspContainer("Descriptive Plots")
+      jaspResults[["descriptivesPlots"]]$dependOn(options =c("descriptivesPlots", "descriptivesPlotsCredibleInterval"))
+      jaspResults[["descriptivesPlots"]]$position <- 4
       }
-      for (variable in unlist(options[["variables"]])){
-          if(is.null(jaspResults[["descriptivesPlots"]][[variable]]))
+      for (variable in unlist(options[["variables"]])) {
+          if (is.null(jaspResults[["descriptivesPlots"]][[variable]]))
           {
             variableData <- dataset[[ .v(variable) ]]
             variableData <- variableData[ ! is.na(variableData) ]
@@ -286,7 +286,7 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
             jaspResults[["descriptivesPlots"]][[variable]]        $dependOn(optionContainsValue=list("variables" = variable))
           }
       }
-  } else if(options[["descriptivesPlots"]]){
+  } else if (options[["descriptivesPlots"]]) {
     emptyPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plots")
     jaspResults[["descriptivesPlots"]] <- emptyPlot
     jaspResults[["descriptivesPlots"]]$dependOn(options =c("variables", "descriptivesPlots"))
@@ -342,7 +342,7 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   }
 }
 
-.plot.BainT <- function (x, y, ...){
+.plot.BainT <- function(x, y, ...) {
     if (length(x) == 4 && names(x)[1] == "BF_0u") {
         PMP <- x$PMP_0
         lab = c("H0", "H1")

--- a/JASP-Engine/JASP/R/bainttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianonesample.R
@@ -235,13 +235,13 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
       descriptivesTable$addColumnInfo(name="v",                    title = "", type="string")
       descriptivesTable$addColumnInfo(name="N",                    title = "N", type="integer")
       descriptivesTable$addColumnInfo(name="mean",                 title = "Mean", type="number")
-      descriptivesTable$addColumnInfo(name="sd",                   title = "sd", type="number")
-      descriptivesTable$addColumnInfo(name="se",                   title = "se", type="number")
+      descriptivesTable$addColumnInfo(name="sd",                   title = "SD", type="number")
+      descriptivesTable$addColumnInfo(name="se",                   title = "SE", type="number")
 
       interval <- 100 * options[["descriptivesPlotsCredibleInterval"]]
       overTitle <- paste0(interval, "% Credible Interval")
-      descriptivesTable$addColumnInfo(name="lowerCI",              title = "lowerCI", type="number", overtitle = overTitle)
-      descriptivesTable$addColumnInfo(name="upperCI",              title = "upperCI", type="number", overtitle = overTitle)
+      descriptivesTable$addColumnInfo(name="lowerCI",              title = "Lower", type="number", overtitle = overTitle)
+      descriptivesTable$addColumnInfo(name="upperCI",              title = "Upper", type="number", overtitle = overTitle)
       
       jaspResults[["descriptivesTable"]] <- descriptivesTable
 

--- a/JASP-Engine/JASP/R/bainttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianonesample.R
@@ -32,7 +32,7 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   .bainOneSampleDescriptivesTable(dataset, options, jaspResults, ready)
   
   ### BAYES FACTOR PLOTS ###
-  .bainOneSampleBayesFactorPlots(dataset, options, jaspResults, ready)
+  .bainTTestFactorPlots(dataset, options, jaspResults, ready, "oneSample")
   
   ### DESCRIPTIVES PLOTS ###
   .bainOneSampleDescriptivesPlot(dataset, options, jaspResults, ready)
@@ -45,7 +45,7 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
             dataset                                 <- .readDataSetToEnd(columns.as.numeric = options[["variables"]], exclude.na.listwise = options[["variables"]])
     }
     .hasErrors(dataset, perform, type=c("infinity", "variance", "observations"),
-                all.target = options[["variables"]], message="short", observations.amount="< 3",
+                all.target = options[["variables"]], observations.amount="< 3",
                 exitAnalysisIfErrors = TRUE)
     readList <- list()
     readList[["dataset"]] <- dataset
@@ -67,24 +67,24 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   bf.title <- "BF"
 
   if(options$hypothesis == "allTypes"){
-          bainTable$addColumnInfo(name="Variable", type="string", title="")
-          bainTable$addColumnInfo(name = "type[equal]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name="BF[equal]", type="number", format="sf:4;dp:3", title=bf.title)
-          bainTable$addColumnInfo(name="pmp[equal]", type="number", format="dp:3", title="Posterior probability")
-          bainTable$addColumnInfo(name = "type[greater]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name="BF[greater]", type="number", format="sf:4;dp:3", title="bf.title")
-          bainTable$addColumnInfo(name="pmp[greater]", type="number", format="dp:3", title="Posterior probability")
-          bainTable$addColumnInfo(name = "type[less]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name = "BF[less]", type = "number", format="sf:4;dp:3", title = bf.title)
-          bainTable$addColumnInfo(name="pmp[less]", type="number", format="dp:3", title="Posterior probability")
+    bainTable$addColumnInfo(name="Variable",      type="string", title="")
+    bainTable$addColumnInfo(name="type[equal]",   type="string", title="Hypothesis")
+    bainTable$addColumnInfo(name="BF[equal]",     type="number", title=bf.title)
+    bainTable$addColumnInfo(name="pmp[equal]",    type="number", format="dp:3", title="Posterior probability")
+    bainTable$addColumnInfo(name="type[greater]", type="string", title="Hypothesis")
+    bainTable$addColumnInfo(name="BF[greater]",   type="number", title="bf.title")
+    bainTable$addColumnInfo(name="pmp[greater]",  type="number", format="dp:3", title="Posterior probability")
+    bainTable$addColumnInfo(name="type[less]",    type="string", title="Hypothesis")
+    bainTable$addColumnInfo(name="BF[less]",      type="number", title=bf.title)
+    bainTable$addColumnInfo(name="pmp[less]",     type="number", format="dp:3", title="Posterior probability")
   } else {
-          bainTable$addColumnInfo(name="Variable", type="string", title="")
-          bainTable$addColumnInfo(name = "hypothesis[type1]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name="BF[type1]", type="number", format="sf:4;dp:3", title=bf.title)
-          bainTable$addColumnInfo(name="pmp[type1]", type="number", format="dp:3", title="Posterior probability")
-          bainTable$addColumnInfo(name = "hypothesis[type2]", type = "string", title = "Hypothesis")
-          bainTable$addColumnInfo(name="BF[type2]", type="number", format="sf:4;dp:3", title=bf.title)
-          bainTable$addColumnInfo(name="pmp[type2]", type="number", format="dp:3", title="Posterior probability")
+    bainTable$addColumnInfo(name="Variable",          type="string", title="")
+    bainTable$addColumnInfo(name="hypothesis[type1]", type="string", title="Hypothesis")
+    bainTable$addColumnInfo(name="BF[type1]",         type="number", title=bf.title)
+    bainTable$addColumnInfo(name="pmp[type1]",        type="number", format="dp:3", title="Posterior probability")
+    bainTable$addColumnInfo(name="hypothesis[type2]", type="string", title="Hypothesis")
+    bainTable$addColumnInfo(name="BF[type2]",         type="number", title=bf.title)
+    bainTable$addColumnInfo(name="pmp[type2]",        type="number", format="dp:3", title="Posterior probability")
   }
   
   type <- base::switch(options[["hypothesis"]],
@@ -105,11 +105,9 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
                             "lessThanTestValue"     = paste0(note, options[["testValue"]], "."," The posterior probabilities are based on equal prior probabilities."),
                             "_4type"                = paste0("The hypothesis H1 specifies that the mean is bigger than ",options[["testValue"]]," and the hypothesis H2 specifies that the mean is smaller than ",options[["testValue"]],". The posterior probabilities are based on equal prior probabilities."),
                             "allTypes"              = paste0(note, options[["testValue"]], " is tested against the other hypotheses. H1 states that the mean is bigger than ", options[["testValue"]]," and H2 states that the mean is smaller than ",options[["testValue"]],". The posterior probabilities are based on equal prior probabilities."))
-  bainTable$addFootnote(message=message, symbol="<i>Note.</i>")
+  bainTable$addFootnote(message=message)
 
-  bainTable$addCitation("Gu, X., Mulder, J., and Hoijtink, H. (2017). Approximate adjusted fractional Bayes factors: A general method for testing informative hypotheses. British Journal of Mathematical and Statistical Psychology. DOI:10.1111/bmsp.12110")
-  bainTable$addCitation("Hoijtink, H., Mulder, J., van Lissa, C., and Gu, X. (2018). A Tutorial on testing hypotheses using the Bayes factor. Psychological Methods.")
-  bainTable$addCitation("Hoijtink, H., Gu, X., and Mulder, J. (2018). Bayesian evaluation of informative hypotheses for multiple populations. Britisch Journal of Mathematical and Statistical Psychology. DOI: 10.1111/bmsp.12145")
+  bainTable$addCitation(.bainGetCitations())
 
   if(!ready)
     return()
@@ -119,23 +117,24 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   
   for (variable in options[["variables"]]){
 
-      if(variable %in% missingValuesIndicator){
-        bainTable$addFootnote(message= paste0("The variable ", variable, " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-      }
+    if(variable %in% missingValuesIndicator){
+      bainTable$addFootnote(message= paste0("The variable ", variable, " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
+    }
 
-      variableData <- dataset[[ .v(variable) ]]
-      variableData <- variableData[ ! is.na(variableData) ]
-      variableData <- variableData - options[["testValue"]] # subtract test value from data points
+    variableData <- dataset[[ .v(variable) ]]
+    variableData <- variableData[ ! is.na(variableData) ]
+    variableData <- variableData - options[["testValue"]] # subtract test value from data points
 
-      p <- try({
-          bainAnalysis <- Bain::Bain_ttestData(variableData, type = type)
-          bainResult[[variable]] <- bainAnalysis
-      })
+    p <- try({
+      bainAnalysis <- Bain::Bain_ttestData(variableData, nu = options$testValue, type = type)
+      bainResult[[variable]] <- bainAnalysis
+    })
 
-      if(class(p) == "try-error"){
-          bainTable$setError("An error occurred in the analysis. Please double check your variables.")
-          return()
-      }
+    if (inherits(p, "try-error")) {
+      bainTable$addFootnote(message=paste0("Results for ", variable, " not computed: ", .extractErrorMessage(p)), symbol="<b>Error.</b>")
+      jaspResults$progressbarTick()
+      next
+    }
 
     if(type == 1){
         BF_0u <- bainAnalysis$BF_0u
@@ -182,43 +181,43 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
 
     if(options$bayesFactorType == "BF01"){
         if(options$hypothesis == "notEqualToTestValue"){
-            row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=.clean(BF_0u), "pmp[type1]" = .clean(PMP_0),
-                                            "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = "", "pmp[type2]" = .clean(PMP_u))
+            row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_0u, "pmp[type1]" = PMP_0,
+                                            "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = "", "pmp[type2]" = PMP_u)
         } else if(options$hypothesis == "greaterThanTestValue"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=.clean(BF_01), "pmp[type1]" = .clean(PMP_0),
-                                            "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = "", "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
+                                            "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = "", "pmp[type2]" = PMP_1)
         } else if(options$hypothesis == "lessThanTestValue"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"=.clean(BF_01), "pmp[type1]" = .clean(PMP_0),
-                                            "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = "", "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
+                                            "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_1)
         } else if (options$hypothesis == "_4type"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"=.clean(BF_01), "pmp[type1]" = .clean(PMP_0),
-                                            "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = "", "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"=BF_01, "pmp[type1]" = PMP_0,
+                                            "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_1)
         } else if (options$hypothesis == "allTypes"){
-            row <-list(Variable=variable, "type[equal]" = "H0: Equal", "BF[equal]"= "", "pmp[equal]" = .clean(PMP_0), 
-                                            "type[greater]" = "H1: Bigger", "BF[greater]" = .clean(BF_01), "pmp[greater]" = .clean(PMP_1),
-                                            "type[less]" = "H2: Smaller", "BF[less]" = .clean(BF_02), "pmp[less]" = .clean(PMP_2))
+            row <-list(Variable=variable, "type[equal]" = "H0: Equal", "BF[equal]"= "", "pmp[equal]" = PMP_0, 
+                                            "type[greater]" = "H1: Bigger", "BF[greater]" = BF_01, "pmp[greater]" = PMP_1,
+                                            "type[less]" = "H2: Smaller", "BF[less]" = BF_02, "pmp[less]" = PMP_2)
         }
     } else if (options$bayesFactorType == "BF10"){
         if(options$hypothesis == "notEqualToTestValue"){
-            row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = .clean(PMP_0),
-                                              "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = .clean(BF_0u), "pmp[type2]" = PMP_u)
+            row <- list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
+                                              "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = BF_0u, "pmp[type2]" = PMP_u)
         } else if(options$hypothesis == "greaterThanTestValue"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = .clean(PMP_0),
-                                            "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = .clean(BF_01), "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
+                                            "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
         } else if(options$hypothesis == "lessThanTestValue"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"="", "pmp[type1]" = .clean(PMP_0),
-                                            "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = .clean(BF_01), "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H0: Equal", "BF[type1]"="", "pmp[type1]" = PMP_0,
+                                            "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
         } else if (options$hypothesis == "_4type"){
-            row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"= "", "pmp[type1]" = .clean(PMP_0),
-                                            "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = .clean(BF_01), "pmp[type2]" = .clean(PMP_1))
+            row <-list(Variable=variable, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"= "", "pmp[type1]" = PMP_0,
+                                            "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
         } else if (options$hypothesis == "allTypes"){
-            row <-list(Variable=variable, "type[equal]" = "H0: Equal", "BF[equal]"= "", "pmp[equal]" = .clean(PMP_0),
-                                            "type[greater]"= "H1: Bigger", "BF[greater]" = .clean(BF_01), "pmp[greater]" = .clean(PMP_1),
-                                            "type[less]" = "H2: Smaller", "BF[less]" = .clean(BF_02), "pmp[less]" = .clean(PMP_2))
+            row <-list(Variable=variable, "type[equal]" = "H0: Equal", "BF[equal]"= "", "pmp[equal]" = PMP_0,
+                                            "type[greater]"= "H1: Bigger", "BF[greater]" = BF_01, "pmp[greater]" = PMP_1,
+                                            "type[less]" = "H2: Smaller", "BF[less]" = BF_02, "pmp[less]" = PMP_2)
         }
     }
-      bainTable$addRows(row)
-      jaspResults$progressbarTick()
+    bainTable$addRows(row)
+    jaspResults$progressbarTick()
   }
   jaspResults[["bainResult"]] <- createJaspState(bainResult)
   jaspResults[["bainResult"]]$dependOn(optionsFromObject =bainTable)
@@ -229,21 +228,22 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   if(!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it
     if(options[["descriptives"]]){
       
-      descriptivesTable                                            <- createJaspTable("Descriptive Statistics")
-      jaspResults[["descriptivesTable"]]                           <- descriptivesTable
+      descriptivesTable <- createJaspTable("Descriptive Statistics")
       descriptivesTable$dependOn(options =c("variables", "descriptives", "descriptivesPlotsCredibleInterval"))
       descriptivesTable$position <- 2
 
       descriptivesTable$addColumnInfo(name="v",                    title = "", type="string")
       descriptivesTable$addColumnInfo(name="N",                    title = "N", type="integer")
-      descriptivesTable$addColumnInfo(name="mean",                 title = "Mean", type="number", format="sf:4;dp:3")
-      descriptivesTable$addColumnInfo(name="sd",                   title = "sd", type="number", format="sf:4;dp:3")
-      descriptivesTable$addColumnInfo(name="se",                   title = "se", type="number", format="sf:4;dp:3")
+      descriptivesTable$addColumnInfo(name="mean",                 title = "Mean", type="number")
+      descriptivesTable$addColumnInfo(name="sd",                   title = "sd", type="number")
+      descriptivesTable$addColumnInfo(name="se",                   title = "se", type="number")
 
       interval <- 100 * options[["descriptivesPlotsCredibleInterval"]]
       overTitle <- paste0(interval, "% Credible Interval")
-      descriptivesTable$addColumnInfo(name="lowerCI",              title = "lowerCI", type="number", format="sf:4;dp:3", overtitle = overTitle)
-      descriptivesTable$addColumnInfo(name="upperCI",              title = "upperCI", type="number", format="sf:4;dp:3", overtitle = overTitle)
+      descriptivesTable$addColumnInfo(name="lowerCI",              title = "lowerCI", type="number", overtitle = overTitle)
+      descriptivesTable$addColumnInfo(name="upperCI",              title = "upperCI", type="number", overtitle = overTitle)
+      
+      jaspResults[["descriptivesTable"]] <- descriptivesTable
 
       if(!ready)
         return()
@@ -252,15 +252,15 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
           data <- na.omit(dataset[[ .v(variable) ]])
           if (class(data) != "factor"){ # TODO: Fix this...
             posteriorSummary <- .posteriorSummaryGroupMean(variable=data, descriptivesPlotsCredibleInterval=options$descriptivesPlotsCredibleInterval)
-            ciLower <- .clean(round(posteriorSummary$ciLower,3))
-            ciUpper <- .clean(round(posteriorSummary$ciUpper,3))
-            n    <- .clean(length(data))
-            mean <- .clean(round(mean(data),3))
-            stdDeviation <- .clean(round(sd(data),3))
-            stdErrorMean <- .clean(round((sd(data)/sqrt(length(data))),3))
+            ciLower <- round(posteriorSummary$ciLower,3)
+            ciUpper <- round(posteriorSummary$ciUpper,3)
+            n    <- length(data)
+            mean <- round(mean(data),3)
+            stdDeviation <- round(sd(data),3)
+            stdErrorMean <- round((sd(data)/sqrt(length(data))),3)
             row <- list(v=variable, N=n, mean=mean, sd=stdDeviation, se=stdErrorMean, lowerCI = ciLower, upperCI = ciUpper)
           } else {
-            n <- .clean(length(data))
+            n <- length(data)
             row <- list(v=variable, N=n, mean="", sd="", se="", lowerCI="", upperCI="")
         }
         descriptivesTable$addRows(row)
@@ -268,42 +268,11 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
     }
 }
 
-.bainOneSampleBayesFactorPlots <- function(dataset, options, jaspResults, ready){
-  bainResult <- jaspResults[["bainResult"]]$object
-  if(options[["bayesFactorPlot"]] && ready){
-      if(is.null(jaspResults[["BFplots"]])){
-      jaspResults[["BFplots"]]                    <- createJaspContainer("Bayes Factor Comparison")
-      jaspResults[["BFplots"]]                    $dependOn(options =c("variables", "testValue", "hypothesis", "bayesFactorPlot"))
-      jaspResults[["BFplots"]]					          $position <- 3
-      }
-      for (variable in options[["variables"]]){
-          if(is.null(jaspResults[["BFplots"]][[variable]])){
-              if(is.null(bainResult[[variable]])){
-                errorPlot <- createJaspPlot(plot = NULL, title = variable, height = 400, width = 600)
-                errorPlot$setError("Plotting not possible: No analysis has been run.")
-                jaspResults[["BFplots"]][[variable]] <- errorPlot
-                jaspResults[["BFplots"]][[variable]]$dependOn(optionContainsValue=list("variables" = variable))
-              } else{
-                p <- .plot.BainT(bainResult[[variable]])
-                jaspResults[["BFplots"]][[variable]] <- createJaspPlot(plot = p, title = variable, height = 400, width = 600)
-                jaspResults[["BFplots"]][[variable]]$dependOn(optionContainsValue=list("variables" = variable))
-              }
-          }
-      }
-  } else if(options[["bayesFactorPlot"]]){
-    errorPlot <- createJaspPlot(plot = NULL, title = "Bayes Factor Comparison", height = 400, width = 600)
-    errorPlot$setError("Plotting not possible: No analysis has been run.")
-    jaspResults[["BFplots"]] <- errorPlot
-    jaspResults[["BFplots"]]$dependOn(options =c("variables", "bayesFactorPlot"))
-    jaspResults[["BFplots"]]$position <- 3
-  }
-}
-
 .bainOneSampleDescriptivesPlot <- function(dataset, options, jaspResults, ready){
   if(options[["descriptivesPlots"]] && ready){
       if(is.null(jaspResults[["descriptivesPlots"]])){
       jaspResults[["descriptivesPlots"]]          <- createJaspContainer("Descriptive Plots")
-      jaspResults[["descriptivesPlots"]]          $dependOn(options =c("variables", "testValue", "descriptivesPlots", "descriptivesPlotsCredibleInterval"))
+      jaspResults[["descriptivesPlots"]]          $dependOn(options =c("descriptivesPlots", "descriptivesPlotsCredibleInterval"))
       jaspResults[["descriptivesPlots"]]			    $position <- 4
       }
       for (variable in unlist(options[["variables"]])){
@@ -318,11 +287,58 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
           }
       }
   } else if(options[["descriptivesPlots"]]){
-    errorPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plots")
-    errorPlot$setError("Plotting not possible: No analysis has been run.")
-    jaspResults[["descriptivesPlots"]] <- errorPlot
+    emptyPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plots")
+    jaspResults[["descriptivesPlots"]] <- emptyPlot
     jaspResults[["descriptivesPlots"]]$dependOn(options =c("variables", "descriptivesPlots"))
     jaspResults[["descriptivesPlots"]]$position <- 4
+  }
+}
+
+.bainTTestFactorPlots <- function(dataset, options, jaspResults, ready, type) {
+  if (!options[["bayesFactorPlot"]]) return()
+
+  if (is.null(jaspResults[["BFplots"]])) {
+    BFplots <- createJaspContainer("Bayes Factor Comparison")
+    BFplots$dependOn(options=c("testValue", "hypothesis", "bayesFactorPlot", "groupingVariable"))
+    BFplots$position <- 3
+    jaspResults[["BFplots"]] <- BFplots
+  } else {
+    BFplots <- jaspResults[["BFplots"]]
+  }
+
+  if (!ready) {
+    BFplots[["placeHolder"]] <- createJaspPlot(plot = NULL, title = "", height = 400, width = 600, dependencies=c("pairs", "variables"))
+    return()
+  }
+  
+  bainResult <- jaspResults[["bainResult"]]$object
+  
+  if (type == "pairedSamples") {
+    option <- "pairs"
+    dependencies <- options$pairs
+    variables <- unlist(lapply(options$pairs, paste, collapse=" - "))
+  } else {
+    option <- "variables"
+    variables <- dependencies <- options$variables
+  }
+  
+  for (i in seq_along(variables)) {
+    variable <- variables[i]
+    if (!is.null(BFplots[[variable]]))
+      next
+
+    plot <- createJaspPlot(plot = NULL, title = variable, height = 400, width = 600)
+
+    dependency <- list()
+    dependency[[option]] <- dependencies[[i]]
+    plot$dependOn(optionContainsValue=dependency)
+
+    if (!is.null(bainResult[[variable]]))
+      plot$plotObject <- .plot.BainT(bainResult[[variable]])
+    else
+      plot$setError("Plotting not possible: the results for this variable were not computed.")
+      
+    BFplots[[variable]] <- plot
   }
 }
 

--- a/JASP-Engine/JASP/R/bainttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianonesample.R
@@ -117,10 +117,6 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
   
   for (variable in options[["variables"]]) {
 
-    if (variable %in% missingValuesIndicator) {
-      bainTable$addFootnote(message= paste0("The variable ", variable, " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-    }
-
     variableData <- dataset[[ .v(variable) ]]
     variableData <- variableData[ ! is.na(variableData) ]
     variableData <- variableData - options[["testValue"]] # subtract test value from data points
@@ -131,10 +127,15 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
     })
 
     if (inherits(p, "try-error")) {
-      bainTable$addFootnote(message=paste0("Results for ", variable, " not computed: ", .extractErrorMessage(p)), symbol="<b>Error.</b>")
-      jaspResults$progressbarTick()
-      next
-    }
+			bainTable$addRows(list(Variable=variable), rowNames=variable)
+			bainTable$addFootnote(message=paste0("Results not computed: ", .extractErrorMessage(p)), colNames="Variable", rowNames=variable)
+			jaspResults$progressbarTick()
+			next
+		}
+		
+		if (variable %in% missingValuesIndicator) {
+			bainTable$addFootnote(message= paste0("Variable contains missing values, the rows containing these values are removed in the analysis."), colNames="Variable", rowNames=variable)
+		}
 
     if (type == 1) {
         BF_0u <- bainAnalysis$BF_0u
@@ -216,7 +217,7 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
                                             "type[less]" = "H2: Smaller", "BF[less]" = BF_02, "pmp[less]" = PMP_2)
         }
     }
-    bainTable$addRows(row)
+    bainTable$addRows(row, rowNames=variable)
     jaspResults$progressbarTick()
   }
   jaspResults[["bainResult"]] <- createJaspState(bainResult)

--- a/JASP-Engine/JASP/R/bainttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianonesample.R
@@ -125,7 +125,7 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
       bainResult[[variable]] <- bainAnalysis
     })
 
-    if (inherits(p, "try-error")) {
+    if (isTryError(p)) {
 			bainTable$addRows(list(Variable=variable), rowNames=variable)
 			bainTable$addFootnote(message=paste0("Results not computed: ", .extractErrorMessage(p)), colNames="Variable", rowNames=variable)
 			jaspResults$progressbarTick()

--- a/JASP-Engine/JASP/R/bainttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianonesample.R
@@ -119,7 +119,6 @@ BainTTestBayesianOneSample <- function(jaspResults, dataset, options, ...) {
 
     variableData <- dataset[[ .v(variable) ]]
     variableData <- variableData[ ! is.na(variableData) ]
-    variableData <- variableData - options[["testValue"]] # subtract test value from data points
 
     p <- try({
       bainAnalysis <- Bain::Bain_ttestData(variableData, nu = options$testValue, type = type)

--- a/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
@@ -265,13 +265,13 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
     descriptivesTable$addColumnInfo(name="v",                    title = "", type="string")
     descriptivesTable$addColumnInfo(name="N",                    title = "N", type="integer")
     descriptivesTable$addColumnInfo(name="mean",                 title = "Mean", type="number")
-    descriptivesTable$addColumnInfo(name="sd",                   title = "sd", type="number")
-    descriptivesTable$addColumnInfo(name="se",                   title = "se", type="number")
+    descriptivesTable$addColumnInfo(name="sd",                   title = "SD", type="number")
+    descriptivesTable$addColumnInfo(name="se",                   title = "SE", type="number")
 
     interval <- 100 * options[["descriptivesPlotsCredibleInterval"]]
     overTitle <- paste0(interval, "% Credible Interval")
-    descriptivesTable$addColumnInfo(name="lowerCI",              title = "lowerCI", type="number", overtitle = overTitle)
-    descriptivesTable$addColumnInfo(name="upperCI",              title = "upperCI", type="number", overtitle = overTitle)
+    descriptivesTable$addColumnInfo(name="lowerCI",              title = "Lower", type="number", overtitle = overTitle)
+    descriptivesTable$addColumnInfo(name="upperCI",              title = "Upper", type="number", overtitle = overTitle)
     
     jaspResults[["descriptivesTable"]] <- descriptivesTable
     

--- a/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
@@ -117,7 +117,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
 
         if (analysisPerformed) {
 
-            if (inherits(p, "try-error")) {
+            if (isTryError(p)) {
               bainTable$addRows(list(Variable=variable), rowNames=variable)
               bainTable$addFootnote(message=paste0("Results not computed: ", .extractErrorMessage(p)), colNames="Variable", rowNames=currentPair)
               jaspResults$progressbarTick()

--- a/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
@@ -18,7 +18,7 @@
 BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
 
   ### READY ###
-  ready <- !(""%in%unlist(options[["pairs"]])) && !is.null(unlist(options[["pairs"]])) # TODO: Fix this
+  ready <- !("" %in% unlist(options[["pairs"]])) && !is.null(unlist(options[["pairs"]])) # TODO: Fix this
   
   ### READ DATA ###
   readList <- .readDataBainPairedSamples(options, dataset)
@@ -96,15 +96,6 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
 
     for (pair in options[["pairs"]]) {
 
-      if (any(pair %in% missingValuesIndicator)) {
-        i <- which(pair %in% missingValuesIndicator)
-          if (length(i) > 1) {
-            bainTable$addFootnote(message= paste0("The variables ", pair[1], " and ", pair[2], " contain missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-          } else if (length(i) == 1) {
-            bainTable$addFootnote(message= paste0("The variable ", pair[i], " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-          }
-      }
-
         currentPair <- paste(pair, collapse=" - ")
 
         if (length(pair) > 0 && pair[[2]] != "" && pair[[1]] != pair[[2]]) {
@@ -127,9 +118,20 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
         if (analysisPerformed) {
 
             if (inherits(p, "try-error")) {
-              bainTable$addFootnote(message=paste0("Results for ", currentPair, " not computed: ", .extractErrorMessage(p)), symbol="<b>Error.</b>")
+              bainTable$addRows(list(Variable=variable), rowNames=variable)
+              bainTable$addFootnote(message=paste0("Results not computed: ", .extractErrorMessage(p)), colNames="Variable", rowNames=currentPair)
               jaspResults$progressbarTick()
               next
+            } 
+            
+            if (any(pair %in% missingValuesIndicator)) {
+              i <- which(pair %in% missingValuesIndicator)
+              if (length(i) > 1) {
+                message <- paste0("Both variables contain missing values, the rows containing these values are removed in the analysis.")
+              } else {
+                message <- paste0("The variable ", pair[i], " contains missing values, the rows containing these values are removed in the analysis.")
+              }
+              bainTable$addFootnote(message=message, colNames="Variable", rowNames=currentPair)
             }
 
             if (type == 1) {
@@ -244,7 +246,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
                                "hypothesis[type2]" = ".", "BF[type2]" = ".", "pmp[type2]" = ".")
         }
     }
-    bainTable$addRows(row)
+    bainTable$addRows(row, rowNames=currentPair)
     jaspResults$progressbarTick()
   }
   jaspResults[["bainResult"]] <- createJaspState(bainResult)

--- a/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/bainttestbayesianpairedsamples.R
@@ -39,7 +39,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
 }
 
 .bainPairedSamplesResultsTable <- function(dataset, options, jaspResults, missingValuesIndicator, ready) {
-    if(!is.null(jaspResults[["bainTable"]])) return()
+    if (!is.null(jaspResults[["bainTable"]])) return()
 
     bainTable <- createJaspTable("Bain Paired Samples T-Test Result")
     bainTable$dependOn(options =c("pairs", "hypothesis", "bayesFactorType"))
@@ -49,7 +49,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
     BFH1H0 <- FALSE
     bf.title <- "BF"
 
-    if(options$hypothesis == "allTypes"){
+    if (options$hypothesis == "allTypes") {
             bainTable$addColumnInfo(name="Variable", type="string", title="")
             bainTable$addColumnInfo(name = "type[equal]", type = "string", title = "Hypothesis")
             bainTable$addColumnInfo(name="BF[equal]", type="number", title=bf.title)
@@ -88,26 +88,26 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
     
     jaspResults[["bainTable"]] <- bainTable
 
-    if(!ready)
+    if (!ready)
       return()
 
     jaspResults$startProgressbar(length(options[["pairs"]]))
     bainResult <- list()
 
-    for (pair in options[["pairs"]]){
+    for (pair in options[["pairs"]]) {
 
-      if(any(pair %in% missingValuesIndicator)){
+      if (any(pair %in% missingValuesIndicator)) {
         i <- which(pair %in% missingValuesIndicator)
-          if(length(i) > 1){
+          if (length(i) > 1) {
             bainTable$addFootnote(message= paste0("The variables ", pair[1], " and ", pair[2], " contain missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
-          } else if (length(i) == 1){
+          } else if (length(i) == 1) {
             bainTable$addFootnote(message= paste0("The variable ", pair[i], " contains missing values, the rows containing these values are removed in the analysis."), symbol="<b>Warning.</b>")
           }
       }
 
         currentPair <- paste(pair, collapse=" - ")
 
-        if(length(pair) > 0 && pair[[2]] != "" && pair[[1]] != pair[[2]]){
+        if (length(pair) > 0 && pair[[2]] != "" && pair[[1]] != pair[[2]]) {
 
             subDataSet <- subset(dataset, select=c(.v(pair[[1]]), .v(pair[[2]])) )
             subDataSet <- na.omit(subDataSet)
@@ -124,7 +124,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
             analysisPerformed <- FALSE
         }
 
-        if(analysisPerformed){
+        if (analysisPerformed) {
 
             if (inherits(p, "try-error")) {
               bainTable$addFootnote(message=paste0("Results for ", currentPair, " not computed: ", .extractErrorMessage(p)), symbol="<b>Error.</b>")
@@ -132,42 +132,42 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
               next
             }
 
-            if(type == 1){
+            if (type == 1) {
                 BF_0u <- bainAnalysis$BF_0u
                 PMP_u <- bainAnalysis$PMP_u
                 PMP_0 <- bainAnalysis$PMP_0
-                if(options$bayesFactorType == "BF10")
+                if (options$bayesFactorType == "BF10")
                   BF_0u <- 1/BF_0u
             }
-            if(type == 2){
+            if (type == 2) {
                 BF_01 <- bainAnalysis$BF_01
                 PMP_1 <- bainAnalysis$PMP_1
                 PMP_0 <- bainAnalysis$PMP_0
-                if(options$bayesFactorType == "BF10")
+                if (options$bayesFactorType == "BF10")
                     BF_01 <- 1/BF_01
             }
-            if(type == 3){
+            if (type == 3) {
                 BF_01 <- bainAnalysis$BF_01
                 PMP_0 <- bainAnalysis$PMP_0
                 PMP_1 <- bainAnalysis$PMP_1
-                if(options$bayesFactorType == "BF10")
+                if (options$bayesFactorType == "BF10")
                     BF_01 <- 1/BF_01
             }
-             if (type == 4){
+             if (type == 4) {
                 BF_01 <- bainAnalysis$BF_12
                 PMP_0 <- bainAnalysis$PMP_1
                 PMP_1 <- bainAnalysis$PMP_2
-                if(options$bayesFactorType == "BF10")
+                if (options$bayesFactorType == "BF10")
                     BF_01 <- 1/BF_01
             }
-             if (type == 5){
+             if (type == 5) {
                 BF_01 <- bainAnalysis$BF_01
                 BF_02 <- bainAnalysis$BF_02
                 BF_12 <- bainAnalysis$BF_12
                 PMP_0 <- bainAnalysis$PMP_0
                 PMP_1 <- bainAnalysis$PMP_1
                 PMP_2 <- bainAnalysis$PMP_2
-                if(options$bayesFactorType == "BF10")
+                if (options$bayesFactorType == "BF10")
                 {
                     BF_01 <- 1/BF_01
                     BF_02 <- 1/BF_02
@@ -175,24 +175,24 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
                 }
             }
 
-        if(options$bayesFactorType == "BF01"){
-            if(options$hypothesis == "groupsNotEqual"){
+        if (options$bayesFactorType == "BF01") {
+            if (options$hypothesis == "groupsNotEqual") {
                 row <- list(Variable=currentPair, "hypothesis[type1]" = "H0: Equal","BF[type1]"=BF_0u, "pmp[type1]" = PMP_0,
                                     "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = "", "pmp[type2]" = PMP_u)
             }
-            if(options$hypothesis == "groupTwoGreater"){
+            if (options$hypothesis == "groupTwoGreater") {
                 row <-list(Variable=currentPair, "hypothesis[type1]" = "H0: Equal","BF[type1]"= BF_01, "pmp[type1]" = PMP_0,
                                    "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_1)
             }
-            if(options$hypothesis == "groupOneGreater"){
+            if (options$hypothesis == "groupOneGreater") {
                 row <-list(Variable=currentPair, "hypothesis[type1]" = "H0: Equal", "BF[type1]"= BF_01, "pmp[type1]" = PMP_0,
                                    "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = "", "pmp[type2]" = PMP_1)
             }
-            if(options$hypothesis == "_4type"){
+            if (options$hypothesis == "_4type") {
                 row <-list(Variable=currentPair, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"= BF_01, "pmp[type1]" = PMP_0,
                                    "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = "", "pmp[type2]" = PMP_1)
             }
-            if(options$hypothesis == "allTypes"){
+            if (options$hypothesis == "allTypes") {
                 row <-list(Variable=currentPair,
                                    "type[equal]" = "H0: Equal",
                                    "BF[equal]"= "",
@@ -204,24 +204,24 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
                                    "BF[less]" = BF_02,
                                    "pmp[less]" = PMP_2)
             }
-        } else if (options$bayesFactorType == "BF10"){
-            if(options$hypothesis == "groupsNotEqual"){
+        } else if (options$bayesFactorType == "BF10") {
+            if (options$hypothesis == "groupsNotEqual") {
                 row <- list(Variable=currentPair, "hypothesis[type1]" = "H0: Equal","BF[type1]"="", "pmp[type1]" = PMP_0,
                                     "hypothesis[type2]" = "H1: Not equal", "BF[type2]" = BF_0u, "pmp[type2]" = PMP_u)
             }
-            if(options$hypothesis == "groupTwoGreater"){
+            if (options$hypothesis == "groupTwoGreater") {
                 row <-list(Variable=currentPair, "hypothesis[type1]" = "H0: Equal","BF[type1]"= "", "pmp[type1]" = PMP_0,
                                    "hypothesis[type2]" = "H1: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
             }
-            if(options$hypothesis == "groupOneGreater"){
+            if (options$hypothesis == "groupOneGreater") {
                 row <-list(Variable=currentPair, "hypothesis[type1]" = "H0: Equal", "BF[type1]"= "", "pmp[type1]" = PMP_0,
                                    "hypothesis[type2]" = "H1: Bigger", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
             }
-            if(options$hypothesis == "_4type"){
+            if (options$hypothesis == "_4type") {
                 row <-list(Variable=currentPair, "hypothesis[type1]" = "H1: Bigger", "BF[type1]"= "", "pmp[type1]" = PMP_0,
                                    "hypothesis[type2]" = "H2: Smaller", "BF[type2]" = BF_01, "pmp[type2]" = PMP_1)
             }
-            if(options$hypothesis == "allTypes"){
+            if (options$hypothesis == "allTypes") {
                 row <-list(Variable=currentPair,
                                    "type[equal]" = "H0: Equal",
                                    "BF[equal]"= "",
@@ -235,7 +235,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
             }
         }
     } else {
-        if(options$hypothesis == "allTypes"){
+        if (options$hypothesis == "allTypes") {
             row <- list(Variable=currentPair, "type[equal]" = ".", "BF[equal]"= ".", "pmp[equal]" = ".",
                                "type[greater]"= ".", "BF[greater]" = ".", "pmp[greater]" = ".",
                                "type[less]" = ".", "BF[less]" = ".", "pmp[less]" = ".")
@@ -251,10 +251,10 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
   jaspResults[["bainResult"]]$dependOn(optionsFromObject =bainTable)
 }
 
-.bainPairedSamplesDescriptivesTable <- function(dataset, options, jaspResults, ready){
+.bainPairedSamplesDescriptivesTable <- function(dataset, options, jaspResults, ready) {
 
-    if(!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it  
-      if(options[["descriptives"]]){
+    if (!is.null(jaspResults[["descriptivesTable"]])) return() #The options for this table didn't change so we don't need to rebuild it  
+      if (options[["descriptives"]]) {
       
     descriptivesTable <- createJaspTable("Descriptive Statistics")
     descriptivesTable$dependOn(options =c("pairs", "descriptives", "descriptivesPlotsCredibleInterval"))
@@ -273,12 +273,12 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
     
     jaspResults[["descriptivesTable"]] <- descriptivesTable
     
-    if(!ready)
+    if (!ready)
       return()
 
-    for(variable in unique(unlist(options[["pairs"]]))){
+    for (variable in unique(unlist(options[["pairs"]]))) {
 
-        if(variable == "")
+        if (variable == "")
             next
 
         variableData <- dataset[[.v(variable)]]
@@ -294,7 +294,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
         m <- as.numeric(mean(variableDataOm))
         std <- as.numeric(sd(variableDataOm))
 
-        if(is.numeric(std)){
+        if (is.numeric(std)) {
             se <- round((as.numeric(std/sqrt(n))),3)
         } else {
             se <- "NaN"
@@ -333,15 +333,15 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
 }
 }
 
-.bainPairedSamplesDescriptivesPlots <- function(dataset, options, jaspResults, ready){
-  if(options[["descriptivesPlots"]] && ready){
-      if(is.null(jaspResults[["descriptivesPlots"]])){
-      jaspResults[["descriptivesPlots"]]          <- createJaspContainer("Descriptive Plots")
-      jaspResults[["descriptivesPlots"]]          $dependOn(options =c("descriptivesPlots", "descriptivesPlotsCredibleInterval"))
-      jaspResults[["descriptivesPlots"]]			    $position <- 4
+.bainPairedSamplesDescriptivesPlots <- function(dataset, options, jaspResults, ready) {
+  if (options[["descriptivesPlots"]] && ready) {
+      if (is.null(jaspResults[["descriptivesPlots"]])) {
+        jaspResults[["descriptivesPlots"]] <- createJaspContainer("Descriptive Plots")
+        jaspResults[["descriptivesPlots"]]$dependOn(options =c("descriptivesPlots", "descriptivesPlotsCredibleInterval"))
+        jaspResults[["descriptivesPlots"]]$position <- 4
       }
-      for (pair in options[["pairs"]]){
-          if(is.null(jaspResults[["descriptivesPlots"]][[paste(pair, collapse=" - ")]]) && length(pair)==2)
+      for (pair in options[["pairs"]]) {
+          if (is.null(jaspResults[["descriptivesPlots"]][[paste(pair, collapse=" - ")]]) && length(pair)==2)
           {
             subDataSet <- subset(dataset, select=c(.v(pair[[1]]), .v(pair[[2]])) )
             subDataSet <- na.omit(subDataSet)
@@ -354,7 +354,7 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
             jaspResults[["descriptivesPlots"]][[paste(pair, collapse=" - ")]]        $dependOn(optionContainsValue=list(pairs = pair))
           }
       }
-  } else if(options[["descriptivesPlots"]]){
+  } else if (options[["descriptivesPlots"]]) {
     emptyPlot <- createJaspPlot(plot = NULL, title = "Descriptives Plots")
     jaspResults[["descriptivesPlots"]] <- emptyPlot
     jaspResults[["descriptivesPlots"]]$dependOn(options =c("pairs", "descriptivesPlots"))
@@ -362,14 +362,14 @@ BainTTestBayesianPairedSamples <- function(jaspResults, dataset, options, ...) {
   }
 }
 
-.readDataBainPairedSamples <- function(options, dataset){
+.readDataBainPairedSamples <- function(options, dataset) {
     all.variables                                                       <- unique(unlist(options$pairs))
     all.variables                                                       <- all.variables[all.variables != ""]
     pairs                                                               <- options$pairs
     # Read in data
     if (is.null(dataset)) {
             trydata                                                     <- .readDataSetToEnd(columns.as.numeric=all.variables)
-            missingValuesIndicator                                      <- .unv(names(which(apply(trydata, 2, function(x){ any(is.na(x))} ))))
+            missingValuesIndicator                                      <- .unv(names(which(apply(trydata, 2, function(x) { any(is.na(x))} ))))
             dataset                                                     <- .readDataSetToEnd(columns.as.numeric=all.variables, exclude.na.listwise=all.variables)
     }
     .hasErrors(dataset, perform, type=c("infinity", "variance", "observations"),

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2202,6 +2202,18 @@ as.list.footnotes <- function(footnotes) {
   return(NULL)
 }
 
+.suppressGrDevice <- function(plotFunc) {
+  plotFunc <- substitute(plotFunc)
+  tmpFile <- tempfile()
+  png(tmpFile)
+  on.exit({
+    dev.off()
+    if (file.exists(tmpFile))
+      file.remove(tmpFile)
+  })
+  eval(plotFunc, parent.frame())
+}
+
 .writeImage <- function(width=320, height=320, plot, obj = TRUE, relativePathpng = NULL) {
 	# Initialise output object
 	image <- list()

--- a/JASP-R-Interface/jaspResults/R/zzzWrappers.R
+++ b/JASP-R-Interface/jaspResults/R/zzzWrappers.R
@@ -212,8 +212,6 @@ jaspObjR <- R6Class(
 				for (i in seq_along(optionContainsValue)) {
 					name <- names(optionContainsValue)[i]
 					value <- optionContainsValue[[i]]
-					if (length(value) != 1 || !is.atomic(value))
-						stop("value provided in `optionContainsValue` must be of type atomic and length 1")
 					private$jaspObject$setOptionMustContainDependency(name, value)
 				}
 			}

--- a/Resources/BAIN/qml/BainAncovaBayesian.qml
+++ b/Resources/BAIN/qml/BainAncovaBayesian.qml
@@ -73,7 +73,7 @@ Form
 		{
 			name: "model"
 			implicitHeight: 200
-			infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Crtl + Enter to apply"
+			infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Ctrl + Enter to apply"
 			text: ""
 			textType: "model"
 			trim: true

--- a/Resources/BAIN/qml/BainAncovaBayesian.qml
+++ b/Resources/BAIN/qml/BainAncovaBayesian.qml
@@ -46,7 +46,7 @@ Form
 		}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Tables")
 
@@ -54,7 +54,7 @@ Form
 		CheckBox { name: "coefficients";		text: qsTr("Coefficients")			}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Plots")
 
@@ -62,7 +62,7 @@ Form
 		CheckBox { name: "descriptivesPlot";	text: qsTr("Descriptives plot")			}
 	}
 
-	ExpanderButton
+	Section
 	{
 		text: qsTr("Model Constraints")
 		columns: 1
@@ -76,6 +76,7 @@ Form
 			infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Crtl + Enter to apply"
 			text: ""
 			textType: "model"
+			trim: true
 	   }
 	}
 }

--- a/Resources/BAIN/qml/BainAnovaBayesian.qml
+++ b/Resources/BAIN/qml/BainAnovaBayesian.qml
@@ -70,7 +70,7 @@ Form
 		{
 				name: "model"
 				implicitHeight: 200
-				infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Crtl + Enter to apply"
+				infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Ctrl + Enter to apply"
 				text: ""
 				textType: "model"
 				trim: true

--- a/Resources/BAIN/qml/BainAnovaBayesian.qml
+++ b/Resources/BAIN/qml/BainAnovaBayesian.qml
@@ -40,7 +40,7 @@ Form
 
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Tables")
 
@@ -53,14 +53,14 @@ Form
 		}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Plots")
 		CheckBox { name: "bayesFactorPlot";		text: qsTr("Bayes factor comparison")	}
 		CheckBox { name: "descriptivesPlot";	text: qsTr("Descriptives plot")			}
 	}
 
-	ExpanderButton
+	Section
 	{
 		text: qsTr("Model Constraints")
 		columns: 1
@@ -73,6 +73,7 @@ Form
 				infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Crtl + Enter to apply"
 				text: ""
 				textType: "model"
+				trim: true
 		}
 	}
 }

--- a/Resources/BAIN/qml/BainRegressionLinearBayesian.qml
+++ b/Resources/BAIN/qml/BainRegressionLinearBayesian.qml
@@ -72,7 +72,7 @@ Form
 		{
 			name: "model"
 			implicitHeight: 200
-			infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Crtl + Enter to apply"
+			infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Ctrl + Enter to apply"
 			text: ""
 			textType: "model"
 			trim: true

--- a/Resources/BAIN/qml/BainRegressionLinearBayesian.qml
+++ b/Resources/BAIN/qml/BainRegressionLinearBayesian.qml
@@ -41,7 +41,7 @@ Form
 		}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Tables")
 
@@ -49,19 +49,19 @@ Form
 		CheckBox { name: "coefficients";		text: qsTr("Coefficients")			}
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Plots")
 		CheckBox { name: "bayesFactorPlot"; text: qsTr("Bayes factor comparison") }
 	}
 
-	GroupBox
+	Group
 	{
 		title: qsTr("Additional Options")
 		CheckBox { name: "standardized"; text: qsTr("Standardize")	}
 	}
 
-	ExpanderButton
+	Section
 	{
 		text: qsTr("Model Constraints")
 		columns: 1
@@ -75,6 +75,7 @@ Form
 			infoText: Qt.platform.os == "osx" ? "\u2318 + Enter to apply" : "Crtl + Enter to apply"
 			text: ""
 			textType: "model"
+			trim: true
 		}
 	}
 }

--- a/Resources/BAIN/qml/BainTTestBayesianIndependentSamples.qml
+++ b/Resources/BAIN/qml/BainTTestBayesianIndependentSamples.qml
@@ -66,13 +66,13 @@ Form
 
 	ColumnLayout
 	{
-		GroupBox
+		Group
 		{
 			title: qsTr("Tables")
 			CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
 		}
 
-		GroupBox
+		Group
 		{
 			title: qsTr("Plots")
 			CheckBox { name: "bayesFactorPlot"; text: qsTr("Bayes factor comparison") }

--- a/Resources/BAIN/qml/BainTTestBayesianIndependentSamples.qml
+++ b/Resources/BAIN/qml/BainTTestBayesianIndependentSamples.qml
@@ -23,7 +23,8 @@ Form
 {
 	VariablesForm
 	{
-		AvailableVariablesList { name: "variablesList"; suggestedColumns: ["nominal", "scale"]}
+		height: 200
+		AvailableVariablesList { name: "variablesList" }
 		AssignedVariablesList
 		{
             name: "variables"

--- a/Resources/BAIN/qml/BainTTestBayesianOneSample.qml
+++ b/Resources/BAIN/qml/BainTTestBayesianOneSample.qml
@@ -23,7 +23,8 @@ Form
 {
 	VariablesForm
 	{
-		AvailableVariablesList { name: "variablesList"; suggestedColumns: ["scale"]}
+		height: 200
+		AvailableVariablesList { name: "variablesList" }
 		AssignedVariablesList {
 			name: "variables"
 			title: qsTr("Variables")

--- a/Resources/BAIN/qml/BainTTestBayesianOneSample.qml
+++ b/Resources/BAIN/qml/BainTTestBayesianOneSample.qml
@@ -38,8 +38,7 @@ Form
 			text: qsTr("Test value")
 			defaultValue: 0
 			name: "testValue"
-			min: 0
-			max: 99999
+			negativeValues: true
 			decimals: 2
 		}
 
@@ -67,14 +66,14 @@ Form
 
 	ColumnLayout
 	{
-		GroupBox
+		Group
 		{
 			title: qsTr("Tables")
 
 			CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
 		}
 
-		GroupBox
+		Group
 		{
 			title: qsTr("Plots")
 

--- a/Resources/BAIN/qml/BainTTestBayesianPairedSamples.qml
+++ b/Resources/BAIN/qml/BainTTestBayesianPairedSamples.qml
@@ -54,13 +54,13 @@ Form
 
 	ColumnLayout
 	{
-		GroupBox
+		Group
 		{
 			title: qsTr("Tables")
 			CheckBox { name: "descriptives"; text: qsTr("Descriptives") }
 		}
 
-		GroupBox
+		Group
 		{
 			title: qsTr("Plots")
 


### PR DESCRIPTION
I removed redundant `format`'s and `.clean`'s and tidied up some functions. Furthermore I fixed

- dependencies in a few plots (e.g., the bayes factor comparison plot of the independent samples ttest didn't update when you changed the grouping variable)
- error propagation anova's/regression: if the model cannot be computed then don't try to compute stuff dependent on the model (this fixes the unexpected errors)
- error propagation ttests: if results for one variable cannot be computed, still compute for others (this still needs a proper $addRows() that adds NaN's)
- test value in one sample ttest was not used and could not be negative
- whitespace in the model constraint text area no longer errors the analysis
- the styling to be more inline with the JASP R styleguide

The data reading and descriptives functions overlap and should probably be simplified further

Partially fixes jasp-stats/jasp-issues#380 (I'm not sure when variables are allowed to occur in multiple hypotheses; I think this is more of a bain package parser issue)

@koenderks maybe you can test the changes and we can see if you agree with them.