### PR TITLE
Set seed

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/SetSeed.qml
+++ b/JASP-Desktop/components/JASP/Widgets/SetSeed.qml
@@ -1,0 +1,40 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+
+import QtQuick 2.8
+import JASP.Controls 1.0
+
+Group
+{
+	title: qsTr("Repeatability")
+
+	CheckBox {
+		name: "setSeed"
+		text: qsTr("Set seed:")
+		childrenOnSameRow: true
+
+		DoubleField {
+			name: "seed"
+			defaultValue: 1
+			min: -999999
+			max: 999999
+			fieldWidth: 60
+		}
+	}
+}

--- a/JASP-Desktop/components/JASP/Widgets/qmldir
+++ b/JASP-Desktop/components/JASP/Widgets/qmldir
@@ -40,3 +40,4 @@ ModulesMenu                 1.0 ModulesMenu.qml
 SaveDiscardCancelDialog     1.0 SaveDiscardCancelDialog.qml
 PlotEditor                  1.0 PlotEditor.qml
 CustomContrastsTableView    1.0 CustomContrastsTableView.qml
+SetSeed                     1.0 SetSeed.qml

--- a/JASP-Desktop/qml.qrc
+++ b/JASP-Desktop/qml.qrc
@@ -132,5 +132,6 @@
         <file>components/JASP/Controls/AssignedPairsVariablesList.qml</file>
         <file>components/JASP/Controls/AssignedRepeatedMeasuresCells.qml</file>
         <file>components/JASP/Controls/ComponentsList.qml</file>
+        <file>components/JASP/Widgets/SetSeed.qml</file>
     </qresource>
 </RCC>

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -3008,3 +3008,15 @@ postProcessModuleInstall <- function(moduleLibraryPath)
       return(FALSE)
   return(TRUE)
 }
+
+.setSeedJASP <- function(options) {
+  
+  if (is.list(options) && c("setSeed", "seed") %in% names(options)) {
+    if (isTRUE(options[["setSeed"]]))
+      set.seed(options[["seed"]])
+  } else {
+    stop(paste(".setSeedJASP was called with an incorrect argument.",
+               "The argument options should be the options list from QML.",
+               "Ensure that the SetSeed{} QML component is present in the QML file for this analysis."))
+  }
+}

--- a/JASP-Engine/JASP/R/commonbayesianttest.R
+++ b/JASP-Engine/JASP/R/commonbayesianttest.R
@@ -1,3 +1,4 @@
+
 #
 # Copyright (C) 2013-2018 University of Amsterdam
 #
@@ -28,7 +29,7 @@
   #     |            "informativeNormalStd", "informativeStandardizedEffectSize",
   #     |            "informativeTDf", "informativeTLocation", "informativeTScale",
   #     |            "missingValues", "priorWidth", "testStatistic", "wilcoxonSamplesNumber",
-  #     |            "testValue"
+  #     |            "testValue", "seed"
   #     | ))
   #     |-ttestResults (main table with BF for each test)
   #
@@ -80,7 +81,7 @@
       "informativeNormalStd", "informativeStandardizedEffectSize",
       "informativeTDf", "informativeTLocation", "informativeTScale",
       "missingValues", "priorWidth", "testStatistic", "wilcoxonSamplesNumber",
-      "testValue"
+      "testValue","seed", "setSeed"
     ))
     ttestContainer$position <- 1L
   } else {
@@ -1839,6 +1840,7 @@
   } else {
     # sample from delta posterior
     if (!wilcoxTest) {
+      .setSeedJASP(options)
       bfObject <- BayesFactor::meta.ttestBF(t = t, n1 = n1, n2 = n2, rscale = r)
       # library(BayesFactor)
       samples <- BayesFactor::posterior(model = bfObject, iterations = iterations,
@@ -2048,6 +2050,7 @@
     return(NULL)
   }
 }
+
 # citations ----
 .ttestBayesianCitations <- c(
   "MoreyEtal2015"    = "Morey, R. D., & Rouder, J. N. (2015). BayesFactor (Version 0.9.11-3)[Computer software].",

--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -116,7 +116,7 @@ RegressionLinearBayesian <- function(jaspResults, dataset = NULL, options) {
       "priorRegressionCoefficients", "alpha", "rScale",
       "modelPrior", "betaBinomialParamA", "betaBinomialParamB", "bernoulliParam",
       "wilsonParamLambda", "castilloParamU",
-      "samplingMethod", "iterationsMCMC", "numberOfModels"
+      "samplingMethod", "iterationsMCMC", "numberOfModels", "seed", "setSeed"
     ))
     jaspResults[["basreg"]] <- basregContainer
   }
@@ -128,7 +128,7 @@ RegressionLinearBayesian <- function(jaspResults, dataset = NULL, options) {
     postSumContainer <- createJaspContainer("Posterior Summary")
     postSumContainer$position <- position
     postSumContainer$dependOn(c(
-      "summaryType", "posteriorSummaryPlotCredibleIntervalValue", "nSimForCRI"
+      "summaryType", "posteriorSummaryPlotCredibleIntervalValue", "nSimForCRI", "seed", "setSeed"
     ))
     basregContainer[["postSumContainer"]] <- postSumContainer
   }
