### PR TITLE
Users cannot select a different executable manually on flatpak

### DIFF
--- a/JASP-Desktop/components/JASP/Theme/DarkTheme.qml
+++ b/JASP-Desktop/components/JASP/Theme/DarkTheme.qml
@@ -41,7 +41,7 @@ Theme
 	controlWarningBackgroundColor:		"#620"
 	controlWarningTextColor:			"#B80"
 
-	textDisabled:						gray
+	textDisabled:						grayLighter
 	buttonColorDisabled:				gray
 	buttonBorderColorHovered:			black
 }

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -46,27 +46,43 @@ Item
 
 			Item //Use default spreadsheet editor
 			{
-				height:	useDefaultEditor.height + (editCustomEditor.visible ? editCustomEditor.height : 0)
-				width:	parent.width - jaspTheme.generalAnchorMargin
+
+				height:		useDefaultEditor.height + (editCustomEditor.visible ? editCustomEditor.height : linuxInfo.visible ? linuxInfo.height : 0)
+				width:		parent.width - jaspTheme.generalAnchorMargin
 
 				CheckBox
 				{
 					id:					useDefaultEditor
 					label:				qsTr("Use default spreadsheet editor")
-					checked:			preferencesModel.useDefaultEditor
+					checked:			LINUX || preferencesModel.useDefaultEditor
 					onCheckedChanged:	preferencesModel.useDefaultEditor = checked
 					KeyNavigation.down:	browseEditorButton
 					KeyNavigation.tab:	browseEditorButton
+					enabled:			!LINUX
+				}
+
+				Label
+				{
+					id:					linuxInfo
+					text:				"<i>On linux the default spreadsheet editor is always used.</i>"
+					visible:			LINUX
+					textFormat:			Text.StyledText
+
+					anchors
+					{
+						top:			useDefaultEditor.bottom
+						left:			useDefaultEditor.left
+						leftMargin:		jaspTheme.subOptionOffset
+					}
 				}
 
 				Item
 				{
 					id:					editCustomEditor
-					visible:			!preferencesModel.useDefaultEditor
+					visible:			!LINUX && !preferencesModel.useDefaultEditor
 					width:				parent.width
 					height:				browseEditorButton.height
 					anchors.top:		useDefaultEditor.bottom
-
 
 					RectangularButton
 					{
@@ -118,7 +134,6 @@ Item
 								target:					preferencesModel
 								onCustomEditorChanged:	customEditorText.text = preferencesModel.customEditor
 							}
-
 						}
 					}
 				}

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -384,8 +384,9 @@ void MainWindow::loadQML()
 	_qml->rootContext()->setContextProperty("columnTypeNominal",		int(columnType::nominal)		);
 	_qml->rootContext()->setContextProperty("columnTypeNominalText",	int(columnType::nominalText)	);
 
-	bool	debug = false,
-			isMac = false;
+	bool	debug	= false,
+			isMac	= false,
+			isLinux = false;
 
 #ifdef JASP_DEBUG
 	debug = true;
@@ -395,8 +396,16 @@ void MainWindow::loadQML()
 	isMac = true;
 #endif
 
+#ifdef __linux__
+	isLinux = true;
+#endif
+
+	bool isWindows = !isMac && !isLinux;
+
 	_qml->rootContext()->setContextProperty("DEBUG_MODE",			debug);
 	_qml->rootContext()->setContextProperty("MACOS",				isMac);
+	_qml->rootContext()->setContextProperty("LINUX",				isLinux);
+	_qml->rootContext()->setContextProperty("WINDOWS",				isWindows);
 	_qml->rootContext()->setContextProperty("iconFiles",			_iconFiles);
 	_qml->rootContext()->setContextProperty("iconInactiveFiles",	_iconInactiveFiles);
 	_qml->rootContext()->setContextProperty("iconDisabledFiles",	_iconDisabledFiles);
@@ -1400,6 +1409,10 @@ void MainWindow::startDataEditor(QString path)
 {
 	QFileInfo fileInfo(path);
 
+#ifdef __linux__
+	//Linux means flatpak, which doesn't support launching a random binary
+#else
+
 	bool useDefaultSpreadsheetEditor = Settings::value(Settings::USE_DEFAULT_SPREADSHEET_EDITOR).toBool();
 	QString appname = Settings::value(Settings::SPREADSHEET_EDITOR_NAME).toString();
 
@@ -1425,6 +1438,7 @@ void MainWindow::startDataEditor(QString path)
 			MessageForwarder::showWarning("Start Editor", "Unable to start the editor : " + appname + ". Please check your editor settings in the preference menu.");
 	}
 	else
+#endif
 		if (!QDesktopServices::openUrl(QUrl("file:///" + path, QUrl::TolerantMode)))
 			MessageForwarder::showWarning("Start Spreadsheet Editor", "No default spreadsheet editor for file " + fileInfo.completeBaseName() + ". Use Preferences to set the right editor.");
 


### PR DESCRIPTION
Related to https://github.com/jasp-stats/jasp-issues/issues/591

Problem here is that flatpak sandboxes the application so that we aren't allowed to start a random executable. The only way to open a file properly is through a file portal, so we let flatpak + linux handle all that stuff.

