### PR TITLE
Bugfixes in Machine Learning Module

### DIFF
--- a/JASP-Engine/JASP-Engine.pro
+++ b/JASP-Engine/JASP-Engine.pro
@@ -121,6 +121,7 @@ DISTFILES += \
     JASP/R/anovaoneway.R \
     JASP/R/anovarepeatedmeasures.R \
     JASP/R/anovarepeatedmeasuresbayesian.R \
+	JASP/R/assignFunctionInPackage.R \
     JASP/R/bainancovabayesian.R \
     JASP/R/bainanovabayesian.R \
     JASP/R/bainregressionlinearbayesian.R \

--- a/JASP-Engine/JASP/R/assignFunctionInPackage.R
+++ b/JASP-Engine/JASP/R/assignFunctionInPackage.R
@@ -1,0 +1,69 @@
+assignFunctionInPackage <- function(fun, name, package) {
+  #'@title Overwrite functions inside R packages
+  #' 
+  #'@param fun    : function you want to replace
+  #'@param name   : the name of the function in a package
+  #'@param package: the name of the package
+  #'  
+  #' example usage:
+  #' avoid a parallel backend from being registered which triggers a firewall message
+  ns <- getNamespace(package)
+  unlockBinding(name, ns)
+  assign(name, fun, ns)
+  lockBinding(name, ns)
+}
+
+# NOTE: let's make it a custom to start the new function names with "fake" followed by the name of the original 
+# function. Also, let's put all "modified" versions of functions in this file. Note that thise file probably needs
+# to be resolved completely for R syntax.
+
+# mlRegressionBoosting ----
+fakeGbmCrossValModelBuild <- function(cv.folds, cv.group, n.cores, i.train, x, y, offset, 
+                                      distribution, w, var.monotone, n.trees, interaction.depth, 
+                                      n.minobsinnode, shrinkage, bag.fraction, var.names, response.name, 
+                                      group) {
+  # the first two lines create a parallel backend and trigger a firewall message
+  # cluster <- gbmCluster(n.cores)
+  # on.exit(parallel::stopCluster(cluster))
+  seeds <- as.integer(runif(cv.folds, -(2^31 - 1), 2^31))
+  # parallel::parLapply(cl = NULL, X = 1:cv.folds, fun = gbmDoFold, 
+  #                     i.train, x, y, offset, distribution, w, var.monotone, 
+  #                     n.trees, interaction.depth, n.minobsinnode, shrinkage, 
+  #                     bag.fraction, cv.group, var.names, response.name, group, 
+  #                     seeds)
+  
+  # NOTE: gbm::gbmDoFold calls library(gbm, silent = TRUE) so we make another fake function
+  fakeGbmDoFold <- function(X, i.train, x, y, offset, distribution, w, var.monotone,
+                            n.trees, interaction.depth, n.minobsinnode, shrinkage, bag.fraction,
+                            cv.group, var.names, response.name, group, s) {
+    set.seed(s[[X]])
+    i <- order(cv.group == X)
+    x <- x[i.train, , drop = TRUE][i, , drop = FALSE]
+    y <- y[i.train][i]
+    offset <- offset[i.train][i]
+    nTrain <- length(which(cv.group != X))
+    group <- group[i.train][i]
+    res <- gbm::gbm.fit(x = x, y = y, offset = offset, distribution = distribution, 
+                        w = w, var.monotone = var.monotone, n.trees = n.trees, 
+                        interaction.depth = interaction.depth, n.minobsinnode = n.minobsinnode, 
+                        shrinkage = shrinkage, bag.fraction = bag.fraction, nTrain = nTrain, 
+                        keep.data = FALSE, verbose = FALSE, response.name = response.name, 
+                        group = group)
+    res
+  }
+  lapply(X = 1:cv.folds, FUN = fakeGbmDoFold, i.train, x, y, offset, distribution, w, var.monotone, n.trees, 
+         interaction.depth, n.minobsinnode, shrinkage, bag.fraction, cv.group, var.names, response.name, group, seeds)
+}
+
+fakeGbmCrossValErr <- function(cv.models, cv.folds, cv.group, nTrain, n.trees) {
+  in.group <- tabulate(cv.group, nbins = cv.folds)
+  cv.error <- vapply(1:cv.folds, function(index) {
+    model <- cv.models[[index]]
+    model$valid.error * in.group[[index]]
+  }, double(n.trees))
+  if (is.matrix(cv.error))
+    return(rowSums(cv.error)/nTrain)
+  else
+    return(cv.error / nTrain)
+}
+

