### PR TITLE
ReadStatImporter changes

### DIFF
--- a/JASP-Desktop/data/importers/readstat/readstatimportcolumn.h
+++ b/JASP-Desktop/data/importers/readstat/readstatimportcolumn.h
@@ -22,7 +22,9 @@ public:
 	void						addValue(const double			& val);
 	void						addValue(const int				& val);
 	void						addValue(const std::string		& val);
+
 	void						addLabel(const int				& val,	const std::string & label);
+	void						addLabel(const double			& val,	const std::string & label);
 	void						addLabel(const std::string		& val,	const std::string & label);
 
 	bool						isMissingValue(double d)		const { return isnan(d);				}
@@ -46,6 +48,8 @@ public:
 
 	const std::map<int,std::string>			&	intLabels()		const { return _intLabels; }
 	const std::map<std::string,std::string>	&	strLabels()		const { return _strLabels; }
+
+	void						tryNominalMinusText();
 
 private:
 	std::string					_labelsID;

--- a/JASP-Desktop/data/importers/readstatimporter.cpp
+++ b/JASP-Desktop/data/importers/readstatimporter.cpp
@@ -111,6 +111,8 @@ void ReadStatImporter::initColumn(QVariant colId, ImportColumn * importColumn)
 {
 	ReadStatImportColumn * col = static_cast<ReadStatImportColumn*>(importColumn);
 
+	col->tryNominalMinusText(); //If we converted some doubles to strings as value because spss has weird datatypes then maybe they are ints anyway. so try to convert it back to nominal in that case.
+
 	switch(col->getColumnType())
 	{
 	case columnType::scale:
@@ -120,7 +122,7 @@ void ReadStatImporter::initColumn(QVariant colId, ImportColumn * importColumn)
 	case columnType::ordinal:
 	case columnType::nominal:
 		if(col->hasLabels())	DataSetPackage::pkg()->initColumnAsNominalOrOrdinal(colId, col->name(), col->ints(), col->intLabels(),	col->getColumnType() == columnType::ordinal);
-		else					DataSetPackage::pkg()->initColumnAsNominalOrOrdinal(colId, col->name(), col->ints(),						col->getColumnType() == columnType::ordinal);
+		else					DataSetPackage::pkg()->initColumnAsNominalOrOrdinal(colId, col->name(), col->ints(),					col->getColumnType() == columnType::ordinal);
 		break;
 
 	case columnType::nominalText:


### PR DESCRIPTION
- Issue fixed: https://github.com/jasp-stats/jasp-issues/issues/590
- Now when type is changed also the labels are converted as well
- if doubles are used as key for nominal or ordinal then they are converted to string instead of ignoring them.
- then at the end, an attempt is made to convert all string-keys to int and if that works the type is changed to nominal

