### PR TITLE
FormulaField for math expressions

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/FormulaField.qml
+++ b/JASP-Desktop/components/JASP/Controls/FormulaField.qml
@@ -23,11 +23,11 @@ import JASP 1.0
 
 TextField
 {
-	id: formulaField
-	property double defaultValue:		0
+					id:					formulaField
+					defaultValue:		"0"
 	property double	min:				-Infinity
 	property double	max:				Infinity
-	property string inclusive:			"yes"
+	property string	inclusive:			"yes"
 					inputType:			"formula"
-					fieldWidth:			jaspTheme.numericFieldWidth
+					fieldWidth:			jaspTheme.textFieldWidth / 2
 }

--- a/JASP-Desktop/components/JASP/Controls/FormulaField.qml
+++ b/JASP-Desktop/components/JASP/Controls/FormulaField.qml
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+import QtQuick 2.11
+import JASP.Controls 1.0
+
+import JASP 1.0
+
+TextField
+{
+	id: formulaField
+	property double defaultValue:		0
+	property double	min:				-Infinity
+	property double	max:				Infinity
+	property string inclusive:			"yes"
+					inputType:			"formula"
+					fieldWidth:			jaspTheme.numericFieldWidth
+}

--- a/JASP-Desktop/components/JASP/Controls/qmldir
+++ b/JASP-Desktop/components/JASP/Controls/qmldir
@@ -12,7 +12,7 @@ ExpanderButton   1.0 ExpanderButton.qml
 Section          1.0 ExpanderButton.qml
 Form             1.0 Form.qml
 GridLayout        1.0 GridLayout.qml
-Group	             1.0 GroupBox.qml
+Group	           1.0 GroupBox.qml
 GroupBox            1.0 GroupBox.qml
 IntegerField         1.0 IntegerField.qml
 JASPControl           1.0 JASPControl.qml
@@ -35,6 +35,7 @@ VariablesForm           1.0 VariablesForm.qml
 VariablesList          1.0 VariablesList.qml
 ExtraControlColumn    1.0 ExtraControlColumn.qml
 ExtraControls        1.0 ExtraControls.qml
-ComputedColumnField  1.0 ComputedColumnField.qml
-AddColumnField      1.0 AddColumnField.qml
-HelpButton         1.0 HelpButton.qml
+ComputedColumnField 1.0 ComputedColumnField.qml
+FormulaField       1.0 FormulaField.qml
+AddColumnField    1.0 AddColumnField.qml
+HelpButton       1.0 HelpButton.qml

--- a/JASP-Desktop/qml.qrc
+++ b/JASP-Desktop/qml.qrc
@@ -128,5 +128,6 @@
         <file>components/JASP/Controls/InputListView.qml</file>
         <file>components/JASP/Controls/ExtraControls.qml</file>
         <file>components/JASP/Controls/JASPListControl.qml</file>
+        <file>components/JASP/Controls/FormulaField.qml</file>
     </qresource>
 </RCC>

--- a/JASP-Desktop/widgets/boundqmltextinput.cpp
+++ b/JASP-Desktop/widgets/boundqmltextinput.cpp
@@ -22,8 +22,6 @@
 #include <QQmlProperty>
 #include <QQuickItem>
 
-using namespace std;
-
 BoundQMLTextInput::BoundQMLTextInput(QQuickItem* item, AnalysisForm* form)
 	: QMLItem(item, form)
 	, QObject(form)
@@ -43,6 +41,7 @@ void BoundQMLTextInput::initTextInput()
 	else if (type == "doubleArray")		_inputType = TextInputType::DoubleArrayInputType;
 	else if (type == "computedColumn")	_inputType = TextInputType::ComputedColumnType;
 	else if (type == "addColumn")		_inputType = TextInputType::AddColumnType;
+	else if (type == "formula")			_inputType = TextInputType::FormulaType;
 	else								_inputType = TextInputType::StringInputType;
 
 	if (_item)
