### PR TITLE
Fix gettextf bug in bayesian linear regression

### DIFF
--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -186,8 +186,13 @@ for sparse regression when there are more covariates than observations (Castillo
     if (sum(basregModel$nuisanceTerms) > 0)
       generalNote <- gettextf("All models include %s.", paste(names(which(basregModel$nuisanceTerms)), collapse = ", "))
     
-    if (options$shownModels == "limited" && options$numShownModels < length(basregModel$which))
-      generalNote <- gettextf("%s Table displays only a subset of models; to see all models, select \"No\" under \"Limit No. Models Shown\".", generalNote)
+    if (options$shownModels == "limited" && options$numShownModels < length(basregModel$which)) {
+      if (is.null(generalNote)) {
+        generalNote <- gettext("Table displays only a subset of models; to see all models, select \"No\" under \"Limit No. Models Shown\".")
+      } else {
+        generalNote <- gettextf("%s Table displays only a subset of models; to see all models, select \"No\" under \"Limit No. Models Shown\".", generalNote)
+      }
+    }
     
     if (!is.null(generalNote))
       modelComparisonTable$addFootnote(message = generalNote)

--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -188,10 +188,11 @@ for sparse regression when there are more covariates than observations (Castillo
     
     if (options$shownModels == "limited" && options$numShownModels < length(basregModel$which)) {
       if (is.null(generalNote)) {
-        generalNote <- gettext("Table displays only a subset of models; to see all models, select \"No\" under \"Limit No. Models Shown\".")
+        s1 <- ""
       } else {
-        generalNote <- gettextf("%s Table displays only a subset of models; to see all models, select \"No\" under \"Limit No. Models Shown\".", generalNote)
+        s1 <- paste0(generalNote, " ") # hopefully all languages want a " " after a full stop.
       }
+      generalNote <- gettextf("%sTable displays only a subset of models; to see all models, select \"No\" under \"Limit No. Models Shown\".", s1)
     }
     
     if (!is.null(generalNote))


### PR DESCRIPTION
see title. If `generalNote = NULL`, then `gettextf("%s", generalNote) = NULL`, which causes the footnote to complain.