### PR TITLE
Changed size calculation of svg plots

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2263,9 +2263,11 @@ openGrDevice <- function(...) {
     ppi             <- .fromRCPP(".ppi")
   }
   
-  # convert width & height from pixels to inches. ppi = pixels per inch. 96 is a magic number inherited from the past.
-  width  <- width  / 96
-  height <- height / 96
+  # convert width & height from pixels to inches. ppi = pixels per inch. 72 is a magic number inherited from the past.
+  # originally, this number was 96 but svglite scales this by (72/96 = 0.75). 0.75 * 96 = 72.
+  # for reference see https://cran.r-project.org/web/packages/svglite/vignettes/scaling.html
+  width  <- width  / 72
+  height <- height / 72
   image <- list()
   
   # TRUE if called from analysis, FALSE if called from editImage

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2263,9 +2263,9 @@ openGrDevice <- function(...) {
     ppi             <- .fromRCPP(".ppi")
   }
   
-  # convert width & height from pixels to inches. ppi = pixels per inch. 4 is a magic number.
-  width  <- width  / ppi * 4
-  height <- height / ppi * 4
+  # convert width & height from pixels to inches. ppi = pixels per inch. 96 is a magic number inherited from the past.
+  width  <- width  / 96
+  height <- height / 96
   image <- list()
   
   # TRUE if called from analysis, FALSE if called from editImage

--- a/JASP-R-Interface/jaspResults/R/writeImage.R
+++ b/JASP-R-Interface/jaspResults/R/writeImage.R
@@ -49,9 +49,11 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
   setwd(root)
   on.exit(setwd(oldwd))
 
-  # convert width & height from pixels to inches. ppi = pixels per inch. 96 is a magic number inherited from the past.
-  width  <- width  / 96
-  height <- height / 96
+  # convert width & height from pixels to inches. ppi = pixels per inch. 72 is a magic number inherited from the past.
+  # originally, this number was 96 but svglite scales this by (72/96 = 0.75). 0.75 * 96 = 72.
+  # for reference see https://cran.r-project.org/web/packages/svglite/vignettes/scaling.html
+  width  <- width  / 72
+  height <- height / 72
 
   plot2draw <- decodeplot(plot)
 

--- a/JASP-R-Interface/jaspResults/R/writeImage.R
+++ b/JASP-R-Interface/jaspResults/R/writeImage.R
@@ -49,9 +49,9 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
   setwd(root)
   on.exit(setwd(oldwd))
 
-  # convert width & height from pixels to inches. ppi = pixels per inch. 4 is a magic number.
-  width  <- width  / ppi * 4
-  height <- height / ppi * 4
+  # convert width & height from pixels to inches. ppi = pixels per inch. 96 is a magic number inherited from the past.
+  width  <- width  / 96
+  height <- height / 96
 
   plot2draw <- decodeplot(plot)
 


### PR DESCRIPTION
So we used (see https://github.com/jasp-stats/jasp-desktop/blob/ad4d3615c2db2279d2d8d86b8d1dd8898b84d244/JASP-R-Interface/jaspResults/R/writeImage.R):

```r
pngMultip <- ppi / 96
ggplot2::ggsave(
		...
    	width     = width  * pngMultip,
    	height    = height * pngMultip,
```

Usually, `inch * ppi = pixels` or `inch = pixels/ ppi`. Width used to be in pixels: `width(px) * ppi / 96`. So dividing by ppi gives: `width (inches) = width(px) / 96`, which is what this PR implements.

My flatpak jasp doesn't work right now so I cannot compare this to a previous jasp version.. :(

Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/598

