### PR TITLE
Machine learning fixes 2

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/Label.qml
+++ b/JASP-Desktop/components/JASP/Controls/Label.qml
@@ -22,6 +22,7 @@ import JASP.Theme		1.0
 
 Label
 {
+    property bool alwaysEnabled: false // ensures that Labels within RadioButton are always Enabled
 	font:	Theme.font
-	color:	enabled ? Theme.textEnabled : Theme.textDisabled
+	color:	alwaysEnabled ? Theme.textEnabled : enabled ? Theme.textEnabled : Theme.textDisabled
 }

--- a/JASP-Desktop/components/JASP/Controls/Label.qml
+++ b/JASP-Desktop/components/JASP/Controls/Label.qml
@@ -22,7 +22,6 @@ import JASP.Theme		1.0
 
 Label
 {
-    property bool alwaysEnabled: false // ensures that Labels within RadioButton are always Enabled
 	font:	Theme.font
-	color:	alwaysEnabled ? Theme.textEnabled : enabled ? Theme.textEnabled : Theme.textDisabled
+	color:	enabled ? Theme.textEnabled : Theme.textDisabled
 }

--- a/JASP-Engine/JASP/R/commonMachineLearningClassification.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningClassification.R
@@ -20,16 +20,16 @@
   testSetIndicator          <- NULL 
   if(options[["target"]] != "")
     target                  <- options[["target"]]
-  predictors                <- unlist(options['predictors'])
+  predictors                <- unlist(options["predictors"])
   predictors                <- predictors[predictors != ""]
   if(options[["testSetIndicatorVariable"]] != "" && options[["holdoutData"]] == "testSetIndicator")
     testSetIndicator                  <- options[["testSetIndicatorVariable"]]
   variables.to.read         <- c(target, predictors, testSetIndicator)
   if (is.null(dataset)){
-    dataset <- .readDataSetToEnd(columns.as.numeric = variables.to.read, exclude.na.listwise = variables.to.read)
+    dataset <- .readDataSetToEnd(columns = variables.to.read, exclude.na.listwise = variables.to.read)
   }
   if(length(unlist(options[["predictors"]])) > 0 && options[["scaleEqualSD"]])
-    dataset[,.v(options[["predictors"]])] <- scale(dataset[,.v(options[["predictors"]])])
+    dataset[,.v(options[["predictors"]])] <- .scaleNumericData(dataset[,.v(options[["predictors"]])])
   if(options[["target"]] != "")
     dataset[, .v(options[["target"]])] <- factor(dataset[, .v(options[["target"]])])
   return(dataset)

--- a/JASP-Engine/JASP/R/commonMachineLearningClassification.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningClassification.R
@@ -20,7 +20,7 @@
   testSetIndicator          <- NULL 
   if(options[["target"]] != "")
     target                  <- options[["target"]]
-  predictors                <- unlist(options["predictors"])
+  predictors                <- unlist(options[["predictors"]])
   predictors                <- predictors[predictors != ""]
   if(options[["testSetIndicatorVariable"]] != "" && options[["holdoutData"]] == "testSetIndicator")
     testSetIndicator                  <- options[["testSetIndicatorVariable"]]

--- a/JASP-Engine/JASP/R/commonMachineLearningRegression.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningRegression.R
@@ -20,16 +20,16 @@
   testSetIndicator          <- NULL 
   if(options[["target"]] != "")
     target                  <- options[["target"]]
-  predictors                <- unlist(options['predictors'])
+  predictors                <- unlist(options[["predictors"]])
   predictors                <- predictors[predictors != ""]
   if(options[["testSetIndicatorVariable"]] != "" && options[["holdoutData"]] == "testSetIndicator")
     testSetIndicator                  <- options[["testSetIndicatorVariable"]]
   variables.to.read         <- c(target, predictors, testSetIndicator)
   if (is.null(dataset)){
-    dataset <- .readDataSetToEnd(columns.as.numeric = variables.to.read, exclude.na.listwise = variables.to.read)
+    dataset <- .readDataSetToEnd(columns = variables.to.read, exclude.na.listwise = variables.to.read)
   }
   if(length(unlist(options[["predictors"]])) > 0 && options[["target"]] != "" && options[["scaleEqualSD"]])
-    dataset[,.v(c(options[["predictors"]], options[["target"]]))] <- scale(dataset[,.v(c(options[["predictors"]], options[["target"]]))])
+    dataset[,.v(c(options[["predictors"]], options[["target"]]))] <- .scaleNumericData(dataset[,.v(c(options[["predictors"]], options[["target"]]))])
   return(dataset)
 }
 
@@ -398,3 +398,20 @@
     jaspResults[["testIndicatorColumn"]]$setNominal(testIndicatorColumn)
   }  
 }
+
+.scaleNumericData <- function(x) {
+  UseMethod(".scaleNumericData", x)
+}
+
+.scaleNumericData.data.frame <- function(x) {
+  idx <- sapply(x, is.numeric)
+  x[, idx] <- scale(x[, idx, drop = FALSE])
+  attr(x, which = "scaled:center") <- NULL
+  attr(x, which = "scaled:scale")  <- NULL
+  return(x)
+}
+
+.scaleNumericData.numeric <- function(x) {
+  return((x - mean(x)) / sd(x))
+}
+

