### PR TITLE
Toggle the status indicator as soon as an analysis status changes

### DIFF
--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -159,6 +159,7 @@ void Analyses::storeAnalysis(Analysis* analysis, size_t id, bool notifyAll)
 void Analyses::bindAnalysisHandler(Analysis* analysis)
 {
 	connect(analysis, &Analysis::optionsChanged,					this, &Analyses::analysisOptionsChanged				);
+	connect(analysis, &Analysis::statusChanged,						this, &Analyses::analysisStatusChanged				);
 	connect(analysis, &Analysis::sendRScript,						this, &Analyses::sendRScriptHandler					);
 	connect(analysis, &Analysis::toRefreshSignal,					this, &Analyses::analysisToRefresh					);
 	connect(analysis, &Analysis::titleChanged,						this, &Analyses::setChangedAnalysisTitle			);

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -142,6 +142,7 @@ signals:
 	void analysisResultsChanged(		Analysis *	source);
 	void analysisTitleChanged(			Analysis *  source);
 	void analysisOptionsChanged(		Analysis *	source);
+	void analysisStatusChanged(			Analysis *	source);
 	void sendRScript(					QString		script, int requestID, bool whiteListedVersion);
 	void analysisSelectedIndexResults(	int			row);
 	void showAnalysisInResults(			int			id);

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -26,7 +26,6 @@
 #include "dirs.h"
 #include "analyses.h"
 #include "analysisform.h"
-#include "utilities/qutils.h"
 #include "log.h"
 
 
@@ -317,6 +316,8 @@ void Analysis::setStatus(Analysis::Status status)
 	}
 
 	_status = status;
+
+	emit statusChanged(this);
 
 	Log::log() << "Analysis " << title() << " (" << id() << ") now has status: " << statusToString(_status) << std::endl;
 }

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -30,6 +30,7 @@
 #include <QObject>
 #include "modules/dynamicmodules.h"
 #include "data/datasetpackage.h"
+#include "utilities/qutils.h"
 
 class ComputedColumn;
 class Analyses;
@@ -89,15 +90,16 @@ public:
 	const	Json::Value		&	results()			const	{ return _results;							}
 	const	Json::Value		&	userData()			const	{ return _userData;							}
 	const	std::string		&	name()				const	{ return _name;								}
-	const	QString				nameQ()				const	{ return QString::fromStdString(_name);		}
+	const	QString				nameQ()				const	{ return tq(_name);							}
 	const	Version			&	version()			const	{ return _version;							}
 	const	std::string		&	title()				const	{ return _title;							}
-			QString				titleQ()			const	{ return QString::fromStdString(_title);	}
+			QString				titleQ()			const	{ return tq(_title);						}
 	const	std::string		&	rfile()				const	{ return _rfile;							}
 	const	std::string		&	module()			const	{ return _module;							}
 			size_t				id()				const	{ return _id;								}
 			bool				usesJaspResults()	const	{ return _useJaspResults;					}
 			Status				status()			const	{ return _status;							}
+			QString				statusQ()			const	{ return tq(statusToString(_status));		}
 			int					revision()			const	{ return _revision;							}
 			bool				isRefreshBlocked()	const	{ return _refreshBlocked;					}
 			QString				helpFile()			const	{ return _helpFile;							}
@@ -143,6 +145,7 @@ public:
 signals:
 	void				nameChanged();
 	void				sendRScript(			Analysis * analysis, QString script, QString controlName, bool whiteListedVersion);
+	void				statusChanged(			Analysis * analysis);
 	void				optionsChanged(			Analysis * analysis);
 	void				saveImageSignal(		Analysis * analysis);
 	void				editImageSignal(		Analysis * analysis);
@@ -166,7 +169,7 @@ public slots:
 	void					setNameQ(QString name) { setName(name.toStdString()); }
 	void					setHelpFile(QString helpFile);
 	void					setTitleQ(QString title);
-	void					setTitle(std::string title) { setTitleQ(QString::fromStdString(title)); }
+	void					setTitle(std::string title) { setTitleQ(tq(title)); }
 	void					refreshAvailableVariablesModels();
 	void					emitDuplicationSignals();
 	void					showDependenciesOnQMLForObject(QString uniqueName); //uniqueName is basically "name" in meta in results.
@@ -177,9 +180,9 @@ protected:
 
 private:
 	void					optionsChangedHandler(Option *option = nullptr);
