### PR TITLE
quick fix

### DIFF
--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -520,7 +520,7 @@ Descriptives <- function(jaspResults, dataset, options) {
   for (i in seq_along(variables)) {
     variable2check  <- na.omit(dataset[[variables[i]]])
     d[i]            <- class(variable2check)
-    sdCheck[i]      <- sd(variable2check) > 0
+    sdCheck[i]      <- if (d[i] != "factor") sd(variable2check) > 0 else FALSE
     infCheck[i]     <- all(is.finite(variable2check))
   }
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/416 , or at least when we upgrade to R 3.6

Something to note is that when `d[i]` is a factor there is another check outside of sd that will make the analysis realize this variable is unsuitable for some output:
```r
if (!numericCheck[i]) variable.statuses[[i]]$plottingError <- "Variable is not continuous"
```
For example, this check fails for boxplots.
