### PR TITLE
tweaks to JASPgraphs documentation

### DIFF
--- a/JASP-Engine/JASPgraphs/R/PlotPieChart.R
+++ b/JASP-Engine/JASPgraphs/R/PlotPieChart.R
@@ -31,7 +31,9 @@ plotPieChart <- function(value, group,
 
   # change the default arguments for themeJasp
   dots <- list(...)
-  dots <- setDefaults(dots, legend.position = "right")
+  dots <- setDefaults(dots,
+                      legend.position = "right",
+                      bty = "o")
 
   if (asPercentages)
     value <- value / sum(value) * 100

--- a/JASP-Engine/JASPgraphs/R/geom_rangeframe.R
+++ b/JASP-Engine/JASPgraphs/R/geom_rangeframe.R
@@ -30,7 +30,7 @@ ggname <- function(prefix, grob) {
 #' @param panelInfo A list that specifies what information is drawn from what component of panel_scales. 
 #' Usually, \code{x.major} corresponds to the bottom axis. However, if a scale is used to move e.g., 
 #' the x-axis to be above the plot then this needs to be adjusted to \code{x.sec.major_source}. By default,
-#' this argument assumes that axis lines above and right of a plot use \code{\link[ggplot2]{sec.axis}} and are
+#' this argument assumes that axis lines above and right of a plot use \code{\link[ggplot2]{sec_axis}} and are
 #' therefore draw information from \code{*.sec.major_source}. You can partially set this list; if e.g., 
 #' \code{"t"} is missing it will be filled with its default value.
 #' 

--- a/JASP-Engine/JASPgraphs/R/printJASPgraphs.R
+++ b/JASP-Engine/JASPgraphs/R/printJASPgraphs.R
@@ -3,7 +3,8 @@
 print.JASPgraphs <- function(x, ...) {
 
   if (ggplot2::is.ggplot(x)) {
-    ggplot2:::print.ggplot(x, ...)
+    # do not call ggplot2:::print.ggplot() to please R CMD check
+    NextMethod()
   } else if (inherits(x, c("gtable", "gTree", "grob", "gDesc"))) {
     gridExtra::grid.arrange(x, ...)
   } else if (length(class(x)) > 1L) {

--- a/JASP-Engine/JASPgraphs/R/themeJasp.R
+++ b/JASP-Engine/JASPgraphs/R/themeJasp.R
@@ -7,7 +7,7 @@
 #' @rdname themeJasp
 #'
 #' @param graph a ggplot2 object
-#' @param sides see \link{\code{geom_rangeframe}}
+#' @param sides see \code{\link{geom_rangeframe}}
 #' @param axis.title.cex scalar magnification for the title of the axes.
 #' @param bty remake R's bty  = 'n'?
 #' @param fontsize global font size.

--- a/JASP-Engine/JASPgraphs/inst/examples/ex-PlotPieChart.R
+++ b/JASP-Engine/JASPgraphs/inst/examples/ex-PlotPieChart.R
@@ -1,3 +1,4 @@
+library(ggplot2)
 value <- c(25, 25, 50)
 gg <- letters[1:3]
 ga <- letters[4:6]

--- a/JASP-Engine/JASPgraphs/inst/examples/ex-ggMatrixPlot.R
+++ b/JASP-Engine/JASPgraphs/inst/examples/ex-ggMatrixPlot.R
@@ -1,4 +1,5 @@
 ## Not run:
+library(ggplot2)
 data("diamonds", package = "ggplot2")
 vars  <- colnames(diamonds)[c(1, 5)]
 nvars <- length(vars)
@@ -22,6 +23,7 @@ for (i in seq_along(vars)) for (j in seq_along(vars)) {
 
 ggMatrixPlot(plotMatrix)
 
-# gives an idea about how ggMatrixPlot works, you can add labels on all sides of the center (where the plots should be).
+# gives an idea about how ggMatrixPlot works, you can add labels on all sides
+# of the center (where the plots should be).
 ggMatrixPlot(debug = TRUE)
-##
+## End(Not run)

--- a/JASP-Engine/JASPgraphs/man/geom_rangeframe.Rd
+++ b/JASP-Engine/JASPgraphs/man/geom_rangeframe.Rd
@@ -51,7 +51,7 @@ Note that this is checked at drawing time, so 'b' always means bottom even when 
 \item{panelInfo}{A list that specifies what information is drawn from what component of panel_scales. 
 Usually, \code{x.major} corresponds to the bottom axis. However, if a scale is used to move e.g., 
 the x-axis to be above the plot then this needs to be adjusted to \code{x.sec.major_source}. By default,
-this argument assumes that axis lines above and right of a plot use \code{\link[ggplot2]{sec.axis}} and are
+this argument assumes that axis lines above and right of a plot use \code{\link[ggplot2]{sec_axis}} and are
 therefore draw information from \code{*.sec.major_source}. You can partially set this list; if e.g., 
 \code{"t"} is missing it will be filled with its default value.}
 

--- a/JASP-Engine/JASPgraphs/man/ggMatrixPlot.Rd
+++ b/JASP-Engine/JASPgraphs/man/ggMatrixPlot.Rd
@@ -69,6 +69,7 @@ This function is intended to be calles with a matrix as first argument, although
 }
 \examples{
 ## Not run:
+library(ggplot2)
 data("diamonds", package = "ggplot2")
 vars  <- colnames(diamonds)[c(1, 5)]
 nvars <- length(vars)
@@ -92,7 +93,8 @@ for (i in seq_along(vars)) for (j in seq_along(vars)) {
 
 ggMatrixPlot(plotMatrix)
 
-# gives an idea about how ggMatrixPlot works, you can add labels on all sides of the center (where the plots should be).
+# gives an idea about how ggMatrixPlot works, you can add labels on all sides
+# of the center (where the plots should be).
 ggMatrixPlot(debug = TRUE)
-##
+## End(Not run)
 }

--- a/JASP-Engine/JASPgraphs/man/plotPieChart.Rd
+++ b/JASP-Engine/JASPgraphs/man/plotPieChart.Rd
@@ -34,6 +34,7 @@ a ggplot object.
 Make a Pie Chart
 }
 \examples{
+library(ggplot2)
 value <- c(25, 25, 50)
 gg <- letters[1:3]
 ga <- letters[4:6]

--- a/JASP-Engine/JASPgraphs/man/themeJasp.Rd
+++ b/JASP-Engine/JASPgraphs/man/themeJasp.Rd
@@ -25,7 +25,7 @@ themeJaspRaw(legend.position = "none", xMargin = c(20, 0, 0, 0),
 \arguments{
 \item{graph}{a ggplot2 object}
 
-\item{sides}{see \link{geom_rangeframe}}
+\item{sides}{see \code{\link{geom_rangeframe}}}
 
 \item{axis.title.cex}{scalar magnification for the title of the axes.}
 


### PR DESCRIPTION
Fixes the incorrect documentation and ensures all examples work.
It should be `\code{\link{geom_rangeframe}}`, rather than `\link{\code{geom_rangeframe}}`.