### PR TITLE
Add stacktrace to unit tests when an analysis terminates unexpectedly

### DIFF
--- a/JASP-Tests/R/tests/testthat/helper-plots.R
+++ b/JASP-Tests/R/tests/testthat/helper-plots.R
@@ -1,7 +1,7 @@
 expect_equal_plots <- function(test, name, dir) {
   errorMsg <- jasptools:::.getErrorMsgFromLastResults()
   if (!is.null(errorMsg))
-    stop(paste("Tried retrieving plot from results, but last run of jasptools exited with an error:", errorMsg), call.=FALSE)
+    stop(paste("Tried retrieving plot from results, but last run of jasptools exited with an error:\n", errorMsg), call.=FALSE)
     
   if (length(test) == 0)
       stop("The new plot has no data. Please check your unit test; is the index path to the plot specified correctly?", call.=FALSE)

--- a/JASP-Tests/R/tests/testthat/helper-tables.R
+++ b/JASP-Tests/R/tests/testthat/helper-tables.R
@@ -114,7 +114,7 @@ expect_equal_tables <- function(test, ref, label=NULL) {
     
   errorMsg <- jasptools:::.getErrorMsgFromLastResults()
   if (!is.null(errorMsg))
-    stop(paste("Tried retrieving table from results, but last run of jasptools exited with an error:", errorMsg), call.=FALSE)
+    stop(paste("Tried retrieving table from results, but last run of jasptools exited with an error:\n", errorMsg), call.=FALSE)
     
   if (length(test) == 0)
       stop(paste(label, "has no data. Please check your unit test; is the index path to the table specified correctly?"), call.=FALSE)

--- a/Tools/jasptools/DESCRIPTION
+++ b/Tools/jasptools/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jasptools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 0.8.4
+Version: 0.8.5
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/Tools/jasptools/R/utils.R
+++ b/Tools/jasptools/R/utils.R
@@ -364,9 +364,13 @@ collapseTable <- function(rows) {
 }
 
 .errorMsgFromHtml <- function(html) {
-  parsedMsg <- gsub("<br>", " ", html, fixed=TRUE)
-  indexStackTrace <- unlist(gregexpr("<div class=stack-trace", parsedMsg, fixed=TRUE))[1]
-  if (indexStackTrace > -1)
-    parsedMsg <- substr(parsedMsg, 1, indexStackTrace - 1)
+  indexStackTrace <- unlist(gregexpr("<div class=stack-trace", html, fixed=TRUE))[1]
+  if (indexStackTrace > -1) {
+    error <- substr(html, 1, indexStackTrace - 1)
+    error <- gsub("<br>", " ", error, fixed=TRUE)
+    stackTrace <- stringr::str_match(html, "<div class=stack-trace>(.*)<\\/div>")[1, 2]
+    html <- paste0(error, "\n\nStacktrace within JASP:\n----------\n", stackTrace, "\n----------\n")
+  }
+  parsedMsg <- gsub("<br>", "\n", html, fixed=TRUE)
   return(parsedMsg)
 }


### PR DESCRIPTION
E.g., 
```
test-correlation.R:61: error: Spearman's rho heatmap matches
Tried retrieving plot from results, but last run of jasptools exited with an error:
 This analysis terminated unexpectedly.  Expecting a single string value: [type=character; extent=2].  

Stacktrace within JASP:
----------
tryCatchOne(expr, names, parentenv, handlers[[1]])

doTryCatch(return(expr), name, parentenv, handler)

withCallingHandlers(expr = analysis(jaspResults = jaspResults, dataset = dataset, options = options), error = .addStackTrace)

analysis(jaspResults = jaspResults, dataset = dataset, options = options)

.corrMainResults(jaspResults, dataset, options, ready)

.corrInitMainTable(jaspResults, options)

.corrInitCorrelationTable(mainTable, options, variables)

.corrInitCorrelationTableRowAsColumn(mainTable, options, variables[vi], testsTitles[ti], tests[ti], overtitle)

mainTable$addColumnInfo(name = sprintf(name, 'upper.ci'), title = gettext('Upper %s%% CI', 100 * options$confidenceIntervalsInterval), type = 'number', overtitle = overtitle)

private$jaspObject$addColumnInfoHelper(name, title, type, format, combine, overtitle)
----------
```

@vandenman: I think this implements https://github.com/jasp-stats/INTERNAL-jasp/issues/648 sufficiently?