@@ -760,7 +760,7 @@ RegressionLinearBayesian <- function(jaspResults, dataset = NULL, options) {
   postDistContainer$position <- position
   postDistContainer$dependOn(c(
     "plotCoefficientsPosterior", "summaryType", 
-    "posteriorSummaryPlotCredibleIntervalValue", "nSimForCRI"
+    "posteriorSummaryPlotCredibleIntervalValue", "nSimForCRI", "seed", "setSeed"
   )) #TODO: check if dependencies are correct for this item: was probably wrong in release
 
   .basregInsertPosteriorDistributionPlots("placeholders", postDistContainer, plotNames, options, basregModel)
@@ -1022,6 +1022,7 @@ RegressionLinearBayesian <- function(jaspResults, dataset = NULL, options) {
   )
   
   # Bayesian Adaptive Sampling
+  .setSeedJASP(options)
   bas_lm <- try(BAS::bas.lm(
     formula         = formula,
     data            = dataset,
@@ -1093,6 +1094,7 @@ RegressionLinearBayesian <- function(jaspResults, dataset = NULL, options) {
   # if a user selects the same options. (The method uses approximations and otherwise decimals are off)
   footnote <- NULL
   
+  .setSeedJASP(options)
   coefBMA <- .basregOverwritecoefBas(basregModel, estimator = "BMA", dataset = dataset, options = options, weights = basregModel[["weights"]])
   conf95BMA <- try(stats::confint(coefBMA, level = 0.95, nsim = options$nSimForCRI))
   if (isTryError(conf95BMA)) {
@@ -1110,6 +1112,7 @@ RegressionLinearBayesian <- function(jaspResults, dataset = NULL, options) {
     coef <- coefBMA
     conf95 <- conf95BMA
   } else {
+    .setSeedJASP(options)
     coef <- .basregOverwritecoefBas(basregModel, estimator = estimator, dataset = dataset, options = options, weights = basregModel[["weights"]])
     conf95 <- stats::confint(coef, level = criVal, nsim = options$nSimForCRI)
   }
@@ -1129,7 +1132,8 @@ RegressionLinearBayesian <- function(jaspResults, dataset = NULL, options) {
                            conf95 = conf95, coefBMA = coefBMA, conf95BMA = conf95BMA, footnote = footnote)
   
   basregContainer[["postSumModel"]] <- createJaspState(postSumModel)
-  basregContainer[["postSumModel"]]$dependOn(c("summaryType", "posteriorSummaryPlotCredibleIntervalValue", "nSimForCRI"))
+  basregContainer[["postSumModel"]]$dependOn(c("summaryType", "posteriorSummaryPlotCredibleIntervalValue", "nSimForCRI",
+                                               "seed", "setSeed"))
   
   return(postSumModel)
 }

--- a/JASP-Engine/JASP/R/regressionloglinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionloglinearbayesian.R
@@ -138,6 +138,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset = NULL, options, ..
       names(dataset)[names(dataset) == "freq"] <- dependentBase64
     # Calculate here
     #gives an object computed using Bayesian Analysis of Complete Contingency Tables
+    .setSeedJASP(options)
     bcctObj <- try(conting::bcct(formula = modelFormula, data = dataset, 
                                  prior = "SBH", n.sample = 2000, 
                                  a = options$priorShape, b = options$priorScale), 
@@ -146,6 +147,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset = NULL, options, ..
     
     # Always do auto and then manual adds additional samples
     if (options$sampleMode == "manual"){
+      .setSeedJASP(options)
       bcctObj <- try(conting::bcctu(object = bcctObj, 
                                     n.sample = options$fixedSamplesNumber), 
                      silent = TRUE)
@@ -189,7 +191,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset = NULL, options, ..
     }
   } 
   container[["bfObject"]] <- createJaspState(bfObject)
-  container[["bfObject"]]$dependOn(c("fixedSamplesNumber", "sampleMode"))
+  container[["bfObject"]]$dependOn(c("fixedSamplesNumber", "sampleMode", "seed", "setSeed"))
   return(bfObject)
 }
 
@@ -429,7 +431,7 @@ RegressionLogLinearBayesian <- function(jaspResults, dataset = NULL, options, ..
   if(is.null(jaspResults[["Container"]])) {
     jaspResults[["Container"]] <- createJaspContainer()
     jaspResults[["Container"]]$dependOn(c("counts", "modelTerms", "priorShape", 
-                                          "priorScale", "sampleMode", "fixedSamplesNumber"))
+                                          "priorScale", "sampleMode", "fixedSamplesNumber", "seed", "setSeed"))
   }
 }
 

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -134,6 +134,7 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
 
         } else {
 
+          .setSeedJASP(options)
           r <- try(.rankSumGibbsSampler(
             x = group1, y = group2, nSamples = options[["wilcoxonSamplesNumber"]], nBurnin = 0,
             cauchyPriorParameter = options[["priorWidth"]]

--- a/Resources/ANOVA/qml/AncovaBayesian.qml
+++ b/Resources/ANOVA/qml/AncovaBayesian.qml
@@ -39,7 +39,7 @@ Form
 		title: qsTr("Tables")
 		CheckBox
 		{
-            name: "effects"; label: qsTr("Effects");
+			name: "effects"; label: qsTr("Effects");
 			RadioButtonGroup
 			{
 				name: "effectsType"
@@ -47,36 +47,36 @@ Form
 				RadioButton { value: "matchedModels";	label: qsTr("Across matched models")			}
 			}
 		}
-        CheckBox { name: "posteriorEstimates"; label: qsTr("Estimates") }
-        CheckBox { name: "criTable";           label: qsTr("Model averaged R\u00B2") }
-        CheckBox { name: "descriptives";       label: qsTr("Descriptives") }
-        CIField { name: "credibleInterval";	label: qsTr("Credible interval") }
-    }
+		CheckBox { name: "posteriorEstimates"; label: qsTr("Estimates") }
+		CheckBox { name: "criTable";		   label: qsTr("Model averaged R\u00B2") }
+		CheckBox { name: "descriptives";	   label: qsTr("Descriptives") }
+		CIField { name: "credibleInterval";	label: qsTr("Credible interval") }
+	}
 		
-    RadioButtonGroup
-    {
-        title: qsTr("Order")
-        name: "bayesFactorOrder"
-        RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model"); checked: true}
-        RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model")               }
-        
-    }
-    
-    GroupBox
-    {
-        title: qsTr("Plots")
-        CheckBox {
-            label: qsTr("Model averaged posteriors");    name: "posteriorPlot"
-            RadioButtonGroup
-            {
-                name: "groupPosterior"
-                RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
-                RadioButton { value: "individual";	label: qsTr("Individual plot per level")                 }
-            }
-        }
-        CheckBox { label: qsTr("Q-Q plot of residuals") ;    name: "qqPlot" }
-        CheckBox { label: qsTr("Posterior R\u00B2") ;        name: "rsqPlot"}
-    }
+	RadioButtonGroup
+	{
+		title: qsTr("Order")
+		name: "bayesFactorOrder"
+		RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model"); checked: true}
+		RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model")				}
+
+	}
+
+	GroupBox
+	{
+		title: qsTr("Plots")
+		CheckBox {
+			label: qsTr("Model averaged posteriors");	name: "posteriorPlot"
+			RadioButtonGroup
+			{
+				name: "groupPosterior"
+				RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
+				RadioButton { value: "individual";	label: qsTr("Individual plot per level")				 }
+			}
+		}
+		CheckBox { label: qsTr("Q-Q plot of residuals") ;	name: "qqPlot" }
+		CheckBox { label: qsTr("Posterior R\u00B2") ;		name: "rsqPlot"}
+	}
 	
 	Section
 	{
@@ -92,54 +92,56 @@ Form
 				title: qsTr("Components")
 				source: ["fixedFactors", "randomFactors", "covariates"]
 			}
+
 			ModelTermsList {}
+
 		}
 	}
 	