--- a/JASP-Engine/JASP/R/assignFunctionInPackage.R
+++ b/JASP-Engine/JASP/R/assignFunctionInPackage.R
@@ -67,3 +67,8 @@ fakeGbmCrossValErr <- function(cv.models, cv.folds, cv.group, nTrain, n.trees) {
     return(cv.error / nTrain)
 }
 
+
+
+# assign the functions ----
+assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
+assignFunctionInPackage(fakeGbmCrossValErr,        "gbmCrossValErr",        "gbm")

--- a/JASP-Engine/JASP/R/commonMachineLearningClustering.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningClustering.R
@@ -18,25 +18,22 @@
 .readDataClusteringAnalyses <- function(dataset, options){
   predictors <- unlist(options[['predictors']])
   predictors <- predictors[predictors != ""]
-  if (is.null(dataset)) {
+  if (is.null(dataset))
     dataset <- .readDataSetToEnd(columns.as.numeric = predictors, exclude.na.listwise = predictors)
-  }
-  if(options[["scaleEqualSD"]]){
-    dataset <- scale(dataset)
-  }
+
+  if(options[["scaleEqualSD"]])
+    dataset <- as.data.frame(scale(dataset))
+
   return(dataset)
 }
 
 .errorHandlingClusteringAnalyses <- function(dataset, options){
   predictors <- unlist(options$predictors)
-  if(length(predictors[predictors != '']) > 0){
-      for(i in 1:length(predictors)){
-          errors <- .hasErrors(dataset, perform, type = c('infinity', 'observations'),
-                               all.target = predictors[i],
-                               observations.amount = "< 2",
-                               exitAnalysisIfErrors = TRUE)
-      }
-  }
+  
+  if(length(predictors[predictors != ""]) > 0L)
+    .hasErrors(dataset, perform, type = c('infinity', 'observations'), all.target = predictors, 
+               observations.amount = "< 2", exitAnalysisIfErrors = TRUE)
+  return()
 }
 
 .clusterAnalysesReady <- function(options){

--- a/JASP-Engine/JASP/R/mlClassificationLda.R
+++ b/JASP-Engine/JASP/R/mlClassificationLda.R
@@ -449,20 +449,23 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   target <- as.numeric(dataset[, .v(options[["target"]])])
   predictors <- as.matrix(dataset[, .v(options[["predictors"]])])
 
-  manovaResult <- manova(predictors ~ target)
-  manovaSummary <- summary(manovaResult, test="Wilks")
-
-  # Individual models
-  anovaSummary <- summary.aov(manovaResult)
-  for(i in 1:length(anovaSummary)){
-    sumTmp <- as.matrix(anovaSummary[[i]])
-    F <- sumTmp[1, 4]
-    df1 <- sumTmp[1, 1]
-    df2 <- sumTmp[2, 1]
-    p <- sumTmp[1, 5]
-    row <- data.frame(model = options[["predictors"]][i], f = F, df1 = df1, df2 = df2, p = p)
-    manovaTable$addRows(row)
-  }
+  tryCatch({
+    manovaResult <- manova(predictors ~ target)
+    manovaSummary <- summary(manovaResult, test="Wilks")
+    
+    # Individual models
+    anovaSummary <- summary.aov(manovaResult)
+    for(i in 1:length(anovaSummary)){
+      sumTmp <- as.matrix(anovaSummary[[i]])
+      Fstat <- sumTmp[1, 4]
+      df1 <- sumTmp[1, 1]
+      df2 <- sumTmp[2, 1]
+      p <- sumTmp[1, 5]
+      row <- data.frame(model = options[["predictors"]][i], f = Fstat, df1 = df1, df2 = df2, p = p)
+      manovaTable$addRows(row)
+    }
+  }, error = function(e) manovaTable$setError(.extractErrorMessage(e))
+  )
 
 }
 

--- a/JASP-Engine/JASP/R/mlRegressionBoosting.R
+++ b/JASP-Engine/JASP/R/mlRegressionBoosting.R
@@ -79,9 +79,6 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
 
   trees <- base::switch(options[["modelOpt"]], "optimizationManual" = options[["noOfTrees"]], "optimizationOOB" = options[["maxTrees"]])
   
