### PR TITLE
Fixes for first testround bugs I found

### DIFF
--- a/Docs/development/jasp-building-guide.md
+++ b/Docs/development/jasp-building-guide.md
@@ -112,6 +112,7 @@ Because the **jasp-required-files** folder contains binary files as well as R pa
 
 	\<JASP\>\build-release-64\R  
 	\<JASP\>\build-release-64\*.lib and *.dll  
+	\<JASP\>\build-release-64\JAGS\*
    
 6.	**Install Qt 5.13.1**  
 	Go to https://www.qt.io/download  
@@ -232,6 +233,7 @@ In both case, I've added the flag "-j4" to make use of all my four cores on my m
  ![Image of folder structure](https://static.jasp-stats.org/images/jasp5.FolderStructure.png)
 
 where the blue files are the binaries that are added manually. The process will be smoothened out in the near future.
+You should also make sure to copy the `JAGS` folder together with the binaries.
 
 4. Make a symbolic link to Frameworks
 If you've paid an exceptional amount of attention to the above folder-structure you will notice that there is a folder **Frameworks** next to **jasp-required-files** and the others. With even more attention it will be noticed that **jasp-required-files** also contains a folder called **Frameworks**. These are in fact one and the same!

--- a/JASP-Common/column.cpp
+++ b/JASP-Common/column.cpp
@@ -406,9 +406,9 @@ bool Column::resetEmptyValues(std::map<int, string> &emptyValuesMap)
 	switch(_columnType)
 	{
 	case columnType::ordinal:
-	case columnType::nominal:		return _resetEmptyValuesForNominal(emptyValuesMap);
+	case columnType::nominal:	return _resetEmptyValuesForNominal(emptyValuesMap);
 	case columnType::scale:		return _resetEmptyValuesForScale(emptyValuesMap);
-	default:							return _resetEmptyValuesForNominalText(emptyValuesMap);
+	default:					return _resetEmptyValuesForNominalText(emptyValuesMap);
 	}
 }
 
@@ -449,6 +449,7 @@ bool Column::_changeColumnToNominalOrOrdinal(enum columnType newColumnType)
 			}
 
 			values.push_back(intValue);
+
 			if (intValue != INT_MIN)
 			{
 				if (uniqueIntValues.find(intValue) != uniqueIntValues.end())
@@ -496,7 +497,7 @@ bool Column::_changeColumnToNominalOrOrdinal(enum columnType newColumnType)
 
 			for (double doubleValue : AsDoubles)
 				if (std::isnan(doubleValue))	values.push_back(Utils::emptyValue);
-				else							values.push_back(std::to_string(doubleValue));
+				else							values.push_back(Utils::doubleToString(doubleValue));
 
 			setColumnAsNominalText(values);
 			return true;
@@ -538,6 +539,8 @@ bool Column::_changeColumnToScale()
 				if (!Utils::isEmptyValue(value))
 					converted = Utils::getDoubleValue(value, doubleValue);
 			}
+			else
+				converted = true; //Because if key == INT_MIN then it is missing value
 
 			if (converted)	values.push_back(doubleValue);
 			else			return false;

--- a/JASP-Common/utils.cpp
+++ b/JASP-Common/utils.cpp
@@ -411,3 +411,10 @@ bool Utils::convertValueToDoubleForImport(const std::string &strValue, double &d
 
 	return true;
 }
+
+std::string Utils::doubleToString(double dbl)
+{
+	std::stringstream conv; //Use this instead of std::to_string to make sure there are no trailing zeroes (and to get full precision)
+	conv << dbl;
+	return conv.str();
+}

--- a/JASP-Common/utils.h
+++ b/JASP-Common/utils.h
@@ -62,8 +62,9 @@ public:
 	static bool isEmptyValue(const std::string& val);
 	static bool isEmptyValue(const double& val);
 
