### PR TITLE
reintroduce function needed by Bain

### DIFF
--- a/JASP-Engine/JASP/R/commonbayesianttest.R
+++ b/JASP-Engine/JASP/R/commonbayesianttest.R
@@ -1132,7 +1132,7 @@
 				# axis.ticks.margin = grid::unit(1,"mm"),
 				axis.ticks.length = grid::unit(3, "mm"),
 				plot.margin = grid::unit(c(.5,0,.5,.5), "cm")) +
-				.base_breaks_y4(summaryStat, testValueOpt) +
+				.base_breaks_y2(summaryStat, testValueOpt) +
 				.base_breaks_x(summaryStat$groupingVariable)
 
 	if (!is.null(testValueOpt))
@@ -1140,16 +1140,6 @@
 
 	return(p)
 
-}
-
-.base_breaks_y4 <- function(x, testValue) {
-
-  values <- c(testValue, x$ciLower, x$ciUpper)
-  ci.pos <- c(min(values), max(values))
-  b <- pretty(ci.pos)
-  d <- data.frame(x=-Inf, xend=-Inf, y=min(b), yend=max(b))
-  list(ggplot2::geom_segment(data=d, ggplot2::aes(x=x, y=y, xend=xend, yend=yend), inherit.aes=FALSE, size = 1),
-       ggplot2::scale_y_continuous(breaks=c(min(b), testValue, max(b))))
 }
 
 .base_breaks_x <- function(x) {

--- a/JASP-Engine/JASP/R/ttestplotfunctions.R
+++ b/JASP-Engine/JASP/R/ttestplotfunctions.R
@@ -2335,3 +2335,13 @@
   list(ggplot2::geom_segment(data=d, ggplot2::aes(x=x, y=y, xend=xend, yend=yend), inherit.aes=FALSE, size = 1),
        ggplot2::scale_y_continuous(breaks=c(min(b), testValue, max(b))))
 }
+
+# only used by bain!
+.base_breaks_y3 <- function(x) {
+
+	ci.pos <- c(x$ciLower, x$ciUpper)
+	b <- pretty(ci.pos)
+	d <- data.frame(x=-Inf, xend=-Inf, y=min(b), yend=max(b))
+	list(	ggplot2::geom_segment(data=d, ggplot2::aes(x=x, y=y, xend=xend, yend=yend), inherit.aes=FALSE, size = 1),
+			ggplot2::scale_y_continuous(breaks=c(min(b),max(b)))	)
+}

--- a/JASP-Engine/JASP/R/ttestplotfunctions.R
+++ b/JASP-Engine/JASP/R/ttestplotfunctions.R
@@ -2294,7 +2294,7 @@
 			ggplot2::geom_point(position=pd, size=4) +
 			ggplot2::ylab(dependentName) +
 			ggplot2::xlab(groupingName) +
-			.base_breaks_y3(summaryStat) +
+			.base_breaks_y2(summaryStat, NULL) +
 			.base_breaks_x(summaryStat$groupingVariable)
 
 	p <- JASPgraphs::themeJasp(p)
@@ -2334,14 +2334,4 @@
   d <- data.frame(x=-Inf, xend=-Inf, y=min(b), yend=max(b))
   list(ggplot2::geom_segment(data=d, ggplot2::aes(x=x, y=y, xend=xend, yend=yend), inherit.aes=FALSE, size = 1),
        ggplot2::scale_y_continuous(breaks=c(min(b), testValue, max(b))))
-}
-
-# only used by bain!
-.base_breaks_y3 <- function(x) {
-
-	ci.pos <- c(x$ciLower, x$ciUpper)
-	b <- pretty(ci.pos)
-	d <- data.frame(x=-Inf, xend=-Inf, y=min(b), yend=max(b))
-	list(	ggplot2::geom_segment(data=d, ggplot2::aes(x=x, y=y, xend=xend, yend=yend), inherit.aes=FALSE, size = 1),
-			ggplot2::scale_y_continuous(breaks=c(min(b),max(b)))	)
 }


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/297

function `.base_breaks_y3` is taken from the history of JASP:
https://github.com/jasp-stats/jasp-desktop/blob/2576fdd3337a460abb7a47fce52bcee62cc37033/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R

