### PR TITLE
Bayesian log linear regression now uses jaspResults

### DIFF
--- a/JASP-Engine/JASP/R/regressionloglinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionloglinearbayesian.R
@@ -70,13 +70,13 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   }
   
   do.call(.hasErrors, args)
-
+  
   # Error check 2: 0 observations for a level of a variable
   for (factor in options$factors) {
     column <- dataset[[.v(factor)]]
     data   <- column[!is.na(column)]
     levels <- levels(data)
-  
+    
     for (level in levels) {
       .hasErrors(
         dataset              = data[data == level],
@@ -115,7 +115,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     dependentVariable <- unlist(options$counts)
   
   dependentBase64 <- .v(dependentVariable)
-
+  
   if (length(options$modelTerms) > 0) {
     variablesInModel <- NULL
     variablesInModelBase64 <- NULL
@@ -335,7 +335,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     
     len.Blogreg <- length(results) + 1
     results[[ len.Blogreg ]] <- dotted.line
-    
+
     if (length(bfObject$variables) > 0) {
       
       variablesInModel <- bfObject$variables
@@ -345,7 +345,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
       for (var in 1:length(variablesInModel)) {
         
         results[[ len.Blogreg ]] <- dotted.line
-        
+
         if (base::grepl(":", variablesInModel[var])) {
           
           # if interaction term					

--- a/JASP-Engine/JASP/R/regressionloglinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionloglinearbayesian.R
@@ -117,8 +117,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   dependentBase64 <- .v(dependentVariable)
   
   if (length(options$modelTerms) > 0) {
-    variablesInModel <- NULL
-    variablesInModelBase64 <- NULL
+    variablesInModel <- variablesInModelBase64 <- NULL
     
     for (i in seq_along(options$modelTerms)) {
       components <- options$modelTerms[[i]]$components
@@ -277,7 +276,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   bfObject <- .basRegLogLinComputeBFObject(jaspResults, dataset, options)
 
   #for empty elements in tables w/ output
-  emptyRow    <- .basRegLogLinSummaryLine(char = "", prob = TRUE) 
+  emptyRow    <- .basRegLogLinSummaryLine(char = "",  prob = TRUE) 
   dotted.line <- .basRegLogLinSummaryLine(char = ".", prob = TRUE) #for empty tables
 
   results <- list()
@@ -364,16 +363,14 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
 }
 
 .basRegLogLinSubSummaryResults <- function(jaspResults, dataset, options) {
-  if(!is.null(jaspResults[["Container"]][["SubSummaryResults"]])) 
-    return()
-  if(!options$regressionCoefficientsSubmodel) 
+  if(!is.null(jaspResults[["Container"]][["SubSummaryResults"]]) || !options$regressionCoefficientsSubmodel) 
     return()
   # Get Model
   bfObject <- jaspResults[["Container"]][["bfObject"]]$object
   
 
   #for empty elements in tables w/ output
-  emptyRow <- .basRegLogLinSummaryLine(char = "") 
+  emptyRow    <- .basRegLogLinSummaryLine(char = "") 
   dotted.line <- .basRegLogLinSummaryLine(char = ".") #for empty tables
 
   results <- list()
@@ -523,7 +520,8 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
 }
 
 .basRegLogLinSummaryTable <- function(jaspResults, dataset, options, ready){
-  if (!is.null(jaspResults[["Container"]][["SummaryTable"]]) || !options$regressionCoefficientsEstimates) 
+  if (!is.null(jaspResults[["Container"]][["SummaryTable"]]) || 
+      !options$regressionCoefficientsEstimates) 
     return()
   
   # Create table
@@ -563,7 +561,8 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
 }
 
 .basRegLogLinSubSummaryTable <- function(jaspResults, dataset, options, ready){
-  if (!is.null(jaspResults[["Container"]][["SubSummaryTable"]]) || !options$regressionCoefficientsSubmodel) 
+  if (!is.null(jaspResults[["Container"]][["SubSummaryTable"]]) || 
+      !options$regressionCoefficientsSubmodel) 
     return()
   
   # Create table

--- a/JASP-Engine/JASP/R/regressionloglinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionloglinearbayesian.R
@@ -115,7 +115,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     dependentVariable <- unlist(options$counts)
   
   dependentBase64 <- .v(dependentVariable)
-  
+
   if (length(options$modelTerms) > 0) {
     variablesInModel <- NULL
     variablesInModelBase64 <- NULL
@@ -279,7 +279,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   #for empty elements in tables w/ output
   emptyRow    <- .basRegLogLinSummaryLine(char = "", prob = TRUE) 
   dotted.line <- .basRegLogLinSummaryLine(char = ".", prob = TRUE) #for empty tables
-  
+
   results <- list()
   
   lookup.table <- .regressionLogLinearBayesianBuildLookup(dataset, options$factors)
@@ -301,7 +301,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
       variablesInModel <- bfObject$variables
       terms <- as.character(logBlm.estimates$term)
       coef  <- base::strsplit (terms, split = ":", fixed = TRUE)				
-      
+
       for (var in seq_along(coef)) {
         
         results[[ len.Blogreg ]] <- emptyRow
@@ -330,7 +330,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
         len.Blogreg <- len.Blogreg + 1
       }		
     }			
-    
+
   } else {
     
     len.Blogreg <- length(results) + 1
@@ -514,7 +514,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   mainTable$addColumnInfo(name = "pMdata", title = "P(M|data)", type = "number", 
                           format = "dp:3")
   mainTable$addColumnInfo(name = "bf", title = bfTitle, type = "number")
-  
+
   jaspResults[["Container"]][["MainTable"]] <- mainTable
   if (!ready) 
     return()

--- a/JASP-Engine/JASP/R/regressionloglinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionloglinearbayesian.R
@@ -224,15 +224,11 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
 }
 
 .basRegLogLinMainResults <- function(jaspResults, dataset, options) {
-  if(!is.null(jaspResults[["Container"]][["MainResults"]])) 
-    return()
-  # Compute the model
-  .basRegLogLinComputeBFObject(jaspResults, dataset, options)
-  # Get Model
-  bfObject <- jaspResults[["Container"]][["bfObject"]]$object
+  # Compute/get the model
+  bfObject <- .basRegLogLinComputeBFObject(jaspResults, dataset, options)
   
   #for empty elements in tables w/ output
-  emptyRow <- .basRegLogLinMainLine(char = "") 
+  emptyRow    <- .basRegLogLinMainLine(char = "") 
   dotted.line <- .basRegLogLinMainLine(char = ".") #for empty tables
   
   posteriorTableRows <- list()
@@ -271,27 +267,17 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     posteriorTableRows[[i]]$"bf"      <- reportBfs[i]
   }
   
-  results[["footnotes"]] <- paste("Total number of models visited =", 
-                                  bfObject$nModelsVisited, sep=" ")
-  
-  results[["data"]] <- posteriorTableRows
-  jaspResults[["Container"]][["MainResults"]] <- createJaspState(results)
-  jaspResults[["Container"]][["MainResults"]]$dependOn(
-    optionsFromObject = jaspResults[["Container"]][["MainTable"]]
-  )
-  return(results)
+  message <- paste("Total number of models visited =", bfObject$nModelsVisited, sep=" ")
+  jaspResults[["Container"]][["MainTable"]]$addFootnote(message)
+  jaspResults[["Container"]][["MainTable"]]$addRows(posteriorTableRows)
 }
 
 .basRegLogLinSummaryResults <- function(jaspResults, dataset, options) {
-  if(!is.null(jaspResults[["Container"]][["SummaryResults"]])) 
-    return()
-  if(!options$regressionCoefficientsEstimates) 
-    return()
-  # Get Model
-  bfObject <- jaspResults[["Container"]][["bfObject"]]$object
+  # Compute/get the model
+  bfObject <- .basRegLogLinComputeBFObject(jaspResults, dataset, options)
   
   #for empty elements in tables w/ output
-  emptyRow <- .basRegLogLinSummaryLine(char = "", prob = TRUE) 
+  emptyRow    <- .basRegLogLinSummaryLine(char = "", prob = TRUE) 
   dotted.line <- .basRegLogLinSummaryLine(char = ".", prob = TRUE) #for empty tables
   
   results <- list()
@@ -318,7 +304,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
       
       for (var in seq_along(coef)) {
         
-        results[["data"]][[ len.Blogreg ]] <- emptyRow
+        results[[ len.Blogreg ]] <- emptyRow
         terms <- coef[[var]]
         actualName <- list()
         
@@ -326,19 +312,19 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
           actualName[[j]] <- paste(lookup.table[[ terms[j] ]], collapse = " = ")
         varName <- paste0(actualName, collapse = "*")
         
-        results[["data"]][[ len.Blogreg ]]$"Name"      <- varName
+        results[[ len.Blogreg ]]$"Name"      <- varName
         post_prob <- as.numeric(logBlm.estimates$prob[var])
-        results[["data"]][[ len.Blogreg ]]$"post_prob" <- post_prob
+        results[[ len.Blogreg ]]$"post_prob" <- post_prob
         post_mean <- as.numeric(logBlm.estimates$post_mean[var])
-        results[["data"]][[ len.Blogreg ]]$"post_mean" <- post_mean
+        results[[ len.Blogreg ]]$"post_mean" <- post_mean
         post_var <- as.numeric(logBlm.estimates$post_var[var])
-        results[["data"]][[ len.Blogreg ]]$"post_var" <- post_var
+        results[[ len.Blogreg ]]$"post_var" <- post_var
         
         if (options$regressionCoefficientsCredibleIntervals == TRUE){			
           lower_lim <- as.numeric(logBlm.estimates$lower[var])
-          results[["data"]][[ len.Blogreg ]]$"lower_lim" <- lower_lim
+          results[[ len.Blogreg ]]$"lower_lim" <- lower_lim
           upper_lim <- as.numeric(logBlm.estimates$upper[var])
-          results[["data"]][[ len.Blogreg ]]$"upper_lim" <- upper_lim
+          results[[ len.Blogreg ]]$"upper_lim" <- upper_lim
         }
         
         len.Blogreg <- len.Blogreg + 1
@@ -348,7 +334,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   } else {
     
     len.Blogreg <- length(results) + 1
-    results[["data"]][[ len.Blogreg ]] <- dotted.line
+    results[[ len.Blogreg ]] <- dotted.line
     
     if (length(bfObject$variables) > 0) {
       
@@ -358,7 +344,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
       
       for (var in 1:length(variablesInModel)) {
         
-        results[["data"]][[ len.Blogreg ]] <- dotted.line
+        results[[ len.Blogreg ]] <- dotted.line
         
         if (base::grepl(":", variablesInModel[var])) {
           
@@ -369,17 +355,12 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
         } else 
           name <- as.character(variablesInModel[ var])
         
-        results[["data"]][[ len.Blogreg ]]$"Name" <- name
+        results[[ len.Blogreg ]]$"Name" <- name
         len.Blogreg <- len.Blogreg + 1
       }
     }
   }
-  
-  jaspResults[["Container"]][["SummaryResults"]] <- createJaspState(results)
-  jaspResults[["Container"]][["SummaryResults"]]$dependOn(
-    optionsFromObject = jaspResults[["Container"]][["SummaryTable"]]
-  )
-  return(results)
+  jaspResults[["Container"]][["SummaryTable"]]$addRows(results)
 }
 
 .basRegLogLinSubSummaryResults <- function(jaspResults, dataset, options) {
@@ -396,8 +377,6 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   dotted.line <- .basRegLogLinSummaryLine(char = ".") #for empty tables
   
   results <- list()
-  results[["footnotes"]] <- list()
-  results[["data"]] <- list()
   
   lookup.table <- .regressionLogLinearBayesianBuildLookup(dataset, options$factors)
   lookup.table[["(Intercept)"]] <- "(Intercept)"
@@ -421,8 +400,8 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
       extractedModelFormula <- as.character(extractedModelFormula)
       extractedModelFormula <- substring(extractedModelFormula, first = 2) # trim leading ~
       extractedModelFormula <- .unvf(extractedModelFormula)	
-      results[["footnotes"]][["modelFormula"]]  <- extractedModelFormula
-      results[["footnotes"]][["posteriorProb"]] <- paste(round(logBlm.subestimates$post_prob, 3))
+      jaspResults[["Container"]][["SubSummaryTable"]]$addFootnote(extractedModelFormula, symbol = "<em>Model formula:</em>")
+      jaspResults[["Container"]][["SubSummaryTable"]]$addFootnote(paste(round(logBlm.subestimates$post_prob, 3)), symbol = "<em>Posterior model probability =</em>")
       
       if (length(bfObject$variables) > 0) {
         
@@ -432,7 +411,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
         
         for (var in seq_along(coef)) {
           
-          results[["data"]][[ len.Blogreg ]] <- emptyRow
+          results[[ len.Blogreg ]] <- emptyRow
           terms      <- coef[[var]]
           actualName <- list()
           
@@ -440,17 +419,17 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
             actualName[[j]] <- paste(lookup.table[[ terms[j] ]], collapse = " = ")
           varName <- paste0(actualName, collapse = "*")
           
-          results[["data"]][[ len.Blogreg ]]$"Name"      <- varName
+          results[[ len.Blogreg ]]$"Name"      <- varName
           post_mean <- as.numeric(logBlm.subestimates$post_mean[var])
-          results[["data"]][[ len.Blogreg ]]$"post_mean" <- post_mean
+          results[[ len.Blogreg ]]$"post_mean" <- post_mean
           post_var <- as.numeric(logBlm.subestimates$post_var[var])
-          results[["data"]][[ len.Blogreg ]]$"post_var"  <- post_var
+          results[[ len.Blogreg ]]$"post_var"  <- post_var
           
           if (options$regressionCoefficientsSubmodelCredibleIntervals){			
             lower_lim <- as.numeric(logBlm.subestimates$lower[var])
-            results[["data"]][[ len.Blogreg ]]$"lower_lim" <- lower_lim
+            results[[ len.Blogreg ]]$"lower_lim" <- lower_lim
             upper_lim <- as.numeric(logBlm.subestimates$upper[var])
-            results[["data"]][[ len.Blogreg ]]$"upper_lim" <- upper_lim
+            results[[ len.Blogreg ]]$"upper_lim" <- upper_lim
           }
           len.Blogreg <- len.Blogreg + 1
         }		
@@ -459,7 +438,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     } else {
       
       len.Blogreg <- length(results) + 1
-      results[["data"]][[ len.Blogreg ]] <- dotted.line
+      results[[ len.Blogreg ]] <- dotted.line
       
       if (length(bfObject$variables) > 0) {
         
@@ -469,7 +448,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
         
         for (var in 1:length(variablesInModel)) {
           
-          results[["data"]][[ len.Blogreg ]] <- dotted.line
+          results[[ len.Blogreg ]] <- dotted.line
           
           if (base::grepl(":", variablesInModel[var])) {
             
@@ -480,7 +459,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
           } else 
             name <- as.character(variablesInModel[ var])
           
-          results[["data"]][[ len.Blogreg ]]$"Name" <- name
+          results[[ len.Blogreg ]]$"Name" <- name
           len.Blogreg <- len.Blogreg + 1
         }
       }
@@ -493,15 +472,10 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     if (length(bfObject$variables) > 0) 
       variablesInModel <- bfObject$variables
     
-    results[["data"]][[ len.Blogreg ]] <- dotted.line
-    results[["data"]][[ len.Blogreg ]]$"Model" <- 1
+    results[[ len.Blogreg ]] <- dotted.line
+    results[[ len.Blogreg ]]$"Model" <- 1
   }
-  
-  jaspResults[["Container"]][["SubSummaryResults"]] <- createJaspState(results)
-  jaspResults[["Container"]][["SubSummaryResults"]]$dependOn(
-    optionsFromObject = jaspResults[["Container"]][["SubSummaryTable"]]
-  )
-  return(results)
+  jaspResults[["Container"]][["SubSummaryTable"]]$addRows(results)
 }
 
 # Container
@@ -543,18 +517,13 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   if (!ready) 
     return()
   res <- try(.basRegLogLinMainResults(jaspResults, dataset, options))
-  .basRegLogLinSetErrorOrFill(res, mainTable)
-  if(!isTryError(res) && !is.null(res[["footnotes"]])){
-    message <- res[["footnotes"]]
-    mainTable$addFootnote(message)
-  }
+  .basRegLogLinSetError(res, mainTable)
 }
 
 .basRegLogLinSummaryTable <- function(jaspResults, dataset, options, ready){
-  if (!is.null(jaspResults[["Container"]][["SummaryTable"]])) 
+  if (!is.null(jaspResults[["Container"]][["SummaryTable"]]) || !options$regressionCoefficientsEstimates) 
     return()
-  if(!options$regressionCoefficientsEstimates) 
-    return()
+  
   # Create table
   summaryTable <- createJaspTable(title = "Posterior Summary Statistics")
   summaryTable$dependOn(c("regressionCoefficientsEstimates",
@@ -582,19 +551,19 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   }
   
   jaspResults[["Container"]][["SummaryTable"]] <- summaryTable
+  
   if (!ready) 
     return()
   
   res <- try(.basRegLogLinSummaryResults(jaspResults, dataset, options))
   
-  .basRegLogLinSetErrorOrFill(res, summaryTable)
+  .basRegLogLinSetError(res, summaryTable)
 }
 
 .basRegLogLinSubSummaryTable <- function(jaspResults, dataset, options, ready){
-  if (!is.null(jaspResults[["Container"]][["SubSummaryTable"]])) 
+  if (!is.null(jaspResults[["Container"]][["SubSummaryTable"]]) || !options$regressionCoefficientsSubmodel) 
     return()
-  if(!options$regressionCoefficientsSubmodel) 
-    return()
+  
   # Create table
   title <- paste("Posterior Summary Statistics For Submodel", 
                  options$regressionCoefficientsSubmodelNo, sep=" ")
@@ -626,16 +595,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   if (!ready) 
     return()
   res <- try(.basRegLogLinSubSummaryResults(jaspResults, dataset, options))
-  .basRegLogLinSetErrorOrFill(res, subSummaryTable)
-  if(!is.null(res[["footnotes"]][["posteriorProb"]])){
-    posteriorProb <- res[["footnotes"]][["posteriorProb"]]
-    subSummaryTable$addFootnote(posteriorProb, 
-                                symbol = "<em>Posterior model probability =</em>")
-  }
-  if(!is.null(res[["footnotes"]][["modelFormula"]])){
-    modelFormula <- res[["footnotes"]][["modelFormula"]]
-    subSummaryTable$addFootnote(modelFormula, symbol = "<em>Model formula:</em>") 
-  }
+  .basRegLogLinSetError(res, subSummaryTable)
 }
 
 # Other 
@@ -646,12 +606,9 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   table$addCitation(citation)
 }
 
-.basRegLogLinSetErrorOrFill <- function(res, table) {
+.basRegLogLinSetError <- function(res, table) {
   if(isTryError(res))
     table$setError(.extractErrorMessage(res))
-  else 
-    for (level in 1:length(res[["data"]])) 
-      table$addRows(res[["data"]][[level]])
 }
 
 .basRegLogLinSummaryLine <- function(char, prob = FALSE) {

--- a/JASP-Engine/JASP/R/regressionloglinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionloglinearbayesian.R
@@ -16,7 +16,7 @@
 #
 
 RegressionLogLinearBayesian <- function(jaspResults, dataset = NULL, options, ...) {
-  ready <- length(options$factors) != 0
+  ready <- length(options$factors) > 1
   if(ready){
     dataset <- .basRegLogLinReadData(dataset, options)
     .basRegLogLinCheckErrors(dataset, options)
@@ -74,7 +74,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset = NULL, options, ..
       .hasErrors(
         dataset              = data[data == level],
         type                 = "observations",
-        observations.amount  = "< 1",
+        observations.amount  = "< 2",
         exitAnalysisIfErrors = TRUE
       )
     }
@@ -341,6 +341,8 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset = NULL, options, ..
     return()
   # Compute/get the model
   bfObject <- .basRegLogLinComputeBFObject(container, dataset, options)
+  if(!(options$regressionCoefficientsSubmodelNo %in% 1:bfObject$nModelsVisited))
+    stop("Submodel specified is not within possible submodels")
   
   results <- list()
   lookup.table <- .regressionLogLinearBayesianBuildLookup(dataset, options$factors)

--- a/JASP-Engine/JASP/R/regressionloglinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionloglinearbayesian.R
@@ -15,811 +15,700 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-RegressionLogLinearBayesian <- function(dataset, options, perform="run", callback, ...) {
-    # Init end result container
-    endResults <- list()
-    
-    # subsresult containter 
-    results <- list()
-    meta <- list()
-    .meta <-  list(list(name="title", type="title"),
-                   list(name="table", type="table"),
-                   list(name="posteriorTable", type="table"),
-                   list(name="Bayesianlogregression", type="table"),
-                   list(name="BayesianSublogregression", type="table")
+RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
+  # Read dataset
+  dataset <- .basRegLogLinReadData(dataset, options)
+  
+  ready <- length(options$factors) != 0
+  
+  # Error checking
+  .basRegLogLinCheckErrors(dataset, options, ready)
+  
+  # Compute the results
+  bfObject <- .basRegLogLinComputeBFObject(jaspResults, dataset, options, ready)
+  
+  # Container
+  .basRegLogLinContainer(jaspResults, dataset, options, ready)
+
+  # Output tables (each calls its own results function)
+  .basRegLogLinMainTable(      jaspResults, dataset, options, bfObject, ready)
+  .basRegLogLinSummaryTable(   jaspResults, dataset, options, bfObject, ready)
+  .basRegLogLinSubSummaryTable(jaspResults, dataset, options, bfObject, ready)
+  
+  return()
+}
+
+# Preprocessing functions 
+.basRegLogLinReadData <- function(dataset, options) {
+  if (!is.null(dataset)) {
+    return(dataset)
+  } else {
+    counts  <- NULL
+    factors <- NULL
+    if(options$counts != "")
+      counts <- options$counts
+    if(length(options$modelTerms) > 0)
+      factors <- options$modelTerms
+    return(.readDataSetToEnd(columns.as.factor = factors, 
+                             columns.as.numeric = counts))
+  }
+}  
+
+.basRegLogLinCheckErrors <- function(dataset, options, ready) {
+  # Error Check 1
+  if (ready) {
+    args <- list(
+      dataset = dataset,
+      type    = c("missingValues", "modelInteractions"),
+      modelInteractions.modelTerms = options$modelTerms,
+      missingValues.target = options$factors,
+      exitAnalysisIfErrors = TRUE
     )
     
-    
-    results[[".meta"]] <- .meta
-    results[["title"]] <- "Bayesian Log-Linear Regression"
-    
-    logLinearBayesianCitations <- 	list(
-        "Overstall, A., & King, R. (2014). conting: an R package for Bayesian analysis of complete and incomplete contingency tables. Journal of Statistical Software, 58(7), 1-27."
-    )
-    
-    # Init table
-    posteriorTable <- list()
-    
-    posteriorTable[["title"]] <- "Model Comparison"
-    posteriorTable[["citation"]] <- logLinearBayesianCitations
-    
-    if (options$bayesFactorType == "BF10") {
-        bfTitle <- "BF<sub>10</sub>"
-    } else if (options$bayesFactorType == "BF01") {
-        bfTitle <- "BF<sub>01</sub>"
-    } else {
-        bfTitle <- "Log(BF<sub>10</sub>)"
+    if (options$counts != "") {
+      args$type <- c(args$type, "infinity", "negativeValues")
+      args$missingValues.target <- c(options$counts, options$factors)
     }
     
-    # Declare table elements
-    fields <- list(
-        list(name = "number", type = "integer",title = " "),
-        list(name = "model", type = "string", title = "Models"),
-        list(name = "pMdata", type = "number", format = "dp:3", title = "P(M|data)"),
-        list(name = "bf", type = "number", format="sf:4;dp:3", title = bfTitle)
-    )
+    do.call(.hasErrors, args)
+  }
+  
+  # Error check 2: 0 observations for a level of a variable
+  for (factor in options$factors) {
     
-    emptyRow <- list( #for empty elements in tables when given output
-        "number" = "",
-        "model" = "",
-        "pMdata" = "",
-        "bf" = ""
-    )
+    column <- dataset[[.v(factor)]]
+    data   <- column[!is.na(column)]
+    levels <- levels(data)
     
-    dotted.line <- list( #for empty tables
-        "number" = ".",
-        "model" = ".",
-        "pMdata" = ".",
-        "bf" = "."
-    )
+    for (level in levels) {
+      .hasErrors(
+        dataset              = data[data == level],
+        perform              = "run",
+        type                 = "observations",
+        observations.amount  = "< 1",
+        exitAnalysisIfErrors = TRUE
+      )
+    }
+  }
+} 
+
+# Compute results 
+.basRegLogLinComputeBFObject <- function(jaspResults, dataset, options, ready) {
+  if(!is.null(jaspResults[["bfObject"]])) 
+    return()
+  if(!ready)
+    return()
+  
+  bfObject <- list("anthonyObj"     = NULL, 
+                   "variables"      = c("...", "... "),
+                   "nModelsVisited" = NULL,
+                   "nBurnIn"        = NULL,
+                   "bf10s"          = rep(".", length=2), 
+                   "postModelProbs" = rep(".", length=2), 
+                   "modelNames"     = NULL)
+  numberOfModels   <- length(options$modelTerms)
+  variablesInModel <- NULL
+  anthonyObj       <- NULL
+  
+  if (options$counts == "")
+    dataset <- plyr::count(dataset)
+  else
+    dataset <- dataset
+  
+  # Extract models needed to be compared
+  if (options$counts == "")
+    dependentVariable <- "freq"
+  else
+    dependentVariable <- unlist(options$counts)
+  
+  dependentBase64 <- .v(dependentVariable)
+
+    if (length(options$modelTerms) > 0) {
+    variablesInModel <- NULL
+    variablesInModelBase64 <- NULL
     
-    posteriorTable[["schema"]] <- list(fields = fields)
+    for (i in seq_along(options$modelTerms)) {
+      components <- options$modelTerms[[i]]$components
+      
+      if (length(components) == 1) {
+        term <- components[[1]]
+        termBase64 <- .v(components[[1]])
+      } else {
+        componentsUnlisted <- unlist(components)
+        term       <- paste0(componentsUnlisted, collapse = ":")
+        termBase64 <- paste0(.v(componentsUnlisted), collapse = ":")
+      }
+      # Add to tally
+      variablesInModel       <- c(variablesInModel, term)
+      variablesInModelBase64 <- c(variablesInModelBase64, termBase64)
+      
+      # Remove empty stuff
+      variablesInModel <- variablesInModel[variablesInModel != ""]
+    }
+  }
+  
+  # Prune the variables
+  if (length(variablesInModel) == 0) {
+    variablesInModel <- c("...", "... ")
+    modelDefinition  <- NULL #this model has no parameters
+  } else if (length(variablesInModel) == 1 && options$counts == "") {
+    variablesInModel <- c(variablesInModel, "... ")
+    modelDefinition  <- NULL #this model has only one parameter
+  } else if (length(variablesInModel) > 1 || options$counts != "") {
+    modelDefinition <- paste(dependentBase64, "~", 
+                             paste(variablesInModelBase64, collapse = "+"))
+  } else {
+    # Nothing worked out:
+    modelDefinition <- NULL #this model has no parameters
+    stop("variables cannot be read")
+  }
+  
+  # Save in object
+  bfObject$variables <- variablesInModel
+  
+  # START analysis Bayesian Log Linear regression
+  if (!is.null(modelDefinition)) {
+    modelFormula <- as.formula(modelDefinition)
     
-    footnotes <- .newFootnotes()
+    if (options$counts == "")
+      names(dataset)[names(dataset) == "freq"] <- dependentBase64
     
-    if (is.null(dataset)) {
-	    if (options$counts == "") {
-	        countsVar <- NULL
-	    } else {
-	        countsVar <- options$counts
-	    }
-	    
-	    if (perform == "run") {
-	        dataset <- .readDataSetToEnd(columns.as.factor=options$factors, columns.as.numeric=countsVar)
-	    } else {
-	        dataset <- .readDataSetHeader(columns.as.factor=options$factors, columns.as.numeric=countsVar)
-		}
-	}	 
-	 
-	listOfErrors <- list()
-	errorMessage <- NULL
-	
-	# Default error result
-	# 
-	# 
-	initialObject <- list("anthonyObj" = NULL, 
-	                      "variables" = c("...", "... "),
-	                      "nModelsVisited" = NULL,
-	                      "nBurnIn" = NULL,
-	                      "bf10s" = rep(".", length=2), 
-	                      "postModelProbs" = rep(".", length=2), 
-	                      "modelNames" = NULL, 
-	                      "hasErrors" = FALSE, 
-	                      "errorMessages" = list()
-	)
-	
-	errorBfObj <- list(nModelsVisited=NA, postModelProbs=rep(NA, length=options$maxModels), 
-	                    bf10s=rep(NA, length=options$maxModels)
-	)
-	
-	numberOfModels <- length(options$modelTerms)
-	
-	variablesInModel <- NULL
-	
-	if (perform == "init") {
-	    if (numberOfModels == 0) {
-	        variablesInModel <- c("...", "... ")
-	    } else {
-	        for (i in 1:length(options$modelTerms)){
-	            components <- options$modelTerms[[i]]$components
-	            
-	            if (length(components) == 1) {
-	                variablesInModel <- c(variablesInModel, components[[1]])
-	            } else {
-	                componentsUnlisted <- unlist(components)
-	                variablesInModel <- c(variablesInModel, paste0(componentsUnlisted, collapse=":"))
-	            }
-	        }
-	        
-	        
-	        # Remove all empty variables
-	        variablesInModel <- variablesInModel[ variablesInModel != ""]
-	        
-	        
-	        if (length(variablesInModel)==0){
-	            variablesInModel <- c("...", "... ")
-	        } else if ( length(variablesInModel) == 1 ) {
-	            variablesInModel <- c(variablesInModel, "... ")
-	        }
-	    } 
-	    
-	    bfObject <- initialObject
-	    bfObject$variables <- variablesInModel
-	}
-	
-	# 
-	if (perform == "run"){
-	    # Data screening
-	    #
-	    # TODO: STATE RETRIEVAL HERE State retrieval here. If not retrieval, then create bfObject
-	    #   Try saving them by names of the variables.
-	    # 
-	    # order(variablesInModel) 
-	    # TODO: Ask Anthony about what to do when we subset models 
-	    # 
-	    bfObject <- initialObject
-	    anthonyObj <- NULL
-	    
-	    
-	    # TODO: If bfObject has an error, then skip this 
-	    # if (isTRUE(bfObject$error)) 
-	    
-		if (length(options$factors) > 0 && perform == "run") {
-			args <- list(
-				dataset = dataset,
-				type = c("missingValues", "modelInteractions"),
-				modelInteractions.modelTerms = options$modelTerms,
-				missingValues.target = options$factors,
-				exitAnalysisIfErrors = TRUE
-			)
-			
-			if (options$counts != "") {
-				args$type <- c(args$type, "infinity", "negativeValues")
-				args$missingValues.target <- c(options$counts, options$factors)
-			}
-			
-			do.call(.hasErrors, args)
-		}
-	    
-	    # Counts not given
-	    #
-	    if (options$counts == "") {
-	        dataset <- plyr::count(dataset)
-	    } else {
-	        dataset <- dataset
-	    }
+    # Calculate here
+    anthonyObj <- try(conting::bcct(formula = modelFormula, data = dataset, 
+                                    prior = "SBH", n.sample = 2000, 
+                                    a = options$priorShape, b = options$priorScale), 
+                      silent = TRUE)
+    bfObject$nBurnIn <- 2000 * 0.2
+    
+    # Always do auto and then manual adds additional samples
+    if (options$sampleMode == "manual"){
+      anthonyObj <- try(conting::bcctu(object = anthonyObj, 
+                                       n.sample = options$fixedSamplesNumber), 
+                        silent = TRUE)
+      bfObject$nBurnIn <- (2000 + options$fixedSamplesNumber) * 0.2
+    }
+    
+    # Anthony object checking
+    if (class(anthonyObj) == "bcct")
+      bfObject$anthonyObj <- anthonyObj
+    
+  } else if (isTRUE(bfObject$hasErrors)) {
+    # NAs: nModelsVisited, bf10s, postModelProbs
+    bfObject <- modifyList(bfObject, errorBfObj)
+  } else if (is.null(modelDefinition)) {
+    # NAs: nModelsVisited, bf10s, postModelProbs
+    bfObject <- modifyList(bfObject, errorBfObj)
+    stop("Cannot define model")
+  }
+  
+  # Post processing
+  if (class(bfObject$anthonyObj) == "bcct") {
+    # Good case
+    # TODO: Here check anthonySummary$totmodsvisit if this is one, 
+    # then nothing going on, resample
+    #
+    anthonySummary <- try(conting::mod_probs(bfObject$anthonyObj, scale = 0, 
+                                             best = options$maxModels), silent = TRUE)
+    
+    if (inherits(anthonySummary, "modprobs")) {
+      # Good case
+      bfObject$nModelsVisited <- anthonySummary$totmodsvisit
+      modelnames <- anthonySummary$table$model_formula
+      bfObject$modelNames <- substring(as.character(modelnames), first=2)
+      
+      if (bfObject$nModelsVisited == 1) {
+        bfObject$postModelProbs <- 1
+        bfObject$bf10s <- 1
+      } else if (bfObject$nModelsVisited > 1) {
+        # Note the following BFs are based on a uniform prior on the models
+        
+        if (!is.null(anthonySummary$table$prob.Freq)) {
+          postModelProbs <- anthonySummary$table$prob.Freq
+          bfObject$postModelProbs <- postModelProbs
+          bfObject$bf10s <-  postModelProbs/ max(postModelProbs)
+        } else {
+          # NAs: nModelsVisited, bf10s, postModelProbs
+          stop("R Package error: Cannot retrieve table probabilities")
+        }
+      }
+    }
+  } 
+  jaspResults[["bfObject"]] <- createJaspState(bfObject)
+  #jaspResults[["bfObject"]]$dependOn(c("counts", "modelTerms", "VovkSellkeMPR"))
+  
+  return(bfObject)
+}
 
-	    # Extract models needed to be compared
-	    # 
-	    if (options$counts == ""){
-	        dependentVariable <- "freq"
-	    } else {
-	        dependentVariable <- unlist(options$counts)
-	    }
+.basRegLogLinMainResults <- function(jaspResults, dataset, options, bfObject, ready) {
+  if(!is.null(jaspResults[["MainResults"]])) 
+    return()
+  
+  emptyRow <- list( #for empty elements in tables when given output
+    "number" = "",
+    "model"  = "",
+    "pMdata" = "",
+    "bf"     = ""
+  )
+  
+  dotted.line <- list( #for empty tables
+    "number" = ".",
+    "model"  = ".",
+    "pMdata" = ".",
+    "bf"     = "."
+  )
+  
+  posteriorTableRows <- list()
+  # posteriorTableRows <- list()
+  
+  nModelsReport <- try(min(bfObject$nModelsVisited, options$maxModels))
+  
+  if (!is.null(bfObject$modelNames))
+    reportNames <- .unvf(bfObject$modelNames)
+  else if (!is.null(bfObject$variables)) 
+    reportNames <- bfObject$variables
+  else 
+    reportNames <- c("...", "... ")
+  
+  if (!is.null(bfObject$bf10s))
+    reportBfs <- bfObject$bf10s
+  else # TODO: Too much with the error list already??
+    reportBfs <- rep(NA, length=nModelsReport) 
+  
+  if (is.numeric(reportBfs)) {
+    if (options$bayesFactorType == "BF01")
+      reportBfs <- 1/reportBfs
+    else if (options$bayesFactorType == "LogBF10")
+      reportBfs <- log(reportBfs)
+  }
+  
+  if (!is.null(bfObject$postModelProbs))
+    reportPostModelProbs <- bfObject$postModelProbs
+  else
+    reportPostModelProbs <- rep(NA, length=nModelsReport)
+  
+  for (i in 1:nModelsReport){
+    posteriorTableRows[[i]]           <- emptyRow
+    posteriorTableRows[[i]]$"number"  <- as.integer(i)
+    posteriorTableRows[[i]]$"model"   <- .clean(reportNames[i])
+    posteriorTableRows[[i]]$"pMdata"  <- .clean(reportPostModelProbs[i])
+    posteriorTableRows[[i]]$"bf"      <- .clean(reportBfs[i])
+    #posteriorTableRows[[i]]$"footnotes" <- as.list(".")
+  }
+  
+  #message <- paste ("Total number of models visited =", 
+  #                  bfObject$nModelsVisited, sep=" ")
+  #.addFootnote (footnotes, symbol = "<em>Note.</em>", text = message)
+  
+  results   <- posteriorTableRows
+  
+  jaspResults[["Container"]][["MainResults"]] <- results
+  #jaspResults[["MainResults"]]$dependOn(c("counts", "modelTerms", "VovkSellkeMPR"))
+  
+  return(results)
+}
 
-	    dependentBase64 <- .v(dependentVariable)
+.basRegLogLinSummaryResults <- function(jaspResults, dataset, options, bfObject, ready) {
+  if(!is.null(jaspResults[["SummaryResults"]])) 
+    return()
+  if(!options$regressionCoefficientsEstimates) 
+    return()
+  
+  emptyRow <- list( #for empty elements in tables when given output
+    "Name" = "",
+    "post_prob" = "",
+    "post_mean" = "",
+    "post_var" = "",
+    "lower_lim" = "",
+    "upper_lim" = "")
+  
+  dotted.line <- list( #for empty tables
+    "Name" = ".",
+    "post_prob" = ".",
+    "post_mean" = ".",
+    "post_var" = ".",
+    "lower_lim" = ".",
+    "upper_lim" = ".")
+  
+  results <- list()
+  
+  lookup.table <- .regressionLogLinearBayesianBuildLookup(dataset, options$factors)
+  lookup.table[["(Intercept)"]] <- "(Intercept)"
+  
+  if (ready) {
+    if ( class(bfObject$anthonyObj) == "bcct") {
+      probLevel <- options$regressionCoefficientsCredibleIntervalsInterval
+      logBlm.summary   <- summary(bfObject$anthonyObj, 
+                                  n.burnin=bfObject$nBurnIn, 
+                                  cutoff = options$posteriorProbabilityCutOff, 
+                                  prob.level = probLevel)
+      logBlm.estimates <- logBlm.summary$int_stats
+      
+      len.Blogreg <- length(results) + 1		
+      term.names  <- logBlm.estimates$term			
+      
+      if (length(bfObject$variables) > 0) {
+        
+        variablesInModel <- bfObject$variables
+        terms <- as.character(logBlm.estimates$term)
+        coef  <- base::strsplit (terms, split = ":", fixed = TRUE)				
+        
+        for (var in seq_along(coef)) {
+          
+          results[[ len.Blogreg ]] <- emptyRow
+          terms <- coef[[var]]
+          actualName <- list()
+          
+          for (j in seq_along(terms))
+            actualName[[j]] <- paste(lookup.table[[ terms[j] ]], collapse = " = ")
+          varName <- paste0(actualName, collapse = "*")
+          
+          results[[ len.Blogreg ]]$"Name"      <- varName
+          results[[ len.Blogreg ]]$"post_prob" <- as.numeric(logBlm.estimates$prob[var])
+          results[[ len.Blogreg ]]$"post_mean" <- as.numeric(logBlm.estimates$post_mean[var])
+          results[[ len.Blogreg ]]$"post_var"  <- as.numeric(logBlm.estimates$post_var[var])
+          
+          if (options$regressionCoefficientsCredibleIntervals == TRUE){			
+            results[[ len.Blogreg ]]$"lower_lim" <- as.numeric(logBlm.estimates$lower[var])
+            results[[ len.Blogreg ]]$"upper_lim" <- as.numeric(logBlm.estimates$upper[var])
+          }
+          
+          len.Blogreg <- len.Blogreg + 1
+        }		
+      }			
+      
+    } else {
+      
+      len.Blogreg <- length(results) + 1
+      results[[ len.Blogreg ]] <- dotted.line
+      
+      if (length(bfObject$variables) > 0) {
+        
+        variablesInModel <- bfObject$variables
+        
+        len.Blogreg <- len.Blogreg + 1
+        
+        for (var in 1:length(variablesInModel)) {
+          
+          results[[ len.Blogreg ]] <- dotted.line
+          
+          if (base::grepl(":", variablesInModel[var])) {
+            
+            # if interaction term					
+            vars <- unlist(strsplit(variablesInModel[var], split = ":"))
+            name <- paste0(vars, collapse="\u2009\u273b\u2009")
+            
+          } else 
+            name <- as.character(variablesInModel[ var])
+          
+          results[[ len.Blogreg ]]$"Name" <- name
+          len.Blogreg <- len.Blogreg + 1
+        }
+      }
+    }
+    
+  } else {
+    
+    len.Blogreg <- length(results) + 1
+    
+    if (length(bfObject$variables) > 0) 
+      variablesInModel <- bfObject$variables
+    
+    results[[ len.Blogreg ]] <- dotted.line
+    #len.Blogreg <- length(Bayesianlogregression.result) + 1
+    #results[[ len.Blogreg ]] <- dotted.line
+    results[[ len.Blogreg ]]$"Model" <- 1
+  }
+  
+  #Bayesianlogregression[["data"]] <- Bayesianlogregression.result
+  #results   <- Bayesianlogregression.result
+  
+  jaspResults[["Container"]][["SummaryResults"]] <- results
+  #jaspResults[["SummaryResults"]]$dependOn(c("counts", "modelTerms", "VovkSellkeMPR"))
+  
+  return(results)
+}
 
-	    # Retrieve model terms
-	    #
-	    # Start tallying
-	    # 
-	    variablesInModel <- NULL
-	    variablesInModelBase64 <- NULL
-	    
-	    for (i in seq_along(options$modelTerms)) {
-	        components <- options$modelTerms[[i]]$components
+.basRegLogLinSubSummaryResults <- function(jaspResults, dataset, options, bfObject, ready) {
+  if(!is.null(jaspResults[["SubSummaryResults"]])) 
+    return()
+  if(!options$regressionCoefficientsSubmodel) 
+    return()
+  
+  emptyRow <- list(#for empty elements in tables when given output
+    "Name" = "",
+    "post_mean" = "",
+    "post_var" = "",
+    "lower_lim" = "",
+    "upper_lim" = "")
+  
+  dotted.line <- list(#for empty tables
+    "Name" = ".",
+    "post_mean" = ".",
+    "post_var" = ".",
+    "lower_lim" = ".",
+    "upper_lim" = ".")
+  
+  results <- list()
+  
+  lookup.table <- .regressionLogLinearBayesianBuildLookup(dataset, options$factors)
+  lookup.table[["(Intercept)"]] <- "(Intercept)"
+  #footnotes <- .newFootnotes()
+  
+  
+  if (ready && !is.null(bfObject$anthonyObj)  ) {
+    probLevel <- options$regressionCoefficientsSubmodelCredibleIntervalsInterval
+    order     <- options$regressionCoefficientsSubmodelNo
+    logBlm.subestimates = try(conting::sub_model(bfObject$anthonyObj, 
+                                                 n.burnin   = bfObject$nBurnIn, 
+                                                 order      = order, 
+                                                 prob.level = probLevel), 
+                              silent = TRUE)
+    
+    if ( class(logBlm.subestimates) == "submod"){
+      
+      len.Blogreg <- length(results) + 1		
+      term.names <- logBlm.subestimates$term	
+      
+      extractedModelFormula <- logBlm.subestimates$formula
+      
+      extractedModelFormula <- as.character(extractedModelFormula)
+      extractedModelFormula <- substring(extractedModelFormula, first=2)  # trim leading ~
+      extractedModelFormula <- .unvf(extractedModelFormula)	
+      #message1 <- extractedModelFormula
+      #.addFootnote (footnotes, symbol = "<em>Model formula:</em>", text = message1)
+      
+      #Post.pob <- round(logBlm.subestimates$post_prob, 3)
+      #.addFootnote (footnotes, symbol = "<em>Posterior model probability =</em>", 
+      #              text = Post.pob )	
+      
+      if (length(bfObject$variables) > 0) {
+        
+        variablesInModel <- bfObject$variables
+        terms <- as.character(logBlm.subestimates$term)
+        coef  <- base::strsplit (terms, split = ":", fixed = TRUE)				
+        
+        for (var in seq_along(coef)) {
+          
+          results[[ len.Blogreg ]] <- emptyRow
+          terms      <- coef[[var]]
+          actualName <- list()
+          
+          for (j in seq_along(terms))
+            actualName[[j]] <- paste(lookup.table[[ terms[j] ]], collapse = " = ")
+          varName<-paste0(actualName, collapse="*")
+          
+          results[[ len.Blogreg ]]$"Name"      <- varName
+          results[[ len.Blogreg ]]$"post_mean" <- as.numeric(logBlm.subestimates$post_mean[var])
+          results[[ len.Blogreg ]]$"post_var"  <- as.numeric(logBlm.subestimates$post_var[var])
+          
+          if (options$regressionCoefficientsSubmodelCredibleIntervals){			
+            results[[ len.Blogreg ]]$"lower_lim" <- as.numeric(logBlm.subestimates$lower[var])
+            results[[ len.Blogreg ]]$"upper_lim" <- as.numeric(logBlm.subestimates$upper[var])
+          }
+          
+          len.Blogreg <- len.Blogreg + 1
+        }		
+      }			
+      
+    } else {
+      
+      len.Blogreg <- length(results) + 1
+      results[[ len.Blogreg ]] <- dotted.line
+      
+      if (length(bfObject$variables) > 0) {
+        
+        variablesInModel <- bfObject$variables
+        
+        len.Blogreg <- len.Blogreg + 1
+        
+        for (var in 1:length(variablesInModel)) {
+          
+          results[[ len.Blogreg ]] <- dotted.line
+          
+          if (base::grepl(":", variablesInModel[var])) {
+            
+            # if interaction term					
+            vars <- unlist(strsplit(variablesInModel[var], split = ":"))
+            name <- paste0(vars, collapse="\u2009\u273b\u2009")
+            
+          } else 
+            name <- as.character(variablesInModel[ var])
+          
+          results[[ len.Blogreg ]]$"Name" <- name
+          len.Blogreg <- len.Blogreg + 1
+        }
+      }
+    }
+    
+  } else {		
+    
+    len.Blogreg <- length(results) + 1
+    
+    if (length(bfObject$variables) > 0) 
+      variablesInModel <- bfObject$variables
+    
+    results[[ len.Blogreg ]] <- dotted.line
+    results[[ len.Blogreg ]]$"Model" <- 1
+  }
+  #BayesianSublogregression[["data"]]      <- BayesianSublogregression.result
+  #results   <- BayesianSublogregression.result
+  
+  jaspResults[["Container"]][["SubSummaryResults"]] <- results
+  #jaspResults[["SubSummaryResults"]]$dependOn(c("counts", "modelTerms", "VovkSellkeMPR"))
+  
+  return(results)
+}
 
-	        if (length(components) == 1) {
-	            term <- components[[1]]
-	            termBase64 <- .v(components[[1]])
-	        } else {
-	            componentsUnlisted <- unlist(components)
-	            term <- paste0(componentsUnlisted, collapse=":")
-	            termBase64 <- paste0(.v(componentsUnlisted), collapse=":")
-	        }
+# Container
+.basRegLogLinContainer <- function(jaspResults, dataset, options, ready) {
+  if(is.null(jaspResults[["Container"]])) {
+    jaspResults[["Container"]] <- createJaspContainer("Tables")
+    #jaspResults[["Container"]]$dependOn(c())
+  }
+}
 
-	        # Add to tally
-	        variablesInModel <- c(variablesInModel, term)
-	        variablesInModelBase64 <- c(variablesInModelBase64, termBase64)
+# Tables
+.basRegLogLinMainTable <- function(jaspResults, dataset, options, bfObject, ready) {
+  if (!is.null(jaspResults[["Container"]][["MainTable"]])) 
+    return()
+  
+  # Create table
+  mainTable <- createJaspTable(title = "Model Comparison")
+  #mainTable$dependOn(c("counts", "modelTerms", "VovkSellkeMPR"))
+  .basRegLogLinCitation(mainTable)
+  mainTable$showSpecifiedColumnsOnly <- TRUE
+  mainTable$position <- 1
+  
+  if (options$bayesFactorType == "BF10") 
+    bfTitle <- "BF<sub>10</sub>"
+  else if (options$bayesFactorType == "BF01") 
+    bfTitle <- "BF<sub>01</sub>"
+  else 
+    bfTitle <- "Log(BF<sub>10</sub>)"
+  
+  # Add columns to table
+  mainTable$addColumnInfo(name = "number", title = " ",         type = "integer")
+  mainTable$addColumnInfo(name = "model",  title = "Models",    type = "string")
+  mainTable$addColumnInfo(name = "pMdata", title = "P(M|data)", type = "number", 
+                          format = "dp:3")
+  mainTable$addColumnInfo(name = "bf",     title = bfTitle,     type = "number", 
+                          format="sf:4;dp:3")
+  
+  jaspResults[["Container"]][["MainTable"]] <- mainTable
+  if (!ready) 
+    return()
+  res <- try(.basRegLogLinMainResults(jaspResults, dataset, options, bfObject, ready))
+  .basRegLogLinSetErrorOrFill(res, mainTable)
+}
 
-	        # Remove empty stuff
-	        variablesInModel <- variablesInModel[variablesInModel != ""]
-	    }
+.basRegLogLinSummaryTable <- function(jaspResults, dataset, options, bfObject, ready){
+  if (!is.null(jaspResults[["Container"]][["SummaryTable"]])) 
+    return()
+  if(!options$regressionCoefficientsSubmodel) 
+    return()
+  # Create table
+  summaryTable <- createJaspTable(title = "Posterior Summary Statistics")
+  summaryTable$dependOn(c("counts", "modelTerms", "VovkSellkeMPR"))
+  .basRegLogLinCitation(summaryTable)
+  summaryTable$showSpecifiedColumnsOnly <- TRUE
+  summaryTable$position <- 2
+  
+  # Add columns to table
+  summaryTable$addColumnInfo(name = "Name",      title = " ", 
+                             type = "string")
+  summaryTable$addColumnInfo(name = "post_prob", title = "P(incl|data)", 
+                             type = "number", format = "dp:3")
+  summaryTable$addColumnInfo(name = "post_mean", title = "Mean",
+                             type = "number", format = "dp:3")
+  summaryTable$addColumnInfo(name = "post_var",  title = "Variance",
+                             type = "number", format = "dp:3")
+  if(options$regressionCoefficientsCredibleIntervals){
+    ci.label <- paste0(100*options$regressionCoefficientsCredibleIntervalsInterval, 
+                       "% Credible intervals")
+    summaryTable$addColumnInfo(name = "lower_lim", title = "Lower", 
+                               type = "number", format = "sf:4;dp:3", 
+                               overtitle = ci.label)
+    summaryTable$addColumnInfo(name = "upper_lim", title = "Upper", 
+                               type = "number", format = "sf:4;dp:3", 
+                               overtitle = ci.label)
+  }
+  
+  jaspResults[["Container"]][["SummaryTable"]] <- summaryTable
+  if (!ready) 
+    return()
+  
+  res <- try(.basRegLogLinSummaryResults(jaspResults, dataset, options, bfObject, ready))
+  
+  .basRegLogLinSetErrorOrFill(res, summaryTable)
+}
 
-	    # Prune the variables
-	    #
-	    if (length(variablesInModel)==0) {
-	        variablesInModel <- c("...", "... ")
-	        modelDefinition <- NULL #this model has no parameters
-	    } else if (length(variablesInModel)==1 && options$counts =="") {
-	        variablesInModel <- c(variablesInModel, "... ")
-	        modelDefinition <- NULL #this model has only one parameters
-	    } else if (length(variablesInModel) > 1 || options$counts != "") {
-	        modelDefinition <- paste(dependentBase64, "~", paste(variablesInModelBase64, collapse = "+"))
-	    } else {
-	        # Nothing worked out:
-	        modelDefinition <- NULL #this model has no parameters
-	        
-	        # TODO: Tim's centralised error message 
-	        bfObject$hasErrors <- TRUE
-	        bfObject$errorMessages[[length(bfObject$errorMessages)+1]] <- list(errorMessage="variables cannot be read", 
-	                                                                           errorType="input")
-	    }
-	    
-	    # Save in object
-	    bfObject$variables <- variablesInModel
-	    
-	    # START analysis Bayesian Log Linear regression -----------------
-	    # if no error and modelDefinition is okay
-	    #
-	    if (!is.null(modelDefinition) && !isTRUE(bfObject$hasErrors)) {
-		    modelFormula <- as.formula(modelDefinition)
+.basRegLogLinSubSummaryTable <- function(jaspResults, dataset, options, bfObject, ready){
+  if (!is.null(jaspResults[["Container"]][["SubSummaryTable"]])) 
+    return()
+  if(!options$regressionCoefficientsSubmodel) 
+    return()
+  # Create table
+  title <- paste("Posterior Summary Statistics For Submodel", 
+                 options$regressionCoefficientsSubmodelNo, sep=" ")
+  subSummaryTable <- createJaspTable(title = title)
+  #subSummaryTable$dependOn(c("counts", "modelTerms", "VovkSellkeMPR"))
+  .basRegLogLinCitation(subSummaryTable)
+  subSummaryTable$showSpecifiedColumnsOnly <- TRUE
+  subSummaryTable$position <- 3
+  
+  # Add columns to table
+  subSummaryTable$addColumnInfo(name = "Name", title = " ", type = "string")
+  subSummaryTable$addColumnInfo(name = "post_mean", title = "Mean",
+                                type = "number", format = "dp:3")
+  subSummaryTable$addColumnInfo(name = "post_var", title = "Variance",
+                                type = "number", format = "dp:3")
+  if(options$regressionCoefficientsCredibleIntervals){
+    ciVal <- options$regressionCoefficientsCredibleIntervalsInterval
+    ci.label <- paste0(100*ciVal, "% Credible intervals")
+    subSummaryTable$addColumnInfo(name = "lower_lim", title = "Lower", type = "number", 
+                                  format = "sf:4;dp:3", overtitle = ci.label)
+    subSummaryTable$addColumnInfo(name = "upper_lim", title = "Upper", type = "number", 
+                                  format = "sf:4;dp:3", overtitle = ci.label)
+  }
+  
+  jaspResults[["Container"]][["SubSummaryTable"]] <- subSummaryTable
+  if (!ready) 
+    return()
+  res <- try(.basRegLogLinSubSummaryResults(jaspResults, dataset, options, bfObject, ready))
+  .basRegLogLinSetErrorOrFill(res, subSummaryTable)
+}
 
-		    if (options$counts == ""){
-	 			names(dataset)[names(dataset)== "freq"] <- dependentBase64
-		    }
+# Other 
+.basRegLogLinCitation <- function(table) {
+  citation <- ("Overstall, A., & King, R. (2014). conting: an R package for 
+                Bayesian analysis of complete and incomplete contingency tables. 
+                Journal of Statistical Software, 58(7), 1-27.")
+  table$addCitation(citation)
+}
 
-		    # Calculate here
-		    anthonyObj <- try(conting::bcct(formula=modelFormula, data = dataset, prior = "SBH", n.sample=2000, a=options$priorShape, b=options$priorScale), silent = TRUE)
-		    # anthonyObj <- conting::bcct(formula=modelFormula, data = dataset, prior = "SBH", n.sample=2000, a=options$priorShape, b=options$priorScale)
-		    bfObject$nBurnIn <- 2000 * 0.2
-		    
-		    # TODO: check the maximal number of models visited, if it's one, then sample more
-		    # dim(anthonyObj$maximal.mod$x)[2] <- gives the max number of model visited, or
-		    #
-		    # Alternative, constraint the maximum number of additional iterations
-		    # In between do call.backs() <- need to figure out
-
-		    # Always do auto and then manual adds additional samples
-		    if (options$sampleMode == "manual"){
-		        anthonyObj <- try(conting::bcctu(object = anthonyObj, n.sample = options$fixedSamplesNumber), silent = TRUE)
-		        bfObject$nBurnIn <- (2000 + options$fixedSamplesNumber)* 0.2
-		    }
-		    
-		    # Anthony object checking
-		    if (class(anthonyObj) == "bcct") {
-		        bfObject$anthonyObj <- anthonyObj
-		    } else if (isTryError(anthonyObj)) {
-		        error <- paste0("R Package error: ", .extractErrorMessage(anthonyObj))
-		        listOfErrors[[ length(listOfErrors) + 1 ]]  <- error
-		        
-		        bfObject <- list(anthonyObj = NA, variables = variablesInModel)
-		        # NAs: nModelsVisited, bf10s, postModelProbs
-		        bfObject <- modifyList(bfObject, errorBfObj)
-		        
-		        bfObject$hasErrors <- TRUE
-		        bfObject$errorMessages[[length(bfObject$errorMessages)+1]] <- list(errorMessage=error, 
-		                                                                           errorType="package")
-		    } 
-		    # No clue error changed in to exception
-		    # else {
-		    #     # NAs: nModelsVisited, bf10s, postModelProbs
-		    #     bfObject <- modifyList(bfObject, errorBfObj)
-		    #     bfObject$hasErrors <- TRUE
-		    #     bfObject$errorMessages[[length(bfObject$errorMessages)+1]] <- list(errorMessage="No clue", 
-		    #                                                                        errorType="code")
-		    # }
-		} else if (isTRUE(bfObject$hasErrors)) {
-		    # NAs: nModelsVisited, bf10s, postModelProbs
-		    bfObject <- modifyList(bfObject, errorBfObj)
-		} else if (is.null(modelDefinition)) {
-		    # NAs: nModelsVisited, bf10s, postModelProbs
-		    bfObject <- modifyList(bfObject, errorBfObj)
-		    
-		    bfObject$hasErrors <- TRUE
-		    bfObject$errorMessages[[length(bfObject$errorMessages)+1]] <- list(errorMessage="Cannot define model", 
-		                                                                       errorType="input")
-		}
-	    # No clue error changed in to exception
-	    # else { 
-		#     # NAs: nModelsVisited, bf10s, postModelProbs
-		#     bfObject <- modifyList(bfObject, errorBfObj)
-		#     bfObject <- list(anthonyObj = NA, variables = variablesInModel)
-		#     
-		#     # Add error message to bfObject
-		#     bfObject$hasErrors <- TRUE
-		#     bfObject$errorMessages[[length(bfObject$errorMessages)+1]] <- list(errorMessage="No clue", 
-		#                                                                        errorType="code")
-		# }
-	    
-	    # Post processing
-	    #########################################################################
-	    #						 Posterior model probabilities  				#
-	    #########################################################################
-	    #
-	    #
-	    if (!isTRUE(bfObject$hasErrors)) {
-	        if (class(bfObject$anthonyObj) == "bcct") {
-	            # Good case
-	            # TODO: Here check anthonySummary$totmodsvisit if this is one, then nothing going on, resample
-	            #
-	            anthonySummary <- try(conting::mod_probs(bfObject$anthonyObj, scale=0, best = options$maxModels), silent=TRUE)
-	            
-	            if (inherits(anthonySummary, "modprobs")) {
-	                # Good case
-	                bfObject$nModelsVisited <- anthonySummary$totmodsvisit
-	                bfObject$modelNames <- substring(as.character(anthonySummary$table$model_formula), first=2)
-	                
-	                if (bfObject$nModelsVisited == 1) {
-	                    bfObject$postModelProbs <- 1
-	                    bfObject$bf10s <- 1
-	                } else if (bfObject$nModelsVisited > 1) {
-	                    # Note the following BFs are based on a uniform prior on the models
-	                    
-	                    if (!is.null(anthonySummary$table$prob.Freq)) {
-	                        bfObject$postModelProbs <- anthonySummary$table$prob.Freq
-	                        bfObject$bf10s <- anthonySummary$table$prob.Freq / max(anthonySummary$table$prob.Freq)
-	                    } else {
-	                        # NAs: nModelsVisited, bf10s, postModelProbs
-	                        bfObject <- modifyList(bfObject, errorBfObj)
-	                        
-	                        bfObject$hasErrors <- TRUE
-	                        bfObject$errorMessages <- list(errorMessages="R Package error: Cannot retrieve table probabilities", errorType="package")
-	                    }
-	                }
-	                # No clue error changed in to exception
-	                # else {
-	                #     # This means that bfObject$nModelsVisited not >= 1
-	                #     # TODO return error totally
-	                #     # NAs: nModelsVisited, bf10s, postModelProbs
-	                #     bfObject <- modifyList(bfObject, errorBfObj)
-	                #     
-	                #     bfObject$hasErrors <- TRUE
-	                #     bfObject$errorMessages <- list(errorMessages="No clue", errorType="code")
-	                # }
-	            } else if (isTryError(anthonySummary)) {
-	                # NAs: nModelsVisited, bf10s, postModelProbs
-	                bfObject <- modifyList(bfObject, errorBfObj)
-	                
-	                # TODO: Tim centralised 
-	                #
-	                bfObject$hasErrors <- TRUE
-	                bfObject$errorMessages[[length(bfObject$errorMessages)+1]] <- list(errorMessage=paste0("R Package error: ",.extractErrorMessage(anthonySummary)), 
-	                                                                                   errorType="package")
-	            } 
-	            # No clue error changed in to exception
-	            # else {
-	            #     # NAs: nModelsVisited, bf10s, postModelProbs
-	            #     bfObject <- modifyList(bfObject, errorBfObj)
-	            #     
-	            #     # TODO: Tim centralised 
-	            #     #
-	            #     bfObject$hasErrors <- TRUE
-	            #     bfObject$errorMessages[[length(bfObject$errorMessages)+1]] <- list(errorMessage="No clue", 
-	            #                                                                        errorType="code")
-	            # }
-	        } else {
-	            # Here bfObject$anthonyObj is not of the right class "bcct"
-	            # NAs: nModelsVisited, bf10s, postModelProbs
-	            bfObject <- modifyList(bfObject, errorBfObj)
-	            
-	            # TODO: Tim centralised 
-	            #
-	            bfObject$hasErrors <- TRUE
-	            bfObject$errorMessages[[length(bfObject$errorMessages)+1]] <- list(errorMessage="R Package error: Object of wrong class", 
-	                                                                               errorType="package")
-	        }
-	    } else {
-	        # Meaning error detected: listOfErrors > 0
-	        
-	        # NAs: nModelsVisited, bf10s, postModelProbs
-	        bfObject <- modifyList(bfObject, errorBfObj)
-	    }
-	} # ends performs=="run" to calculate a bfObject
-	
-	
-	# TODO: I'm not sure what this is about, perhaps I should ask Tahira
-	#
-	# if (length(listOfErrors) > 1){
-	#     anthonyObj <- try(conting::bcct(modelFormula, data = dataset,  prior = "SBH", n.sample=1000), silent = TRUE)
-	#     
-	#     # try(conting::bcct(formula=modelFormula, data = dataset, prior = "SBH", n.sample=2000, a=options$priorShape, b=options$priorScale), silent = TRUE)
-	# 
-	# 	if (isTryError(anthonyObj)) {
-	# 		error <- .extractErrorMessage(anthonyObj)
-	# 	}
-	# 	posteriorTable[["error"]] <- list(errorType="badData", errorMessage = error)
-	# } else if (length(listOfErrors) == 1){
-	# 	posteriorTable[["error"]] <- list(errorType = "badData", errorMessage = listOfErrors[[ 1 ]])
-	# }
-	
-	
-	
-	
-	
-	# Result processing --------------------
-	# always result processing
-	#
-	posteriorTableRows <- list()
-	# posteriorTableRows <- list()
-	
-	nModelsReport <- try(min(bfObject$nModelsVisited, options$maxModels))
-	
-	if (isTryError(nModelsReport) || isTRUE(bfObject$hasErrors) || perform=="init") {
-	    # Report error Bfs
-	    nModelsReport <- 2
-	} 
-	
-	if (!is.null(bfObject$modelNames)) {
-	    reportNames <- .unvf(bfObject$modelNames)
-	} else if (!is.null(bfObject$variables)) {
-	    reportNames <- bfObject$variables
-	} else {
-	    reportNames <- c("...", "... ")
-	}
-	
-	if (!is.null(bfObject$bf10s)) {
-	    reportBfs <- bfObject$bf10s
-	} else {
-	    # TODO: Too much with the error list already??
-	    reportBfs <- rep(NA, length=nModelsReport)
-	}
-	
-	if (is.numeric(reportBfs)) {
-	    if (options$bayesFactorType == "BF01") {
-	        reportBfs <- 1/reportBfs
-	    } else if (options$bayesFactorType == "LogBF10") {
-	        reportBfs <- log(reportBfs)
-	    }
-	}
-	
-	if (!is.null(bfObject$postModelProbs)) {
-	    reportPostModelProbs <- bfObject$postModelProbs
-	} else {
-	    reportPostModelProbs <- rep(NA, length=nModelsReport)
-	}
-	
-	for (i in 1:nModelsReport){
-	    posteriorTableRows[[i]] <- emptyRow
-	    posteriorTableRows[[i]]$"number" <- as.integer(i)
-	    # posteriorTableRows[[i]]$"Model" <- .clean(reportNames[i])
-	    posteriorTableRows[[i]]$"model" <- .clean(reportNames[i])
-	    posteriorTableRows[[i]]$"pMdata" <- .clean(reportPostModelProbs[i])
-	    posteriorTableRows[[i]]$"bf" <- .clean(reportBfs[i])
-	    # posteriorTableRows[[i]]$"footnotes" <- as.list(".")
-	}
-	
-	message <- paste ("Total number of models visited =", bfObject$nModelsVisited, sep=" ")
-	.addFootnote (footnotes, symbol = "<em>Note.</em>", text = message)
-	
-	if (isTRUE(bfObject$hasErrors)) {
-	    for (i in 1:length(bfObject$errorMessage)) {
-	        # Note: Most likely i == 1
-	        # TODO: Figure out how error messages are stacked
-	        posteriorTable[["error"]] <- bfObject$errorMessage[[i]]
-	    }
-	} 
-		
-    posteriorTable[["footnotes"]] <- as.list(footnotes)
-	posteriorTable[["data"]] <- posteriorTableRows
-	results[["posteriorTable"]] <- posteriorTable
-	
-	################################################################################
-	#						   MODEL COEFFICIENTS TABLE   						#
-	################################################################################		
-	if (options$regressionCoefficientsEstimates  == TRUE){
-		Bayesianlogregression <- list()
-		Bayesianlogregression[["title"]] <- "Posterior Summary Statistics"
-		Bayesianlogregression[["citation"]] <- logLinearBayesianCitations
-		#ci.label <- paste(100*options$regressionCoefficientsCredibleIntervalsInterval, "% Highest posterior density intervals", sep="")
-		ci.label <- paste0(100*options$regressionCoefficientsCredibleIntervalsInterval, "% Credible intervals")
-		# Declare table elements
-		fields <- list(
-			list(name = "Name", title = " ", type = "string"),
-			list(name = "post_prob", title="P(incl|data)", type = "number", format = "dp:3"),
-			list(name = "post_mean", title = "Mean",type="number", format = "dp:3"),
-			list(name = "post_var", title = "Variance",type="number", format = "dp:3"))
-		if (options$regressionCoefficientsCredibleIntervals == TRUE){
-			fields <- c(fields,list(
-				list(name = "lower_lim", title = "Lower", overTitle=ci.label, type="number", format = "sf:4;dp:3"),
-				list(name = "upper_lim", title = "Upper", overTitle=ci.label, type = "number", format = "sf:4;dp:3")))
-		}
-
-		emptyRow <- list(                     #for empty elements in tables when given output
-			"Name" = "",
-			"post_prob" = "",
-			"post_mean" = "",
-			"post_var" = "",
-			"lower_lim" = "",
-			"upper_lim" = "")
-	
-		dotted.line <- list(                     #for empty tables
-			"Name" = ".",
-			"post_prob" = ".",
-			"post_mean" = ".",
-			"post_var" = ".",
-			"lower_lim" = ".",
-			"upper_lim" = ".")
-
-		Bayesianlogregression[["schema"]] <- list(fields = fields)
-		
-		Bayesianlogregression.result <- list()
-		
-		lookup.table <- .regressionLogLinearBayesianBuildLookup(dataset, options$factors)
-		lookup.table[["(Intercept)"]] <- "(Intercept)"
-			
-		if (perform == "run" && length(listOfErrors) == 0 ) {
-		    if (inherits(bfObject$anthonyObj, "try-error")) {
-				error <- .extractErrorMessage (bfObject$anthonyObj)
-				Bayesianlogregression[["error"]] <- list(errorType= "badData",errorMessage = error)
-			} else if ( class(bfObject$anthonyObj) == "bcct") {
-			    logBlm.summary = summary(bfObject$anthonyObj, n.burnin=bfObject$nBurnIn, cutoff = options$posteriorProbabilityCutOff, prob.level = options$regressionCoefficientsCredibleIntervalsInterval)
-				logBlm.estimates<- logBlm.summary$int_stats
-		
-				len.Blogreg <- length(Bayesianlogregression.result) + 1		
-				term.names <- logBlm.estimates$term			
-				
-				if (length(bfObject$variables) > 0) {
-				
-					variablesInModel <- bfObject$variables
-					terms<- as.character(logBlm.estimates$term)
-					coef<-base::strsplit (terms, split = ":", fixed = TRUE)				
-					
-					for (var in seq_along(coef)) {
-					
-						Bayesianlogregression.result[[ len.Blogreg ]] <- emptyRow
-						terms <- coef[[var]]
-						actualName<-list()
-					
-						for (j in seq_along(terms)){
-							actualName[[j]] <- paste(lookup.table[[ terms[j] ]], collapse=" = ")
-						}			
-						varName<-paste0(actualName, collapse="*")
-							
-						Bayesianlogregression.result[[ len.Blogreg ]]$"Name" <- varName
-						Bayesianlogregression.result[[ len.Blogreg ]]$"post_prob" <- as.numeric(logBlm.estimates$prob[var])
-						Bayesianlogregression.result[[ len.Blogreg ]]$"post_mean" <- as.numeric(logBlm.estimates$post_mean[var])
-						Bayesianlogregression.result[[ len.Blogreg ]]$"post_var" <- as.numeric(logBlm.estimates$post_var[var])
-						
-						if (options$regressionCoefficientsCredibleIntervals == TRUE){			
-							Bayesianlogregression.result[[ len.Blogreg ]]$"lower_lim" <- as.numeric(logBlm.estimates$lower[var])
-							Bayesianlogregression.result[[ len.Blogreg ]]$"upper_lim" <- as.numeric(logBlm.estimates$upper[var])
-						}
-					
-						len.Blogreg <- len.Blogreg + 1
-					}		
-				}			
-
-			} else {
-		
-				len.Blogreg <- length(Bayesianlogregression.result) + 1
-				Bayesianlogregression.result[[ len.Blogreg ]] <- dotted.line
-		
-				if (length(bfObject$variables) > 0) {
-			
-					variablesInModel <- bfObject$variables
-			
-					len.Blogreg <- len.Blogreg + 1
-			
-					for (var in 1:length(variablesInModel)) {
-				
-						Bayesianlogregression.result[[ len.Blogreg ]] <- dotted.line
-				
-						if (base::grepl(":", variablesInModel[var])) {
-					
-							# if interaction term					
-							vars <- unlist(strsplit(variablesInModel[var], split = ":"))
-							name <- paste0(vars, collapse="\u2009\u273b\u2009")
-					
-						} else {
-					
-							name <- as.character(variablesInModel[ var])
-						}
-				
-						Bayesianlogregression.result[[ len.Blogreg ]]$"Name" <- name
-						len.Blogreg <- len.Blogreg + 1
-					}
-				}
-			}
-		
-		} else {
-						
-			len.Blogreg <- length(Bayesianlogregression.result) + 1
-
-			if (length(bfObject$variables) > 0) {
-
-				variablesInModel <- bfObject$variables
-				
-			}
-
-			Bayesianlogregression.result[[ len.Blogreg ]] <- dotted.line
-			#len.Blogreg <- length(Bayesianlogregression.result) + 1
-			#Bayesianlogregression.result[[ len.Blogreg ]] <- dotted.line
-			Bayesianlogregression.result[[ len.Blogreg ]]$"Model" <- 1
-			if (length(listOfErrors) == 1){
-			    Bayesianlogregression[["error"]] <- list(errorType = "badData", errorMessage = listOfErrors[[ 1 ]])
-			}
-		}
-	
-		
-		Bayesianlogregression[["data"]] <- Bayesianlogregression.result
-		results[["Bayesianlogregression"]] <- Bayesianlogregression
-	}
-	
-################################################################################
-	#						  SUB-MODEL COEFFICIENTS TABLE   						#
-################################################################################		
-	if (options$regressionCoefficientsSubmodel  == TRUE){
-		BayesianSublogregression <- list()
-		BayesianSublogregression[["title"]] <-paste( "Posterior Summary Statistics For Submodel", options$regressionCoefficientsSubmodelNo, sep=" ")
-		BayesianSublogregression[["citation"]] <- logLinearBayesianCitations
-		ci.label <- paste(100*options$regressionCoefficientsSubmodelCredibleIntervalsInterval, "% Credible intervals", sep="")
-		# Declare table elements
-		fields <- list(
-			list(name = "Name", title = " ", type = "string"),
-			list(name = "post_mean", title="Mean", type = "number", format = "dp:3"),
-			list(name = "post_var", title = "Variance",type="number", format = "dp:3"))
-		if (options$regressionCoefficientsSubmodelCredibleIntervals == TRUE){
-			fields <- c(fields,list(
-				list(name = "lower_lim", title = "Lower", overTitle=ci.label, type="number", format = "sf:4;dp:3"),
-				list(name = "upper_lim", title = "Upper", overTitle=ci.label, type = "number", format = "sf:4;dp:3")))
-		}
-
-		emptyRow <- list(                     #for empty elements in tables when given output
-			"Name" = "",
-			"post_mean" = "",
-			"post_var" = "",
-			"lower_lim" = "",
-			"upper_lim" = "")
-	
-		dotted.line <- list(                     #for empty tables
-			"Name" = ".",
-			"post_mean" = ".",
-			"post_var" = ".",
-			"lower_lim" = ".",
-			"upper_lim" = ".")
-
-		BayesianSublogregression[["schema"]] <- list(fields = fields)
-		
-		BayesianSublogregression.result <- list()
-		
-		lookup.table <- .regressionLogLinearBayesianBuildLookup(dataset, options$factors)
-		lookup.table[["(Intercept)"]] <- "(Intercept)"
-		footnotes <- .newFootnotes()
-		
-			
-		if (perform == "run" && length(listOfErrors) == 0 && !is.null(bfObject$anthonyObj)  ) {
-		    logBlm.subestimates = try(conting::sub_model(bfObject$anthonyObj, n.burnin=bfObject$nBurnIn, order=options$regressionCoefficientsSubmodelNo, 
-				             prob.level = options$regressionCoefficientsSubmodelCredibleIntervalsInterval), silent = TRUE)
-			
-			if (inherits(logBlm.subestimates, "try-error")) {
-				error <- .extractErrorMessage (logBlm.subestimates)
-				BayesianSublogregression[["error"]] <- list(errorType= "badData",errorMessage = error)
-		
-			} else if ( class(logBlm.subestimates) == "submod"){
-	
-				len.Blogreg <- length(BayesianSublogregression.result) + 1		
-				term.names <- logBlm.subestimates$term	
-				
-				extractedModelFormula <- logBlm.subestimates$formula
-				
-				extractedModelFormula <- as.character(extractedModelFormula)
-				extractedModelFormula <- substring(extractedModelFormula, first=2)  # trim leading ~
-				extractedModelFormula <- .unvf(extractedModelFormula)	
-				message1 <- extractedModelFormula
-				.addFootnote (footnotes, symbol = "<em>Model formula:</em>", text = message1)
-													
-				Post.pob <- round(logBlm.subestimates$post_prob, 3)
-				.addFootnote (footnotes, symbol = "<em>Posterior model probability =</em>", text = Post.pob )	
-	
-				if (length(bfObject$variables) > 0) {
-				
-					variablesInModel <- bfObject$variables
-					terms<- as.character(logBlm.subestimates$term)
-					coef<-base::strsplit (terms, split = ":", fixed = TRUE)				
-					
-					for (var in seq_along(coef)) {
-					
-						BayesianSublogregression.result[[ len.Blogreg ]] <- emptyRow
-						terms <- coef[[var]]
-						actualName<-list()
-					
-						for (j in seq_along(terms)){
-							actualName[[j]] <- paste(lookup.table[[ terms[j] ]], collapse=" = ")
-						}			
-						varName<-paste0(actualName, collapse="*")
-							
-						BayesianSublogregression.result[[ len.Blogreg ]]$"Name" <- varName
-						BayesianSublogregression.result[[ len.Blogreg ]]$"post_mean" <- as.numeric(logBlm.subestimates$post_mean[var])
-						BayesianSublogregression.result[[ len.Blogreg ]]$"post_var" <- as.numeric(logBlm.subestimates$post_var[var])
-						
-						if (options$regressionCoefficientsSubmodelCredibleIntervals == TRUE){			
-							BayesianSublogregression.result[[ len.Blogreg ]]$"lower_lim" <- as.numeric(logBlm.subestimates$lower[var])
-							BayesianSublogregression.result[[ len.Blogreg ]]$"upper_lim" <- as.numeric(logBlm.subestimates$upper[var])
-						}
-					
-						len.Blogreg <- len.Blogreg + 1
-					}		
-				}			
-
-			} else {
-		
-				len.Blogreg <- length(BayesianSublogregression.result) + 1
-				BayesianSublogregression.result[[ len.Blogreg ]] <- dotted.line
-		
-				if (length(bfObject$variables) > 0) {
-			
-					variablesInModel <- bfObject$variables
-			
-					len.Blogreg <- len.Blogreg + 1
-			
-					for (var in 1:length(variablesInModel)) {
-				
-						BayesianSublogregression.result[[ len.Blogreg ]] <- dotted.line
-				
-						if (base::grepl(":", variablesInModel[var])) {
-					
-							# if interaction term					
-							vars <- unlist(strsplit(variablesInModel[var], split = ":"))
-							name <- paste0(vars, collapse="\u2009\u273b\u2009")
-					
-						} else {
-					
-							name <- as.character(variablesInModel[ var])
-						}
-				
-						BayesianSublogregression.result[[ len.Blogreg ]]$"Name" <- name
-						len.Blogreg <- len.Blogreg + 1
-					}
-				}
-			}
-		
-		} else {		
-			
-			len.Blogreg <- length(BayesianSublogregression.result) + 1
-
-			if (length(bfObject$variables) > 0) {
-			    variablesInModel <- bfObject$variables
-			}
-
-			BayesianSublogregression.result[[ len.Blogreg ]] <- dotted.line
-			BayesianSublogregression.result[[ len.Blogreg ]]$"Model" <- 1
-			
-			if (length(listOfErrors) == 1){
-				BayesianSublogregression[["error"]] <- list(errorType = "badData", errorMessage = listOfErrors[[ 1 ]])
-			}
-		}
-		BayesianSublogregression[["footnotes"]] <- as.list (footnotes)	
-		BayesianSublogregression[["data"]] <- BayesianSublogregression.result
-		results[["BayesianSublogregression"]] <- BayesianSublogregression
-		
-	}
-	
-########################################################################	
-	if (perform == "init") {
-	    if (options$counts == "" && numberOfModels < 2) {
-	        endResults <- list(results=results, status="complete") #, keep=keep)
-	    } else if (options$counts != "" && numberOfModels < 1) {
-	        endResults <- list(results=results, status="complete") #, keep=keep)
-	    } else {
-	        endResults <- list(results=results, status="inited") #, state=state, keep=keep)
-	    }
-	} else {
-	    endResults <- list(results=results, status="complete")
-	}
-	
-	return(endResults)
+.basRegLogLinSetErrorOrFill <- function(res, table) {
+  if(isTryError(res))
+    table$setError(res)
+  else {
+    for (level in 1:length(res)) {
+      row <- res[[level]]
+      table$addRows(row)
+    }
+  }
 }
 
 .regressionLogLinearBayesianBuildLookup <- function(dataset, factors) {
-    table <- list()
-
-	for (factorName in factors) {
-	    levels <- base::levels(dataset[[ .v(factorName) ]])
-	    
-	    for (i in seq_along(levels)) {
-	        levelName <- levels[i]
-	        base64Name <- paste(.v(factorName), i, sep="")
-	        actualName <- c(factorName, levelName)
-			table[[base64Name]] <- actualName
-		}
-	}
-	return(table)
+  table <- list()
+  
+  for (factorName in factors) {
+    levels <- base::levels(dataset[[ .v(factorName) ]])
+    
+    for (i in seq_along(levels)) {
+      levelName <- levels[i]
+      base64Name <- paste(.v(factorName), i, sep="")
+      actualName <- c(factorName, levelName)
+      table[[base64Name]] <- actualName
+    }
+  }
+  return(table)
 }
-
-
-# levels(checkData[[.v("facGender")]])
-# 
-# for myOptions$factors
-# .regressionLogLinearBayesianBuildLookup(checkData, myOptions$factors)
-# 

--- a/JASP-Engine/JASP/R/regressionloglinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionloglinearbayesian.R
@@ -26,7 +26,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   
   # Container
   .basRegLogLinContainer(jaspResults, dataset, options)
-  
+
   # Output tables (each calls its own results function)
   .basRegLogLinMainTable(      jaspResults, dataset, options, ready)
   .basRegLogLinSummaryTable(   jaspResults, dataset, options, ready)
@@ -70,13 +70,13 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   }
   
   do.call(.hasErrors, args)
-  
+
   # Error check 2: 0 observations for a level of a variable
   for (factor in options$factors) {
     column <- dataset[[.v(factor)]]
     data   <- column[!is.na(column)]
     levels <- levels(data)
-    
+  
     for (level in levels) {
       .hasErrors(
         dataset              = data[data == level],
@@ -104,7 +104,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   numberOfModels   <- length(options$modelTerms)
   variablesInModel <- NULL
   bcctObj          <- NULL
-  
+
   if (options$counts == "")
     dataset <- plyr::count(dataset)
   
@@ -195,7 +195,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     #
     bcctSummary <- try(conting::mod_probs(bfObject$bcctObj, scale = 0, 
                                           best = options$maxModels), silent = TRUE)
-    
+
     if (inherits(bcctSummary, "modprobs")) {
       # Good case
       bfObject$nModelsVisited <- bcctSummary$totmodsvisit
@@ -226,7 +226,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
 .basRegLogLinMainResults <- function(jaspResults, dataset, options) {
   # Compute/get the model
   bfObject <- .basRegLogLinComputeBFObject(jaspResults, dataset, options)
-  
+
   #for empty elements in tables w/ output
   emptyRow    <- .basRegLogLinMainLine(char = "") 
   dotted.line <- .basRegLogLinMainLine(char = ".") #for empty tables
@@ -275,7 +275,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
 .basRegLogLinSummaryResults <- function(jaspResults, dataset, options) {
   # Compute/get the model
   bfObject <- .basRegLogLinComputeBFObject(jaspResults, dataset, options)
-  
+
   #for empty elements in tables w/ output
   emptyRow    <- .basRegLogLinSummaryLine(char = "", prob = TRUE) 
   dotted.line <- .basRegLogLinSummaryLine(char = ".", prob = TRUE) #for empty tables
@@ -297,7 +297,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     term.names  <- logBlm.estimates$term			
     
     if (length(bfObject$variables) > 0) {
-      
+
       variablesInModel <- bfObject$variables
       terms <- as.character(logBlm.estimates$term)
       coef  <- base::strsplit (terms, split = ":", fixed = TRUE)				
@@ -307,7 +307,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
         results[[ len.Blogreg ]] <- emptyRow
         terms <- coef[[var]]
         actualName <- list()
-        
+
         for (j in seq_along(terms))
           actualName[[j]] <- paste(lookup.table[[ terms[j] ]], collapse = " = ")
         varName <- paste0(actualName, collapse = "*")
@@ -339,7 +339,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     if (length(bfObject$variables) > 0) {
       
       variablesInModel <- bfObject$variables
-      
+
       len.Blogreg <- len.Blogreg + 1
       
       for (var in 1:length(variablesInModel)) {
@@ -371,12 +371,14 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
   # Get Model
   bfObject <- jaspResults[["Container"]][["bfObject"]]$object
   
-  
+
   #for empty elements in tables w/ output
   emptyRow <- .basRegLogLinSummaryLine(char = "") 
   dotted.line <- .basRegLogLinSummaryLine(char = ".") #for empty tables
-  
+
   results <- list()
+  results[["footnotes"]] <- list()
+  results[["data"]] <- list()
   
   lookup.table <- .regressionLogLinearBayesianBuildLookup(dataset, options$factors)
   lookup.table[["(Intercept)"]] <- "(Intercept)"
@@ -402,7 +404,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
       extractedModelFormula <- .unvf(extractedModelFormula)	
       jaspResults[["Container"]][["SubSummaryTable"]]$addFootnote(extractedModelFormula, symbol = "<em>Model formula:</em>")
       jaspResults[["Container"]][["SubSummaryTable"]]$addFootnote(paste(round(logBlm.subestimates$post_prob, 3)), symbol = "<em>Posterior model probability =</em>")
-      
+
       if (length(bfObject$variables) > 0) {
         
         variablesInModel <- bfObject$variables
@@ -411,7 +413,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
         
         for (var in seq_along(coef)) {
           
-          results[[ len.Blogreg ]] <- emptyRow
+          results[["data"]][[ len.Blogreg ]] <- emptyRow
           terms      <- coef[[var]]
           actualName <- list()
           
@@ -438,7 +440,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     } else {
       
       len.Blogreg <- length(results) + 1
-      results[[ len.Blogreg ]] <- dotted.line
+      results[["data"]][[ len.Blogreg ]] <- dotted.line
       
       if (length(bfObject$variables) > 0) {
         
@@ -448,7 +450,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
         
         for (var in 1:length(variablesInModel)) {
           
-          results[[ len.Blogreg ]] <- dotted.line
+          results[["data"]][[ len.Blogreg ]] <- dotted.line
           
           if (base::grepl(":", variablesInModel[var])) {
             
@@ -459,7 +461,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
           } else 
             name <- as.character(variablesInModel[ var])
           
-          results[[ len.Blogreg ]]$"Name" <- name
+          results[["data"]][[ len.Blogreg ]]$"Name" <- name
           len.Blogreg <- len.Blogreg + 1
         }
       }
@@ -472,8 +474,8 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset, options, ...) {
     if (length(bfObject$variables) > 0) 
       variablesInModel <- bfObject$variables
     
-    results[[ len.Blogreg ]] <- dotted.line
-    results[[ len.Blogreg ]]$"Model" <- 1
+    results[["data"]][[ len.Blogreg ]] <- dotted.line
+    results[["data"]][[ len.Blogreg ]]$"Model" <- 1
   }
   jaspResults[["Container"]][["SubSummaryTable"]]$addRows(results)
 }

--- a/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
@@ -25,7 +25,7 @@ test_that("Main table results match", {
   options$maxModels <- 2
   options$posteriorProbabilityCutOff <- 0.001
   results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
-  table <- results[["results"]][["posteriorTable"]][["data"]]
+  table <- results[["results"]][["Container"]][["collection"]][["Container_MainTable"]][["data"]]
   expect_equal_tables(table,
     list(1, "contBinom + facGender", 0.963333333333333, 1, 2,
          "contBinom + facGender + contBinom<unicode><unicode><unicode>facGender",
@@ -46,7 +46,7 @@ test_that("General summary statistics table matches", {
   options$regressionCoefficientsCredibleIntervals <- TRUE
   options$regressionCoefficientsCredibleIntervalsInterval <- 0.90
   results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
-  table <- results[["results"]][["Bayesianlogregression"]][["data"]]
+  table <- results[["results"]][["Container"]][["collection"]][["Container_SummaryTable"]][["data"]]
   expect_equal_tables(table,
     list("(Intercept)", 1, 2.28941355597128, 0.0114477565469203, 2.12177466183418,
          2.45495750281602, "contBinom = 0", 1, 0.0303566571915708, 0.00356265251723887,
@@ -82,7 +82,7 @@ test_that("Submodel summary statistics table matches", {
   options$regressionCoefficientsSubmodelEstimates <- TRUE
   options$regressionCoefficientsSubmodelNo <- 2
   results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
-  table <- results[["results"]][["BayesianSublogregression"]][["data"]]
+  table <- results[["results"]][["Container"]][["collection"]][["Container_SubSummaryTable"]][["data"]]
   expect_equal_tables(table,
     list("(Intercept)", 2.29560729883006, 0.00945972825329099, 2.12809954463567,
          2.52220705393406, "contBinom = 0", 0.045757962353209, 0.00487119274553831,
@@ -93,4 +93,23 @@ test_that("Submodel summary statistics table matches", {
          -0.151633708350598, 0.242411127225971, "facFive = 4", 0.00306711588492548,
          0.0107120223942474, -0.234264000793185, 0.230287649489829)
   )
+})
+
+test_that("Analysis handles errors - Infinity", {
+  set.seed(0)
+  options <- initOpts()
+  options$factors <- "contBinom"
+  options$counts <- "debInf"
+  results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
+  errorMsg <- results[["results"]][["errorMessage"]]
+  expect_is(errorMsg, "character")
+})
+
+test_that("Analysis handles errors - Missing values (factor)", {
+  set.seed(0)
+  options <- initOpts()
+  options$factors <- "debBinMiss20"
+  results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
+  errorMsg <- results[["results"]][["errorMessage"]]
+  expect_is(errorMsg, "character")
 })

--- a/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
@@ -106,6 +106,9 @@ test_that("Analysis handles errors - Missing values (factor)", {
   set.seed(0)
   options <- initOpts()
   options$factors <- "debBinMiss20"
+  options$modelTerms <- list(
+    list(components="debBinMiss20")
+  )
   results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
   errorMsg <- results[["results"]][["errorMessage"]]
   expect_is(errorMsg, "character")

--- a/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
@@ -1,8 +1,5 @@
 context("Bayesian Log-Linear Regression")
 
-# does not test
-# - error handling
-
 initOpts <- function() {
   options <- jasptools::analysisOptions("RegressionLogLinearBayesian")
   options$sampleMode <- "manual"

--- a/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
@@ -95,7 +95,7 @@ test_that("Submodel summary statistics table matches", {
 test_that("Analysis handles errors - Infinity", {
   set.seed(0)
   options <- initOpts()
-  options$factors <- "contBinom"
+  options$factors <- c("contBinom", "facFive")
   options$counts <- "debInf"
   results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
   status <- results[["status"]]
@@ -105,7 +105,7 @@ test_that("Analysis handles errors - Infinity", {
 test_that("Analysis handles errors - Missing values (factor)", {
   set.seed(0)
   options <- initOpts()
-  options$factors <- "debBinMiss20"
+  options$factors <- c("debBinMiss20", "contBinom")
   options$modelTerms <- list(
     list(components="debBinMiss20")
   )

--- a/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-regressionloglinearbayesian.R
@@ -98,8 +98,8 @@ test_that("Analysis handles errors - Infinity", {
   options$factors <- "contBinom"
   options$counts <- "debInf"
   results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
-  errorMsg <- results[["results"]][["errorMessage"]]
-  expect_is(errorMsg, "character")
+  status <- results[["status"]]
+  expect_identical(status, "validationError")
 })
 
 test_that("Analysis handles errors - Missing values (factor)", {
@@ -110,6 +110,6 @@ test_that("Analysis handles errors - Missing values (factor)", {
     list(components="debBinMiss20")
   )
   results <- jasptools::run("RegressionLogLinearBayesian", "test.csv", options)
-  errorMsg <- results[["results"]][["errorMessage"]]
-  expect_is(errorMsg, "character")
+  status <- results[["status"]]
+  expect_identical(status, "validationError")
 })

--- a/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
@@ -89,8 +89,7 @@ Form
 			{
 				indent: true;
 				enabled: regressionCoefficientsSubmodel.checked
-				CheckBox { name: "regressionCoefficientsSubmodelEstimates"; label: qsTr("Estimates") }
-				CheckBox
+                CheckBox
 				{
 					name: "regressionCoefficientsSubmodelCredibleIntervals"; label: qsTr("Credible intervals")
 					CIField { name: "regressionCoefficientsSubmodelCredibleIntervalsInterval"; label: qsTr("Interval") }

--- a/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
@@ -22,8 +22,6 @@ import JASP.Widgets 1.0
 
 Form
 {
-    usesJaspResults: true
-	
 	VariablesForm
 	{
 		AvailableVariablesList { name: "allVariablesList" }		

--- a/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
@@ -22,7 +22,7 @@ import JASP.Widgets 1.0
 
 Form
 {
-	usesJaspResults: false
+    usesJaspResults: true
 	
 	VariablesForm
 	{

--- a/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
@@ -30,7 +30,7 @@ Form
 	}
 	
 	columns: 3
-	BayesFactorType {}
+    BayesFactorType { }
 
 	Group
 	{


### PR DESCRIPTION
**regressionloglinear.R**
Now uses jaspResults
The analysis is still quite slow as it needs to compute the `BFObject` and has sampling; maybe there could be a nice way to add a progress bar (even though it's mainly the one computation slowing it up)

**test-regressionloglinear.R**
Added error handling unit tests

**RegressionLogLinear.qml**
Removed useless submodel estimates checkbox
Some of the options have overly-long names; is this always necessary?