### PR TITLE
Network analysis - remove layout from data set if checkbox is unchecked

### DIFF
--- a/Resources/Network/qml/NetworkAnalysis.qml
+++ b/Resources/Network/qml/NetworkAnalysis.qml
@@ -439,10 +439,22 @@ Form
 			text: qsTr("Save the layout in the data set")
 			name: "addLayoutToData"
 			Layout.columnSpan: 2
-			ComputedColumnField { name: "computedLayoutX"; text: qsTr("name for x-coordinates") }
-			ComputedColumnField { name: "computedLayoutY"; text: qsTr("name for y-coordinates") }
+			ComputedColumnField { name: "computedLayoutX"; text: qsTr("name for x-coordinates"); id: layoutX }
+			ComputedColumnField { name: "computedLayoutY"; text: qsTr("name for y-coordinates"); id: layoutY }
 			enabled: !dataRatioButton.checked
 			visible: !dataRatioButton.checked
+			id: layoutCheckbox
+			onCheckedChanged:
+			{
+				if (!layoutCheckbox.checked)
+				{
+//					The user no longer wants to add the layout to the dataset so we remove it from the dataset if it was there.
+					layoutX.value = ""
+					layoutY.value = ""
+					layoutX.doEditingFinished()
+					layoutY.doEditingFinished()
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/513

Removes the columns from the data set when the checkbox is unchecked.

Just setting the value to `""` wasn't enough, I also had to trigger some signal so this actually got processed, which I did using `doEditingFinished()`. Let me know if I should do this differently!
