### PR TITLE
Overwrite pdf() with cairo_pdf() on Windows

### DIFF
--- a/JASP-Engine/JASP/R/assignFunctionInPackage.R
+++ b/JASP-Engine/JASP/R/assignFunctionInPackage.R
@@ -63,3 +63,18 @@ fakeGbmCrossValErr <- function(cv.models, cv.folds, cv.group, nTrain, n.trees) {
   }, double(n.trees))
   return(rowSums(as.matrix(cv.error))/nTrain)
 }
+
+# cowplot, used in flexplot (and other analyses that open pdf devices on Windows) ----
+fakeGrDevicesPdf <- function(file = if(onefile) "Rplots.pdf" else "Rplot%03d.pdf",
+                             width, height, onefile, family, title, fonts, version,
+                             paper, encoding, bg, fg, pointsize, pagecentre, colormodel,
+                             useDingbats, useKerning, fillOddEven, compress) { 
+  args <- as.list(match.call())
+  matchedIdx <- which(names(args) %in% c("file", "width", "height", "oneFile", "family", "bg", "pointsize"))
+  matchedArgs <- args[matchedIdx]
+  
+  matchedArgs[["filename"]] <- matchedArgs[["file"]]
+  matchedArgs[["file"]] <- NULL
+  
+  do.call(grDevices::cairo_pdf, matchedArgs, envir = parent.frame())
+}

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -261,6 +261,9 @@ initEnvironment <- function() {
   Sys.setlocale("LC_CTYPE", "UTF-8")
   packages <- c("BayesFactor") # Add any package that needs pre-loading
 
+  if (identical(.Platform$OS.type, "windows"))
+    assignFunctionInPackage(fakeGrDevicesPdf, "pdf", "grDevices") # this fixes the problem that grDevices::pdf() does not work within JASP (https://github.com/jasp-stats/INTERNAL-jasp/issues/682)
+  
   for (package in packages)
     if (base::isNamespaceLoaded(package) == FALSE)
       try(base::loadNamespace(package), silent=TRUE)


### PR DESCRIPTION
This fixes the univariate/diagnostics plots in Flexplot on Windows (so a work-around for https://github.com/jasp-stats/INTERNAL-jasp/issues/682)