### PR TITLE
[0.11] Correlation and machine learning test-release issues

### DIFF
--- a/JASP-Engine/JASP/R/commonMachineLearningRegression.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningRegression.R
@@ -482,6 +482,8 @@
 }
 
 .scaleNumericData.data.frame <- function(x, center = TRUE, scale = TRUE) {
+  if (nrow(x) == 0)
+    return(x)
   idx <- sapply(x, is.numeric)
   x[, idx] <- scale(x[, idx, drop = FALSE], center, scale)
   attr(x, which = "scaled:center") <- NULL

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -1135,7 +1135,7 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
     candidateAcceptance[iter] <- logTargetCandidates[iter]+.logProposal(z=zCurrent, n=n, r=r)-
       (.logTarget(rho=rhoCurrent, n=n, r=r, kappa=kappa)+logPropCandidates[iter])
     
-    if (log(acceptMechanism[iter]) <= candidateAcceptance[iter]) {
+    if (is.finite(candidateAcceptance[iter]) && log(acceptMechanism[iter]) <= candidateAcceptance[iter]) {
       # Accept candidate and update rhoCurrent for next iteration
       rhoCurrent <- rhoCandidates[iter]
     } 
@@ -1626,7 +1626,6 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
         # 4. Marsman sampler
 
         result <- .bfCorrieKernel(n=n, r=r, kappa=kappa, method=methodNumber, ciValue=ciValue, hyperGeoOverFlowThreshold=hyperGeoOverFlowThreshold)
-        #}
         methodNumber <- methodNumber+1
     }
 
@@ -2160,10 +2159,13 @@ CorrelationBayesian <- function(dataset=NULL, options, perform="run",
 .betaParameterEstimates <- function(someMean, someVar) {
 	# someMean \in (0, 1)
 	# TODO: think about someMean = 0
-	some.a <- someMean*(someMean*(1-someMean)/someVar-1)
-	some.b <- (1-someMean)*(someMean*(1-someMean)/someVar-1)
+  result <- list(betaA=NA, betaB=NA)
+  if (!is.finite(someMean) || !is.finite(someVar) || someVar == 0)
+    return(result)
+    
+	result$betaA <- someMean*(someMean*(1-someMean)/someVar-1)
+	result$betaB <- (1-someMean)*(someMean*(1-someMean)/someVar-1)
 
-	result <- list(betaA=some.a, betaB=some.b)
 	return(result)
 }
 

--- a/JASP-Engine/JASP/R/correlationbayesianpairs.R
+++ b/JASP-Engine/JASP/R/correlationbayesianpairs.R
@@ -599,13 +599,18 @@ CorrelationBayesianPairs <- function(dataset=NULL, options, perform="run", callb
 						    BF10post[i] <- log(bfObject$bfMin0)
 						}
 					}
-
-					if (is.null(errorMessage) && is.infinite(BF10post[i])) {
-						unplotable <- TRUE
-						unplotableMessage <- "Bayes factor is infinity"
-					} else if (is.null(errorMessage) && BF10post[i] == 1 / Inf) {
-						unplotable <- TRUE
-						unplotableMessage <- "The Bayes factor is too small"
+					
+					if (is.null(errorMessage)) {
+					  if (is.na(BF10post[i])) {
+					    unplotable <- TRUE
+					    unplotableMessage <- "The Bayes factor could not be computed"
+					  } else if (is.infinite(BF10post[i])) {
+					    unplotable <- TRUE
+					    unplotableMessage <- "Bayes factor is infinity"
+					  } else if (BF10post[i] == 1 / Inf) {
+					    unplotable <- TRUE
+					    unplotableMessage <- "The Bayes factor is too small"
+					  }
 					}
 
 					if (!is.null(index)) {


### PR DESCRIPTION
Sort of fixes https://github.com/jasp-stats/jasp-test-release/issues/295
The error message is not that much better, but what can you do when all four methods fail and return `NA`? At least now only that particular correlation is not computed, while others still are.

Also added a check for the number of rows in the machine learning analyses, so in the future https://github.com/jasp-stats/jasp-test-release/issues/353 will be handled correctly