### PR TITLE
Rewriting Contingency Tables to jaspResults

### DIFF
--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -311,6 +311,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     
     # Add columns to table
     .crossTabLayersColumns(crossTabGamma, analysis)
+    #crossTabGamma$addColumnInfo(name = "type[gammaCoef]",  title = "", type="string")
     crossTabGamma$addColumnInfo(name = "value[gammaCoef]", title = "Gamma",          
                                 type = "number")
     crossTabGamma$addColumnInfo(name = "Sigma[gammaCoef]", title = "Standard Error", 
@@ -347,6 +348,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     
     # Add columns to table
     .crossTabLayersColumns(crossTabKendallTau, analysis)
+    #crossTabKendallTau$addColumnInfo(name = "type[kTauB]",  title = "", type="string")
     crossTabKendallTau$addColumnInfo(name = "value[kTauB]", title = "Kendall's Tau-b ", 
                                      type = "number")
     crossTabKendallTau$addColumnInfo(name = "statistic[kTauB]", title = "Z", 
@@ -947,13 +949,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 }
 
 .crossTabTestsRows <- function(analysisContainer, var.name, groupList, options, ready, counts.fp) {
-  if(!options$chiSquared && 
-     !options$chiSquaredContinuityCorrection && 
-     !options$likelihoodRatio) 
-    return()
-  if(!is.null(analysisContainer[["resultsChisq"]]))
-    return()
-  
   tests.rows     <- list()
   group.matrices <- groupList$group.matrices
   groups         <- groupList$groups
@@ -1072,10 +1067,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     row <- .crossTabLayerNames(row, group)
     tests.rows[[length(tests.rows) + 1]] <- row
   }
-  chisq <- createJaspState(tests.rows)
-  table <- analysisContainer[["crossTabChisq"]]
-  chisq$dependOn(optionsFromObject = table)
-  analysisContainer[["resultsChisq"]] <- chisq
   return(tests.rows)
 }
 
@@ -1162,9 +1153,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 }
 
 .crossTabNominalRows <- function(analysisContainer, var.name, groupList, options, ready) {
-  if (!options$contingencyCoefficient && !options$phiAndCramersV && !options$lambda)
-    return()
-  
   nominal.rows   <- list()
   group.matrices <- groupList$group.matrices
   groups         <- groupList$groups
@@ -1212,9 +1200,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 }
 
 .crossTabGammaRows <- function(analysisContainer, var.name, groupList, options, ready) {
-  if (!options$gamma)
-    return()
-  
   ordinal.rows   <- list()
   group.matrices <- groupList$group.matrices
   groups         <- groupList$groups
@@ -1253,8 +1238,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
 }
 
 .crossTabKendallsTauRows <- function(analysisContainer, var.name, groupList, options, ready) {
-  if (!options$kendallsTauB)
-    return()
   kendalls.rows  <- list()
   group.matrices <- groupList$group.matrices
   groups         <- groupList$groups

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -15,1778 +15,1621 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-ContingencyTables <- function(dataset=NULL, options, perform="run", callback=function(...) 0, ...) {
-
-	layer.variables <- c()
-
-	for (layer in options$layers)
-		layer.variables <- c(layer.variables, unlist(layer$variables))
-
-	counts.var <- options$counts
-	if (counts.var == "")
-		counts.var <- NULL
-
-	factors <- c(unlist(options$rows), unlist(options$columns), layer.variables)
-
-	if (is.null(dataset))
-	{
-		if (perform == "run") {
-			dataset <- .readDataSetToEnd(columns.as.factor=factors, columns.as.numeric=counts.var)
-		} else {
-			dataset <- .readDataSetHeader(columns.as.factor=factors, columns.as.numeric=counts.var)
-		}
-	} else {
-		dataset <- .vdf(dataset, columns.as.factor=factors, columns.as.numeric=counts.var)
-	}
-
-	results <- list()
-
-	### TITLE
-
-	results[["title"]] <- "Contingency Tables"
-
-	meta <- list()
-
-	### CROSS TABS
-
-	crosstabs <- list()
-
-	rows    <- as.vector(options$rows,    "character")
-	columns <- as.vector(options$columns, "character")
-
-	if (length(rows) == 0)
-		rows <- ""
-
-	if (length(columns) == 0)
-		columns <- ""
-
-	analyses <- data.frame("columns"=columns, stringsAsFactors=FALSE)
-	analyses <- cbind(analyses, "rows"=rep(rows, each=dim(analyses)[1]), stringsAsFactors=FALSE)
-
-	for (layer in options$layers)
-	{
-		layer.vars <- as.vector(layer$variables, "character")
-		analyses <- cbind(analyses, rep(layer.vars, each=dim(analyses)[1]), stringsAsFactors=FALSE)
-		names(analyses)[dim(analyses)[2]] <- layer$name
-	}
-
-	analyses <- .dataFrameToRowList(analyses)
-
-	for (i in 1:length(analyses))
-	{
-		analysis <- analyses[[i]]
-		tables <- .crosstab(dataset, options, perform, analysis)
-
-		if (!is.null(tables[["counts.table"]])) {
-
-			results[[paste("Counts Table", i)]] <- tables[["counts.table"]]
-			meta[[length(meta)+1]] <- list(name=paste("Counts Table", i), type="table")
-
-		}
-		if (!is.null(tables[["tests.table"]])) {
-
-			results[[paste("Tests Table", i)]] <- tables[["tests.table"]]
-			meta[[length(meta)+1]] <- list(name=paste("Tests Table", i), type="table")
-
-		}
-		if (!is.null(tables[["odds.ratio.table"]])) {
-
-			results[[paste("Odds Ratio Table", i)]] <- tables[["odds.ratio.table"]]
-			meta[[length(meta)+1]] <- list(name=paste("Odds Ratio Table", i), type="table")
-
-		}
-		if (!is.null(tables[["nominal.table"]])) {
-
-			results[[paste("Nominal Table", i)]] <- tables[["nominal.table"]]
-			meta[[length(meta)+1]] <- list(name=paste("Nominal Table", i), type="table")
-
-		}
-		if (!is.null(tables[["ordinal.table"]])) {
-
-			results[[paste("Ordinal Table", i)]] <- tables[["ordinal.table"]]
-			meta[[length(meta)+1]] <- list(name=paste("Ordinal Table", i), type="table")
-
-		}
-		if (!is.null(tables[["kendalls.table"]])) {
-
-			results[[paste("Kendalls Table", i)]] <- tables[["kendalls.table"]]
-			meta[[length(meta)+1]] <- list(name=paste("Kendalls Table", i), type="table")
-
-		}
-	}
-
-	results[[".meta"]] <- meta
-
-
-
-	if (perform == "run" || length(options$rows) == 0 || length(options$columns) == 0) {
-
-		list(results=results, status="complete")
-
-	} else {
-
-		list(results=results, status="inited")
-	}
+ContingencyTables <- function(jaspResults, dataset, options, ...) {
+  
+  # Read dataset
+  dataset <- .crossTabReadData(dataset, options)
+  
+  ready <- !(length(options$rows) == 0 || length(options$columns) == 0)
+  
+  # Error checking
+  .crossTabCheckErrors(dataset, options)
+  
+  # Compute the results
+  crossTabResults <- .crossTabComputeResults(jaspResults, dataset, options, ready)
+  
+  # Tables container
+  .crossTabContainer(jaspResults, crossTabResults, ready)
+    
+  # Output tables
+  .crossTabMain(      jaspResults, dataset, options, crossTabResults, ready)
+  .crossTabChisq(     jaspResults, dataset, options, crossTabResults, ready)
+  .crossTabLogOdds(   jaspResults, dataset, options, crossTabResults, ready)
+  .crossTabNominal(   jaspResults, dataset, options, crossTabResults, ready)
+  .crossTabGamma(     jaspResults, dataset, options, crossTabResults, ready)
+  .crossTabKendallTau(jaspResults, dataset, options, crossTabResults, ready)
+    
+  return()
 }
 
-
-.crosstab <- function(dataset, options, perform, analysis) {
-
-	# analysis is a list of the form :
-	# list(columns="var.name", rows="var.name", "Layer 1"="var.name", etc...)
-
-	counts.var <- options$counts
-	if (counts.var == "")
-		counts.var <- NULL
-
-	status <- list(error=FALSE, ready=TRUE)
-
-	if (length(options$rows) == 0 || length(options$columns) == 0) {
-
-		status$ready <- FALSE
-
-	} else {
-
-		all.vars <- c(unlist(analysis), counts.var)
-		dataset <- subset(dataset, select=.v(all.vars))
-	}
-
-	# the following creates a 'groups' list
-	# a 'group' represents a combinations of the levels from the layers
-	# if no layers are specified, groups is null
-
-	if (length(analysis) >= 3) {  # if layers are specified
-
-		lvls <- base::levels(dataset[[ .v(analysis[[3]]) ]])
-
-		if (length(lvls) < 2) {
-
-			lvls <- ""
-
-		} else {
-
-			lvls <- c(lvls, "")  # blank means total
-		}
-
-		# here we create all combinations of the levels from the layers
-		# it is easiest to do this with a data frame
-		# at the end we convert this to a list of rows
-
-		groups <- data.frame(lvls, stringsAsFactors=FALSE)
-		base::names(groups) <- analysis[[3]]
-
-		if (length(analysis) >= 4) {
-
-			for (j in 4:length(analysis))
-			{
-				lvls <- base::levels(dataset[[ .v(analysis[[j]]) ]])
-				lvls <- c(lvls, "")  # blank means total
-
-				groups <- cbind(rep(lvls, each=dim(groups)[1]), groups, stringsAsFactors=FALSE)
-				names(groups)[1] <- analysis[[j]]
-			}
-		}
-
-		# convert all the combinations to a list of rows
-
-		groups <- .dataFrameToRowList(groups)
-
-	} else {  # if layers are not specified
-
-		groups <- NULL
-	}
-
-
-	tables <- list()
-
-
-	### SETUP COLUMNS COMMON TO BOTH TABLES
-
-	fields <- list()
-
-	if (length(analysis) >= 3) {
-
-		for (j in length(analysis):3)
-			fields[[length(fields)+1]] <- list(name=analysis[[j]], type="string", combine=TRUE)
-	}
-
-
-	### SETUP COUNTS TABLE SCHEMA
-
-	counts.table <- list()
-
-	counts.table[["title"]] <- "Contingency Tables"
-
-	counts.fields <- fields
-
-	counts.fields[[length(counts.fields)+1]] <- list(name=analysis$rows, type="string", combine=TRUE)
-
-	lvls <- c()
-
-	if (analysis$columns == "") {
-
-		lvls <- c(".", ". ")
-
-	} else if (is.factor(dataset[[ .v(analysis$columns) ]] )) {
-
-		lvls <- base::levels(dataset[[ .v(analysis$columns) ]])
-		if (options$columnOrder == "descending") {
-			lvls <- base::rev(lvls)
-		} else {
-			lvls <- lvls
-		}
-
-	} else if (perform == "run") {
-
-		lvls <- base::unique(dataset[[ .v(analysis$columns) ]])
-
-		if (options$columnOrder == "descending") {
-			lvls <- base::rev(lvls, decreasing = TRUE)
-		} else {
-			lvls <- lvls
-		}
-	}
-
-	counts.fp <- FALSE  # whether the counts are float point or not; changes formatting
-
-	if (is.null(counts.var) == FALSE) {
-
-		counts <- dataset[[ .v(counts.var) ]]
-		if (identical(counts, as.integer(counts)) == FALSE)  # are the counts floating point?
-			counts.fp <- TRUE
-	}
-
-	if (options$countsExpected || options$percentagesRow || options$percentagesColumn || options$percentagesTotal ) {
-
-		counts.fields[[length(counts.fields)+1]] <- list(name="type[counts]", title="", type="string")
-
-		if (options$countsExpected) {
-			counts.fields[[length(counts.fields)+1]] <- list(name="type[expected]", title="", type="string")
-		}
-
-		if (options$percentagesRow) {
-
-			counts.fields[[length(counts.fields)+1]] <- list(name="type[row.proportions]", title="", type="string")
-		}
-
-		if (options$percentagesColumn) {
-
-			counts.fields[[length(counts.fields)+1]] <- list(name="type[col.proportions]", title="", type="string")
-		}
-
-		if (options$percentagesTotal) {
-
-			counts.fields[[length(counts.fields)+1]] <- list(name="type[proportions]", title="", type="string")
-		}
-
-	}
-
-	overTitle <- unlist(analysis$columns)
-	if (overTitle == "")
-		overTitle <- "."
-
-	for (column.name in lvls) {
-
-		private.name <- base::paste(column.name,"[counts]", sep="")
-
-		if (counts.fp || options$countsExpected || options$percentagesRow || options$percentagesColumn || options$percentagesTotal ) {
-
-			counts.fields[[length(counts.fields)+1]] <- list(name=private.name, title=column.name, overTitle=overTitle, type="number", format="sf:4;dp:2")
-
-		} else {
-
-			counts.fields[[length(counts.fields)+1]] <- list(name=private.name, title=column.name, overTitle=overTitle, type="integer")
-		}
-
-		if (options$countsExpected) {
-
-			private.name <- base::paste(column.name,"[expected]", sep="")
-			counts.fields[[length(counts.fields)+1]] <- list(name=private.name, title=column.name, type="number", format="sf:4;dp:2")
-		}
-
-		if (options$percentagesRow) {
-
-			private.name <- base::paste(column.name,"[row.proportions]", sep="")
-			counts.fields[[length(counts.fields)+1]] <- list(name=private.name, title=column.name, type="number", format="dp:1;pc")
-		}
-
-		if (options$percentagesColumn) {
-
-			private.name <- base::paste(column.name,"[col.proportions]", sep="")
-			counts.fields[[length(counts.fields)+1]] <- list(name=private.name, title=column.name, type="number", format="dp:1;pc")
-		}
-
-		if (options$percentagesTotal) {
-
-			private.name <- base::paste(column.name,"[proportions]", sep="")
-			counts.fields[[length(counts.fields)+1]] <- list(name=private.name, title=column.name, type="number", format="dp:1;pc")
-		}
-	}
-
-	# Totals columns
-
-	if (counts.fp || options$countsExpected || options$percentagesRow || options$percentagesColumn || options$percentagesTotal) {
-
-		counts.fields[[length(counts.fields)+1]] <- list(name="total[counts]", title="Total", type="number", format="sf:4;dp:2")
-
-	} else {
-
-		counts.fields[[length(counts.fields)+1]] <- list(name="total[counts]", title="Total", type="integer")
-	}
-
-	if (options$countsExpected) {
-
-		counts.fields[[length(counts.fields)+1]] <- list(name="total[expected]", title="Total", type="number", format="sf:4;dp:2")
-	}
-
-	if (options$percentagesRow) {
-
-		counts.fields[[length(counts.fields)+1]] <- list(name="total[row.proportions]", title="Total", type="number", format="dp:1;pc")
-	}
-
-	if (options$percentagesColumn) {
-
-		counts.fields[[length(counts.fields)+1]] <- list(name="total[col.proportions]", title="Total", type="number", format="dp:1;pc")
-	}
-
-	if (options$percentagesTotal) {
-
-		counts.fields[[length(counts.fields)+1]] <- list(name="total[proportions]", title="Total", type="number", format="dp:1;pc")
-	}
-
-	schema <- list(fields=counts.fields)
-
-	counts.table[["schema"]] <- schema
-
-
-	### SETUP TESTS TABLE SCHEMA
-
-	if (options$chiSquared || options$chiSquaredContinuityCorrection || options$likelihoodRatio) {
-
-		tests.table <- list()
-
-		tests.table[["title"]] <- "Chi-Squared Tests"
-
-		tests.fields <- fields
-
-		if (options$chiSquared){
-
-			tests.fields[[length(tests.fields)+1]] <- list(name="type[chiSquared]", title="", type="string")
-			tests.fields[[length(tests.fields)+1]] <- list(name="value[chiSquared]", title="Value", type="number", format="sf:4;dp:3")
-			tests.fields[[length(tests.fields)+1]] <- list(name="df[chiSquared]", title="df", type="integer")
-			tests.fields[[length(tests.fields)+1]] <- list(name="p[chiSquared]", title="p", type="number", format="dp:3;p:.001")
-			if (options$VovkSellkeMPR) {
-				tests.fields[[length(tests.fields)+1]] <- list(name = "MPR[chiSquared]",
-							                                        title = "VS-MPR",
-							                                        type = "number",
-							                                        format = "sf:4;dp:3")
-			}
-		}
-
-		if (options$chiSquaredContinuityCorrection){
-			tests.fields[[length(tests.fields)+1]] <- list(name="type[chiSquared-cc]", title="", type="string")
-			tests.fields[[length(tests.fields)+1]] <- list(name="value[chiSquared-cc]", title="Value", type="number", format="sf:4;dp:3")
-			tests.fields[[length(tests.fields)+1]] <- list(name="df[chiSquared-cc]", title="df", type="integer")
-			tests.fields[[length(tests.fields)+1]] <- list(name="p[chiSquared-cc]", title="p", type="number", format="dp:3;p:.001")
-			if (options$VovkSellkeMPR) {
-				tests.fields[[length(tests.fields)+1]] <- list(name = "MPR[chiSquared-cc]",
-							                                        title = "VS-MPR",
-							                                        type = "number",
-							                                        format = "sf:4;dp:3")
-			}
-		}
-
-		if (options$likelihoodRatio) {
-			tests.fields[[length(tests.fields)+1]] <- list(name="type[likelihood]", title="", type="string")
-			tests.fields[[length(tests.fields)+1]] <- list(name="value[likelihood]", title="Value", type="number", format="sf:4;dp:3")
-			tests.fields[[length(tests.fields)+1]] <- list(name="df[likelihood]", title="df", type="integer")
-			tests.fields[[length(tests.fields)+1]] <- list(name="p[likelihood]", title="p", type="number", format="dp:3;p:.001")
-			if (options$VovkSellkeMPR) {
-				tests.fields[[length(tests.fields)+1]] <- list(name = "MPR[likelihood]",
-							                                        title = "VS-MPR",
-							                                        type = "number",
-							                                        format = "sf:4;dp:3")
-			}
-		}
-
-		tests.fields[[length(tests.fields)+1]] <- list(name="type[N]", title="", type="string")
-
-		if (counts.fp) {
-
-			tests.fields[[length(tests.fields)+1]] <- list(name="value[N]", title="Value", type="number", format="sf:4;dp:2")
-
-		} else {
-
-			tests.fields[[length(tests.fields)+1]] <- list(name="value[N]", title="Value", type="integer")
-		}
-
-		tests.fields[[length(tests.fields)+1]] <- list(name="df[N]", title="df")
-		tests.fields[[length(tests.fields)+1]] <- list(name="p[N]", title="p")
-		if (options$VovkSellkeMPR) {
-			tests.fields[[length(tests.fields)+1]] <- list(name = "MPR[N]",
-																										title = "VS-MPR",
-																										type = "number",
-																										format = "sf:4;dp:3")
-		}
-		schema <- list(fields=tests.fields)
-
-		tests.table[["schema"]] <- schema
-
-	}
-
-	############# Odds ratio
-
-	if (options$oddsRatio) {
-
-		odds.ratio.table <- list()
-
-		odds.ratio.table[["title"]] <- "Log Odds Ratio"
-		ci.label <- paste(100*options$oddsRatioConfidenceIntervalInterval, "% Confidence Intervals", sep="")
-
-		odds.ratio.fields <- fields
-
-		odds.ratio.fields[[length(odds.ratio.fields)+1]] <- list(name="type[oddsRatio]", title="", type="string")
-		odds.ratio.fields[[length(odds.ratio.fields)+1]] <- list(name="value[oddsRatio]", title="Log Odds Ratio", type="number", format="sf:4;dp:3")
-		odds.ratio.fields[[length(odds.ratio.fields)+1]] <- list(name="low[oddsRatio]", title="Lower",overTitle=ci.label, type="number", format="dp:3")
-		odds.ratio.fields[[length(odds.ratio.fields)+1]] <- list(name="up[oddsRatio]",  title="Upper",overTitle=ci.label, type="number", format="dp:3")
-
-		odds.ratio.fields[[length(odds.ratio.fields)+1]] <- list(name="type[FisherTest]", title="", type="string")
-		odds.ratio.fields[[length(odds.ratio.fields)+1]] <- list(name="value[FisherTest]", title="Log Odds Ratio", type="number", format="sf:4;dp:3")
-		odds.ratio.fields[[length(odds.ratio.fields)+1]] <- list(name="low[FisherTest]", title="Lower", overTitle=ci.label, type="number", format="dp:3")
-		odds.ratio.fields[[length(odds.ratio.fields)+1]] <- list(name="up[FisherTest]",  title="Upper", overTitle=ci.label, type="number", format="dp:3")
-
-		schema <- list(fields=odds.ratio.fields)
-
-		odds.ratio.table[["schema"]] <- schema
-	}
-
-
-	##### Nominal Table (Symmetric Measures)
-
-	if (options$contingencyCoefficient|| options$phiAndCramersV || options$lambda) {
-
-		nominal.table <- list()
-
-		nominal.table[["title"]] <- "Nominal"
-
-		nominal.fields <- fields
-
-		if (options$contingencyCoefficient){
-
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="type[ContCoef]", title="", type="string")
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="value[ContCoef]", title="Value", type="number", format="sf:4;dp:3")
-		}
-
-		if (options$phiAndCramersV) {
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="type[PhiCoef]", title="", type="string")
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="value[PhiCoef]", title="Value", type="number", format="sf:4;dp:3")
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="type[CramerV]", title="", type="string")
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="value[CramerV]", title="Value", type="number", format="sf:4;dp:3")
-		}
-
-		if (options$lambda) {
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="type[LambdaR]", title="", type="string")
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="value[LambdaR]", title="Value", type="number", format="sf:4;dp:3")
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="type[LambdaC]", title="", type="string")
-			nominal.fields[[length(nominal.fields)+1]] <- list(name="value[LambdaC]", title="Value", type="number", format="sf:4;dp:3")
-		}
-
-		schema <- list(fields=nominal.fields)
-
-		nominal.table[["schema"]] <- schema
-	}
-
-	##### Ordinal Table
-
-	if (options$gamma) {
-
-		ordinal.table <- list()
-
-		ordinal.table[["title"]] <- "Ordinal Gamma"
-		ci.label <- paste( "95% Confidence Intervals")
-
-		ordinal.fields <- fields
-
-		ordinal.fields[[length(ordinal.fields)+1]] <- list(name="value[gammaCoef]", title="Gamma", type="number", format="sf:4;dp:3")
-		ordinal.fields[[length(ordinal.fields)+1]] <- list(name="Sigma[gammaCoef]", title="Standard Error", type="number", format="dp:3")
-		ordinal.fields[[length(ordinal.fields)+1]] <- list(name="low[gammaCoef]", title="Lower",overTitle=ci.label, type="number", format="dp:3")
-		ordinal.fields[[length(ordinal.fields)+1]] <- list(name="up[gammaCoef]",  title="Upper",overTitle=ci.label, type="number", format="dp:3")
-		#ordinal.fields[[length(ordinal.fields)+1]] <- list(name="low[gammaCoef]", title="Lower CI", type="number", format="dp:3")
-		#ordinal.fields[[length(ordinal.fields)+1]] <- list(name="up[gammaCoef]",  title="Upper CI", type="number", format="dp:3")
-
-		schema <- list(fields=ordinal.fields)
-
-		ordinal.table[["schema"]] <- schema
-	}
-
-	########## Kendall Tau-B table
-
-	if (options$kendallsTauB) {
-
-		kendalls.table <- list()
-
-		kendalls.table[["title"]] <- "Kendall's Tau"
-
-		kendalls.fields <- fields
-
-		#kendalls.fields[[length(kendalls.fields)+1]] <- list(name="type[kTauB]", title="", type="string")
-		kendalls.fields[[length(kendalls.fields)+1]] <- list(name="value[kTauB]", title="Kendall's Tau-b ", type="number", format="sf:4;dp:3")
-		kendalls.fields[[length(kendalls.fields)+1]] <- list(name="statistic[kTauB]", title="Z", type="number", format="dp:3")
-		kendalls.fields[[length(kendalls.fields)+1]] <- list(name="p[kTauB]", title="p", type="number", format="dp:3;p:.001")
-		if (options$VovkSellkeMPR){
-			kendalls.fields[[length(kendalls.fields)+1]] <- list(name = "MPR[kTauB]",
-									                                        title = "VS-MPR",
-									                                        type = "number",
-									                                        format = "sf:4;dp:3")
-		}
-
-
-		schema <- list(fields=kendalls.fields)
-
-		kendalls.table[["schema"]] <- schema
-	}
-
-	if (is.null(counts.var) == FALSE) {
-
-		counts <- stats::na.omit(dataset[[ .v(counts.var) ]])
-
-		if (any(counts < 0)|| any(is.infinite(counts))) {
-
-			status$error <- TRUE
-			status$errorMessage <- "Counts may not contain negative numbers or infinities"
-		}
-	}
-
-
-	# POPULATE TABLES
-
-	# create count matrices for each group
-
-	group.matrices <- .crosstabsCreateGroupMatrices(dataset, analysis$rows, analysis$columns, groups, counts.var, options$rowOrder=="descending", options$columnOrder=="descending", perform=perform, status=status)
-
-	counts.rows <- list()
-	tests.rows <- list()
-	odds.ratio.rows <- list()
-	nominal.rows <- list()
-	ordinal.rows <- list()
-	kendalls.rows <- list()
-
-	tests.footnotes <- .newFootnotes()
-	odds.ratio.footnotes <- .newFootnotes()
-	nominal.footnotes <- .newFootnotes()
-	ordinal.footnotes <- .newFootnotes()
-	kendalls.footnotes <- .newFootnotes()
-
-	for (i in 1:length(group.matrices)) {
-
-		group.matrix <- group.matrices[[i]]
-
-		if ( ! is.null(groups)) {
-
-			group <- groups[[i]]
-
-		} else {
-
-			group <- NULL
-		}
-
-		next.rows <- .crosstabsCreateCountsRows(analysis$rows, group.matrix, options, perform, group, status)
-		counts.rows <- c(counts.rows, next.rows)
-
-		next.rows <- .crosstabsCreateTestsRows(analysis$rows, group.matrix, tests.footnotes, options, perform, group, status)
-		tests.rows <- c(tests.rows, next.rows)
-
-		next.rows <- .crosstabsCreateOddsRatioRows(analysis$rows, group.matrix, odds.ratio.footnotes, options, perform, group, status)
-		odds.ratio.rows <- c(odds.ratio.rows, next.rows)
-
-		next.rows <- .crosstabsCreateNominalRows(analysis$rows, group.matrix, nominal.footnotes, options, perform, group, status)
-		nominal.rows <- c(nominal.rows, next.rows)
-
-		next.rows <- .crosstabsCreateOrdinalRows(analysis$rows, group.matrix, ordinal.footnotes, options, perform, group, status)
-		ordinal.rows <- c(ordinal.rows, next.rows)
-
-		next.rows <- .crosstabsCreateOrdinalTau(analysis$rows, group.matrix, kendalls.footnotes, options, perform, group, status)
-		kendalls.rows <- c(kendalls.rows, next.rows)
-	}
-
-	counts.table[["data"]] <- counts.rows
-	if (status$error)
-		counts.table[["error"]] <- list(errorType="badData", errorMessage=status$errorMessage)
-
-	tables[["counts.table"]] <- counts.table
-
-	if (options$chiSquared || options$chiSquaredContinuityCorrection || options$likelihoodRatio ) {
-
-		tests.table[["data"]] <- tests.rows
-		tests.table[["footnotes"]] <- as.list(tests.footnotes)
-
-		if (status$error)
-			tests.table[["error"]] <- list(errorType="badData")
-
-		tables[["tests.table"]] <- tests.table
-	}
-
-	if (options$oddsRatio) {
-		odds.ratio.table[["data"]] <- odds.ratio.rows
-		odds.ratio.table[["footnotes"]] <- as.list(odds.ratio.footnotes)
-
-		if (status$error)
-			odds.ratio.table[["error"]] <- list(errorType="badData")
-
-		tables[["odds.ratio.table"]] <- odds.ratio.table
-	}
-
-	if (options$contingencyCoefficient || options$phiAndCramersV || options$lambda) {
-
-		nominal.table[["data"]] <- nominal.rows
-		nominal.table[["footnotes"]] <- as.list(nominal.footnotes)
-
-		if (status$error)
-			nominal.table[["error"]] <- list(errorType="badData")
-
-		tables[["nominal.table"]] <- nominal.table
-	}
-
-	if (options$gamma) {
-
-		ordinal.table[["data"]] <- ordinal.rows
-		ordinal.table[["footnotes"]] <- as.list(ordinal.footnotes)
-
-		if (status$error)
-			ordinal.table[["error"]] <- list(errorType="badData")
-
-		tables[["ordinal.table"]] <- ordinal.table
-	}
-
-	if (options$kendallsTauB) {
-
-		kendalls.table[["data"]] <- kendalls.rows
-		kendalls.table[["footnotes"]] <- as.list(kendalls.footnotes)
-
-		if (status$error)
-			kendalls.table[["error"]] <- list(errorType="badData")
-
-		tables[["kendalls.table"]] <- kendalls.table
-	}
-
-	tables
+# Preprocessing functions ----
+.crossTabReadData <- function(dataset, options) {
+  if (!is.null(dataset)) {
+    return(dataset)
+  } else {
+    layer.variables <- c()
+    for (layer in options$layers)
+      layer.variables <- c(layer.variables, unlist(layer$variables))
+    
+    counts.var <- options$counts
+    if (counts.var == "")
+      counts.var <- NULL
+    
+    factors <- c(unlist(options$rows), unlist(options$columns), layer.variables)
+    
+    return(.readDataSetToEnd(columns.as.factor=factors, columns.as.numeric=counts.var))
+  }
 }
 