--- a/JASP-Engine/JASP/R/commonMachineLearningRegression.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningRegression.R
@@ -399,19 +399,31 @@
   }  
 }
 
-.scaleNumericData <- function(x) {
+# these could also extend the S3 method scale although that could be somewhat unexpected
+.scaleNumericData <- function(x, ...) {
   UseMethod(".scaleNumericData", x)
 }
 
-.scaleNumericData.data.frame <- function(x) {
+.scaleNumericData.data.frame <- function(x, center = TRUE, scale = TRUE) {
   idx <- sapply(x, is.numeric)
-  x[, idx] <- scale(x[, idx, drop = FALSE])
+  x[, idx] <- scale(x[, idx, drop = FALSE], center, scale)
   attr(x, which = "scaled:center") <- NULL
   attr(x, which = "scaled:scale")  <- NULL
   return(x)
 }
 
-.scaleNumericData.numeric <- function(x) {
-  return((x - mean(x)) / sd(x))
+.scaleNumericData.matrix <- function(x, center = TRUE, scale = TRUE) {
+  x <- scale(x, center, scale)
+  attr(x, which = "scaled:center") <- NULL
+  attr(x, which = "scaled:scale")  <- NULL
+  return(x)
+}
+
+.scaleNumericData.numeric <- function(x, center = TRUE, scale = TRUE) {
+  if (center)
+    x <- x - mean(x)
+  if (scale)
+    x <- x / sd(x)
+  return(x)
 }
 

--- a/JASP-Engine/JASP/R/mlClassificationLda.R
+++ b/JASP-Engine/JASP/R/mlClassificationLda.R
@@ -372,13 +372,13 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 .ldaDensityplot <- function(classificationResult, options, col){
 
   target <- classificationResult[["train"]][, .v(options[["target"]])]
-    
+  lda.fit.scaled <- cbind.data.frame(
+    .scaleNumericData(as.matrix(classificationResult[["train"]][,.v(options[["predictors"]])]), scale = FALSE) %*% classificationResult[["scaling"]], 
+    V2 = classificationResult[["train"]][,.v(options[["target"]])]
+  )
+  
   if (length(colnames(classificationResult[["scaling"]])) == 1) {
-      lda.fit.scaled <- cbind.data.frame(
-                          scale(as.matrix(classificationResult[["train"]][,.v(options[["predictors"]])]), scale = FALSE) %*% classificationResult[["scaling"]], 
-                          V2 = classificationResult[["train"]][,.v(options[["target"]])]
-                        )
-    
+
     p <- ggplot2::ggplot(data = lda.fit.scaled, ggplot2::aes(x = lda.fit.scaled[,paste("LD", col, sep = "")], group = as.factor(V2), color = as.factor(V2), show.legend = TRUE)) +
           JASPgraphs::geom_line(stat = "density") + 
           ggplot2::ylab("Density") + 
@@ -392,11 +392,6 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
     
   } else {
 
-    lda.fit.scaled <- cbind.data.frame(
-                        scale(as.matrix(classificationResult[["train"]][,.v(options[["predictors"]])]), scale = FALSE) %*% classificationResult[["scaling"]], 
-                        V2 = classificationResult[["train"]][,.v(options[["target"]])]
-                        )
-      
     p <- ggplot2::ggplot(data = lda.fit.scaled, ggplot2::aes(x = lda.fit.scaled[,paste("LD", col, sep = "")], group = as.factor(V2), color = as.factor(V2), show.legend = FALSE)) +
           JASPgraphs::geom_line(stat = "density") + 
           ggplot2::ylab("Density") + 

--- a/JASP-Engine/JASP/R/mlRegressionRegularized.R
+++ b/JASP-Engine/JASP/R/mlRegressionRegularized.R
@@ -71,7 +71,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   }
   
   if(length(unlist(options[["predictors"]])) > 0 && options[["target"]] != "" && options[["scaleEqualSD"]])
-    dataset[,.v(c(options[["predictors"]], options[["target"]]))] <- scale(dataset[,.v(c(options[["predictors"]], options[["target"]]))])
+    dataset[,.v(c(options[["predictors"]], options[["target"]]))] <- .scaleNumericData(dataset[,.v(c(options[["predictors"]], options[["target"]]))])
   
   return(dataset)
 }

--- a/Resources/Machine Learning/qml/common/DataSplit.qml
+++ b/Resources/Machine Learning/qml/common/DataSplit.qml
@@ -1,0 +1,142 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+import QtQuick			2.8
+import QtQuick.Layouts	1.3
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP.Theme		1.0
+
+Section
+{
+    property alias leaveOneOutVisible:  leaveOneOut.visible
+    property alias kFoldsVisible:       kFolds.visible
+    
+    title: qsTr("Data Split Preferences")
+
+    RadioButtonGroup 
+    {
+        title: qsTr("Holdout Test Data")
+        name: "holdoutData"
+
+        RadioButton 
+        {
+            id: holdoutManual
+            name: "holdoutManual"
+            childrenOnSameRow: true
+            text: qsTr("Sample")
+
+            RowLayout 
+            {
+                PercentField 
+                {    
+                    name: "testDataManual"
+                    defaultValue: 20
+                    min: 5
+                    max: 95 
+                    afterLabel: qsTr("% of all data")
+                }
+            }
+        }
+
+        CheckBox 
+        { 
+            id: addIndicator  
+            name: "addIndicator"
+            text: qsTr("Add generated indicator to data")
+            Layout.leftMargin: 20
+            enabled: holdoutManual.checked
+
+            ComputedColumnField 
+            { 
+                name: 		"testIndicatorColumn"
+                text: 		"Name: "
+                fieldWidth: 120
+                visible:    addIndicator.checked
+            }
+        }
+
+        RadioButton 
+        {
+            name: "testSetIndicator"
+            label: qsTr("Test set indicator:")
+            childrenOnSameRow: true
+
+            DropDown 
+            {
+                id: testSetIndicatorVariable
+                name: "testSetIndicatorVariable"
+                showVariableTypeIcon: true
+                addEmptyValue: true
+                placeholderText: qsTr("None")
+            }
+        }
+    }
+
+    RadioButtonGroup 
+    {
+        title: qsTr("Training and Validation Data")
+        name: "modelValid"
+
+        RadioButton 
+        {
+            name: "validationManual"
+            childrenOnSameRow: true
+            checked: true
+            text: qsTr("Sample")
+
+            RowLayout {
+
+                PercentField {     
+                    name: "validationDataManual"
+                    defaultValue: 20
+                    min: 5
+                    max: 95
+                    afterLabel: qStr("% for validation data")
+                }
+            }
+        }
+
+        RadioButton 
+        { 
+            id: kFolds
+            name: "validationKFold"
+            childrenOnSameRow: true
+            text: qsTr("K-fold with")
+
+            RowLayout 
+            {
+
+                IntegerField {
+                    name: "noOfFolds"
+                    defaultValue: 5
+                    min: 2
+                    max: 999
+                    fieldWidth: 30
+                    afterLabel: qsTr("folds")
+                } 
+            }
+        }
+
+        RadioButton { 
+            id: leaveOneOut
+            text: qsTr("Leave-one-out")                 
+            name: "validationLeaveOneOut"
+        }
+    }
+}

--- a/Resources/Machine Learning/qml/mlClassificationBoosting.qml
+++ b/Resources/Machine Learning/qml/mlClassificationBoosting.qml
@@ -148,9 +148,9 @@ Form {
                         max: 95 
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("of all data")
-                        enabled: true
+                        alwaysEnabled: true
                     }
                 }
             }
@@ -204,9 +204,9 @@ Form {
                         max: 95
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("for validation data")
-                        enabled: true
+                        alwaysEnabled: true
                     }
                 }
             }
