### PR TITLE
Make ribbonbar behave nicer with a custom menu

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/CustomMenu.qml
+++ b/JASP-Desktop/components/JASP/Widgets/CustomMenu.qml
@@ -40,6 +40,7 @@ FocusScope
 	property point	menuMaxPos	: "0,0"
 	property bool	menuMinIsMin: false
 	property bool	showMe		: false
+	property bool	isRibbonMenu: false
 
 	property point	scrollOri	: "0,0" //Just for other qmls to use as a general storage of the origin of their scrolling
 
@@ -53,13 +54,14 @@ FocusScope
 
 	function showMenu(item, props, x_offset, y_offset)
 	{
-		menu.menuMaxPos.x	= Qt.binding(function() { return mainWindowRoot.width;  });
-		menu.menuMaxPos.y	= Qt.binding(function() { return mainWindowRoot.height; });
-		menu.menuMinPos	= item.mapToItem(null, 1, 1);
-		menu.props		= props;
-		menu.menuOffset.x	= x_offset;
-		menu.menuOffset.y	= y_offset;
-		menu.showMe		= true;
+		customMenu.isRibbonMenu	= item.objectName === "ribbonButton";
+		customMenu.menuMaxPos.x	= Qt.binding(function() { return mainWindowRoot.width;  });
+		customMenu.menuMaxPos.y	= Qt.binding(function() { return mainWindowRoot.height; });
+		customMenu.menuMinPos	= item.mapToItem(null, 1, 1);
+		customMenu.props		= props;
+		customMenu.menuOffset.x	= x_offset;
+		customMenu.menuOffset.y	= y_offset;
+		menu.showMe				= true;
 		menu.forceActiveFocus();
 	}
 

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
@@ -94,17 +94,50 @@ FocusScope
 			bottom	: parent.bottom
 		}
 	}
+	
+	Rectangle  // a line underneath ribbonbar, just like in filemenu
+	{
+		z		: 3
+		height	: 1
+		color	: Theme.uiBorder
+
+		anchors
+		{
+			top		: parent.bottom
+			left	: parent.left
+			right	: parent.right
+		}
+	}
 
 	Rectangle
 	{
-		id		: shadow
+		id		: leftShadow
 		y		: ribbonMenu.height
 		z		: 1
 		height	: Theme.shadowRadius
+		width   : customMenu.isRibbonMenu && customMenu.visible ? customMenu.x : ribbonBar.width
 
 		anchors
 		{
 			left	: parent.left
+		}
+
+		gradient	: Gradient {
+			GradientStop { position: 0.0; color: Theme.shadow }
+			GradientStop { position: 1.0; color: "transparent" } }
+
+	}
+	
+	Rectangle
+	{
+		id		: rightShadow
+		y		: ribbonMenu.height
+		z		: 1
+		height	: Theme.shadowRadius
+		width	: customMenu.isRibbonMenu && customMenu.visible ? (ribbonBar.width - (customMenu.x + customMenu.width)) : 0
+
+		anchors
+		{
 			right	: parent.right
 		}
 
@@ -112,18 +145,5 @@ FocusScope
 			GradientStop { position: 0.0; color: Theme.shadow }
 			GradientStop { position: 1.0; color: "transparent" } }
 
-		Rectangle  // a line underneath ribbonbar, just like in filemenu
-		{
-			z		: 3
-			height	: 1
-			color	: Theme.uiBorder
-
-			anchors
-			{
-				top		: parent.top
-				left	: parent.left
-				right	: parent.right
-			}
-		}
 	}
 }

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -28,9 +28,8 @@ Rectangle
 	width			: (innerText.width > _imgIndWidth ? innerText.width : _imgIndWidth) + (2 * Theme.ribbonButtonPadding) // + 2*tbutton.width
 	height			: Theme.ribbonButtonHeight
 	color			: showPressed ? Theme.grayLighter : "transparent"
-	border.color	: myMenuOpen  ? Theme.grayDarker  : Theme.gray
-	border.width	: showPressed ? 1 : 0
 	z				: 1
+    objectName      : "ribbonButton"
 	//radius			: 4
 
 	property alias	text		: innerText.text
@@ -46,6 +45,32 @@ Rectangle
 	property real _imgIndWidth: backgroundImage.width + (menuIndicator.visible ? (menuIndicator.width + menuIndicator.anchors.leftMargin) * 2 : 0)
 
 	signal clicked
+
+    Rectangle
+    {
+        id      : borderLeft
+        width   : showPressed ? 1 : 0
+        color   : myMenuOpen  ? Theme.grayDarker  : Theme.gray
+        anchors
+        {
+            left	: parent.left
+            top		: parent.top
+            bottom	: parent.bottom
+        }
+    }
+
+    Rectangle
+    {
+        id      : borderRight
+        width   : showPressed ? 1 : 0
+        color   : myMenuOpen  ? Theme.grayDarker  : Theme.gray
+        anchors
+        {
+            right	: parent.right
+            top		: parent.top
+            bottom	: parent.bottom
+        }
+    }
 
 	Item
 	{


### PR DESCRIPTION
new <-> old
<img width="956" alt="Screenshot 2019-06-21 at 18 27 17" src="https://user-images.githubusercontent.com/18737241/59937252-39d4fe80-9452-11e9-89fc-659da08f5679.png">

- shadow no longer overlaps with the custom menu (part of jasp-stats/jasp-issues#381)
- the border of the pressed ribbonbar button no longer "misaligns" with the top/bottom of the ribbonbar