### PR TITLE
fix typo in jasptool init

### DIFF
--- a/Tools/jasptools/DESCRIPTION
+++ b/Tools/jasptools/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jasptools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 0.7.5
+Version: 0.7.6
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/Tools/jasptools/R/initPackage.R
+++ b/Tools/jasptools/R/initPackage.R
@@ -133,7 +133,7 @@ isJaspDesktopDir <- function(path) {
 
     # get the path to JASP R packages so users do not need to install any additional packages
     # retrieving os bit: http://conjugateprior.org/2015/06/identifying-the-os-from-r/
-    pathsToPackages <- NULL
+    pathToPackages <- NULL
 
     os <- .getOS()
     if (!is.null(os)) {


### PR DESCRIPTION
https://github.com/jasp-stats/jasp-desktop/commit/605390cf28891b6d0570496fd58679672efc32bc#diff-f9562ccfcced4a237ba5b1d4de419b43 changed `pathsToPackages` to `pathToPackages` but forgot one spot, which causes an error on Linux only.