### PR TITLE
Two strings in Robustness plots can now be modified

### DIFF
--- a/JASP-Engine/JASPgraphs/DESCRIPTION
+++ b/JASP-Engine/JASPgraphs/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: JASPgraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.4.6
+Version: 0.4.7
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: ...

--- a/JASP-Engine/JASPgraphs/inst/examples/ex-PlotRobustnessSequential.R
+++ b/JASP-Engine/JASPgraphs/inst/examples/ex-PlotRobustnessSequential.R
@@ -88,3 +88,25 @@ PlotRobustnessSequential(
   xName        = expression(paste("Prior width ", kappa)), 
   dfPoints     = dfPoints
 )
+
+# convenience function for showing plots side by side. You may need to click zoom in Rstudio
+# to properly view the plots.
+showSideBySide <- function(..., nrow = 1L, ncol = ...length()) {
+  require(gridExtra)
+  jaspgraphplot2grob <- function(x) {
+    if (!inherits(x, "JASPgraphsPlot")) return(x)
+    else return(x$plotFunction(x$subplots, args = x$plotArgs, grob = TRUE))
+  }
+  gridExtra::grid.arrange(gridExtra::arrangeGrob(grobs = lapply(list(...), jaspgraphplot2grob),  nrow = nrow, ncol = ncol))
+}
+
+# arrow labels can be modified
+g1 <- PlotRobustnessSequential(dfLines = dfLines, arrowLabel = c("top", "bottom"))
+g2 <- PlotRobustnessSequential(dfLines = dfLines, arrowLabel = JASPgraphs::parseThis(c("alpha", "beta")))
+showSideBySide(g1, g2)
+
+# text in the top right (evidence text) can be modified
+g1 <- PlotRobustnessSequential(dfLines = dfLines, BF = 1)
+g2 <- PlotRobustnessSequential(dfLines = dfLines, BF = 1, evidenceTxt = c("I'm above!", "I'm below!"))
+g3 <- PlotRobustnessSequential(dfLines = dfLines, BF = 1, evidenceTxt = JASPgraphs::parseThis(c("alpha", "omega")))
+showSideBySide(g1, g2, g3)

--- a/JASP-Engine/JASPgraphs/man/PlotRobustnessSequential.Rd
+++ b/JASP-Engine/JASPgraphs/man/PlotRobustnessSequential.Rd
@@ -30,6 +30,8 @@ PlotRobustnessSequential(
   pointFill = c("grey", "black", "white"),
   pointColor = rep("black", 3),
   pointSize = c(3, 2, 2),
+  evidenceTxt = NULL,
+  arrowLabel = NULL,
   ...
 )
 }
@@ -84,6 +86,10 @@ Ignored if \code{!is.null(dfLines$g) && linesLegend}.}
 \item{pointColor}{String, if \code{plotLineOrPoint == "point"} then this controls the color aesthetic.}
 
 \item{pointSize}{String, if \code{plotLineOrPoint == "point"} then this controls the size aesthetic.}
+
+\item{evidenceTxt}{String to display evidence level in the topright of the plot. If NULL then a default is used.}
+
+\item{arrowLabel}{String to display text next to arrows inside the plot. If NULL then a default is used.}
 
 \item{...}{Unused.}
 }
@@ -181,4 +187,26 @@ PlotRobustnessSequential(
   xName        = expression(paste("Prior width ", kappa)), 
   dfPoints     = dfPoints
 )
+
+# convenience function for showing plots side by side. You may need to click zoom in Rstudio
+# to properly view the plots.
+showSideBySide <- function(..., nrow = 1L, ncol = ...length()) {
+  require(gridExtra)
+  jaspgraphplot2grob <- function(x) {
+    if (!inherits(x, "JASPgraphsPlot")) return(x)
+    else return(x$plotFunction(x$subplots, args = x$plotArgs, grob = TRUE))
+  }
+  gridExtra::grid.arrange(gridExtra::arrangeGrob(grobs = lapply(list(...), jaspgraphplot2grob),  nrow = nrow, ncol = ncol))
+}
+
+# arrow labels can be modified
+g1 <- PlotRobustnessSequential(dfLines = dfLines, arrowLabel = c("top", "bottom"))
+g2 <- PlotRobustnessSequential(dfLines = dfLines, arrowLabel = JASPgraphs::parseThis(c("alpha", "beta")))
+showSideBySide(g1, g2)
+
+# text in the top right (evidence text) can be modified
+g1 <- PlotRobustnessSequential(dfLines = dfLines, BF = 1)
+g2 <- PlotRobustnessSequential(dfLines = dfLines, BF = 1, evidenceTxt = c("I'm above!", "I'm below!"))
+g3 <- PlotRobustnessSequential(dfLines = dfLines, BF = 1, evidenceTxt = JASPgraphs::parseThis(c("alpha", "omega")))
+showSideBySide(g1, g2, g3)
 }

--- a/JASP-Tests/R/tests/figs/jasp-deps.txt
+++ b/JASP-Tests/R/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- JASPgraphs: 0.4.6
+- JASPgraphs: 0.4.7


### PR DESCRIPTION
Per the request of @Jillderon. This PR allows for:

![image](https://user-images.githubusercontent.com/21319932/73064890-8417d580-3ea2-11ea-87a4-fffc1545e10a.png)

(top and bottom text can now be modified)
and

![image](https://user-images.githubusercontent.com/21319932/73064912-8e39d400-3ea2-11ea-9d29-759a0071044b.png)

(evidence text in the top right corner can be modified)

Please merge this after #3762 (that PR and this one will cause a merge conflict and I prefer to fix this PR rather than that one).

@Jillderon please let me know if this is what you had in mind!
