### PR TITLE
fixes to machine learning

### DIFF
--- a/JASP-Engine/JASP/R/assignFunctionInPackage.R
+++ b/JASP-Engine/JASP/R/assignFunctionInPackage.R
@@ -61,14 +61,5 @@ fakeGbmCrossValErr <- function(cv.models, cv.folds, cv.group, nTrain, n.trees) {
     model <- cv.models[[index]]
     model$valid.error * in.group[[index]]
   }, double(n.trees))
-  if (is.matrix(cv.error))
-    return(rowSums(cv.error)/nTrain)
-  else
-    return(cv.error / nTrain)
+  return(rowSums(as.matrix(cv.error))/nTrain)
 }
-
-
-
-# assign the functions ----
-assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
-assignFunctionInPackage(fakeGbmCrossValErr,        "gbmCrossValErr",        "gbm")

--- a/JASP-Engine/JASP/R/commonMachineLearningRegression.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningRegression.R
@@ -302,7 +302,7 @@
 
   regressionResult <- jaspResults[["regressionResult"]]$object
   
-  predPerformance <- data.frame(true = regressionResult[["testReal"]], predicted = regressionResult[["testPred"]])
+  predPerformance <- data.frame(true = c(regressionResult[["testReal"]]), predicted = regressionResult[["testPred"]])
 
   allBreaks <- JASPgraphs::getPrettyAxisBreaks(predPerformance[, 1], min.n = 4)
 

--- a/JASP-Engine/JASP/R/mlClassificationBoosting.R
+++ b/JASP-Engine/JASP/R/mlClassificationBoosting.R
@@ -90,6 +90,11 @@ mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
     valid <- trainAndValid
   }
 
+  assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
+  assignFunctionInPackage(fakeGbmCrossValErr,        "gbmCrossValErr",        "gbm")
+  # gbm expects the columns in the data to be in the same order as the variables...
+  train <- train[, match(names(train), all.vars(formula))]
+
   trees <- base::switch(options[["modelOpt"]], "optimizationManual" = options[["noOfTrees"]], "optimizationOOB" = options[["maxTrees"]])
 
   bfit <- gbm::gbm(formula = formula, data = train, n.trees = trees,

--- a/JASP-Engine/JASP/R/mlRegressionBoosting.R
+++ b/JASP-Engine/JASP/R/mlRegressionBoosting.R
@@ -77,6 +77,11 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
     valid <- trainAndValid
   }
 
+  assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
+  assignFunctionInPackage(fakeGbmCrossValErr,        "gbmCrossValErr",        "gbm")
+  # gbm expects the columns in the data to be in the same order as the variables...
+  train <- train[, match(names(train), all.vars(formula))]
+
   trees <- base::switch(options[["modelOpt"]], "optimizationManual" = options[["noOfTrees"]], "optimizationOOB" = options[["maxTrees"]])
   
   bfit <- gbm::gbm(formula = formula, data = train, n.trees = trees,

--- a/JASP-Engine/JASP/R/mlRegressionKnn.R
+++ b/JASP-Engine/JASP/R/mlRegressionKnn.R
@@ -269,3 +269,7 @@ mlRegressionKnn <- function(jaspResults, dataset, options, state=NULL) {
   plotErrorVsK$plotObject <- p
   
 }
+
+# kknn::kknn calls stats::model.matrix which needs these two functions and looks for them by name in the global namespace
+contr.dummy   <- kknn::contr.dummy
+contr.ordinal <- kknn::contr.ordinal

--- a/Resources/Machine Learning/qml/common/DataSplit.qml
+++ b/Resources/Machine Learning/qml/common/DataSplit.qml
@@ -102,12 +102,12 @@ Section
 
             RowLayout {
 
-                PercentField {     
+                PercentField {
                     name: "validationDataManual"
                     defaultValue: 20
                     min: 5
                     max: 95
-                    afterLabel: qStr("% for validation data")
+                    afterLabel: qsTr("% for validation data")
                 }
             }
         }

--- a/Resources/Machine Learning/qml/mlRegressionRegularized.qml
+++ b/Resources/Machine Learning/qml/mlRegressionRegularized.qml
@@ -38,7 +38,7 @@ Form {
             id: predictors
             name: "predictors"
             title: qsTr("Predictors") 
-            allowedColumns: ["scale", "nominal", "ordinal", "nominalText"]       
+            allowedColumns: ["scale", "nominal", "ordinal"]
         }
         AssignedVariablesList  { 
             name: "weights"    


### PR DESCRIPTION
Fixes:

https://github.com/jasp-stats/INTERNAL-jasp/issues/424
https://github.com/jasp-stats/INTERNAL-jasp/issues/423
https://github.com/jasp-stats/INTERNAL-jasp/issues/421
https://github.com/jasp-stats/INTERNAL-jasp/issues/420

@AlexanderLyNL I moved the `assignFunctionInPackage` back to the functions because otherwise they are ignored (at least on Linux).

@koenderks the change to regularized regression is because glmnet just can't handle characters. I have no idea how they handle factors, as they convert everything to numeric(ish).