### PR TITLE
Convert plot functions to recordedPlots in jaspPlot

### DIFF
--- a/JASP-R-Interface/jaspResults/R/writeImage.R
+++ b/JASP-R-Interface/jaspResults/R/writeImage.R
@@ -81,7 +81,7 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
       eval(plot())
       if (obj) plot <- recordPlot() # save plot to R object
     } else if (isRecordedPlot) { # function was called from editImage to resize the plot
-      .redrawPlot(plot) #(see below)
+      redrawPlotJaspResults(plot) #(see below)
     } else if (inherits(plot, "qgraph")) {
       qgraph:::plot.qgraph(plot)
     } else {

--- a/JASP-R-Interface/jaspResults/src/jaspPlot.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspPlot.cpp
@@ -69,6 +69,10 @@ void jaspPlot::setPlotObject(Rcpp::RObject obj)
 		static Rcpp::Function tryToWriteImage = jaspResults::isInsideJASP() ? Rcpp::Function("tryToWriteImageJaspResults") : Rcpp::Environment::namespace_env("jaspResults")["tryToWriteImageJaspResults"];
 		Rcpp::List writeResult = tryToWriteImage(Rcpp::_["width"] = _width, Rcpp::_["height"] = _height, Rcpp::_["plot"] = obj);
 
+		// we need to overwrite plot functions with their recordedplot result
+		if(Rcpp::is<Rcpp::Function>(obj) && writeResult.containsElementNamed("obj"))
+			plotInfo["obj"] = writeResult[writeResult.findName("obj")];
+		
 		if(writeResult.containsElementNamed("png"))
 			_filePathPng = Rcpp::as<std::string>(writeResult[writeResult.findName("png")]);
 

--- a/JASP-R-Interface/jaspResults/src/jaspPlot.cpp
+++ b/JASP-R-Interface/jaspResults/src/jaspPlot.cpp
@@ -71,15 +71,15 @@ void jaspPlot::setPlotObject(Rcpp::RObject obj)
 
 		// we need to overwrite plot functions with their recordedplot result
 		if(Rcpp::is<Rcpp::Function>(obj) && writeResult.containsElementNamed("obj"))
-			plotInfo["obj"] = writeResult[writeResult.findName("obj")];
+			plotInfo["obj"] = writeResult["obj"];
 		
 		if(writeResult.containsElementNamed("png"))
-			_filePathPng = Rcpp::as<std::string>(writeResult[writeResult.findName("png")]);
+			_filePathPng = Rcpp::as<std::string>(writeResult["png"]);
 
 		if(writeResult.containsElementNamed("error"))
 		{
 			_error			= "Error during writeImage";
-			_errorMessage	= Rcpp::as<std::string>(writeResult[writeResult.findName("error")]);
+			_errorMessage	= Rcpp::as<std::string>(writeResult["error"]);
 		}
 
 		if(_status == "waiting" || _status == "running")


### PR DESCRIPTION
It was not possible to save images that were created with plot functions in jaspResults.
(Plus it's better not to store the functions with their environments, as this can be quite sizable.)

I'm not entirely sure why you use `*.findName("")` on the lists after checking `*.containsElementNamed("")` @JorisGoosen, is this simply preference over `[""]` indexing? Or something else?