-	static bool		convertValueToIntForImport(		const std::string &strValue, int &intValue);
-	static bool		convertValueToDoubleForImport(	const std::string &strValue, double &doubleValue);
+	static bool			convertValueToIntForImport(		const std::string &strValue, int &intValue);
+	static bool			convertValueToDoubleForImport(	const std::string &strValue, double &doubleValue);
+	static std::string	doubleToString(double dbl);
 
 private:
 	static std::string _deEuropeaniseForImport(		const std::string &value);

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/OSF.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/OSF.qml
@@ -183,11 +183,13 @@ Item
 			{
 				id					: foldernameText
 				selectByMouse		: true
-				selectedTextColor	: jaspTheme.white
+				selectedTextColor	: jaspTheme.textDisabled
 				selectionColor		: jaspTheme.itemSelectedColor
+				color				: jaspTheme.textEnabled
 
 				text				: fileMenuModel.osf.savefoldername
 				font				: jaspTheme.fontRibbon
+
 
 				anchors.fill		: parent
 				anchors.leftMargin	: jaspTheme.itemPadding
@@ -289,8 +291,9 @@ Item
 			{
 				id					: filenameText
 				selectByMouse		: true
-				selectedTextColor	: jaspTheme.white
+				selectedTextColor	: jaspTheme.textDisabled
 				selectionColor		: jaspTheme.itemSelectedColor
+				color				: jaspTheme.textEnabled
 
 				text				: fileMenuModel.osf.savefilename
 				font				: jaspTheme.fontRibbon

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
@@ -77,8 +77,8 @@ FocusScope
 	{
 		id: labelExplain
 
-		text : qsTr("Sign in with your OSF account to continue")
-		color:jaspTheme.black
+		text :	qsTr("Sign in with your OSF account to continue")
+		color:	jaspTheme.textEnabled
 		font.pointSize: 11 * preferencesModel.uiScale
 		font.family:	jaspTheme.font.family
 
@@ -133,8 +133,9 @@ FocusScope
 				anchors.fill		: parent
 				anchors.leftMargin	: 10 * preferencesModel.uiScale
 				selectByMouse		: true
-				selectedTextColor	: jaspTheme.white
+				selectedTextColor	: jaspTheme.textDisabled
 				selectionColor		: jaspTheme.itemSelectedColor
+				color				: jaspTheme.textEnabled
 
 
 				verticalAlignment	: Text.AlignVCenter
@@ -180,8 +181,9 @@ FocusScope
 				verticalAlignment	: Text.AlignVCenter
 				echoMode			: TextInput.Password
 				selectByMouse		: true
-				selectedTextColor	: jaspTheme.white
+				selectedTextColor	: jaspTheme.textDisabled
 				selectionColor		: jaspTheme.itemSelectedColor
+				color				: jaspTheme.textEnabled
 
 				font.pixelSize    : 14 * preferencesModel.uiScale
 

--- a/JASP-Desktop/components/JASP/Widgets/FilterConstructor/String.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FilterConstructor/String.qml
@@ -21,6 +21,7 @@ Item
 		anchors.verticalCenter:		parent.verticalCenter
 
 		font.pixelSize: filterConstructor.fontPixelSize
+		color:			jaspTheme.textEnabled
 
 		onAccepted: focus = false
 		onActiveFocusChanged:	if(!activeFocus) { if(text === "") destroyMe(); else filterConstructor.somethingChanged = true; }

--- a/JASP-Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainWindow.qml
@@ -65,16 +65,16 @@ Window
 		anchors.fill:	parent
 		focus:			true
 
-		Shortcut { onActivated: mainWindow.saveKeyPressed();					sequences: ["Ctrl+S"];											}
+		Shortcut { onActivated: mainWindow.saveKeyPressed();					sequences: ["Ctrl+S", Qt.Key_Save];								}
 		Shortcut { onActivated: mainWindow.openKeyPressed();					sequences: ["Ctrl+O"];											}
-		Shortcut { onActivated: mainWindow.syncKeyPressed();					sequences: ["Ctrl+Y"];											}
+		Shortcut { onActivated: mainWindow.syncKeyPressed();					sequences: ["Ctrl+Y", Qt.Key_Reload];							}
 		Shortcut { onActivated: mainWindow.zoomInKeyPressed();					sequences: [Qt.Key_ZoomIn, "Ctrl+Plus", "Ctrl+\+", "Ctrl+\="];	}
 		Shortcut { onActivated: mainWindow.zoomOutKeyPressed();					sequences: [Qt.Key_ZoomOut, "Ctrl+Minus", "Ctrl+\-"];			}
-		Shortcut { onActivated: mainWindow.refreshKeyPressed();					sequences: ["Ctrl+R"];											}
-		Shortcut { onActivated: mainWindow.zoomResetKeyPressed();				sequences: ["Ctrl+0"];											}
+		Shortcut { onActivated: mainWindow.refreshKeyPressed();					sequences: ["Ctrl+R", Qt.Key_Refresh];							}
+		Shortcut { onActivated: mainWindow.zoomResetKeyPressed();				sequences: ["Ctrl+0", Qt.Key_Zoom];								}
 		Shortcut { onActivated: mainWindowRoot.close();							sequences: ["Ctrl+Q", Qt.Key_Close];							}
-		Shortcut { onActivated: mainWindowRoot.toggleFullScreen();				sequences: ["Ctrl+M"];											}
-		Shortcut { onActivated: fileMenuModel.visible = !fileMenuModel.visible; sequences: ["Home"];											}
+		Shortcut { onActivated: mainWindowRoot.toggleFullScreen();				sequences: ["Ctrl+M", Qt.Key_F11];								}
+		Shortcut { onActivated: fileMenuModel.visible = !fileMenuModel.visible; sequences: ["Home",   Qt.Key_Home, Qt.Key_Menu];				}
 
 		RibbonBar
 		{

--- a/JASP-Desktop/components/JASP/Widgets/VariablesWindow.qml
+++ b/JASP-Desktop/components/JASP/Widgets/VariablesWindow.qml
@@ -264,7 +264,7 @@ FocusScope
 					{
 						visible:			styleData.column === 1
 						
-						color:				jaspTheme.textDisabled
+						color:				jaspTheme.grayDarker
 						text:				styleData.value
 						elide:				Text.ElideMiddle
 						font:				jaspTheme.font

--- a/JASP-Desktop/data/datasetpackage.cpp
+++ b/JASP-Desktop/data/datasetpackage.cpp
@@ -366,6 +366,8 @@ bool DataSetPackage::setData(const QModelIndex &index, const QVariant &value, in
 			return false;
 
 		default:
+		{
+			QString originalLabel = tq(labels.getLabelFromRow(index.row()));
 			if(labels.setLabelFromRow(index.row(), value.toString().toStdString()))
 			{
 				QModelIndex parent	= index.parent();
@@ -377,10 +379,12 @@ bool DataSetPackage::setData(const QModelIndex &index, const QVariant &value, in
 				parent = parentModelForType(parIdxType::data);
 				emit dataChanged(DataSetPackage::index(0, col, parent), DataSetPackage::index(rowCount(), col, parent), { Qt::DisplayRole });
 
-				emit labelChanged(columnIndex);
+				emit labelChanged(tq(getColumnName(col)), originalLabel, tq(labels.getLabelFromRow(index.row())));
+				emit refreshAnalysesWithColumn(tq(getColumnName(columnIndex)));
 				return true;
 			}
 			break;
+		}
 		}
 	}
 	}
@@ -1273,6 +1277,7 @@ void DataSetPackage::labelMoveRows(size_t column, std::vector<size_t> rows, bool
 	for(size_t row: rowsChanged)
 		emit dataChanged(index(row, 0, p), index(row, columnCount(p), p));
 
+	emit labelsReordered(tq(getColumnName(column)));
 	emit refreshAnalysesWithColumn(tq(getColumnName(column)));
 }
 
@@ -1287,6 +1292,7 @@ void DataSetPackage::labelReverse(size_t column)
 	QModelIndex p = parentModelForType(parIdxType::label, column);
 
 	emit dataChanged(index(0, 0, p), index(rowCount(p), columnCount(p), p));
+	emit labelsReordered(tq(getColumnName(column)));
 	emit refreshAnalysesWithColumn(tq(getColumnName(column)));
 }
 

--- a/JASP-Desktop/data/datasetpackage.h
+++ b/JASP-Desktop/data/datasetpackage.h
@@ -218,10 +218,11 @@ signals:
 				void				badDataEntered(const QModelIndex index);
 				void				allFiltersReset();
 				void				labelFilterChanged();
-				void				labelChanged(int column);
+				void				labelChanged(QString columnName, QString originalLabel, QString newLabel);
 				void				dataSetChanged();
 				void				columnDataTypeChanged(std::string columnName);
 				void				refreshAnalysesWithColumn(QString columnName);
+				void				labelsReordered(		  QString columnName);
 				void				isModifiedChanged();
 				void				pauseEnginesSignal();
 				void				resumeEnginesSignal();

--- a/JASP-Desktop/data/importers/readstat/readstatimportcolumn.cpp
+++ b/JASP-Desktop/data/importers/readstat/readstatimportcolumn.cpp
@@ -23,13 +23,6 @@ size_t ReadStatImportColumn::size() const
 	}
 }
 
-std::string ReadStatImportColumn::doubleAsString(double dbl)	const
-{
-	std::stringstream conv; //Use this instead of std::to_string to make sure there are no trailing zeroes
-	conv << dbl;
-	return conv.str();
-}
-
 std::string ReadStatImportColumn::valueAsString(size_t row) const
 {
 	if(row >= size())	return Utils::emptyValue;
@@ -37,7 +30,7 @@ std::string ReadStatImportColumn::valueAsString(size_t row) const
 	switch(_type)
 	{
 	default:						return Utils::emptyValue;
-	case columnType::scale:			return doubleAsString(_doubles[row]);
+	case columnType::scale:			return Utils::doubleToString(_doubles[row]);
 	case columnType::ordinal:		[[clang::fallthrough]];
 	case columnType::nominal:		return std::to_string(_ints[row]);
 	case columnType::nominalText:	return _strings[row];
@@ -85,14 +78,14 @@ void ReadStatImportColumn::setType(columnType newType)
 		case columnType::nominal:
 			for(double d : _doubles)
 				if(isMissingValue(d))			_ints.push_back(missingValueInt());
-				else if(d != double(int(d)))	conversionFailed("Double '" + doubleAsString(d) + "' cannot be converted to int.");
+				else if(d != double(int(d)))	conversionFailed("Double '" + Utils::doubleToString(d) + "' cannot be converted to int.");
 				else							_ints.push_back(int(d));
 
 			break;
 
 		case columnType::nominalText:
 			for(double d : _doubles)
-				_strings.push_back(isMissingValue(d) ? missingValueString() : doubleAsString(d));
+				_strings.push_back(isMissingValue(d) ? missingValueString() : Utils::doubleToString(d));
 			_doubles.clear();
 			break;
 		}
@@ -235,7 +228,7 @@ void ReadStatImportColumn::addValue(const double & val)
 		[[clang::fallthrough]];
 
 	case columnType::nominalText:
-		addValue(doubleAsString(val));
+		addValue(Utils::doubleToString(val));
 		break;
 	}
 }