-	ComputedColumn *		requestComputedColumnCreationHandler(std::string columnName)		{ return requestComputedColumnCreation(QString::fromStdString(columnName), this); }
-	void					requestColumnCreationHandler(std::string columnName, int colType)	{ return requestColumnCreation(QString::fromStdString(columnName), this, colType); }
-	void					requestComputedColumnDestructionHandler(std::string columnName)		{ requestComputedColumnDestruction(QString::fromStdString(columnName)); }
+	ComputedColumn *		requestComputedColumnCreationHandler(std::string columnName)		{ return requestComputedColumnCreation(tq(columnName), this); }
+	void					requestColumnCreationHandler(std::string columnName, int colType)	{ return requestColumnCreation(tq(columnName), this, colType); }
+	void					requestComputedColumnDestructionHandler(std::string columnName)		{ requestComputedColumnDestruction(tq(columnName)); }
 	void					processResultsForDependenciesToBeShown();
 	bool					processResultsForDependenciesToBeShownMetaTraverser(const Json::Value & array);
 	bool					_editOptionsOfPlot(const Json::Value & results, const std::string & uniqueName, Json::Value & editOptions);

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -65,6 +65,14 @@ $(document).ready(function () {
 
 		window.scrollToTopView(selectedAnalysis.$el);
 	}
+	
+	window.setStatus = function(id, status) {
+		var analysis = analyses.getAnalysis(id);
+		if (analysis === undefined) return;
+
+		analysis.toolbar.setStatus(status);
+		analysis.toolbar.render();
+	}
 
 	window.changeTitle = function(id, title) {
 		var analysis = analyses.getAnalysis(id);
@@ -430,7 +438,6 @@ $(document).ready(function () {
 			jaspWidget.on("toolbar:showMenu", function (obj, options) {
 
 				jasp.showAnalysesMenu(JSON.stringify(options));
-				console.log(options);
 				window.menuObject = obj;
 			});
 		}

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -261,6 +261,7 @@ void MainWindow::makeConnections()
 	connect(_analyses,				&Analyses::analysisAdded,							this,					&MainWindow::analysisAdded									);
 	connect(_analyses,				&Analyses::analysisAdded,							_fileMenu,				&FileMenu::analysisAdded									);
 	connect(_analyses,				&Analyses::analysesExportResults,					_fileMenu,				&FileMenu::analysesExportResults							);
+	connect(_analyses,				&Analyses::analysisStatusChanged,					_resultsJsInterface,	&ResultsJsInterface::setStatus								);
 	connect(_analyses,              &Analyses::analysisTitleChanged,                    _resultsJsInterface,    &ResultsJsInterface::changeTitle							);
 	connect(_analyses,				&Analyses::showAnalysisInResults,					_resultsJsInterface,	&ResultsJsInterface::showAnalysis							);
 	connect(_analyses,				&Analyses::unselectAnalysisInResults,				_resultsJsInterface,	&ResultsJsInterface::unselect								);

--- a/JASP-Desktop/results/resultsjsinterface.cpp
+++ b/JASP-Desktop/results/resultsjsinterface.cpp
@@ -211,6 +211,14 @@ void ResultsJsInterface::displayMessageFromResults(QString msg)
 	MessageForwarder::showWarning("Results Warning", msg);
 }
 
+void ResultsJsInterface::setStatus(Analysis *analysis)
+{
+	int id = analysis->id();
+	QString status = analysis->statusQ();
+
+	emit runJavaScript("window.setStatus(" + QString::number(id) + ", '" + status + "')");
+}
+
 void ResultsJsInterface::changeTitle(Analysis *analysis)
 {
     int id = analysis->id();

--- a/JASP-Desktop/results/resultsjsinterface.h
+++ b/JASP-Desktop/results/resultsjsinterface.h
@@ -38,7 +38,8 @@ class ResultsJsInterface : public QObject
 public:
 	explicit ResultsJsInterface(QObject *parent = 0);
 
-	void changeTitle(Analysis *analyses);
+	void setStatus(Analysis *analysis);
+	void changeTitle(Analysis *analysis);
 	void showAnalysis(int id);
 	void analysisChanged(Analysis *analysis);
 	void setResultsMeta(QString str);


### PR DESCRIPTION
Open descriptives, add a bunch of variables and as soon as the results are calculated tick "Correlation plots" -- no feedback whatsoever until the plot is created. This PR addresses that issue.