-    Section
-    {
-        title: qsTr("Single Model Inference")
+	Section
+	{
+		title: qsTr("Single Model Inference")
 
-        VariablesForm
-        {
-            height: 200
+		VariablesForm
+		{
+			height: 200
 
 			AvailableVariablesList { name: "components2"; title: qsTr("Components"); source: ["fixedFactors", "randomFactors", 'covariates'] }
-            AssignedVariablesList
-            {
+			AssignedVariablesList
+			{
 				title: qsTr("Specific Model Terms")
-                name: "singleModelTerms"
-                listViewType: "Interaction"
-            }
-        }
+				name: "singleModelTerms"
+				listViewType: "Interaction"
+			}
+		}
 
-        GridLayout
-        {
+		GridLayout
+		{
 
-            GroupBox
-            {
-                title: qsTr("Tables")
-                CheckBox { label: qsTr("Estimates"); name: "singleModelEstimates"}
-                CheckBox { label: qsTr("R\u00B2");   name: "singleModelCriTable" }
-            }
+			GroupBox
+			{
+				title: qsTr("Tables")
+				CheckBox { label: qsTr("Estimates"); name: "singleModelEstimates"}
+				CheckBox { label: qsTr("R\u00B2");   name: "singleModelCriTable" }
+			}
 
-            GroupBox
-            {
-                title: qsTr("Plots")
-                CheckBox { 
-                    label: qsTr("Marginal posteriors");    name: "singleModelPosteriorPlot"
-                    RadioButtonGroup
-                    {
-                        name: "singleModelGroupPosterior"
-                        RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
-                        RadioButton { value: "individual";	label: qsTr("Individual plot per level")                 }
-                    }
-                }
-                CheckBox { label: qsTr("Q-Q plot of residuals");  name: "singleModelqqPlot" }
-                CheckBox { label: qsTr("Posterior R\u00B2") ;     name: "singleModelrsqPlot"}
-            }
-        }       
-    }
+			GroupBox
+			{
+				title: qsTr("Plots")
+				CheckBox {
+					label: qsTr("Marginal posteriors");	name: "singleModelPosteriorPlot"
+					RadioButtonGroup
+					{
+						name: "singleModelGroupPosterior"
+						RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
+						RadioButton { value: "individual";	label: qsTr("Individual plot per level")				 }
+					}
+				}
+				CheckBox { label: qsTr("Q-Q plot of residuals");  name: "singleModelqqPlot" }
+				CheckBox { label: qsTr("Posterior R\u00B2") ;	 name: "singleModelrsqPlot"}
+			}
+		}
+	}
 
 	Section
 	{
@@ -165,10 +167,10 @@ Form
 		
 		VariablesForm
 		{
-            AvailableVariablesList { name: "descriptivePlotsVariables";	source: ["fixedFactors", "covariates"] }
-            AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis")  ; singleVariable: true}
-            AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate Lines")	; singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
-            AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate Plots")   ; singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
+			AvailableVariablesList { name: "descriptivePlotsVariables";	source: ["fixedFactors", "covariates"] }
+			AssignedVariablesList { name: "plotHorizontalAxis";			title: qsTr("Horizontal Axis")  ; singleVariable: true}
+			AssignedVariablesList { name: "plotSeparateLines";			title: qsTr("Separate Lines")	; singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
+			AssignedVariablesList { name: "plotSeparatePlots";			title: qsTr("Separate Plots")   ; singleVariable: true; suggestedColumns: ["ordinal", "nominal"] }
 		}
 		
 		Group
@@ -192,47 +194,50 @@ Form
 			title: qsTr("Prior")
 			DoubleField { name: "priorFixedEffects";		label: qsTr("r scale fixed effects");	defaultValue: 0.5;	 max: 2; inclusive: "maxOnly"; decimals: 3 }
 			DoubleField { name: "priorRandomEffects";		label: qsTr("r scale random effects");	defaultValue: 1;	 max: 2; inclusive: "maxOnly"; decimals: 3 }
-            DoubleField { name: "priorCovariates";	        label: qsTr("r scale covariates");		defaultValue: 0.354; max: 2; inclusive: "maxOnly"; decimals: 3 }
+			DoubleField { name: "priorCovariates";			label: qsTr("r scale covariates");		defaultValue: 0.354; max: 2; inclusive: "maxOnly"; decimals: 3 }
 		}
 
-        RadioButtonGroup
+		RadioButtonGroup
 		{
 			name: "sampleModeNumAcc"
 			title: qsTr("Numerical Accuracy")
-            RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
+			RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
 			RadioButton
 			{
-                value: "manual";	label: qsTr("Manual")
+				value: "manual";	label: qsTr("Manual")
 				IntegerField
 				{
 					name: "fixedNumAcc"
-                    label: qsTr("No. samples")
+					label: qsTr("No. samples")
 					defaultValue: 1e4
 					fieldWidth: 50
-                    min: 100
-                    max: 1e7
+					min: 100
+					max: 1e7
 				}
 			}
 		}
 
-        RadioButtonGroup
+		RadioButtonGroup
 		{
 			name: "sampleModeMCMC"
 			title: qsTr("Posterior Samples")
-            RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
+			RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
 			RadioButton
 			{
-                value: "manual";	label: qsTr("Manual")
+				value: "manual";	label: qsTr("Manual")
 				IntegerField
 				{
 					name: "fixedMCMCSamples"
-                    label: qsTr("No. samples")
+					label: qsTr("No. samples")
 					defaultValue: 1e3
 					fieldWidth: 50
-                    min: 100
-                    max: 1e7
+					min: 100
+					max: 1e7
 				}
 			}
 		}
+
+		SetSeed{}
+
 	}
 }