@@ -293,7 +286,7 @@ void ReadStatImportColumn::addLabel(const double & val, const std::string & labe
 		setType(columnType::nominalText); //Because we do not support having doubles as values for labels
 	}
 
-	addLabel(doubleAsString(val), label);
+	addLabel(Utils::doubleToString(val), label);
 }
 
 void ReadStatImportColumn::addLabel(const std::string & val, const std::string & label)

--- a/JASP-Desktop/data/importers/readstat/readstatimportcolumn.h
+++ b/JASP-Desktop/data/importers/readstat/readstatimportcolumn.h
@@ -40,7 +40,6 @@ public:
 	void						setType(columnType newType);
 
 	std::string					valueAsString(size_t row)	const;
-	std::string					doubleAsString(double dbl)	const;
 
 	const std::vector<int>					&	ints()			const { return _ints;		}
 	const std::vector<double>				&	doubles()		const { return _doubles;	}

--- a/JASP-Desktop/qquick/datasetview.cpp
+++ b/JASP-Desktop/qquick/datasetview.cpp
@@ -97,11 +97,8 @@ void DataSetView::modelDataChanged(const QModelIndex &index, const QModelIndex &
 	int col = index.column();
 	QSizeF calcSize = getColumnSize(col);
 
-	if (int(_cellSizes[size_t(col)].width() * 10) != int(calcSize.width() * 10))
-	{
-		modelAboutToBeReset();
+	if (_cacheItems || int(_cellSizes[size_t(col)].width() * 10) != int(calcSize.width() * 10)) //If we cache items we are not expecting the user to make regular manual changes to the data, so if something changes we can do a reset. Otherwise we are in TableView and we do it only when the column size changes.
 		calculateCellSizes();
-	}
 }
 
 void DataSetView::modelHeaderDataChanged(Qt::Orientation, int, int)

