### PR TITLE
Use unicode not equal to in abtest

### DIFF
--- a/JASP-Engine/JASP/R/abtestbayesian.R
+++ b/JASP-Engine/JASP/R/abtestbayesian.R
@@ -166,7 +166,7 @@ ABTestBayesian <- function(jaspResults, dataset, options, ...) {
   if (orNotEqualTo1Prob > 0) {
     rowCount = rowCount + 1
     output.rows[[rowCount]] <- list(
-      "Models"    = "Log odds ratio ≠ 0",
+      "Models"    = "Log odds ratio \u2260 0",
       "BF"        = ab_obj$bf[["bf10"]],
       "P(M|data)" = ab_obj$post_prob[["H1"]],
       "P(M)"      = orNotEqualTo1Prob


### PR DESCRIPTION
In an attempt to fix https://github.com/jasp-stats/INTERNAL-jasp/issues/610
I can't reproduce the problem