--- a/Resources/ANOVA/qml/AnovaBayesian.qml
+++ b/Resources/ANOVA/qml/AnovaBayesian.qml
@@ -25,7 +25,7 @@ Form
 	
 	VariablesForm
 	{
-		AvailableVariablesList { name: "allVariablesList" }		
+		AvailableVariablesList { name: "allVariablesList" }
 		AssignedVariablesList { name: "dependent";		title: qsTr("Dependent Variable");	suggestedColumns: ["scale"]; singleVariable: true	}
 		AssignedVariablesList { name: "fixedFactors";	title: qsTr("Fixed Factors");		suggestedColumns: ["ordinal", "nominal"]			}
 		AssignedVariablesList { name: "randomFactors";	title: qsTr("Random Factors");		suggestedColumns: ["ordinal", "nominal"]			}
@@ -36,45 +36,45 @@ Form
 	Group
 	{
 		title: qsTr("Tables")
-        CheckBox
-        {
-            name: "effects"; label: qsTr("Effects");
-            RadioButtonGroup
-            {
-                name: "effectsType"
-                RadioButton { value: "allModels";		label: qsTr("Across all models"); checked: true	}
-                RadioButton { value: "matchedModels";	label: qsTr("Across matched models")				}
-            }
-        }
-        CheckBox { name: "posteriorEstimates"; label: qsTr("Estimates") }
-        CheckBox { name: "criTable";           label: qsTr("Model averaged R\u00B2") }
-        CheckBox { name: "descriptives";       label: qsTr("Descriptives") }
-        CIField {  name: "credibleInterval";   label: qsTr("Credible interval") }
-    }
+		CheckBox
+		{
+				name: "effects"; label: qsTr("Effects");
+				RadioButtonGroup
+			{
+				name: "effectsType"
+				RadioButton { value: "allModels";		label: qsTr("Across all models"); checked: true	}
+				RadioButton { value: "matchedModels";	label: qsTr("Across matched models")			}
+				}
+		}
+		CheckBox { name: "posteriorEstimates";	label: qsTr("Estimates") }
+		CheckBox { name: "criTable";			label: qsTr("Model averaged R\u00B2") }
+		CheckBox { name: "descriptives";		label: qsTr("Descriptives") }
+		CIField {  name: "credibleInterval";	label: qsTr("Credible interval") }
+		}
 
-    RadioButtonGroup
-    {
-        title: qsTr("Order")
-        name: "bayesFactorOrder"
-        RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model"); checked: true}
-        RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model")               }
-    }
+		RadioButtonGroup
+		{
+		title: qsTr("Order")
+		name: "bayesFactorOrder"
+		RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model"); checked: true}
+		RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model")				}
+		}
 
