### PR TITLE
Fisher fix

### DIFF
--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -578,20 +578,6 @@ ContingencyTables <- function(dataset=NULL, options, perform="run", callback=fun
 	ordinal.footnotes <- .newFootnotes()
 	kendalls.footnotes <- .newFootnotes()
 
-	# Fisher test table footnote
-	if(length(group.matrices) >= 1 & options$oddsRatio & perform == "run" & options$oddsRatioHypothesis != "two.sided"){
-	  gp1 <- dimnames(group.matrices[[1]])[[1]][1]
-	  gp2 <- dimnames(group.matrices[[1]])[[1]][2]
-
-	  if(options$oddsRatioHypothesis == "less"){
-	    message <- paste("For all tests, the alternative hypothesis specifies that group <em>", gp1, "</em> is less than group <em>", gp2, ".</em>", sep="")
-	    .addFootnote(odds.ratio.footnotes, symbol="<em>Note.</em>", text=message)
-	  }else if(options$oddsRatioHypothesis == "greater"){
-	    message <- paste("For all tests, the alternative hypothesis specifies that group <em>", gp1, "</em> is greater than group <em>", gp2, ".</em>", sep="")
-	    .addFootnote(odds.ratio.footnotes, symbol="<em>Note.</em>", text=message)
-	  }
-	}
-	
 	for (i in 1:length(group.matrices)) {
 
 		group.matrix <- group.matrices[[i]]
@@ -642,6 +628,23 @@ ContingencyTables <- function(dataset=NULL, options, perform="run", callback=fun
 	}
 
 	if (options$oddsRatio) {
+	  
+	  # Fisher test table footnote
+	  if(length(odds.ratio.footnotes$footnotes) == 0){
+	    if(length(group.matrices) >= 1  & perform == "run" & options$oddsRatioHypothesis != "two.sided"){
+	      gp1 <- dimnames(group.matrices[[1]])[[1]][1]
+	      gp2 <- dimnames(group.matrices[[1]])[[1]][2]
+	      
+	      if(options$oddsRatioHypothesis == "less"){
+	        message <- paste("For all tests, the alternative hypothesis specifies that group <em>", gp1, "</em> is less than group <em>", gp2, ".</em>", sep="")
+	        .addFootnote(odds.ratio.footnotes, symbol="<em>Note.</em>", text=message)
+	      }else if(options$oddsRatioHypothesis == "greater"){
+	        message <- paste("For all tests, the alternative hypothesis specifies that group <em>", gp1, "</em> is greater than group <em>", gp2, ".</em>", sep="")
+	        .addFootnote(odds.ratio.footnotes, symbol="<em>Note.</em>", text=message)
+	      }
+	    }
+	  }
+	  
 		odds.ratio.table[["data"]] <- odds.ratio.rows
 		odds.ratio.table[["footnotes"]] <- as.list(odds.ratio.footnotes)
 

--- a/Resources/Frequencies/qml/ContingencyTables.qml
+++ b/Resources/Frequencies/qml/ContingencyTables.qml
@@ -41,6 +41,7 @@ Form
 			CheckBox { name: "chiSquared";						label: qsTr("χ²"); checked: true			}
 			CheckBox { name: "chiSquaredContinuityCorrection";	label: qsTr("χ² continuity correction")	}
 			CheckBox { name: "likelihoodRatio";					label: qsTr("Likelihood ratio")			}
+            CheckBox { name: "VovkSellkeMPR";                   label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}
 
 		Group
@@ -49,9 +50,18 @@ Form
 			{
 				name: "oddsRatio"; label: qsTr("Log odds ratio (2x2 only)")
 				CIField { name: "oddsRatioConfidenceIntervalInterval"; label: qsTr("Confidence interval") }
-			}
-			CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke maximum p-ratio") }
-		}
+
+                RadioButtonGroup
+                {
+                    title: qsTr("Alt. Hypothesis")
+                    name: "oddsRatioHypothesis"
+                    RadioButton { value: "two.sided";   label: qsTr("Group one ≠ Group two"); checked: true    }
+                    RadioButton { value: "greater";     label: qsTr("Group one > Group two")                   }
+                    RadioButton { value: "less";        label: qsTr("Group one < Group two")                   }
+                }
+            }
+
+        }
 
 		Group
 		{


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/500

- adds a menu for the alternative hypothesis selection in the same style as in Bayesian Contingency Tables (BCT)
![image](https://user-images.githubusercontent.com/38475991/66387367-1b285280-e9c4-11e9-862e-02e87a28d83b.png)
- adds p-values for Fisher's exact test
- adds a note to the resulting table with the direction of the alternative hypothesis (as in BCT)
 
I would consider renaming the checkbox from "Logs odds ratio (2x2 only)" to something like "Logs odds ratio & Fisher's exact test (2x2 only)" because it might be hard to find how to do the Fisher's exact test.
