### PR TITLE
Fix a number of interface issues

### DIFF
--- a/JASP-Desktop/html/css/darkTheme-jasp.css
+++ b/JASP-Desktop/html/css/darkTheme-jasp.css
@@ -383,7 +383,7 @@ div.jasp-image-image.no-data.error {
   opacity: 0.33
 }
 
-.error-state {
+.error-state:not(.jasp-analysis), .jasp-analysis.error-state>.jasp-analysis {
   color: darkgray;
 }
 

--- a/JASP-Desktop/html/css/lightTheme-jasp.css
+++ b/JASP-Desktop/html/css/lightTheme-jasp.css
@@ -17,7 +17,7 @@ body.selected {
 
 
 body.selected .jasp-analysis:not(.selected){
-    filter: opacity(0.5);
+    filter: opacity(0.75);
 }
 
 h1, .h1-toolbar .jasp-menu {
@@ -378,7 +378,7 @@ div.jasp-image-image.no-data.error {
 	opacity: 0.33
 }
 
-.error-state {
+.error-state:not(.jasp-analysis), .jasp-analysis.error-state>.jasp-analysis {
 	color: silver;
 }
 

--- a/JASP-Desktop/html/js/analysis.js
+++ b/JASP-Desktop/html/js/analysis.js
@@ -560,6 +560,8 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		errorMessage = errorMessage.replace(/\n/g, '<br>');
 		errorMessage = errorMessage.replace(/  /g, '&nbsp;&nbsp;');
 
+		$lastResult.removeClass("unselected selected");
+
 		if ($lastResult.hasClass("error-state"))
 			$result.append($lastResult.find(".jasp-analysis").not(".error-state").clone())
 		else

--- a/JASP-Desktop/html/js/jaspwidgets.js
+++ b/JASP-Desktop/html/js/jaspwidgets.js
@@ -951,7 +951,8 @@ JASPWidgets.Progressbar = Backbone.Model.extend({
 
 JASPWidgets.ProgressbarView = JASPWidgets.View.extend({
 	initialize: function() {
-		this.fadeOutDuration = 500;
+		this.$el.addClass("jasp-progressbar-container");
+		this.fadeOutActive = false;
 	},
 
 	render: function() {
@@ -983,7 +984,7 @@ JASPWidgets.ProgressbarView = JASPWidgets.View.extend({
 
 	clear: function() {
 		this.$el.empty();
-		this.$el.addClass("jasp-progressbar-container");
+		this.initialize();
 	},
 
 	isActive: function() {
@@ -1001,10 +1002,15 @@ JASPWidgets.ProgressbarView = JASPWidgets.View.extend({
 	},
 
 	_fadeOut: function() {
+		this.fadeOutActive = true;
 		var self = this;
 		window.setTimeout(function() {
-			self._getCurrent().fadeOut();
-		}, this.fadeOutDuration);
+			if (self.fadeOutActive) { // no new progressbar was made in the mean time
+				self._getCurrent().fadeOut(750, function() {
+					self.clear();
+				});
+			}
+		}, 250);
 	},
 
 	_getCurrent: function() {

--- a/JASP-Engine/JASP/R/correlation.R
+++ b/JASP-Engine/JASP/R/correlation.R
@@ -134,7 +134,7 @@ Correlation <- function(jaspResults, dataset, options){
   pairTitles <- combn(variables, 2, simplify = FALSE)
   
   mainTable$addColumnInfo(name = "variable1", title = "", type = "string")
-  mainTable$addColumnInfo(name = "separator", title = "", type = "string")
+  mainTable$addColumnInfo(name = "separator", title = "", type = "separator")
   mainTable$addColumnInfo(name = "variable2", title = "", type = "string")
 
   mainTable[['variable1']] <- sapply(pairTitles, function(x) x[[1]])
@@ -513,7 +513,7 @@ Correlation <- function(jaspResults, dataset, options){
   shapiroTable$showSpecifiedColumnsOnly <- TRUE
   
   shapiroTable$addColumnInfo(name = "var1",      title = "",                      type = "string")
-  shapiroTable$addColumnInfo(name = "separator", title = "",                      type = "string")
+  shapiroTable$addColumnInfo(name = "separator", title = "",                      type = "separator")
   shapiroTable$addColumnInfo(name = "var2",      title = "",                      type = "string")
   shapiroTable$addColumnInfo(name = "W",         title = gettext("Shapiro-Wilk"), type = "number")
   shapiroTable$addColumnInfo(name = "p",         title = gettext("p"),            type = "pvalue")

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -165,7 +165,7 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
   # Add the variables names paired
   #
   table$addColumnInfo(name="variable1", title="", type="string")
-  table$addColumnInfo(name="separator", title="", type="string")
+  table$addColumnInfo(name="separator", title="", type="separator")
   table$addColumnInfo(name="variable2", title="", type="string")
   
   if (options[["reportN"]])

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -230,8 +230,8 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 .addMatrixTableColumnMarkupCorBayes <- function(table, methodItems, options) {
   # Note(Alexander): Correlation Matrix
   #
-  table$addColumnInfo(name="variable", title="", type="string", combine=TRUE)
-  table$addColumnInfo(name="itemColumn", title="", type="number")
+  table$addColumnInfo(name="variable", title=gettext("Variable"), type="string", combine=TRUE)
+  table$addColumnInfo(name="itemColumn", title="", type="string")
   
   nVariables <- length(options[["variables"]])
   if (nVariables < 2) {
@@ -299,9 +299,9 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 .insertMatrixDefaultEmptyTableCellsCorBayes <- function(table, options) {
   variables <- unlist(options[["variables"]])
   if (length(variables) == 1)
-    variables <- c(variables, "...")
+    variables <- c(paste("1.", variables), "2. ...")
   else
-    variables <- c("...", "... ") # this space is a little hack to ensure the js combine shows both 'variables'
+    variables <- c("1. ...", "2. ...")
   
   methodItems <- .getCorMethods(options)
   itemNames <- .bSelectItems(options)
@@ -454,7 +454,7 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
       
       for (k in seq_along(itemNames)) {
         if (k == 1 && m == 1)
-          tempRow <- list(variable = var1, itemColumn = rowItemNames[[k]], .isNewGroup = TRUE) # First item gets the variable name
+          tempRow <- list(variable = paste0(i, ". ", var1), itemColumn = rowItemNames[[k]], .isNewGroup = TRUE) # First item gets the variable name
         else
           tempRow <- list(variable = "", itemColumn = rowItemNames[[k]], .isNewGroup = FALSE)
         

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -144,7 +144,7 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
   bfTitle <- .ttestBayesianGetBFTitle(bfType, hypothesis)
 
   jaspTable$addColumnInfo(name = "variable1", title = "",      type = "string")
-  jaspTable$addColumnInfo(name = "separator", title = "",      type = "string")
+  jaspTable$addColumnInfo(name = "separator", title = "",      type = "separator")
   jaspTable$addColumnInfo(name = "variable2", title = "",      type = "string")
   jaspTable$addColumnInfo(name = "BF",        title = bfTitle, type = "number")
 

--- a/JASP-Engine/JASP/R/ttestpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestpairedsamples.R
@@ -167,9 +167,9 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
 .ttestPairedMainFill <-function(jaspResults, dataset, options, testStat, optionsList) {
   direction <- .ttestMainGetDirection(options$hypothesis)
   
-  rowNo      <- 1
   ttest.rows <- list() # for each pair and each test, save stuff in there
   whichTests <- list("1" = optionsList$wantsStudents, "2" = optionsList$wantsWilcox)
+  numTests <- sum(optionsList$allTests)
   
   ## add a row for each variable, even before we are conducting tests
   
@@ -189,17 +189,28 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     
     ## test is a number, indicating which tests should be run
     for (test in seq_len(length(optionsList$whichTests))) {
-      row <- list(v1 = p1, sep = "-", v2 = p2)
+      row <- list()
+      
       currentTest <- optionsList$whichTests[[test]]
       ## don't run a test the user doesn't want
       if (!currentTest)
         next
+      
+      ## hide the name of the variable pair for the second statistic
+      isSecondStatisticOfPair <- numTests > 1 && test == 2
+      row[["v1"]]  <- ifelse(isSecondStatisticOfPair, "", p1)
+      row[["sep"]] <- ifelse(isSecondStatisticOfPair, "", "-")
+      row[["v2"]]  <- ifelse(isSecondStatisticOfPair, "", p2)
+      
+      if (numTests > 1) {
+        if (test == 1)
+          row[["test"]] <- "Student"
+        else if (test == 2)
+          row[["test"]] <- "Wilcoxon"
+      }
+      
       if (!identical(errors, FALSE) && length(pair[pair != ""]) == 2){
         jaspResults[["ttest"]]$addFootnote(errors$message, colNames = testStat, rowNames = paste(p1, p2, sep = "-"))
-        isFirst <- (rowNo %% 2 == 1 && sum(optionsList$allTests) == 2) || (sum(optionsList$allTests) == 1)
-        row <- list(v1  = ifelse(isFirst, p1, ""),
-                    sep = ifelse(isFirst, "-", ""),
-                    v2  = ifelse(isFirst, p2, ""))
         row[[testStat]] <- NaN
         jaspResults[["ttest"]]$addRows(row, rowNames = paste(p1, p2, sep = "-"))
         next
@@ -290,37 +301,20 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
         sed <- ifelse(is.null(result$parameter), "", sed)
         
         # add things to the intermediate results object
-        row <- list(df = df, p = p, md = m, d = d,
+        row <- c(row, list(df = df, p = p, md = m, d = d,
                     lowerCIlocationParameter = ciLow, upperCIlocationParameter = ciUp, 
                     lowerCIeffectSize = ciLowEffSize, upperCIeffectSize = ciUpEffSize,
-                    sed = sed)
+                    sed = sed))
         
         if (options$VovkSellkeMPR)
           row[["VovkSellkeMPR"]] <- .VovkSellkeMPR(p)
         row[[testStat]] <- stat
       } else {
-        row <- list(df = "", p = "", md = "", d = "", lowerCI = "", upperCI = "", sed = "")
+        row <- c(row, list(df = "", p = "", md = "", d = "", lowerCI = "", upperCI = "", sed = ""))
         row[[testStat]] <- ""
       }
       
-      ## if this is the first test / row for specific variables, add variable names
-      ## since we have only two tests, the first test always will be an odd number
-      isFirst <- (rowNo %% 2 == 1 && sum(optionsList$allTests) %in% 1:2)
-      row[["v1"]]  <- ifelse(isFirst, p1, "")
-      row[["sep"]] <- ifelse(isFirst, "-", "")
-      row[["v2"]]  <- ifelse(isFirst, p2, "")
-      
-      if (!isFirst)
-        row[["test"]] <- "Wilcoxon"
-        ##jaspResults[["ttest"]][["data"]][[rowNo - 1]][["test"]] <- "Student"
-        #ttest.rows[[rowNo - 1]][["test"]] <- "Student"
-      #}
-      if(test == 1)
-        row[["test"]] <- "Student"
-      
       jaspResults[["ttest"]]$addRows(row)
-      #ttest.rows[[rowNo]] <- row
-      rowNo <- rowNo + 1
     }
   }
   
@@ -329,7 +323,6 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
 
 .ttestPairedNormalFill <- function(container, dataset, options, ready) {
   pairs <- options$pairs
-  rowNo <- 1
   if (!ready)
     pairs[[1]] <- list(".", ".")
   for (pair in pairs) {
@@ -358,9 +351,8 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
       row <- list(v1 = p1, sep = "-", v2 = p2, W = W,    p = p)
     } else 
       row <- list(v1 = p1, sep = "-", v2 = p2, W = ".",  p = ".")
-    row[[".isNewGroup"]] <- rowNo == 1
+
     container[["ttestNormalTable"]]$addRows(row)
-    rowNo <- rowNo + 1
   }
 }
 
@@ -393,7 +385,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   
   if(length(desc.vars) == 0)
     return()
-  rowNo <- 1
+
   for (var in desc.vars) {
     row <- list(v = var)
     
@@ -411,7 +403,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     row[["mean"]] <- m
     row[["sd"]]   <- std
     row[["se"]]   <- se
-    rowNo <- rowNo + 1
+
     container[["table"]]$addRows(row)
   }
 }

--- a/JASP-Engine/JASP/R/ttestpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestpairedsamples.R
@@ -50,7 +50,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   ttest$position <- 1
   
   ttest$addColumnInfo(name = "v1", type = "string", title = "")
-  ttest$addColumnInfo(name = "sep",  type = "string", title = "")
+  ttest$addColumnInfo(name = "sep",  type = "separator", title = "")
   ttest$addColumnInfo(name = "v2", type = "string", title = "")
   if (optionsList$wantsWilcox && optionsList$onlyTest) {
     ttest$addFootnote(gettext("Wilcoxon signed-rank test."))
@@ -148,7 +148,7 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   
   
   ttestNormalTable$addColumnInfo(name = "v1",  type = "string", title = "")
-  ttestNormalTable$addColumnInfo(name = "sep", type = "string", title = "")
+  ttestNormalTable$addColumnInfo(name = "sep", type = "separator", title = "")
   ttestNormalTable$addColumnInfo(name = "v2",  type = "string", title = "")
   ttestNormalTable$addColumnInfo(name = "W",   type = "number", title = gettext("W"))
   ttestNormalTable$addColumnInfo(name = "p",   type = "pvalue", title = gettext("p"))

--- a/JASP-R-Interface/jaspResults/DESCRIPTION
+++ b/JASP-R-Interface/jaspResults/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspResults
 Type: Package
 Title: Easy results for your JASP analysis
-Version: 1.12
+Version: 1.13
 Date: 2018-12-07
 Author: Joris Goosen
 Maintainer: Joris Goosen <j.c.goosen@uva.nl>

--- a/JASP-R-Interface/jaspResults/R/zzzWrappers.R
+++ b/JASP-R-Interface/jaspResults/R/zzzWrappers.R
@@ -546,9 +546,10 @@ jaspTableR <- R6Class(
 
     addColumnInfo = function(name = NULL, title = NULL, overtitle = NULL, type = NULL, format = NULL, combine = NULL) {
 			if (!is.null(type)) {
-				permittedTypes <- c("integer", "number", "pvalue", "string")
+				permittedTypes <- c("integer", "number", "pvalue", "string", "separator")
 				if (!type %in% permittedTypes)
 					stop("type must be ", paste0("`", permittedTypes, "`", collapse=", "), " (provided type: `", type, "`)")
+
 				if (is.null(format) && type == "number")
 					format <- "sf:4;dp:3"
 				else if (type == "pvalue")

--- a/JASP-Tests/R/tests/testthat/test-correlationbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-correlationbayesian.R
@@ -16,13 +16,13 @@ test_that("Bayesian Correlation Table results match", {
   results <- jasptools::run("CorrelationBayesian", "test.csv", options)
   table <- results[["results"]][["corBayesTable"]][["data"]]
   expect_equal_tables(table,
-                      list("TRUE", "<unicode>", "Pearson's r", "contcor1", "FALSE", "<unicode>",
+                      list("TRUE", "<unicode>", "Pearson's r", "1. contcor1", "FALSE", "<unicode>",
                            "BF<unicode><unicode>", "", "FALSE", "<unicode>", "Upper 95% CI",
                            "", "FALSE", "<unicode>", "Lower 95% CI", "", "FALSE", "<unicode>",
                            "Kendall's tau", "", "FALSE", "<unicode>", "BF<unicode><unicode>",
                            "", "FALSE", "<unicode>", "Upper 95% CI", "", "FALSE", "<unicode>",
                            "Lower 95% CI", "", 1, "TRUE", 0.657010063712354, "<unicode>",
-                           "Pearson's r", "contcor2", "FALSE", 71191291327.7135, "<unicode>",
+                           "Pearson's r", "2. contcor2", "FALSE", 71191291327.7135, "<unicode>",
                            "BF<unicode><unicode>", "", "FALSE", 0.753487301516098, "<unicode>",
                            "Upper 95% CI", "", "FALSE", 0.524567068817432, "<unicode>",
                            "Lower 95% CI", "", 1, "FALSE", 0.503030303030303, "<unicode>",

--- a/JASP-Tests/R/tests/testthat/test-ttestpairedsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestpairedsamples.R
@@ -4,7 +4,7 @@ context("Paired Samples TTest")
 # - missing values exclusion
 # - error handling of plots
 
-test_that("Main table results match", {
+test_that("Main table results match for one pair * multiple tests", {
   options <- jasptools::analysisOptions("TTestPairedSamples")
   options$pairs <- list(c("contNormal", "contGamma"))
   options$wilcoxonSignedRank <- TRUE
@@ -24,6 +24,18 @@ test_that("Main table results match", {
   )
 })
 
+test_that("Main table results match for multiple pairs * one test", {
+  options <- jasptools::analysisOptions("TTestPairedSamples")
+  options$pairs <- list(c("contNormal", "contGamma"), c("contNormal", "contcor1"))
+  results <- jasptools::run("TTestPairedSamples", "test.csv", options)
+  table <- results[["results"]][["ttest"]][["data"]]
+  expect_equal_tables(table,
+                      list(99, 3.4809614504484e-20, "-", -11.6121720596087, "contNormal",
+                           "contGamma", 99, 0.0750733655901379, "-", -1.79895113042557,
+                           "contNormal", "contcor1")
+  )
+})
+
 test_that("Normality table matches", {
   options <- jasptools::analysisOptions("TTestPairedSamples")
   options$pairs <- list(c("contNormal", "contGamma"))
@@ -31,8 +43,7 @@ test_that("Normality table matches", {
   results <- jasptools::run("TTestPairedSamples", "test.csv", options)
   table <- results[["results"]][["AssumptionChecks"]][["collection"]][["AssumptionChecks_ttestNormalTable"]][["data"]]
   expect_equal_tables(table,
-    list("contNormal", "-", "contGamma", 0.969542808533914, 0.0203952735337306,
-         "TRUE")
+                      list(0.969542808533914, 0.0203952735337306, "-", "contNormal", "contGamma")
   )
 })
 


### PR DESCRIPTION
1. Transposed tables look a little nicer:

before
<img width="385" alt="Screenshot 2020-01-23 at 10 32 08" src="https://user-images.githubusercontent.com/18737241/72972417-b571a200-3dcb-11ea-8837-ef0431be7722.png">
after
<img width="421" alt="Screenshot 2020-01-23 at 10 27 28" src="https://user-images.githubusercontent.com/18737241/72972410-b276b180-3dcb-11ea-9748-a2f6c550d6e9.png">

2. The progressbar container is always included in the DOM to ensure results don't shift when a progressbar is added (regression)

3. If an analysis wide error occurs the results show this visually by greying out (regression)
before <-> after
<img width="1077" alt="Screenshot 2020-01-23 at 10 38 27" src="https://user-images.githubusercontent.com/18737241/72972893-860f6500-3dcc-11ea-8bf2-ef3609e7d8b6.png">

4. The separator in all analyses that showed variable pairs was very misaligned (regression; fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/586):

5. Paired samples ttest table now shows all variable pairs (regression; fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/668, https://github.com/jasp-stats/jasp-issues/issues/594)

6. Bayesian Correlation and frequentist correlation tables are more similar now