### PR TITLE
Fixes some problems loading older <0.8.3.1 jasp-files

### DIFF
--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -67,15 +67,15 @@ Analysis* Analyses::createFromJaspFileEntry(Json::Value analysisData, RibbonMode
 		Json::Value	&	versionJson		= analysisData["version"];
 		Version			version			= versionJson.isNull() ? AppInfo::version : Version(versionJson.asString());
 
-		QString			name				= QString::fromStdString(analysisData["name"].asString()),
-						module				= analysisData["module"].asString() != "" ? QString::fromStdString(analysisData["module"].asString()) : "Common",
-						title				= QString::fromStdString(analysisData.get("title", "").asString()),
-						qml					= QString::fromStdString(analysisData.get("title", name.toStdString()).asString());
-
+		QString			name			= tq(analysisData["name"].asString()),
+						module			= analysisData["module"].asString() != "" ? tq(analysisData["module"].asString()) : "Common",
+						title			= tq(analysisData.get("title", "").asString());
 		auto		*	analysisEntry	= ribbonModel->getAnalysis(module.toStdString(), name.toStdString());
+		QString			qml				= analysisEntry ? tq(analysisEntry->qml()) : name + ".qml";
+
 
 		if(title == "")
-			title = analysisEntry ? QString::fromStdString(analysisEntry->title()) : name;
+			title = analysisEntry ? tq(analysisEntry->title()) : name;
 		
 		analysis = create(module, name, qml, title, id, version, &optionsJson, status, false);
 
@@ -169,7 +169,7 @@ void Analyses::bindAnalysisHandler(Analysis* analysis)
 	
 	if (Settings::value(Settings::DEVELOPER_MODE).toBool())
 	{
-		QString filePath = QString::fromStdString(analysis->qmlFormPath());
+		QString filePath = tq(analysis->qmlFormPath());
 		
 		if (filePath.startsWith("file:"))
 			filePath.remove(0,5);
@@ -226,10 +226,10 @@ void Analyses::reload(Analysis *analysis, bool logProblem)
 }
 
 
-bool Analyses::allCreatedInCurrentVersion() const
+bool Analyses::allFresh() const
 {
 	for (auto idAnalysis : _analysisMap)
-		if (idAnalysis.second->version() != AppInfo::version)
+		if (idAnalysis.second->needsRefresh())
 			return false;
 
 	return true;
@@ -443,10 +443,10 @@ QVariant Analyses::data(const QModelIndex &index, int role)	const
 
 	switch(role)
 	{
-	case formPathRole:		return QString::fromStdString(analysis->qmlFormPath());
+	case formPathRole:		return tq(analysis->qmlFormPath());
 	case Qt::DisplayRole:
-	case titleRole:			return QString::fromStdString(analysis->title());
-	case nameRole:			return QString::fromStdString(analysis->name());
+	case titleRole:			return tq(analysis->title());
+	case nameRole:			return tq(analysis->name());
 	case analysisRole:		return QVariant::fromValue(analysis);
 	case idRole:			return int(analysis->id());
 	default:				return QVariant();

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -68,7 +68,7 @@ public:
 	void		clear();
 	void		reload(Analysis* analysis, bool logProblem);
 	
-	bool		allCreatedInCurrentVersion() const;
+	bool		allFresh() const;
 
 	void		setAnalysesUserData(Json::Value userData);
 	void		refreshAnalysesUsingColumns(std::vector<std::string> changedColumns,	 std::vector<std::string> missingColumns,	 std::map<std::string, std::string> changeNameColumns,	 std::vector<std::string> oldColumnNames, bool hasNewColumns = false);

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -158,6 +158,8 @@ void Analysis::setResults(const Json::Value & results, const Json::Value & progr
 	emit resultsChangedSignal(this);
 
 	processResultsForDependenciesToBeShown();
+
+	_wasUpgraded = false;
 }
 
 void Analysis::imageSaved(const Json::Value & results)
@@ -645,4 +647,9 @@ std::string Analysis::upgradeMsgsForOption(const std::string & name) const
 		out << (i > 0 ? "\n" : "") << msg[i];
 
 	return out.str();
+}
+
+bool Analysis::needsRefresh() const
+{
+	return version() != AppInfo::version || _wasUpgraded;
 }

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -67,8 +67,9 @@ public:
 	Q_INVOKABLE	QString	fullHelpPath(QString helpFileName);
 	Q_INVOKABLE void	duplicateMe();
 
-	bool isWaitingForModule()	{ return _moduleData == nullptr ? false : !_moduleData->dynamicModule()->readyForUse(); }
-	bool isDynamicModule()		{ return _moduleData == nullptr ? false : _moduleData->dynamicModule() != nullptr; }
+	bool needsRefresh()			const;
+	bool isWaitingForModule()	const { return _moduleData == nullptr ? false : !_moduleData->dynamicModule()->readyForUse(); }
+	bool isDynamicModule()		const { return _moduleData == nullptr ? false : _moduleData->dynamicModule() != nullptr; }
 	void setResults(	const Json::Value & results, const Json::Value & progress = Json::nullValue);
 	void imageSaved(	const Json::Value & results);
 	void saveImage(		const Json::Value & options);
@@ -146,7 +147,7 @@ public:
 	void					replaceVariableName(std::string oldName, std::string newName)	{ _options->replaceVariableName(oldName, newName);	}
 	void					runScriptRequestDone(const QString& result, const QString& controlName);
 
-	void					setUpgradeMsgs(const Modules::UpgradeMsgs & msgs) { _msgs = msgs; }
+	void					setUpgradeMsgs(const Modules::UpgradeMsgs & msgs) { _msgs = msgs; _wasUpgraded = true; }
 	std::string				upgradeMsgsForOption(const std::string & name) const;
 
 
@@ -221,7 +222,8 @@ private:
 							_rfile,
 							_showDepsName	= "";
 	bool					_useJaspResults = false,
-							_isDuplicate	= false;
+							_isDuplicate	= false,
+							_wasUpgraded	= false;
 	Version					_version;
 	int						_revision		= 0;
 

--- a/JASP-Desktop/html/css/darkTheme-jasp.css
+++ b/JASP-Desktop/html/css/darkTheme-jasp.css
@@ -8,16 +8,13 @@ body {
         margin:           0;
         cursor:           default;
         color:            #EEE;
-        background-color: #444 ; /*grayLighter*/
+        background-color: #222 ; /*grayLighter*/
         font-size:        12px;
-}
-
-body.selected {
-        background-color: #212121 ; /*grayMuchLighter*/
 }
 
 body.selected .jasp-analysis:not(.selected){
     filter: opacity(0.5);
+    background-color: #333 ;
 }
 
 h1, .h1-toolbar .jasp-menu {

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -658,7 +658,7 @@ void MainWindow::plotPPIChangedHandler(int, bool wasUserAction)
 
 void MainWindow::refreshPlotsHandler(bool askUserForRefresh)
 {
-	if (_analyses->allCreatedInCurrentVersion())
+	if (_analyses->allFresh())
 		_engineSync->refreshAllPlots();
 	else if (askUserForRefresh && MessageForwarder::showYesNo("Version incompatibility", "Your analyses were created in an older version of JASP, to change the PPI of the images they must be refreshed first.\n\nRefresh all analyses?"))
 		_analyses->refreshAllAnalyses();
@@ -693,7 +693,7 @@ void MainWindow::analysisSaveImageHandler(int id, QString options)
 	if (analysis == nullptr)
 		return;
 
-	if (analysis->version() != AppInfo::version)
+	if (analysis->needsRefresh())
 	{
 		if(MessageForwarder::showYesNo("Version incompatibility", "This analysis was created in an older version of JASP, to save the image it must be refreshed first.\n\nRefresh the analysis?"))
 			analysis->refresh();
@@ -765,7 +765,7 @@ void MainWindow::analysisEditImageHandler(int id, QString options)
     if (analysis == nullptr)
         return;
 
-	if (analysis->version() != AppInfo::version)
+	if (analysis->needsRefresh())
 	{
 		if (MessageForwarder::showYesNo("Version incompatibility", "This analysis was created in an older version of JASP, to resize the image it must be refreshed first.\n\nRefresh the analysis?"))
 			analysis->refresh();

--- a/JASP-Desktop/modules/upgrader/upgradechange.h
+++ b/JASP-Desktop/modules/upgrader/upgradechange.h
@@ -13,6 +13,8 @@ typedef std::map<std::string, std::vector<std::string>> UpgradeMsgs; //option na
 DECLARE_ENUM(BoolOpType, AND, OR, NOT, XOR);
 DECLARE_ENUM(ModifyType, Flatten); //Looks silly now but maybe we will have more then one possibility later ;)
 
+extern const char * logId;
+
 struct BoolOp
 {
 	BoolOp() : _noOp(true) {}
@@ -21,6 +23,8 @@ struct BoolOp
 	static bool optionContainsConditional(const Json::Value & conditional, const Json::Value & options);
 
 	bool apply(const Json::Value & options) const;
+
+	std::string toString() const;
 
 private:
 	BoolOpType					_type;
@@ -47,9 +51,9 @@ private:
 	void applyRename(	Json::Value & options, const std::string & oldName, const std::string & newName,	UpgradeMsgs & msgs)	const;
 	void applyCopy(		Json::Value & options, const std::string & oldName, const std::string & newName,	UpgradeMsgs & msgs)	const;
 	void applyRemove(	Json::Value & options, const std::string & name,									UpgradeMsgs & msgs)	const;
-	void applySetValue(	Json::Value & options, const std::string & name,	const Json::Value & newValue)						const;
-	void applySetBool(	Json::Value & options, const std::string & name,	const BoolOp	  & newBool)						const;
-	void applyModifier(	Json::Value & options, const std::string & name,	const ModifyType	modifier)						const;
+	void applySetValue(	Json::Value & options, const std::string & name,	const Json::Value & newValue,	UpgradeMsgs & msgs) const;
+	void applySetBool(	Json::Value & options, const std::string & name,	const BoolOp	  & newBool ,	UpgradeMsgs & msgs) const;
+	void applyModifier(	Json::Value & options, const std::string & name,	const ModifyType	modifier,	UpgradeMsgs & msgs) const;
 
 	BoolOp								_conditional;
 	std::map<std::string, std::string>	_optionMsgs,

--- a/JASP-Desktop/modules/upgrader/upgrades.json
+++ b/JASP-Desktop/modules/upgrader/upgrades.json
@@ -157,6 +157,21 @@
 	},
 
 	{
+		"from": { "module": "Common",		"version": "0.8.2", 	"function": "CorrelationBayesianPairs"	},
+		"to":	{ "module": "Common",		"version": "0.8.3.1"											},
+
+		"options":	
+		[
+			{
+				"changes":
+				{ 
+					"plotBayesFactorRobustnessAdditionalInfo":	true
+				}
+			}
+		]
+	},
+
+	{
 		"msg": 	"For version 0.12 we merged Bayesian Correlation Pairs into Bayesian Correlation Matrix, all options are migrated and the values kept.",
 		"from": { "module": "Regression",		"version": "0.11.1", 	"function": "CorrelationBayesianPairs"	},
 		"to":	{ "module": "Regression",		"version": "0.12", 		"function": "CorrelationBayesian"		},
@@ -181,7 +196,9 @@
 				"plotBfRobustness":			{ "_renamed": "plotBayesFactorRobustness" },
 				"plotBfRobustnessAddInfo":	{ "_renamed": "plotBayesFactorRobustnessAdditionalInfo" },
 				"plotBfSequential":			{ "_renamed": "plotSequentialAnalysis" },
-				"plotBfSequentialAddInfo":	{ "_renamed": "plotSequentialAnalysisRobustness" }
+				"plotBfSequentialAddInfo":	{ "_renamed": "plotSequentialAnalysisRobustness" },
+				"displayPairwise":			true,
+				"reportBayesFactors":		true
 			}
 		},
 		{

--- a/JASP-Desktop/modules/upgrader/version.cpp
+++ b/JASP-Desktop/modules/upgrader/version.cpp
@@ -14,7 +14,7 @@ const char * Version::encodingError::what() const noexcept
 
 Version::Version(std::string version)
 {
-	const static std::regex parseIt("(\\d+)(\\.(\\d+))?(\\.(\\d+))?"); //(sub)groups: 1 3 5 //0 is whole match/line
+	const static std::regex parseIt("(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\.(\\d+))?"); //(sub)groups: 1 3 5 7//0 is whole match/line
 
 	std::smatch found;
 	if(!std::regex_match(version, found, parseIt))
@@ -22,7 +22,8 @@ Version::Version(std::string version)
 
 	std::string majorStr	= found[1],
 				minorStr	= found[3],
-				releaseStr	= found[5];
+				releaseStr	= found[5],
+				fourthStr	= found[7];
 
 
 	try
@@ -30,16 +31,22 @@ Version::Version(std::string version)
 		if(majorStr		!= "")	_major		= std::stoul(majorStr);
 		if(minorStr		!= "")	_minor		= std::stoul(minorStr);
 		if(releaseStr	!= "")	_release	= std::stoul(releaseStr);
+		if(fourthStr	!= "")	_fourth		= std::stoul(fourthStr);
 	}
 	catch(...) { throw encodingError(version); }
 }
 
 std::string Version::toString() const
 {
+	bool	addFourth	=				_fourth  > 0,
+			addRelease	= addFourth  || _release > 0,
+			addMinor	= addRelease || _minor   > 0;
+
 	std::stringstream out;
-										out			<< std::to_string(_major);
-	if(_release > 0 || _minor > 0)		out << "."	<< std::to_string(_minor);
-	if(_release > 0)					out << "."	<< std::to_string(_release);
+						out			<< std::to_string(_major);
+	if(addMinor)		out << "."	<< std::to_string(_minor);
+	if(addRelease)		out << "."	<< std::to_string(_release);
+	if(addFourth)		out << "."	<< std::to_string(_fourth);
 
 	return out.str();
 }
@@ -49,6 +56,7 @@ void Version::swap(Version &other)
 	std::swap(_major,	other._major	);
 	std::swap(_minor,	other._minor	);
 	std::swap(_release, other._release	);
+	std::swap(_fourth,  other._fourth	);
 }
 
 Version & Version::operator = (const Version & other)
@@ -56,6 +64,7 @@ Version & Version::operator = (const Version & other)
 	_major		= other._major;
 	_minor		= other._minor;
 	_release	= other._release;
+	_fourth		= other._fourth;
 
 	return *this;
 }
@@ -67,18 +76,21 @@ bool	Version::operator >		(const Version & other) const { return operator!=(othe
 
 bool Version::operator !=	(const Version & other) const
 {
-	return _major != other._major || _minor != other._minor || _release != other._release;
+	return _major != other._major || _minor != other._minor || _release != other._release || _fourth != other._fourth;
 }
 
 bool Version::operator <	(const Version & other) const
 {
-	if(_major <	other._major)	return true;
-	if(_major >	other._major)	return false;
+	if(_major	< other._major)		return true;
+	if(_major	> other._major)		return false;
 
-	if(_minor < other._minor)	return true;
-	if(_minor > other._minor)	return false;
+	if(_minor	< other._minor)		return true;
+	if(_minor	> other._minor)		return false;
 
-	if(_release < other._release) return true;
+	if(_release < other._release)	return true;
+	if(_release > other._release)	return false;
+
+	if(_fourth	< other._fourth)	return true;
 
 	return false;
 }

--- a/JASP-Desktop/modules/upgrader/version.h
+++ b/JASP-Desktop/modules/upgrader/version.h
@@ -18,13 +18,14 @@ public:
 	};
 
 	Version(std::string version);
-	Version(unsigned int major = 0, unsigned int minor = 0, unsigned release = 0) : _major(major), _minor(minor), _release(release) {}
+	Version(unsigned int major = 0, unsigned int minor = 0, unsigned int release = 0, unsigned int fourth = 0) : _major(major), _minor(minor), _release(release), _fourth(fourth) {}
 
 	std::string toString() const;
 
 	unsigned int major()	const { return _major; }
 	unsigned int minor()	const { return _minor; }
 	unsigned int release()	const { return _release; }
+	unsigned int fourth()	const { return _fourth; }
 
 	void		swap(Version &other );
 
@@ -40,7 +41,8 @@ public:
 private:
 	unsigned int	_major		= 0,
 					_minor		= 0,
-					_release	= 0;
+					_release	= 0,
+					_fourth		= 0; //This is just here to be able to parse older files...
 };
 }
 

--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -259,14 +259,14 @@ Descriptives <- function(jaspResults, dataset, options) {
     tempPercentNames <- 1/equalGroupsNo * 1:(equalGroupsNo-1) * 100
     
     for (i in seq_along(tempPercentNames)) 
-      stats$addColumnInfo(name=paste("eg", i, sep=""), title=gettextf("%dth percentile", round(tempPercentNames[i], 2)), type="number")
+      stats$addColumnInfo(name=paste("eg", i, sep=""), title=gettextf("%gth percentile", round(tempPercentNames[i], 2)), type="number")
     
   }
 
   if (options$percentileValuesPercentiles) {
     
     for (i in percentilesPercentiles) 
-      stats$addColumnInfo(name=paste("pc", i, sep=""), title=gettextf("%dth percentile", i), type="number")
+      stats$addColumnInfo(name=paste("pc", i, sep=""), title=gettextf("%gth percentile", i), type="number")
     
   }
   

--- a/Tools/flatpak/gather-r-package-info.R
+++ b/Tools/flatpak/gather-r-package-info.R
@@ -137,6 +137,7 @@ giveOrderedDependencies <- function()
 specials <- new.env(hash = TRUE, parent = parent.frame())
 specials[['abtest']]       <- list(type='github', commit='503c50e96768a0134b755747e0421d820cc1a115', repo='quentingronau/abtest')
 specials[['BAS']]          <- list(type='github', commit='daba70f5a5d60bfa63386d4e6a6522f86a04946c', repo='merliseclyde/BAS')
+specials[['bstats']]       <- list(type='github', commit='a6fdbea42078b8d275a98dd1e37c113118555b6f', repo='AlexanderLyNL/bstats')
 #specials[['Bain']]         <- list(type='github', commit='1b03f71204839da29a4219e8bba99b8ec8479612', repo='jasp-stats/BAIN-for-JASP')
 #specials[['KneeArrower']]  <- list(type='github', commit='cdb14e574e00914e4e7019a4cf3c5fcda7426466', repo='agentlans/KneeArrower')
 


### PR DESCRIPTION
- Fixed a gettext in descriptives
- made the background in results in darkTheme a bit darker
- Should fix most of the points mentioned under: https://github.com/jasp-stats/INTERNAL-jasp/issues/675
- added bstats package of Ly to flatpak as a special
- more elaborate logging on what is going on during upgrade process

