### PR TITLE
fixed two bugs in Bayesian independent samples t-test

### DIFF
--- a/JASP-Engine/JASP/R/commonbayesianttest.R
+++ b/JASP-Engine/JASP/R/commonbayesianttest.R
@@ -438,7 +438,7 @@
 .ttestBayesianSetupWilcoxProgressBar <- function(nvar, ttestState, noSamples) {
   # all variables minus the ones we sampled before
   todo <- nvar
-  if (!is.null(ttestState[["delta"]]))
+  if (length(ttestState[["delta"]]) > 0L)
     todo <- todo - sum(sapply(ttestState[["delta"]], Negate(is.null)))
   if (todo > 0L) {
     # times 5 since there are 5 chains by default

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -154,7 +154,8 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
           }
         }
 
-        ttestResults[["tValue"]][[var]] <- median(ttestResults[["delta"]][[var]])
+        if (!is.null(ttestResults[["delta"]][[var]]))
+          ttestResults[["tValue"]][[var]] <- median(ttestResults[["delta"]][[var]])
         wValue <- unname(wilcox.test(group2, group1, paired = FALSE)[["statistic"]])
         error <- wValue
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/300

In addition, if a grouping variable was entered first, `ttestState[["delta"]]` would become `list()` rather than `NULL`, which caused an error. That's why `.ttestBayesianSetupWilcoxProgressBar` now checks the length rather than for `NULL`.