-    GroupBox
-    {
-        title: qsTr("Plots")
-        CheckBox {
-            label: qsTr("Model averaged posteriors");    name: "posteriorPlot"
-            RadioButtonGroup
-            {
-                name: "groupPosterior"
-                RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
-                RadioButton { value: "individual";	label: qsTr("Individual plot per level")                 }
-            }
-        }
-        CheckBox { label: qsTr("Q-Q plot of residuals") ;    name: "qqPlot" }
-        CheckBox { label: qsTr("Posterior R\u00B2") ;        name: "rsqPlot"}
-    }
+		GroupBox
+		{
+		title: qsTr("Plots")
+		CheckBox {
+				label: qsTr("Model averaged posteriors");		name: "posteriorPlot"
+				RadioButtonGroup
+				{
+				name: "groupPosterior"
+				RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
+				RadioButton { value: "individual";	label: qsTr("Individual plot per level")				 }
+				}
+		}
+		CheckBox { label: qsTr("Q-Q plot of residuals") ;		name: "qqPlot" }
+		CheckBox { label: qsTr("Posterior R\u00B2") ;			name: "rsqPlot"}
+		}
 
 	Section
 	{
@@ -89,50 +89,50 @@ Form
 		}
 	}
 
-    Section
-    {
-        title: qsTr("Single Model Inference")
+		Section
+		{
+		title: qsTr("Single Model Inference")
 
-        VariablesForm
-        {
-            height: 200
-            AvailableVariablesList { name: "components2"; title: qsTr("Components"); source: ["fixedFactors", "randomFactors"]}
-            AssignedVariablesList
-            {
+		VariablesForm
+		{
+				height: 200
+				AvailableVariablesList { name: "components2"; title: qsTr("Components"); source: ["fixedFactors", "randomFactors"]}
+				AssignedVariablesList
+				{
 				title: qsTr("Specific Model Terms")
-                name: "singleModelTerms"
-                listViewType: "Interaction"
-            }
-        }
+				name: "singleModelTerms"
+				listViewType: "Interaction"
+				}
+		}
 
-        GridLayout
-        {
+		GridLayout
+		{
 
-            GroupBox
-            {
-                title: qsTr("Tables")
-                CheckBox { label: qsTr("Estimates"); name: "singleModelEstimates"}
-                CheckBox { label: qsTr("R\u00B2");   name: "singleModelCriTable" }
-            }
+				GroupBox
+				{
+				title: qsTr("Tables")
+				CheckBox { label: qsTr("Estimates"); name: "singleModelEstimates"}
+				CheckBox { label: qsTr("R\u00B2");   name: "singleModelCriTable" }
+				}
 
-            GroupBox
-            {
-                title: qsTr("Plots")
-                CheckBox { 
-                    label: qsTr("Marginal posteriors");    name: "singleModelPosteriorPlot"
-                    RadioButtonGroup
-                    {
-                        name: "singleModelGroupPosterior"
-                        RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
-                        RadioButton { value: "individual";	label: qsTr("Individual plot per level")                 }
-                    }
-                }
-                CheckBox { label: qsTr("Q-Q plot of residuals");  name: "singleModelqqPlot" }
-                CheckBox { label: qsTr("Posterior R\u00B2") ;     name: "singleModelrsqPlot"}
-            }
+				GroupBox
+				{
+				title: qsTr("Plots")
+				CheckBox {
+					label: qsTr("Marginal posteriors");		name: "singleModelPosteriorPlot"
+					RadioButtonGroup
+					{
+							name: "singleModelGroupPosterior"
+							RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
+							RadioButton { value: "individual";	label: qsTr("Individual plot per level")				 }
+					}
+				}
+				CheckBox { label: qsTr("Q-Q plot of residuals");	name: "singleModelqqPlot" }
+				CheckBox { label: qsTr("Posterior R\u00B2") ;		name: "singleModelrsqPlot"}
+				}
 
-        }
-    }
+		}
+		}
 	Section
 	{
 		title: qsTr("Post Hoc Tests")
@@ -187,44 +187,47 @@ Form
 			DoubleField { name: "priorRandomEffects";	label: qsTr("r scale random effects"); defaultValue: 1;   max: 2; inclusive: "maxOnly"; decimals: 3 }
 		}
 
-        RadioButtonGroup
+		RadioButtonGroup
 		{
 			name: "sampleModeNumAcc"
 			title: qsTr("Numerical Accuracy")
-            RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
+				RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
 			RadioButton
 			{
-                value: "manual";	label: qsTr("Manual")
+				value: "manual";	label: qsTr("Manual")
 				IntegerField
 				{
 					name: "fixedNumAcc"
-                    label: qsTr("No. samples")
+					label: qsTr("No. samples")
 					defaultValue: 1e4
 					fieldWidth: 50
-                    min: 100
-                    max: 1e7
+					min: 100
+					max: 1e7
 				}
 			}
 		}
 
-        RadioButtonGroup
+		RadioButtonGroup
 		{
 			name: "sampleModeMCMC"
 			title: qsTr("Posterior Samples")
-            RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
+			RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
 			RadioButton
 			{
 				value: "manual";	label: qsTr("Manual")
 				IntegerField
 				{
 					name: "fixedMCMCSamples"
-                    label: qsTr("No. samples")
+					label: qsTr("No. samples")
 					defaultValue: 1e3
 					fieldWidth: 50
-                    min: 100
-                    max: 1e7
+					min: 100
+					max: 1e7
 				}
 			}
 		}
+
+		SetSeed{}
+
 	}
 }

--- a/Resources/ANOVA/qml/AnovaRepeatedMeasuresBayesian.qml
+++ b/Resources/ANOVA/qml/AnovaRepeatedMeasuresBayesian.qml
@@ -68,34 +68,34 @@ Form
 				RadioButton { value: "matchedModels";	label: qsTr("Across matched models")			}
 			}
 		}
