### PR TITLE
Bayes multinomial

### DIFF
--- a/JASP-Engine/JASP/R/multinomialtest.R
+++ b/JASP-Engine/JASP/R/multinomialtest.R
@@ -67,10 +67,20 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
   
   # Test 3: Levels and integer check for counts
   if(options$factor != ""){
+    
+    # Number of levels of the variables must be bigger than 1
+    .hasErrors(dataset              = dataset,
+               perform              = "run",
+               type                 = "factorLevels",
+               factorLevels.target  = options$factor,
+               factorLevels.amount  = '< 1',
+               exitAnalysisIfErrors = TRUE)
+    
     # first determine the hypotheses
     factorVariable <- na.omit(dataset[[.v(options$factor)]])
     factorVariable <- as.factor(factorVariable)
-    nlevels <- nlevels(factorVariable)
+    nlevels        <- nlevels(factorVariable)
+    
     if (options$counts != "") {
       counts   <- na.omit(dataset[[.v(options$counts)]])
       variable <- "Invalid counts: "

--- a/JASP-Engine/JASP/R/multinomialtestbayesian.R
+++ b/JASP-Engine/JASP/R/multinomialtestbayesian.R
@@ -31,31 +31,6 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   return()
 }
 
-
-#' Funciton checks for errors
-#'   1. Number of levels of the variables must be bigger than 1
-#'   2. 0 observations for a level of a variable
-#'
-#' @param dataset
-#' @param options user input options
-# .multinomCheckErrors <- function(dataset, options) {
-# 
-#   if (options$factor == "")
-#     return()
-# 
-#   fact <- options$factor
-# 
-#   # Error Check 1: Number of levels of the variables must be bigger than 1
-#   .hasErrors(dataset              = dataset,
-#              perform              = "run",
-#              type                 = "factorLevels",
-#              factorLevels.target  = fact,
-#              factorLevels.amount  = '< 1',
-#              exitAnalysisIfErrors = TRUE)
-# 
-# }
-
-
 #' Compute results for multinomial table
 #'
 #' @param jaspResults
@@ -79,7 +54,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
 
   if (!multinomialResults$specs[["ready"]])
     return(multinomialResults)
-
+  
   # Prepare for running the Bayesian Multinomial test
   factorVariable <- multinomialResults$specs$factorVariable
   countVariable  <- multinomialResults$specs$countVariable

--- a/JASP-Engine/JASP/R/multinomialtestbayesian.R
+++ b/JASP-Engine/JASP/R/multinomialtestbayesian.R
@@ -20,7 +20,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
 
   dataset            <- .multinomialBayesReadData(dataset, options)
 
-  .multinomialBayesCheckErrors(dataset, options)
+  .multinomCheckErrors(dataset, options)
 
   multinomialResults <- .computeMultinomialResults(jaspResults, dataset, options)
 
@@ -38,22 +38,22 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
 #'
 #' @param dataset
 #' @param options user input options
-.multinomialBayesCheckErrors <- function(dataset, options) {
-
-  if (options$factor == "")
-    return()
-
-  fact <- options$factor
-
-  # Error Check 1: Number of levels of the variables must be bigger than 1
-  .hasErrors(dataset              = dataset,
-             perform              = "run",
-             type                 = "factorLevels",
-             factorLevels.target  = fact,
-             factorLevels.amount  = '< 1',
-             exitAnalysisIfErrors = TRUE)
-
-}
+# .multinomCheckErrors <- function(dataset, options) {
+# 
+#   if (options$factor == "")
+#     return()
+# 
+#   fact <- options$factor
+# 
+#   # Error Check 1: Number of levels of the variables must be bigger than 1
+#   .hasErrors(dataset              = dataset,
+#              perform              = "run",
+#              type                 = "factorLevels",
+#              factorLevels.target  = fact,
+#              factorLevels.amount  = '< 1',
+#              exitAnalysisIfErrors = TRUE)
+# 
+# }
 
 
 #' Compute results for multinomial table
@@ -93,8 +93,6 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
     counts <- dataset[[.v(options$counts)]]
     # omit count entries for which factor variable is NA
     counts <- counts[!is.na(fact)]
-    # check for invalid counts
-    .checkCountsMultinomial(counts, nlev)
     dataTable        <- counts
     names(dataTable) <- levels(fact)
   } else {

--- a/JASP-Tests/R/tests/testthat/test-multinomialtestbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-multinomialtestbayesian.R
@@ -46,3 +46,17 @@ test_that("Descriptives plots match", {
   expect_equal_plots(testPlot, "multinomialBayesianDescriptivesPlot", dir="MultinomialTestBayesian")
 })
 
+test_that("Bayesian Multinomial Test table results match in short data format", {
+  options <- jasptools::analysisOptions("MultinomialTestBayesian")
+  options$factor <- "Month"
+  options$counts <- "Stress.frequency"
+  options$priorCounts <- list(list(values = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+                                              1, 1, 1, 1), levels = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+                                                                      1, 1, 1, 1, 1)))
+  set.seed(1)
+  results <- jasptools::run("MultinomialTestBayesian", "Memory of Life Stresses.csv", options)
+  table <- results[["results"]][["multinomialTable"]][["data"]]
+  expect_equal_tables(table,
+                      list(27.1062505863656, "Multinomial", 18))
+})
+


### PR DESCRIPTION
The analysis crashed for data sets in the short format (i.e., one factor level per row). I fixed this my deleting some redundant functions in the bayesian multinomial (.checkCountsMultinomial()). Instead, I merged the error checks for the frequentist and bayesian multinomial test which also checks the counts in the multinomial dataset.