### PR TITLE
fixed .scaleNumericData and added fallback

### DIFF
--- a/JASP-Engine/JASP/R/commonMachineLearningClassification.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningClassification.R
@@ -29,7 +29,7 @@
     dataset <- .readDataSetToEnd(columns = variables.to.read, exclude.na.listwise = variables.to.read)
   }
   if(length(unlist(options[["predictors"]])) > 0 && options[["scaleEqualSD"]])
-    dataset[,.v(options[["predictors"]])] <- .scaleNumericData(dataset[,.v(options[["predictors"]])])
+    dataset[,.v(options[["predictors"]])] <- .scaleNumericData(dataset[,.v(options[["predictors"]]), drop = FALSE])
   if(options[["target"]] != "")
     dataset[, .v(options[["target"]])] <- factor(dataset[, .v(options[["target"]])])
   return(dataset)

--- a/JASP-Engine/JASP/R/commonMachineLearningRegression.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningRegression.R
@@ -427,6 +427,12 @@
   return(x)
 }
 
+.scaleNumericData.default <- function(x, center = TRUE, scale = TRUE) {
+  warning(".scaleNumericData.default was called! you probably didn't want that!")
+  # just do nothing
+  return(x)
+}
+
 .regressionAddValuesToData <- function(options, jaspResults, ready){
   if(!ready || !options[["addValues"]] || options[["valueColumn"]] == "")  return()
 

--- a/JASP-Engine/JASP/R/commonMachineLearningRegression.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningRegression.R
@@ -413,6 +413,10 @@
 }
 
 .scaleNumericData.matrix <- function(x, center = TRUE, scale = TRUE) {
+  if (!is.numeric(x)) {
+    warning(sprintf("Object passed to .scaleNumericData.matrix was not numeric!"))
+    return(x)
+  }
   x <- scale(x, center, scale)
   attr(x, which = "scaled:center") <- NULL
   attr(x, which = "scaled:scale")  <- NULL
@@ -427,11 +431,8 @@
   return(x)
 }
 
-.scaleNumericData.default <- function(x, center = TRUE, scale = TRUE) {
-  warning(".scaleNumericData.default was called! you probably didn't want that!")
-  # just do nothing
-  return(x)
-}
+# fallback when .scaleNumericData is called with factor/ character data
+.scaleNumericData.default <- function(x, center = TRUE, scale = TRUE) return(x)
 
 .regressionAddValuesToData <- function(options, jaspResults, ready){
   if(!ready || !options[["addValues"]] || options[["valueColumn"]] == "")  return()


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/288

adding `, drop = FALSE` avoids the subsetting from converting the data.frame to a factor, so now the correct method gets called. 

I also added `.scaleNumericData.default` as a fallback function, just as a precaution.

@koenderks I have some issues with JASP atm, I checked the bug disappeared with jasptools, can you verify the bug is gone in JASP?