### PR TITLE
Manova

### DIFF
--- a/JASP-Engine/JASP/R/manova.R
+++ b/JASP-Engine/JASP/R/manova.R
@@ -17,6 +17,9 @@
 
 Manova <- function(jaspResults, dataset, options) {
   
+  # Check if we're ready to actually compute something or just show empty tables
+  ready <- length(options$dependent) > 1 && length(options$fixedFactors) > 0 && length(options$modelTerms) > 0
+
   dependentVariables <- unlist(options$dependent)
   randomFactors <- unlist(options$fixedFactors)
 
@@ -26,25 +29,25 @@ Manova <- function(jaspResults, dataset, options) {
   dataset <- na.omit(dataset)
   
   # Error checking
-  errors <- .manovaCheckErrors(dataset, options)
+  .manovaCheckErrors(dataset, options, ready)
 
   # Compute the results
-  manovaResults <- .manovaComputeResults(jaspResults, dataset, options, errors)
+  manovaResults <- .manovaComputeResults(jaspResults, dataset, options, ready)
   
   # Output tables
-  .manovaTableMain(jaspResults, dataset, options, manovaResults, errors)
+  .manovaTableMain(jaspResults, dataset, options, manovaResults, ready)
 
-  .uniAnovaTables(jaspResults, dataset, options, manovaResults, errors)
+  .uniAnovaTables(jaspResults, dataset, options, manovaResults, ready)
   
-  .assumptionTables(jaspResults, dataset, options, errors)
+  .assumptionTables(jaspResults, dataset, options, ready)
   
   return()
   
 }
 
-.manovaComputeResults <- function(jaspResults, dataset, options, errors) {
+.manovaComputeResults <- function(jaspResults, dataset, options, ready) {
   
-  if (!is.null(errors) && errors == "No variables") return()
+  if (!ready) return()
   
   # Take results from state if possible
   if (!is.null(jaspResults[["stateManovaResults"]])) return(jaspResults[["stateManovaResults"]]$object)
@@ -119,7 +122,7 @@ Manova <- function(jaspResults, dataset, options) {
   return(results)
 }
 
-.manovaTableMain <- function(jaspResults, dataset, options, manovaResults, errors) {
+.manovaTableMain <- function(jaspResults, dataset, options, manovaResults, ready) {
   
   if (!is.null(jaspResults[["manovaContainer"]])) return()
   
@@ -162,7 +165,7 @@ Manova <- function(jaspResults, dataset, options) {
     
     jaspResults[["manovaContainer"]][[thisTest]] <- manovaTable
     
-    if (!is.null(errors) && errors == "No variables")
+    if (!ready)
       next
     
 
@@ -180,7 +183,7 @@ Manova <- function(jaspResults, dataset, options) {
   }
 }
 
-.uniAnovaTables <- function(jaspResults, dataset, options, manovaResults, errors) {
+.uniAnovaTables <- function(jaspResults, dataset, options, manovaResults, ready) {
   
   if (!is.null(jaspResults[["anovaContainer"]]) || !options$includeAnovaTables) return()
   
@@ -218,7 +221,7 @@ Manova <- function(jaspResults, dataset, options) {
       anovaTable$addColumnInfo(name = "VovkSellkeMPR", title = "VS-MPR\u002A", type = "number")
     }
     
-    if (!is.null(errors) && errors == "No variables")
+    if (!ready)
       return()
     
     jaspResults[["anovaContainer"]][[thisVar]] <- anovaTable
@@ -238,7 +241,7 @@ Manova <- function(jaspResults, dataset, options) {
   }
 }
 
-.boxComputation <- function(dataset, options, errors) {
+.boxComputation <- function(dataset, options) {
 
   depData <- dataset[, .v(options$dependent)]
   factorData <- as.matrix(dataset[, .v(options$fixedFactors)])
@@ -250,6 +253,7 @@ Manova <- function(jaspResults, dataset, options) {
   lev <- levels(grouping)
   dfs <- tapply(grouping, grouping, length) - 1
   
+  errors <- NULL
   if (any(dfs < p)) 
     errors <- "Too few observations to calculate statistic. Each (sub)group must have at least as many observations as there are dependent variables."
   
@@ -273,7 +277,7 @@ Manova <- function(jaspResults, dataset, options) {
   return(list(result = list(ChiSq = chiSq, df = df, p = pval), errors = errors))
 }
 
-.multivariateShapiroComputation <- function(dataset, options, errors) {
+.multivariateShapiroComputation <- function(dataset, options) {
 
   # From mvnormtest
   depData <- t(as.matrix(dataset[, .v(options$dependent)]))
@@ -289,16 +293,21 @@ Manova <- function(jaspResults, dataset, options) {
     result <- stats::shapiro.test(Z)
   }, silent = TRUE)
 
-  if (grepl(tryResult[[1]], pattern = "singular")) {
-    errors <- "The design matrix is not invertible. This might be due to collinear dependent variables."
+  if (isTryError(tryResult)) {
     result <- NULL
+    if (grepl(tryResult[[1]], pattern = "singular"))
+      errors <- "The design matrix is not invertible. This might be due to collinear dependent variables."
+    else
+      errors <- .extractErrorMessage(tryResult)
+  } else {
+    errors <- NULL
   }
   
    
   return(list(result = result, errors = errors))
 }
 
-.assumptionTables <- function(jaspResults, dataset, options, errors) {
+.assumptionTables <- function(jaspResults, dataset, options, ready) {
   
   if (!is.null(jaspResults[["assumptionsContainer"]]) || (!options$boxMTest && !options$shapiroTest)) return()
   
@@ -309,9 +318,6 @@ Manova <- function(jaspResults, dataset, options) {
   
   if (options$boxMTest) {
     # Make Box test table
-    boxResult <- .boxComputation(dataset, options, errors)
-    boxErrors <- boxResult$errors
-    boxResult <- boxResult$result
     boxMTable <- createJaspTable(title = "Box's M-test for Homogeneity of Covariance Matrices")
     
     boxMTable$showSpecifiedColumnsOnly <- TRUE
@@ -320,19 +326,21 @@ Manova <- function(jaspResults, dataset, options) {
     boxMTable$addColumnInfo(name = "df",      title = "df",                     type = "integer")
     boxMTable$addColumnInfo(name = "p",       title = "p",                      type = "pvalue")
     
-    boxMTable$addRows(boxResult)
-    
-    if (!is.null(boxErrors))
-      boxMTable$setError(boxErrors)
-    
     jaspResults[["assumptionsContainer"]][["boxMTable"]] <- boxMTable
+    
+    if (ready) {
+      boxResult <- .boxComputation(dataset, options)
+      boxErrors <- boxResult$errors
+      boxResult <- boxResult$result
+      boxMTable$addRows(boxResult)
+    
+      if (!is.null(boxErrors))
+        boxMTable$setError(boxErrors)
+    }
   }
   
   if (options$shapiroTest) {
     # Make multivariate normal Shaprio table
-    shapiroResult <- .multivariateShapiroComputation(dataset, options, errors)
-    shapiroErrors <- shapiroResult$errors
-    shapiroResult <- shapiroResult$result
     shapiroTable <- createJaspTable(title = "Shapiro-Wilk Test for Multivariate Normality")
     
     shapiroTable$showSpecifiedColumnsOnly <- TRUE
@@ -340,22 +348,24 @@ Manova <- function(jaspResults, dataset, options) {
     shapiroTable$addColumnInfo(name = "W", title = "Shapiro-Wilk", type = "number")
     shapiroTable$addColumnInfo(name = "p", title = "p", type = "pvalue")
     
-    shapiroTable$addRows(list(W = shapiroResult$statistic, p = shapiroResult$p.value))
-    
-    if (!is.null(shapiroErrors)) 
-      shapiroTable$setError(shapiroErrors)
-    
     jaspResults[["assumptionsContainer"]][["shapiroTable"]] <- shapiroTable
+    
+    if (ready) {
+      shapiroResult <- .multivariateShapiroComputation(dataset, options)
+      shapiroErrors <- shapiroResult$errors
+      shapiroResult <- shapiroResult$result
+      shapiroTable$addRows(list(W = shapiroResult$statistic, p = shapiroResult$p.value))
+      
+      if (!is.null(shapiroErrors)) 
+        shapiroTable$setError(shapiroErrors)
+    }
   }
 }
 
 
-.manovaCheckErrors <- function(dataset, options) {
-  
-  # Check if results can be computed
-  if ((length(options$dependent) < 2) || length(options$fixedFactors) == 0 || length(options$modelTerms) == 0)
-    return("No variables")
-  
+.manovaCheckErrors <- function(dataset, options, ready) {
+  if (!ready) return()
+
   # Error check
   for(i in length(options$modelTerms):1) {
     .hasErrors(


### PR DESCRIPTION
I exchanged the string checking for a boolean (to be more inline with other analyses) and additionally I fixed the cases where:
- if the analysis was in an unready state and you checked either of the two boxes in Assumptions Checks you would get an unexpected error
- Shapiro computation would only catch one specific try-error instead of all possible try-errors