@@ -226,9 +226,9 @@ Form {
                         fieldWidth: 30
                     } 
 
-                    Text {
+                    Label {
                         text: qsTr("folds")
-                        enabled: true
+                        alwaysEnabled: true
                     }
                 }
             }

--- a/Resources/Machine Learning/qml/mlClassificationBoosting.qml
+++ b/Resources/Machine Learning/qml/mlClassificationBoosting.qml
@@ -21,6 +21,7 @@ import QtQuick.Layouts	1.3
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
+import "./common" as ML
 
 Form {
 
@@ -126,114 +127,8 @@ Form {
         }
     }
 
-    Section {
-        title: qsTr("Data Split Preferences")
-
-        RadioButtonGroup {
-            title: qsTr("Holdout Test Data")
-            name: "holdoutData"
-
-            RadioButton {
-                id: holdoutManual
-                name: "holdoutManual"
-                childrenOnSameRow: true
-                text: qsTr("Sample")
-
-                RowLayout {
-                
-                    PercentField {    
-                        name: "testDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95 
-                    }
-
-                    Label {
-                        text: qsTr("of all data")
-                        alwaysEnabled: true
-                    }
-                }
-            }
-
-            CheckBox { 
-                id: addIndicator  
-                name: "addIndicator"
-                text: qsTr("Add generated indicator to data")
-                Layout.leftMargin: 20
-                enabled: holdoutManual.checked
-
-                ComputedColumnField { 
-                    name: 		"testIndicatorColumn"
-                    text: 		"Name: "
-                    fieldWidth: 120
-                    visible:    addIndicator.checked
-                }
-            }
-
-            RadioButton {
-                id: testSetIndicator
-                name: "testSetIndicator"
-                label: qsTr("Test set indicator:")
-                childrenOnSameRow: true
-
-                DropDown {
-                    name: "testSetIndicatorVariable"
-                    showVariableTypeIcon: true
-                    addEmptyValue: true
-                    placeholderText: qsTr("None")
-                }
-            }
-        }
-
-        RadioButtonGroup {
-            title: qsTr("Training and Validation Data")
-            name: "modelValid"
-
-            RadioButton {
-                name: "validationManual"
-                childrenOnSameRow: true
-                checked: true
-                text: qsTr("Sample")
-
-                RowLayout {
-
-                    PercentField {     
-                        name: "validationDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95
-                    }
-
-                    Label {
-                        text: qsTr("for validation data")
-                        alwaysEnabled: true
-                    }
-                }
-            }
     
-            RadioButton { 
-                name: "validationKFold"
-                childrenOnSameRow: true
-                text: qsTr("K-fold with")
-
-                RowLayout {
-
-                    IntegerField {
-                        name: "noOfFolds"
-                        defaultValue: 5
-                        min: 2
-                        max: 999
-                        fieldWidth: 30
-                    } 
-
-                    Label {
-                        text: qsTr("folds")
-                        alwaysEnabled: true
-                    }
-                }
-            }
-        }
-    }
+    ML.DataSplit {leaveOneOutVisible: false}
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlClassificationBoosting.qml
+++ b/Resources/Machine Learning/qml/mlClassificationBoosting.qml
@@ -128,7 +128,9 @@ Form {
     }
 
     