@@ -64,7 +63,7 @@ QString BoundQMLTextInput::_getPercentValue()
 QString BoundQMLTextInput::_getIntegerArrayValue()
 {
 	QString value;
-	vector<int> intValues = _integerArray->value();
+	std::vector<int> intValues = _integerArray->value();
 	bool first  = true;
 	for (int intValue : intValues)
 	{
@@ -80,7 +79,7 @@ QString BoundQMLTextInput::_getIntegerArrayValue()
 QString BoundQMLTextInput::_getDoubleArrayValue()
 {
 	QString value;
-	vector<double> doubleValues = _doubleArray->value();
+	std::vector<double> doubleValues = _doubleArray->value();
 	bool first  = true;
 	for (double doubleValue : doubleValues)
 	{
@@ -155,6 +154,13 @@ void BoundQMLTextInput::bindTo(Option *option)
 		_option = _computedColumn = dynamic_cast<OptionComputedColumn *>(option);
 		_value	= QString::fromStdString(_computedColumn->value());
 		break;
+	case TextInputType::FormulaType:
+		_formula = dynamic_cast<OptionTerm *>(option);
+		if (!_formula)
+			_formula = new OptionTerm();
+		_option = _formula;
+		_value = _getFormulaValue();
+		break;
 
 	default:
 		_string = dynamic_cast<OptionString *>(option);
@@ -171,7 +177,7 @@ void BoundQMLTextInput::bindTo(Option *option)
 Option *BoundQMLTextInput::createOption()
 {
 	Option* option = nullptr;
-	_value = getItemProperty("value").toString();
+
 	switch (_inputType)
 	{
 	case TextInputType::IntegerInputType:		option = new OptionInteger();			break;
@@ -179,6 +185,7 @@ Option *BoundQMLTextInput::createOption()
 	case TextInputType::PercentIntputType:		option = new OptionNumber();			break;
 	case TextInputType::IntegerArrayInputType:	option = new OptionIntegerArray();		break;
 	case TextInputType::DoubleArrayInputType:	option = new OptionDoubleArray();		break;
+	case TextInputType::FormulaType:			option = new OptionTerm();				break;
 	case TextInputType::ComputedColumnType:
 	{
 		option = new OptionComputedColumn();
@@ -199,7 +206,16 @@ Option *BoundQMLTextInput::createOption()
 	default:									option = new OptionString();			break;
 	}
 
-	_setOptionValue(option, _value);
+	_value = getItemProperty("value").toString();
+	if(_inputType == TextInputType::FormulaType)
+		_setOptionValue(option, _value);
+	else
+	{
+		if(_formula != option)
+			_formula = dynamic_cast<OptionTerm*>(option);
+
+		_setFormulaOptions(fq(_value));
+	}
 	return option;
 }
 
@@ -211,9 +227,10 @@ bool BoundQMLTextInput::isOptionValid(Option *option)
 	case TextInputType::NumberInputType:		return dynamic_cast<OptionNumber*>(option)			!= nullptr;
 	case TextInputType::PercentIntputType:		return dynamic_cast<OptionNumber*>(option)			!= nullptr;
 	case TextInputType::IntegerArrayInputType:	return dynamic_cast<OptionIntegerArray*>(option)	!= nullptr;
-	case TextInputType::DoubleArrayInputType:	return dynamic_cast<OptionDoubleArray*>(option)	!= nullptr;
+	case TextInputType::DoubleArrayInputType:	return dynamic_cast<OptionDoubleArray*>(option)		!= nullptr;
 	case TextInputType::AddColumnType:
 	case TextInputType::ComputedColumnType:		return dynamic_cast<OptionComputedColumn*>(option)	!= nullptr;
+	case TextInputType::FormulaType:			return dynamic_cast<OptionTerm*>(option)			!= nullptr;
 	case TextInputType::StringInputType:
 	default:									return dynamic_cast<OptionString*>(option)			!= nullptr;
 	}
@@ -256,6 +273,48 @@ void BoundQMLTextInput::resetQMLItem(QQuickItem *item)
 	setItemProperty("value", _value);
 	if (_item)
 		QQuickItem::connect(_item, SIGNAL(editingFinished()), this, SLOT(textChangedSlot()));
+}
+
+void BoundQMLTextInput::rScriptDoneHandler(const QString &result)
+{
+	bool succes;
+	double val = result.toDouble(&succes);
+
+	//check min max etc
+
+	if (succes) {
+		_item->setProperty("hasScriptError", false);
+
+	} else {
+		_item->setProperty("hasScriptError", true);
+		_item->setProperty("infoText", result);
+	}
+	_setFormulaValidated(succes);
+}
+
+void BoundQMLTextInput::_setFormulaOptions(std::string formula, bool valid)
+{
+	if (_formula)
+		_formula->setValue( { formula, valid ? "T" : "F"});
+}
+
+void BoundQMLTextInput::_setFormulaValidated(bool valid)
+{
+	if (_formula)
+	{
+		auto oldVal = _formula->term();
+		oldVal[1] = valid ? "T" : "F";
+		_formula->setValue(oldVal);
+	}
+}
+
+QString	BoundQMLTextInput::_getFormulaValue()
+{
+	auto oldVal = _formula->term();
+	if (oldVal.size() > 0)
+		return tq(oldVal[0]);
+	else
+		return QString();
 }
 
 void BoundQMLTextInput::_setOptionValue(Option* option, QString& text)
@@ -314,6 +373,10 @@ void BoundQMLTextInput::_setOptionValue(Option* option, QString& text)
 		dynamic_cast<OptionComputedColumn*>(option)->setValue(text.toStdString());
 		break;
 
+	case TextInputType::FormulaType:
+		//This is done in textChangedSlot
+		break;
+
 	default:
 		dynamic_cast<OptionString*>(option)->setValue(text.toStdString());
 		break;
@@ -323,6 +386,12 @@ void BoundQMLTextInput::_setOptionValue(Option* option, QString& text)
 void BoundQMLTextInput::textChangedSlot()
 {
 	_value = getItemProperty("value").toString();
-	if (_option)
+	if (_inputType == TextInputType::FormulaType)
+	{
+		_setFormulaOptions(fq(_value));
+		runRScript(_value, true);
+	}
+	else if (_option)
 		_setOptionValue(_option, _value);
+
 }

--- a/JASP-Desktop/widgets/boundqmltextinput.cpp
+++ b/JASP-Desktop/widgets/boundqmltextinput.cpp
@@ -214,7 +214,7 @@ Option *BoundQMLTextInput::createOption()
 		if(_formula != option)
 			_formula = dynamic_cast<OptionTerm*>(option);
 
-		_setFormulaOptions(fq(_value));
+		_setFormulaOptions(fq(_value), true);
 	}
 	return option;
 }

--- a/JASP-Desktop/widgets/boundqmltextinput.h
+++ b/JASP-Desktop/widgets/boundqmltextinput.h
@@ -26,7 +26,7 @@
 #include "analysis/options/optioncomputedcolumn.h"
 #include "analysis/options/optionintegerarray.h"
 #include "analysis/options/optiondoublearray.h"
-
+#include "analysis/options/optionterm.h"
 #include <QObject>
 
 
@@ -35,18 +35,19 @@ class BoundQMLTextInput : public QObject, public BoundQMLItem
 	Q_OBJECT
 
 public:
-	enum TextInputType { IntegerInputType = 0, StringInputType, NumberInputType, PercentIntputType, IntegerArrayInputType, DoubleArrayInputType, ComputedColumnType, AddColumnType };
+	enum TextInputType { IntegerInputType = 0, StringInputType, NumberInputType, PercentIntputType, IntegerArrayInputType, DoubleArrayInputType, ComputedColumnType, AddColumnType, FormulaType};
 
 	BoundQMLTextInput(QQuickItem* item, AnalysisForm* form);
 	void initTextInput();
 
 	void bindTo(Option *option)			override;
 
-	Option* createOption()				override;
-	bool isOptionValid(Option* option)	override;
-	bool isJsonValid(const Json::Value& optionValue) override;
-	Option* boundTo()					override { return _option; }
-	void resetQMLItem(QQuickItem *item) override;
+	Option*		createOption()								override;
+	bool		isOptionValid(Option* option)				override;
+	bool		isJsonValid(const Json::Value& optionValue) override;
+	Option*		boundTo()									override { return _option; }
+	void		resetQMLItem(QQuickItem *item)				override;
+	void		rScriptDoneHandler(const QString& result)	override;
 
 signals:
 
@@ -55,10 +56,13 @@ private slots:
 
 private:
 	void _setOptionValue(Option* option, QString& text);
+	void _setFormulaOptions(std::string formula, bool valid = false);
+	void _setFormulaValidated(bool valid);
 
 	QString					  _getPercentValue();
 	QString					  _getIntegerArrayValue();
 	QString					  _getDoubleArrayValue();
+	QString					  _getFormulaValue();
 
 	TextInputType			  _inputType;
 	OptionInteger			* _integer			= nullptr;
@@ -66,6 +70,7 @@ private:
 	OptionDoubleArray		* _doubleArray		= nullptr;
 	OptionNumber			* _number			= nullptr;
 	OptionString			* _string			= nullptr;
+	OptionTerm				* _formula			= nullptr;
 	OptionComputedColumn	* _computedColumn	= nullptr;
 	Option					* _option			= nullptr;
 	QString					  _value;

--- a/JASP-Desktop/widgets/boundqmltextinput.h
+++ b/JASP-Desktop/widgets/boundqmltextinput.h
@@ -40,7 +40,7 @@ public:
 	BoundQMLTextInput(QQuickItem* item, AnalysisForm* form);
 	void initTextInput();
 
-	void bindTo(Option *option)			override;
+	void		bindTo(Option *option)						override;
 
 	Option*		createOption()								override;
 	bool		isOptionValid(Option* option)				override;
@@ -49,8 +49,6 @@ public:
 	void		resetQMLItem(QQuickItem *item)				override;
 	void		rScriptDoneHandler(const QString& result)	override;
 
-signals:
-
 private slots:
 	void textChangedSlot();
 
@@ -58,6 +56,7 @@ private:
 	void _setOptionValue(Option* option, QString& text);
 	void _setFormulaOptions(std::string formula, bool valid = false);
 	void _setFormulaValidated(bool valid);
+	bool _formulaResultInBounds(double result);
 
 	QString					  _getPercentValue();
 	QString					  _getIntegerArrayValue();

--- a/JASP-Desktop/widgets/qmlitem.cpp
+++ b/JASP-Desktop/widgets/qmlitem.cpp
@@ -72,3 +72,12 @@ QVariant QMLItem::getItemProperty(const QString &name)
 	}
 }
 
