### PR TITLE
changed QML_IMPORT_PATH

### DIFF
--- a/JASP-Desktop/JASP-Desktop.pro
+++ b/JASP-Desktop/JASP-Desktop.pro
@@ -54,7 +54,7 @@ INCLUDEPATH += $$PWD/../JASP-Common/
 
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH = $$PWD/imports
-
+QML_IMPORT_PATH += $$PWD/components
 
 exists(/app/lib/*) {
 	flatpak_desktop.files = ../Tools/flatpak/org.jaspstats.JASP.desktop


### PR DESCRIPTION
Previously there was always this (even though JASP would build just fine):

![image](https://user-images.githubusercontent.com/21319932/68752869-4d9d1f00-0604-11ea-8007-e8e922b72da9.png)

and after this PR it's gone:

![image](https://user-images.githubusercontent.com/21319932/68752904-5db4fe80-0604-11ea-9d70-47b278e4c718.png)

this also means that it technically should be possible to use the QML designer that is shipped with qt creator, although it failed for all qml files that I tried.
