### PR TITLE
Bayesian multinomial bugfix

### DIFF
--- a/JASP-Engine/JASP/R/multinomialtestbayesian.R
+++ b/JASP-Engine/JASP/R/multinomialtestbayesian.R
@@ -64,12 +64,17 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   prior          <- options$priorCounts[[1]]
   a              <- setNames(prior$values, prior$levels)
 
+  # we want to reorder levels in the tables and plots if the user does that, so here we compute
+  # how to reorder the counts.
+  factNms        <- options$priorCounts[[1]]$levels
+  ord            <- match(factNms, as.character(fact))
+
   if (options$counts != "") {
-    counts <- dataset[[.v(options$counts)]]
+    counts <- dataset[[.v(options$counts)]][ord]
     # omit count entries for which factor variable is NA
     counts <- counts[!is.na(fact)]
     dataTable        <- counts
-    names(dataTable) <- levels(fact)
+    names(dataTable) <- factNms
   } else {
     dataTable <- table(fact)
   }
@@ -90,7 +95,7 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   }
 
   multinomialResults$mainTable[["prior"]]   <- a
-  multinomialResults$mainTable[["levels"]]  <- levels(fact)
+  multinomialResults$mainTable[["levels"]]  <- factNms
   multinomialResults$mainTable[["nlevels"]] <- nlev
   multinomialResults$mainTable[["hypNames"]]<- nms
   multinomialResults$mainTable[["nhyps"]]   <- nhyps
@@ -100,12 +105,12 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   multinomialResults$descriptivesPlot[["descCounts"]] <- multinomialResults$descriptivesPlot[["descProps"]] * N
   multinomialResults$descriptivesPlot[["descProps"]][["observed"]]  <- as.numeric(dataTable)/N
   multinomialResults$descriptivesPlot[["descCounts"]][["observed"]] <- as.numeric(dataTable)
-  multinomialResults$descriptivesPlot[["descProps"]][["fact"]]  <- levels(fact)
-  multinomialResults$descriptivesPlot[["descCounts"]][["fact"]] <- levels(fact)
+  multinomialResults$descriptivesPlot[["descProps"]][["fact"]]  <- factNms
+  multinomialResults$descriptivesPlot[["descCounts"]][["fact"]] <- factNms
 
   # Results for descriptives table
-  multinomialResults$descriptivesTable[["descProps"]][["fact"]]      <- levels(fact)
-  multinomialResults$descriptivesTable[["descCounts"]][["fact"]]     <- levels(fact)
+  multinomialResults$descriptivesTable[["descProps"]][["fact"]]      <- factNms
+  multinomialResults$descriptivesTable[["descCounts"]][["fact"]]     <- factNms
   multinomialResults$descriptivesTable[["descProps"]][["observed"]]  <- as.numeric(dataTable)/N
   multinomialResults$descriptivesTable[["descCounts"]][["observed"]] <- as.numeric(dataTable)
 

--- a/JASP-Tests/R/tests/testthat/test-multinomialtestbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-multinomialtestbayesian.R
@@ -38,7 +38,7 @@ test_that("Descriptives plots match", {
   options$countProp <- "descProps"
   options$credibleInterval <- TRUE
   options$descriptivesPlot <- TRUE
-  options$priorCounts <- list(list(levels = paste0('level', 1:2),
+  options$priorCounts <- list(list(levels = c("0", "1"),
                                    name   = c('Counts'),
                                    values = rep(1, 2)))
   results <- jasptools::run("MultinomialTestBayesian", "test.csv", options)
@@ -57,6 +57,6 @@ test_that("Bayesian Multinomial Test table results match in short data format", 
   results <- jasptools::run("MultinomialTestBayesian", "Memory of Life Stresses.csv", options)
   table <- results[["results"]][["multinomialTable"]][["data"]]
   expect_equal_tables(table,
-                      list(27.1062505863656, "Multinomial", 18))
+                      list(1.49242615869171e-11, "Multinomial", 18))
 })
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/384

~~This approach, using a QML widget to determine the label orders, is a very unusual way to determine the order in which levels are shown. Basically, every analysis that handles nominal text then needs an invisible QML widget to display things in the correct order? To me, this looks really prone to error. 
Perhaps we can deprecate the reordering when we have plot editing?~~