### PR TITLE
Loading .sav now keeps floating point value for nominal columns

### DIFF
--- a/JASP-Common/appinfo.h
+++ b/JASP-Common/appinfo.h
@@ -18,7 +18,7 @@
 #ifndef APPINFO_H
 #define APPINFO_H
 
-#include "version.h"
+#include "../JASP-Common/version.h"
 
 class AppInfo
 {

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -21,7 +21,7 @@
 #include <boost/uuid/uuid.hpp>
 
 #include "common.h"
-#include "version.h"
+#include "../JASP-Common/version.h"
 
 #include "options/options.h"
 #include "enginedefinitions.h"

--- a/JASP-Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/JASP-Desktop/components/JASP/Widgets/DataTableView.qml
@@ -199,14 +199,11 @@ FocusScope
 					anchors.verticalCenter:		headerRoot.verticalCenter
 				}
 
-				AnimatedImage
+				LoadingIndicator
 				{
 					id:			colIsInvalidated
 
-					source:		jaspTheme.iconPath + "/loading.gif"
-					width:		visible ? headerRoot.__iconDim : 0
-					height:		headerRoot.__iconDim
-					playing:	visible
+					width:		headerRoot.__iconDim
 					visible:	columnIsInvalidated
 
 					anchors.right:			colFilterOn.left

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/OSF.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/OSF.qml
@@ -318,11 +318,7 @@ Item
 			anchors.right		: parent.right
 			anchors.top			: parent.top
 			KeyNavigation.tab	: osfList
-
-			onClicked	:
-			{
-				fileMenuModel.osf.saveFile(filenameText.text)
-			}
+			onClicked			: fileMenuModel.osf.saveFile(filenameText.text)
 		}
 	}
 
@@ -333,7 +329,8 @@ Item
 
 		anchors.horizontalCenter	: osfList.horizontalCenter
 		anchors.verticalCenter		: osfList.verticalCenter
-		width						: parent.width / 1.5
+		width						: parent.width  / 2
+		height						: parent.height / 2
 	}
 
 	FileList

--- a/JASP-Desktop/components/JASP/Widgets/LoadingIndicator.qml
+++ b/JASP-Desktop/components/JASP/Widgets/LoadingIndicator.qml
@@ -1,36 +1,44 @@
 import QtQuick 2.12
 
-Image
+Item
 {
-	id						: img
-	source					: jaspTheme.iconPath + "/loading.svg"
-	sourceSize.width		: width
-	sourceSize.height		: width
-	height					: width
-	transformOrigin			: Item.Center
+	id:				container
+	implicitWidth:	200
+	implicitHeight: 200
 
-
-	property int	segments: 12
-	property real	duration: 1200
-	property int	run		: 0
-
-	onVisibleChanged: if(visible && !anim.running) anim.start()
-
-	SequentialAnimation
+	Image
 	{
-		id			: anim
+		id						: img
+		source					: jaspTheme.iconPath + "/loading.svg"
+		sourceSize.width		: width
+		sourceSize.height		: width
+		height					: width
+		width					: Math.min(parent.width, parent.height)
+		transformOrigin			: Item.Center
+		anchors.centerIn		: parent
 
-		loops		: 1
+		property int	segments: 12
+		property real	duration: 1200
+		property int	run		: 0
 
-		onFinished :
-			if(visible)
-			{
-				img.run ++;
-				img.run %= img.segments
-				start()
-			}
+		onVisibleChanged: if(visible && !anim.running) anim.start()
 
-		PropertyAction	{ value: (360 / img.segments) * img.run;	target: img; property: "rotation" }
-		PauseAnimation	{ duration: img.duration / img.segments }
+		SequentialAnimation
+		{
+			id			: anim
+
+			loops		: 1
+
+			onFinished :
+				if(visible)
+				{
+					img.run ++;
+					img.run %= img.segments
+					start()
+				}
+
+			PropertyAction	{ value: (360 / img.segments) * img.run;	target: img; property: "rotation" }
+			PauseAnimation	{ duration: img.duration / img.segments }
+		}
 	}
 }

--- a/JASP-Desktop/data/datasetpackage.h
+++ b/JASP-Desktop/data/datasetpackage.h
@@ -21,7 +21,7 @@
 #include <QAbstractItemModel>
 #include "common.h"
 #include "dataset.h"
-#include "version.h"
+#include "../JASP-Common/version.h"
 #include <map>
 #include "jsonredirect.h"
 #include "computedcolumns.h"

--- a/JASP-Desktop/data/exporters/jaspexporter.cpp
+++ b/JASP-Desktop/data/exporters/jaspexporter.cpp
@@ -28,7 +28,7 @@
 #include "libzip/archive_entry.h"
 #include "jsonredirect.h"
 #include "filereader.h"
-#include "version.h"
+#include "../JASP-Common/version.h"
 #include "tempfiles.h"
 #include "appinfo.h"
 #include "log.h"

--- a/JASP-Desktop/data/importers/readstat/readstatimportcolumn.cpp
+++ b/JASP-Desktop/data/importers/readstat/readstatimportcolumn.cpp
@@ -91,6 +91,13 @@ void ReadStatImportColumn::addValue(const double & val)
 {
 	switch(_type)
 	{
+	case columnType::ordinal:		//How does ordinal with doubles make sense? Well, it doesn't!
+		//Let us make sure all previous int's are converted to doubles  (Although if this datafile is sane there really shouldn't be any ints...)
+		for(int i : _ints)
+			_doubles.push_back(i);
+		_ints.clear();
+		[[clang::fallthrough]];
+
 	case columnType::unknown:
 		_type = columnType::scale;
 		[[clang::fallthrough]];
@@ -99,13 +106,19 @@ void ReadStatImportColumn::addValue(const double & val)
 		_doubles.push_back(val);
 		break;
 
-	case columnType::nominalText:
-		addValue(std::to_string(val));
-		break;
-
-	case columnType::ordinal:
 	case columnType::nominal:
-		addValue(int(val));
+		_type = columnType::nominalText; //Nominal with float also doesn't work.. Lets make sure any previous ints are converted to string
+		for(int i : _ints)
+			_strings.push_back(std::to_string(i));
+		_ints.clear();
+		[[clang::fallthrough]];
+
+	case columnType::nominalText:
+	{
+		std::stringstream conv;
+		conv << val;
+		addValue(conv.str());
+	}
 		break;
 	}
 }

--- a/JASP-Desktop/data/importers/readstatimporter.cpp
+++ b/JASP-Desktop/data/importers/readstatimporter.cpp
@@ -23,7 +23,7 @@ int handle_variable(int, readstat_variable_t *variable, const char *val_labels, 
 	std::string				name			= readstat_variable_get_name(variable),
 							labelsID		= val_labels != NULL ? val_labels : "";
 	readstat_measure_t		colMeasure		= readstat_variable_get_measure(variable);
-	columnType		colType;
+	columnType				colType;
 
 	switch(colMeasure)
 	{


### PR DESCRIPTION
It converts it to string and thus nominaltext.
If defined as Ordinal it changes columntype to scale.
Fixes issue https://github.com/jasp-stats/jasp-issues/issues/550

This commit also fixes loadingindicator in computed columns
And fixes a small bug with windows finding the wrong "version.h"

