### PR TITLE
Improve the handling of error messages in the results panel

### DIFF
--- a/JASP-Desktop/html/css/theme-jasp.css
+++ b/JASP-Desktop/html/css/theme-jasp.css
@@ -256,10 +256,6 @@ svg > text
 	height: 100% ;
 }
 
-.error-state .jasp-image-image {
-	opacity: 0.33 ;
-}
-
 .etch-editor-panel {
 	position:fixed;
     top:0;
@@ -373,10 +369,17 @@ div.jasp-image-image.no-data {
 	max-width: 480px;
 }
 
+div.jasp-image-image.no-data.error {
+	background-image: linear-gradient(rgba(255,255,255,0.67), rgba(255,255,255,0.67)), url('images/empty-plot.png');
+}
+
 .error-state {
 	color: silver;
-	min-height: 200px;
+}
+
+.jasp-analysis.error-state {
 	min-width: 500px;
+	min-height: 200px;
 }
 
 .fatalError.error-message-box {

--- a/JASP-Desktop/html/js/analysis.js
+++ b/JASP-Desktop/html/js/analysis.js
@@ -550,6 +550,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 			$result.append($lastResult.clone());
 
 		$result.find(".status").removeClass("waiting running");
+		$result.find(".error-message-box").remove();
 		$result.addClass('error-state');
 
 		$result.append('<div class="' + status + ' analysis-error-message error-message-box ui-state-error"><span class="ui-icon ui-icon-' + (status === "fatalError" ? 'alert' : 'info') + '" style="float: left; margin-right: .3em;"></span>' + errorMessage + '</div>');

--- a/JASP-Desktop/html/js/image.js
+++ b/JASP-Desktop/html/js/image.js
@@ -165,11 +165,11 @@ JASPWidgets.imagePrimitive= JASPWidgets.View.extend({
 			var id = data.replace(/[^A-Za-z0-9]/g, '-');
 			var url = window.globSet.tempFolder + data;
 			html += ' id="' + id + '" style="';
-			html += 'background-image : url(\'' + url + '?x=' + Math.random() + '\'); '
+			html += error ? 'background-image: linear-gradient(rgba(255,255,255,0.67), rgba(255,255,255,0.67)),' : 'background-image:'
+			html += 'url(\'' + url + '?x=' + Math.random() + '\'); '
 			html += 'background-size : 100% 100%">'
-		} else {
-			if (height > 100 && width > 100)
-				html += '<div class="jasp-image-image no-data">';
+		} else if (height > 100 && width > 100) {
+			html += '<div class="jasp-image-image no-data' + (error ? ' error' : '') + '">'
 		}
 
 		if (error && error.errorMessage) {


### PR DESCRIPTION
This fixes some inconsistencies with regards to the errors in the output

- The message in tables is opaque but in plots it isn't:
<img width="372" alt="Screenshot 2019-07-17 at 14 10 47" src="https://user-images.githubusercontent.com/18737241/61385797-5fb7bc80-a8b3-11e9-8a0d-cff0e48e45ee.png">

- It was possible to have overlapping error messages:
<img width="522" alt="Screenshot 2019-07-17 at 16 02 13" src="https://user-images.githubusercontent.com/18737241/61385798-60505300-a8b3-11e9-9491-ae7077a0d909.png">

- Tables become very large if an error is set on it:
<img width="455" alt="Screenshot 2019-07-17 at 16 03 24" src="https://user-images.githubusercontent.com/18737241/61385799-60505300-a8b3-11e9-978b-afa8c5362eb3.png">