-    ML.DataSplit {leaveOneOutVisible: false}
+    ML.DataSplit {
+        leaveOneOutVisible: false
+    }
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlClassificationKnn.qml
+++ b/Resources/Machine Learning/qml/mlClassificationKnn.qml
@@ -21,6 +21,7 @@ import QtQuick.Layouts	1.3
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
+import "./common" as ML
 
 Form {
 
@@ -113,116 +114,7 @@ Form {
         }
     }
 
-    Section {
-        title: qsTr("Data Split Preferences")
-
-        RadioButtonGroup {
-            title: qsTr("Holdout Test Data")
-            name: "holdoutData"
-
-            RadioButton {
-                id: holdoutManual
-                name: "holdoutManual"
-                childrenOnSameRow: true
-                text: qsTr("Sample")
-
-                RowLayout {
-                
-                    PercentField {    
-                        name: "testDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95 
-                    }
-
-                    Label {
-                        text: qsTr("of all data")
-                    }
-                }
-            }
-
-            CheckBox { 
-                id: addIndicator  
-                name: "addIndicator"
-                text: qsTr("Add generated indicator to data")
-                Layout.leftMargin: 20
-                enabled: holdoutManual.checked
-
-                ComputedColumnField { 
-                    name: 		"testIndicatorColumn"
-                    text: 		"Name: "
-                    fieldWidth: 120
-                    visible:    addIndicator.checked
-                }
-            }
-
-            RadioButton {
-                name: "testSetIndicator"
-                label: qsTr("Test set indicator:")
-                childrenOnSameRow: true
-
-                DropDown {
-                    id: testSetIndicatorVariable
-                    name: "testSetIndicatorVariable"
-                    showVariableTypeIcon: true
-                    addEmptyValue: true
-                    placeholderText: qsTr("None")
-                }
-            }
-        }
-
-        RadioButtonGroup {
-            title: qsTr("Training and Validation Data")
-            name: "modelValid"
-
-            RadioButton {
-                name: "validationManual"
-                childrenOnSameRow: true
-                checked: true
-                text: qsTr("Sample")
-
-                RowLayout {
-
-                    PercentField {     
-                        name: "validationDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95
-                    }
-
-                    Label {
-                        text: qsTr("for validation data")
-                    }
-                }
-            }
-    
-            RadioButton { 
-                name: "validationKFold"
-                childrenOnSameRow: true
-                text: qsTr("K-fold with")
-
-                RowLayout {
-
-                    IntegerField {
-                        name: "noOfFolds"
-                        defaultValue: 5
-                        min: 2
-                        max: 999
-                        fieldWidth: 30
-                    } 
-
-                    Label {
-                        text: qsTr("folds")
-                    }
-                }
-            }
-
-            RadioButton { 
-                text: qsTr("Leave-one-out")                 
-                name: "validationLeaveOneOut"
-            }
-        }
-    }
+    ML.DataSplit{}
     
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlClassificationKnn.qml
+++ b/Resources/Machine Learning/qml/mlClassificationKnn.qml
@@ -135,9 +135,8 @@ Form {
                         max: 95 
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("of all data")
-                        enabled: true
                     }
                 }
             }
@@ -191,9 +190,8 @@ Form {
                         max: 95
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("for validation data")
-                        enabled: true
                     }
                 }
             }
@@ -213,9 +211,8 @@ Form {
                         fieldWidth: 30
                     } 
 
-                    Text {
+                    Label {
                         text: qsTr("folds")
-                        enabled: true
                     }
                 }
             }

--- a/Resources/Machine Learning/qml/mlClassificationKnn.qml
+++ b/Resources/Machine Learning/qml/mlClassificationKnn.qml
@@ -114,7 +114,7 @@ Form {
         }
     }
 
