### PR TITLE
Forbid ci for standardized alpha

### DIFF
--- a/JASP-Engine/JASP/R/reliabilityanalysis.R
+++ b/JASP-Engine/JASP/R/reliabilityanalysis.R
@@ -245,7 +245,7 @@ ReliabilityAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
   if (options$averageInterItemCor)
     scaleTable$addColumnInfo(name = "rho", title = "Average interitem correlation",
                              type = "number")
-  if (options$confAlpha){
+  if (options$confAlpha && options[["alphaScaleStandardized"]] == "_1unstandardized"){
     overTitle <- paste0(100 * options$confAlphaLevel, "% Confidence Interval")
     scaleTable$addColumnInfo(name = "lower", title = "Lower", type = "number", 
                              overtitle = overTitle)

--- a/Resources/Descriptives/qml/ReliabilityAnalysis.qml
+++ b/Resources/Descriptives/qml/ReliabilityAnalysis.qml
@@ -40,8 +40,8 @@ Form
 			RadioButtonGroup
 			{
 				name: "alphaScaleStandardized"
-				RadioButton { value: "_1unstandardized";	label: qsTr("Unstandardized"); checked: true }
-				RadioButton { value: "_2standardized";		label: qsTr("Standardized")					}
+				RadioButton { value: "_1unstandardized";	label: qsTr("Unstandardized"); checked: true; id: alphaUnstandardized	}
+				RadioButton { value: "_2standardized";		label: qsTr("Standardized");											}
 			}
 		}
 		CheckBox { name: "gutmannScale";					label: qsTr("Gutmann's λ6")					}
@@ -88,7 +88,7 @@ Form
 		Group
 		{
 			title: qsTr("Confidence Interval")
-			enabled: chronbach.checked
+			enabled: chronbach.checked && alphaUnstandardized.checked
 			CheckBox {
 				name: "confAlpha"; label: qsTr("Cronbach's α analytical")
 				CIField { name: "confAlphaLevel"; label: qsTr("Confidence"); decimals: 1 }


### PR DESCRIPTION
The CI for Cronbach's alpha is incorrect if alpha is standardized (see https://github.com/jasp-stats/INTERNAL-jasp/issues/533). This PR fixes that by only allowing users to compute the CI when alpha is standardized.