### PR TITLE
translate axes titles in JASPgraphs

### DIFF
--- a/JASP-Engine/JASPgraphs/R/PlotPriorAndPosterior.R
+++ b/JASP-Engine/JASPgraphs/R/PlotPriorAndPosterior.R
@@ -297,7 +297,7 @@ makeBFwheelAndText <- function(BF, bfSubscripts, pizzaTxt, drawPizzaTxt = is.nul
 #"
 #' @export
 PlotPriorAndPosterior <- function(dfLines, dfPoints = NULL, BF = NULL, CRI = NULL, median = NULL, xName = NULL,
-                                  yName = "Density", drawPizzaTxt = !is.null(BF), drawCRItxt = !is.null(CRI),
+                                  yName = gettext("Density"), drawPizzaTxt = !is.null(BF), drawCRItxt = !is.null(CRI),
                                   bfType = c("BF01", "BF10", "LogBF10"),
                                   hypothesis = c("equal", "smaller", "greater"),
                                   bfSubscripts = NULL,

--- a/JASP-Engine/JASPgraphs/R/plotQQnorm.R
+++ b/JASP-Engine/JASPgraphs/R/plotQQnorm.R
@@ -19,7 +19,7 @@
 #'
 #' @export
 plotQQnorm <- function(residuals, lower = NULL, upper = NULL, abline = TRUE, ablineColor = "red",
-                       xName = "Theoretical quantiles", yName = "Observed quantiles") {
+                       xName = gettext("Theoretical quantiles"), yName = gettext("Observed quantiles")) {
 
   n <- length(residuals)
   hasErrorbars <- !is.null(lower) && !is.null(upper)


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/657.

@TimKDJ I did not increment the version number of JASPgraphs because the changes are very minimal (and I'm scared of running the unit tests). I also didn't call `devtools::document()` because that'll trigger an upgrade of roxygen and change many more files than that are affected. I'll leave those for the other pr that fixes Koen's issue.