-    ML.DataSplit{}
+    ML.DataSplit {}
     
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlClassificationLda.qml
+++ b/Resources/Machine Learning/qml/mlClassificationLda.qml
@@ -166,7 +166,10 @@ Form {
         }
     }
 
-    ML.DataSplit{leaveOneOutVisible: false; kFoldsVisible: false}
+    ML.DataSplit {
+        leaveOneOutVisible: false; 
+        kFoldsVisible: false
+    }
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlClassificationLda.qml
+++ b/Resources/Machine Learning/qml/mlClassificationLda.qml
@@ -21,6 +21,7 @@ import QtQuick.Layouts	1.3
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
+import "./common" as ML
 
 Form {
 
@@ -165,90 +166,7 @@ Form {
         }
     }
 
-    Section {
-        title: qsTr("Data Split Preferences")
-
-        RadioButtonGroup {
-            title: qsTr("Holdout Test Data")
-            name: "holdoutData"
-
-            RadioButton {
-                id: holdoutManual
-                name: "holdoutManual"
-                childrenOnSameRow: true
-                text: qsTr("Sample")
-
-                RowLayout {
-                
-                    PercentField {    
-                        name: "testDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95 
-                    }
-
-                    Label {
-                        text: qsTr("of all data")
-                    }
-                }
-            }
-
-            CheckBox { 
-                id: addIndicator  
-                name: "addIndicator"
-                text: qsTr("Add generated indicator to data")
-                Layout.leftMargin: 20
-                enabled: holdoutManual.checked
-
-                ComputedColumnField { 
-                    name: 		"testIndicatorColumn"
-                    text: 		"Name: "
-                    fieldWidth: 120
-                    visible:    addIndicator.checked
-                }
-            }
-
-            RadioButton {
-                id: testSetIndicator
-                name: "testSetIndicator"
-                label: qsTr("Test set indicator:")
-                childrenOnSameRow: true
-
-                DropDown {
-                    name: "testSetIndicatorVariable"
-                    showVariableTypeIcon: true
-                    addEmptyValue: true
-                    placeholderText: qsTr("None")
-                }
-            }
-        }
-
-        RadioButtonGroup {
-            title: qsTr("Training and Validation Data")
-            name: "modelValid"
-
-            RadioButton {
-                name: "validationManual"
-                childrenOnSameRow: true
-                checked: true
-                text: qsTr("Sample")
-
-                RowLayout {
-
-                    PercentField {     
-                        name: "validationDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95
-                    }
-
-                    Label {
-                        text: qsTr("for validation data")
-                    }
-                }
-            }
-        }
-    }
+    ML.DataSplit{leaveOneOutVisible: false; kFoldsVisible: false}
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlClassificationLda.qml
+++ b/Resources/Machine Learning/qml/mlClassificationLda.qml
@@ -187,9 +187,8 @@ Form {
                         max: 95 
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("of all data")
-                        enabled: true
                     }
                 }
             }
@@ -243,9 +242,8 @@ Form {
                         max: 95
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("for validation data")
-                        enabled: true
                     }
                 }
             }

--- a/Resources/Machine Learning/qml/mlClassificationRandomForest.qml
+++ b/Resources/Machine Learning/qml/mlClassificationRandomForest.qml
@@ -148,9 +148,8 @@ Form {
                         max: 95 
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("of all data")
-                        enabled: true
                     }
                 }
             }
@@ -204,9 +203,8 @@ Form {
                         max: 95
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("for validation data")
-                        enabled: true
                     }
                 }
             }

--- a/Resources/Machine Learning/qml/mlClassificationRandomForest.qml
+++ b/Resources/Machine Learning/qml/mlClassificationRandomForest.qml
@@ -21,6 +21,7 @@ import QtQuick.Layouts	1.3
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
+import "./common" as ML
 
 Form {
 
@@ -126,90 +127,7 @@ Form {
         }
     }
 
-    Section {
-        title: qsTr("Data Split Preferences")
-
-        RadioButtonGroup {
-            title: qsTr("Holdout Test Data")
-            name: "holdoutData"
-
-            RadioButton {
-                id: holdoutManual
-                name: "holdoutManual"
-                childrenOnSameRow: true
-                text: qsTr("Sample")
-
-                RowLayout {
-                
-                    PercentField {    
-                        name: "testDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95 
-                    }
-
-                    Label {
-                        text: qsTr("of all data")
-                    }
-                }
-            }
-
-            CheckBox { 
-                id: addIndicator  
-                name: "addIndicator"
-                text: qsTr("Add generated indicator to data")
-                Layout.leftMargin: 20
-                enabled: holdoutManual.checked
-
-                ComputedColumnField { 
-                    name: 		"testIndicatorColumn"
-                    text: 		"Name: "
-                    fieldWidth: 120
-                    visible:    addIndicator.checked
-                }
-            }
-
-            RadioButton {
-                id: testSetIndicator
-                name: "testSetIndicator"
-                label: qsTr("Test set indicator:")
-                childrenOnSameRow: true
-
-                DropDown {
-                    name: "testSetIndicatorVariable"
-                    showVariableTypeIcon: true
-                    addEmptyValue: true
-                    placeholderText: qsTr("None")
-                }
-            }
-        }
-
-        RadioButtonGroup {
-            title: qsTr("Training and Validation Data")
-            name: "modelValid"
-
-            RadioButton {
-                name: "validationManual"
-                childrenOnSameRow: true
-                checked: true
-                text: qsTr("Sample")
-
-                RowLayout {
-
-                    PercentField {     
-                        name: "validationDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95
-                    }
-
-                    Label {
-                        text: qsTr("for validation data")
-                    }
-                }
-            }
-        }
-    }
+    ML.DataSplit{leaveOneOutVisible: false; kFoldsVisible: false}
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlClassificationRandomForest.qml
+++ b/Resources/Machine Learning/qml/mlClassificationRandomForest.qml
@@ -127,7 +127,10 @@ Form {
         }
     }
 