-        CheckBox { name: "posteriorEstimates"; label: qsTr("Estimates") }
-        CheckBox { name: "criTable";           label: qsTr("Model averaged R\u00B2") }
-        CheckBox { name: "descriptives";       label: qsTr("Descriptives") }
-        CIField {  name: "credibleInterval";   label: qsTr("Credible interval") }
-    }
-    RadioButtonGroup
-    {
-        title: qsTr("Order")
-        name: "bayesFactorOrder"
-        RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model"); checked: true}
-        RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model")               }
-    }
-    
-    GroupBox
-    {
-        title: qsTr("Plots")
-        CheckBox {
-            label: qsTr("Model averaged posteriors");    name: "posteriorPlot"
-            RadioButtonGroup
-            {
-                name: "groupPosterior"
-                RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
-                RadioButton { value: "individual";	label: qsTr("Individual plot per level")                 }
-            }
-        }
-        CheckBox { label: qsTr("Q-Q plot of residuals") ;    name: "qqPlot" }
-        CheckBox { label: qsTr("Posterior R\u00B2") ;        name: "rsqPlot"}
-    }
+		CheckBox { name: "posteriorEstimates";	label: qsTr("Estimates") }
+		CheckBox { name: "criTable";			label: qsTr("Model averaged R\u00B2") }
+		CheckBox { name: "descriptives";		label: qsTr("Descriptives") }
+		CIField {  name: "credibleInterval";	label: qsTr("Credible interval") }
+	}
+	RadioButtonGroup
+	{
+		title: qsTr("Order")
+		name: "bayesFactorOrder"
+		RadioButton { value: "bestModelTop"; label: qsTr("Compare to best model"); checked: true}
+		RadioButton { value: "nullModelTop"; label: qsTr("Compare to null model")				}
+	}
+
+	GroupBox
+	{
+		title: qsTr("Plots")
+		CheckBox {
+			label: qsTr("Model averaged posteriors"); name: "posteriorPlot"
+			RadioButtonGroup
+			{
+				name: "groupPosterior"
+				RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true	}
+				RadioButton { value: "individual";	label: qsTr("Individual plot per level")					}
+			}
+		}
+		CheckBox { label: qsTr("Q-Q plot of residuals");	name: "qqPlot" }
+		CheckBox { label: qsTr("Posterior R\u00B2");		name: "rsqPlot"}
+	}
 
 	Section
 	{
@@ -111,56 +111,58 @@ Form
 				title: qsTr("Components")
 				source: ["repeatedMeasuresFactors", "betweenSubjectFactors", "covariates"]
 			}
+
 			ModelTermsList {}
+
 		}
 	}
 	
-    Section
-    {
-        title: qsTr("Single Model Inference")
+	Section
+	{
+		title: qsTr("Single Model Inference")
 
-        VariablesForm
-        {
-            height: 200
-            AvailableVariablesList { name: "components2"; title: qsTr("Components"); source: ["repeatedMeasuresFactors", "betweenSubjectFactors", "covariates"]}
-            AssignedVariablesList
-            {
+		VariablesForm
+		{
+			height: 200
+			AvailableVariablesList { name: "components2"; title: qsTr("Components"); source: ["repeatedMeasuresFactors", "betweenSubjectFactors", "covariates"]}
+			AssignedVariablesList
+			{
 				title: qsTr("Specific Model Terms")
-                name: "singleModelTerms"
-                listViewType: "Interaction"
-            }
-        }
+				name: "singleModelTerms"
+				listViewType: "Interaction"
+			}
+		}
 
-        GridLayout
-        {
+		GridLayout
+		{
 
-            GroupBox
-            {
-                title: qsTr("Tables")
-                CheckBox { label: qsTr("Estimates"); name: "singleModelEstimates"}
-                CheckBox { label: qsTr("R\u00B2");   name: "singleModelCriTable" }
-            }
+			GroupBox
+			{
+				title: qsTr("Tables")
+				CheckBox { label: qsTr("Estimates");	name: "singleModelEstimates"}
+				CheckBox { label: qsTr("R\u00B2");		name: "singleModelCriTable" }
+			}
 
-            GroupBox
-            {
-                title: qsTr("Plots")
-                CheckBox { 
-                    label: qsTr("Marginal posteriors");    name: "singleModelPosteriorPlot"
-                    RadioButtonGroup
-                    {
-                        name: "singleModelGroupPosterior"
-                        RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true}
-                        RadioButton { value: "individual";	label: qsTr("Individual plot per level")                 }
-                    }
-                }
-                CheckBox { label: qsTr("Q-Q plot of residuals");  name: "singleModelqqPlot" }
-                CheckBox { label: qsTr("Posterior R\u00B2") ;     name: "singleModelrsqPlot"}
-            }
+			GroupBox
+			{
+				title: qsTr("Plots")
+				CheckBox {
+					label: qsTr("Marginal posteriors");    name: "singleModelPosteriorPlot"
+					RadioButtonGroup
+					{
+						name: "singleModelGroupPosterior"
+						RadioButton { value: "grouped";		label: qsTr("Group levels in single plot"); checked: true	}
+						RadioButton { value: "individual";	label: qsTr("Individual plot per level")					}
+					}
+				}
+				CheckBox { label: qsTr("Q-Q plot of residuals");	name: "singleModelqqPlot" }
+				CheckBox { label: qsTr("Posterior R\u00B2") ;		name: "singleModelrsqPlot"}
+			}
 
-        }
-    }
+		}
+	}
 
-    Section
+	Section
 	{
 		title: qsTr("Post Hoc Tests")
 
@@ -213,44 +215,47 @@ Form
 			DoubleField { name: "priorCovariates";		label: qsTr("r scale covariates");     defaultValue: 0.354; max: 2; inclusive: "maxOnly"; decimals: 3 }
 		}
 
