### PR TITLE
small bugfix in sequential plot

### DIFF
--- a/JASP-Engine/JASPgraphs/DESCRIPTION
+++ b/JASP-Engine/JASPgraphs/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: JASPgraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.4.3
+Version: 0.4.4
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: ...

--- a/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
+++ b/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
@@ -372,7 +372,7 @@ PlotRobustnessSequential <- function(
     widths  <- c(.4, .2, .4)
 
     plot <- JASPgraphsPlot$new(
-      subplots     = topPlotList,
+      subplots     = topPlotList[!idx],
       layout       = layout,
       heights      = heights,
       widths       = widths

--- a/JASP-Tests/R/tests/figs/jasp-deps.txt
+++ b/JASP-Tests/R/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- JASPgraphs: 0.4.3
+- JASPgraphs: 0.4.4


### PR DESCRIPTION
Small fix for @sophieberkhout

Empty plots didn't get removed from robustness and sequential plots and that caused a crash. No plots in JASP were affected since those either use all subplots or none.