-  assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
-  assignFunctionInPackage(fakeGbmCrossValErr, "gbmCrossValErr", "gbm")
-
   bfit <- gbm::gbm(formula = formula, data = train, n.trees = trees,
                                shrinkage = options[["shrinkage"]], interaction.depth = options[["intDepth"]],
                                cv.folds = noOfFolds, bag.fraction = options[["bagFrac"]],

--- a/JASP-Engine/JASP/R/mlRegressionBoosting.R
+++ b/JASP-Engine/JASP/R/mlRegressionBoosting.R
@@ -79,62 +79,6 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
 
   trees <- base::switch(options[["modelOpt"]], "optimizationManual" = options[["noOfTrees"]], "optimizationOOB" = options[["maxTrees"]])
   
-  fakeGbmCrossValModelBuild <- function(cv.folds, cv.group, n.cores, i.train, x, y, offset, 
-                                        distribution, w, var.monotone, n.trees, interaction.depth, 
-                                        n.minobsinnode, shrinkage, bag.fraction, var.names, response.name, 
-                                        group) {
-    # the first two lines create a parallel backend and trigger a firewall message
-    # cluster <- gbmCluster(n.cores)
-    # on.exit(parallel::stopCluster(cluster))
-    seeds <- as.integer(runif(cv.folds, -(2^31 - 1), 2^31))
-    # parallel::parLapply(cl = NULL, X = 1:cv.folds, fun = gbmDoFold, 
-    #                     i.train, x, y, offset, distribution, w, var.monotone, 
-    #                     n.trees, interaction.depth, n.minobsinnode, shrinkage, 
-    #                     bag.fraction, cv.group, var.names, response.name, group, 
-    #                     seeds)
-    
-    # NOTE: gbm::gbmDoFold calls library(gbm, silent = TRUE) so we make another fake function
-    fakeGbmDoFold <- function(X, i.train, x, y, offset, distribution, w, var.monotone,
-                              n.trees, interaction.depth, n.minobsinnode, shrinkage, bag.fraction,
-                              cv.group, var.names, response.name, group, s) {
-      set.seed(s[[X]])
-      i <- order(cv.group == X)
-      x <- x[i.train, , drop = TRUE][i, , drop = FALSE]
-      y <- y[i.train][i]
-      offset <- offset[i.train][i]
-      nTrain <- length(which(cv.group != X))
-      group <- group[i.train][i]
-      res <- gbm::gbm.fit(x = x, y = y, offset = offset, distribution = distribution, 
-                          w = w, var.monotone = var.monotone, n.trees = n.trees, 
-                          interaction.depth = interaction.depth, n.minobsinnode = n.minobsinnode, 
-                          shrinkage = shrinkage, bag.fraction = bag.fraction, nTrain = nTrain, 
-                          keep.data = FALSE, verbose = FALSE, response.name = response.name, 
-                          group = group)
-      res
-    }
-    lapply(X = 1:cv.folds, FUN = fakeGbmDoFold, i.train, x, y, offset, distribution, w, var.monotone, n.trees, 
-           interaction.depth, n.minobsinnode, shrinkage, bag.fraction, cv.group, var.names, response.name, group, seeds)
-  } 
-  fakeGbmCrossValErr <- function(cv.models, cv.folds, cv.group, nTrain, n.trees) {
-    in.group <- tabulate(cv.group, nbins = cv.folds)
-    cv.error <- vapply(1:cv.folds, function(index) {
-      model <- cv.models[[index]]
-      model$valid.error * in.group[[index]]
-    }, double(n.trees))
-    if (is.matrix(cv.error))
-      return(rowSums(cv.error)/nTrain)
-    else
-      return(cv.error / nTrain)
-  }
-  
-  assignFunctionInPackage <- function(fun, name, package) {
-    # a horrible hack to avoid a parallel backend from being registered
-    ns <- getNamespace(package)
-    unlockBinding(name, ns)
-    assign(name, fun, ns)
-    lockBinding(name, ns)
-  }
-
   assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
   assignFunctionInPackage(fakeGbmCrossValErr, "gbmCrossValErr", "gbm")
 

--- a/JASP-Engine/JASP/R/mlRegressionBoosting.R
+++ b/JASP-Engine/JASP/R/mlRegressionBoosting.R
@@ -78,6 +78,65 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
   }
 
   trees <- base::switch(options[["modelOpt"]], "optimizationManual" = options[["noOfTrees"]], "optimizationOOB" = options[["maxTrees"]])
