### PR TITLE
Stop testthat from terminating early

### DIFF
--- a/JASP-Tests/R/tests/testthat.R
+++ b/JASP-Tests/R/tests/testthat.R
@@ -6,6 +6,8 @@ library(testthat)
 develop(path = file.path("..", "..", ".."))
 setPkgOption("pkgs.dir", "~/pkgs/Frameworks/R.framework/Versions/3.6/Resources/library")
 
+options("testthat.progress.max_fails" = 1E3L)
+
 result <- test_dir("testthat")
 result <- as.data.frame(result)
 


### PR DESCRIPTION
Line 41 of https://github.com/r-lib/testthat/blob/master/R/reporter-progress.R shows that it's actually possible to change the maximum number of failures for `testthat`. I changed it to 1000, so that practically the unit tests will never fail early (unless you mess up fantastically).

In case you consider testing this, if the limit is reached a new file won't be tested, but the current file will still be finished.