### PR TITLE
Fix errors in Bayesian t-tests

### DIFF
--- a/JASP-Engine/JASP/R/commonbayesianttest.R
+++ b/JASP-Engine/JASP/R/commonbayesianttest.R
@@ -1094,29 +1094,14 @@
 
 	pd <- ggplot2::position_dodge(.2)
 
-	p <-	ggplot2::ggplot(summaryStat, mapping = mapping) +
+	p <-	JASPgraphs::themeJasp(ggplot2::ggplot(summaryStat, mapping = mapping) +
 			ggplot2::geom_errorbar(ggplot2::aes(ymin=ciLower, ymax=ciUpper), colour="black", width=.2, position=pd) +
 			ggplot2::geom_line(position=pd, size = .7) +
 			ggplot2::geom_point(position=pd, size=4) +
-			xlab + ylab +
-			ggplot2::theme_bw() +
-			ggplot2::theme(panel.grid.minor=ggplot2::element_blank(), plot.title = ggplot2::element_text(size=18),
-				panel.grid.major=ggplot2::element_blank(),
-				axis.title.x = ggplot2::element_text(size=18,vjust=-.2), axis.title.y = ggplot2::element_text(size=18,vjust=-1),
-				axis.text.x = ggplot2::element_text(size=15), axis.text.y = ggplot2::element_text(size=15),
-				panel.background = ggplot2::element_rect(fill = 'transparent', colour = NA),
-				plot.background = ggplot2::element_rect(fill = 'transparent', colour = NA),
-				legend.background = ggplot2::element_rect(fill = 'transparent', colour = NA),
-				panel.border = ggplot2::element_blank(), axis.line = ggplot2::element_blank(),
-				legend.key = ggplot2::element_blank(),
-				legend.title = ggplot2::element_text(size=12),
-				legend.text = ggplot2::element_text(size = 12),
-				axis.ticks = ggplot2::element_line(size = 0.5),
-				# axis.ticks.margin = grid::unit(1,"mm"),
-				axis.ticks.length = grid::unit(3, "mm"),
-				plot.margin = grid::unit(c(.5,0,.5,.5), "cm")) +
-				.base_breaks_y2(summaryStat, testValueOpt) +
-				.base_breaks_x(summaryStat$groupingVariable)
+			xlab + ylab) + 
+	    JASPgraphs::themeJaspRaw() +
+			.base_breaks_y2(summaryStat, testValueOpt) +
+			.base_breaks_x(summaryStat$groupingVariable)
 
 	if (!is.null(testValueOpt))
 		p <- p + ggplot2::geom_hline(data = testValue, ggplot2::aes(yintercept=testValue), linetype="dashed")

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -105,6 +105,7 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
           ttestResults[["tValue"]][[var]] <- r[["tValue"]]
 
           if (!is.null(error) && is.na(error) && grepl("approximation", r[["method"]])) {
+            error <- NaN
             ttestTable$addFootnote(
               message = "t-value is large. A Savage-Dickey approximation was used to compute the Bayes factor but no error estimate can be given.",
               symbol = "", rowNames = var, colNames = "error")

--- a/JASP-Engine/JASP/R/ttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/ttestbayesianonesample.R
@@ -35,6 +35,7 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
 
   # create empty object for the table, this has previously computed rows already filled in
   ttestRows <- .ttestBayesianCreateTtestRows(dependents, options, derivedOptions, ttestState)
+  ttestTable$setData(ttestRows)
   alreadyComputed <- !is.na(ttestRows[, "BF"])
 
   oneSided <- derivedOptions[["oneSided"]]
@@ -80,6 +81,7 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
         ttestResults[["tValue"]][var]   <- r[["tValue"]]
 
         if (!is.null(error) && is.na(error) && grepl("approximation", r[["method"]])) {
+          error <- NaN
           ttestTable$addFootnote(
             message = "t-value is large. A Savage-Dickey approximation was used to compute the Bayes factor but no error estimate can be given.",
             symbol = "", rowNames = var, colNames = "error")
@@ -137,13 +139,14 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
 
   if (!(options[["hypothesis"]] == "notEqualToTestValue" && options[["testValue"]] == 0)) {
     m0 <- "For all tests, the alternative hypothesis specifies that the population"
+    testValueFormatted <- format(options[["testValue"]], drop0trailing = TRUE)
     m1 <- switch(
       options[["hypothesis"]],
-      "greaterThanTestValue" = "mean is greater than %.3f.",
-      "lessThanTestValue"    = "mean is less than %.3f.",
-      "notEqualToTestValue"  = "mean differs from %.3f."
+      "greaterThanTestValue" = "mean is greater than %s.",
+      "lessThanTestValue"    = "mean is less than %s.",
+      "notEqualToTestValue"  = "mean differs from %s."
     )
-    message <- sprintf(paste(m0, m1), options[["testValue"]])
+    message <- sprintf(paste(m0, m1), testValueFormatted)
     jaspTable$addFootnote(message = message, symbol = "<em>Note.</em>")
   }
 
@@ -163,7 +166,7 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
 .oneSidedTtestBFRichard <- function(x=NULL, y=NULL, paired=FALSE, oneSided="right", r= sqrt(2)/2, iterations=10000) {
 
   # sample from delta posterior
-  samples <- BayesFactor::ttestBF(x=x, y=y, paired=paired, posterior=TRUE, iterations=iterations, rscale=r)
+  samples <- BayesFactor::ttestBF(x=x, y=y, paired=paired, posterior=TRUE, iterations=iterations, rscale=r, progress = FALSE)
 
   if (is.null(y) || paired) {
 

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -87,6 +87,7 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
           ttestResults[["tValue"]][var]   <- r[["tValue"]]
 
           if (!is.null(error) && is.na(error) && grepl("approximation", r[["method"]])) {
+            error <- NaN
             ttestTable$addFootnote(
               message = "t-value is large. A Savage-Dickey approximation was used to compute the Bayes factor but no error estimate can be given.",
               symbol = "", rowNames = var, colNames = "error")

--- a/JASP-Engine/JASPgraphs/DESCRIPTION
+++ b/JASP-Engine/JASPgraphs/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: JASPgraphs
 Type: Package
 Title: Custom graphs for JASP
-Version: 0.3.6
-Author: Don vd Bergh
+Version: 0.3.7
+Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: ...
 License: GPL

--- a/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
+++ b/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
@@ -39,7 +39,7 @@ PlotRobustnessSequential <- function(
   bfType = c("BF01", "BF10", "LogBF10"),
   hypothesis = c("equal", "smaller", "greater"),
   pointColors  = c("red", "grey", "black", "white"),
-  lineColors = c("black", "grey", "black"), #lineTypes = c("dotted", "solid", "solid"),
+  lineColors = c("black", "grey", "black"),
   lineTypes = c("solid", "solid", "dotted"),
   addLineAtOne = TRUE, bty = list(type = "n", ldwX = .5, lwdY = .5),
   plotLineOrPoint = c("line", "point"),

--- a/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
+++ b/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
@@ -39,7 +39,8 @@ PlotRobustnessSequential <- function(
   bfType = c("BF01", "BF10", "LogBF10"),
   hypothesis = c("equal", "smaller", "greater"),
   pointColors  = c("red", "grey", "black", "white"),
-  lineColors = c("black", "grey", "black"), lineTypes = c("dotted", "solid", "solid"),
+  lineColors = c("black", "grey", "black"), #lineTypes = c("dotted", "solid", "solid"),
+  lineTypes = c("solid", "solid", "dotted"),
   addLineAtOne = TRUE, bty = list(type = "n", ldwX = .5, lwdY = .5),
   plotLineOrPoint = c("line", "point"),
   pointShape = rep(21, 3),
@@ -107,10 +108,14 @@ PlotRobustnessSequential <- function(
     to <- ceiling(yRange[2L])
     # rounding + unique avoids fractional breaks which aren't nicely displayed
     yBreaksL <- unique(as.integer(getPrettyAxisBreaks(x = c(from, to))))
+    step <- yBreaksL[2L] - yBreaksL[1L]
+    # add additional breaks to avoid overlap if there are arrows
+    if (addEvidenceArrowText)
+      yBreaksL <- c(yBreaksL[1L] - step, yBreaksL, yBreaksL[length(yBreaksL)] + step)
     if (yBreaksL[1L] == 0)
-      yBreaksL <- c(-1, yBreaksL)
+      yBreaksL <- c(-step, yBreaksL)
     if (yBreaksL[length(yBreaksL)] == 0)
-      yBreaksL <- c(yBreaksL, 1)
+      yBreaksL <- c(yBreaksL, step)
 
     if (max(abs(yBreaksL)) < 6L) { # below 1 000 000
       # show 1 / 100, 1 / 10, ..., 10 , 100, ..., 100 000

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-descriptives.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-descriptives.svg
@@ -12,38 +12,40 @@
   ]]></style>
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: none;' />
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 <defs>
-  <clipPath id='cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw=='>
-    <rect x='68.34' y='34.53' width='651.66' height='486.19' />
+  <clipPath id='cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw=='>
+    <rect x='73.89' y='19.67' width='646.11' height='492.55' />
   </clipPath>
 </defs>
-<rect x='68.34' y='34.53' width='651.66' height='486.19' style='stroke-width: 1.07; stroke: none;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<polyline points='216.45,99.37 275.69,99.37 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<polyline points='246.07,99.37 246.07,367.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<polyline points='216.45,367.63 275.69,367.63 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<polyline points='512.65,181.06 571.90,181.06 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<polyline points='542.28,181.06 542.28,466.45 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<polyline points='512.65,466.45 571.90,466.45 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<polyline points='246.07,233.50 542.28,323.76 ' style='stroke-width: 1.49; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<circle cx='246.07' cy='233.50' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<circle cx='542.28' cy='323.76' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<line x1='68.34' y1='498.62' x2='68.34' y2='56.63' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
-<line x1='246.07' y1='520.72' x2='542.28' y2='520.72' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNjguMzR8NzIwLjAwfDUyMC43MnwzNC41Mw==)' />
+<rect x='73.89' y='19.67' width='646.11' height='492.55' style='stroke-width: 10.67; stroke: none;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<polyline points='220.73,85.36 279.47,85.36 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<polyline points='250.10,85.36 250.10,357.12 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<polyline points='220.73,357.12 279.47,357.12 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<polyline points='514.42,168.12 573.16,168.12 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<polyline points='543.79,168.12 543.79,457.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<polyline points='514.42,457.24 573.16,457.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<polyline points='250.10,221.24 543.79,312.68 ' style='stroke-width: 1.49; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<circle cx='250.10' cy='221.24' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<circle cx='543.79' cy='312.68' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<line x1='250.10' y1='512.22' x2='543.79' y2='512.22' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<line x1='73.89' y1='377.89' x2='73.89' y2='154.00' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<line x1='73.89' y1='489.83' x2='73.89' y2='42.06' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
+<line x1='250.10' y1='512.22' x2='543.79' y2='512.22' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNzMuODl8NzIwLjAwfDUxMi4yMnwxOS42Nw==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='31.79' y='503.78' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='25.86px' lengthAdjust='spacingAndGlyphs'>-0.6</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='36.79' y='61.78' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='20.86px' lengthAdjust='spacingAndGlyphs'>0.2</text></g>
-<polyline points='59.84,498.62 68.34,498.62 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='59.84,56.63 68.34,56.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='246.07,529.22 246.07,520.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='542.28,529.22 542.28,520.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='241.90' y='541.73' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='8.34px' lengthAdjust='spacingAndGlyphs'>0</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='538.10' y='541.73' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='8.34px' lengthAdjust='spacingAndGlyphs'>1</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='351.64' y='562.32' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>contBinom</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(31.53,323.65) rotate(-90)' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='92.06px' lengthAdjust='spacingAndGlyphs'>contNormal</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='68.34' y='26.56' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='389.33px' lengthAdjust='spacingAndGlyphs'>TTestBayesianIndependentSamples-descriptives</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='29.13' y='495.68' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='29.28px' lengthAdjust='spacingAndGlyphs'>-0.6</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='34.79' y='47.91' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='23.62px' lengthAdjust='spacingAndGlyphs'>0.2</text></g>
+<polyline points='65.39,489.83 73.89,489.83 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='65.39,42.06 73.89,42.06 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='250.10,520.73 250.10,512.22 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='543.79,520.73 543.79,512.22 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='245.38' y='539.40' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='539.06' y='539.40' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='9.45px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='356.79' y='568.53' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='80.31px' lengthAdjust='spacingAndGlyphs'>contBinom</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(16.68,309.40) rotate(-90)' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='86.91px' lengthAdjust='spacingAndGlyphs'>contNormal</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='213.16' y='11.70' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='367.56px' lengthAdjust='spacingAndGlyphs'>TTestBayesianIndependentSamples-descriptives</text></g>
 </svg>

--- a/JASP-Tests/R/tests/figs/TTestBayesianOneSample/ttestbayesianonesample-descriptives.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianOneSample/ttestbayesianonesample-descriptives.svg
@@ -12,31 +12,33 @@
   ]]></style>
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: none;' />
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 <defs>
-  <clipPath id='cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw=='>
-    <rect x='50.73' y='34.53' width='669.27' height='503.81' />
+  <clipPath id='cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw=='>
+    <rect x='44.76' y='19.67' width='675.24' height='526.67' />
   </clipPath>
 </defs>
-<rect x='50.73' y='34.53' width='669.27' height='503.81' style='stroke-width: 1.07; stroke: none;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='329.59,72.33 441.14,72.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='385.36,72.33 385.36,474.77 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='329.59,474.77 441.14,474.77 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<circle cx='385.36' cy='273.55' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<line x1='50.73' y1='515.43' x2='50.73' y2='57.43' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<line x1='50.73' y1='57.43' x2='720.00' y2='57.43' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
+<rect x='44.76' y='19.67' width='675.24' height='526.67' style='stroke-width: 10.67; stroke: none;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='326.11,59.18 438.65,59.18 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='382.38,59.18 382.38,479.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='326.11,479.89 438.65,479.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<circle cx='382.38' cy='269.53' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<line x1='382.38' y1='546.33' x2='382.38' y2='546.33' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<line x1='44.76' y1='402.70' x2='44.76' y2='43.61' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<line x1='44.76' y1='522.40' x2='44.76' y2='43.61' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<line x1='44.76' y1='43.61' x2='720.00' y2='43.61' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='14.17' y='520.59' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='25.86px' lengthAdjust='spacingAndGlyphs'>-0.4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='19.17' y='62.58' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='20.86px' lengthAdjust='spacingAndGlyphs'>0.0</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='19.17' y='62.58' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='20.86px' lengthAdjust='spacingAndGlyphs'>0.0</text></g>
-<polyline points='42.22,515.43 50.73,515.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='42.22,57.43 50.73,57.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='42.22,57.43 50.73,57.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='385.36,546.84 385.36,538.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='347.01' y='559.34' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='76.70px' lengthAdjust='spacingAndGlyphs'>contNormal</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='50.73' y='26.56' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='314.22px' lengthAdjust='spacingAndGlyphs'>TTestBayesianOneSample-descriptives</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.00' y='528.25' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='29.28px' lengthAdjust='spacingAndGlyphs'>-0.4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.66' y='49.46' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='23.62px' lengthAdjust='spacingAndGlyphs'>0.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.66' y='49.46' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='23.62px' lengthAdjust='spacingAndGlyphs'>0.0</text></g>
+<polyline points='36.26,522.40 44.76,522.40 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='36.26,43.61 44.76,43.61 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='36.26,43.61 44.76,43.61 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='382.38,554.84 382.38,546.33 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='338.93' y='573.52' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='86.91px' lengthAdjust='spacingAndGlyphs'>contNormal</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='234.04' y='11.70' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='296.67px' lengthAdjust='spacingAndGlyphs'>TTestBayesianOneSample-descriptives</text></g>
 </svg>

--- a/JASP-Tests/R/tests/figs/TTestBayesianPairedSamples/ttestbayesianpairedsamples-descriptives.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianPairedSamples/ttestbayesianpairedsamples-descriptives.svg
@@ -12,36 +12,38 @@
   ]]></style>
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: none;' />
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 <defs>
-  <clipPath id='cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw=='>
-    <rect x='50.73' y='34.53' width='669.27' height='503.81' />
+  <clipPath id='cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw=='>
+    <rect x='44.76' y='19.67' width='675.24' height='526.67' />
   </clipPath>
 </defs>
-<rect x='50.73' y='34.53' width='669.27' height='503.81' style='stroke-width: 1.07; stroke: none;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='202.84,89.89 263.68,89.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='233.26,89.89 233.26,167.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='202.84,167.58 263.68,167.58 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='507.05,441.09 567.89,441.09 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='537.47,441.09 537.47,494.75 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='507.05,494.75 567.89,494.75 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<polyline points='233.26,128.73 537.47,467.92 ' style='stroke-width: 1.49; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<circle cx='233.26' cy='128.73' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<circle cx='537.47' cy='467.92' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<line x1='50.73' y1='515.43' x2='50.73' y2='57.43' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
-<line x1='233.26' y1='538.33' x2='537.47' y2='538.33' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNTAuNzN8NzIwLjAwfDUzOC4zM3wzNC41Mw==)' />
+<rect x='44.76' y='19.67' width='675.24' height='526.67' style='stroke-width: 10.67; stroke: none;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='198.22,77.54 259.61,77.54 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='228.92,77.54 228.92,158.75 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='198.22,158.75 259.61,158.75 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='505.15,444.67 566.54,444.67 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='535.84,444.67 535.84,500.77 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='505.15,500.77 566.54,500.77 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<polyline points='228.92,118.14 535.84,472.72 ' style='stroke-width: 1.49; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<circle cx='228.92' cy='118.14' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<circle cx='535.84' cy='472.72' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<line x1='228.92' y1='546.33' x2='535.84' y2='546.33' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<line x1='44.76' y1='442.60' x2='44.76' y2='123.40' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<line x1='44.76' y1='522.40' x2='44.76' y2='43.61' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
+<line x1='228.92' y1='546.33' x2='535.84' y2='546.33' style='stroke-width: 2.13; stroke-linecap: butt;' clip-path='url(#cpNDQuNzZ8NzIwLjAwfDU0Ni4zM3wxOS42Nw==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='14.17' y='520.59' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='25.86px' lengthAdjust='spacingAndGlyphs'>-0.5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='19.17' y='62.58' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='20.86px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
-<polyline points='42.22,515.43 50.73,515.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='42.22,57.43 50.73,57.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='233.26,546.84 233.26,538.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='537.47,546.84 537.47,538.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='192.40' y='559.34' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='81.72px' lengthAdjust='spacingAndGlyphs'>contGamma</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='499.12' y='559.34' style='font-size: 15.00px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='76.70px' lengthAdjust='spacingAndGlyphs'>contNormal</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='50.73' y='26.56' style='font-size: 18.00px; font-family: Liberation Sans;' textLength='341.23px' lengthAdjust='spacingAndGlyphs'>TTestBayesianPairedSamples-descriptives</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.00' y='528.25' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='29.28px' lengthAdjust='spacingAndGlyphs'>-0.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.66' y='49.46' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='23.62px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<polyline points='36.26,522.40 44.76,522.40 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='36.26,43.61 44.76,43.61 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='228.92,554.84 228.92,546.33 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='535.84,554.84 535.84,546.33 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='182.63' y='573.52' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='92.56px' lengthAdjust='spacingAndGlyphs'>contGamma</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='492.39' y='573.52' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='86.91px' lengthAdjust='spacingAndGlyphs'>contNormal</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='221.29' y='11.70' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='322.19px' lengthAdjust='spacingAndGlyphs'>TTestBayesianPairedSamples-descriptives</text></g>
 </svg>

--- a/JASP-Tests/R/tests/figs/jasp-deps.txt
+++ b/JASP-Tests/R/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- JASPgraphs: 0.3.6
+- JASPgraphs: 0.3.7


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/343
fixes https://github.com/jasp-stats/jasp-test-release/issues/344 by using JASPgraphs::themeJaspRaw()
![afbeelding](https://user-images.githubusercontent.com/21319932/64650327-359bfa00-d41f-11e9-8c89-5760f6baecab.png)

fixes https://github.com/jasp-stats/jasp-test-release/issues/345 by adding a NaN


> 1. We're by default always placing a 3 decimal value in the footnote (so if testValue = 0, the footnote reads 0.000). This should only be a 3 decimal value if that is what the user entered.

Agreed, but it's pretty hard to tell the difference between 1, 1.0, 1.00, and 1.000. My solution right now is to drop any trailing 0s. So the previous all become 1.

> 2. It looks quite strange to have a footnote indicator without a cell value. I think we should put NaN there if a value cannot be computed, like it was beforehand

Agreed, added the NaN:
![afbeelding](https://user-images.githubusercontent.com/21319932/64650396-5f552100-d41f-11e9-8e02-bc31b2d87c0e.png)

fixes https://github.com/jasp-stats/jasp-test-release/issues/346

> Is it by design that the user prior is now the dotted line as opposed to the solid line?

Nope, good catch! Should be fixed now.
![afbeelding](https://user-images.githubusercontent.com/21319932/64650611-e7d3c180-d41f-11e9-9619-524597eab6cb.png)

