### PR TITLE
Revert "Use BF not P(M|data) to sort tables in abtest"

### DIFF
--- a/JASP-Engine/JASP/R/abtestbayesian.R
+++ b/JASP-Engine/JASP/R/abtestbayesian.R
@@ -403,7 +403,7 @@ ABTestBayesian <- function(
 
     if (options$bayesFactorOrder == "bestModelTop") {
 
-        ordered       <- output.rows[order(sapply(output.rows, "[[", "BF"), decreasing = TRUE)]
+        ordered       <- output.rows[order(sapply(output.rows, "[[", "P(M|data)"), decreasing = TRUE)]
         best_model_bf <- ordered[[1]]$BF
 
         output.rows   <- list()

--- a/JASP-Tests/R/tests/testthat/test-abtestbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-abtestbayesian.R
@@ -12,9 +12,9 @@ test_that("Main table results match", {
 
   results  <- jasptools::run("ABTestBayesian", "ab_data.csv", options)
   table    <- results[["results"]][["abTestTable"]][["data"]]
-  refTable <- list("Log odds ratio > 0", 1, 0.318940893382007, 0.25,
-                    "Log odds ratio = 0", 0.811675271883202, 0.517752872701024, 0.5,
-                    "Log odds ratio < 0", 0.512026639749113, 0.163306233916969, 0.25)
+  refTable <- list("Log odds ratio = 0", 1                , 0.517752872701024, 0.5,
+                   "Log odds ratio > 0", 1.23201979244712 , 0.318940893382007, 0.25,
+                   "Log odds ratio < 0", 0.630826954431096, 0.163306233916969, 0.25)
 
   expect_equal_tables(table, refTable)
 })
@@ -54,10 +54,10 @@ test_that("Main table results, log odds neq 0", {
   results  <- jasptools::run("ABTestBayesian", "ab_data.csv", options)
   table    <- results[["results"]][["abTestTable"]][["data"]]
 
-  refTable <- list("Log odds ratio > 0", 1, 0.215969209785004, 0.168168168168168,
-                    "Log odds ratio = 0", 0.811675271883202, 0.51649969761886, 0.495495495495495,
-                    "Log odds ratio <unicode> 0", 0.726719813333075, 0.15694910382065, 0.168168168168168,
-                    "Log odds ratio < 0", 0.512026639749113, 0.110581988775487, 0.168168168168168)
+  refTable <- list("Log odds ratio = 0"        , 1                , 0.51649969761886 , 0.495495495495495,
+                   "Log odds ratio > 0"        , 1.23201979244712 , 0.215969209785004, 0.168168168168168,
+                   "Log odds ratio <unicode> 0", 0.895333193589823, 0.15694910382065 , 0.168168168168168,
+                   "Log odds ratio < 0"        , 0.630826954431096, 0.110581988775487, 0.168168168168168)
 
   expect_equal_tables(table, refTable)
 })


### PR DESCRIPTION
See jasp-stats/jasp-test-release#256

