### PR TITLE
Improve the binomial tests

### DIFF
--- a/JASP-Tests/R/tests/testthat/test-binomialtest.R
+++ b/JASP-Tests/R/tests/testthat/test-binomialtest.R
@@ -10,8 +10,8 @@ test_that("Main table results match", {
   results <- jasptools::run("BinomialTest", "test.csv", options)
   table <- results[["results"]][["binomialTable"]][["data"]]
   expect_equal_tables(table,
-		list(1, 58, 0, 0.4928415, 0.6967399, 0.58, 100, 1, "contBinom", 
-				 1, 42, 1, 0.3364797, 0.9999039, 0.42, 100, 1, "contBinom")
+      list("TRUE", 1, 58, 0, 0.492841460660175, 0.696739870156555, 0.58, 100, 1, "contBinom",
+           "FALSE", 1, 42, 1, 0.336479745077558, 0.999903917924738, 0.42, 100, 1, "contBinom")
   )
 })
 

--- a/JASP-Tests/R/tests/testthat/test-binomialtestbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-binomialtestbayesian.R
@@ -9,15 +9,14 @@ test_that("Main table results match", {
   options$priorB <- 2
   options$testValue <- 0.2
   results <- jasptools::run("BinomialTestBayesian", "test.csv", options)
-  table <- results[["results"]][["bayesianBinomialTable"]][["data"]]
+  table <- results[["results"]][["binomTable"]][["data"]]
   expect_equal_tables(table,
-    list(4.32337507642424e-15, "contBinom", 58, 0, 0.58, 100, 
-         3.43240614623212e-05, "contBinom", 42, 1, 0.42, 100)
+    list("TRUE", 4.32337507642424e-15, "contBinom", 58, 0, 0.58, 100,
+         "FALSE", 3.43240614623212e-05, "contBinom", 42, 1, 0.42, 100)
   )
 })
 
 test_that("Prior posterior plots match", {
-  skip("base plots are not supported in regression testing")
   options <- jasptools::analysisOptions("BinomialTestBayesian")
   options$variables <- "contBinom"
   options$plotPriorAndPosterior <- TRUE

--- a/Resources/Frequencies/qml/BinomialTestBayesian.qml
+++ b/Resources/Frequencies/qml/BinomialTestBayesian.qml
@@ -54,7 +54,7 @@ Form
         CheckBox
         {
             name: "descriptivesPlots";					label: qsTr("Descriptive plots")
-            CIField { name: "descriptivesPlotsConfidenceInterval"; label: qsTr("Confidence interval") }
+            CIField { name: "descriptivesPlotsCredibleInterval"; label: qsTr("Credible interval") }
         }
 	}
 


### PR DESCRIPTION
Considering these analyses are simple and can serve as examples of how to write a JASP analysis, I wanted them to be a bit more inline with the general style of other jaspResults analyses.

This also adds some additional error handling, fixes dependency issues in the Bayesian Binomial Test (e.g., "Prior" is not an interface option), adds .isNewGroup's and removes redudancy in some computation functions.

@AlexanderLyNL Descriptive plots were previously added to the Bayesian Binomial Test; in the interface we speak of a confidence interval, can we change this to credible interval just like we did for t-tests and ANOVA's? In other words, are confidence and credible intervals equivalent here (given a flat prior)?