-        RadioButtonGroup
+		RadioButtonGroup
 		{
 			name: "sampleModeNumAcc"
 			title: qsTr("Numerical Accuracy")
-            RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
+			RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
 			RadioButton
 			{
-                value: "manual";	label: qsTr("Manual")
+				value: "manual";	label: qsTr("Manual")
 				IntegerField
 				{
 					name: "fixedNumAcc"
-                    label: qsTr("No. samples")
+					label: qsTr("No. samples")
 					defaultValue: 1e4
 					fieldWidth: 50
-                    min: 100
-                    max: 1e7
+					min: 100
+					max: 1e7
 				}
 			}
 		}
 
-        RadioButtonGroup
+		RadioButtonGroup
 		{
 			name: "sampleModeMCMC"
 			title: qsTr("Posterior Samples")
-            RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
+			RadioButton { value: "auto";	label: qsTr("Auto"); checked: true }
 			RadioButton
 			{
-                value: "manual";	label: qsTr("Manual")
+				value: "manual";	label: qsTr("Manual")
 				IntegerField
 				{
 					name: "fixedMCMCSamples"
-                    label: qsTr("No. samples")
+					label: qsTr("No. samples")
 					defaultValue: 1e3
 					fieldWidth: 50
-                    min: 100
-                    max: 1e7
+					min: 100
+					max: 1e7
 				}
 			}
 		}
+
+		SetSeed{}
+
 	}
 }

--- a/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
@@ -25,12 +25,12 @@ Form
 	VariablesForm
 	{
 		AvailableVariablesList { name: "allVariablesList" }		
-        AssignedVariablesList { name: "counts";	 title: qsTr("Counts (optional)");	singleVariable: true;	suggestedColumns:["scale", "ordinal"]}
+		AssignedVariablesList { name: "counts";	 title: qsTr("Counts (optional)");	singleVariable: true;	suggestedColumns:["scale", "ordinal"]}
 		AssignedVariablesList { name: "factors"; title: qsTr("Factors"); itemType: "fixedFactors"; suggestedColumns: ["ordinal", "nominal"] }
 	}
 	
 	columns: 3
-    BayesFactorType { }
+	BayesFactorType { }
 
 	Group
 	{
@@ -87,7 +87,7 @@ Form
 			{
 				indent: true;
 				enabled: regressionCoefficientsSubmodel.checked
-                CheckBox
+				CheckBox
 				{
 					name: "regressionCoefficientsSubmodelCredibleIntervals"; label: qsTr("Credible intervals")
 					CIField { name: "regressionCoefficientsSubmodelCredibleIntervalsInterval"; label: qsTr("Interval") }
@@ -111,5 +111,8 @@ Form
 				IntegerField { name: "fixedSamplesNumber"; label: qsTr("No. samples"); defaultValue: 10000; fieldWidth: 60 }
 			}
 		}
+
+		SetSeed{}
+
 	}
 }

--- a/Resources/Regression/qml/RegressionLinearBayesian.qml
+++ b/Resources/Regression/qml/RegressionLinearBayesian.qml
@@ -26,8 +26,8 @@ Form {
 	VariablesForm
 	{
 		AvailableVariablesList	{ name: "allVariablesList" }
-        AssignedVariablesList	{ name: "dependent";	title: qsTr("Dependent Variable");		suggestedColumns: ["scale"];	singleVariable: true	}
-        AssignedVariablesList	{ name: "covariates";	title: qsTr("Covariates");				suggestedColumns: ["scale"];    allowedColumns: ["scale"]   }
+		AssignedVariablesList	{ name: "dependent";	title: qsTr("Dependent Variable");		suggestedColumns: ["scale"];	singleVariable: true	}
+		AssignedVariablesList	{ name: "covariates";	title: qsTr("Covariates");				suggestedColumns: ["scale"];	allowedColumns: ["scale"]}
 		AssignedVariablesList	{ name: "wlsWeights";	title: qsTr("WLS Weights (optional)");	suggestedColumns: ["scale"];	singleVariable: true	}
 	}
 
@@ -39,13 +39,13 @@ Form {
 		columns: 2
 
 		CheckBox{ name: "postSummaryTable"; label: qsTr("Posterior summary"); id: postSummaryTable
-            RadioButtonGroup
-            {
-                name: "effectsType"
-                RadioButton { value: "allModels";		label: qsTr("Across all models");   checked: true	}
-                RadioButton { value: "matchedModels";	label: qsTr("Across matched models")				}
-            }
-        }
+			RadioButtonGroup
+			{
+				name: "effectsType"
+				RadioButton { value: "allModels";		label: qsTr("Across all models");   checked: true	}
+				RadioButton { value: "matchedModels";	label: qsTr("Across matched models")				}
+			}
+		}
 
 		DropDown
 		{
@@ -122,7 +122,9 @@ Form {
 				width: parent.width / 4
 				source: ['covariates']
 			}
+
 			ModelTermsList { width: parent.width * 5 / 9 }
+
 		}
 
 	}
@@ -149,8 +151,8 @@ Form {
 		Group
 		{
 			title: qsTr("Residuals")
-			CheckBox { name: "plotResidualsVsFitted";	label: qsTr("Residuals vs. fitted")				  }
-			CheckBox { name: "plotQQplot";	            label: qsTr("Q-Q plot of model averaged residuals")}
+			CheckBox { name: "plotResidualsVsFitted";	label: qsTr("Residuals vs. fitted")					}
+			CheckBox { name: "plotQQplot";				label: qsTr("Q-Q plot of model averaged residuals")	}
 		}
 	}
 	