+void QMLItem::showControlError(QString msg)
+{
+	QMetaObject::invokeMethod(_item, "showControlError", Q_ARG(QVariant, msg));
+}
+
+void QMLItem::showControlErrorTemporary(QString msg)
+{
+	QMetaObject::invokeMethod(_item, "showControlErrorTemporary", Q_ARG(QVariant, msg));
+}

--- a/JASP-Desktop/widgets/qmlitem.h
+++ b/JASP-Desktop/widgets/qmlitem.h
@@ -46,7 +46,9 @@ public:
 	void						removeDependency(QMLItem* item);
 	QVariant					getItemProperty(const QString& name);
 	void						setItemProperty(const QString& name, const QVariant& value);
-	
+	void						showControlError(QString msg);
+	void						showControlErrorTemporary(QString msg);
+
 protected:
 	
 	QQuickItem*				_item;

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2957,3 +2957,12 @@ postProcessModuleInstall <- function(moduleLibraryPath)
     .postProcessLibraryModule(allFiles)
   }
 }
+
+.parseRcodeFromQt <- function(code) {
+  
+  ans <- eval(parse(text = code))
+  if (!is.numeric(ans) || is.na(ans))
+    return("Expressions was non-numeric or NA.")
+  else
+    return(as.character(ans))
+}

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2958,5 +2958,21 @@ postProcessModuleInstall <- function(moduleLibraryPath)
   }
 }
 
