### PR TITLE
Always order the plots in the state that jasptools returns

### DIFF
--- a/JASP-Tests/R/tests/testthat/test-regressionlinear.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionlinear.R
@@ -183,7 +183,8 @@ test_that("Residuals vs. Dependent plot matches", {
   )
   options$plotResidualsDependent <- TRUE
   results <- jasptools::run("RegressionLinear", "test.csv", options)
-  testPlot <- results[["state"]][["figures"]][[1]][["obj"]]
+
+  testPlot <- results[["state"]][["figures"]][[2]][["obj"]]
   expect_equal_plots(testPlot, "residuals-dependent", dir="RegressionLinear")
 })
 

--- a/JASP-Tests/R/tests/testthat/test-regressionlinearbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionlinearbayesian.R
@@ -59,10 +59,10 @@ test_that("Coefficient plots match", {
     
     results <- jasptools::run("RegressionLinearBayesian", "test.csv", options)
     
-    inclusionProbabilities <- results[['state']][['figures']][[1]][["obj"]]
+    inclusionProbabilities <- results[['state']][['figures']][[5]][["obj"]]
     expect_equal_plots(inclusionProbabilities, "inclusionProbabilities", "RegressionLinearBayesian")
     
-    posteriorCoefficients <- results[['state']][['figures']][[2]][["obj"]]
+    posteriorCoefficients <- results[['state']][['figures']][[1]][["obj"]]
     expect_equal_plots(posteriorCoefficients, "posteriorCoefficients", "RegressionLinearBayesian")
 })
 

--- a/Tools/jasptools/DESCRIPTION
+++ b/Tools/jasptools/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jasptools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 0.6.7
+Version: 0.6.8
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/Tools/jasptools/R/main.R
+++ b/Tools/jasptools/R/main.R
@@ -337,5 +337,9 @@ run <- function(name, dataset, options, perform = "run", view = TRUE, quiet = FA
 
   results[["state"]] <- .getInternal("state")
 
+  figures <- results$state$figures
+  if (length(figures) > 1 && !is.null(names(figures)))
+    results$state$figures <- figures[order(names(figures))]
+
   return(invisible(results))
 }


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp#328 -- it's now the same for jaspResults & old-style analyses. The order of plots is always the same.