--- a/JASP-Desktop/widgets/listmodelanovacustomcontrasts.cpp
+++ b/JASP-Desktop/widgets/listmodelanovacustomcontrasts.cpp
@@ -61,7 +61,7 @@ void ListModelANOVACustomContrasts::setFactorsSource(ListModelRepeatedMeasuresFa
 	setFactors();
 }
 
-QString ListModelANOVACustomContrasts::getColName(size_t index) const
+QString ListModelANOVACustomContrasts::getDefaultColName(size_t index) const
 {
 	if(index > _colNames.size()) return "?";
 
@@ -102,7 +102,7 @@ void ListModelANOVACustomContrasts::setColLabels()
 
 int ListModelANOVACustomContrasts::getMaximumColumnWidthInCharacters(size_t columnIndex) const
 {
-	return std::max(ListModelTableViewBase::getMaximumColumnWidthInCharacters(columnIndex), getColName(columnIndex).size());
+	return std::max(ListModelTableViewBase::getMaximumColumnWidthInCharacters(columnIndex), getDefaultColName(columnIndex).size());
 }
 
 
@@ -145,7 +145,7 @@ void ListModelANOVACustomContrasts::modifyValuesNamesEtcetera()
 	_rowNames.clear();
 
 	for(int i=0; i<_rowCount; i++)
-		_rowNames.push_back(getRowName(i));
+		_rowNames.push_back(getDefaultRowName(i));
 
 	beginResetModel();
 

--- a/JASP-Desktop/widgets/listmodelanovacustomcontrasts.h
+++ b/JASP-Desktop/widgets/listmodelanovacustomcontrasts.h
@@ -39,8 +39,8 @@ public:
 	void			reset()															override;
 
 	QString			colName()												const				{ return _colName;	}
-	QString			getColName(size_t index)								const	override;
-	QString			getRowName(size_t index)								const	override	{ return tr("Contrast %1").arg(index + 1); }
+	QString			getDefaultColName(size_t index)								const	override;
+	QString			getDefaultRowName(size_t index)								const	override	{ return tr("Contrast %1").arg(index + 1); }
 
 	void			setFactorsSource(ListModelRepeatedMeasuresFactors* factorsSourceModel);
 

--- a/JASP-Desktop/widgets/listmodeljagsdatainput.cpp
+++ b/JASP-Desktop/widgets/listmodeljagsdatainput.cpp
@@ -29,9 +29,9 @@ ListModelJAGSDataInput::ListModelJAGSDataInput(BoundQMLTableView *parent, QStrin
 	_defaultCellVal = "...";
 	_colNames.clear();
 	_values.clear();
-	_colNames.push_back(getColName(0));
+	_colNames.push_back(getDefaultColName(0));
 	_values.push_back({});
-	_colNames.push_back(getColName(1));
+	_colNames.push_back(getDefaultColName(1));
 	_values.push_back({});
 }
 
@@ -55,7 +55,7 @@ void ListModelJAGSDataInput::sourceTermsChanged(const Terms *, const Terms *)
 		_rowNames.clear();
 		_rowCount = sourceTerms.size();
 		for (size_t colNb = 1; colNb <= _rowCount; colNb++)
-			_rowNames.push_back(getRowName(colNb));
+			_rowNames.push_back(getDefaultRowName(colNb));
 		QList<QString> firstColumnValues = sourceTerms.asQList();
 		QVector<QVariant> firstColumn;
 		QVector<QVariant> secondColumn;
@@ -77,7 +77,7 @@ void ListModelJAGSDataInput::sourceTermsChanged(const Terms *, const Terms *)
 }
 
 