-.parseRCodeInOptions <- function(code) 
-  return(eval(parse(text = code)))
+.parseRCodeInOptions <- function(option) {
+  if (.RCodeInOptionsIsOk(option))
+    return(eval(parse(text = option[[1L]])))
+  else
+    return(NA)
+}
+
+.RCodeInOptionsIsOk <- function(option) UseMethod(".RCodeInOptionsIsOk", option)
+
+.RCodeInOptionsIsOk.default <- function(option)
+  return(length(option) > 1L && identical(option[[2L]], "T"))
+
+.RCodeInOptionsIsOk.list <- function(option) {
+  for (i in seq_along(option))
+    if (!.RCodeInOptionsIsOk(option[[i]]))
+      return(FALSE)
+  return(TRUE)
+}

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2958,11 +2958,5 @@ postProcessModuleInstall <- function(moduleLibraryPath)
   }
 }
 
-.parseRcodeFromQt <- function(code) {
-  
-  ans <- eval(parse(text = code))
-  if (!is.numeric(ans) || is.na(ans))
-    return("Expressions was non-numeric or NA.")
-  else
-    return(as.character(ans))
-}
+.parseRCodeInOptions <- function(code) 
+  return(eval(parse(text = code)))

--- a/JASP-Tests/R/tests/testthat/test-binomialtestbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-binomialtestbayesian.R
@@ -1,13 +1,20 @@
 context("Binomial Test Bayesian")
 
