### PR TITLE
remove plot environments from ggplot2 objects

### DIFF
--- a/JASP-R-Interface/jaspResults/R/writeImage.R
+++ b/JASP-R-Interface/jaspResults/R/writeImage.R
@@ -40,7 +40,9 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
   if (is.null(relativePathsvg))
     relativePathsvg <- location$relativePath
 
+
   image                           <- list()
+  developerMode                   <- jaspResultsModule$cpp_developerMode() #This function can be used anywhere, also in "old style code" for however long we support it anyway.
   fullPathpng                     <- paste(location$root, relativePathsvg, sep="/")
   plotEditingOptions              <- NULL
   root                            <- location$root

--- a/JASP-R-Interface/jaspResults/src/jaspModuleRegistration.h
+++ b/JASP-R-Interface/jaspResults/src/jaspModuleRegistration.h
@@ -23,6 +23,8 @@ RCPP_MODULE(jaspResults)
 	Rcpp::function("cpp_startProgressbar",	jaspResults::staticStartProgressbar);
 	Rcpp::function("cpp_progressbarTick",	jaspResults::staticProgressbarTick);
 
+	Rcpp::function("cpp_developerMode",		jaspObject::developerMode);
+
 	Rcpp::function("destroyAllAllocatedObjects", jaspObject::destroyAllAllocatedObjects);
 	Rcpp::class_<jaspObject_Interface>("jaspObject")
 

--- a/JASP-R-Interface/jaspResults/src/jaspObject.h
+++ b/JASP-R-Interface/jaspResults/src/jaspObject.h
@@ -125,7 +125,7 @@ public:
 
 	static int getCurrentTimeMs();
 	static void setDeveloperMode(bool developerMode);
-
+	static bool developerMode() { return _developerMode; }
 protected:
 	jaspObjectType				_type;
 	std::string					_errorMessage = "";


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/601.

If a plot fails, the plot environment is kept (and saved) as a fallback. An error is shown on a failing plot, but only in developer mode.