-    ML.DataSplit{leaveOneOutVisible: false; kFoldsVisible: false}
+    ML.DataSplit {
+        leaveOneOutVisible: false; 
+        kFoldsVisible: false
+    }
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlRegressionBoosting.qml
+++ b/Resources/Machine Learning/qml/mlRegressionBoosting.qml
@@ -86,7 +86,9 @@ Form {
         }
     }
 
-    ML.DataSplit{leaveOneOutVisible: false}
+    ML.DataSplit {
+        leaveOneOutVisible: false
+    }
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlRegressionBoosting.qml
+++ b/Resources/Machine Learning/qml/mlRegressionBoosting.qml
@@ -107,9 +107,8 @@ Form {
                         max: 95 
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("of all data")
-                        enabled: true
                     }
                 }
             }
@@ -163,9 +162,8 @@ Form {
                         max: 95
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("for validation data")
-                        enabled: true
                     }
                 }
             }
@@ -185,9 +183,8 @@ Form {
                         fieldWidth: 30
                     } 
 
-                    Text {
+                    Label {
                         text: qsTr("folds")
-                        enabled: true
                     }
                 }
             }

--- a/Resources/Machine Learning/qml/mlRegressionBoosting.qml
+++ b/Resources/Machine Learning/qml/mlRegressionBoosting.qml
@@ -21,6 +21,7 @@ import QtQuick.Layouts	1.3
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
+import "./common" as ML
 
 Form {
 
@@ -85,111 +86,7 @@ Form {
         }
     }
 
-    Section {
-        title: qsTr("Data Split Preferences")
-
-        RadioButtonGroup {
-            title: qsTr("Holdout Test Data")
-            name: "holdoutData"
-
-            RadioButton {
-                id: holdoutManual
-                name: "holdoutManual"
-                childrenOnSameRow: true
-                text: qsTr("Sample")
-
-                RowLayout {
-                
-                    PercentField {    
-                        name: "testDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95 
-                    }
-
-                    Label {
-                        text: qsTr("of all data")
-                    }
-                }
-            }
-
-            CheckBox { 
-                id: addIndicator  
-                name: "addIndicator"
-                text: qsTr("Add generated indicator to data")
-                Layout.leftMargin: 20
-                enabled: holdoutManual.checked
-
-                ComputedColumnField { 
-                    name: 		"testIndicatorColumn"
-                    text: 		"Name: "
-                    fieldWidth: 120
-                    visible:    addIndicator.checked
-                }
-            }
-
-            RadioButton {
-                id: testSetIndicator
-                name: "testSetIndicator"
-                label: qsTr("Test set indicator:")
-                childrenOnSameRow: true
-
-                DropDown {
-                    name: "testSetIndicatorVariable"
-                    showVariableTypeIcon: true
-                    addEmptyValue: true
-                    placeholderText: qsTr("None")
-                }
-            }
-        }
-
-        RadioButtonGroup {
-            title: qsTr("Training and Validation Data")
-            name: "modelValid"
-
-            RadioButton {
-                name: "validationManual"
-                childrenOnSameRow: true
-                checked: true
-                text: qsTr("Sample")
-
-                RowLayout {
-
-                    PercentField {     
-                        name: "validationDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95
-                    }
-
-                    Label {
-                        text: qsTr("for validation data")
-                    }
-                }
-            }
-    
-            RadioButton { 
-                name: "validationKFold"
-                childrenOnSameRow: true
-                text: qsTr("K-fold with")
-
-                RowLayout {
-
-                    IntegerField {
-                        name: "noOfFolds"
-                        defaultValue: 5
-                        min: 2
-                        max: 999
-                        fieldWidth: 30
-                    } 
-
-                    Label {
-                        text: qsTr("folds")
-                    }
-                }
-            }
-        }
-    }
+    ML.DataSplit{leaveOneOutVisible: false}
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlRegressionKnn.qml
+++ b/Resources/Machine Learning/qml/mlRegressionKnn.qml
@@ -74,7 +74,7 @@ Form {
         }
     }
     
