### PR TITLE
[WIP] use grDevices::svg to deal with base plots that open multiple pages

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2246,10 +2246,16 @@ as.list.footnotes <- function(footnotes) {
 }
 
 openGrDevice <- function(...) {
-  if (jaspResultsCalledFromJasp())
-    svglite::svglite(...)
-  else
+  if (jaspResultsCalledFromJasp()) {
+    dots <- list(...)
+    if ("file" %in% names(dots)) {
+      dots[["filename"]] <- dots[["file"]]
+      dots[["file"]]     <- NULL
+    }
+    do.call(grDevices::svg, dots)
+  } else {
     grDevices::png(..., units="in", res = 72, type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
+  }
 }
 
 .writeImage <- function(width=320, height=320, plot, obj = TRUE, relativePathsvg = NULL,

--- a/JASP-R-Interface/jaspResults/R/writeImage.R
+++ b/JASP-R-Interface/jaspResults/R/writeImage.R
@@ -19,18 +19,14 @@ getImageLocation <- function() {
   )
 }
 
-openGrDevice <- function(..., baseSvg = FALSE) {
+openGrDevice <- function(...) {
   if (jaspResultsCalledFromJasp()) {
-    if (baseSvg) {
-      dots <- list(...)
-      if ("file" %in% names(dots)) {
-        dots[["filename"]] <- dots[["file"]]
-        dots[["file"]]     <- NULL
-      }
-      do.call(grDevices::svg, dots)
-    } else {
-      svglite::svglite(...)
+    dots <- list(...)
+    if ("file" %in% names(dots)) {
+      dots[["filename"]] <- dots[["file"]]
+      dots[["file"]]     <- NULL
     }
+    do.call(grDevices::svg, dots)
   } else {
     grDevices::png(..., units="in", res = 72, type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
   }
@@ -90,8 +86,7 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
     isRecordedPlot <- inherits(plot2draw, "recordedplot")
 
     # Open graphics device and plot
-    openGrDevice(file = relativePathsvg, width = width, height = height, bg = backgroundColor,
-                 baseSvg = is.function(plot2draw))
+    openGrDevice(file = relativePathsvg, width = width, height = height, bg = backgroundColor)
     on.exit(dev.off())
 
     if (is.function(plot2draw) && !isRecordedPlot) {


### PR DESCRIPTION
Switch svg backend to `grDevices`. Note that this does not affect ggplot2 plots because those are saved via `ggsave` which internally uses `svglite`. 

Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/618 (in my opinion) and
https://github.com/jasp-stats/INTERNAL-jasp/issues/620 (no error)
