### PR TITLE
Using Split in Descriptives resulted in incorrect plots

### DIFF
--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -36,6 +36,8 @@ Descriptives <- function(jaspResults, dataset, options) {
     # remove missing values from the grouping variable
     dataset <- dataset[!is.na(splitFactor), ]
     dataset.factors <- dataset.factors[!is.na(splitFactor), ]
+	# Actually remove missing values from the split factor
+	splitFactor <- na.omit(splitFactor)
     # create a list of datasets, one for each level
     splitDat         <- split(dataset[.v(variables)],         splitFactor)
     splitDat.factors <- split(dataset.factors[.v(variables)], splitFactor)


### PR DESCRIPTION
Solves https://github.com/jasp-stats/jasp-issues/issues/493

When using split in descriptives and this used split column contained missing values incorrect plots were generated. (In previous versions 0.9.2  the descriptive table was incorrect)

