### PR TITLE
Bayesian t-tests added error ~

### DIFF
--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -220,7 +220,12 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
     jaspTable$addFootnote(paste("Result based on data augmentation algorithm with 5 chains of",
                                 options[["wilcoxonSamplesNumber"]], "iterations."))
   } else {
-    jaspTable$addColumnInfo(name = "error", type = "number", title = "error %")
+    if (options[["hypothesis"]] == "groupsNotEqual") {
+      fmt <- "sf:4;dp:3"
+    } else {
+      fmt <- "sf:4;dp:3;~"
+    }
+    jaspTable$addColumnInfo(name = "error", type = "number", format = fmt, title = "error %")
   }
 
   if (!(is.null(g1) || is.null(g2))) {

--- a/JASP-Engine/JASP/R/ttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/ttestbayesianonesample.R
@@ -150,11 +150,12 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
   jaspTable$addColumnInfo(name = "variable", title = "",      type = "string")
   jaspTable$addColumnInfo(name = "BF",       title = bfTitle, type = "number")
 
-  if (options$hypothesis == "notEqualToTestValue") { # TODO: does this even matter?
-      jaspTable$addColumnInfo(name = "error", type = "number", format = "sf:4;dp:3",  title = "error %")
+  if (options[["hypothesis"]] == "notEqualToTestValue") {
+    fmt <- "sf:4;dp:3"
   } else {
-      jaspTable$addColumnInfo(name = "error", type = "number", format = "sf:4;dp:3;~", title= "error %")
+    fmt <- "sf:4;dp:3;~"
   }
+  jaspTable$addColumnInfo(name = "error", type = "number", format = fmt, title = "error %")
   return(jaspTable)
 }
 

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -144,9 +144,9 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
   jaspTable$addColumnInfo(name = "variable1", title = "",      type = "string")
   jaspTable$addColumnInfo(name = "separator", title = "",      type = "string")
   jaspTable$addColumnInfo(name = "variable2", title = "",      type = "string")
-  jaspTable$addColumnInfo(name = "BF",        title = bfTitle, type = "number", format = "sf:4;dp:3")
+  jaspTable$addColumnInfo(name = "BF",        title = bfTitle, type = "number")
 
-  if (options[["hypothesis"]] == "notEqualToTestValue") { # TODO: does this even matter?
+  if (options[["hypothesis"]] == "groupsNotEqual") {
     fmt <- "sf:4;dp:3"
   } else {
     fmt <- "sf:4;dp:3;~"


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/453

A `~` is now shown in the Bayesian t-tests if the hypothesis type is `>` or `<`.