+  
+  fakeGbmCrossValModelBuild <- function(cv.folds, cv.group, n.cores, i.train, x, y, offset, 
+                                        distribution, w, var.monotone, n.trees, interaction.depth, 
+                                        n.minobsinnode, shrinkage, bag.fraction, var.names, response.name, 
+                                        group) {
+    # the first two lines create a parallel backend and trigger a firewall message
+    # cluster <- gbmCluster(n.cores)
+    # on.exit(parallel::stopCluster(cluster))
+    seeds <- as.integer(runif(cv.folds, -(2^31 - 1), 2^31))
+    # parallel::parLapply(cl = NULL, X = 1:cv.folds, fun = gbmDoFold, 
+    #                     i.train, x, y, offset, distribution, w, var.monotone, 
+    #                     n.trees, interaction.depth, n.minobsinnode, shrinkage, 
+    #                     bag.fraction, cv.group, var.names, response.name, group, 
+    #                     seeds)
+    
+    # NOTE: gbm::gbmDoFold calls library(gbm, silent = TRUE) so we make another fake function
+    fakeGbmDoFold <- function(X, i.train, x, y, offset, distribution, w, var.monotone,
+                              n.trees, interaction.depth, n.minobsinnode, shrinkage, bag.fraction,
+                              cv.group, var.names, response.name, group, s) {
+      set.seed(s[[X]])
+      i <- order(cv.group == X)
+      x <- x[i.train, , drop = TRUE][i, , drop = FALSE]
+      y <- y[i.train][i]
+      offset <- offset[i.train][i]
+      nTrain <- length(which(cv.group != X))
+      group <- group[i.train][i]
+      res <- gbm::gbm.fit(x = x, y = y, offset = offset, distribution = distribution, 
+                          w = w, var.monotone = var.monotone, n.trees = n.trees, 
+                          interaction.depth = interaction.depth, n.minobsinnode = n.minobsinnode, 
+                          shrinkage = shrinkage, bag.fraction = bag.fraction, nTrain = nTrain, 
+                          keep.data = FALSE, verbose = FALSE, response.name = response.name, 
+                          group = group)
+      res
+    }
+    lapply(X = 1:cv.folds, FUN = fakeGbmDoFold, i.train, x, y, offset, distribution, w, var.monotone, n.trees, 
+           interaction.depth, n.minobsinnode, shrinkage, bag.fraction, cv.group, var.names, response.name, group, seeds)
+  } 
+  fakeGbmCrossValErr <- function(cv.models, cv.folds, cv.group, nTrain, n.trees) {
+    in.group <- tabulate(cv.group, nbins = cv.folds)
+    cv.error <- vapply(1:cv.folds, function(index) {
+      model <- cv.models[[index]]
+      model$valid.error * in.group[[index]]
+    }, double(n.trees))
+    if (is.matrix(cv.error))
+      return(rowSums(cv.error)/nTrain)
+    else
+      return(cv.error / nTrain)
+  }
+  
+  assignFunctionInPackage <- function(fun, name, package) {
+    # a horrible hack to avoid a parallel backend from being registered
+    ns <- getNamespace(package)
+    unlockBinding(name, ns)
+    assign(name, fun, ns)
+    lockBinding(name, ns)
+  }
+
+  assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
+  assignFunctionInPackage(fakeGbmCrossValErr, "gbmCrossValErr", "gbm")
 
   bfit <- gbm::gbm(formula = formula, data = train, n.trees = trees,
                                shrinkage = options[["shrinkage"]], interaction.depth = options[["intDepth"]],


### PR DESCRIPTION
Fixes everything in https://github.com/jasp-stats/INTERNAL-jasp/issues/398, except for the code duplication and the unit-tests.

- [x] parallelization should be avoided or we need to give users some warning
- [x] debMiss99 breaks all 5 clustering analyses
- [x] Bug in LDA

the parallelization issue is avoided by overwriting the function in the `gbm` packages with functions that don't create a parallel backend. This is very hacky, but the only thing I could come up with.