@@ -165,7 +167,7 @@ Form {
 
 			RadioButton { value: "AIC";			label: qsTr("AIC")		}
 			RadioButton { value: "BIC";			label: qsTr("BIC")		}
-			RadioButton { value: "EB-global";	label: qsTr("EB-global")	}
+			RadioButton { value: "EB-global";	label: qsTr("EB-global")}
 			RadioButton { value: "EB-local";	label: qsTr("EB-local")	}
 			RadioButton { value: "g-prior";		label: qsTr("g-prior")	}
 			GridLayout
@@ -174,7 +176,7 @@ Form {
 				columnSpacing: 0
 				Group
 				{
-					RadioButton { value: "hyper-g";			label: qsTr("Hyper-g");			    id: hyperg			}
+					RadioButton { value: "hyper-g";			label: qsTr("Hyper-g");				id: hyperg			}
 					RadioButton { value: "hyper-g-laplace";	label: qsTr("Hyper-g-Laplace");		id: hyperglaplace	}
 					RadioButton { value: "hyper-g-n";		label: qsTr("Hyper-g-n");			id: hypergn			}
 				}
@@ -184,9 +186,9 @@ Form {
 					label: qsTr("alpha")
 					enabled: hyperg.checked || hyperglaplace.checked || hypergn.checked
 					defaultValue: 3.0
-                    min: 2
-                    max: 4
-                    inclusive: "no"
+					min: 2
+					max: 4
+					inclusive: "no"
 				}
 				RadioButton { value: "JZS"; label: qsTr("JZS"); checked: true; id: jzs }
 				DoubleField
@@ -197,7 +199,7 @@ Form {
 					fieldWidth: 50
 					defaultValue: 0.354
 					max: 100000
-                    inclusive: "maxOnly"
+					inclusive: "maxOnly"
 				}
 			}
 		}
@@ -273,6 +275,9 @@ Form {
 					max: 1000000
 				}
 			}
+
+			SetSeed{}
+
 		}
 	}
 

--- a/Resources/T-Tests/qml/TTestBayesianIndependentSamples.qml
+++ b/Resources/T-Tests/qml/TTestBayesianIndependentSamples.qml
@@ -55,14 +55,14 @@ Form {
 
 		CheckBox
 		{
-            enabled: student.checked
+			enabled: student.checked
 			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
 			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-            enabled: student.checked
+			enabled: student.checked
 			name: "plotSequentialAnalysis";		label: qsTr("Sequential analysis")
 			CheckBox { name: "plotSequentialAnalysisRobustness";		label: qsTr("Robustness check") }
 		}
@@ -82,11 +82,11 @@ Form {
 		title: qsTr("Tests")
 		RadioButton
 		{
-            id: student
+			id: student
 			value: "Student";	label: qsTr("Student"); checked: true }
 		RadioButton
 		{
-			value: "Wilcoxon";	label: qsTr("Mann-Whitney");
+			value: "Wilcoxon";	label: qsTr("Mann-Whitney"); id: testWilcoxon
 			IntegerField { name: "wilcoxonSamplesNumber"; label: qsTr("No. samples"); defaultValue: 1000; min: 100; max: 10000; fieldWidth: 60 }
 		}
 	}
@@ -105,5 +105,7 @@ Form {
 		CheckBox { name: "descriptives"; label: qsTr("Descriptives") }
 	}
 
-    SubjectivePriors { informedPriorsEnabled: student.checked }
+	SetSeed{}
+
+	SubjectivePriors { informedPriorsEnabled: student.checked }
 }

--- a/Resources/T-Tests/qml/TTestBayesianOneSample.qml
+++ b/Resources/T-Tests/qml/TTestBayesianOneSample.qml
@@ -94,6 +94,9 @@ Form
 		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")							}
 	}
 	
+
+	SetSeed{}
+
 	SubjectivePriors { }
 	
 }

--- a/Resources/T-Tests/qml/TTestBayesianPairedSamples.qml
+++ b/Resources/T-Tests/qml/TTestBayesianPairedSamples.qml
@@ -88,6 +88,8 @@ Form {
 		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")							}
 	}
 
+	SetSeed{}
+
 	SubjectivePriors { }
 
 }

--- a/Tools/jasptools/R/optionsParserQML.R
+++ b/Tools/jasptools/R/optionsParserQML.R
@@ -21,7 +21,8 @@
     "ExpanderButton",
     "BayesFactorType",
     "SubjectivePriors",
-    "ContrastsList"
+    "ContrastsList",
+    "SetSeed"
   )
 
   fileSize <- file.info(file)$size 
@@ -70,6 +71,12 @@
   regMatch <- "ContrastsList\\{"
   if (grepl(regMatch, fileContents)) {
     result[["contrast"]] <- "none"
+  }
+  
+  regMatch <- "SetSeed\\{"
+  if (grepl(regMatch, fileContents)) {
+    result[["setSeed"]] <- FALSE
+    result[["seed"]] <- 1
   }
   
   regMatch <- "SubjectivePriors\\{"


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-issues/issues/126

Adding an option to set seed for the following analysis using sampling:
- (T-Test) - Bayesian t-tests
- (ANOVA) -Bayesian ANOVA, repeated-measures ANOVA, ANCOVA
- (Frequencies) - Bayesian log-linear regression
- (Regression) - Bayesian linear regression

Additional minor changes
- I also reformated some qml files that didn't adhere to tab policy. 