### PR TITLE
make CRI text adjustable

### DIFF
--- a/JASP-Engine/JASPgraphs/DESCRIPTION
+++ b/JASP-Engine/JASPgraphs/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: JASPgraphs
 Type: Package
 Title: Custom graphs for JASP
-Version: 0.3.4
+Version: 0.3.5
 Author: Don vd Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: ...

--- a/JASP-Engine/JASPgraphs/R/PlotPriorAndPosterior.R
+++ b/JASP-Engine/JASPgraphs/R/PlotPriorAndPosterior.R
@@ -287,6 +287,8 @@ makeBFwheelAndText <- function(BF, bfSubscripts, pizzaTxt, drawPizzaTxt = is.nul
 #' @param bfSubscripts String, manually specify the BF labels.
 #' @param pizzaTxt String vector of length 2, text to be drawn above and below pizza plot.
 #' @param bty List of three elements. Type specifies the box type, ldwX the width of the x-axis, lwdY the width of the y-axis.
+#' @param CRItxt String, display the credible interval as \code{paste0(CRItxt, "[", lower, ", ", upper, "]")}.
+#' @param medianTxt String, display the median as \code{paste(medianTxt, formatC(median, 3, format = "f"))}.
 #' @param ... Unused.
 #'
 #' @return If BF, CRI, and median are all NULL a ggplot, otherwise a gtable.
@@ -300,7 +302,9 @@ PlotPriorAndPosterior <- function(dfLines, dfPoints = NULL, BF = NULL, CRI = NUL
                                   hypothesis = c("equal", "smaller", "greater"),
                                   bfSubscripts = NULL,
                                   pizzaTxt = hypothesis2BFtxt(hypothesis)$pizzaTxt, 
-                                  bty = list(type = "n", ldwX = .5, lwdY = .5), ...) {
+                                  bty = list(type = "n", ldwX = .5, lwdY = .5),
+                                  CRItxt = "95% CI: ", medianTxt = "Median:",
+                                  ...) {
   
 	errCheckPlots(dfLines, dfPoints, CRI, median, BF)
   bfType <- match.arg(bfType)
@@ -339,14 +343,14 @@ PlotPriorAndPosterior <- function(dfLines, dfPoints = NULL, BF = NULL, CRI = NUL
     #maxheight / 8
     #)
     if (drawCRItxt) {
-      labelsCRI <- paste("95% CI: [",
-                         bquote(.(formatC(dfCI$xmin, 3, format = "f"))), ", ",
-                         bquote(.(formatC(dfCI$xmax, 3, format = "f"))), "]", sep = "")
+      labelsCRI <- paste0(CRItxt, "[",
+                          bquote(.(formatC(dfCI$xmin, 3, format = "f"))), ", ",
+                          bquote(.(formatC(dfCI$xmax, 3, format = "f"))), "]")
     }
   }
 
   if (!is.null(median)) {
-  	labelsCRI <- c(labelsCRI, paste("Median:", formatC(median, 3, format = "f")))
+  	labelsCRI <- c(labelsCRI, paste(medianTxt, formatC(median, 3, format = "f")))
   }
 
   if (length(labelsCRI) > 0) {

--- a/JASP-Engine/JASPgraphs/man/PlotPriorAndPosterior.Rd
+++ b/JASP-Engine/JASPgraphs/man/PlotPriorAndPosterior.Rd
@@ -10,7 +10,8 @@ PlotPriorAndPosterior(dfLines, dfPoints = NULL, BF = NULL,
   bfType = c("BF01", "BF10", "LogBF10"), hypothesis = c("equal",
   "smaller", "greater"), bfSubscripts = NULL,
   pizzaTxt = hypothesis2BFtxt(hypothesis)$pizzaTxt, bty = list(type =
-  "n", ldwX = 0.5, lwdY = 0.5), ...)
+  "n", ldwX = 0.5, lwdY = 0.5), CRItxt = "95\% CI: ",
+  medianTxt = "Median:", ...)
 }
 \arguments{
 \item{dfLines}{A dataframe with \code{$x}, \code{$y}, and optionally \code{$g}.}
@@ -40,6 +41,10 @@ PlotPriorAndPosterior(dfLines, dfPoints = NULL, BF = NULL,
 \item{pizzaTxt}{String vector of length 2, text to be drawn above and below pizza plot.}
 
 \item{bty}{List of three elements. Type specifies the box type, ldwX the width of the x-axis, lwdY the width of the y-axis.}
+
+\item{CRItxt}{String, display the credible interval as \code{paste0(CRItxt, "[", lower, ", ", upper, "]")}.}
+
+\item{medianTxt}{String, display the median as \code{paste(medianTxt, formatC(median, 3, format = "f"))}.}
 
 \item{...}{Unused.}
 }

--- a/JASP-Engine/JASPgraphs/man/PlotRobustnessSequential.Rd
+++ b/JASP-Engine/JASPgraphs/man/PlotRobustnessSequential.Rd
@@ -67,10 +67,9 @@ Create a robustness or sequential plot
 }
 \examples{
 n <- 100
-x <- seq(-3, 3, length.out = n)
 dfLines <- data.frame(
   x = seq_len(n),
-  y = rnorm(x, seq_len(n) / 30, .5)
+  y = c(0, rnorm(n - 1, seq_len(n - 1) / 30, .5)) # log Bayes factor
 )
 
 PlotRobustnessSequential(
@@ -78,11 +77,11 @@ PlotRobustnessSequential(
   xName        = "n",
 )
 
-LogBF10 <- tail(dfLines, 1)$y
+BF10 <- exp(tail(dfLines, 1)$y)
 PlotRobustnessSequential(
   dfLines      = dfLines,
   xName        = "n",
-  BF           = LogBF10,
-  bfType       = "LogBF10"
+  BF           = BF10,
+  bfType       = "BF10"
 )
 }

--- a/JASP-Tests/R/tests/figs/jasp-deps.txt
+++ b/JASP-Tests/R/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- JASPgraphs: 0.3.4
+- JASPgraphs: 0.3.5


### PR DESCRIPTION
implements https://github.com/jasp-stats/INTERNAL-jasp/issues/397 and makes the text for credible interval and median adjustable for the prior and posterior plots.


the change to `JASP-Engine/JASPgraphs/man/PlotRobustnessSequential.Rd` is because I forgot to call `devtools::document()` last time.

@gibbona1 please let me know if this does all that you wanted!