### PR TITLE
use JASPgraphs for making axis tick labels

### DIFF
--- a/JASP-Engine/JASP/R/ancova.R
+++ b/JASP-Engine/JASP/R/ancova.R
@@ -3176,30 +3176,14 @@ Ancova <- function(dataset=NULL, options, perform="run", callback=function(...) 
     xhigh <- max(pretty(xVar))
     xticks <- pretty(c(xlow, xhigh))
     
-    # format x labels
-    xLabs <- vector("character", length(xticks))
-    for (i in seq_along(xticks)) {
-      if (xticks[i] < 10^6) {
-        xLabs[i] <- format(xticks[i], digits= 3, scientific = FALSE)
-      } else {
-        xLabs[i] <- format(xticks[i], digits= 3, scientific = TRUE)
-      }
-    }
-    
-    # Format y ticks
+      # Format y ticks
     ylow <- min(pretty(yVar))
     yhigh <- max(pretty(yVar))        
     yticks <- pretty(c(ylow, yhigh))
     
-    # format y labels
-    yLabs <- vector("character", length(yticks))
-    for (i in seq_along(yticks)) {
-      if (yticks[i] < 10^6) {
-        yLabs[i] <- format(yticks[i], digits= 3, scientific = FALSE)
-      } else {
-        yLabs[i] <- format(yticks[i], digits= 3, scientific = TRUE)
-      }
-    }
+    # format axes labels
+    xLabs <- JASPgraphs::axesLabeller(xticks)
+    yLabs <- JASPgraphs::axesLabeller(yticks)
     
     p <- JASPgraphs::drawAxis(xName = "Theoretical Quantiles", yName = "Standardized Residuals", xBreaks = xticks, yBreaks = xticks, yLabels = xLabs, xLabels = xLabs, force = TRUE)
     p <- p + ggplot2::geom_line(data = data.frame(x = c(min(xticks), max(xticks)), y = c(min(xticks), max(xticks))), mapping = ggplot2::aes(x = x, y = y), col = "darkred", size = 1)

--- a/JASP-Engine/JASP/R/correlationbayesianpairs.R
+++ b/JASP-Engine/JASP/R/correlationbayesianpairs.R
@@ -1023,25 +1023,9 @@ CorrelationBayesianPairs <- function(dataset=NULL, options, perform="run", callb
         
     yticks <- pretty(c(ylow, yhigh))
     
-    # format x labels
-    xLabs <- vector("character", length(xticks))
-    for (i in seq_along(xticks)) {
-        if (xticks[i] < 10^6) {
-            xLabs[i] <- format(xticks[i], digits= 3, scientific = FALSE)
-        } else {
-            xLabs[i] <- format(xticks[i], digits= 3, scientific = TRUE)
-        }
-    }
-    
-    # Format y labels
-    yLabs <- vector("character", length(yticks))
-    for (i in seq_along(yticks)) {
-        if (yticks[i] < 10^6 && yticks[i] > 10^-6) {
-            yLabs[i] <- format(yticks[i], digits= 3, scientific = FALSE)
-        } else {
-            yLabs[i] <- format(yticks[i], digits= 3, scientific = TRUE)
-        }
-    }
+    # format axes labels
+    xLabs <- JASPgraphs::axesLabeller(xticks)
+    yLabs <- JASPgraphs::axesLabeller(yticks)
 
     p <- JASPgraphs::drawAxis(xName = xlab, yName = ylab, xBreaks = xticks, yBreaks = yticks, yLabels = yLabs, xLabels = xLabs, force = TRUE)
     p <- JASPgraphs::drawPoints(p, dat = d, size = 3)

--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -1212,30 +1212,15 @@ Descriptives <- function(jaspResults, dataset, options) {
     xhigh  <- max(pretty(xVar))
     xticks <- pretty(c(xlow, xhigh))
 
-    # format x labels
-    xLabs <- vector("character", length(xticks))
-    for (i in seq_along(xticks)) {
-      if (xticks[i] < 10^6) {
-        xLabs[i] <- format(xticks[i], digits= 3, scientific = FALSE)
-      } else {
-        xLabs[i] <- format(xticks[i], digits= 3, scientific = TRUE)
-      }
-    }
-
     # Format y ticks
     ylow   <- min(pretty(yVar))
     yhigh  <- max(pretty(yVar))
     yticks <- pretty(c(ylow, yhigh))
 
-    # format y labels
-    yLabs <- vector("character", length(yticks))
-    for (i in seq_along(yticks)) {
-      if (yticks[i] < 10^6) {
-        yLabs[i] <- format(yticks[i], digits= 3, scientific = FALSE)
-      } else {
-        yLabs[i] <- format(yticks[i], digits= 3, scientific = TRUE)
-      }
-    }
+    # format axes labels
+    xLabs <- JASPgraphs::axesLabeller(xticks)
+    yLabs <- JASPgraphs::axesLabeller(yticks)
+    
     p <- JASPgraphs::drawAxis(xName = "Theoretical Quantiles", yName = paste0("Standardised Residuals"), xBreaks = xticks, yBreaks = xticks, yLabels = xLabs, xLabels = xLabs, force = TRUE)
     p <- p + ggplot2::geom_line(data = data.frame(x = c(min(xticks), max(xticks)), y = c(min(xticks), max(xticks))), mapping = ggplot2::aes(x = x, y = y), col = "darkred", size = 1)
     p <- JASPgraphs::drawPoints(p, dat = data.frame(xVar, yVar), size = 3)

--- a/JASP-Engine/JASP/R/regressionlinear.R
+++ b/JASP-Engine/JASP/R/regressionlinear.R
@@ -3828,23 +3828,9 @@ RegressionLinear <- function(dataset=NULL, options, perform="run", callback=func
 
     yticks <- pretty(c(ylow, yhigh, 0))
 	
-		xLabs <- vector("character", length(xticks))
-		for (i in seq_along(xticks)) {
-			if (xticks[i] < 10^6) {
-				xLabs[i] <- format(xticks[i], digits= 3, scientific = FALSE)
-			} else {
-				xLabs[i] <- format(xticks[i], digits= 3, scientific = TRUE)
-			}
-		}
-
-    yLabs <- vector("character", length(yticks))
-    for (i in seq_along(yticks)) {
-        if (yticks[i] < 10^6) {
-            yLabs[i] <- format(yticks[i], digits= 3, scientific = FALSE)
-        } else {
-            yLabs[i] <- format(yticks[i], digits= 3, scientific = TRUE)
-        }
-    }
+		# format axes labels
+    xLabs <- JASPgraphs::axesLabeller(xticks, digits = 3)
+    yLabs <- JASPgraphs::axesLabeller(yticks, digits = 3)
 
 	if (standardizedResiduals == TRUE) {
 		

--- a/JASP-Engine/JASPgraphs/DESCRIPTION
+++ b/JASP-Engine/JASPgraphs/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: JASPgraphs
 Type: Package
 Title: Custom graphs for JASP
-Version: 0.3.2
+Version: 0.3.3
 Author: Don vd Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: ...

--- a/JASP-Engine/JASPgraphs/R/functions.R
+++ b/JASP-Engine/JASPgraphs/R/functions.R
@@ -204,11 +204,17 @@ drawAxis <- function(graph = NULL, xName = waiver(), yName = waiver(), breaks = 
         }
     }
 
-    if (!is.null(xBreaks) && !is.waive(xBreaks) && is.waive(xLimits))
+    if (!is.null(xBreaks) && !is.waive(xBreaks) && is.waive(xLimits)) {
         xLimits <- range(xBreaks)
+        if (is.waive(xLabels))
+          xLabels <- axesLabeller(xBreaks)
+    }
 
-    if (!is.null(yBreaks) && !is.waive(yBreaks) && is.waive(yLimits))
+    if (!is.null(yBreaks) && !is.waive(yBreaks) && is.waive(yLimits)) {
         yLimits <- range(yBreaks)
+        if (is.waive(yLabels))
+          yLabels <- axesLabeller(yBreaks)
+    }
 
     if (is.null(graph))
         graph <- ggplot2::ggplot()

--- a/JASP-Engine/JASPgraphs/R/jaspLabelAxes.R
+++ b/JASP-Engine/JASPgraphs/R/jaspLabelAxes.R
@@ -8,10 +8,11 @@ axesLabeller <- function(x, ...) {
   xnum <- suppressWarnings(as.numeric(x))
   if (all(is.na(xnum))) {
     return(x)
-  } else if (max(abs(xnum), na.rm = TRUE) > 1e4 || max(abs(xnum), na.rm = TRUE) < 1e-4) {
+  } else if (max(abs(xnum), na.rm = TRUE) >= 1e4 || max(abs(xnum), na.rm = TRUE) <= 1e-3) {
     return(axesLabelScientific(xnum, ...))
   } else {
-  	x
+    # ensure that everything is parsed without scientific notation
+  	return(formatC(x, format = "fg"))
     # return(axesLabelNumber(xnum, ...))
   }
 }

--- a/JASP-Tests/R/tests/figs/CorrelationBayesianPairs/correlationbayesianpairs-scatterplot.svg
+++ b/JASP-Tests/R/tests/figs/CorrelationBayesianPairs/correlationbayesianpairs-scatterplot.svg
@@ -14,149 +14,149 @@
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 <defs>
-  <clipPath id='cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc='>
-    <rect x='100.33' y='19.67' width='619.67' height='490.23' />
+  <clipPath id='cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw=='>
+    <rect x='62.05' y='19.67' width='657.95' height='490.23' />
   </clipPath>
 </defs>
-<rect x='100.33' y='19.67' width='619.67' height='490.23' style='stroke-width: 10.67; stroke: none;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<polyline points='128.49,487.61 691.83,41.95 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='552.97' cy='154.78' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='324.69' cy='340.04' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='352.62' cy='286.78' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='285.01' cy='258.16' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='407.55' cy='226.35' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='530.01' cy='217.94' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='423.78' cy='239.67' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='319.61' cy='379.19' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='598.52' cy='162.97' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='490.97' cy='165.94' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='332.34' cy='272.41' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='352.74' cy='233.28' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='584.63' cy='114.40' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='470.45' cy='252.02' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='324.36' cy='260.06' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='442.90' cy='147.43' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='501.84' cy='197.51' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='360.74' cy='318.87' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='441.34' cy='220.92' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='400.16' cy='289.80' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='316.07' cy='312.08' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='468.97' cy='128.71' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='549.52' cy='106.21' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='445.32' cy='188.54' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='529.47' cy='169.31' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='215.52' cy='321.88' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='310.80' cy='375.44' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='449.72' cy='266.00' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='282.85' cy='358.19' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='471.08' cy='265.84' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='402.41' cy='269.90' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='370.18' cy='226.84' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='447.14' cy='257.01' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='582.58' cy='247.99' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='436.24' cy='276.32' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='331.94' cy='348.55' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='509.28' cy='230.77' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='261.27' cy='355.25' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='413.46' cy='295.07' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='372.89' cy='286.96' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='545.31' cy='207.70' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='396.24' cy='199.84' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='282.87' cy='303.44' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='208.56' cy='393.25' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='357.50' cy='235.10' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='467.65' cy='211.68' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='369.59' cy='332.14' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='385.26' cy='316.24' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='438.33' cy='278.80' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='487.67' cy='192.89' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='422.65' cy='256.42' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='359.89' cy='250.36' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='338.92' cy='346.56' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='458.32' cy='184.79' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='631.92' cy='156.43' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='530.08' cy='230.30' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='500.60' cy='124.22' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='323.40' cy='347.03' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='379.29' cy='207.92' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='352.48' cy='299.55' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='493.00' cy='268.64' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='352.41' cy='283.73' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='388.20' cy='133.68' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='421.97' cy='318.01' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='481.01' cy='293.52' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='324.11' cy='316.83' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='331.41' cy='289.14' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='312.13' cy='331.16' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='582.51' cy='106.56' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='528.23' cy='230.18' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='315.84' cy='320.77' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='394.48' cy='301.85' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='387.07' cy='254.32' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='451.56' cy='265.05' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='447.63' cy='363.83' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='512.08' cy='251.09' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='392.67' cy='176.30' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='488.21' cy='204.36' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='378.44' cy='295.52' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='406.82' cy='180.13' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='327.86' cy='294.11' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='432.94' cy='466.07' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='454.79' cy='207.06' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='590.71' cy='277.12' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='328.97' cy='256.18' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='268.79' cy='380.56' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='437.44' cy='265.13' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='302.06' cy='346.10' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='509.99' cy='171.55' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='470.78' cy='272.06' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='622.68' cy='119.56' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='284.41' cy='230.82' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='312.80' cy='444.35' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='484.69' cy='170.08' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='268.57' cy='291.12' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='362.49' cy='343.96' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='444.07' cy='363.37' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='486.88' cy='255.29' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='283.86' cy='298.69' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<circle cx='544.71' cy='222.54' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<polyline points='128.49,407.44 134.19,404.50 139.88,401.57 145.57,398.63 151.26,395.70 156.95,392.76 162.64,389.83 168.33,386.89 174.02,383.96 179.71,381.02 185.40,378.09 191.09,375.15 196.78,372.22 202.47,369.28 208.16,366.35 213.85,363.41 219.54,360.48 225.23,357.54 230.92,354.61 236.61,351.67 242.30,348.74 247.99,345.80 253.68,342.87 259.37,339.93 265.06,337.00 270.75,334.06 276.44,331.12 282.13,328.19 287.82,325.25 293.51,322.32 299.20,319.38 304.89,316.45 310.58,313.51 316.27,310.58 321.96,307.64 327.65,304.71 333.35,301.77 339.04,298.84 344.73,295.90 350.42,292.97 356.11,290.03 361.80,287.10 367.49,284.16 373.18,281.23 378.87,278.29 384.56,275.36 390.25,272.42 395.94,269.49 401.63,266.55 407.32,263.62 413.01,260.68 418.70,257.75 424.39,254.81 430.08,251.88 435.77,248.94 441.46,246.01 447.15,243.07 452.84,240.14 458.53,237.20 464.22,234.27 469.91,231.33 475.60,228.40 481.29,225.46 486.98,222.52 492.67,219.59 498.36,216.65 504.05,213.72 509.74,210.78 515.43,207.85 521.12,204.91 526.81,201.98 532.51,199.04 538.20,196.11 543.89,193.17 549.58,190.24 555.27,187.30 560.96,184.37 566.65,181.43 572.34,178.50 578.03,175.56 583.72,172.63 589.41,169.69 595.10,166.76 600.79,163.82 606.48,160.89 612.17,157.95 617.86,155.02 623.55,152.08 629.24,149.15 634.93,146.21 640.62,143.28 646.31,140.34 652.00,137.41 657.69,134.47 663.38,131.54 669.07,128.60 674.76,125.67 680.45,122.73 686.14,119.79 691.83,116.86 ' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<line x1='128.49' y1='509.89' x2='691.83' y2='509.89' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
-<line x1='100.33' y1='487.61' x2='100.33' y2='41.95' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMTAwLjMzfDcyMC4wMHw1MDkuODl8MTkuNjc=)' />
+<rect x='62.05' y='19.67' width='657.95' height='490.23' style='stroke-width: 10.67; stroke: none;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<polyline points='91.95,487.61 690.09,41.95 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='542.65' cy='154.78' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='300.27' cy='340.04' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='329.92' cy='286.78' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='258.14' cy='258.16' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='388.25' cy='226.35' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='518.27' cy='217.94' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='405.48' cy='239.67' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='294.88' cy='379.19' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='591.02' cy='162.97' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='476.82' cy='165.94' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='308.39' cy='272.41' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='330.05' cy='233.28' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='576.27' cy='114.40' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='455.03' cy='252.02' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='299.92' cy='260.06' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='425.79' cy='147.43' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='488.36' cy='197.51' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='338.55' cy='318.87' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='424.12' cy='220.92' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='380.40' cy='289.80' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='291.12' cy='312.08' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='453.47' cy='128.71' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='538.99' cy='106.21' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='428.35' cy='188.54' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='517.70' cy='169.31' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='184.35' cy='321.88' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='285.53' cy='375.44' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='433.02' cy='266.00' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='255.84' cy='358.19' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='455.71' cy='265.84' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='382.79' cy='269.90' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='348.57' cy='226.84' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='430.28' cy='257.01' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='574.09' cy='247.99' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='418.71' cy='276.32' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='307.97' cy='348.55' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='496.27' cy='230.77' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='232.93' cy='355.25' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='394.52' cy='295.07' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='351.44' cy='286.96' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='534.52' cy='207.70' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='376.24' cy='199.84' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='255.87' cy='303.44' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='176.97' cy='393.25' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='335.10' cy='235.10' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='452.07' cy='211.68' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='347.94' cy='332.14' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='364.59' cy='316.24' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='420.93' cy='278.80' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='473.32' cy='192.89' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='404.28' cy='256.42' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='337.64' cy='250.36' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='315.37' cy='346.56' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='442.16' cy='184.79' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='626.48' cy='156.43' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='518.35' cy='230.30' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='487.05' cy='124.22' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='298.90' cy='347.03' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='358.25' cy='207.92' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='329.78' cy='299.55' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='478.98' cy='268.64' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='329.71' cy='283.73' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='367.70' cy='133.68' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='403.55' cy='318.01' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='466.25' cy='293.52' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='299.65' cy='316.83' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='307.41' cy='289.14' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='286.94' cy='331.16' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='574.02' cy='106.56' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='516.38' cy='230.18' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='290.87' cy='320.77' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='374.37' cy='301.85' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='366.50' cy='254.32' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='434.98' cy='265.05' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='430.81' cy='363.83' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='499.24' cy='251.09' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='372.45' cy='176.30' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='473.89' cy='204.36' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='357.34' cy='295.52' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='387.48' cy='180.13' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='303.63' cy='294.11' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='415.21' cy='466.07' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='438.41' cy='207.06' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='582.72' cy='277.12' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='304.81' cy='256.18' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='240.92' cy='380.56' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='419.98' cy='265.13' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='276.25' cy='346.10' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='497.02' cy='171.55' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='455.39' cy='272.06' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='616.67' cy='119.56' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='257.50' cy='230.82' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='287.65' cy='444.35' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='470.16' cy='170.08' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='240.68' cy='291.12' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='340.40' cy='343.96' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='427.03' cy='363.37' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='472.48' cy='255.29' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='256.92' cy='298.69' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<circle cx='533.88' cy='222.54' r='3.56pt' style='stroke-width: 0.71; fill: #BEBEBE;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<polyline points='91.95,407.44 98.00,404.50 104.04,401.57 110.08,398.63 116.12,395.70 122.16,392.76 128.20,389.83 134.25,386.89 140.29,383.96 146.33,381.02 152.37,378.09 158.41,375.15 164.46,372.22 170.50,369.28 176.54,366.35 182.58,363.41 188.62,360.48 194.66,357.54 200.71,354.61 206.75,351.67 212.79,348.74 218.83,345.80 224.87,342.87 230.92,339.93 236.96,337.00 243.00,334.06 249.04,331.12 255.08,328.19 261.12,325.25 267.17,322.32 273.21,319.38 279.25,316.45 285.29,313.51 291.33,310.58 297.38,307.64 303.42,304.71 309.46,301.77 315.50,298.84 321.54,295.90 327.58,292.97 333.63,290.03 339.67,287.10 345.71,284.16 351.75,281.23 357.79,278.29 363.84,275.36 369.88,272.42 375.92,269.49 381.96,266.55 388.00,263.62 394.04,260.68 400.09,257.75 406.13,254.81 412.17,251.88 418.21,248.94 424.25,246.01 430.30,243.07 436.34,240.14 442.38,237.20 448.42,234.27 454.46,231.33 460.50,228.40 466.55,225.46 472.59,222.52 478.63,219.59 484.67,216.65 490.71,213.72 496.76,210.78 502.80,207.85 508.84,204.91 514.88,201.98 520.92,199.04 526.96,196.11 533.01,193.17 539.05,190.24 545.09,187.30 551.13,184.37 557.17,181.43 563.21,178.50 569.26,175.56 575.30,172.63 581.34,169.69 587.38,166.76 593.42,163.82 599.47,160.89 605.51,157.95 611.55,155.02 617.59,152.08 623.63,149.15 629.67,146.21 635.72,143.28 641.76,140.34 647.80,137.41 653.84,134.47 659.88,131.54 665.93,128.60 671.97,125.67 678.01,122.73 684.05,119.79 690.09,116.86 ' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<line x1='91.95' y1='509.89' x2='690.09' y2='509.89' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
+<line x1='62.05' y1='487.61' x2='62.05' y2='41.95' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNjIuMDV8NzIwLjAwfDUwOS44OXwxOS42Nw==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='31.46' y='493.46' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='53.39px' lengthAdjust='spacingAndGlyphs'>-3e+00</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='31.46' y='419.19' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='53.39px' lengthAdjust='spacingAndGlyphs'>-2e+00</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='31.46' y='344.91' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='53.39px' lengthAdjust='spacingAndGlyphs'>-1e+00</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='37.12' y='270.63' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='47.73px' lengthAdjust='spacingAndGlyphs'>0e+00</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='75.40' y='196.36' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>1</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='75.40' y='122.08' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='75.40' y='47.80' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>3</text></g>
-<polyline points='91.82,487.61 100.33,487.61 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='91.82,413.33 100.33,413.33 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='91.82,339.06 100.33,339.06 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='91.82,264.78 100.33,264.78 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='91.82,190.50 100.33,190.50 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='91.82,116.23 100.33,116.23 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='91.82,41.95 100.33,41.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='128.49,518.40 128.49,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='222.38,518.40 222.38,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='316.27,518.40 316.27,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='410.16,518.40 410.16,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='504.05,518.40 504.05,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='597.94,518.40 597.94,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='691.83,518.40 691.83,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='120.94' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='214.83' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='308.72' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='405.44' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>0</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='499.33' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>1</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='593.22' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='687.11' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='371.04' y='568.53' style='font-size: 20.40px; font-family: Liberation Sans;' textLength='78.25px' lengthAdjust='spacingAndGlyphs'>contcor1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='31.46' y='493.46' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='31.46' y='419.19' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='31.46' y='344.91' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='37.12' y='270.63' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='37.12' y='196.36' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='37.12' y='122.08' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='37.12' y='47.80' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<polyline points='53.54,487.61 62.05,487.61 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='53.54,413.33 62.05,413.33 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='53.54,339.06 62.05,339.06 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='53.54,264.78 62.05,264.78 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='53.54,190.50 62.05,190.50 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='53.54,116.23 62.05,116.23 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='53.54,41.95 62.05,41.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='91.95,518.40 91.95,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='191.64,518.40 191.64,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='291.33,518.40 291.33,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='391.02,518.40 391.02,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='490.71,518.40 490.71,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='590.40,518.40 590.40,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='690.09,518.40 690.09,509.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='84.40' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='184.09' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='283.78' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='15.11px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='386.30' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='485.99' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='585.68' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='685.37' y='537.07' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='351.90' y='568.53' style='font-size: 20.40px; font-family: Liberation Sans;' textLength='78.25px' lengthAdjust='spacingAndGlyphs'>contcor1</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(19.01,303.91) rotate(-90)' style='font-size: 20.40px; font-family: Liberation Sans;' textLength='78.25px' lengthAdjust='spacingAndGlyphs'>contcor2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='272.23' y='11.70' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='275.88px' lengthAdjust='spacingAndGlyphs'>CorrelationBayesianPairs-scatterplot</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='253.09' y='11.70' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='275.88px' lengthAdjust='spacingAndGlyphs'>CorrelationBayesianPairs-scatterplot</text></g>
 </svg>

--- a/JASP-Tests/R/tests/figs/jasp-deps.txt
+++ b/JASP-Tests/R/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- JASPgraphs: 0.3.2
+- JASPgraphs: 0.3.3


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/368 and a couple of other similar methods for creating axis tick labels.

I did a `Ctrl+Shift+F` for `xLabs <- vector("character", length(xticks))` and replaced the code everywhere I saw it with `xLabs <- JASPgraphs::axesLabeller(xticks)`, which should do the same. That guarantees a uniform way to create axes tick labels and we can adjust it for all plots at once if we want to. The change to `JASPgraphs::axesLabeller` should ensure that either all axis labels are displayed in scientific notation or none of them.


The only place where I did not change this is `commonAudit.R`, because there the labels never switch to scientific notation (I can also do it there if @koenderks thinks that's a good idea).

The `digits = 3` is skipped from `JASPgraphs::axesLabeller(xticks)`, because `digits = 3` is the default argument for that function.