+addFormulaFieldOptions <- function(options) {
+  options$priorA    <- list("1",   "T")
+  options$priorB    <- list("1",   "T")
+  options$testValue <- list("0.5", "T")
+  return(options)
+}
+
 test_that("Main table results match", {
   options <- jasptools::analysisOptions("BinomialTestBayesian")
   options$variables <- "contBinom"
   options$bayesFactorType <- "BF01"
   options$hypothesis <- "notEqualToTestValue"
-  options$priorA <- 4
-  options$priorB <- 2
-  options$testValue <- 0.2
+  options$priorA <- list("4", "T")
+  options$priorB <- list("2", "T")
+  options$testValue <- list("0.2", "T")
   results <- jasptools::run("BinomialTestBayesian", "test.csv", options)
   table <- results[["results"]][["binomTable"]][["data"]]
   expect_equal_tables(table,
@@ -18,6 +25,7 @@ test_that("Main table results match", {
 
 test_that("Prior posterior plots match", {
   options <- jasptools::analysisOptions("BinomialTestBayesian")
+  options <- addFormulaFieldOptions(options)
   options$variables <- "contBinom"
   options$plotPriorAndPosterior <- TRUE
   options$plotPriorAndPosteriorAdditionalInfo <- TRUE
@@ -32,6 +40,7 @@ test_that("Prior posterior plots match", {
 
 test_that("Sequential analysis plots match", {
   options <- jasptools::analysisOptions("BinomialTestBayesian")
+  options <- addFormulaFieldOptions(options)
   options$variables <- "contBinom"
   options$plotSequentialAnalysis <- TRUE
   results <- jasptools::run("BinomialTestBayesian", "test.csv", options)

--- a/Resources/Frequencies/qml/BinomialTestBayesian.qml
+++ b/Resources/Frequencies/qml/BinomialTestBayesian.qml
@@ -65,6 +65,6 @@ Form
 		title: qsTr("Prior")
 		DoubleField { name: "priorA"; label: qsTr("Beta prior: parameter a"); defaultValue: 1; max: 10000; inclusive: "no"; decimals: 3 }
 		DoubleField { name: "priorB"; label: qsTr("Beta prior: parameter b"); defaultValue: 1; max: 10000; inclusive: "no"; decimals: 3 }
-		FormulaField{ name: "priorC"; label: qsTr("Test");}
+		FormulaField { name: "priorC"; label: qsTr("Test"); min: 0; max: 1}
 	}
 }

--- a/Resources/Frequencies/qml/BinomialTestBayesian.qml
+++ b/Resources/Frequencies/qml/BinomialTestBayesian.qml
@@ -65,5 +65,6 @@ Form
 		title: qsTr("Prior")
 		DoubleField { name: "priorA"; label: qsTr("Beta prior: parameter a"); defaultValue: 1; max: 10000; inclusive: "no"; decimals: 3 }
 		DoubleField { name: "priorB"; label: qsTr("Beta prior: parameter b"); defaultValue: 1; max: 10000; inclusive: "no"; decimals: 3 }
+		FormulaField{ name: "priorC"; label: qsTr("Test");}
 	}
 }

--- a/Resources/Frequencies/qml/BinomialTestBayesian.qml
+++ b/Resources/Frequencies/qml/BinomialTestBayesian.qml
@@ -32,7 +32,7 @@ Form
 		AssignedVariablesList { name: "variables"; suggestedColumns: ["ordinal", "nominal"] }
 	}
 	
-	DoubleField { label: qsTr("Test value: "); name: "testValue"; defaultValue: 0.5 ; max: 1; decimals: 2; Layout.columnSpan: 2 }
+	FormulaField { label: qsTr("Test value: "); name: "testValue"; defaultValue: "0.5" ; min:0; max: 1; Layout.columnSpan: 2 }
 	
 	RadioButtonGroup
 	{
@@ -63,8 +63,7 @@ Form
 	Group
 	{
 		title: qsTr("Prior")
-		DoubleField { name: "priorA"; label: qsTr("Beta prior: parameter a"); defaultValue: 1; max: 10000; inclusive: "no"; decimals: 3 }
-		DoubleField { name: "priorB"; label: qsTr("Beta prior: parameter b"); defaultValue: 1; max: 10000; inclusive: "no"; decimals: 3 }
-		FormulaField { name: "priorC"; label: qsTr("Test"); min: 0; max: 1}
+		FormulaField { name: "priorA"; label: qsTr("Beta prior: parameter a"); defaultValue: "1"; min:0; max: 10000; inclusive: "no" }
+		FormulaField { name: "priorB"; label: qsTr("Beta prior: parameter b"); defaultValue: "1"; min:0; max: 10000; inclusive: "no" }
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/578

This PR introduces the widget `FormulaField` in QML where people can type math expressions in addition to single numbers.

The current implementation is somewhat suboptimal because the code is parsed multiple times, both in C++ and in R, but it's the best we can at the moment.

On the R side, I introduced the functions `.parseRCodeInOptions` which parses the code if it is valid and `.RCodeInOptionsIsOk` to test if the R code in the options is valid. These two functions may seem a little bit redundant, but this way we can easily change the C++/ QML API and only have to change two functions in R.

As a minimal example, FormulaField is now used in the Bayesian binomial test.