-    ML.DataSplit{}
+    ML.DataSplit {}
     
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlRegressionKnn.qml
+++ b/Resources/Machine Learning/qml/mlRegressionKnn.qml
@@ -21,6 +21,7 @@ import QtQuick.Layouts	1.3
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
+import "./common" as ML
 
 Form {
 
@@ -73,116 +74,7 @@ Form {
         }
     }
     
-    Section {
-        title: qsTr("Data Split Preferences")
-
-        RadioButtonGroup {
-            title: qsTr("Holdout Test Data")
-            name: "holdoutData"
-
-            RadioButton {
-                id: holdoutManual
-                name: "holdoutManual"
-                childrenOnSameRow: true
-                text: qsTr("Sample")
-
-                RowLayout {
-                
-                    PercentField {    
-                        name: "testDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95 
-                    }
-
-                    Label {
-                        text: qsTr("of all data")
-                    }
-                }
-            }
-
-            CheckBox { 
-                id: addIndicator  
-                name: "addIndicator"
-                text: qsTr("Add generated indicator to data")
-                Layout.leftMargin: 20
-                enabled: holdoutManual.checked
-
-                ComputedColumnField { 
-                    name: 		"testIndicatorColumn"
-                    text: 		"Name: "
-                    fieldWidth: 120
-                    visible:    addIndicator.checked
-                }
-            }
-
-            RadioButton {
-                id: testSetIndicator
-                name: "testSetIndicator"
-                label: qsTr("Test set indicator:")
-                childrenOnSameRow: true
-
-                DropDown {
-                    name: "testSetIndicatorVariable"
-                    showVariableTypeIcon: true
-                    addEmptyValue: true
-                    placeholderText: qsTr("None")
-                }
-            }
-        }
-
-        RadioButtonGroup {
-            title: qsTr("Training and Validation Data")
-            name: "modelValid"
-
-            RadioButton {
-                name: "validationManual"
-                childrenOnSameRow: true
-                checked: true
-                text: qsTr("Sample")
-
-                RowLayout {
-
-                    PercentField {     
-                        name: "validationDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95
-                    }
-
-                    Label {
-                        text: qsTr("for validation data")
-                    }
-                }
-            }
-    
-            RadioButton { 
-                name: "validationKFold"
-                childrenOnSameRow: true
-                text: qsTr("K-fold with")
-
-                RowLayout {
-
-                    IntegerField {
-                        name: "noOfFolds"
-                        defaultValue: 5
-                        min: 2
-                        max: 999
-                        fieldWidth: 30
-                    } 
-
-                    Label {
-                        text: qsTr("folds")
-                    }
-                }
-            }
-
-            RadioButton { 
-                text: qsTr("Leave-one-out")                 
-                name: "validationLeaveOneOut"
-            }
-        }
-    }
+    ML.DataSplit{}
     
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlRegressionKnn.qml
+++ b/Resources/Machine Learning/qml/mlRegressionKnn.qml
@@ -95,9 +95,8 @@ Form {
                         max: 95 
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("of all data")
-                        enabled: true
                     }
                 }
             }
@@ -151,9 +150,8 @@ Form {
                         max: 95
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("for validation data")
-                        enabled: true
                     }
                 }
             }
@@ -173,9 +171,8 @@ Form {
                         fieldWidth: 30
                     } 
 
-                    Text {
+                    Label {
                         text: qsTr("folds")
-                        enabled: true
                     }
                 }
             }

--- a/Resources/Machine Learning/qml/mlRegressionRandomForest.qml
+++ b/Resources/Machine Learning/qml/mlRegressionRandomForest.qml
@@ -21,6 +21,7 @@ import QtQuick.Layouts	1.3
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
+import "./common" as ML
 
 Form {
 
@@ -86,90 +87,7 @@ Form {
 
     }
 
-    Section {
-        title: qsTr("Data Split Preferences")
-
-        RadioButtonGroup {
-            title: qsTr("Holdout Test Data")
-            name: "holdoutData"
-
-            RadioButton {
-                id: holdoutManual
-                name: "holdoutManual"
-                childrenOnSameRow: true
-                text: qsTr("Sample")
-
-                RowLayout {
-                
-                    PercentField {    
-                        name: "testDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95 
-                    }
-
-                    Label {
-                        text: qsTr("of all data")
-                    }
-                }
-            }
-
-            CheckBox { 
-                id: addIndicator  
-                name: "addIndicator"
-                text: qsTr("Add generated indicator to data")
-                Layout.leftMargin: 20
-                enabled: holdoutManual.checked
-
-                ComputedColumnField { 
-                    name: 		"testIndicatorColumn"
-                    text: 		"Name: "
-                    fieldWidth: 120
-                    visible:    addIndicator.checked
-                }
-            }
-
-            RadioButton {
-                id: testSetIndicator
-                name: "testSetIndicator"
-                label: qsTr("Test set indicator:")
-                childrenOnSameRow: true
-
-                DropDown {
-                    name: "testSetIndicatorVariable"
-                    showVariableTypeIcon: true
-                    addEmptyValue: true
-                    placeholderText: qsTr("None")
-                }
-            }
-        }
-
-        RadioButtonGroup {
-            title: qsTr("Training and Validation Data")
-            name: "modelValid"
-
-            RadioButton {
-                name: "validationManual"
-                childrenOnSameRow: true
-                checked: true
-                text: qsTr("Sample")
-
-                RowLayout {
-
-                    PercentField {     
-                        name: "validationDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95
-                    }
-
-                    Label {
-                        text: qsTr("for validation data")
-                    }
-                }
-            }
-        }
-    }
+    ML.DataSplit{leaveOneOutVisible: false; kFoldsVisible: false}
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlRegressionRandomForest.qml
+++ b/Resources/Machine Learning/qml/mlRegressionRandomForest.qml
@@ -108,9 +108,8 @@ Form {
                         max: 95 
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("of all data")
-                        enabled: true
                     }
                 }
             }