-QString ListModelJAGSDataInput::getColName(size_t index) const
+QString ListModelJAGSDataInput::getDefaultColName(size_t index) const
 {
 	if(index == 0)
 		return "Parameter";
@@ -111,14 +111,14 @@ OptionsTable *ListModelJAGSDataInput::createOption()
 	{
 		std::vector<std::string> stdlevels;
 		for (int row=0; row<_initialRowCnt; row++)
-			stdlevels.push_back(fq(getRowName(row)));
+			stdlevels.push_back(fq(getDefaultRowName(row)));
 
 		std::vector<Options*> allOptions;
 
 		for (int colIndex = 0; colIndex < _initialColCnt; colIndex++)
 		{
 			Options* options =		new Options();
-			options->add("name",	new OptionString(fq(getColName(colIndex))));
+			options->add("name",	new OptionString(fq(getDefaultColName(colIndex))));
 			options->add("levels",	new OptionVariables(stdlevels));
 
 			std::vector<std::string> tempValues;

--- a/JASP-Desktop/widgets/listmodeljagsdatainput.h
+++ b/JASP-Desktop/widgets/listmodeljagsdatainput.h
@@ -33,7 +33,7 @@ public:
 
 	int getMaximumColumnWidthInCharacters(size_t columnIndex)	const	override;
 
-	QString			getColName(size_t index)					const	override;
+	QString			getDefaultColName(size_t index)					const	override;
 	OptionsTable *	createOption()										override;
 	void			initValues(OptionsTable * bindHere)					override;
 

--- a/JASP-Desktop/widgets/listmodelmultinomialchi2test.h
+++ b/JASP-Desktop/widgets/listmodelmultinomialchi2test.h
@@ -27,17 +27,17 @@ class ListModelMultinomialChi2Test : public ListModelTableViewBase
 	Q_OBJECT
 
 public:
-	explicit ListModelMultinomialChi2Test(BoundQMLTableView * parent, QString tableType) : ListModelTableViewBase(parent, tableType)
-	{
-		_defaultCellVal		= 1;
-		_initialColCnt		= 1;
-		_keepRowsOnReset	= true;
-	}
+	explicit ListModelMultinomialChi2Test(BoundQMLTableView * parent, QString tableType);
 
-	QString			getColName(size_t index)							const	override;
+	QString	getDefaultColName(size_t index) const override;
 
 public slots:
 	void sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved)	override;
+	void labelChanged(	 QString columnName, QString originalLabel, QString newLabel);
+	void labelsReordered(QString columnName);
+
+private:
+	QString _columnBeingTracked = "";
 };
 
 #endif // LISTMODELMULTINOMIALCHI2TEST_H

--- a/JASP-Desktop/widgets/listmodeltableviewbase.cpp
+++ b/JASP-Desktop/widgets/listmodeltableviewbase.cpp
@@ -77,6 +77,21 @@ int ListModelTableViewBase::getMaximumColumnWidthInCharacters(size_t columnIndex
 	return maxL + 3;
 }
 
+
+QString ListModelTableViewBase::getMaximumRowHeaderString() const
+{
+	int maxL = 6;
+
+	for(QString val : _rowNames)
+			maxL = std::max(val.size(), maxL);
+
+	QString dummyText;
+	while(maxL > dummyText.length())
+		dummyText += "X";
+
+	return dummyText;
+}
+
 void ListModelTableViewBase::addColumn(bool emitStuff)
 {
 	if(emitStuff)
@@ -84,7 +99,7 @@ void ListModelTableViewBase::addColumn(bool emitStuff)
 
 	if (columnCount() < _maxColumn)
 	{
-		_colNames.push_back(getColName(columnCount()));
+		_colNames.push_back(getDefaultColName(columnCount()));
 		_values.push_back(QVector<QVariant>(_rowNames.length(), _defaultCellVal));
 		_columnCount++;
 	}
@@ -126,7 +141,7 @@ void ListModelTableViewBase::addRow(bool emitStuff)
 
 	if (rowCount() < _maxRow)
 	{
-		_rowNames.push_back(getRowName(rowCount()));
+		_rowNames.push_back(getDefaultRowName(rowCount()));
 		_rowCount++;
 
 		for (QVector<QVariant> & value : _values)
@@ -285,7 +300,7 @@ QVariant ListModelTableViewBase::headerData( int section, Qt::Orientation orient
 
 		return dummyText;
 	}
-	case int(specialRoles::maxRowHeaderString):	return getRowName(size_t(rowCount())) + "XXX";
+	case int(specialRoles::maxRowHeaderString):	return getMaximumRowHeaderString();
 	case Qt::DisplayRole:						return QVariant(orientation == Qt::Horizontal ? _colNames[section] : _rowNames[section]);
 	case Qt::TextAlignmentRole:					return QVariant(Qt::AlignCenter);
 	default:									return QVariant();

--- a/JASP-Desktop/widgets/listmodeltableviewbase.h
+++ b/JASP-Desktop/widgets/listmodeltableviewbase.h
@@ -47,6 +47,7 @@ public:
 				QVariant			headerData ( int section, Qt::Orientation orientation, int role = Qt::DisplayRole )	const	override;
 
 	virtual		int					getMaximumColumnWidthInCharacters(size_t columnIndex)								const;
+				QString				getMaximumRowHeaderString()															const;
 
 				void				addColumn(					bool emitStuff = true);
 				void				removeColumn(size_t index,	bool emitStuff = true);
@@ -58,8 +59,8 @@ public:
 	virtual		void				itemChanged(int column, int row, QVariant value);
 	virtual		void				refreshModel()							{ return ListModel::refresh(); }
 	virtual		void				initValues(OptionsTable * bindHere);
-	virtual		QString				getColName(size_t index)		const	{ return tr("Col %1").arg(index); }
-	virtual		QString				getRowName(size_t index)		const	{ return tr("Row %1").arg(index); }
+	virtual		QString				getDefaultColName(size_t index)		const	{ return tr("Col %1").arg(index); }
+	virtual		QString				getDefaultRowName(size_t index)		const	{ return tr("Row %1").arg(index); }
 	virtual		OptionsTable *		createOption();
 	virtual		void				modelChangedSlot();
 


### PR DESCRIPTION
- More shortcut sequences
- OSF login (And other texts) readable
- Value in VariablesWindow readable
-- Fixes https://github.com/jasp-stats/jasp-test-release/issues/382
- String in FilterConstructor should also have textEnabled color
- doubles are now converting with stringstream instead of std::to_string which keeps precision
-- Fixes https://github.com/jasp-stats/jasp-test-release/issues/377
- Making sure data is updated when labels change, as well as analyses
- Scale -> Nominal Text -> Scale works again
-- Fixes https://github.com/jasp-stats/jasp-test-release/issues/378

