### PR TITLE
Feature request: Fisher's Exact Test

### DIFF
--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -491,7 +491,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
   table$addColumnInfo(name = paste0("up[", fold, "]"),    title = "Upper", 
                                 overtitle = ci.label, type = "number", format = "dp:3")
   table$addColumnInfo(name = paste0("p[", fold, "]"),     title = "p", 
-                                type = "number", format = "dp:3;p:.001")
+                                type = "pvalue")
 
 }
 

--- a/JASP-Tests/R/tests/testthat/test-contingencytables.R
+++ b/JASP-Tests/R/tests/testthat/test-contingencytables.R
@@ -122,9 +122,9 @@ test_that("Log Odds Ratio table results match", {
   results <- jasptools::run("ContingencyTables", "test.csv", options)
   table <- results[["results"]][["container1"]][["collection"]][["container1_crossTabLogOdds"]][["data"]]
   expect_equal_tables(table,
-    list("Odds ratio", -0.329205575243527, -0.998167649205055, 0.339756498718001,
+    list("Odds ratio", -0.329205575243527, -0.998167649205055, 0.339756498718001,"",
          "Fisher's exact test ", -0.325882968750928, -1.07370478788709,
-         0.415368461868818)
+         0.415368461868818, 0.5435617)
   )
 })
 

--- a/Resources/Frequencies/qml/ContingencyTables.qml
+++ b/Resources/Frequencies/qml/ContingencyTables.qml
@@ -39,6 +39,7 @@ Form
 			CheckBox { name: "chiSquared";						label: qsTr("χ²"); checked: true			}
 			CheckBox { name: "chiSquaredContinuityCorrection";	label: qsTr("χ² continuity correction")	}
 			CheckBox { name: "likelihoodRatio";					label: qsTr("Likelihood ratio")			}
+            CheckBox { name: "VovkSellkeMPR";                   label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}
 
 		Group
@@ -47,8 +48,15 @@ Form
 			{
 				name: "oddsRatio"; label: qsTr("Log odds ratio (2x2 only)")
 				CIField { name: "oddsRatioConfidenceIntervalInterval"; label: qsTr("Confidence interval") }
+                RadioButtonGroup
+                {
+                    title: qsTr("Alt. Hypothesis")
+                    name: "oddsRatioHypothesis"
+                    RadioButton { value: "two.sided";   label: qsTr("Group one ≠ Group two"); checked: true    }
+                    RadioButton { value: "greater";     label: qsTr("Group one > Group two")                   }
+                    RadioButton { value: "less";        label: qsTr("Group one < Group two")                   }
+                }
 			}
-			CheckBox { name: "VovkSellkeMPR";	label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}
 
 		Group

--- a/Resources/Frequencies/qml/ContingencyTables.qml
+++ b/Resources/Frequencies/qml/ContingencyTables.qml
@@ -26,7 +26,7 @@ Form
 		AvailableVariablesList { name: "allVariablesList" }		
 		AssignedVariablesList { name: "rows";		title: qsTr("Rows");	suggestedColumns: ["ordinal", "nominal"] }
 		AssignedVariablesList { name: "columns";	title: qsTr("Columns");	suggestedColumns: ["ordinal", "nominal"] }
-        AssignedVariablesList { name: "counts";		title: qsTr("Counts");	suggestedColumns: ["scale", "ordinal"]; singleVariable: true }
+		AssignedVariablesList { name: "counts";		title: qsTr("Counts");	suggestedColumns: ["scale", "ordinal"]; singleVariable: true }
 		AssignedVariablesList { name: "layers";		title: qsTr("Layers");	suggestedColumns: ["ordinal", "nominal"]; listViewType: "Layers"; height: 120 }
 	}
 	
@@ -39,7 +39,7 @@ Form
 			CheckBox { name: "chiSquared";						label: qsTr("χ²"); checked: true			}
 			CheckBox { name: "chiSquaredContinuityCorrection";	label: qsTr("χ² continuity correction")	}
 			CheckBox { name: "likelihoodRatio";					label: qsTr("Likelihood ratio")			}
-            CheckBox { name: "VovkSellkeMPR";                   label: qsTr("Vovk-Sellke maximum p-ratio") }
+			CheckBox { name: "VovkSellkeMPR";					label: qsTr("Vovk-Sellke maximum p-ratio") }
 		}
 
 		Group
@@ -48,14 +48,14 @@ Form
 			{
 				name: "oddsRatio"; label: qsTr("Log odds ratio (2x2 only)")
 				CIField { name: "oddsRatioConfidenceIntervalInterval"; label: qsTr("Confidence interval") }
-                RadioButtonGroup
-                {
-                    title: qsTr("Alt. Hypothesis")
-                    name: "oddsRatioHypothesis"
-                    RadioButton { value: "two.sided";   label: qsTr("Group one ≠ Group two"); checked: true    }
-                    RadioButton { value: "greater";     label: qsTr("Group one > Group two")                   }
-                    RadioButton { value: "less";        label: qsTr("Group one < Group two")                   }
-                }
+				RadioButtonGroup
+				{
+					title: qsTr("Alt. Hypothesis (Fisher's exact test)")
+					name: "oddsRatioHypothesis"
+					RadioButton { value: "two.sided";	label: qsTr("Group one ≠ Group two"); checked: true	}
+					RadioButton { value: "greater";		label: qsTr("Group one > Group two")				}
+					RadioButton { value: "less";		label: qsTr("Group one < Group two")				}
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/500
the second try of adding p-values and one-sided p-values for Fisher exact test

- adds a menu for the alternative hypothesis selection in the same style as in Bayesian Contingency Tables (BCT)
![image](https://user-images.githubusercontent.com/38475991/66387367-1b285280-e9c4-11e9-862e-02e87a28d83b.png)
- adds p-values for Fisher's exact test
- adds a note to the resulting table with the direction of the alternative hypothesis (as in BCT) - I'm extracting the dimnames from the generated data matrix, couldn't come up with a more elegant way
 
I would consider renaming the checkbox from "Logs odds ratio (2x2 only)" to something like "Logs odds ratio & Fisher's exact test (2x2 only)" because it might be hard to find how to do the Fisher's exact test now.

questions:
1) is it possible to add a column to only one row? I tried to add p-values only for the row with the Fisher exact test, however, it's started filling it in the log odds ratio row (now I'm adding the column to both rows and filling it with "" in the logs odds column.