@@ -164,9 +163,8 @@ Form {
                         max: 95
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("for validation data")
-                        enabled: true
                     }
                 }
             }

--- a/Resources/Machine Learning/qml/mlRegressionRandomForest.qml
+++ b/Resources/Machine Learning/qml/mlRegressionRandomForest.qml
@@ -87,7 +87,10 @@ Form {
 
     }
 
-    ML.DataSplit{leaveOneOutVisible: false; kFoldsVisible: false}
+    ML.DataSplit {
+        leaveOneOutVisible: false
+        kFoldsVisible: false
+    }
 
     Section {
         title: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlRegressionRegularized.qml
+++ b/Resources/Machine Learning/qml/mlRegressionRegularized.qml
@@ -21,6 +21,7 @@ import QtQuick.Layouts	1.3
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
 import JASP.Theme		1.0
+import "./common" as ML
 
 Form {
 
@@ -98,90 +99,7 @@ Form {
         }
     }
 
-    Section {
-        title: qsTr("Data Split Preferences")
-
-        RadioButtonGroup {
-            title: qsTr("Holdout Test Data")
-            name: "holdoutData"
-
-            RadioButton {
-                id: holdoutManual
-                name: "holdoutManual"
-                childrenOnSameRow: true
-                text: qsTr("Sample")
-
-                RowLayout {
-                
-                    PercentField {    
-                        name: "testDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95 
-                    }
-
-                    Label {
-                        text: qsTr("of all data")
-                    }
-                }
-            }
-
-            CheckBox { 
-                id: addIndicator  
-                name: "addIndicator"
-                text: qsTr("Add generated indicator to data")
-                Layout.leftMargin: 20
-                enabled: holdoutManual.checked
-
-                ComputedColumnField { 
-                    name: 		"testIndicatorColumn"
-                    text: 		"Name: "
-                    fieldWidth: 120
-                    visible:    addIndicator.checked
-                }
-            }
-
-            RadioButton {
-                id: testSetIndicator
-                name: "testSetIndicator"
-                label: qsTr("Test set indicator:")
-                childrenOnSameRow: true
-
-                DropDown {
-                    name: "testSetIndicatorVariable"
-                    showVariableTypeIcon: true
-                    addEmptyValue: true
-                    placeholderText: qsTr("None")
-                }
-            }
-        }
-
-        RadioButtonGroup {
-            title: qsTr("Training and Validation Data")
-            name: "modelValid"
-
-            RadioButton {
-                name: "validationManual"
-                childrenOnSameRow: true
-                checked: true
-                text: qsTr("Sample")
-
-                RowLayout {
-
-                    PercentField {     
-                        name: "validationDataManual"
-                        defaultValue: 20
-                        min: 5
-                        max: 95
-                    }
-
-                    Label {
-                        text: qsTr("for validation data")
-                    }
-                }
-            }
-        }
-    }
+    ML.DataSplit{leaveOneOutVisible: false; kFoldsVisible: false}
 
     Section {
         text: qsTr("Training Parameters")

--- a/Resources/Machine Learning/qml/mlRegressionRegularized.qml
+++ b/Resources/Machine Learning/qml/mlRegressionRegularized.qml
@@ -120,9 +120,8 @@ Form {
                         max: 95 
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("of all data")
-                        enabled: true
                     }
                 }
             }
@@ -176,9 +175,8 @@ Form {
                         max: 95
                     }
 
-                    Text {
+                    Label {
                         text: qsTr("for validation data")
-                        enabled: true
                     }
                 }
             }

--- a/Resources/Machine Learning/qml/mlRegressionRegularized.qml
+++ b/Resources/Machine Learning/qml/mlRegressionRegularized.qml
@@ -99,7 +99,10 @@ Form {
         }
     }
 
-    ML.DataSplit{leaveOneOutVisible: false; kFoldsVisible: false}
+    ML.DataSplit {
+        leaveOneOutVisible: false; 
+        kFoldsVisible: false
+    }
 
     Section {
         text: qsTr("Training Parameters")


### PR DESCRIPTION
Fixes the following:

- [x] scaling data (e.g., substracting the mean) happens for factors!
- [x] rescaling of qml does not happen for data split preferences, zoom JASP and look at the consequences for the labels.

In addition, I moved the data split prefernces to a single qml component rather than copy pasting it 8 times.