### PR TITLE
Ensure jaspContainer sets its error on a suitable child

### DIFF
--- a/JASP-R-Interface/jaspResults/src/jaspContainer.h
+++ b/JASP-R-Interface/jaspResults/src/jaspContainer.h
@@ -53,7 +53,6 @@ protected:
 	std::map<std::string, jaspObject*>	_data;
 	std::map<std::string, int>			_data_order;
 	int									_order_increment = 0;
-	bool								_passErrorMessageToNextChild = false;
 	
 	std::vector<std::string>			getSortedDataFields();
 

--- a/JASP-R-Interface/jaspResults/src/jaspObject.h
+++ b/JASP-R-Interface/jaspResults/src/jaspObject.h
@@ -48,6 +48,7 @@ public:
 			bool		getError()							{ return _error; }
 	virtual void		setError()							{ _error = true; }
 	virtual void		setError(std::string message)		{ _errorMessage = message; _error = true; }
+	virtual bool		canShowErrorMessage()				{ return false; }
 
 			void		print()								{ try { jaspPrint(toString()); } catch(std::exception e) { jaspPrint(std::string("toString failed because of: ") + e.what()); } }
 			void		addMessage(std::string msg)			{ _messages.push_back(msg); }

--- a/JASP-R-Interface/jaspResults/src/jaspPlot.h
+++ b/JASP-R-Interface/jaspResults/src/jaspPlot.h
@@ -28,6 +28,8 @@ public:
 	Json::Value convertToJSON() override;
 	void		convertFromJSON_SetFields(Json::Value in) override;
 
+	bool		canShowErrorMessage() override { return true; }
+
 private:
 	void initEnvName();
 	void setChangedDimensionsFromStateObject();

--- a/JASP-R-Interface/jaspResults/src/jaspTable.h
+++ b/JASP-R-Interface/jaspResults/src/jaspTable.h
@@ -94,6 +94,8 @@ public:
 
 	void		complete() { if(_status == "running") _status = "complete"; }
 
+	bool		canShowErrorMessage() override { return true; }
+
 	Json::Value	metaEntry() override { return constructMetaEntry("table"); }
 	Json::Value	dataEntry() override;
 	std::string	toHtml()	override;


### PR DESCRIPTION
- it did not honor the ordering people can set to the elements in a container
- it tried to set the error on elements not suitable to show it (e.g., jaspState)