### PR TITLE
parse JAGS code with logit(theta[i, j]) correctly

### DIFF
--- a/JASP-Desktop/widgets/boundqmltextarea.h
+++ b/JASP-Desktop/widgets/boundqmltextarea.h
@@ -64,6 +64,7 @@ protected:
 	QString						_text;
 	TextType					_textType;
 	QString						_applyScriptInfo;
+	QSet<QString>				_usedColumnNames;
 	
 	LavaanSyntaxHighlighter*	_lavaanHighlighter = nullptr;
 	ListModelTermsAvailable*	_model = nullptr;

--- a/JASP-Engine/JASP/R/jagsModule.R
+++ b/JASP-Engine/JASP/R/jagsModule.R
@@ -168,7 +168,7 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
 	})
 
 	# if something went wrong, present useful error message
-	if (JASP:::isTryError(e)) {
+	if (isTryError(e)) {
 	  jaspResults[["mainContainer"]]$setError(.JAGSmodelError(e, pattern, model, options))
 	  return(NULL)
 	}
@@ -881,9 +881,9 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
         # return()
       }
       obj <- try(eval(parse(text = string)))
-      if (JASP:::isTryError(obj)) {
+      if (isTryError(obj)) {
         jaspResults[["mainContainer"]]$setError(sprintf("The R code for %s crashed with error:\n%s",
-                                                       type, JASP:::.extractErrorMessage(obj)))
+                                                       type, .extractErrorMessage(obj)))
         return()
       } else if (!is.numeric(obj)) {
         jaspResults[["mainContainer"]]$setError("The result of %s R code should be numeric but it was of mode %s and class %s",


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/587

@boutinb the latest state of JAGS, see the comment for where we could use the column names.