-.crosstabsCreateTestsRows <- function(var.name, counts.matrix, footnotes, options, perform, group, status) {
-
-	row <- list()
-	row.footnotes <- list()
-
-	for (layer in names(group)) {
-
-		level <- group[[layer]]
-
-		if (level == "") {
-
-			row[[layer]] <- "Total"
-
-		} else {
-
-			row[[layer]] <- level
-		}
-	}
-
-	row[["type[N]"]] <- "N"
-	row[["df[N]"]] <- ""
-	row[["p[N]"]] <- ""
-	row[["MPR[N]"]] <- ""
-
-	if (perform == "run" && status$error == FALSE && status$ready) {
-
-		row[["value[N]"]] <- base::sum(counts.matrix)
-
-	} else {
-
-		row[["value[N]"]] <- "."
-	}
-
-	if (options$chiSquared) {
-
-		row[["type[chiSquared]"]] <- "\u03A7\u00B2"
-
-		if (perform == "run" && status$error == FALSE && status$ready) {
-
-			chi.result <- try({
-
-				chi.result <- stats::chisq.test(counts.matrix, correct=FALSE)
-			})
-
-			if (class(chi.result) == "try-error") {
-
-				row[["value[chiSquared]"]] <- .clean(NaN)
-				row[["df[chiSquared]"]]<- " "
-				row[["p[chiSquared]"]]<- " "
-				row[["MPR[chiSquared]"]]<- " "
-
-				error <- .extractErrorMessage(chi.result)
-
-				if (error == "at least one entry of 'x' must be positive")
-					error <- "\u03A7\u00B2 could not be calculated, contains no observations"
-
-				sup	<- .addFootnote(footnotes, error)
-				row.footnotes[["value[chiSquared]"]]=list(sup)
-
-			} else if (is.na(chi.result$statistic)) {
-
-				row[["value[chiSquared]"]] <- .clean(NaN)
-				row[["df[chiSquared]"]]<- " "
-				row[["p[chiSquared]"]]<- " "
-				row[["MPR[chiSquared]"]]<- " "
-
-				message <- "\u03A7\u00B2 could not be calculated - At least one row or column contains all zeros"
-
-				#sup <- .addFootnote(footnotes, "Odds ratio restricted to 2 x 2 tables")
-				#row.footnotes[["value[oddsRatio]"]]=list(sup)
-
-				#warn <- warnings()
-				#if (length(warn) > 0)
-				#	message <- paste(message, names(warn)[1], sep=" : ")
-
-				sup <- .addFootnote(footnotes, message)
-				row.footnotes [["value[chiSquared]"]]=list(sup)
-
-			} else {
-
-				row[["value[chiSquared]"]] <- unname(chi.result$statistic)
-				row[["df[chiSquared]"]] <- unname(chi.result$parameter)
-				row[["p[chiSquared]"]] <- unname(chi.result$p.value)
-				row[["MPR[chiSquared]"]]<- .VovkSellkeMPR(row[["p[chiSquared]"]])
-			}
-
-		} else {
-
-			row[["value[chiSquared]"]] <- "."
-
-		}
-	}
-
-	if (options$chiSquaredContinuityCorrection) {
-
-		row[["type[chiSquared-cc]"]] <- "\u03A7\u00B2 continuity correction"
-
-		if (perform == "run" && status$error == FALSE && status$ready) {
-
-			chi.result <- try({
-
-				chi.result <- stats::chisq.test(counts.matrix)
-				#row <- list(Method="Pearson's Chi-squared", X2=unname(chi$statistic), df=unname(chi$parameter), p=chi$p.value)
-			})
-
-			if (class(chi.result) == "try-error") {
-
-				row[["value[chiSquared-cc]"]] <- .clean(NaN)
-				row[["df[chiSquared-cc]"]]<- " "
-				row[["p[chiSquared-cc]"]]<- " "
-				row[["MPR[chiSquared-cc]"]]<- " "
-
-				error <- .extractErrorMessage(chi.result)
-
-				if (error == "at least one entry of 'x' must be positive")
-					error <- "\u03A7\u00B2 could not be calculated, contains no observations"
-
-				sup	<- .addFootnote(footnotes, error)
-				row.footnotes [["value[chiSquared-cc]"]]=list(sup)
-
-			} else if (is.na(chi.result$statistic)) {
-
-				row[["value[chiSquared-cc]"]] <- .clean(NaN)
-				row[["df[chiSquared-cc]"]]<- " "
-				row[["p[chiSquared-cc]"]]<- " "
-				row[["MPR[chiSquared-cc]"]]<- " "
-
-				sup <- .addFootnote(footnotes, "\u03A7\u00B2 could not be calculated - At least one row or column contains all zeros")
-				row.footnotes [["value[chiSquared-cc]"]]=list(sup)
-
-			} else {
-
-				row[["value[chiSquared-cc]"]] <- unname(chi.result$statistic)
-				row[["df[chiSquared-cc]"]] <- unname(chi.result$parameter)
-				row[["p[chiSquared-cc]"]] <- unname(chi.result$p.value)
-				row[["MPR[chiSquared-cc]"]]<- .VovkSellkeMPR(row[["p[chiSquared-cc]"]])
-
-			}
-
-		} else {
-
-			row[["value[chiSquared-cc]"]] <- "."
-		}
-	}
-
-	if (options$likelihoodRatio) {
-
-		row[["type[likelihood]"]] <- "Likelihood ratio"
-
-		if (perform == "run" && status$error == FALSE && status$ready) {
-
-			chi.result <- try({
-
-				chi.result <- vcd::assocstats(counts.matrix)
-
-			})
-
-			if (class(chi.result) == "try-error") {
-
-				row[["value[likelihood]"]] <- .clean(NaN)
-				row[["df[likelihood]"]] <- ""
-				row[["p[likelihood]"]] <-""
-				row[["MPR[likelihood]"]] <-""
-
-				error <- .extractErrorMessage(chi.result)
-
-				sup	<- .addFootnote(footnotes, error)
-				row.footnotes[["value[likelihood]"]] = list(sup)
-
-			} else {
-
-				row[["value[likelihood]"]] <- chi.result$chisq_tests[1]
-				row[["df[likelihood]"]] <- chi.result$chisq_tests[3]
-				row[["p[likelihood]"]] <- chi.result$chisq_tests[5]
-				row[["MPR[likelihood]"]] <- .VovkSellkeMPR(row[["p[likelihood]"]])
-			}
-
-		} else {
-
-			row[["value[likelihood]"]] <- "."
-		}
-	}
-
-	row[[".footnotes"]] <- row.footnotes
-
-	list(row)
+.crossTabCheckErrors <- function(dataset, options) {
+  .hasErrors(dataset, 
+             type = c('negativeValues', 'infinity'), 
+             all.target = c(options$counts), 
+             exitAnalysisIfErrors = TRUE)
 }
 
-.crosstabsCreateNominalRows <- function(var.name, counts.matrix, footnotes, options, perform, group, status) {
-
-	row <- list()
-
-	for (layer in names(group)) {
-
-		level <- group[[layer]]
-
-		if (level == "") {
-
-			row[[layer]] <- "Total"
-
-		} else {
-
-			row[[layer]] <- level
-		}
-	}
-
-	row.footnotes <- list ()
-
-	if (options$contingencyCoefficient) {
-
-		row[["type[ContCoef]"]] <- "Contingency coefficient"
-
-		if (perform == "run" && status$error == FALSE) {
-
-			 chi.result <- try({
-
-				 chi.result <- vcd::assocstats(counts.matrix)
-
-			})
-
-			if (class(chi.result) == "try-error") {
-
-				row[["value[ContCoef]"]] <- .clean(NaN)
-
-				error <- .extractErrorMessage(chi.result)
-
-				sup	<- .addFootnote(footnotes, error)
-				row.footnotes[["value[ContCoef]"]] <- list(sup)
-
-			} else if (is.na(chi.result$contingency)) {
-
-					row[["value[ContCoef]"]] <- .clean(NaN)
-
-					sup <- .addFootnote(footnotes, "Value could not be calculated - At least one row or column contains all zeros")
-					row.footnotes[["value[ContCoef]"]] <- list(sup)
-
-			} else {
-
-				 row[["value[ContCoef]"]] <- chi.result$contingency
-			}
-
-		} else {
-
-			row[["value[ContCoef]"]] <- "."
-		}
-
-	}
-
-	if (options$phiAndCramersV) {
-
-		row[["type[PhiCoef]"]] <- "Phi-coefficient"
-
-
-		if (perform == "run" && status$error == FALSE) {
-
-			chi.result <- try({
-
-				chi.result <- vcd::assocstats(counts.matrix)
-			})
-
-			if (class(chi.result) == "try-error") {
-
-				row[["value[PhiCoef]"]] <- .clean(NaN)
-
-				error <- .extractErrorMessage(chi.result)
-
-				sup	<- .addFootnote(footnotes, error)
-				row[["value[PhiCoef]"]] <- list(sup)
-
-			} else if (is.na(chi.result$phi)) {
-
-				row[["value[PhiCoef]"]] <- .clean(NaN)
-
-				sup <- .addFootnote(footnotes, "Value could not be calculated - At least one row or column contains all zeros")
-				row.footnotes[["value[PhiCoef]"]] <- list(sup)
-				#row.footnotes <- c(row.footnotes, list("value[PhiCoef]"=list(sup)))
-
-			} else {
-
-				row[["value[PhiCoef]"]] <- chi.result$phi
-			}
-
-		} else {
-
-			row[["value[PhiCoef]"]] <- "."
-		}
-
-	 }
-
-	 if (options$phiAndCramersV) {
-
-		row[["type[CramerV]"]] <- "Cramer's V "
-
-		if (perform == "run" && status$error == FALSE) {
-
-			chi.result <- try({
-
-				chi.result <- vcd::assocstats(counts.matrix)
-
-			})
-
-			if (class(chi.result) == "try-error") {
-
-				row[["value[CramerV]"]] <- .clean(NaN)
-
-				error <- .extractErrorMessage(chi.result)
-
-				sup	<- .addFootnote(footnotes, error)
-				row.footnotes[["value[CramerV]"]] <- list(sup)
-
-			} else if (is.na(chi.result$cramer)) {
-
-				row[["value[CramerV]"]] <- .clean(NaN)
-
-				sup <- .addFootnote(footnotes, "Value could not be calculated - At least one row or column contains all zeros")
-				row.footnotes[["value[CramerV]"]] <- list(sup)
-
-			} else {
-
-				row[["value[CramerV]"]] <- chi.result$cramer
-			}
-
-		} else {
-
-			row[["value[CramerV]"]] <- "."
-		}
-	}
-
-	 if (options$lambda) {
-
-		row[["type[LambdaR]"]] <- paste("Lambda (", options$rows, "dependent)", sep= " ")
-
-		if (perform == "run" && status$error == FALSE) {
-
-				N <- sum(counts.matrix)
-				E1 <- N- max(rowSums(counts.matrix))
-				E2 <- sum(apply(counts.matrix,2, function (x) sum(x)-max(x) ))
-				lambda<-(E1-E2)/E1
-				row[["value[LambdaR]"]] <- lambda
-
-		 if (is.na(lambda)) {
-
-				row[["value[LambdaR]"]] <- .clean(NaN)
-
-				sup <- .addFootnote(footnotes, "Value could not be calculated - At least one row sums or column sums contains all zeros")
-				row.footnotes[["value[LambdaR]"]] <- list(sup)
-
-
-		}
-		} else {
-
-			row[["value[LambdaR]"]] <- "."
-		}
-	}
-
-
-	if (options$lambda) {
-
-		row[["type[LambdaC]"]] <- paste("Lambda (", options$columns, "dependent)", sep= " ")
-
-		if (perform == "run" && status$error == FALSE) {
-
-				N <- sum(counts.matrix)
-				E1 <- N- max(colSums(counts.matrix))
-				E2 <- sum(apply(counts.matrix,1, function (x) sum(x)-max(x) ))
-				lambda<-(E1-E2)/E1
-				print(N)
-				print(E1)
-				print(E2)
-				print(lambda)
-				row[["value[LambdaC]"]] <- lambda
-
-
-		} else {
-
-			row[["value[LambdaC]"]] <- "."
-		}
-	}
-
-
-
-	row[[".footnotes"]] <- row.footnotes
-	list(row)
+# Results ----
+.crossTabComputeAnalyses <- function(dataset, options) {
+  rows    <- as.vector(options$rows,    "character")
+  columns <- as.vector(options$columns, "character")
+  
+  if (length(rows) == 0)
+    rows <- ""
+  
+  if (length(columns) == 0)
+    columns <- ""
+  
+  analyses <- data.frame("columns" = columns, stringsAsFactors = FALSE)
+  analyses <- cbind(analyses, "rows" = rep(rows, each = dim(analyses)[1]), stringsAsFactors = FALSE)
+  
+  for (layer in options$layers) {
+    layer.vars <- as.vector(layer$variables, "character")
+    analyses <- cbind(analyses, rep(layer.vars, each = dim(analyses)[1]), stringsAsFactors = FALSE)
+    names(analyses)[dim(analyses)[2]] <- layer$name
+  }
+  
+  analyses <- .dataFrameToRowList(analyses)
+  return(analyses)
 }
 
-.crosstabsCreateOrdinalRows <- function(var.name, counts.matrix, footnotes, options, perform, group, status) {
-
-	row <- list()
-	for (layer in names(group)) {
-
-		level <- group[[layer]]
-
-		if (level == "") {
-
-			row[[layer]] <- "Total"
-
-		} else {
-
-			row[[layer]] <- level
-		}
-	}
-
-
-
-	if (options$gamma) {
-
-		row[["type[gammaCoef]"]] <- "Gamma coefficient"
-
-
-		if (perform == "run" && status$error == FALSE) {
-
-			chi.result <- try({
-
-				chi.result <- vcdExtra::GKgamma(counts.matrix)
-
-			})
-
-			print(chi.result)
-			print("we are here")
-
-			if (class(chi.result) == "try-error") {
-
-				row[["value[gammaCoef]"]] <- .clean(NaN)
-
-				error <- .extractErrorMessage(chi.result)
-
-				sup	<- .addFootnote(footnotes, error)
-				row[[".footnotes"]] <- list("value[gammaCoef]"=list(sup))
-
-			} else {
-
-				row[["value[gammaCoef]"]] <- chi.result$gamma
-				row[["Sigma[gammaCoef]"]] <- chi.result$sigma
-				row[["low[gammaCoef]"]] <- chi.result$CI[1]
-				row[["up[gammaCoef]"]] <-  chi.result$CI[2]
-			}
-
-		} else {
-
-			 row[["value[gammaCoef]"]] <- "."
-			 row[["Sigma[gammaCoef]"]] <- "."
-		  	 row[["low[gammaCoef]"]] <- "."
-		  	 row[["up[gammaCoef]"]] <-  "."
-		}
-
-	}
-
-	list(row)
-
+.crossTabComputeResults <- function(jaspResults, dataset, options, ready) {
+  # Take results from state if possible
+  if (!is.null(jaspResults[["stateCrossTabResults"]])) 
+    return(jaspResults[["stateCrossTabResults"]]$object)
+  
+  results <- list()
+  results[["analysesOrder"]] <- list()
+  
+  # These are the groups of rows, columns, layers for the tables
+  analyses <- .crossTabComputeAnalyses(dataset, options)
+  results[["analysesOrder"]] <- analyses
+  
+  counts.var <- NULL
+  if(options$counts != "")
+    counts.var <- options$counts
+  
+    for (i in 1:length(analyses)) {
+      analysis <- analyses[[i]]
+      counts.var <- options$counts
+      if (counts.var == "")
+        counts.var <- NULL
+      
+      if(ready) {
+        all.vars <- c(unlist(analysis), counts.var)
+        dataset <- subset(dataset, select = .v(all.vars))
+      }
+      
+      # the following creates a 'groups' list
+      # a 'group' represents a combinations of the levels from the layers
+      # if no layers are specified, groups is null
+      
+      if (length(analysis) >= 3) {  # if layers are specified
+        
+        lvls <- base::levels(dataset[[ .v(analysis[[3]]) ]])
+        
+        if (length(lvls) < 2) {
+          
+          lvls <- ""
+          
+        } else {
+          
+          lvls <- c(lvls, "")  # blank means total
+        }
+        
+        # here we create all combinations of the levels from the layers
+        # it is easiest to do this with a data frame
+        # at the end we convert this to a list of rows
+        
+        groups <- data.frame(lvls, stringsAsFactors=FALSE)
+        base::names(groups) <- analysis[[3]]
+        
+        if (length(analysis) >= 4) {
+          
+          for (j in 4:length(analysis))
+          {
+            lvls <- base::levels(dataset[[ .v(analysis[[j]]) ]])
+            lvls <- c(lvls, "")  # blank means total
+            
+            groups <- cbind(rep(lvls, each=dim(groups)[1]), groups, stringsAsFactors=FALSE)
+            names(groups)[1] <- analysis[[j]]
+          }
+        }
+        
+        # convert all the combinations to a list of rows
+        
+        groups <- .dataFrameToRowList(groups)
+        
+      } else {  # if layers are not specified
+        groups <- NULL
+      }
+      
+      if (!is.null(counts.var)) {
+        counts <- stats::na.omit(dataset[[ .v(counts.var) ]])
+      }
+      
+      #Fill tables
+      group.matrices <- .crosstabsCreateGroupMatrices(dataset, analysis$rows, analysis$columns, groups, counts.var, 
+                                                      options$rowOrder=="descending", options$columnOrder=="descending", ready)
+      counts.rows     <- list()
+      tests.rows      <- list()
+      odds.ratio.rows <- list()
+      nominal.rows    <- list()
+      ordinal.rows    <- list()
+      kendalls.rows   <- list()
+      
+      for (g in 1:length(group.matrices)) {
+        
+        group.matrix <- group.matrices[[g]]
+        
+        if (!is.null(groups)) {
+          
+          group <- groups[[g]]
+          
+        } else {
+          group <- NULL
+        }
+        
+        next.rows <- .crosstabsCreateCountsRows(analysis$rows, group.matrix, options, group, ready)
+        counts.rows <- c(counts.rows, next.rows)
+        
+        next.rows <- .crosstabsCreateTestsRows(analysis$rows, group.matrix, options, group, ready)
+        tests.rows <- c(tests.rows, next.rows)
+        
+        next.rows <- .crosstabsCreateOddsRatioRows(analysis$rows, group.matrix, options, group, ready)
+        odds.ratio.rows <- c(odds.ratio.rows, next.rows)
+        
+        next.rows <- .crosstabsCreateNominalRows(analysis$rows, group.matrix, options, group, ready)
+        nominal.rows <- c(nominal.rows, next.rows)
+        
+        next.rows <- .crosstabsCreateOrdinalRows(analysis$rows, group.matrix, options, group, ready)
+        ordinal.rows <- c(ordinal.rows, next.rows)
+        
+        next.rows <- .crosstabsCreateOrdinalTau(analysis$rows, group.matrix, options, group, ready)
+        kendalls.rows <- c(kendalls.rows, next.rows)
+      }
+      
+      results[[paste0("tables", analysis$rows, analysis$columns)]][["maintable"]][["data"]]     <- counts.rows
+      
+      results[[paste0("tables", analysis$rows, analysis$columns)]][["crossTabChisq"]][["data"]] <- tests.rows
+      
+      results[[paste0("tables", analysis$rows, analysis$columns)]][["logodds"]][["data"]]       <- odds.ratio.rows
+      
+      results[[paste0("tables", analysis$rows, analysis$columns)]][["nominal"]][["data"]]       <- nominal.rows
+      
+      results[[paste0("tables", analysis$rows, analysis$columns)]][["gamma"]][["data"]]         <- ordinal.rows
+      
+      results[[paste0("tables", analysis$rows, analysis$columns)]][["kendallTau"]][["data"]]    <- kendalls.rows
+    }
+  
+  # Save results to state
+  jaspResults[["stateCrossTabResults"]] <- createJaspState(results)
+  jaspResults[["stateCrossTabResults"]]$dependOn(c("rows", "columns", "counts", "layers",
+                                                   "chiSquared", "chiSquaredContinuityCorrection", "likelihoodRatio",
+                                                   "oddsratio", "oddsRatioConfidenceIntervalInterval", "VovkSellkeMPR", 
+                                                   "phiAndCramersV", "contingencyCoefficient", "gamma", "kendallsTauB",
+                                                   "countsExpected", "percentagesRow", "percentagesColumn", "percentagesTotal"))
+  
+  # Return results object
+  return(results)
 }
 
-.crosstabsCreateOrdinalTau <- function(var.name, counts.matrix, footnotes, options, perform, group, status) {
-
-	row <- list()
-	for (layer in names(group)) {
-
-		level <- group[[layer]]
-
-		if (level == "") {
-
-			row[[layer]] <- "Total"
-
-		} else {
-
-			row[[layer]] <- level
-		}
-	}
-
-	if (options$kendallsTauB) {
-
-		row[["type[kTauB]"]] <- "Kendall's Tau-b"
-
-
-		if (perform == "run" && status$error == FALSE) {
-
-			chi.result <- try({
-
-				count.dat <- stats::ftable(counts.matrix)
-				count.dat <- as.data.frame(count.dat)
-				Var1<-rep(count.dat[,1],times=count.dat$Freq)
-				Var2<-rep(count.dat[,2],times=count.dat$Freq)
-				chi.result <- stats::cor.test(as.numeric(Var1), as.numeric(Var2), method="kendall")
-
-			})
-
-			if (class(chi.result) == "try-error") {
-
-				row[["value[kTauB]"]] <- .clean(NaN)
-
-				error <- .extractErrorMessage(chi.result)
-
-				sup	<- .addFootnote(footnotes, error)
-				row[[".footnotes"]] <- list("value[kTauB]"=list(sup))
-
-			} else {
-
-				row[["value[kTauB]"]] <- unname(chi.result$estimate)
-				row[["p[kTauB]"]] <- chi.result$p.value
-				if (options$VovkSellkeMPR){
-					row[["MPR[kTauB]"]] <- .VovkSellkeMPR(row[["p[kTauB]"]])
-				}
-				row[["statistic[kTauB]"]] <- unname(chi.result$statistic)
-
-			}
-
-		} else {
-
-			 row[["value[kTauB]"]] <- "."
-			 row[["p[kTauB]"]] <- "."
-			 if (options$VovkSellkeMPR){
-				 row[["MPR[kTauB]"]] <- "."
-			 }
-		   row[["statistic[kTauB]"]] <- "."
-		}
-
-	}
-
-	list(row)
-
+# Container ----
+.crossTabContainer <- function(jaspResults, crossTabResults, ready) {
+  analyses <- crossTabResults[["analysesOrder"]]
+  for (analysis in analyses) {
+    if (is.null(jaspResults[[paste("tables", analysis$rows, analysis$columns)]])) {
+      jaspResults[[paste("tables", analysis$rows, analysis$columns)]] <- createJaspContainer("Contingency Tables")
+      jaspResults[[paste("tables", analysis$rows, analysis$columns)]]$dependOn(c("rows", "columns", "layers"))
+    }
+  }
 }
 
-.crosstabsCreateOddsRatioRows <- function(var.name, counts.matrix, footnotes, options, perform, group, status) {
+# Output Tables ----
+.crossTabMain <- function(jaspResults, dataset, options, crossTabResults, ready) {
+  analyses <- crossTabResults[["analysesOrder"]]
+  for (analysis in analyses){
+    #analysis <- analyses[[i]]
+    if (!is.null(jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabMain"]])) 
+      return()
+      
+    # Create table
+    crossTabMain <- createJaspTable(title = "Contingency Tables")
+    crossTabMain$dependOn(c("counts", "countsExpected", "percentagesRow", "percentagesColumn", "percentagesTotal"))
+    crossTabMain$showSpecifiedColumnsOnly <- TRUE
+      
+    .addLayerColumnToTable(crossTabMain, analysis)
+    if(analysis$rows == "")
+      crossTabMain$addColumnInfo(name = analysis$rows, title = " ", type = "string", combine = TRUE)
+    else 
+      crossTabMain$addColumnInfo(name = analysis$rows, type = "string", combine = TRUE)
+      
+    lvls <- c()
+      
+    if (is.factor(dataset[[ .v(analysis$columns) ]] )) {
+      lvls <- base::levels(dataset[[ .v(analysis$columns) ]])
+      if (options$columnOrder == "descending") {
+        lvls <- base::rev(lvls)
+      }
+        
+    } else {
+      lvls <- base::unique(dataset[[ .v(analysis$columns) ]])
+      if (options$columnOrder == "descending") {
+        lvls <- base::rev(lvls, decreasing = TRUE)
+      }
+    }
+    
+    overTitle <- unlist(analysis$columns)
+    if (overTitle == ""){
+      overTitle <- "."
+      lvls <- c(" .", " . ")
+    }
+      
+    counts.fp <- FALSE  # whether the counts are float point or not; changes formatting
+      
+    if (length(options$counts) > 0) {
+      counts <- dataset[[ .v(options$counts) ]]
+      if (identical(counts, as.integer(counts)) == FALSE)  # are the counts floating point?
+        counts.fp <- TRUE
+    }
+      
+    if (options$countsExpected || options$percentagesRow || options$percentagesColumn || options$percentagesTotal ) {
+      crossTabMain$addColumnInfo(name = "type[counts]", title = "", type = "string")
+        
+      if (options$countsExpected) {
+        crossTabMain$addColumnInfo(name = "type[expected]",        title = "", type = "string")
+      }
+      if (options$percentagesRow) {
+        crossTabMain$addColumnInfo(name = "type[row.proportions]", title = "", type = "string")
+      }
+      if (options$percentagesColumn) {
+        crossTabMain$addColumnInfo(name = "type[col.proportions]", title = "", type = "string")
+      }
+      if (options$percentagesTotal) {
+        crossTabMain$addColumnInfo(name = "type[proportions]",     title = "", type = "string")
+      }
+    }
+      
+    for (column.name in lvls) {
+      private.name <- base::paste(column.name,"[counts]", sep = "")
+        
+      if (counts.fp || options$countsExpected || options$percentagesRow || options$percentagesColumn || options$percentagesTotal ) 
+        crossTabMain$addColumnInfo(name = private.name, title = column.name, overtitle = overTitle, type = "number", format = "sf:4;dp:2")
+      else 
+        crossTabMain$addColumnInfo(name = private.name, title = column.name, overtitle = overTitle, type = "integer")
+      
+      if (options$countsExpected) { 
+        private.name <- base::paste(column.name,"[expected]", sep = "")
+        crossTabMain$addColumnInfo(name = private.name, title = column.name, type = "number", format = "sf:4;dp:2")
+      }
+      if (options$percentagesRow) {
+        private.name <- base::paste(column.name,"[row.proportions]", sep = "")
+        crossTabMain$addColumnInfo(name = private.name, title = column.name, type = "number", format = "dp:1;pc")
+      }
+      if (options$percentagesColumn) {
+        private.name <- base::paste(column.name,"[col.proportions]", sep = "")
+        crossTabMain$addColumnInfo(name = private.name, title = column.name, type = "number", format = "dp:1;pc")
+      }
+      if (options$percentagesTotal) {
+        private.name <- base::paste(column.name,"[proportions]", sep = "")
+        crossTabMain$addColumnInfo(name = private.name, title = column.name, type = "number", format = "dp:1;pc")
+      }
+    }
+      
+    # Totals columns
+    if (counts.fp || options$countsExpected || options$percentagesRow || options$percentagesColumn || options$percentagesTotal) 
+      crossTabMain$addColumnInfo(name = "total[counts]", title = "Total", type = "number", format = "sf:4;dp:2")
+    else 
+      crossTabMain$addColumnInfo(name = "total[counts]", title = "Total", type = "integer")
+      
+    if (options$countsExpected) 
+      crossTabMain$addColumnInfo(name = "total[expected]", title = "Total", type = "number", format = "sf:4;dp:2")
 
-	row <- list()
-
-	for (layer in names(group)) {
-
-		level <- group[[layer]]
-
-		if (level == "") {
-
-			row[[layer]] <- "Total"
-			#row[[".isNewGroup"]] <- TRUE
-
-		} else {
-
-			row[[layer]] <- level
-		}
-	}
-
-	row.footnotes <- list()
-
-	if (options$oddsRatio ) {
-
-		row[["type[oddsRatio]"]] <- "Odds ratio"
-
-		if (perform == "run" && status$error == FALSE) {
-
-			if ( ! identical(dim(counts.matrix),as.integer(c(2,2)))) {
-
-				row[["value[oddsRatio]"]] <- .clean(NaN)
-				row[["low[oddsRatio]"]] <- ""
-				row[["up[oddsRatio]"]] <-  ""
-
-				sup <- .addFootnote(footnotes, "Odds ratio restricted to 2 x 2 tables")
-				row.footnotes[["value[oddsRatio]"]]=list(sup)
-
-			} else {
-
-				chi.result <- try({
-
-					chi.result <- vcd::oddsratio(counts.matrix)
-					CI <- stats::confint(chi.result, level = options$oddsRatioConfidenceIntervalInterval)
-					LogOR <- unname(chi.result$coefficients)
-					log.CI.low <- CI[1]
-					log.CI.high <- CI[2]
-				})
-
-				if (class(chi.result) == "try-error") {
-
-					row[["value[oddsRatio]"]] <- .clean(NaN)
-
-					error <- .extractErrorMessage(chi.result)
-
-					if (error == "at least one entry of 'x' must be positive")
-						error <- "\u03A7\u00B2 could not be calculated, contains no observations"
-
-					sup   <- .addFootnote(footnotes, error)
-					row.footnotes[["value[oddsRatio]"]]=list(sup)
-
-				} else if (is.na(chi.result)) {
-
-					row[["value[oddsRatio]"]] <- .clean(NaN)
-
-					sup <- .addFootnote(footnotes, "\u03A7\u00B2 could not be calculated")
-					row.footnotes[["value[oddsRatio]"]]=list(sup)
-
-				} else {
-
-					row[["value[oddsRatio]"]] <-LogOR
-					row[["low[oddsRatio]"]] <- log.CI.low
-					row[["up[oddsRatio]"]] <- log.CI.high
-				}
-
-				row[["value[oddsRatio]"]] <- .clean(LogOR)
-				row[["low[oddsRatio]"]] <- .clean(log.CI.low)
-				row[["up[oddsRatio]"]] <-  .clean(log.CI.high)
-			}
-		}
-
-	} else {
-
-		row[["value[oddsRatio]"]] <- "."
-
-	}
-
-	if (options$oddsRatio ) {
-
-		row[["type[FisherTest]"]] <- "Fisher's exact test "
-
-		if (perform == "run" && status$error == FALSE) {
-
-			if ( ! identical(dim(counts.matrix),as.integer(c(2,2)))) {
-
-				row[["value[FisherTest]"]] <- .clean(NaN)
-				row[["low[FisherTest]"]] <- ""
-				row[["up[FisherTest]"]] <-  ""
-
-				sup <- .addFootnote(footnotes, "Odds ratio restricted to 2 x 2 tables")
-				row.footnotes[["value[FisherTest]"]]=list(sup)
-
-			} else {
-
-				chi.result <- try({
-
-					chi.result <- stats::fisher.test(counts.matrix, conf.level = options$oddsRatioConfidenceIntervalInterval)
-					OR <- unname(chi.result$estimate)
-					logOR <- log(OR)
-					log.CI.low <- log(chi.result$conf.int[1])
-					log.CI.high <- log(chi.result$conf.int[2])
-
-				})
-
-				if (class(chi.result) == "try-error") {
-
-					row[["value[FisherTest]"]] <- .clean(NaN)
-
-					error <- .extractErrorMessage(chi.result)
-
-					if (error == "at least one entry of 'x' must be positive")
-						error <- "\u03A7\u00B2 could not be calculated, contains no observations"
-
-					sup   <- .addFootnote(footnotes, error)
-					row.footnotes[["value[FisherTest]"]]=list(sup)
-
-				} else if (is.na(chi.result)) {
-
-					row[["value[FisherTest]"]] <- .clean(NaN)
-
-					sup <- .addFootnote(footnotes, "\u03A7\u00B2 could not be calculated")
-					row.footnotes[["value[FisherTest]"]]=list(sup)
-
-				} else {
-
-					row[["value[FisherTest]"]] <- logOR
-					row[["low[FisherTest]"]] <- log.CI.low
-					row[["up[FisherTest]"]] <-  log.CI.high
-				}
-
-				row[["value[FisherTest]"]] <- .clean(logOR)
-				row[["low[FisherTest]"]] <- .clean(log.CI.low)
-				row[["up[FisherTest]"]] <-  .clean(log.CI.high)
-			}
-		}
-
-	} else {
-
-		row[["value[FisherTest]"]] <- "."
-	}
-
-	row[[".footnotes"]] <- row.footnotes
-
-
-	list(row)
+    if (options$percentagesRow)
+      crossTabMain$addColumnInfo(name = "total[row.proportions]", title = "Total", type = "number", format = "dp:1;pc")
+    
+    if (options$percentagesColumn) 
+      crossTabMain$addColumnInfo(name = "total[col.proportions]", title = "Total", type = "number", format = "dp:1;pc")
+    
+    if (options$percentagesTotal) 
+      crossTabMain$addColumnInfo(name = "total[proportions]", title = "Total", type = "number", format = "dp:1;pc")
+    
+    jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabMain"]] <- crossTabMain
+    #browser()
+      #print(length(crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["maintable"]][["data"]]))
+    for (level in 1){#1:length(crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["maintable"]][["data"]])) {
+      row <- crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["maintable"]][["data"]][[level]]
+      crossTabMain$addRows(row)
+    }
+  }
 }
 
-
-
-
-.crosstabsCreateCountsRows <- function(var.name, counts.matrix, options, perform, group, status) {
-
-	rows <- list()
-	row.count <- list()
-	row.expected <- list()
-	row.row.proportions <- list()
-	row.col.proportions <- list()
-	row.proportions <- list()
-	row.count[["type[counts]"]] <- "Count"
-	row.count[["type[proportions]"]] <- "% of total"
-
-
-	if (perform == "run" && status$error == FALSE && status$ready) {
-
-		expected.matrix <- try({
-
-			stats::chisq.test(counts.matrix, correct=FALSE)$expected
-		})
-
-		if (class(expected.matrix) == "try-error") {
-
-			expected.matrix <- counts.matrix
-			expected.matrix[,] <- "&nbsp;"
-		}
-
-	} else {
-
-		expected.matrix <- counts.matrix
-	}
-
-######percentages
-
-	if (perform == "run" && status$error == FALSE && status$ready) {
-
-		row.proportions.matrix <- try({
-
-			base::prop.table(counts.matrix, 1)
-		})
-
-		if (class(row.proportions.matrix) == "try-error") {
-
-			row.proportions.matrix <- counts.matrix
-			row.proportions.matrix[,] <- "&nbsp;"
-		}
-
-	} else {
-
-		row.proportions.matrix <- counts.matrix
-	}
-
-	if (perform == "run" && status$error == FALSE && status$ready) {
-
-		col.proportions.matrix <- try({
-
-			base::prop.table(counts.matrix, 2)
-		})
-
-		if (class(col.proportions.matrix) == "try-error") {
-
-			col.proportions.matrix <- counts.matrix
-			col.proportions.matrix[,] <- "&nbsp;"
-		}
-
-	} else {
-
-		col.proportions.matrix <- counts.matrix
-	}
-
-
-	if (perform == "run" && status$error == FALSE && status$ready) {
-
-		proportions.matrix <- try({
-
-			base::prop.table(counts.matrix, margin = NULL)
-		})
-
-		if (class(proportions.matrix) == "try-error") {
-
-			proportions.matrix <- counts.matrix
-			proportions.matrix[,] <- "&nbsp;"
-		}
-
-	} else {
-
-		proportions.matrix <- counts.matrix
-	}
-
-
-	for (i in 1:dim(counts.matrix)[[1]]) {
-
-		if (perform == "run" && status$error == FALSE && status$ready) {
-
-			row <- as.list(counts.matrix[i,])
-			names(row) <- base::paste(names(row),"[counts]",	sep="")
-			row[["total[counts]"]] <- base::sum(counts.matrix[i,])
-			row <- c(row.count, row)
-
-			if (options$countsExpected) {
-
-				row.expected[["type[expected]"]] <- "Expected count"
-
-				expected <- as.list(expected.matrix[i,])
-				names(expected) <- paste(names(expected),"[expected]",  sep="")
-
-				if (class(expected.matrix[1,1]) == "character") {
-					expected[["total[expected]"]] <- ""
-				} else {
-					expected[["total[expected]"]] <- base::sum(expected.matrix[i,])
-				}
-
-				expected <- c(row.expected, expected)
-				row <- c(row, expected)
-			}
-
-			if (options$percentagesRow) {
-
-				row.row.proportions[["type[row.proportions]"]] <- " % within row"
-
-				row.proportions <- as.list(row.proportions.matrix[i,])
-				row.proportions <- .clean(row.proportions)
-				names(row.proportions) <- paste(names(row.proportions),"[row.proportions]",  sep="")
-
-				if (class(row.proportions.matrix[1,1]) == "character") {
-					row.proportions[["total[row.proportions]"]] <- ""
-				} else {
-					row.proportions[["total[row.proportions]"]] <- .clean(base::sum(row.proportions.matrix[i,]))
-				}
-
-				row.proportions <- c(row.row.proportions, row.proportions)
-				row <- c(row, row.proportions)
-			}
-
-			if (options$percentagesColumn) {
-
-				row.col.proportions[["type[col.proportions]"]] <- " % within column"
-
-				col.proportions <- as.list(col.proportions.matrix[i,])
-				col.proportions <- .clean(col.proportions)
-				names(col.proportions) <- paste(names(col.proportions),"[col.proportions]",  sep="")
-
-				if (class(col.proportions.matrix[1,1]) == "character") {
-					col.proportions[["total[col.proportions]"]] <- ""
-				} else {
-
-					row.sum <- base::margin.table(counts.matrix, 1)
-					row.prop <- as.list( base::prop.table(row.sum))
-					row.prop <- .clean(row.prop)
-					col.proportions[["total[col.proportions]"]] <- row.prop[[i]]
-				}
-
-				col.proportions <- c(row.col.proportions, col.proportions)
-				row <- c(row, col.proportions)
-			}
-
-			if (options$percentagesTotal) {
-
-				row.proportions[["type[proportions]"]] <- " % of total"
-
-				proportions <- as.list(proportions.matrix[i,])
-				proportions <- .clean(proportions)
-				names(proportions) <- paste(names(proportions),"[proportions]",  sep="")
-
-				if (class(proportions.matrix[1,1]) == "character") {
-					proportions[["total[proportions]"]] <- ""
-				} else {
-					proportions[["total[proportions]"]] <- .clean(base::sum(proportions.matrix[i,]))
-				}
-
-				proportions <- c(row.proportions, proportions)
-				row <- c(row, proportions)
-			}
-
-		} else {
-
-			row <- list()
-		}
-
-		row[[var.name]] <- dimnames(counts.matrix)[[1]][i]
-
-		for (layer in names(group)) {
-
-			level <- group[[layer]]
-
-			if (level == "") {
-
-				row[[layer]] <- "Total"
-
-			} else {
-
-				row[[layer]] <- level
-			}
-		}
-
-		if (i == 1 && options$countsExpected == FALSE && options$percentagesRow == FALSE && options$percentagesCol == FALSE && options$percentagesTotal == FALSE) {
-
-			row[[".isNewGroup"]] <- TRUE
-		}
-
-		rows[[length(rows)+1]] <- row
-	}
-
-
-	if (perform == "run" && status$error == FALSE && status$ready) {
-
-		row <- apply(counts.matrix, 2, base::sum)
-		row <- as.list(row)
-		names(row) <- base::paste(names(row),"[counts]",	sep="")
-		row[["total[counts]"]] <- base::sum(counts.matrix)
-		row <- c(row.count, row)
-
-		if (options$countsExpected) {
-
-			if (class(expected.matrix[1,1]) == "character") {
-				expected <- expected.matrix[1,]
-			} else {
-				expected <- apply(expected.matrix, 2, base::sum)
-			}
-
-			expected <- as.list(expected)
-			names(expected) <- paste(names(expected),"[expected]", sep="")
-
-			if (class(expected.matrix[1,1]) == "character") {
-				expected[["total[expected]"]] <- ""
-			} else {
-				expected[["total[expected]"]] <- base::sum(expected.matrix)
-			}
-
-			expected<-c(row.expected, expected)
-
-			row <- c(row,  expected)
-		}
-
-		if (options$percentagesRow) {
-
-			if (class(row.proportions.matrix[1,1]) == "character") {
-				row.proportions <- row.proportions.matrix[1,]
-			} else {
-				m <- base::margin.table(counts.matrix, 2)
-				rowproportion <- base::prop.table(m)
-			}
-
-			row.proportions <- as.list(rowproportion)
-			row.proportions <- .clean(row.proportions)
-			names(row.proportions) <- paste(names(row.proportions),"[row.proportions]", sep="")
-
-			if (class(row.proportions.matrix[1,1]) == "character") {
-				row.proportions[["total[row.proportions]"]] <- ""
-			} else {
-				row.proportions[["total[row.proportions]"]] <- .clean(base::sum(rowproportion))
-			}
-
-			row.proportions<-c(row.row.proportions, row.proportions)
-
-			row <- c(row,  row.proportions)
-		}
-
-		if (options$percentagesColumn) {
-
-			if (class(col.proportions.matrix[1,1]) == "character") {
-				col.proportions <- col.proportions.matrix[1,]
-			} else {
-				colproportion <- apply(col.proportions.matrix, 2, base::sum)
-			}
-
-			col.proportions <- as.list(colproportion)
-			col.proportions <- .clean(col.proportions)
-			names(col.proportions) <- paste(names(col.proportions),"[col.proportions]", sep="")
-
-			if (class(row.proportions.matrix[1,1]) == "character") {
-				col.proportions[["total[col.proportions]"]] <- ""
-			} else {
-				row.sum <- base::margin.table(counts.matrix, 1)
-				row.prop <- base::prop.table(row.sum)
-				col.proportions[["total[col.proportions]"]] <- .clean(base::sum(row.prop))
-			}
-
-			col.proportions<-c(row.col.proportions, col.proportions)
-
-			row <- c(row,  col.proportions)
-		}
-
-
-		if (options$percentagesTotal) {
-
-			if (class(proportions.matrix[1,1]) == "character") {
-				proportions <- proportions.matrix[1,]
-			} else {
-				proportions <- apply(proportions.matrix, 2, base::sum)
-			}
-
-			proportions <- as.list(proportions)
-			proportions <- .clean(proportions)
-			names(proportions) <- paste(names(proportions),"[proportions]", sep="")
-
-			if (class(proportions.matrix[1,1]) == "character") {
-				proportions[["total[proportions]"]] <- ""
-			} else {
-				proportions[["total[proportions]"]] <- .clean(base::sum(proportions.matrix))
-			}
-
-			proportions <- c(row.proportions, proportions)
-
-			row <- c(row,  proportions)
-		}
-
-	} else {
-
-		row <- list()
-	}
-
-	row[[var.name]] <- "Total"
-	if (options$countsExpected == FALSE && options$percentagesRow == FALSE && options$percentagesCol == FALSE && options$percentagesTotal == FALSE)
-		row[[".isNewGroup"]] <- TRUE
-
-	for (layer in names(group)) {
-
-		level <- group[[layer]]
-
-		if (level == "") {
-
-			row[[layer]] <- "Total"
-
-		} else {
-
-			row[[layer]] <- level
-		}
-	}
-
-	rows[[length(rows)+1]] <- row
-
-	rows
+.crossTabChisq <- function(jaspResults, dataset, options, crossTabResults, ready) {
+  if(!options$chiSquared && !options$chiSquaredContinuityCorrection && !options$likelihoodRatio) 
+    return()
+  analyses <- crossTabResults[["analysesOrder"]]
+  for (analysis in analyses){
+    #analysis <- analyses[[i]]
+    if (!is.null(jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabChisq"]])) 
+      return()
+    # Create table
+    crossTabChisq <- createJaspTable(title = "Chi-Squared Tests")
+    crossTabChisq$dependOn(c("chiSquared", "chiSquaredContinuityCorrection", "likelihoodRatio", "VovkSellkeMPR"))
+    crossTabChisq$showSpecifiedColumnsOnly <- TRUE
+    
+    # Footnotes
+    #p <- try({
+    #  crossTab <- 
+    #  crossTab[[analysis]] <- crossTab
+    #})
+    
+    #if (isTryError(p)) {
+    #  crossTabChisq$addRows(list(Variable=variable), rowNames=variable)
+    #  crossTabChisq$addFootnote(message=paste0("Results not computed: ", .extractErrorMessage(p)))
+    #}
+    #p <-
+    #message <- "\u03A7\u00B2 could not be calculated, contains no observations"
+    
+    
+    
+    
+    counts.fp <- FALSE  # whether the counts are float point or not; changes formatting
+    
+    if (length(options$counts) > 0) {
+      
+      counts <- dataset[[ .v(options$counts) ]]
+      if (identical(counts, as.integer(counts)) == FALSE)  # are the counts floating point?
+        counts.fp <- TRUE
+    }
+    # Add columns to table
+    .addLayerColumnToTable(crossTabChisq, analysis)
+    if(options$chiSquared) {
+      crossTabChisq$addColumnInfo(name = "type[chiSquared]",  title = "",      type = "string")
+      crossTabChisq$addColumnInfo(name = "value[chiSquared]", title = "Value", type = "number", format = "sf:4;dp:3")
+      crossTabChisq$addColumnInfo(name = "df[chiSquared]",    title = "df",    type = "integer")
+      crossTabChisq$addColumnInfo(name = "p[chiSquared]",     title = "p",     type = "number", format = "dp:3;p:.001")
+      if (options$VovkSellkeMPR) {
+        crossTabChisq$addColumnInfo(name = "MPR[chiSquared]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
+      }
+    }
+      
+    if(options$chiSquaredContinuityCorrection) {
+      crossTabChisq$addColumnInfo(name = "type[chiSquared-cc]", title = "", type = "string")
+      crossTabChisq$addColumnInfo(name = "value[chiSquared-cc]", title = "Value", type = "number", format = "sf:4;dp:3")
+      crossTabChisq$addColumnInfo(name = "df[chiSquared-cc]", title = "df", type = "integer")
+      crossTabChisq$addColumnInfo(name = "p[chiSquared-cc]", title = "p", type = "number", format = "dp:3;p:.001")
+      if (options$VovkSellkeMPR) {
+        crossTabChisq$addColumnInfo(name = "MPR[chiSquared-cc]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
+      }
+    }
+       
+    if(options$likelihoodRatio) {
+      crossTabChisq$addColumnInfo(name = "type[likelihood]", title = "", type = "string")
+      crossTabChisq$addColumnInfo(name = "value[likelihood]", title = "Value", type = "number", format = "sf:4;dp:3")
+      crossTabChisq$addColumnInfo(name = "df[likelihood]", title = "df", type = "integer")
+      crossTabChisq$addColumnInfo(name = "p[likelihood]", title = "p", type = "number", format = "dp:3;p:.001")
+      if (options$VovkSellkeMPR) {
+        crossTabChisq$addColumnInfo(name = "MPR[likelihood]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
+      }
+    }
+    
+    crossTabChisq$addColumnInfo(name = "type[N]", title = "", type = "string")
+    
+    if (counts.fp) {
+      crossTabChisq$addColumnInfo(name = "value[N]", title = "Value", type = "number", format = "sf:4;dp:2")
+    } else { 
+      crossTabChisq$addColumnInfo(name = "value[N]", title = "Value", type = "integer")
+    }
+    
+    crossTabChisq$addColumnInfo(name = "df[N]", title = "df")
+    crossTabChisq$addColumnInfo(name = "p[N]", title = "p")
+    if (options$VovkSellkeMPR) {
+      crossTabChisq$addColumnInfo(name = "MPR[N]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
+    }
+    
+    jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabChisq"]] <- crossTabChisq
+    
+    for (level in 1:length(crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["crossTabChisq"]][["data"]])) {
+      row <- crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["crossTabChisq"]][["data"]][[level]]
+      crossTabChisq$addRows(row)
+    }
+  }
 }
 
+.crossTabLogOdds <- function(jaspResults, dataset, options, crossTabResults, ready) {
+  if(!options$oddsRatio)
+    return()
+  analyses <- crossTabResults[["analysesOrder"]]
+  for (analysis in analyses) {
+    #analysis <- analyses[[i]]
+    if (!is.null(jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabLogOdds"]])) 
+      return()
+    
+    # Create table
+    crossTabLogOdds <- createJaspTable(title = "Log Odds Ratio")
+    crossTabLogOdds$dependOn(c("oddsRatio"))
+    crossTabLogOdds$showSpecifiedColumnsOnly <- TRUE
+    
+    ci.label <- paste(100*options$oddsRatioConfidenceIntervalInterval, "% Confidence Intervals", sep = "")
+    
+    # Add columns to table
+    .addLayerColumnToTable(crossTabLogOdds, analysis)
+    crossTabLogOdds$addColumnInfo(name = "type[oddsRatio]", title = "", type = "string")
+    crossTabLogOdds$addColumnInfo(name = "value[oddsRatio]", title = "Log Odds Ratio", type = "number", format = "sf:4;dp:3")
+    crossTabLogOdds$addColumnInfo(name = "low[oddsRatio]", title = "Lower",overtitle = ci.label, type = "number", format = "dp:3")
+    crossTabLogOdds$addColumnInfo(name = "up[oddsRatio]",  title = "Upper",overtitle = ci.label, type = "number", format = "dp:3")
+    
+    crossTabLogOdds$addColumnInfo(name = "type[FisherTest]", title = "", type = "string")
+    crossTabLogOdds$addColumnInfo(name = "value[FisherTest]", title = "Log Odds Ratio", type = "number", format = "sf:4;dp:3")
+    crossTabLogOdds$addColumnInfo(name = "low[FisherTest]", title = "Lower", overtitle = ci.label, type = "number", format = "dp:3")
+    crossTabLogOdds$addColumnInfo(name = "up[FisherTest]",  title = "Upper", overtitle = ci.label, type = "number", format = "dp:3")
+    
+    jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabLogOdds"]] <- crossTabLogOdds
+    
+    for (level in 1:length(crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["logodds"]][["data"]])) {
+      row <- crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["logodds"]][["data"]][[level]]
+      crossTabLogOdds$addRows(row)
+    }
+  }
+}
 
-.crosstabsCreateGroupMatrices <- function(dataset, rows, columns, groups, counts=NULL, rowOrderDescending=FALSE,columnOrderDescending=FALSE, perform="run", status=NULL) {
+.crossTabNominal <- function(jaspResults, dataset, options, crossTabResults, ready) {
+  if (!options$contingencyCoefficient && !options$phiAndCramersV && !options$lambda)
+    return()
+  
+  analyses <- crossTabResults[["analysesOrder"]]
+  for (analysis in analyses){
+    #analysis <- analyses[[i]]
+    
+    if (!is.null(jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabNominal"]])) 
+      return()
+    
+    # Create table
+    crossTabNominal <- createJaspTable(title = "Nominal")
+    crossTabNominal$dependOn(c("contingencyCoefficient", "phiAndCramersV"))
+    crossTabNominal$showSpecifiedColumnsOnly <- TRUE
+    
+    # Add columns to table
+    .addLayerColumnToTable(crossTabNominal, analysis)
+    if (options$contingencyCoefficient){
+      crossTabNominal$addColumnInfo(name = "type[ContCoef]", title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[ContCoef]", title = "Value", type = "number", format = "sf:4;dp:3")
+    }
+    
+    if (options$phiAndCramersV) {
+      crossTabNominal$addColumnInfo(name = "type[PhiCoef]", title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[PhiCoef]", title = "Value", type = "number", format = "sf:4;dp:3")
+      crossTabNominal$addColumnInfo(name = "type[CramerV]", title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[CramerV]", title = "Value", type = "number", format = "sf:4;dp:3")
+    }
+    
+    if (options$lambda) {
+      crossTabNominal$addColumnInfo(name = "type[LambdaR]", title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[LambdaR]", title = "Value", type = "number", format = "sf:4;dp:3")
+      crossTabNominal$addColumnInfo(name = "type[LambdaC]", title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[LambdaC]", title = "Value", type = "number", format = "sf:4;dp:3")
+    }
+    
+    jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabNominal"]] <- crossTabNominal
+    
+    for (level in 1:length(crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["nominal"]][["data"]])) {
+      row <- crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["nominal"]][["data"]][[level]]
+      crossTabNominal$addRows(row)
+    }
+  }
+}
 
-	# this creates count matrices for each of the groups
+.crossTabGamma <- function(jaspResults, dataset, options, crossTabResults, ready) {
+  if (!options$gamma)
+    return()
+  analyses <- crossTabResults[["analysesOrder"]]
+  for (analysis in analyses) {
+    #analysis <- analyses[[i]]
+    if (!is.null(jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabGamma"]])) 
+      return()
+    
+    # Create table
+    crossTabGamma <- createJaspTable(title = "Ordinal Gamma")
+    crossTabGamma$dependOn(c("gamma"))
+    crossTabGamma$showSpecifiedColumnsOnly <- TRUE
+    
+    ci.label <- paste("95% Confidence Intervals")
+    
+    # Add columns to table
+    if (length(analysis) >= 3) {
+      for (j in length(analysis):3)
+        crossTabGamma$addColumnInfo(name = analysis[[j]], type = "string", combine = TRUE)
+    }
+    crossTabGamma$addColumnInfo(name = "value[gammaCoef]", title = "Gamma", type = "number", format = "sf:4;dp:3")
+    crossTabGamma$addColumnInfo(name = "Sigma[gammaCoef]", title = "Standard Error", type = "number", format = "dp:3")
+    crossTabGamma$addColumnInfo(name = "low[gammaCoef]", title = "Lower",overtitle = ci.label, type = "number", format = "dp:3")
+    crossTabGamma$addColumnInfo(name = "up[gammaCoef]",  title = "Upper",overtitle = ci.label, type = "number", format = "dp:3")
+  
+    jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabGamma"]] <- crossTabGamma
+    
+    for (level in 1:length(crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["gamma"]][["data"]])) {
+      row <- crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["gamma"]][["data"]][[level]]
+      crossTabGamma$addRows(row)
+    }
+  }
+}
 
-	matrices <- list()
+.crossTabKendallTau <- function(jaspResults, dataset, options, crossTabResults, ready) {
+  if (!options$kendallsTauB)
+    return()
+  analyses <- crossTabResults[["analysesOrder"]]
+  for (analysis in analyses) {
+    #analysis <- analyses[[i]]
+    if (!is.null(jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabKendallTau"]])) 
+      return()
+    # Create table
+    crossTabKendallTau <- createJaspTable(title = "Kendall's Tau")
+    crossTabKendallTau$dependOn(c("kendallsTauB", "VovkSellkeMPR"))
+    crossTabKendallTau$showSpecifiedColumnsOnly <- TRUE
+    
+    # Add columns to table
+    if (length(analysis) >= 3) {
+      for (j in length(analysis):3)
+        crossTabKendallTau$addColumnInfo(name = analysis[[j]], type = "string", combine = TRUE)
+    }
+    crossTabKendallTau$addColumnInfo(name = "value[kTauB]", title = "Kendall's Tau-b ", type = "number", format = "sf:4;dp:3")
+    crossTabKendallTau$addColumnInfo(name = "statistic[kTauB]", title = "Z", type = "number", format = "dp:3")
+    crossTabKendallTau$addColumnInfo(name = "p[kTauB]", title = "p", type = "number", format = "dp:3;p:.001")
+    if (options$VovkSellkeMPR){
+      crossTabKendallTau$addColumnInfo(name = "MPR[kTauB]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
+    }
+    jaspResults[[paste("tables", analysis$rows, analysis$columns)]][["crossTabKendallTau"]] <- crossTabKendallTau
+    
+    for (level in 1:length(crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["kendallTau"]][["data"]])) {
+      row <- crossTabResults[[paste0("tables", analysis$rows, analysis$columns)]][["kendallTau"]][["data"]][[level]]
+      crossTabKendallTau$addRows(row)
+    }
+  }
+}
 
-	if (is.null(groups)) {
+# Other ----
+.addLayerColumnToTable <- function(table, analysis) {
+  if (length(analysis) >= 3)
+    for (j in length(analysis):3)
+      table$addColumnInfo(name = analysis[[j]], type = "string", combine = TRUE)
+}
 
-		if (status$ready == FALSE || perform == "init") {
+.crosstabsCreateGroupMatrices <- function(dataset, rows, columns, groups, counts = NULL, rowOrderDescending=FALSE, columnOrderDescending=FALSE, ready) {
+  
+  # this creates count matrices for each of the groups
+  
+  matrices <- list()
+  
+  if (is.null(groups)) {
+    
+    if (!ready) {
+      
+      row.levels <- c(" .", " . ")
+      col.levels <- c(" .", " . ")
+      
+      if (rows != "")
+        row.levels <- base::levels(dataset[[ .v(rows) ]])
+      if (columns != "")
+        col.levels <- base::levels(dataset[[ .v(columns) ]])
+      
+      ss.matrix <- base::matrix(0, nrow = length(row.levels), ncol = length(col.levels), dimnames = list(row.levels, col.levels))
+      
+    } else if (is.null(counts)) {
+      ss.dataset <- base::subset(dataset, select = .v(c(rows, columns)))
+      ss.table   <- base::table(ss.dataset)
+      ss.matrix  <- base::matrix(ss.table, nrow = dim(ss.table)[1], ncol = dim(ss.table)[2], dimnames = dimnames(ss.table))
+      
+    } else {
+      ss.dataset <- base::subset(dataset, select = .v(c(rows, columns, counts)))
+      ss.matrix  <- base::tapply(ss.dataset[[ .v(counts) ]], list(ss.dataset[[ .v(rows) ]], ss.dataset[[ .v(columns) ]]), base::sum)
+      ss.matrix[is.na(ss.matrix)] <- 0
+    }
+    
+    if (rowOrderDescending) {
+      ss.matrix <- base::apply(ss.matrix, 2, base::rev)
+    } else {
+      ss.matrix <- ss.matrix
+    }
+    
+    if (columnOrderDescending) {
+      ss.matrix <- ss.matrix[ , ncol(ss.matrix):1]
+    } else {
+      ss.matrix <- ss.matrix
+    }
+    
+    ss.matrix[base::is.na(ss.matrix)] <- 0
+    
+    matrices[[1]] <- ss.matrix
+    
+  } else {
+    
+    for (group in groups) {
+      
+      group <- group[group != ""]
+      
+      if (!ready) {
+        # do nothing
+      } else if (length(group) == 0) {
+        ss.dataset <- base::subset(dataset, select = .v(c(rows, columns, counts)))
+      } else {
+        ss.filter.string <- base::paste(.v(names(group)), "==\"", group, "\"", sep = "", collapse = "&")
+        ss.expression    <- base::parse(text = ss.filter.string)
+        ss.dataset	     <- base::subset(dataset, select = .v(c(rows, columns, counts)), subset = eval(ss.expression))
+      }
+      
+      if (!ready) {
+        ss.matrix <- base::matrix(c(0,0,0,0), nrow = 2, ncol = 2)
+      } else if (is.null(counts)) {
+        ss.table  <- base::table(ss.dataset)
+        ss.matrix <- base::matrix(ss.table, nrow = dim(ss.table)[1], ncol = dim(ss.table)[2], dimnames = dimnames(ss.table))
+      } else {
+        ss.matrix <- base::tapply(ss.dataset[[ .v(counts) ]], list(ss.dataset[[ .v(rows) ]], ss.dataset[[ .v(columns) ]]), base::sum)
+      }
+      
+      ss.matrix[base::is.na(ss.matrix)] <- 0
+      
+      if (rowOrderDescending) {
+        ss.matrix <- base::apply(ss.matrix, 2, base::rev)
+      } else {
+        ss.matrix <- ss.matrix
+      }
+      
+      if (columnOrderDescending) {
+        ss.matrix <- ss.matrix[ , ncol(ss.matrix):1]
+      } else {
+        ss.matrix <- ss.matrix
+      }
+      matrices[[length(matrices)+1]] <- ss.matrix
+    }
+  }
+  return(matrices)
+}
 
-			row.levels <- c(".", ". ")
-			col.levels <- c(".", ". ")
+.crosstabsCreateCountsRows <- function(var.name, counts.matrix, options, group, ready) {
+  
+  rows <- list()
+  row.count <- list()
+  row.expected <- list()
+  row.row.proportions <- list()
+  row.col.proportions <- list()
+  row.proportions <- list()
+  row.count[["type[counts]"]] <- "Count"
+  row.count[["type[proportions]"]] <- "% of total"
+  
+  if (ready) {
+    
+    expected.matrix <- try({
+      
+      stats::chisq.test(counts.matrix, correct=FALSE)$expected
+    })
+    
+    if (class(expected.matrix) == "try-error") {
+      expected.matrix <- counts.matrix
+      expected.matrix[,] <- "&nbsp;"
+    }
+    
+  } else {
+    expected.matrix <- counts.matrix
+  }
+  ######percentages
+  if (ready) {
+    
+    row.proportions.matrix <- try({
+      
+      base::prop.table(counts.matrix, 1)
+    })
+    
+    if (class(row.proportions.matrix) == "try-error") {
+      
+      row.proportions.matrix <- counts.matrix
+      row.proportions.matrix[,] <- "&nbsp;"
+    }
+    
+  } else {
+    
+    row.proportions.matrix <- counts.matrix
+  }
+  
+  if (ready) {
+    
+    col.proportions.matrix <- try({
+      
+      base::prop.table(counts.matrix, 2)
+    })
+    
+    if (class(col.proportions.matrix) == "try-error") {
+      
+      col.proportions.matrix    <- counts.matrix
+      col.proportions.matrix[,] <- "&nbsp;"
+    }
+    
+  } else {
+    
+    col.proportions.matrix <- counts.matrix
+  }
+  
+  if (ready) {
+    
+    proportions.matrix <- try({
+      
+      base::prop.table(counts.matrix, margin = NULL)
+    })
+    
+    if (class(proportions.matrix) == "try-error") {
+      
+      proportions.matrix    <- counts.matrix
+      proportions.matrix[,] <- "&nbsp;"
+    }
+    
+  } else {
+    
+    proportions.matrix <- counts.matrix
+  }
+  
+  for (i in 1:dim(counts.matrix)[[1]]) {
+    
+    if (ready) {
+      
+      row <- as.list(counts.matrix[i,])
+      names(row) <- base::paste(names(row),"[counts]",	sep = "")
+      row[["total[counts]"]] <- base::sum(counts.matrix[i,])
+      row <- c(row.count, row)
+      
+      if (options$countsExpected) {
+        
+        row.expected[["type[expected]"]] <- "Expected count"
+        
+        expected <- as.list(expected.matrix[i,])
+        names(expected) <- paste(names(expected),"[expected]",  sep = "")
+        
+        if (class(expected.matrix[1,1]) == "character") {
+          expected[["total[expected]"]] <- ""
+        } else {
+          expected[["total[expected]"]] <- base::sum(expected.matrix[i,])
+        }
+        
+        expected <- c(row.expected, expected)
+        row <- c(row, expected)
+      }
+      
+      if (options$percentagesRow) {
+        
+        row.row.proportions[["type[row.proportions]"]] <- " % within row"
+        
+        row.proportions <- as.list(row.proportions.matrix[i,])
+        row.proportions <- .clean(row.proportions)
+        names(row.proportions) <- paste(names(row.proportions),"[row.proportions]",  sep = "")
+        
+        if (class(row.proportions.matrix[1,1]) == "character") {
+          row.proportions[["total[row.proportions]"]] <- ""
+        } else {
+          row.proportions[["total[row.proportions]"]] <- .clean(base::sum(row.proportions.matrix[i,]))
+        }
+        
+        row.proportions <- c(row.row.proportions, row.proportions)
+        row <- c(row, row.proportions)
+      }
+      
+      if (options$percentagesColumn) {
+        
+        row.col.proportions[["type[col.proportions]"]] <- " % within column"
+        
+        col.proportions <- as.list(col.proportions.matrix[i,])
+        col.proportions <- .clean(col.proportions)
+        names(col.proportions) <- paste(names(col.proportions),"[col.proportions]",  sep = "")
+        
+        if (class(col.proportions.matrix[1,1]) == "character") {
+          col.proportions[["total[col.proportions]"]] <- ""
+        } else {
+          
+          row.sum  <- base::margin.table(counts.matrix, 1)
+          row.prop <- as.list( base::prop.table(row.sum))
+          row.prop <- .clean(row.prop)
+          col.proportions[["total[col.proportions]"]] <- row.prop[[i]]
+        }
+        
+        col.proportions <- c(row.col.proportions, col.proportions)
+        row <- c(row, col.proportions)
+      }
+      
+      if (options$percentagesTotal) {
+        
+        row.proportions[["type[proportions]"]] <- " % of total"
+        
+        proportions <- as.list(proportions.matrix[i,])
+        proportions <- .clean(proportions)
+        names(proportions) <- paste(names(proportions),"[proportions]",  sep="")
+        
+        if (class(proportions.matrix[1,1]) == "character") {
+          proportions[["total[proportions]"]] <- ""
+        } else {
+          proportions[["total[proportions]"]] <- .clean(base::sum(proportions.matrix[i,]))
+        }
+        
+        proportions <- c(row.proportions, proportions)
+        row <- c(row, proportions)
+      }
+      
+    } else {
+      
+      row <- list()
+    }
+    
+    row[[var.name]] <- dimnames(counts.matrix)[[1]][i]
+    
+    for (layer in names(group)) {
+      
+      level <- group[[layer]]
+      
+      if (level == "") {
+        
+        row[[layer]] <- "Total"
+        
+      } else {
+        
+        row[[layer]] <- level
+      }
+    }
+    
+    if (i == 1 && options$countsExpected == FALSE && options$percentagesRow == FALSE && options$percentagesCol == FALSE && options$percentagesTotal == FALSE) {
+      
+      row[[".isNewGroup"]] <- TRUE
+    }
+    
+    rows[[length(rows)+1]] <- row
+  }
+  
+  if (ready) {
+    
+    row <- apply(counts.matrix, 2, base::sum)
+    row <- as.list(row)
+    names(row) <- base::paste(names(row),"[counts]",	sep="")
+    row[["total[counts]"]] <- base::sum(counts.matrix)
+    row <- c(row.count, row)
+    
+    if (options$countsExpected) {
+      
+      if (class(expected.matrix[1,1]) == "character") {
+        expected <- expected.matrix[1,]
+      } else {
+        expected <- apply(expected.matrix, 2, base::sum)
+      }
+      
+      expected <- as.list(expected)
+      names(expected) <- paste(names(expected),"[expected]", sep="")
+      
+      if (class(expected.matrix[1,1]) == "character") {
+        expected[["total[expected]"]] <- ""
+      } else {
+        expected[["total[expected]"]] <- base::sum(expected.matrix)
+      }
+      
+      expected<-c(row.expected, expected)
+      
+      row <- c(row,  expected)
+    }
+    
+    if (options$percentagesRow) {
+      
+      if (class(row.proportions.matrix[1,1]) == "character") {
+        row.proportions <- row.proportions.matrix[1,]
+      } else {
+        m <- base::margin.table(counts.matrix, 2)
+        rowproportion <- base::prop.table(m)
+      }
+      
+      row.proportions <- as.list(rowproportion)
+      row.proportions <- .clean(row.proportions)
+      names(row.proportions) <- paste(names(row.proportions),"[row.proportions]", sep="")
+      
+      if (class(row.proportions.matrix[1,1]) == "character") {
+        row.proportions[["total[row.proportions]"]] <- ""
+      } else {
+        row.proportions[["total[row.proportions]"]] <- .clean(base::sum(rowproportion))
+      }
+      
+      row.proportions<-c(row.row.proportions, row.proportions)
+      
+      row <- c(row,  row.proportions)
+    }
+    
+    if (options$percentagesColumn) {
+      
+      if (class(col.proportions.matrix[1,1]) == "character") {
+        col.proportions <- col.proportions.matrix[1,]
+      } else {
+        colproportion <- apply(col.proportions.matrix, 2, base::sum)
+      }
+      
+      col.proportions <- as.list(colproportion)
+      col.proportions <- .clean(col.proportions)
+      names(col.proportions) <- paste(names(col.proportions),"[col.proportions]", sep="")
+      
+      if (class(row.proportions.matrix[1,1]) == "character") {
+        col.proportions[["total[col.proportions]"]] <- ""
+      } else {
+        row.sum <- base::margin.table(counts.matrix, 1)
+        row.prop <- base::prop.table(row.sum)
+        col.proportions[["total[col.proportions]"]] <- .clean(base::sum(row.prop))
+      }
+      
+      col.proportions<-c(row.col.proportions, col.proportions)
+      
+      row <- c(row,  col.proportions)
+    }
+    
+    
+    if (options$percentagesTotal) {
+      
+      if (class(proportions.matrix[1,1]) == "character") {
+        proportions <- proportions.matrix[1,]
+      } else {
+        proportions <- apply(proportions.matrix, 2, base::sum)
+      }
+      
+      proportions <- as.list(proportions)
+      proportions <- .clean(proportions)
+      names(proportions) <- paste(names(proportions),"[proportions]", sep="")
+      
+      if (class(proportions.matrix[1,1]) == "character") {
+        proportions[["total[proportions]"]] <- ""
+      } else {
+        proportions[["total[proportions]"]] <- .clean(base::sum(proportions.matrix))
+      }
+      
+      proportions <- c(row.proportions, proportions)
+      
+      row <- c(row,  proportions)
+    }
+    
+  } else {
+    
+    row <- list()
+  }
+  
+  row[[var.name]] <- "Total"
+  if (options$countsExpected == FALSE && options$percentagesRow == FALSE && options$percentagesCol == FALSE && options$percentagesTotal == FALSE)
+    row[[".isNewGroup"]] <- TRUE
+  
+  for (layer in names(group)) {
+    
+    level <- group[[layer]]
+    
+    if (level == "") {
+      
+      row[[layer]] <- "Total"
+      
+    } else {
+      
+      row[[layer]] <- level
+    }
+  }
+  
+  rows[[length(rows)+1]] <- row
+  
+  rows
+}
 
-			if (rows != "")
-				row.levels <- base::levels(dataset[[ .v(rows) ]])
-			if (columns != "")
-				col.levels <- base::levels(dataset[[ .v(columns) ]])
+.crosstabsCreateTestsRows <- function(var.name, counts.matrix, options, group, ready) {
+  if(!options$chiSquared && !options$chiSquaredContinuityCorrection && !options$likelihoodRatio) 
+    return()
+  
+  row <- list()
+  
+  for (layer in names(group)) {
+    level <- group[[layer]]
+    if (level == "") {
+      row[[layer]] <- "Total"
+    } else {
+      row[[layer]] <- level
+    }
+  }
+  
+  row[["type[N]"]] <- "N"
+  row[["df[N]"]]   <- ""
+  row[["p[N]"]]    <- ""
+  row[["MPR[N]"]]  <- ""
+  
+  if (ready)
+    row[["value[N]"]] <- base::sum(counts.matrix)
+  else 
+    row[["value[N]"]] <- "."
+  
+  if (options$chiSquared) {
+    
+    row[["type[chiSquared]"]] <- "\u03A7\u00B2"
+    
+    if (ready) {
+      
+      chi.result <- try({
+        chi.result <- stats::chisq.test(counts.matrix, correct = FALSE)
+      })
+      
+      if (class(chi.result) == "try-error") {
+        
+        row[["value[chiSquared]"]] <- .clean(NaN)
+        row[["df[chiSquared]"]]    <- " "
+        row[["p[chiSquared]"]]     <- " "
+        row[["MPR[chiSquared]"]]   <- " "
+        
+        #error <- .extractErrorMessage(chi.result)
+        
+        #if (error == "at least one entry of 'x' must be positive")
+        #  error <- "\u03A7\u00B2 could not be calculated, contains no observations"
+        
+        #sup	<- .addFootnote(footnotes, error)
+        #row.footnotes[["value[chiSquared]"]]=list(sup)
+        
+      } else if (is.na(chi.result$statistic)) {
+        
+        row[["value[chiSquared]"]] <- .clean(NaN)
+        row[["df[chiSquared]"]]    <- " "
+        row[["p[chiSquared]"]]     <- " "
+        row[["MPR[chiSquared]"]]   <- " "
+        
+        #message <- "\u03A7\u00B2 could not be calculated - At least one row or column contains all zeros"
+        
+        #sup <- .addFootnote(footnotes, "Odds ratio restricted to 2 x 2 tables")
+        #row.footnotes[["value[oddsRatio]"]]=list(sup)
+        
+        #warn <- warnings()
+        #if (length(warn) > 0)
+        #	message <- paste(message, names(warn)[1], sep = " : ")
+        
+        #sup <- .addFootnote(footnotes, message)
+        #row.footnotes [["value[chiSquared]"]]=list(sup)
+        
+      } else {
+        
+        row[["value[chiSquared]"]] <- unname(chi.result$statistic)
+        row[["df[chiSquared]"]]    <- unname(chi.result$parameter)
+        row[["p[chiSquared]"]]     <- unname(chi.result$p.value)
+        row[["MPR[chiSquared]"]]   <- .VovkSellkeMPR(row[["p[chiSquared]"]])
+      }
+    } else {
+      row[["value[chiSquared]"]] <- "."
+    }
+  }
+  
+  if (options$chiSquaredContinuityCorrection) {
+    
+    row[["type[chiSquared-cc]"]] <- "\u03A7\u00B2 continuity correction"
+    
+    if (ready) {
+      
+      chi.result <- try({
+        chi.result <- stats::chisq.test(counts.matrix)
+        #row <- list(Method="Pearson's Chi-squared", X2=unname(chi$statistic), df=unname(chi$parameter), p = chi$p.value)
+      })
+      
+      if (class(chi.result) == "try-error") {
+        
+        row[["value[chiSquared-cc]"]] <- .clean(NaN)
+        row[["df[chiSquared-cc]"]]    <- " "
+        row[["p[chiSquared-cc]"]]     <- " "
+        row[["MPR[chiSquared-cc]"]]   <- " "
+        
+        #error <- .extractErrorMessage(chi.result)
+        
+        #if (error == "at least one entry of 'x' must be positive")
+        #  error <- "\u03A7\u00B2 could not be calculated, contains no observations"
+        
+        #sup	<- .addFootnote(footnotes, error)
+        #row.footnotes [["value[chiSquared-cc]"]]=list(sup)
+        
+      } else if (is.na(chi.result$statistic)) {
+        
+        row[["value[chiSquared-cc]"]] <- .clean(NaN)
+        row[["df[chiSquared-cc]"]]    <- " "
+        row[["p[chiSquared-cc]"]]     <- " "
+        row[["MPR[chiSquared-cc]"]]   <- " "
+        
+        #sup <- .addFootnote(footnotes, "\u03A7\u00B2 could not be calculated - At least one row or column contains all zeros")
+        #row.footnotes [["value[chiSquared-cc]"]]=list(sup)
+        
+      } else {
+        
+        row[["value[chiSquared-cc]"]] <- unname(chi.result$statistic)
+        row[["df[chiSquared-cc]"]]    <- unname(chi.result$parameter)
+        row[["p[chiSquared-cc]"]]     <- unname(chi.result$p.value)
+        row[["MPR[chiSquared-cc]"]]   <- .VovkSellkeMPR(row[["p[chiSquared-cc]"]])
+        
+      }
+      
+    } else {
+      
+      row[["value[chiSquared-cc]"]] <- "."
+    }
+  }
+  
+  if (options$likelihoodRatio) {
+    
+    row[["type[likelihood]"]] <- "Likelihood ratio"
+    
+    if (ready) {
+      
+      chi.result <- try({
+        chi.result <- vcd::assocstats(counts.matrix)
+      })
+      
+      if (class(chi.result) == "try-error") {
+        
+        row[["value[likelihood]"]] <- .clean(NaN)
+        row[["df[likelihood]"]]    <- ""
+        row[["p[likelihood]"]]     <-""
+        row[["MPR[likelihood]"]]   <-""
+        
+        #error <- .extractErrorMessage(chi.result)
+        
+        #sup	<- .addFootnote(footnotes, error)
+        #row.footnotes[["value[likelihood]"]] = list(sup)
+        
+      } else {
+        row[["value[likelihood]"]] <- chi.result$chisq_tests[1]
+        row[["df[likelihood]"]]    <- chi.result$chisq_tests[3]
+        row[["p[likelihood]"]]     <- chi.result$chisq_tests[5]
+        row[["MPR[likelihood]"]]   <- .VovkSellkeMPR(row[["p[likelihood]"]])
+      }
+      
+    } else {
+      row[["value[likelihood]"]] <- "."
+    }
+  }
+  
+  list(row)
+}
 
-			ss.matrix <- base::matrix(0, nrow=length(row.levels), ncol=length(col.levels), dimnames=list(row.levels, col.levels))
+.crosstabsCreateOddsRatioRows <- function(var.name, counts.matrix, options, group, ready) {
+  if(!options$oddsRatio)
+    return()
+  
+  row <- list()
+  
+  for (layer in names(group)) {
+    
+    level <- group[[layer]]
+    
+    if (level == "") {
+      
+      row[[layer]] <- "Total"
+      #row[[".isNewGroup"]] <- TRUE
+      
+    } else {
+      
+      row[[layer]] <- level
+    }
+  }
+  
+  row.footnotes <- list()
+  
+  if (options$oddsRatio ) {
+    
+    row[["type[oddsRatio]"]] <- "Odds ratio"
+    
+    if (ready) {
+      
+      if ( ! identical(dim(counts.matrix),as.integer(c(2,2)))) {
+        
+        row[["value[oddsRatio]"]] <- .clean(NaN)
+        row[["low[oddsRatio]"]] <- ""
+        row[["up[oddsRatio]"]] <-  ""
+        
+        #sup <- .addFootnote(footnotes, "Odds ratio restricted to 2 x 2 tables")
+        #row.footnotes[["value[oddsRatio]"]]=list(sup)
+        
+      } else {
+        
+        chi.result <- try({
+          
+          chi.result <- vcd::oddsratio(counts.matrix)
+          CI <- stats::confint(chi.result, level = options$oddsRatioConfidenceIntervalInterval)
+          LogOR <- unname(chi.result$coefficients)
+          log.CI.low <- CI[1]
+          log.CI.high <- CI[2]
+        })
+        
+        if (class(chi.result) == "try-error") {
+          
+          row[["value[oddsRatio]"]] <- .clean(NaN)
+          
+          error <- .extractErrorMessage(chi.result)
+          
+          if (error == "at least one entry of 'x' must be positive")
+            error <- "\u03A7\u00B2 could not be calculated, contains no observations"
+          
+          sup   <- .addFootnote(footnotes, error)
+          row.footnotes[["value[oddsRatio]"]]=list(sup)
+          
+        } else if (is.na(chi.result)) {
+          
+          row[["value[oddsRatio]"]] <- .clean(NaN)
+          
+          sup <- .addFootnote(footnotes, "\u03A7\u00B2 could not be calculated")
+          row.footnotes[["value[oddsRatio]"]]=list(sup)
+          
+        } else {
+          
+          row[["value[oddsRatio]"]] <-LogOR
+          row[["low[oddsRatio]"]] <- log.CI.low
+          row[["up[oddsRatio]"]] <- log.CI.high
+        }
+        
+        row[["value[oddsRatio]"]] <- .clean(LogOR)
+        row[["low[oddsRatio]"]] <- .clean(log.CI.low)
+        row[["up[oddsRatio]"]] <-  .clean(log.CI.high)
+      }
+    }
+    
+  } else {
+    
+    row[["value[oddsRatio]"]] <- "."
+    
+  }
+  
+  if (options$oddsRatio ) {
+    
+    row[["type[FisherTest]"]] <- "Fisher's exact test "
+    
+    if (ready) {
+      
+      if ( ! identical(dim(counts.matrix),as.integer(c(2,2)))) {
+        
+        row[["value[FisherTest]"]] <- .clean(NaN)
+        row[["low[FisherTest]"]] <- ""
+        row[["up[FisherTest]"]] <-  ""
+        
+        #sup <- .addFootnote(footnotes, "Odds ratio restricted to 2 x 2 tables")
+        #row.footnotes[["value[FisherTest]"]]=list(sup)
+        
+      } else {
+        
+        chi.result <- try({
+          chi.result  <- stats::fisher.test(counts.matrix, conf.level = options$oddsRatioConfidenceIntervalInterval)
+          OR          <- unname(chi.result$estimate)
+          logOR       <- log(OR)
+          log.CI.low  <- log(chi.result$conf.int[1])
+          log.CI.high <- log(chi.result$conf.int[2])
+        })
+        
+        if (class(chi.result) == "try-error") {
+          
+          row[["value[FisherTest]"]] <- .clean(NaN)
+          
+          #error <- .extractErrorMessage(chi.result)
+          
+          #if (error == "at least one entry of 'x' must be positive")
+          #  error <- "\u03A7\u00B2 could not be calculated, contains no observations"
+          
+          #sup   <- .addFootnote(footnotes, error)
+          #row.footnotes[["value[FisherTest]"]]=list(sup)
+          
+        } else if (is.na(chi.result)) {
+          
+          row[["value[FisherTest]"]] <- .clean(NaN)
+          
+          #sup <- .addFootnote(footnotes, "\u03A7\u00B2 could not be calculated")
+          #row.footnotes[["value[FisherTest]"]]=list(sup)
+          
+        } else {
+          row[["value[FisherTest]"]] <- logOR
+          row[["low[FisherTest]"]]   <- log.CI.low
+          row[["up[FisherTest]"]]    <- log.CI.high
+        }
+        
+        row[["value[FisherTest]"]] <- .clean(logOR)
+        row[["low[FisherTest]"]]   <- .clean(log.CI.low)
+        row[["up[FisherTest]"]]    <- .clean(log.CI.high)
+      }
+    }
+    
+  } else {
+    row[["value[FisherTest]"]] <- "."
+  }
+  
+  #row[[".footnotes"]] <- row.footnotes
+  list(row)
+}
 
-		} else if (is.null(counts)) {
+.crosstabsCreateNominalRows <- function(var.name, counts.matrix, options, group, ready) {
+  if (!options$contingencyCoefficient && !options$phiAndCramersV && !options$lambda)
+    return()
+  
+  row <- list()
+  
+  for (layer in names(group)) {
+    
+    level <- group[[layer]]
+    
+    if (level == "") {
+      
+      row[[layer]] <- "Total"
+      
+    } else {
+      
+      row[[layer]] <- level
+    }
+  }
+  
+  row.footnotes <- list ()
+  
+  if (options$contingencyCoefficient) {
+    
+    row[["type[ContCoef]"]] <- "Contingency coefficient"
+    
+    if (ready) {
+      
+      chi.result <- try({
+        
+        chi.result <- vcd::assocstats(counts.matrix)
+        
+      })
+      
+      if (class(chi.result) == "try-error") {
+        
+        row[["value[ContCoef]"]] <- .clean(NaN)
+        
+        error <- .extractErrorMessage(chi.result)
+        
+        sup	<- .addFootnote(footnotes, error)
+        row.footnotes[["value[ContCoef]"]] <- list(sup)
+        
+      } else if (is.na(chi.result$contingency)) {
+        
+        row[["value[ContCoef]"]] <- .clean(NaN)
+        
+        sup <- .addFootnote(footnotes, "Value could not be calculated - At least one row or column contains all zeros")
+        row.footnotes[["value[ContCoef]"]] <- list(sup)
+        
+      } else {
+        
+        row[["value[ContCoef]"]] <- chi.result$contingency
+      }
+      
+    } else {
+      row[["value[ContCoef]"]] <- "."
+    }
+  }
+  if (options$phiAndCramersV) {
+    
+    row[["type[PhiCoef]"]] <- "Phi-coefficient"
+    
+    if (ready) {
+      chi.result <- try({
+        chi.result <- vcd::assocstats(counts.matrix)
+      })
+      
+      if (class(chi.result) == "try-error") {
+        
+        row[["value[PhiCoef]"]] <- .clean(NaN)
+        
+        #error <- .extractErrorMessage(chi.result)
+        
+        #sup	<- .addFootnote(footnotes, error)
+        #row[["value[PhiCoef]"]] <- list(sup)
+        
+      } else if (is.na(chi.result$phi)) {
+        
+        row[["value[PhiCoef]"]] <- .clean(NaN)
+        
+        #sup <- .addFootnote(footnotes, "Value could not be calculated - At least one row or column contains all zeros")
+        #row.footnotes[["value[PhiCoef]"]] <- list(sup)
+        #row.footnotes <- c(row.footnotes, list("value[PhiCoef]"=list(sup)))
+        
+      } else {
+        row[["value[PhiCoef]"]] <- chi.result$phi
+      }
+    } else {
+      row[["value[PhiCoef]"]] <- "."
+    }
+  }
+  if (options$phiAndCramersV) {
+    
+    row[["type[CramerV]"]] <- "Cramer's V "
+    
+    if (ready) {
+      
+      chi.result <- try({
+        
+        chi.result <- vcd::assocstats(counts.matrix)
+        
+      })
+      
+      if (class(chi.result) == "try-error") {
+        
+        row[["value[CramerV]"]] <- .clean(NaN)
+        
+        #error <- .extractErrorMessage(chi.result)
+        
+        #sup	<- .addFootnote(footnotes, error)
+        #row.footnotes[["value[CramerV]"]] <- list(sup)
+        
+      } else if (is.na(chi.result$cramer)) {
+        
+        row[["value[CramerV]"]] <- .clean(NaN)
+        
+        #sup <- .addFootnote(footnotes, "Value could not be calculated - At least one row or column contains all zeros")
+        #row.footnotes[["value[CramerV]"]] <- list(sup)
+        
+      } else {
+        
+        row[["value[CramerV]"]] <- chi.result$cramer
+      }
+      
+    } else {
+      
+      row[["value[CramerV]"]] <- "."
+    }
+  }
+  if (options$lambda) {
+    
+    row[["type[LambdaR]"]] <- paste("Lambda (", options$rows, "dependent)", sep =  " ")
+    
+    if (ready) {
+      
+      N <- sum(counts.matrix)
+      E1 <- N- max(rowSums(counts.matrix))
+      E2 <- sum(apply(counts.matrix,2, function (x) sum(x)-max(x) ))
+      lambda<-(E1-E2)/E1
+      row[["value[LambdaR]"]] <- lambda
+      
+      if (is.na(lambda)) {
+        
+        row[["value[LambdaR]"]] <- .clean(NaN)
+        
+        #sup <- .addFootnote(footnotes, "Value could not be calculated - At least one row sums or column sums contains all zeros")
+        #row.footnotes[["value[LambdaR]"]] <- list(sup)
+      }
+    } else {
+      
+      row[["value[LambdaR]"]] <- "."
+    }
+  }
+  if (options$lambda) {
+    
+    row[["type[LambdaC]"]] <- paste("Lambda (", options$columns, "dependent)", sep =  " ")
+    
+    if (ready) {
+      
+      N <- sum(counts.matrix)
+      E1 <- N- max(colSums(counts.matrix))
+      E2 <- sum(apply(counts.matrix,1, function (x) sum(x)-max(x) ))
+      lambda<-(E1-E2)/E1
+      #print(N)
+      #print(E1)
+      #print(E2)
+      #print(lambda)
+      row[["value[LambdaC]"]] <- lambda
+    } else {
+      row[["value[LambdaC]"]] <- "."
+    }
+  }
+  #row[[".footnotes"]] <- row.footnotes
+  list(row)
+}
 
-			ss.dataset <- base::subset(dataset, select=.v(c(rows, columns)))
-			ss.table   <- base::table(ss.dataset)
-			ss.matrix  <- base::matrix(ss.table, nrow=dim(ss.table)[1], ncol=dim(ss.table)[2], dimnames=dimnames(ss.table))
+.crosstabsCreateOrdinalRows <- function(var.name, counts.matrix, options, group, ready) {
+  if (!options$gamma)
+    return()
+  
+  row <- list()
+  for (layer in names(group)) {
+    
+    level <- group[[layer]]
+    
+    if (level == "") {
+      
+      row[[layer]] <- "Total"
+      
+    } else {
+      
+      row[[layer]] <- level
+    }
+  }
 
-		} else {
+  if (options$gamma) {
+    
+    row[["type[gammaCoef]"]] <- "Gamma coefficient"
+    
+    chi.result <- try({
+      chi.result <- vcdExtra::GKgamma(counts.matrix)
+    })
+      
+    #print(chi.result)
+    #print("we are here")
+      
+    if (class(chi.result) == "try-error") {
+      row[["value[gammaCoef]"]] <- .clean(NaN)
+      #error <- .extractErrorMessage(chi.result)
+        
+      #sup	<- .addFootnote(footnotes, error)
+      #row[[".footnotes"]] <- list("value[gammaCoef]"=list(sup))
+    } else {
+      row[["value[gammaCoef]"]] <- chi.result$gamma
+      row[["Sigma[gammaCoef]"]] <- chi.result$sigma
+      row[["low[gammaCoef]"]]   <- chi.result$CI[1]
+      row[["up[gammaCoef]"]]    <- chi.result$CI[2]
+    }
+  }
+  list(row)
+}
 
-			ss.dataset <- base::subset(dataset, select=.v(c(rows, columns, counts)))
-			ss.matrix  <- base::tapply(ss.dataset[[ .v(counts) ]], list(ss.dataset[[ .v(rows) ]], ss.dataset[[ .v(columns) ]]), base::sum)
-			ss.matrix[is.na(ss.matrix)] <- 0
-		}
-
-		if (rowOrderDescending) {
-			ss.matrix <- base::apply(ss.matrix, 2, base::rev)
-		} else {
-			ss.matrix <- ss.matrix
-		}
-
-		if (columnOrderDescending) {
-			ss.matrix <- ss.matrix[ , ncol(ss.matrix):1]
-		} else {
-			ss.matrix <- ss.matrix
-		}
-
-		ss.matrix[base::is.na(ss.matrix)] <- 0
-
-		matrices[[1]] <- ss.matrix
-
-	} else {
-
-		for (group in groups) {
-
-			group <- group[group != ""]
-
-			if (status$ready == FALSE) {
-
-				# do nothing
-
-			} else if (length(group) == 0) {
-
-				ss.dataset <- base::subset(dataset, select=.v(c(rows, columns, counts)))
-
-			} else {
-
-				ss.filter.string <- base::paste(.v(names(group)), "==\"", group, "\"", sep="", collapse="&")
-				ss.expression <- base::parse(text=ss.filter.string)
-				ss.dataset	  <- base::subset(dataset, select=.v(c(rows, columns, counts)), subset=eval(ss.expression))
-			}
-
-
-			if (status$ready == FALSE) {
-
-				ss.matrix <- base::matrix(c(0,0,0,0), nrow=2, ncol=2)
-
-			} else if (is.null(counts)) {
-
-				ss.table  <- base::table(ss.dataset)
-				ss.matrix <- base::matrix(ss.table, nrow=dim(ss.table)[1], ncol=dim(ss.table)[2], dimnames=dimnames(ss.table))
-
-			} else {
-
-				ss.matrix <- base::tapply(ss.dataset[[ .v(counts) ]], list(ss.dataset[[ .v(rows) ]], ss.dataset[[ .v(columns) ]]), base::sum)
-			}
-
-			ss.matrix[base::is.na(ss.matrix)] <- 0
-
-			if (rowOrderDescending) {
-				ss.matrix <- base::apply(ss.matrix, 2, base::rev)
-			} else {
-				ss.matrix <- ss.matrix
-			}
-
-			if (columnOrderDescending) {
-				ss.matrix <- ss.matrix[ , ncol(ss.matrix):1]
-			} else {
-				ss.matrix <- ss.matrix
-			}
-
-			matrices[[length(matrices)+1]] <- ss.matrix
-		}
-	}
-
-	matrices
+.crosstabsCreateOrdinalTau <- function(var.name, counts.matrix, options, group, ready) {
+  if (!options$kendallsTauB)
+    return()
+  
+  row <- list()
+  for (layer in names(group)) {
+    
+    level <- group[[layer]]
+    
+    if (level == "") {
+      
+      row[[layer]] <- "Total"
+      
+    } else {
+      
+      row[[layer]] <- level
+    }
+  }
+  
+  if (options$kendallsTauB) {
+    
+    row[["type[kTauB]"]] <- "Kendall's Tau-b"
+    
+    if (ready) {
+      
+      chi.result <- try({
+        count.dat  <- stats::ftable(counts.matrix)
+        count.dat  <- as.data.frame(count.dat)
+        Var1       <- rep(count.dat[,1],times=count.dat$Freq)
+        Var2       <- rep(count.dat[,2],times=count.dat$Freq)
+        chi.result <- stats::cor.test(as.numeric(Var1), as.numeric(Var2), method="kendall")
+      })
+      
+      if (class(chi.result) == "try-error") {
+        
+        row[["value[kTauB]"]] <- .clean(NaN)
+        
+        #error <- .extractErrorMessage(chi.result)
+        
+        #sup	<- .addFootnote(footnotes, error)
+        #row[[".footnotes"]] <- list("value[kTauB]"=list(sup))
+        
+      } else {
+        row[["value[kTauB]"]] <- unname(chi.result$estimate)
+        row[["p[kTauB]"]]     <- chi.result$p.value
+        if (options$VovkSellkeMPR){
+          row[["MPR[kTauB]"]] <- .VovkSellkeMPR(row[["p[kTauB]"]])
+        }
+        row[["statistic[kTauB]"]] <- unname(chi.result$statistic)
+      }
+    } else {
+      row[["value[kTauB]"]] <- "."
+      row[["p[kTauB]"]]     <- "."
+      if (options$VovkSellkeMPR){
+        row[["MPR[kTauB]"]] <- "."
+      }
+      row[["statistic[kTauB]"]] <- "."
+    }
+  }
+  list(row)
 }

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -311,7 +311,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     
     # Add columns to table
     .crossTabLayersColumns(crossTabGamma, analysis)
-    #crossTabGamma$addColumnInfo(name = "type[gammaCoef]",  title = "", type="string")
     crossTabGamma$addColumnInfo(name = "value[gammaCoef]", title = "Gamma",          
                                 type = "number")
     crossTabGamma$addColumnInfo(name = "Sigma[gammaCoef]", title = "Standard Error", 
@@ -348,7 +347,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     
     # Add columns to table
     .crossTabLayersColumns(crossTabKendallTau, analysis)
-    #crossTabKendallTau$addColumnInfo(name = "type[kTauB]",  title = "", type="string")
     crossTabKendallTau$addColumnInfo(name = "value[kTauB]", title = "Kendall's Tau-b ", 
                                      type = "number")
     crossTabKendallTau$addColumnInfo(name = "statistic[kTauB]", title = "Z", 
@@ -1211,7 +1209,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       group <- NULL
     
     row <- list()
-    row[["type[gammaCoef]"]] <- "Gamma coefficient"
     if(ready) {
       chi.result <- try({
         chi.result <- vcdExtra::GKgamma(counts.matrix)
@@ -1250,7 +1247,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       group <- NULL
     
     row <- list()
-    row[["type[kTauB]"]] <- "Kendall's Tau-b"
     if (ready) {
       chi.result <- try({
         count.dat  <- stats::ftable(counts.matrix)

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -592,7 +592,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     else 
       row[[layer]] <- level
   }
-  #browser()
   return(row)
 }
 
@@ -1387,7 +1386,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     
     row <- list()
     if (options$kendallsTauB) {
-      #row[["type[kTauB]"]] <- "Kendall's Tau-b"
       if (ready) {
         chi.result <- try({
           count.dat  <- stats::ftable(counts.matrix)

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -974,7 +974,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
         options$percentagesCol == FALSE && options$percentagesTotal == FALSE)
       row[[".isNewGroup"]] <- TRUE
     
-    row <- .crossTabLayerNames(row, group)
+    #row <- .crossTabLayerNames(row, group)
     rows[[length(rows) + 1]] <- row
     counts.rows <- c(counts.rows, rows)
   }
@@ -1386,6 +1386,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     
     row <- list()
     if (options$kendallsTauB) {
+      row[["type[kTauB]"]] <- "Kendall's Tau-b"
       if (ready) {
         chi.result <- try({
           count.dat  <- stats::ftable(counts.matrix)

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -584,7 +584,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     table$addColumnInfo(name = paste0("MPR[", fold, "]"), title = "VS-MPR\u002A", type = "number")
 }
 
-.crossTabChisqAddColInfo <- function(fold, table) {
+.crossTabChisqAddColInfo <- function(fold, table, options) {
   table$addColumnInfo(name = paste0("type[", fold, "]"),  title = "", type = "string")
   table$addColumnInfo(name = paste0("value[", fold, "]"), title = "Value", type = "number")
   table$addColumnInfo(name = paste0("df[", fold, "]"),    title = "df", type = "integer")

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -590,7 +590,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
   table$addColumnInfo(name = paste0("df[", fold, "]"),    title = "df", type = "integer")
   table$addColumnInfo(name = paste0("p[", fold, "]"),     title = "p",  type = "pvalue")
   if (options$VovkSellkeMPR)
-    table$addColumnInfo(name = paste0("MPR[", fold, "]"), title = "VS-MPR", type = "number")
+    table$addColumnInfo(name = paste0("MPR[", fold, "]"), title = "VS-MPR\u002A", type = "number")
 }
 
 .crossTabLayerNames <- function(row, group) {

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -201,7 +201,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       if (identical(counts, as.integer(counts)) == FALSE)          
         counts.fp <- TRUE
     }
-    
+
     if (options$countsExpected || options$percentagesRow || 
         options$percentagesColumn || options$percentagesTotal )  
       crossTabMain$addColumnInfo(name = "type[counts]", title = "", 
@@ -310,7 +310,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     analysisContainer <- jaspResults[[paste0("tables", i)]]
     if (!is.null(analysisContainer[["crossTabLogOdds"]])) 
       next
-    
+
     # Create table
     crossTabLogOdds <- createJaspTable(title = "Log Odds Ratio")
     crossTabLogOdds$dependOn(c("oddsRatio", "oddsRatioConfidenceIntervalInterval"))
@@ -355,7 +355,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     analysisContainer <- jaspResults[[paste0("tables", i)]]
     if (!is.null(analysisContainer[["crossTabNominal"]])) 
       next
-    
+
     # Create table
     crossTabNominal <- createJaspTable(title = "Nominal")
     crossTabNominal$dependOn(c("contingencyCoefficient", "phiAndCramersV"))
@@ -406,7 +406,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     analysisContainer <- jaspResults[[paste0("tables", i)]]
     if (!is.null(analysisContainer[["crossTabGamma"]])) 
       next
-    
+
     # Create table
     crossTabGamma <- createJaspTable(title = "Ordinal Gamma")
     crossTabGamma$dependOn(c("gamma"))
@@ -788,7 +788,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
             expected[["total[expected]"]] <- ""
           else 
             expected[["total[expected]"]] <- base::sum(expected.matrix[j,])
-          
+
           expected <- c(row.expected, expected)
           row <- c(row, expected)
         }
@@ -1387,7 +1387,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     
     row <- list()
     if (options$kendallsTauB) {
-      row[["type[kTauB]"]] <- "Kendall's Tau-b"
+      #row[["type[kTauB]"]] <- "Kendall's Tau-b"
       if (ready) {
         chi.result <- try({
           count.dat  <- stats::ftable(counts.matrix)

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -16,22 +16,21 @@
 #
 
 ContingencyTables <- function(jaspResults, dataset, options, ...) {
-  
   # Read dataset
   dataset <- .crossTabReadData(dataset, options)
   
   ready <- !(length(options$rows) == 0 || length(options$columns) == 0)
-  
+
   # Error checking
   .crossTabCheckErrors(dataset, options)
   
-  # Compute the results
+  # Compute the combinations of rows, columns, layers
   analyses <- .crossTabComputeAnalyses(dataset, options, ready)
   
   # Tables container
   .crossTabContainer(jaspResults, options, analyses, ready)
     
-  # Output tables
+  # Output tables (each calls its own results function)
   .crossTabMain(      jaspResults, dataset, options, analyses, ready)
   .crossTabChisq(     jaspResults, dataset, options, analyses, ready)
   .crossTabLogOdds(   jaspResults, dataset, options, analyses, ready)
@@ -69,7 +68,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
              exitAnalysisIfErrors = TRUE)
 }
 
-# Results ----
+# Combinations of rows, columns, layers ----
 .crossTabComputeAnalyses <- function(dataset, options, ready) {
   rows    <- as.vector(options$rows,    "character")
   columns <- as.vector(options$columns, "character")
@@ -79,41 +78,38 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
   
   if (length(columns) == 0)
     columns <- ""
-  
-  analyses <- data.frame("columns" = columns, stringsAsFactors = FALSE)
-  analyses <- cbind(analyses, "rows" = rep(rows, each = dim(analyses)[1]), 
+  analyses <- list()
+  analyses$analyses <- data.frame("columns" = columns, stringsAsFactors = FALSE)
+  analyses$analyses <- cbind(analyses$analyses, 
+                             "rows" = rep(rows, each = dim(analyses$analyses)[1]), 
                     stringsAsFactors = FALSE)
   
   for (layer in options$layers) {
     layer.vars <- as.vector(layer$variables, "character")
-    analyses <- cbind(analyses, rep(layer.vars, each = dim(analyses)[1]), 
+    analyses$analyses <- cbind(analyses$analyses, 
+                               rep(layer.vars, each = dim(analyses$analyses)[1]), 
                       stringsAsFactors = FALSE)
-    names(analyses)[dim(analyses)[2]] <- layer$name
+    names(analyses$analyses)[dim(analyses$analyses)[2]] <- layer$name
   }
   
-  analyses <- .dataFrameToRowList(analyses)
-  
-  add.groups <- list()
-  add.group.matrices <- list()
-  
-  for (i in 1:length(analyses)) {
-    analysis <- analyses[[i]]
+  analyses$analyses <- .dataFrameToRowList(analyses$analyses)
+  for (i in 1:length(analyses$analyses)) {
+    analysis   <- analyses$analyses[[i]]
     counts.var <- options$counts
     if (counts.var == "")
       counts.var <- NULL
-    
     if(ready) {
-      all.vars <- c(unlist(analysis), counts.var)
-      dataset <- subset(dataset, select = .v(all.vars))
+      all.vars   <- c(unlist(analysis), counts.var)
+      subdataset <- subset(dataset, select = .v(all.vars))
     }
-    
+    else
+      subdataset <- dataset
     # the following creates a 'groups' list
     # a 'group' represents a combinations of the levels from the layers
     # if no layers are specified, groups is null
-    
     if (length(analysis) >= 3) {  # if layers are specified
       
-      lvls <- base::levels(dataset[[ .v(analysis[[3]]) ]])
+      lvls <- base::levels(subdataset[[ .v(analysis[[3]]) ]])
       
       if (length(lvls) < 2)
         lvls <- ""
@@ -129,12 +125,12 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       
       if (length(analysis) >= 4) {
         
-        for (j in 4:(length(analysis)-2)) {
-          lvls <- base::levels(dataset[[ .v(analysis[[j]]) ]])
+        for (j in 4:(length(analysis))) {
+          lvls <- base::levels(subdataset[[ .v(analysis[[j]]) ]])
           lvls <- c(lvls, "")  # blank means total
           
-          groups <- cbind(rep(lvls, each=dim(groups)[1]), groups, 
-                          stringsAsFactors=FALSE)
+          groups <- cbind(rep(lvls, each = dim(groups)[1]), groups, 
+                          stringsAsFactors = FALSE)
           names(groups)[1] <- analysis[[j]]
         }
       }
@@ -142,390 +138,383 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       # convert all the combinations to a list of rows
       groups <- .dataFrameToRowList(groups)
       
-    } else {  # if layers are not specified
+    } else  # if layers are not specified
       groups <- NULL
-    }
-    analyses[[i]] <- c(analyses[[i]], list("groups" = groups))
+    analyses$groups[[i]] <- groups
     if (!is.null(counts.var))
-      counts <- stats::na.omit(dataset[[ .v(counts.var) ]])
-    grp.mat <- .crosstabsCreateGroupMatrices(dataset, analysis$rows, 
+      counts <- stats::na.omit(subdataset[[ .v(counts.var) ]])
+    grp.mat <- .crossTabGroupMatrices(subdataset, analysis$rows, 
                                              analysis$columns, groups, 
                                              counts.var, 
                                              options$rowOrder=="descending", 
                                              options$columnOrder=="descending", 
                                              ready)
-    analyses[[i]] <- c(analyses[[i]], list("group.matrices" = grp.mat))
+    analyses$group.matrices[[i]] <- grp.mat
   }
-  
   return(analyses)
 }
 
 # Container ----
 .crossTabContainer <- function(jaspResults, options, analyses, ready) {
-  for (i in 1:length(analyses)){
-    analysis <- analyses[[i]]
+  for (i in 1:length(analyses$analyses)){
+    analysis <- analyses$analyses[[i]]
     if (is.null(jaspResults[[paste0("tables", i)]])) {
-      jaspResults[[paste0("tables", i)]] <- createJaspContainer()
-      jaspResults[[paste0("tables", i)]]$dependOn(optionContainsValue = 
-                                                  list("rows" = analysis$rows, 
-                                                       "columns" = analysis$columns, 
-                                                       "layers" = options$layers))
+      container <- createJaspContainer()
+      container$dependOn(options              = c("layers", "counts"),
+                         optionContainsValue  = list(rows     = analysis$rows, 
+                                                     columns  = analysis$columns))
+      jaspResults[[paste0("tables", i)]] <- container
     }
   }
 }
 
 # Output Tables ----
 .crossTabMain <- function(jaspResults, dataset, options, analyses, ready) {
-  for (i in 1:length(analyses)){
-    analysis <- analyses[[i]]
-    if (!is.null(jaspResults[[paste0("tables", i)]][["crossTabMain"]])) 
-      return()
-      
+  for (i in 1:length(analyses$analyses)){
+    
+    analysis <- analyses$analyses[[i]]
+    analysisContainer <- jaspResults[[paste0("tables", i)]]
+    if (!is.null(analysisContainer[["crossTabMain"]])) 
+      next
+    
     # Create table
     crossTabMain <- createJaspTable(title = "Contingency Tables")
-    crossTabMain$dependOn(c("counts", "countsExpected", "percentagesRow", 
-                            "percentagesColumn", "percentagesTotal"))
+    crossTabMain$dependOn(c("countsExpected", "percentagesRow", 
+                            "percentagesColumn", "percentagesTotal", 
+                            "rowOrder", "columnOrder"))
     crossTabMain$showSpecifiedColumnsOnly <- TRUE
+    crossTabMain$position <- 1
       
-    .crossTabMainAddLayersColumns(crossTabMain, analysis)
+    .crossTabLayersColumns(crossTabMain, analysis)
     if(analysis$rows == "")
       crossTabMain$addColumnInfo(name = analysis$rows, title = " ", 
                                  type = "string", combine = TRUE)
     else 
       crossTabMain$addColumnInfo(name = analysis$rows, type = "string", 
                                  combine = TRUE)
-
-    counts.fp <- FALSE  # whether the counts are float point or not; changes formatting
+    
+    # whether the counts are float point or not; changes formatting
+    counts.fp <- FALSE  
       
-    if (length(options$counts) > 0) {
+    if (options$counts != "") {
       counts <- dataset[[ .v(options$counts) ]]
       if (identical(counts, as.integer(counts)) == FALSE)          
         counts.fp <- TRUE
     }
-      
-    if (options$countsExpected || options$percentagesRow || 
-        options$percentagesColumn || options$percentagesTotal ) {
-      crossTabMain$addColumnInfo(name = "type[counts]", title = "", type = "string")
-        
-      if (options$countsExpected) {
-        crossTabMain$addColumnInfo(name = "type[expected]",        title = "", type = "string")
-      }
-      if (options$percentagesRow) {
-        crossTabMain$addColumnInfo(name = "type[row.proportions]", title = "", type = "string")
-      }
-      if (options$percentagesColumn) {
-        crossTabMain$addColumnInfo(name = "type[col.proportions]", title = "", type = "string")
-      }
-      if (options$percentagesTotal) {
-        crossTabMain$addColumnInfo(name = "type[total.proportions]",     title = "", type = "string")
-      }
-    }
     
-    .crossTabMainOvertitle(dataset, options, crossTabMain, analysis)
+    if (options$countsExpected || options$percentagesRow || 
+        options$percentagesColumn || options$percentagesTotal )  
+      crossTabMain$addColumnInfo(name = "type[counts]", title = "", 
+                                 type = "string")
+      
+    if (options$countsExpected) 
+      crossTabMain$addColumnInfo(name = "type[expected]", title = "", 
+                                 type = "string")
+    if (options$percentagesRow) 
+      crossTabMain$addColumnInfo(name = "type[row.proportions]", title = "", 
+                                 type = "string")
+    if (options$percentagesColumn) 
+      crossTabMain$addColumnInfo(name = "type[col.proportions]", title = "", 
+                                 type = "string")
+    if (options$percentagesTotal) 
+      crossTabMain$addColumnInfo(name = "type[proportions]", title = "", 
+                                 type = "string")
+    
+    .crossTabMainOvertitle(dataset, options, crossTabMain, analysis, counts.fp)
       
     # Totals columns
     if (counts.fp || options$countsExpected || options$percentagesRow || 
-        options$percentagesColumn || options$percentagesTotal) 
-      crossTabMain$addColumnInfo(name = "total[counts]",   title = "Total", type = "number", format = "sf:4;dp:2")
-    else 
-      crossTabMain$addColumnInfo(name = "total[counts]",   title = "Total", type = "integer")
+        options$percentagesColumn || options$percentagesTotal) {
+      crossTabMain$addColumnInfo(name = "total[counts]",   title = "Total", 
+                                 type = "number", format = "sf:4;dp:2")
+      if (options$countsExpected) 
+        crossTabMain$addColumnInfo(name = "total[expected]", title = "Total", 
+                                   type = "number", format = "sf:4;dp:2")
+      if (options$percentagesRow)
+        crossTabMain$addColumnInfo(name = "total[row.proportions]", title = "Total", 
+                                   type = "number", format = "dp:1;pc")
+      if (options$percentagesColumn) 
+        crossTabMain$addColumnInfo(name = "total[col.proportions]", title = "Total", 
+                                   type = "number", format = "dp:1;pc")
+      if (options$percentagesTotal) 
+        crossTabMain$addColumnInfo(name = "total[proportions]", title = "Total", 
+                                   type = "number", format = "dp:1;pc")
+    } else 
+      crossTabMain$addColumnInfo(name = "total[counts]", title = "Total", 
+                                 type = "integer")
       
-    if (options$countsExpected) 
-      crossTabMain$addColumnInfo(name = "total[expected]", title = "Total", type = "number", format = "sf:4;dp:2")
-
-    if (options$percentagesRow)
-      crossTabMain$addColumnInfo(name = "total[row.proportions]", title = "Total", type = "number", format = "dp:1;pc")
-    
-    if (options$percentagesColumn) 
-      crossTabMain$addColumnInfo(name = "total[col.proportions]", title = "Total", type = "number", format = "dp:1;pc")
-    
-    if (options$percentagesTotal) 
-      crossTabMain$addColumnInfo(name = "total[total.proportions]", title = "Total", type = "number", format = "dp:1;pc")
-    
-    jaspResults[[paste0("tables", i)]][["crossTabMain"]] <- crossTabMain
-    
-    res <- try(.crosstabsCreateCountsRows(analysis$rows, analysis$group.matrices, 
-                                          analysis$groups, i, options, ready))
-    if(isTryError(res))
-      crossTabMain$setError(res)
-    else {
-      for (level in 1:length(res)) {
-        row <- res[[level]]
-        crossTabMain$addRows(row)
-      }
-    }
+    analysisContainer[["crossTabMain"]] <- crossTabMain
+    res <- try(.crossTabCountsRows(jaspResults, analysis$rows, analyses$group.matrices[[i]], 
+                                   analyses$groups[[i]], analysisContainer, options, ready, counts.fp))
+    .crossTabSetErrorOrFill(res, crossTabMain)
   }
 }
 
 .crossTabChisq <- function(jaspResults, dataset, options, analyses, ready) {
-  if(!options$chiSquared && !options$chiSquaredContinuityCorrection && !options$likelihoodRatio) 
+  if(!options$chiSquared && 
+     !options$chiSquaredContinuityCorrection && 
+     !options$likelihoodRatio) 
     return()
-  for (i in 1:length(analyses)){
-    analysis <- analyses[[i]]
-    if (!is.null(jaspResults[[paste0("tables", i)]][["crossTabChisq"]])) 
-      return()
+  for (i in 1:length(analyses$analyses)){
+    analysis <- analyses$analyses[[i]]
+    analysisContainer <- jaspResults[[paste0("tables", i)]]
+    if (!is.null(analysisContainer[["crossTabChisq"]])) 
+      next
+    
     # Create table
     crossTabChisq <- createJaspTable(title = "Chi-Squared Tests")
     crossTabChisq$dependOn(c("chiSquared", "chiSquaredContinuityCorrection", 
                              "likelihoodRatio", "VovkSellkeMPR"))
     crossTabChisq$showSpecifiedColumnsOnly <- TRUE
+    crossTabChisq$position <- 2
     
-    counts.fp <- FALSE  # whether the counts are float point or not; changes formatting
+    # whether the counts are float point or not; changes formatting
+    counts.fp <- FALSE  
     
-    if (length(options$counts) > 0) {
-      
+    if (options$counts != "") {
       counts <- dataset[[ .v(options$counts) ]]
-      if (identical(counts, as.integer(counts)) == FALSE) 
+      if (identical(counts, as.integer(counts)) == FALSE)          
         counts.fp <- TRUE
     }
+    
     # Add columns to table
-    .crossTabMainAddLayersColumns(crossTabChisq, analysis)
-    if(options$chiSquared) {
-      crossTabChisq$addColumnInfo(name = "type[chiSquared]",  title = "",      type = "string")
-      crossTabChisq$addColumnInfo(name = "value[chiSquared]", title = "Value", type = "number", format = "sf:4;dp:3")
-      crossTabChisq$addColumnInfo(name = "df[chiSquared]",    title = "df",    type = "integer")
-      crossTabChisq$addColumnInfo(name = "p[chiSquared]",     title = "p",     type = "number", format = "dp:3;p:.001")
-      if (options$VovkSellkeMPR)
-        crossTabChisq$addColumnInfo(name = "MPR[chiSquared]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
+    .crossTabLayersColumns(crossTabChisq, analysis)
+    if (options$chiSquared)
+      .crossTabChisqAddColInfo(fold = "chiSquared", crossTabChisq, options)
+    if (options$chiSquaredContinuityCorrection)
+      .crossTabChisqAddColInfo(fold = "chiSquared-cc", crossTabChisq, options)
+    if (options$likelihoodRatio)
+      .crossTabChisqAddColInfo(fold = "likelihood", crossTabChisq, options)
+    .crossTabChisqAddColInfo(fold = "N", crossTabChisq, options, counts.fp)
+    if(options$VovkSellkeMPR){
+      message <- ("Vovk-Sellke Maximum  <em>p</em>-Ratio: Based the <em>p</em>-value, 
+      the maximum possible odds in favor of H\u2081 over H\u2080 equals 
+      1/(-e <em>p</em> log(<em>p</em>)) for <em>p</em> \u2264 .37
+      (Sellke, Bayarri, & Berger, 2001).")
+      crossTabChisq$addFootnote(message, symbol = "\u002A")
     }
       
-    if(options$chiSquaredContinuityCorrection) {
-      crossTabChisq$addColumnInfo(name = "type[chiSquared-cc]", title = "", type = "string")
-      crossTabChisq$addColumnInfo(name = "value[chiSquared-cc]", title = "Value", type = "number", format = "sf:4;dp:3")
-      crossTabChisq$addColumnInfo(name = "df[chiSquared-cc]", title = "df", type = "integer")
-      crossTabChisq$addColumnInfo(name = "p[chiSquared-cc]", title = "p", type = "number", format = "dp:3;p:.001")
-      if (options$VovkSellkeMPR) 
-        crossTabChisq$addColumnInfo(name = "MPR[chiSquared-cc]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
-    }
-       
-    if(options$likelihoodRatio) {
-      crossTabChisq$addColumnInfo(name = "type[likelihood]", title = "", type = "string")
-      crossTabChisq$addColumnInfo(name = "value[likelihood]", title = "Value", type = "number", format = "sf:4;dp:3")
-      crossTabChisq$addColumnInfo(name = "df[likelihood]", title = "df", type = "integer")
-      crossTabChisq$addColumnInfo(name = "p[likelihood]", title = "p", type = "number", format = "dp:3;p:.001")
-      if (options$VovkSellkeMPR)
-        crossTabChisq$addColumnInfo(name = "MPR[likelihood]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
-    }
+    analysisContainer[["crossTabChisq"]] <- crossTabChisq
     
-    crossTabChisq$addColumnInfo(name = "type[N]", title = "", type = "string")
-    
-    if (counts.fp)
-      crossTabChisq$addColumnInfo(name = "value[N]", title = "Value", type = "number", format = "sf:4;dp:2")
-    else 
-      crossTabChisq$addColumnInfo(name = "value[N]", title = "Value", type = "integer")
-    
-    crossTabChisq$addColumnInfo(name = "df[N]", title = "df")
-    crossTabChisq$addColumnInfo(name = "p[N]", title = "p")
-    if (options$VovkSellkeMPR)
-      crossTabChisq$addColumnInfo(name = "MPR[N]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
-    
-    jaspResults[[paste0("tables", i)]][["crossTabChisq"]] <- crossTabChisq
-    
-    res <- try(.crosstabsCreateTestsRows(analysis$rows, analysis$group.matrices, 
-                                         analysis$groups, i, options, ready))
-    if(isTryError(res))
-      crossTabChisq$setError(res)
-    else {
-      crossTabChisq$setData(res)
-    }
+    res <- try(.crossTabTestsRows(jaspResults, analysis$rows, analyses$group.matrices[[i]], 
+                                  analyses$groups[[i]], analysisContainer, options, ready, counts.fp))
+    .crossTabSetErrorOrFill(res, crossTabChisq)
   }
 }
 
 .crossTabLogOdds <- function(jaspResults, dataset, options, analyses, ready) {
   if(!options$oddsRatio)
     return()
-  for (i in 1:length(analyses)){
-    analysis <- analyses[[i]]
-    if (!is.null(jaspResults[[paste0("tables", i)]][["crossTabLogOdds"]])) 
-      return()
+  for (i in 1:length(analyses$analyses)){
+    analysis <- analyses$analyses[[i]]
+    analysisContainer <- jaspResults[[paste0("tables", i)]]
+    if (!is.null(analysisContainer[["crossTabLogOdds"]])) 
+      next
     
     # Create table
     crossTabLogOdds <- createJaspTable(title = "Log Odds Ratio")
-    crossTabLogOdds$dependOn(c("oddsRatio"))
+    crossTabLogOdds$dependOn(c("oddsRatio", "oddsRatioConfidenceIntervalInterval"))
     crossTabLogOdds$showSpecifiedColumnsOnly <- TRUE
+    crossTabLogOdds$position <- 3
     
     ci.label <- paste(100*options$oddsRatioConfidenceIntervalInterval, 
                       "% Confidence Intervals", sep = "")
     
     # Add columns to table
-    .crossTabMainAddLayersColumns(crossTabLogOdds, analysis)
-    crossTabLogOdds$addColumnInfo(name = "type[oddsRatio]", title = "", type = "string")
-    crossTabLogOdds$addColumnInfo(name = "value[oddsRatio]", title = "Log Odds Ratio", type = "number", format = "sf:4;dp:3")
-    crossTabLogOdds$addColumnInfo(name = "low[oddsRatio]", title = "Lower",overtitle = ci.label, type = "number", format = "dp:3")
-    crossTabLogOdds$addColumnInfo(name = "up[oddsRatio]",  title = "Upper",overtitle = ci.label, type = "number", format = "dp:3")
+    .crossTabLayersColumns(crossTabLogOdds, analysis)
+    crossTabLogOdds$addColumnInfo(name = "type[oddsRatio]",  title = "", type = "string")
+    crossTabLogOdds$addColumnInfo(name = "value[oddsRatio]", title = "Log Odds Ratio", 
+                                  type = "number")
+    crossTabLogOdds$addColumnInfo(name = "low[oddsRatio]",   title = "Lower", 
+                                  overtitle = ci.label, type = "number", format = "dp:3")
+    crossTabLogOdds$addColumnInfo(name = "up[oddsRatio]",    title = "Upper", 
+                                  overtitle = ci.label, type = "number", format = "dp:3")
     
-    crossTabLogOdds$addColumnInfo(name = "type[FisherTest]", title = "", type = "string")
-    crossTabLogOdds$addColumnInfo(name = "value[FisherTest]", title = "Log Odds Ratio", type = "number", format = "sf:4;dp:3")
-    crossTabLogOdds$addColumnInfo(name = "low[FisherTest]", title = "Lower", overtitle = ci.label, type = "number", format = "dp:3")
-    crossTabLogOdds$addColumnInfo(name = "up[FisherTest]",  title = "Upper", overtitle = ci.label, type = "number", format = "dp:3")
+    crossTabLogOdds$addColumnInfo(name = "type[FisherTest]",  title = "", type = "string")
+    crossTabLogOdds$addColumnInfo(name = "value[FisherTest]", title = "Log Odds Ratio", 
+                                  type = "number")
+    crossTabLogOdds$addColumnInfo(name = "low[FisherTest]",   title = "Lower", 
+                                  overtitle = ci.label, type = "number", format = "dp:3")
+    crossTabLogOdds$addColumnInfo(name = "up[FisherTest]",    title = "Upper", 
+                                  overtitle = ci.label, type = "number", format = "dp:3")
     
-    jaspResults[[paste0("tables", i)]][["crossTabLogOdds"]] <- crossTabLogOdds
+    analysisContainer[["crossTabLogOdds"]] <- crossTabLogOdds
     
-    res <- try(.crosstabsCreateOddsRatioRows(analysis$rows, analysis$group.matrices, 
-                                             analysis$groups, i, options, ready))
-    if(isTryError(res))
-      crossTabLogOdds$setError(res)
-    else {
-      crossTabLogOdds$setData(res)
-    }
+    res <- try(.crossTabOddsRatioRows(jaspResults, analysis$rows, 
+                                      analyses$group.matrices[[i]], 
+                                      analyses$groups[[i]], analysisContainer, options, ready))
+    .crossTabSetErrorOrFill(res, crossTabLogOdds)
   }
 }
 
 .crossTabNominal <- function(jaspResults, dataset, options, analyses, ready) {
   if (!options$contingencyCoefficient && !options$phiAndCramersV && !options$lambda)
     return()
-  for (i in 1:length(analyses)){
-    analysis <- analyses[[i]]
-    
-    if (!is.null(jaspResults[[paste0("tables", i)]][["crossTabNominal"]])) 
-      return()
+  for (i in 1:length(analyses$analyses)){
+    analysis <- analyses$analyses[[i]]
+    analysisContainer <- jaspResults[[paste0("tables", i)]]
+    if (!is.null(analysisContainer[["crossTabNominal"]])) 
+      next
     
     # Create table
     crossTabNominal <- createJaspTable(title = "Nominal")
     crossTabNominal$dependOn(c("contingencyCoefficient", "phiAndCramersV"))
     crossTabNominal$showSpecifiedColumnsOnly <- TRUE
+    crossTabNominal$position <- 4
     
     # Add columns to table
-    .crossTabMainAddLayersColumns(crossTabNominal, analysis)
+    .crossTabLayersColumns(crossTabNominal, analysis)
     if (options$contingencyCoefficient){
-      crossTabNominal$addColumnInfo(name = "type[ContCoef]", title = "", type = "string")
-      crossTabNominal$addColumnInfo(name = "value[ContCoef]", title = "Value", type = "number", format = "sf:4;dp:3")
+      crossTabNominal$addColumnInfo(name = "type[ContCoef]",  title = "", 
+                                    type = "string")
+      crossTabNominal$addColumnInfo(name = "value[ContCoef]", title = "Value", 
+                                    type = "number")
     }
     
     if (options$phiAndCramersV) {
-      crossTabNominal$addColumnInfo(name = "type[PhiCoef]", title = "", type = "string")
-      crossTabNominal$addColumnInfo(name = "value[PhiCoef]", title = "Value", type = "number", format = "sf:4;dp:3")
-      crossTabNominal$addColumnInfo(name = "type[CramerV]", title = "", type = "string")
-      crossTabNominal$addColumnInfo(name = "value[CramerV]", title = "Value", type = "number", format = "sf:4;dp:3")
+      crossTabNominal$addColumnInfo(name = "type[PhiCoef]",  title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[PhiCoef]", title = "Value", 
+                                    type = "number")
+      crossTabNominal$addColumnInfo(name = "type[CramerV]",  title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[CramerV]", title = "Value", 
+                                    type = "number")
     }
     
     if (options$lambda) {
-      crossTabNominal$addColumnInfo(name = "type[LambdaR]", title = "", type = "string")
-      crossTabNominal$addColumnInfo(name = "value[LambdaR]", title = "Value", type = "number", format = "sf:4;dp:3")
-      crossTabNominal$addColumnInfo(name = "type[LambdaC]", title = "", type = "string")
-      crossTabNominal$addColumnInfo(name = "value[LambdaC]", title = "Value", type = "number", format = "sf:4;dp:3")
+      crossTabNominal$addColumnInfo(name = "type[LambdaR]",  title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[LambdaR]", title = "Value", 
+                                    type = "number")
+      crossTabNominal$addColumnInfo(name = "type[LambdaC]",  title = "", type = "string")
+      crossTabNominal$addColumnInfo(name = "value[LambdaC]", title = "Value", 
+                                    type = "number")
     }
     
-    jaspResults[[paste0("tables", i)]][["crossTabNominal"]] <- crossTabNominal
+    analysisContainer[["crossTabNominal"]] <- crossTabNominal
     
-    res <- try(.crosstabsCreateNominalRows(analysis$rows, analysis$group.matrices, 
-                                           analysis$groups, i, options, ready))
-    if(isTryError(res))
-      crossTabNominal$setError(res)
-    else {
-      crossTabNominal$setData(res)
-    }
+    res <- try(.crossTabNominalRows(jaspResults, analysis$rows, 
+                                    analyses$group.matrices[[i]], 
+                                    analyses$groups[[i]], analysisContainer, options, ready))
+    .crossTabSetErrorOrFill(res, crossTabNominal)
   }
 }
 
 .crossTabGamma <- function(jaspResults, dataset, options, analyses, ready) {
   if (!options$gamma)
     return()
-  for (i in 1:length(analyses)){
-    analysis <- analyses[[i]]
-    if (!is.null(jaspResults[[paste0("tables", i)]][["crossTabGamma"]])) 
-      return()
+  for (i in 1:length(analyses$analyses)){
+    analysis <- analyses$analyses[[i]]
+    analysisContainer <- jaspResults[[paste0("tables", i)]]
+    if (!is.null(analysisContainer[["crossTabGamma"]])) 
+      next
     
     # Create table
     crossTabGamma <- createJaspTable(title = "Ordinal Gamma")
     crossTabGamma$dependOn(c("gamma"))
     crossTabGamma$showSpecifiedColumnsOnly <- TRUE
+    crossTabGamma$position <- 5
     
     ci.label <- paste("95% Confidence Intervals")
     
     # Add columns to table
-    .crossTabMainAddLayersColumns(crossTabGamma, analysis)
-    crossTabGamma$addColumnInfo(name = "value[gammaCoef]", title = "Gamma",          type = "number", format = "sf:4;dp:3")
-    crossTabGamma$addColumnInfo(name = "Sigma[gammaCoef]", title = "Standard Error", type = "number", format = "dp:3")
-    crossTabGamma$addColumnInfo(name = "low[gammaCoef]",   title = "Lower",  type = "number", format = "dp:3", overtitle = ci.label)
-    crossTabGamma$addColumnInfo(name = "up[gammaCoef]",    title = "Upper",  type = "number", format = "dp:3", overtitle = ci.label)
+    .crossTabLayersColumns(crossTabGamma, analysis)
+    crossTabGamma$addColumnInfo(name = "value[gammaCoef]", title = "Gamma",          
+                                type = "number")
+    crossTabGamma$addColumnInfo(name = "Sigma[gammaCoef]", title = "Standard Error", 
+                                type = "number", format = "dp:3")
+    crossTabGamma$addColumnInfo(name = "low[gammaCoef]",   title = "Lower",  
+                                type = "number", format = "dp:3", overtitle = ci.label)
+    crossTabGamma$addColumnInfo(name = "up[gammaCoef]",    title = "Upper",  
+                                type = "number", format = "dp:3", overtitle = ci.label)
   
-    jaspResults[[paste0("tables", i)]][["crossTabGamma"]] <- crossTabGamma
+    analysisContainer[["crossTabGamma"]] <- crossTabGamma
     
-    res <- try(.crosstabsCreateGammaRows(analysis$rows, analysis$group.matrices, 
-                                         analysis$groups, i, options, ready))
-    if(isTryError(res))
-      crossTabGamma$setError(res)
-    else {
-      crossTabGamma$setData(res)
-    }
+    res <- try(.crossTabGammaRows(jaspResults, analysis$rows, 
+                                  analyses$group.matrices[[i]], 
+                                  analyses$groups[[i]], analysisContainer, options, ready))
+    .crossTabSetErrorOrFill(res, crossTabGamma)
   }
 }
 
 .crossTabKendallTau <- function(jaspResults, dataset, options, analyses, ready) {
   if (!options$kendallsTauB)
     return()
-  for (i in 1:length(analyses)){
-    analysis <- analyses[[i]]
-    if (!is.null(jaspResults[[paste0("tables", i)]][["crossTabKendallTau"]])) 
-      return()
+  for (i in 1:length(analyses$analyses)){
+    analysis <- analyses$analyses[[i]]
+    analysisContainer <- jaspResults[[paste0("tables", i)]]
+    if (!is.null(analysisContainer[["crossTabKendallTau"]])) 
+      next
+    
     # Create table
     crossTabKendallTau <- createJaspTable(title = "Kendall's Tau")
     crossTabKendallTau$dependOn(c("kendallsTauB", "VovkSellkeMPR"))
     crossTabKendallTau$showSpecifiedColumnsOnly <- TRUE
+    crossTabKendallTau$position <- 6
     
     # Add columns to table
-    .crossTabMainAddLayersColumns(crossTabKendallTau, analysis)
-    crossTabKendallTau$addColumnInfo(name = "value[kTauB]", title = "Kendall's Tau-b ", type = "number", format = "sf:4;dp:3")
-    crossTabKendallTau$addColumnInfo(name = "statistic[kTauB]", title = "Z", type = "number", format = "dp:3")
-    crossTabKendallTau$addColumnInfo(name = "p[kTauB]", title = "p", type = "number", format = "dp:3;p:.001")
-    if (options$VovkSellkeMPR)
-      crossTabKendallTau$addColumnInfo(name = "MPR[kTauB]", title = "VS-MPR", type = "number", format = "sf:4;dp:3")
+    .crossTabLayersColumns(crossTabKendallTau, analysis)
+    crossTabKendallTau$addColumnInfo(name = "value[kTauB]", title = "Kendall's Tau-b ", 
+                                     type = "number")
+    crossTabKendallTau$addColumnInfo(name = "statistic[kTauB]", title = "Z", 
+                                     type = "number", format = "dp:3")
+    crossTabKendallTau$addColumnInfo(name = "p[kTauB]", title = "p", 
+                                     type = "number", format = "dp:3;p:.001")
+    if (options$VovkSellkeMPR) 
+      crossTabKendallTau$addColumnInfo(name = "MPR[kTauB]", title = "VS-MPR\u002A", 
+                                       type = "number")
 
-    jaspResults[[paste0("tables", i)]][["crossTabKendallTau"]] <- crossTabKendallTau
+    analysisContainer[["crossTabKendallTau"]] <- crossTabKendallTau
     
-    res <- try(.crosstabsCreateKendallsTauRows(analysis$rows, analysis$group.matrices, 
-                                               analysis$groups, i, options, ready))
-    if(isTryError(res))
-      crossTabKendallTau$setError(res)
-    else 
-      crossTabKendallTau$setData(res)
+    res <- try(.crossTabKendallsTauRows(jaspResults, analysis$rows, 
+                                        analyses$group.matrices[[i]], 
+                                        analyses$groups[[i]], analysisContainer, options, ready))
+    .crossTabSetErrorOrFill(res, crossTabKendallTau)
   }
 }
 
-# Other ----
-.crossTabMainAddLayersColumns <- function(table, analysis) {
-  if ((length(analysis)-2) >= 3)
-    for (j in (length(analysis)-2):3)
+# Table functions
+.crossTabLayersColumns <- function(table, analysis) {
+  if ((length(analysis)) >= 3)
+    for (j in (length(analysis)):3)
       table$addColumnInfo(name = analysis[[j]], type = "string", combine = TRUE)
 }
 
-.crossTabMainOvertitle <- function(dataset, options, table, analysis) {
+.crossTabMainOvertitle <- function(dataset, options, table, analysis, counts.fp) {
   
   lvls <- c()
   overTitle <- unlist(analysis$columns)
-  counts.fp <- FALSE  # whether the counts are float point or not; changes formatting
   
-  if (length(options$counts) > 0) {
-    counts <- dataset[[ .v(options$counts) ]]
-    if (identical(counts, as.integer(counts)) == FALSE)  
-      counts.fp <- TRUE
-  }
   if(analysis$columns == "") {
     lvls <- c("a", "b")
     for (column.name in lvls) {
       private.name <- base::paste(column.name,"[counts]", sep = "")
       
-      if (counts.fp || options$countsExpected || options$percentagesRow || options$percentagesColumn || options$percentagesTotal ) 
-        table$addColumnInfo(name = private.name, title = ".", overtitle = ".", type = "number", format = "sf:4;dp:2")
+      if (counts.fp || options$countsExpected || options$percentagesRow || 
+          options$percentagesColumn || options$percentagesTotal ) 
+        table$addColumnInfo(name = private.name, title = ".", 
+                            overtitle = ".", type = "number", format = "sf:4;dp:2")
       else 
-        table$addColumnInfo(name = private.name, title = ".", overtitle = ".", type = "integer")
+        table$addColumnInfo(name = private.name, title = ".", 
+                            overtitle = ".", type = "integer")
       
       if (options$countsExpected) { 
         private.name <- base::paste(column.name,"[expected]", sep = "")
-        table$addColumnInfo(name = private.name, title = ".", type = "number", format = "sf:4;dp:2")
+        table$addColumnInfo(name = private.name, title = ".", 
+                            type = "number", format = "sf:4;dp:2")
       }
       if (options$percentagesRow) {
         private.name <- base::paste(column.name,"[row.proportions]", sep = "")
-        table$addColumnInfo(name = private.name, title = ".", type = "number", format = "dp:1;pc")
+        table$addColumnInfo(name = private.name, title = ".", 
+                            type = "number", format = "dp:1;pc")
       }
       if (options$percentagesColumn) {
         private.name <- base::paste(column.name,"[col.proportions]", sep = "")
-        table$addColumnInfo(name = private.name, title = ".", type = "number", format = "dp:1;pc")
+        table$addColumnInfo(name = private.name, title = ".", 
+                            type = "number", format = "dp:1;pc")
       }
       if (options$percentagesTotal) {
-        private.name <- base::paste(column.name,"[total.proportions]", sep = "")
-        table$addColumnInfo(name = private.name, title = ".", type = "number", format = "dp:1;pc")
+        private.name <- base::paste(column.name,"[proportions]", sep = "")
+        table$addColumnInfo(name = private.name, title = ".", 
+                            type = "number", format = "dp:1;pc")
       }
     }
   } else {
@@ -542,36 +531,75 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     for (column.name in lvls) {
       private.name <- base::paste(column.name,"[counts]", sep = "")
       
-      if (counts.fp || options$countsExpected || options$percentagesRow || options$percentagesColumn || options$percentagesTotal ) 
-        table$addColumnInfo(name = private.name, title = column.name, overtitle = overTitle, type = "number", format = "sf:4;dp:2")
+      if (counts.fp || options$countsExpected || options$percentagesRow || 
+          options$percentagesColumn || options$percentagesTotal ) 
+        table$addColumnInfo(name = private.name, title = column.name, 
+                            overtitle = overTitle, type = "number", 
+                            format = "sf:4;dp:2")
       else 
-        table$addColumnInfo(name = private.name, title = column.name, overtitle = overTitle, type = "integer")
+        table$addColumnInfo(name = private.name, title = column.name, 
+                            overtitle = overTitle, type = "integer")
       
       if (options$countsExpected) { 
         private.name <- base::paste(column.name,"[expected]", sep = "")
-        table$addColumnInfo(name = private.name, title = column.name, type = "number", format = "sf:4;dp:2")
+        table$addColumnInfo(name = private.name, title = column.name, 
+                            type = "number", format = "sf:4;dp:2")
       }
       if (options$percentagesRow) {
         private.name <- base::paste(column.name,"[row.proportions]", sep = "")
-        table$addColumnInfo(name = private.name, title = column.name, type = "number", format = "dp:1;pc")
+        table$addColumnInfo(name = private.name, title = column.name, 
+                            type = "number", format = "dp:1;pc")
       }
       if (options$percentagesColumn) {
         private.name <- base::paste(column.name,"[col.proportions]", sep = "")
-        table$addColumnInfo(name = private.name, title = column.name, type = "number", format = "dp:1;pc")
+        table$addColumnInfo(name = private.name, title = column.name, 
+                            type = "number", format = "dp:1;pc")
       }
       if (options$percentagesTotal) {
-        private.name <- base::paste(column.name,"[total.proportions]", sep = "")
-        table$addColumnInfo(name = private.name, title = column.name, type = "number", format = "dp:1;pc")
+        private.name <- base::paste(column.name,"[proportions]", sep = "")
+        table$addColumnInfo(name = private.name, title = column.name, 
+                            type = "number", format = "dp:1;pc")
       }
     }
   }
 }
 
-.crosstabsCreateGroupMatrices <- function(dataset, rows, columns, groups, 
-                                          counts = NULL,  
-                                          rowOrderDescending=FALSE, 
-                                          columnOrderDescending=FALSE, 
-                                          ready) {
+.crossTabSetErrorOrFill <- function(res, table) {
+  if(isTryError(res))
+    table$setError(.extractErrorMessage(res))
+  else
+    for (level in 1:length(res)) 
+      table$addRows(res[[level]])
+}
+
+.crossTabChisqAddColInfo <- function(fold, table, options, counts.fp = FALSE) {
+  table$addColumnInfo(name = paste0("type[", fold, "]"),  title = "", type = "string")
+  if(fold == "N" && counts.fp == FALSE)
+    table$addColumnInfo(name = paste0("value[", fold, "]"), title = "Value", type = "integer")
+  else
+    table$addColumnInfo(name = paste0("value[", fold, "]"), title = "Value", type = "number")
+  table$addColumnInfo(name = paste0("df[", fold, "]"),    title = "df", type = "integer")
+  table$addColumnInfo(name = paste0("p[", fold, "]"),     title = "p",  type = "pvalue")
+  if (options$VovkSellkeMPR)
+    table$addColumnInfo(name = paste0("MPR[", fold, "]"), title = "VS-MPR\u002A", type = "number")
+}
+
+.crossTabLayerNames <- function(row, group) {
+  for (layer in names(group)) {
+    level <- group[[layer]]
+    if (level == "")
+      row[[layer]] <- "Total"
+    else 
+      row[[layer]] <- level
+  }
+  #browser()
+  return(row)
+}
+
+# Group matrix
+.crossTabGroupMatrices <- function(dataset, rows, columns, groups, counts = NULL, 
+                                   rowOrderDescending = FALSE, 
+                                   columnOrderDescending = FALSE, ready) {
   
   # this creates count matrices for each of the groups
   matrices <- list()
@@ -609,17 +637,15 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       ss.matrix[is.na(ss.matrix)] <- 0
     }
     
-    if (rowOrderDescending) {
+    if (rowOrderDescending)
       ss.matrix <- base::apply(ss.matrix, 2, base::rev)
-    } else {
+    else 
       ss.matrix <- ss.matrix
-    }
     
-    if (columnOrderDescending) {
+    if (columnOrderDescending)
       ss.matrix <- ss.matrix[ , ncol(ss.matrix):1]
-    } else {
+    else 
       ss.matrix <- ss.matrix
-    }
     
     ss.matrix[base::is.na(ss.matrix)] <- 0
     
@@ -630,8 +656,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       
       group <- group[group != ""]
       
-      if (!ready) {
-        # do nothing
+      if (!ready) { # do nothing
       } else if (length(group) == 0) {
         ss.dataset <- base::subset(dataset, select = .v(c(rows, columns, counts)))
       } else {
@@ -660,68 +685,65 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       
       ss.matrix[base::is.na(ss.matrix)] <- 0
       
-      if (rowOrderDescending) {
+      if (rowOrderDescending)
         ss.matrix <- base::apply(ss.matrix, 2, base::rev)
-      } else {
+      else 
         ss.matrix <- ss.matrix
-      }
       
-      if (columnOrderDescending) {
+      if (columnOrderDescending)
         ss.matrix <- ss.matrix[ , ncol(ss.matrix):1]
-      } else {
+      else 
         ss.matrix <- ss.matrix
-      }
-      matrices[[length(matrices)+1]] <- ss.matrix
+      matrices[[length(matrices) + 1]] <- ss.matrix
     }
   }
   return(matrices)
 }
 
-.crosstabsCreateCountsRows <- function(var.name, group.matrices, 
-                                       groups,i, options, ready) {
-  if(!is.null(jaspResults[[paste0("tables", i)]][["resultsMain"]]))
+# Table Results
+.crossTabCountsRows <- function(jaspResults, var.name, group.matrices, 
+                                groups, analysisContainer, options, ready, counts.fp) {
+  if(!is.null(analysisContainer[["resultsMain"]]))
     return()
-  
   counts.rows     <- list()
-  
+
   for (g in 1:length(group.matrices)) {
     counts.matrix <- group.matrices[[g]]
-    
     if (!is.null(groups))
       group <- groups[[g]]
     else
       group <- NULL
-  
-    rows <- list()
-    row.count <- list()
-    row.expected <- list()
-    row.row.proportions <- list()
-    row.col.proportions <- list()
+
+    rows                  <- list()
+    row.count             <- list()
+    row.expected          <- list()
+    row.row.proportions   <- list()
+    row.col.proportions   <- list()
     row.total.proportions <- list()
-    row.proportions <- list()
+    row.proportions       <- list()
     row.count[["type[counts]"]] <- "Count"
     
     if (ready) {
       expected.matrix <- try({
-        stats::chisq.test(counts.matrix, correct=FALSE)$expected
+        stats::chisq.test(counts.matrix, correct = FALSE)$expected
       })
-      if (class(expected.matrix) == "try-error") {
-        expected.matrix <- counts.matrix
+      if (isTryError(expected.matrix)) {
+        expected.matrix    <- counts.matrix
         expected.matrix[,] <- "&nbsp;"
       }
       
       row.proportions.matrix <- try({
         base::prop.table(counts.matrix, 1)
       })
-      if (class(row.proportions.matrix) == "try-error") {
-        row.proportions.matrix <- counts.matrix
+      if (isTryError(row.proportions.matrix)) {
+        row.proportions.matrix    <- counts.matrix
         row.proportions.matrix[,] <- "&nbsp;"
       }
       
       col.proportions.matrix <- try({
         base::prop.table(counts.matrix, 2)
       })
-      if (class(col.proportions.matrix) == "try-error") {
+      if (isTryError(col.proportions.matrix)) {
         col.proportions.matrix    <- counts.matrix
         col.proportions.matrix[,] <- "&nbsp;"
       }
@@ -729,7 +751,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       proportions.matrix <- try({
         base::prop.table(counts.matrix, margin = NULL)
       })
-      if (class(proportions.matrix) == "try-error") {
+      if (isTryError(proportions.matrix)) {
         proportions.matrix    <- counts.matrix
         proportions.matrix[,] <- "&nbsp;"
       }
@@ -747,40 +769,43 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
         
         row <- as.list(counts.matrix[j,])
         names(row) <- base::paste(names(row),"[counts]",	sep = "")
-        row[["total[counts]"]] <- base::sum(counts.matrix[j,])
+        sum <- base::sum(counts.matrix[j,])
+        if(counts.fp || options$countsExpected || options$percentagesRow || 
+           options$percentagesColumn || options$percentagesTotal)
+          row[["total[counts]"]] <- sum
+        else
+          row[["total[counts]"]] <- as.integer(sum)
         row <- c(row.count, row)
         
         if (options$countsExpected) {
           
           row.expected[["type[expected]"]] <- "Expected count"
           
-          expected <- as.list(expected.matrix[i,])
+          expected <- as.list(expected.matrix[j,])
           names(expected) <- paste(names(expected),"[expected]",  sep = "")
           
-          if (class(expected.matrix[1,1]) == "character") {
+          if (inherits(expected.matrix[1,1], "character"))
             expected[["total[expected]"]] <- ""
-          } else {
-            expected[["total[expected]"]] <- base::sum(expected.matrix[i,])
-          }
+          else 
+            expected[["total[expected]"]] <- base::sum(expected.matrix[j,])
           
           expected <- c(row.expected, expected)
           row <- c(row, expected)
         }
-        #browser()
+        
         if (options$percentagesRow) {
           row.proportions <- list()
           row.row.proportions[["type[row.proportions]"]] <- " % within row"
           
           row.proportions <- as.list(row.proportions.matrix[j,])
-          row.proportions <- .clean(row.proportions)
           names(row.proportions) <- paste(names(row.proportions),
                                           "[row.proportions]",  sep = "")
           
-          if (class(row.proportions.matrix[1,1]) == "character") {
-            row.proportions[["total[row.proportions]"]] <- ""
-          } else {
-            row.proportions[["total[row.proportions]"]] <- .clean(base::sum(row.proportions.matrix[j,]))
-          }
+          if (inherits(row.proportions.matrix[1,1], "character"))
+            row.prop <- ""
+          else
+            row.prop <- base::sum(row.proportions.matrix[j,])
+          row.proportions[["total[row.proportions]"]] <- row.prop
           
           row.proportions <- c(row.row.proportions, row.proportions)
           row <- c(row, row.proportions)
@@ -791,16 +816,14 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
           row.col.proportions[["type[col.proportions]"]] <- " % within column"
           
           col.proportions <- as.list(col.proportions.matrix[j,])
-          col.proportions <- .clean(col.proportions)
           names(col.proportions) <- paste(names(col.proportions),
                                           "[col.proportions]",  sep = "")
           
-          if (class(col.proportions.matrix[1,1]) == "character") {
+          if (inherits(col.proportions.matrix[1,1], "character")) {
             col.proportions[["total[col.proportions]"]] <- ""
           } else {
             row.sum  <- base::margin.table(counts.matrix, 1)
             row.prop <- as.list( base::prop.table(row.sum))
-            row.prop <- .clean(row.prop)
             col.proportions[["total[col.proportions]"]] <- row.prop[[j]]
           }
           
@@ -810,71 +833,62 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
         
         if (options$percentagesTotal) {
           total.proportions <- list()
-          row.total.proportions[["type[total.proportions]"]] <- " % of total"
+          row.total.proportions[["type[proportions]"]] <- " % of total"
           
           total.proportions <- as.list(proportions.matrix[j,])
-          total.proportions <- .clean(total.proportions)
           names(total.proportions) <- paste(names(total.proportions),
-                                            "[total.proportions]",  sep="")
+                                            "[proportions]",  sep = "")
           
-          if (class(proportions.matrix[1,1]) == "character")
-            total.proportions[["total[total.proportions]"]] <- ""
+          if (inherits(proportions.matrix[1,1], "character"))
+            tot.prop <- ""
           else 
-            total.proportions[["total[total.proportions]"]] <- .clean(base::sum(proportions.matrix[j,]))
+            tot.prop <- base::sum(proportions.matrix[j,])
+          total.proportions[["total[proportions]"]] <- tot.prop
           
           total.proportions <- c(row.total.proportions, total.proportions)
           row <- c(row, total.proportions)
         }
         
-      } else {
-        
+      } else 
         row <- list()
-      }
-      
       row[[var.name]] <- dimnames(counts.matrix)[[1]][j]
-      
-      for (layer in names(group)) {
-        
-        level <- group[[layer]]
-        
-        if (level == "") 
-          row[[layer]] <- "Total"
-        else 
-          row[[layer]] <- level
-      }
+      row <- .crossTabLayerNames(row, group)
       
       if (j == 1 && options$countsExpected == FALSE && 
           options$percentagesRow == FALSE && 
           options$percentagesCol == FALSE && 
           options$percentagesTotal == FALSE)
         row[[".isNewGroup"]] <- TRUE
-      rows[[length(rows)+1]] <- row
+      rows[[length(rows) + 1]] <- row
     }
     
     if (ready) {
       
       row <- apply(counts.matrix, 2, base::sum)
       row <- as.list(row)
-      names(row) <- base::paste(names(row),"[counts]",	sep="")
-      row[["total[counts]"]] <- base::sum(counts.matrix)
+      names(row) <- base::paste(names(row),"[counts]",	sep = "")
+      sum <- base::sum(counts.matrix)
+      if(counts.fp || options$countsExpected || options$percentagesRow || 
+         options$percentagesColumn || options$percentagesTotal)
+        row[["total[counts]"]] <- sum
+      else
+        row[["total[counts]"]] <- as.integer(sum)
       row <- c(row.count, row)
       
       if (options$countsExpected) {
         
-        if (class(expected.matrix[1,1]) == "character") {
+        if (inherits(expected.matrix[1,1], "character"))
           expected <- expected.matrix[1,]
-        } else {
+        else
           expected <- apply(expected.matrix, 2, base::sum)
-        }
         
         expected <- as.list(expected)
-        names(expected) <- paste(names(expected),"[expected]", sep="")
+        names(expected) <- paste(names(expected),"[expected]", sep = "")
         
-        if (class(expected.matrix[1,1]) == "character") {
+        if (inherits(expected.matrix[1,1], "character"))
           expected[["total[expected]"]] <- ""
-        } else {
+        else 
           expected[["total[expected]"]] <- base::sum(expected.matrix)
-        }
         
         expected <- c(row.expected, expected)
         
@@ -883,23 +897,22 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       
       if (options$percentagesRow) {
         
-        if (class(row.proportions.matrix[1,1]) == "character") {
+        if (inherits(row.proportions.matrix[1,1], "character"))
           row.proportions <- row.proportions.matrix[1,]
-        } else {
+        else {
           m <- base::margin.table(counts.matrix, 2)
           rowproportion <- base::prop.table(m)
         }
         
         row.proportions <- as.list(rowproportion)
-        row.proportions <- .clean(row.proportions)
         names(row.proportions) <- paste(names(row.proportions),
-                                        "[row.proportions]", sep="")
+                                        "[row.proportions]", sep = "")
         
-        if (class(row.proportions.matrix[1,1]) == "character") {
-          row.proportions[["total[row.proportions]"]] <- ""
-        } else {
-          row.proportions[["total[row.proportions]"]] <- .clean(base::sum(rowproportion))
-        }
+        if (inherits(row.proportions.matrix[1,1], "character"))
+          row.prop <- ""
+        else 
+          row.prop <- base::sum(rowproportion)
+        row.proportions[["total[row.proportions]"]] <- row.prop
         
         row.proportions<-c(row.row.proportions, row.proportions)
         
@@ -908,22 +921,22 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       
       if (options$percentagesColumn) {
         
-        if (class(col.proportions.matrix[1,1]) == "character") {
+        if (inherits(col.proportions.matrix[1,1], "character"))
           col.proportions <- col.proportions.matrix[1,]
-        } else {
+        else 
           colproportion <- apply(col.proportions.matrix, 2, base::sum)
-        }
         
         col.proportions <- as.list(colproportion)
-        col.proportions <- .clean(col.proportions)
-        names(col.proportions) <- paste(names(col.proportions),"[col.proportions]", sep="")
+        names(col.proportions) <- paste(names(col.proportions),
+                                        "[col.proportions]", sep = "")
         
-        if (class(row.proportions.matrix[1,1]) == "character") {
+        if (inherits(row.proportions.matrix[1,1], "character")) {
           col.proportions[["total[col.proportions]"]] <- ""
         } else {
-          row.sum <- base::margin.table(counts.matrix, 1)
+          row.sum  <- base::margin.table(counts.matrix, 1)
           row.prop <- base::prop.table(row.sum)
-          col.proportions[["total[col.proportions]"]] <- .clean(base::sum(row.prop))
+          col.prop <- base::sum(row.prop)
+          col.proportions[["total[col.proportions]"]] <- col.prop
         }
         
         col.proportions<-c(row.col.proportions, col.proportions)
@@ -933,20 +946,20 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       
       if (options$percentagesTotal) {
         
-        if (class(proportions.matrix[1,1]) == "character") {
+        if (inherits(proportions.matrix[1,1], "character"))
           total.proportions <- proportions.matrix[1,]
-        } else {
+        else 
           total.proportions <- apply(proportions.matrix, 2, base::sum)
-        }
         
         total.proportions <- as.list(total.proportions)
-        total.proportions <- .clean(total.proportions)
-        names(total.proportions) <- paste(names(total.proportions),"[total.proportions]", sep="")
+        names(total.proportions) <- paste(names(total.proportions),
+                                          "[proportions]", sep = "")
         
-        if (class(proportions.matrix[1,1]) == "character") {
-          total.proportions[["total[total.proportions]"]] <- ""
+        if (inherits(proportions.matrix[1,1], "character")) {
+          total.proportions[["total[proportions]"]] <- ""
         } else {
-          total.proportions[["total[total.proportions]"]] <- .clean(base::sum(proportions.matrix))
+          tot.prop <- base::sum(proportions.matrix)
+          total.proportions[["total[proportions]"]] <- tot.prop
         }
         
         total.proportions <- c(row.total.proportions, total.proportions)
@@ -954,40 +967,32 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
         row <- c(row,  total.proportions)
       }
       
-    } else {
+    } else 
       row <- list()
-    }
-    
-    row[[var.name]] <- "Total"
-    if (options$countsExpected == FALSE && options$percentagesRow == FALSE && 
+    if(var.name != "")
+      row[[var.name]] <- "Total"
+    if (options$countsExpected == FALSE && options$percentagesRow   == FALSE && 
         options$percentagesCol == FALSE && options$percentagesTotal == FALSE)
       row[[".isNewGroup"]] <- TRUE
     
-    for (layer in names(group)) {
-      
-      level <- group[[layer]]
-      
-      if (level == "")
-        row[[layer]] <- "Total"
-      else 
-        row[[layer]] <- level
-    }
-    rows[[length(rows)+1]] <- row
+    row <- .crossTabLayerNames(row, group)
+    rows[[length(rows) + 1]] <- row
     counts.rows <- c(counts.rows, rows)
   }
-  main <- createJaspState(counts.rows)
-  main$dependOn(optionsFromObject = jaspResults[[paste0("tables", i)]][["crossTabMain"]])
-  jaspResults[[paste0("tables", i)]][["resultsMain"]] <- main
+  main  <- createJaspState(counts.rows)
+  table <- analysisContainer[["crossTabMain"]]
+  main$dependOn(optionsFromObject = table)
+  analysisContainer[["resultsMain"]] <- main
   return(counts.rows)
 }
 
-.crosstabsCreateTestsRows <- function(var.name, group.matrices, groups, 
-                                      i, options, ready) {
+.crossTabTestsRows <- function(jaspResults, var.name, group.matrices, 
+                               groups, analysisContainer, options, ready, counts.fp) {
   if(!options$chiSquared && 
      !options$chiSquaredContinuityCorrection && 
      !options$likelihoodRatio) 
     return()
-  if(!is.null(jaspResults[[paste0("tables", i)]][["resultsChisq"]]))
+  if(!is.null(analysisContainer[["resultsChisq"]]))
     return()
   
   tests.rows <- list()
@@ -997,24 +1002,21 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       group <- groups[[g]]
     else
       group <- NULL
-  
-    row <- list()
     
-    for (layer in names(group)) {
-      level <- group[[layer]]
-      if (level == "")
-        row[[layer]] <- "Total"
-      else 
-        row[[layer]] <- level
-    }
+    row <- list()
     
     row[["type[N]"]] <- "N"
     row[["df[N]"]]   <- ""
     row[["p[N]"]]    <- ""
     row[["MPR[N]"]]  <- ""
     
-    if (ready)
-      row[["value[N]"]] <- base::sum(counts.matrix)
+    if (ready){
+      sum <- base::sum(counts.matrix)
+      if(counts.fp)
+        row[["value[N]"]] <- sum
+      else
+        row[["value[N]"]] <- as.integer(sum)
+    }
     else 
       row[["value[N]"]] <- "."
     
@@ -1028,29 +1030,21 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
           chi.result <- stats::chisq.test(counts.matrix, correct = FALSE)
         })
         
-        if (class(chi.result) == "try-error") {
-          
-          row[["value[chiSquared]"]] <- .clean(NaN)
+        if (isTryError(chi.result) || is.na(chi.result$statistic)) {
+          row[["value[chiSquared]"]] <- NaN
           row[["df[chiSquared]"]]    <- " "
           row[["p[chiSquared]"]]     <- " "
           row[["MPR[chiSquared]"]]   <- " "
-        } else if (is.na(chi.result$statistic)) {
-          
-          row[["value[chiSquared]"]] <- .clean(NaN)
-          row[["df[chiSquared]"]]    <- " "
-          row[["p[chiSquared]"]]     <- " "
-          row[["MPR[chiSquared]"]]   <- " "
-          
+          message <- "\u03A7\u00B2 could not be calculated - At least one row or column contains all zeros"
+          analysisContainer[["crossTabChisq"]]$addFootnote(message)
         } else {
-          
           row[["value[chiSquared]"]] <- unname(chi.result$statistic)
           row[["df[chiSquared]"]]    <- unname(chi.result$parameter)
           row[["p[chiSquared]"]]     <- unname(chi.result$p.value)
           row[["MPR[chiSquared]"]]   <- .VovkSellkeMPR(row[["p[chiSquared]"]])
         }
-      } else {
+      } else 
         row[["value[chiSquared]"]] <- "."
-      }
     }
     
     if (options$chiSquaredContinuityCorrection) {
@@ -1067,33 +1061,25 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
                        #p = chi$p.value)
         })
         
-        if (class(chi.result) == "try-error") {
+        if (isTryError(chi.result) || is.na(chi.result$statistic)) {
           
-          row[["value[chiSquared-cc]"]] <- .clean(NaN)
+          row[["value[chiSquared-cc]"]] <- NaN
           row[["df[chiSquared-cc]"]]    <- " "
           row[["p[chiSquared-cc]"]]     <- " "
           row[["MPR[chiSquared-cc]"]]   <- " "
-          
-        } else if (is.na(chi.result$statistic)) {
-          
-          row[["value[chiSquared-cc]"]] <- .clean(NaN)
-          row[["df[chiSquared-cc]"]]    <- " "
-          row[["p[chiSquared-cc]"]]     <- " "
-          row[["MPR[chiSquared-cc]"]]   <- " "
+          message <- "\u03A7\u00B2 could not be calculated - At least one row or column contains all zeros"
+          analysisContainer[["crossTabChisq"]]$addFootnote(message)
           
         } else {
-          
           row[["value[chiSquared-cc]"]] <- unname(chi.result$statistic)
           row[["df[chiSquared-cc]"]]    <- unname(chi.result$parameter)
-          row[["p[chiSquared-cc]"]]     <- unname(chi.result$p.value)
-          row[["MPR[chiSquared-cc]"]]   <- .VovkSellkeMPR(row[["p[chiSquared-cc]"]])
-          
+          pVal                          <- unname(chi.result$p.value)
+          row[["p[chiSquared-cc]"]]     <- pVal
+          row[["MPR[chiSquared-cc]"]]   <- .VovkSellkeMPR(pVal)
         }
         
-      } else {
-        
+      } else 
         row[["value[chiSquared-cc]"]] <- "."
-      }
     }
     
     if (options$likelihoodRatio) {
@@ -1106,35 +1092,38 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
           chi.result <- vcd::assocstats(counts.matrix)
         })
         
-        if (class(chi.result) == "try-error") {
-          
-          row[["value[likelihood]"]] <- .clean(NaN)
+        if (isTryError(chi.result)) {
+          row[["value[likelihood]"]] <- NaN
           row[["df[likelihood]"]]    <- ""
           row[["p[likelihood]"]]     <- ""
-          row[["MPR[likelihood]"]]   <- ""
+          if (options$VovkSellkeMPR)
+            row[["MPR[likelihood]"]]   <- ""
         } else {
           row[["value[likelihood]"]] <- chi.result$chisq_tests[1]
           row[["df[likelihood]"]]    <- chi.result$chisq_tests[3]
-          row[["p[likelihood]"]]     <- chi.result$chisq_tests[5]
-          row[["MPR[likelihood]"]]   <- .VovkSellkeMPR(row[["p[likelihood]"]])
+          pVal                       <- chi.result$chisq_tests[5]
+          row[["p[likelihood]"]]     <- pVal
+          if (options$VovkSellkeMPR)
+            row[["MPR[likelihood]"]]   <- .VovkSellkeMPR(pVal)
         }
-      } else {
+      } else 
         row[["value[likelihood]"]] <- "."
-      }
     }
-    tests.rows <- c(tests.rows, row)
+    row <- .crossTabLayerNames(row, group)
+    tests.rows[[length(tests.rows) + 1]] <- row
   }
   chisq <- createJaspState(tests.rows)
-  chisq$dependOn(optionsFromObject = jaspResults[[paste0("tables", i)]][["crossTabChisq"]])
-  jaspResults[[paste0("tables", i)]][["resultsChisq"]] <- chisq
+  table <- analysisContainer[["crossTabChisq"]]
+  chisq$dependOn(optionsFromObject = table)
+  analysisContainer[["resultsChisq"]] <- chisq
   return(tests.rows)
 }
 
-.crosstabsCreateOddsRatioRows <- function(var.name, group.matrices, 
-                                          groups, i, options, ready) {
+.crossTabOddsRatioRows <- function(jaspResults, var.name,  group.matrices, 
+                                   groups, analysisContainer, options, ready) {
   if(!options$oddsRatio)
     return()
-  if(!is.null(jaspResults[[paste0("tables", i)]][["resultsLogOdds"]]))
+  if(!is.null(analysisContainer[["resultsLogOdds"]]))
     return()
   odds.ratio.rows <- list()
   for (g in 1:length(group.matrices)) {
@@ -1143,51 +1132,42 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       group <- groups[[g]]
     else
       group <- NULL
-  
-    row <- list()
     
-    for (layer in names(group)) {
-      level <- group[[layer]]
-      
-      if (level == "")
-        row[[layer]] <- "Total"
-      else 
-        row[[layer]] <- level
-    }
+    row <- list()
     if (options$oddsRatio ) {
       row[["type[oddsRatio]"]] <- "Odds ratio"
       if (ready) {
         if ( ! identical(dim(counts.matrix),as.integer(c(2,2)))) {
-          row[["value[oddsRatio]"]] <- .clean(NaN)
+          row[["value[oddsRatio]"]] <- NaN
           row[["low[oddsRatio]"]]   <- ""
-          row[["up[oddsRatio]"]]    <-  ""
+          row[["up[oddsRatio]"]]    <- ""
+          stop("Odds ratio restricted to 2 x 2 tables")
         } else {
           chi.result <- try({
-            chi.result <- vcd::oddsratio(counts.matrix)
-            level <- options$oddsRatioConfidenceIntervalInterval
-            CI <- stats::confint(chi.result, level = level)
-            LogOR <- unname(chi.result$coefficients)
-            log.CI.low <- CI[1]
+            chi.result  <- vcd::oddsratio(counts.matrix)
+            level       <- options$oddsRatioConfidenceIntervalInterval
+            CI          <- stats::confint(chi.result, level = level)
+            LogOR       <- unname(chi.result$coefficients)
+            log.CI.low  <- CI[1]
             log.CI.high <- CI[2]
           })
           
-          if (class(chi.result) == "try-error") 
-            row[["value[oddsRatio]"]] <- .clean(NaN)
+          if (isTryError(chi.result)) 
+            row[["value[oddsRatio]"]] <- NaN
           else if (is.na(chi.result))
-            row[["value[oddsRatio]"]] <- .clean(NaN)
+            row[["value[oddsRatio]"]] <- NaN
           else {
-            row[["value[oddsRatio]"]] <-LogOR
-            row[["low[oddsRatio]"]] <- log.CI.low
-            row[["up[oddsRatio]"]] <- log.CI.high
+            row[["value[oddsRatio]"]] <- LogOR
+            row[["low[oddsRatio]"]]   <- log.CI.low
+            row[["up[oddsRatio]"]]    <- log.CI.high
           }
-          row[["value[oddsRatio]"]] <- .clean(LogOR)
-          row[["low[oddsRatio]"]] <- .clean(log.CI.low)
-          row[["up[oddsRatio]"]] <-  .clean(log.CI.high)
+          row[["value[oddsRatio]"]] <- LogOR
+          row[["low[oddsRatio]"]]   <- log.CI.low
+          row[["up[oddsRatio]"]]    <- log.CI.high
         }
       }
-    } else {
+    } else 
       row[["value[oddsRatio]"]] <- "."
-    }
     
     if (options$oddsRatio ) {
       row[["type[FisherTest]"]] <- "Fisher's exact test "
@@ -1195,55 +1175,55 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       if (ready) {
         
         if ( ! identical(dim(counts.matrix),as.integer(c(2,2)))) {
-          row[["value[FisherTest]"]] <- .clean(NaN)
+          row[["value[FisherTest]"]] <- NaN
           row[["low[FisherTest]"]]   <- ""
           row[["up[FisherTest]"]]    <- ""
         } else {
           chi.result <- try({
-            conf.level <- options$oddsRatioConfidenceIntervalInterval
-            chi.result  <- stats::fisher.test(counts.matrix, 
-                                              conf.level = conf.level)
+            conf.level  <- options$oddsRatioConfidenceIntervalInterval
+            chi.result  <- stats::fisher.test(counts.matrix, conf.level = conf.level)
             OR          <- unname(chi.result$estimate)
             logOR       <- log(OR)
             log.CI.low  <- log(chi.result$conf.int[1])
             log.CI.high <- log(chi.result$conf.int[2])
           })
           
-          if (class(chi.result) == "try-error") 
-            row[["value[FisherTest]"]] <- .clean(NaN)
+          if (isTryError(chi.result)) 
+            row[["value[FisherTest]"]] <- NaN
           else if (is.na(chi.result)) 
-            row[["value[FisherTest]"]] <- .clean(NaN)
+            row[["value[FisherTest]"]] <- NaN
           else {
             row[["value[FisherTest]"]] <- logOR
             row[["low[FisherTest]"]]   <- log.CI.low
             row[["up[FisherTest]"]]    <- log.CI.high
           }
-          row[["value[FisherTest]"]] <- .clean(logOR)
-          row[["low[FisherTest]"]]   <- .clean(log.CI.low)
-          row[["up[FisherTest]"]]    <- .clean(log.CI.high)
+          row[["value[FisherTest]"]] <- logOR
+          row[["low[FisherTest]"]]   <- log.CI.low
+          row[["up[FisherTest]"]]    <- log.CI.high
         }
       }
       
-    } else {
+    } else 
       row[["value[FisherTest]"]] <- "."
-    }
    
-    odds.ratio.rows <- c(odds.ratio.rows, row)
+    row <- .crossTabLayerNames(row, group)
+    odds.ratio.rows[[length(odds.ratio.rows) + 1]] <- row
   }
   logOdds <- createJaspState(odds.ratio.rows)
-  logOdds$dependOn(optionsFromObject = jaspResults[[paste0("tables", i)]][["crossTabLogOdds"]])
-  jaspResults[[paste0("tables", i)]][["resultsLogOdds"]] <- logOdds
+  table   <- analysisContainer[["crossTabLogOdds"]]
+  logOdds$dependOn(optionsFromObject = table)
+  analysisContainer[["resultsLogOdds"]] <- logOdds
   return(odds.ratio.rows)
 }
 
-.crosstabsCreateNominalRows <- function(var.name, group.matrices, 
-                                        groups, i, options, ready) {
+.crossTabNominalRows <- function(jaspResults, var.name, group.matrices, 
+                                 groups, analysisContainer, options, ready) {
   if (!options$contingencyCoefficient && !options$phiAndCramersV && !options$lambda)
     return()
-  if(!is.null(jaspResults[[paste0("tables", i)]][["resultsNominal"]]))
+  if(!is.null(analysisContainer[["resultsNominal"]]))
     return()
   
-  nominal.rows    <- list()
+  nominal.rows <- list()
   
   for (g in 1:length(group.matrices)) {
     counts.matrix <- group.matrices[[g]]
@@ -1251,27 +1231,24 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       group <- groups[[g]]
     else 
       group <- NULL
+    
     row <- list()
-    for (layer in names(group)) {
-      level <- group[[layer]]
-      if (level == "") 
-        row[[layer]] <- "Total"
-      else 
-        row[[layer]] <- level
-    }
     if (options$contingencyCoefficient) {
       row[["type[ContCoef]"]] <- "Contingency coefficient"
       if (ready) {
         chi.result <- try({
           chi.result <- vcd::assocstats(counts.matrix)
         })
-        if (class(chi.result) == "try-error") 
-          row[["value[ContCoef]"]] <- .clean(NaN)
-        else if (is.na(chi.result$contingency))
-          row[["value[ContCoef]"]] <- .clean(NaN)
-        else
+        if (isTryError(chi.result)) 
+          row[["value[ContCoef]"]] <- NaN
+        else if (is.na(chi.result$contingency)) {
+          row[["value[ContCoef]"]] <- NaN
+          message <- "Value could not be calculated - At least one row or column contains all zeros"
+          analysisContainer[["crossTabNominal"]]$addFootnote(message)
+        } else
           row[["value[ContCoef]"]] <- chi.result$contingency
-      } else
+      } 
+      else
         row[["value[ContCoef]"]] <- "."
     }
     if (options$phiAndCramersV) {
@@ -1280,26 +1257,32 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
         chi.result <- try({
           chi.result <- vcd::assocstats(counts.matrix)
         })
-        if (class(chi.result) == "try-error")
-          row[["value[PhiCoef]"]] <- .clean(NaN)
-        else if (is.na(chi.result$phi))
-          row[["value[PhiCoef]"]] <- .clean(NaN)
-        else
+        if (isTryError(chi.result))
+          row[["value[PhiCoef]"]] <- NaN
+        else if (is.na(chi.result$phi)){
+          row[["value[PhiCoef]"]] <- NaN
+          message <- "Value could not be calculated - At least one row or column contains all zeros"
+          analysisContainer[["crossTabNominal"]]$addFootnote(message)
+        } else
           row[["value[PhiCoef]"]] <- chi.result$phi
-      } else 
+      } 
+      else 
         row[["value[PhiCoef]"]] <- "."
       row[["type[CramerV]"]] <- "Cramer's V "
       if (ready) {
         chi.result <- try({
           chi.result <- vcd::assocstats(counts.matrix)
         })
-        if (class(chi.result) == "try-error")
-          row[["value[CramerV]"]] <- .clean(NaN)
-        else if (is.na(chi.result$cramer))
-          row[["value[CramerV]"]] <- .clean(NaN)
-        else 
+        if (isTryError(chi.result))
+          row[["value[CramerV]"]] <- NaN
+        else if (is.na(chi.result$cramer)){
+          row[["value[CramerV]"]] <- NaN
+          message <- "Value could not be calculated - At least one row or column contains all zeros"
+          analysisContainer[["crossTabNominal"]]$addFootnote(message)
+        } else 
           row[["value[CramerV]"]] <- chi.result$cramer
-      } else
+      } 
+      else
         row[["value[CramerV]"]] <- "."
     }
     if (options$lambda) {
@@ -1312,35 +1295,37 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
         lambda <- (E1 - E2)/E1
         row[["value[LambdaR]"]] <- lambda
         if (is.na(lambda))
-          row[["value[LambdaR]"]] <- .clean(NaN)
+          row[["value[LambdaR]"]] <- NaN
         else
           row[["value[LambdaR]"]] <- "."
         row[["type[LambdaC]"]] <- paste("Lambda (", options$columns, 
                                         "dependent)", sep =  " ")
         if (ready) {
           N      <- sum(counts.matrix)
-          E1     <- N- max(colSums(counts.matrix))
+          E1     <- N - max(colSums(counts.matrix))
           E2     <- sum(apply(counts.matrix,1, function (x) sum(x)-max(x) ))
-          lambda <- (E1-E2)/E1
+          lambda <- (E1 - E2)/E1
           row[["value[LambdaC]"]] <- lambda
-        } else {
+        } else 
           row[["value[LambdaC]"]] <- "."
-        }
       }
     }
-    nominal.rows <- c(nominal.rows, row)
+    
+    row <- .crossTabLayerNames(row, group)
+    nominal.rows[[length(nominal.rows) + 1]] <- row
   }
   nominal <- createJaspState(nominal.rows)
-  nominal$dependOn(optionsFromObject = jaspResults[[paste0("tables", i)]][["crossTabNominal"]])
-  jaspResults[[paste0("tables", i)]][["resultsNominal"]] <- nominal
+  table   <- analysisContainer[["crossTabNominal"]]
+  nominal$dependOn(optionsFromObject = table)
+  analysisContainer[["resultsNominal"]] <- nominal
   return(nominal.rows)
 }
 
-.crosstabsCreateGammaRows <- function(var.name, group.matrices, 
-                                      groups, i, options, ready) {
+.crossTabGammaRows <- function(jaspResults, var.name, group.matrices, 
+                               groups, analysisContainer, options, ready) {
   if (!options$gamma)
     return()
-  if(!is.null(jaspResults[[paste0("tables", i)]][["resultsGamma"]]))
+  if(!is.null(analysisContainer[["resultsGamma"]]))
     return()
   
   ordinal.rows <- list()
@@ -1350,44 +1335,46 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       group <- groups[[g]]
     else 
       group <- NULL
+    
     row <- list()
-    for (layer in names(group)) {
-      level <- group[[layer]]
-      if (level == "") 
-        row[[layer]] <- "Total"
-      else 
-        row[[layer]] <- level
-    }
-  
     if (options$gamma) {
       
       row[["type[gammaCoef]"]] <- "Gamma coefficient"
-      
-      chi.result <- try({
-        chi.result <- vcdExtra::GKgamma(counts.matrix)
-      })
-     if (class(chi.result) == "try-error") {
-        row[["value[gammaCoef]"]] <- .clean(NaN)
-      } else {
-        row[["value[gammaCoef]"]] <- chi.result$gamma
-        row[["Sigma[gammaCoef]"]] <- chi.result$sigma
-        row[["low[gammaCoef]"]]   <- chi.result$CI[1]
-        row[["up[gammaCoef]"]]    <- chi.result$CI[2]
+      if(ready) {
+        chi.result <- try({
+          chi.result <- vcdExtra::GKgamma(counts.matrix)
+        })
+        if (isTryError(chi.result)) {
+          row[["value[gammaCoef]"]] <- NaN
+        } else {
+          row[["value[gammaCoef]"]] <- chi.result$gamma
+          row[["Sigma[gammaCoef]"]] <- chi.result$sigma
+          row[["low[gammaCoef]"]]   <- chi.result$CI[1]
+          row[["up[gammaCoef]"]]    <- chi.result$CI[2]
+        }
+      }
+      else {
+        row[["value[gammaCoef]"]] <- "."
+        row[["Sigma[gammaCoef]"]] <- "."
+        row[["low[gammaCoef]"]]   <- "."
+        row[["up[gammaCoef]"]]    <- "."
       }
     }
-    ordinal.rows <- c(ordinal.rows, row)
+    row <- .crossTabLayerNames(row, group)
+    ordinal.rows[[length(ordinal.rows) + 1]] <- row
   }
   gamma <- createJaspState(ordinal.rows)
-  gamma$dependOn(optionsFromObject = jaspResults[[paste0("tables", i)]][["crossTabGamma"]])
-  jaspResults[[paste0("tables", i)]][["resultsGamma"]] <- gamma
+  table <- analysisContainer[["crossTabGamma"]]
+  gamma$dependOn(optionsFromObject = table)
+  analysisContainer[["resultsGamma"]] <- gamma
   return(ordinal.rows)
 }
 
-.crosstabsCreateKendallsTauRows <- function(var.name, group.matrices, 
-                                            groups,  i, options, ready) {
+.crossTabKendallsTauRows <- function(jaspResults, var.name, group.matrices, 
+                                     groups, analysisContainer, options, ready) {
   if (!options$kendallsTauB)
     return()
-  if(!is.null(jaspResults[[paste0("tables", i)]][["resultsKendallsTau"]]))
+  if(!is.null(analysisContainer[["resultsKendallsTau"]]))
     return()
   kendalls.rows <- list()
     
@@ -1399,29 +1386,22 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       group <- NULL
     
     row <- list()
-    for (layer in names(group)) {
-      level <- group[[layer]]
-      if (level == "")
-        row[[layer]] <- "Total"
-      else
-        row[[layer]] <- level
-    }
     if (options$kendallsTauB) {
       row[["type[kTauB]"]] <- "Kendall's Tau-b"
       if (ready) {
         chi.result <- try({
           count.dat  <- stats::ftable(counts.matrix)
           count.dat  <- as.data.frame(count.dat)
-          Var1       <- rep(count.dat[,1],times=count.dat$Freq)
-          Var2       <- rep(count.dat[,2],times=count.dat$Freq)
+          Var1       <- rep(count.dat[,1],times = count.dat$Freq)
+          Var2       <- rep(count.dat[,2],times = count.dat$Freq)
           chi.result <- stats::cor.test(as.numeric(Var1), 
                                         as.numeric(Var2), 
-                                        method="kendall")
+                                        method = "kendall")
         })
         
-        if (class(chi.result) == "try-error") {
-          row[["value[kTauB]"]] <- .clean(NaN)
-        } else {
+        if (isTryError(chi.result)) 
+          row[["value[kTauB]"]] <- NaN
+        else {
           row[["value[kTauB]"]] <- unname(chi.result$estimate)
           row[["p[kTauB]"]]     <- chi.result$p.value
           if (options$VovkSellkeMPR)
@@ -1436,10 +1416,12 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
         row[["statistic[kTauB]"]] <- "."
       }
     }
-    kendalls.rows <- c(kendalls.rows, row)
+    row <- .crossTabLayerNames(row, group)
+    kendalls.rows[[length(kendalls.rows) + 1]] <- row
   }
   kendalls <- createJaspState(kendalls.rows)
-  kendalls$dependOn(optionsFromObject = jaspResults[[paste0("tables", i)]][["crossTabKendallTau"]])
-  jaspResults[[paste0("tables", i)]][["resultsKendallsTau"]] <- kendalls
+  table    <- analysisContainer[["crossTabKendallTau"]]
+  kendalls$dependOn(optionsFromObject = table)
+  analysisContainer[["resultsKendallsTau"]] <- kendalls
   return(kendalls.rows)
 }

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -619,7 +619,8 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     else if (is.na(chi.result[[val]])) {
       row[[paste0("value[", type, "]")]] <- NaN
       message <- "Value could not be calculated - At least one row or column contains all zeros"
-      analysisContainer[["crossTabNominal"]]$addFootnote(message)
+      row[["type[", type ,"]"]] <- paste0(row[["type[", type ,"]"]], "\u207A")
+      analysisContainer[["crossTabNominal"]]$addFootnote(message, symbol = "\u207A")
     } else
       row[[paste0("value[", type, "]")]] <- chi.result[[val]]
   } 
@@ -964,7 +965,6 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       group <- NULL
     
     row <- list()
-    
     row[["type[N]"]] <- "N"
     row[["df[N]"]]   <- ""
     row[["p[N]"]]    <- ""
@@ -995,8 +995,9 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
           row[["df[chiSquared]"]]    <- " "
           row[["p[chiSquared]"]]     <- " "
           row[["MPR[chiSquared]"]]   <- " "
+          row[["type[chiSquared]"]] <- "\u03A7\u00B2\u207B"
           message <- "\u03A7\u00B2 could not be calculated - At least one row or column contains all zeros"
-          analysisContainer[["crossTabChisq"]]$addFootnote(message)
+          analysisContainer[["crossTabChisq"]]$addFootnote(message, symbol = "\u207B")
         } else {
           row[["value[chiSquared]"]] <- unname(chi.result$statistic)
           row[["df[chiSquared]"]]    <- unname(chi.result$parameter)
@@ -1022,14 +1023,13 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
         })
         
         if (isTryError(chi.result) || is.na(chi.result$statistic)) {
-          
           row[["value[chiSquared-cc]"]] <- NaN
           row[["df[chiSquared-cc]"]]    <- " "
           row[["p[chiSquared-cc]"]]     <- " "
           row[["MPR[chiSquared-cc]"]]   <- " "
+          row[["type[chiSquared-cc]"]] <- "\u03A7\u00B2 continuity correction\u1D43"
           message <- "\u03A7\u00B2 could not be calculated - At least one row or column contains all zeros"
-          analysisContainer[["crossTabChisq"]]$addFootnote(message)
-          
+          analysisContainer[["crossTabChisq"]]$addFootnote(message, symbol = "\u1D43")
         } else {
           row[["value[chiSquared-cc]"]] <- unname(chi.result$statistic)
           row[["df[chiSquared-cc]"]]    <- unname(chi.result$parameter)

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -619,7 +619,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     else if (is.na(chi.result[[val]])) {
       row[[paste0("value[", type, "]")]] <- NaN
       message <- "Value could not be calculated - At least one row or column contains all zeros"
-      row[["type[", type ,"]"]] <- paste0(row[["type[", type ,"]"]], "\u207A")
+      row[[paste0("type[", type ,"]")]] <- paste0(row[[paste0("type[", type ,"]")]], "\u207A")
       analysisContainer[["crossTabNominal"]]$addFootnote(message, symbol = "\u207A")
     } else
       row[[paste0("value[", type, "]")]] <- chi.result[[val]]
@@ -1172,7 +1172,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
       row[["type[LambdaR]"]] <- paste("Lambda (", options$rows, "dependent)", sep =  " ")
       row[["type[LambdaC]"]] <- paste("Lambda (", options$columns, "dependent)", sep =  " ")
       if (ready) {
-        N      <- sum(counts.matrix)
+        N       <- sum(counts.matrix)
         E1R     <- N - max(rowSums(counts.matrix))
         E2R     <- sum(apply(counts.matrix,2, function (x) sum(x) - max(x) ))
         lambdaR <- (E1 - E2)/E1

--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -219,7 +219,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     if (options$percentagesTotal) 
       crossTabMain$addColumnInfo(name = "type[proportions]", title = "", 
                                  type = "string")
-    
+
     .crossTabMainOvertitle(dataset, options, crossTabMain, analysis, counts.fp)
       
     # Totals columns
@@ -390,7 +390,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     }
     
     analysisContainer[["crossTabNominal"]] <- crossTabNominal
-    
+
     res <- try(.crossTabNominalRows(jaspResults, analysis$rows, 
                                     analyses$group.matrices[[i]], 
                                     analyses$groups[[i]], analysisContainer, options, ready))
@@ -582,6 +582,15 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
   table$addColumnInfo(name = paste0("p[", fold, "]"),     title = "p",  type = "pvalue")
   if (options$VovkSellkeMPR)
     table$addColumnInfo(name = paste0("MPR[", fold, "]"), title = "VS-MPR\u002A", type = "number")
+}
+
+.crossTabChisqAddColInfo <- function(fold, table) {
+  table$addColumnInfo(name = paste0("type[", fold, "]"),  title = "", type = "string")
+  table$addColumnInfo(name = paste0("value[", fold, "]"), title = "Value", type = "number")
+  table$addColumnInfo(name = paste0("df[", fold, "]"),    title = "df", type = "integer")
+  table$addColumnInfo(name = paste0("p[", fold, "]"),     title = "p",  type = "pvalue")
+  if (options$VovkSellkeMPR)
+    table$addColumnInfo(name = paste0("MPR[", fold, "]"), title = "VS-MPR", type = "number")
 }
 
 .crossTabLayerNames <- function(row, group) {

--- a/JASP-Tests/R/tests/testthat/test-contingencytables.R
+++ b/JASP-Tests/R/tests/testthat/test-contingencytables.R
@@ -150,7 +150,7 @@ test_that("Kendall's Tau table results match", {
   results <- jasptools::run("ContingencyTables", "test.csv", options)
   table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabKendallTau"]][["data"]]
   expect_equal_tables(table,
-    list(-0.0810440898473108, 0.420024632711394, 1,
+    list("Kendall's Tau-b", -0.0810440898473108, 0.420024632711394, 1,
          -0.806378512498144)
   )
 })

--- a/JASP-Tests/R/tests/testthat/test-contingencytables.R
+++ b/JASP-Tests/R/tests/testthat/test-contingencytables.R
@@ -136,8 +136,7 @@ test_that("Ordinal Gamma table results match", {
   results <- jasptools::run("ContingencyTables", "test.csv", options)
   table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabGamma"]][["data"]]
   expect_equal_tables(table,
-    list("Gamma coefficient", -0.163132137030995, 0.197938461395245, -0.551084392520947,
-         0.224820118458957)
+    list(-0.163132137030995, 0.197938461395245, -0.551084392520947, 0.224820118458957)
   )
 })
 
@@ -150,8 +149,7 @@ test_that("Kendall's Tau table results match", {
   results <- jasptools::run("ContingencyTables", "test.csv", options)
   table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabKendallTau"]][["data"]]
   expect_equal_tables(table,
-    list("Kendall's Tau-b", -0.0810440898473108, 0.420024632711394, 1,
-         -0.806378512498144)
+    list(-0.0810440898473108, 0.420024632711394, 1, -0.806378512498144)
   )
 })
 

--- a/JASP-Tests/R/tests/testthat/test-contingencytables.R
+++ b/JASP-Tests/R/tests/testthat/test-contingencytables.R
@@ -18,53 +18,45 @@ test_that("Main table results match", {
   options$percentagesColumn <- TRUE
   options$percentagesTotal <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["Counts Table 1"]][["data"]]
+  table   <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabMain"]][["data"]]
   expect_equal_tables(table,
-    list("Count", "% of total", 320, 495, 815, "Expected count", 394.529977794227,
-         420.470022205773, 815, " % within row", 0.392638036809816, 0.607361963190184,
-         1, " % within column", 0.489296636085627, 0.710186513629842,
-         0.603256846780163, " % within row", 0.392638036809816, 0.607361963190184,
-         1, " % of total", 0.236861584011843, 0.36639526276832, 0.603256846780163,
-         "control", "f", "Count", "% of total", 334, 202, 536, "Expected count",
-         259.470022205773, 276.529977794227, 536, " % within row", 0.623134328358209,
-         0.376865671641791, 1, " % within column", 0.510703363914373,
-         0.289813486370158, 0.396743153219837, " % within row", 0.623134328358209,
-         0.376865671641791, 1, " % of total", 0.247224278312361, 0.149518874907476,
-         0.396743153219837, "experimental", "f", "Count", "% of total",
-         654, 697, 1351, "Expected count", 654, 697, 1351, " % within row",
-         0.484085862324204, 0.515914137675796, 1, " % within column",
-         1, 1, 1, " % within row", 0.484085862324204, 0.515914137675796,
-         1, 0.484085862324204, 0.515914137675796, 1, "Total", "f", "Count",
-         "% of total", 253, 182, 435, "Expected count", 271.013344453711,
-         163.986655546289, 435, " % within row", 0.581609195402299, 0.418390804597701,
-         1, " % within column", 0.338688085676037, 0.402654867256637,
-         0.362802335279399, " % within row", 0.581609195402299, 0.418390804597701,
-         1, " % of total", 0.211009174311927, 0.151793160967473, 0.3628023352794,
-         "control", "m", "Count", "% of total", 494, 270, 764, "Expected count",
-         475.986655546289, 288.013344453711, 764, " % within row", 0.646596858638743,
-         0.353403141361257, 1, " % within column", 0.661311914323963,
-         0.597345132743363, 0.6371976647206, " % within row", 0.646596858638743,
-         0.353403141361257, 1, " % of total", 0.412010008340284, 0.225187656380317,
-         0.6371976647206, "experimental", "m", "Count", "% of total",
-         747, 452, 1199, "Expected count", 747, 452, 1199, " % within row",
-         0.62301918265221, 0.37698081734779, 1, " % within column", 1,
-         1, 1, " % within row", 0.62301918265221, 0.37698081734779, 1,
-         0.62301918265221, 0.37698081734779, 1, "Total", "m", "Count",
-         "% of total", 573, 677, 1250, "Expected count", 686.764705882353,
-         563.235294117647, 1250, " % within row", 0.4584, 0.5416, 1,
-         " % within column", 0.408993576017131, 0.589208006962576, 0.490196078431373,
-         " % within row", 0.4584, 0.5416, 1, " % of total", 0.224705882352941,
-         0.265490196078431, 0.490196078431373, "control", "Total", "Count",
-         "% of total", 828, 472, 1300, "Expected count", 714.235294117647,
-         585.764705882353, 1300, " % within row", 0.636923076923077,
-         0.363076923076923, 1, " % within column", 0.591006423982869,
-         0.410791993037424, 0.509803921568627, " % within row", 0.636923076923077,
-         0.363076923076923, 1, " % of total", 0.324705882352941, 0.185098039215686,
-         0.509803921568627, "experimental", "Total", "Count", "% of total",
-         1401, 1149, 2550, "Expected count", 1401, 1149, 2550, " % within row",
-         0.549411764705882, 0.450588235294118, 1, " % within column",
-         1, 1, 1, " % within row", 0.549411764705882, 0.450588235294118,
-         1, 0.549411764705882, 0.450588235294118, 1, "Total", "Total")
+      list(0.489296636085627, 320, 394.529977794227, 0.236861584011843, 0.392638036809816,
+           0.710186513629842, 495, 420.470022205773, 0.36639526276832,
+           0.607361963190184, "control", "f", 0.603256846780163, 815, 815,
+           0.603256846780163, 1, " % within column", "Count", "Expected count",
+           " % of total", " % within row", 0.510703363914373, 334, 259.470022205773,
+           0.247224278312361, 0.623134328358209, 0.289813486370158, 202,
+           276.529977794227, 0.149518874907476, 0.376865671641791, "experimental",
+           "f", 0.396743153219837, 536, 536, 0.396743153219837, 1, " % within column",
+           "Count", "Expected count", " % of total", " % within row", 1,
+           654, 654, 0.484085862324204, 0.484085862324204, 1, 697, 697,
+           0.515914137675796, 0.515914137675796, "Total", 1, 1351, 1351,
+           1, 1, " % within column", "Count", "Expected count", " % of total",
+           " % within row", 0.338688085676037, 253, 271.013344453712, 0.211009174311927,
+           0.581609195402299, 0.402654867256637, 182, 163.986655546289,
+           0.151793160967473, 0.418390804597701, "control", "m", 0.362802335279399,
+           435, 435, 0.362802335279399, 1, " % within column", "Count",
+           "Expected count", " % of total", " % within row", 0.661311914323963,
+           494, 475.986655546288, 0.412010008340284, 0.646596858638743,
+           0.597345132743363, 270, 288.013344453712, 0.225187656380317,
+           0.353403141361257, "experimental", "m", 0.6371976647206, 764,
+           764, 0.6371976647206, 1, " % within column", "Count", "Expected count",
+           " % of total", " % within row", 1, 747, 747, 0.62301918265221,
+           0.62301918265221, 1, 452, 452, 0.37698081734779, 0.37698081734779,
+           "Total", 1, 1199, 1199, 1, 1, " % within column", "Count", "Expected count",
+           " % of total", " % within row", 0.408993576017131, 573, 686.764705882353,
+           0.224705882352941, 0.4584, 0.589208006962576, 677, 563.235294117647,
+           0.265490196078431, 0.5416, "control", "Total", 0.490196078431372,
+           1250, 1250, 0.490196078431373, 1, " % within column", "Count",
+           "Expected count", " % of total", " % within row", 0.591006423982869,
+           828, 714.235294117647, 0.324705882352941, 0.636923076923077,
+           0.410791993037424, 472, 585.764705882353, 0.185098039215686,
+           0.363076923076923, "experimental", "Total", 0.509803921568627,
+           1300, 1300, 0.509803921568627, 1, " % within column", "Count",
+           "Expected count", " % of total", " % within row", 1, 1401, 1401,
+           0.549411764705882, 0.549411764705882, 1, 1149, 1149, 0.450588235294118,
+           0.450588235294118, "Total", ".", 1, 2550, 2550, 1, 1, " % within column",
+           "Count", "Expected count", " % of total", " % within row")
   )
 })
 
@@ -82,8 +74,8 @@ test_that("Multiple row and column variables give multiple main tables", {
   )
 
   for (i in 1:4) {
-    rows <- results[["results"]][[paste("Counts Table", i)]][["schema"]][["fields"]][[1]][["name"]]
-    cols <- results[["results"]][[paste("Counts Table", i)]][["schema"]][["fields"]][[2]][["overTitle"]]
+    rows <- results[["results"]][[paste0("tables", i)]][["collection"]][[paste0("tables", i, "_crossTabMain")]][["schema"]][["fields"]][[1]][["name"]]
+    cols <- results[["results"]][[paste0("tables", i)]][["collection"]][[paste0("tables", i, "_crossTabMain")]][["schema"]][["fields"]][[2]][["overTitle"]]
     expect_identical(c(rows, cols), pairs[[i]], label=paste("Table", i))
   }
 })
@@ -98,12 +90,12 @@ test_that("Chi-Squared test table results match", {
   options$likelihoodRatio <- TRUE
   options$VovkSellkeMPR <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["Tests Table 1"]][["data"]]
+  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabChisq"]][["data"]]
   expect_equal_tables(table,
-    list("N", "", "", "", 2550, "<unicode><unicode>", 82.0397085317219,
-         1, 1.33379878452991e-19, 63462127883801120, "<unicode><unicode> continuity correction",
-         81.3201582621313, 1, 1.91958529099645e-19, 44468347240355080,
-         "Likelihood ratio", 82.4643894680383, 1, 0, "<unicode>")
+    list("N", "", "", "", 2550, 
+         "<unicode>", 82.0397085317219, 1, 1.33379878452991e-19, 63462127883801120, 
+         "<unicode><unicode> continuity correction", 81.3201582621313, 1, 1.91958529099645e-19, 44468347240355080,
+         "Likelihood ratio", 82.4643894680383, 1, 0, "<unicode><unicode>")
   )
 })
 
@@ -114,7 +106,7 @@ test_that("Nominal table results match", {
   options$contingencyCoefficient <- TRUE
   options$phiAndCramersV <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["Nominal Table 1"]][["data"]]
+  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabNominal"]][["data"]]
   expect_equal_tables(table,
     list("Contingency coefficient", 0.0807792391722019, "Phi-coefficient",
          0.0810440898473108, "Cramer's V ", 0.0810440898473108)
@@ -128,7 +120,7 @@ test_that("Log Odds Ratio table results match", {
   options$oddsRatio <- TRUE
   options$oddsRatioConfidenceIntervalInterval <- 0.90
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["Odds Ratio Table 1"]][["data"]]
+  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabLogOdds"]][["data"]]
   expect_equal_tables(table,
     list("Odds ratio", -0.329205575243527, -0.998167649205055, 0.339756498718001,
          "Fisher's exact test ", -0.325882968750928, -1.07370478788709,
@@ -142,7 +134,7 @@ test_that("Ordinal Gamma table results match", {
   options$columns <- "contBinom"
   options$gamma <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["Ordinal Table 1"]][["data"]]
+  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabGamma"]][["data"]]
   expect_equal_tables(table,
     list("Gamma coefficient", -0.163132137030995, 0.197938461395245, -0.551084392520947,
          0.224820118458957)
@@ -156,7 +148,7 @@ test_that("Kendall's Tau table results match", {
   options$kendallsTauB <- TRUE
   options$VovkSellkeMPR <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["Kendalls Table 1"]][["data"]]
+  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabKendallTau"]][["data"]]
   expect_equal_tables(table,
     list("Kendall's Tau-b", -0.0810440898473108, 0.420024632711394, 1,
          -0.806378512498144)
@@ -169,6 +161,6 @@ test_that("Analysis handles errors", {
   options$columns <- "contBinom"
   options$counts <- "contNormal"
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  errorMsg <- results[["results"]][["Counts Table 1"]][["error"]][["errorMessage"]]
+  errorMsg <- results[["results"]][["errorMessage"]]
   expect_is(errorMsg, "character")
 })

--- a/JASP-Tests/R/tests/testthat/test-contingencytables.R
+++ b/JASP-Tests/R/tests/testthat/test-contingencytables.R
@@ -18,7 +18,7 @@ test_that("Main table results match", {
   options$percentagesColumn <- TRUE
   options$percentagesTotal <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table   <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabMain"]][["data"]]
+  table   <- results[["results"]][["container1"]][["collection"]][["container1_crossTabMain"]][["data"]]
   expect_equal_tables(table,
       list(0.489296636085627, 320, 394.529977794227, 0.236861584011843, 0.392638036809816,
            0.710186513629842, 495, 420.470022205773, 0.36639526276832,
@@ -74,8 +74,8 @@ test_that("Multiple row and column variables give multiple main tables", {
   )
 
   for (i in 1:4) {
-    rows <- results[["results"]][[paste0("tables", i)]][["collection"]][[paste0("tables", i, "_crossTabMain")]][["schema"]][["fields"]][[1]][["name"]]
-    cols <- results[["results"]][[paste0("tables", i)]][["collection"]][[paste0("tables", i, "_crossTabMain")]][["schema"]][["fields"]][[2]][["overTitle"]]
+    rows <- results[["results"]][[paste0("container", i)]][["collection"]][[paste0("container", i, "_crossTabMain")]][["schema"]][["fields"]][[1]][["name"]]
+    cols <- results[["results"]][[paste0("container", i)]][["collection"]][[paste0("container", i, "_crossTabMain")]][["schema"]][["fields"]][[2]][["overTitle"]]
     expect_identical(c(rows, cols), pairs[[i]], label=paste("Table", i))
   }
 })
@@ -90,7 +90,7 @@ test_that("Chi-Squared test table results match", {
   options$likelihoodRatio <- TRUE
   options$VovkSellkeMPR <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabChisq"]][["data"]]
+  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabChisq"]][["data"]]
   expect_equal_tables(table,
     list("N", "", "", "", 2550, 
          "<unicode>", 82.0397085317219, 1, 1.33379878452991e-19, 63462127883801120, 
@@ -106,7 +106,7 @@ test_that("Nominal table results match", {
   options$contingencyCoefficient <- TRUE
   options$phiAndCramersV <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabNominal"]][["data"]]
+  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabNominal"]][["data"]]
   expect_equal_tables(table,
     list("Contingency coefficient", 0.0807792391722019, "Phi-coefficient",
          0.0810440898473108, "Cramer's V ", 0.0810440898473108)
@@ -120,7 +120,7 @@ test_that("Log Odds Ratio table results match", {
   options$oddsRatio <- TRUE
   options$oddsRatioConfidenceIntervalInterval <- 0.90
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabLogOdds"]][["data"]]
+  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabLogOdds"]][["data"]]
   expect_equal_tables(table,
     list("Odds ratio", -0.329205575243527, -0.998167649205055, 0.339756498718001,
          "Fisher's exact test ", -0.325882968750928, -1.07370478788709,
@@ -134,7 +134,7 @@ test_that("Ordinal Gamma table results match", {
   options$columns <- "contBinom"
   options$gamma <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabGamma"]][["data"]]
+  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabGamma"]][["data"]]
   expect_equal_tables(table,
     list("Gamma coefficient", -0.163132137030995, 0.197938461395245, -0.551084392520947,
          0.224820118458957)
@@ -148,7 +148,7 @@ test_that("Kendall's Tau table results match", {
   options$kendallsTauB <- TRUE
   options$VovkSellkeMPR <- TRUE
   results <- jasptools::run("ContingencyTables", "test.csv", options)
-  table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabKendallTau"]][["data"]]
+  table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabKendallTau"]][["data"]]
   expect_equal_tables(table,
     list("Kendall's Tau-b", -0.0810440898473108, 0.420024632711394, 1,
          -0.806378512498144)

--- a/JASP-Tests/R/tests/testthat/test-contingencytables.R
+++ b/JASP-Tests/R/tests/testthat/test-contingencytables.R
@@ -150,7 +150,7 @@ test_that("Kendall's Tau table results match", {
   results <- jasptools::run("ContingencyTables", "test.csv", options)
   table <- results[["results"]][["tables1"]][["collection"]][["tables1_crossTabKendallTau"]][["data"]]
   expect_equal_tables(table,
-    list("Kendall's Tau-b", -0.0810440898473108, 0.420024632711394, 1,
+    list(-0.0810440898473108, 0.420024632711394, 1,
          -0.806378512498144)
   )
 })

--- a/JASP-Tests/R/tests/testthat/test-contingencytables.R
+++ b/JASP-Tests/R/tests/testthat/test-contingencytables.R
@@ -30,7 +30,7 @@ test_that("Main table results match", {
            "f", 0.396743153219837, 536, 536, 0.396743153219837, 1, " % within column",
            "Count", "Expected count", " % of total", " % within row", 1,
            654, 654, 0.484085862324204, 0.484085862324204, 1, 697, 697,
-           0.515914137675796, 0.515914137675796, "Total", 1, 1351, 1351,
+           0.515914137675796, 0.515914137675796, "Total", "f", 1, 1351, 1351,
            1, 1, " % within column", "Count", "Expected count", " % of total",
            " % within row", 0.338688085676037, 253, 271.013344453712, 0.211009174311927,
            0.581609195402299, 0.402654867256637, 182, 163.986655546289,
@@ -43,7 +43,7 @@ test_that("Main table results match", {
            764, 0.6371976647206, 1, " % within column", "Count", "Expected count",
            " % of total", " % within row", 1, 747, 747, 0.62301918265221,
            0.62301918265221, 1, 452, 452, 0.37698081734779, 0.37698081734779,
-           "Total", 1, 1199, 1199, 1, 1, " % within column", "Count", "Expected count",
+           "Total", "m", 1, 1199, 1199, 1, 1, " % within column", "Count", "Expected count",
            " % of total", " % within row", 0.408993576017131, 573, 686.764705882353,
            0.224705882352941, 0.4584, 0.589208006962576, 677, 563.235294117647,
            0.265490196078431, 0.5416, "control", "Total", 0.490196078431372,
@@ -55,7 +55,7 @@ test_that("Main table results match", {
            1300, 1300, 0.509803921568627, 1, " % within column", "Count",
            "Expected count", " % of total", " % within row", 1, 1401, 1401,
            0.549411764705882, 0.549411764705882, 1, 1149, 1149, 0.450588235294118,
-           0.450588235294118, "Total", ".", 1, 2550, 2550, 1, 1, " % within column",
+           0.450588235294118, "Total", "Total", 1, 2550, 2550, 1, 1, " % within column",
            "Count", "Expected count", " % of total", " % within row")
   )
 })

--- a/Resources/Frequencies/qml/ContingencyTables.qml
+++ b/Resources/Frequencies/qml/ContingencyTables.qml
@@ -21,8 +21,6 @@ import JASP.Controls 1.0
 
 Form
 {
-	usesJaspResults: true
-	
 	VariablesForm
 	{
 		AvailableVariablesList { name: "allVariablesList" }		

--- a/Resources/Frequencies/qml/ContingencyTables.qml
+++ b/Resources/Frequencies/qml/ContingencyTables.qml
@@ -21,7 +21,7 @@ import JASP.Controls 1.0
 
 Form
 {
-	usesJaspResults: false
+	usesJaspResults: true
 	
 	VariablesForm
 	{


### PR DESCRIPTION
**contingencytables.R**
Updated Contingency Tables to jaspResults  
Split up the computation of results and creation of tables. 
Each table now calls its own results function
Previously most errors were dealt with by leaving the table empty and adding a footnote. 
I replaced this with putting each result function inside a try() statement and using setError() if needed
Fixed a poor naming error in the main table's results function, which duplicated the "% within row" data 
when multiple options in Cells were selected. The previous function must have ignored this duplication, 
but this meant that the expected table in the unit test was wrong. See below.

**ContingencyTables.qml**
Now uses jaspResults

**test-contingencytables.R**
Main table needed to be adjusted because the previous code duplicated the "% within row" title and 
figures
Once I removed these the old table only disagreed with some character strings, like duplicated layer 
levels.
Chisquare table needed extra unicode expectations, but this might be because when I run the analysis 
the chi symbol is broken down into 3 messy unicode characters. If Travis doesn't do this I can just take 2 
unicode characters out of each part of the expected table and try again.