### PR TITLE
Allow links in results to open in external application

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/VariablesList.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesList.qml
@@ -178,6 +178,8 @@ JASPListControl
 			height: 16 * preferencesModel.uiScale
 			width:	16 * preferencesModel.uiScale
 			z:		2
+			mipmap:	true
+			smooth:	true
 			anchors
 			{
 				bottom:			listRectangle.bottom;
@@ -449,12 +451,14 @@ JASPListControl
 				Image
 				{
 					id:						icon
-					height:					15 * preferencesModel.uiScale
-					width:					source === "" ? 0 : 15 * preferencesModel.uiScale
+					height:					16 * preferencesModel.uiScale
+					width:					source === "" ? 0 : 16 * preferencesModel.uiScale
 					x:						jaspTheme.borderRadius
 					anchors.verticalCenter:	parent.verticalCenter
 					source:					(!(variablesList.showVariableTypeIcon && itemRectangle.isVariable) || !model.columnType) ? "" : jaspTheme.iconPath + (enabled ? iconFiles[model.columnType] : iconDisabledFiles[model.columnType])
 					visible:				variablesList.showVariableTypeIcon && itemRectangle.isVariable && source !== ""
+					mipmap:	true
+					smooth:	true
 				}
 
 				Text

--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -163,8 +163,16 @@ Item
 				url:					resultsJsInterface.resultsPageUrl
 				onLoadingChanged:		resultsJsInterface.resultsPageLoaded(loadRequest.status === WebEngineLoadRequest.LoadSucceededStatus);
 				onContextMenuRequested: request.accepted = true
-				onNavigationRequested:	request.action = request.navigationType === WebEngineNavigationRequest.ReloadNavigation || request.url == resultsJsInterface.resultsPageUrl ? WebEngineNavigationRequest.AcceptRequest : WebEngineNavigationRequest.IgnoreRequest
 				backgroundColor:		jaspTheme.uiBackground
+				onNavigationRequested:
+					if(request.navigationType === WebEngineNavigationRequest.ReloadNavigation || request.url == resultsJsInterface.resultsPageUrl)
+						request.action = WebEngineNavigationRequest.AcceptRequest
+					else
+					{
+						if(request.navigationType === WebEngineNavigationRequest.LinkClickedNavigation)
+							Qt.openUrlExternally(request.url);
+						request.action = WebEngineNavigationRequest.IgnoreRequest;
+					}
 
 				Connections
 				{

--- a/JASP-Desktop/main.cpp
+++ b/JASP-Desktop/main.cpp
@@ -272,6 +272,10 @@ int main(int argc, char *argv[])
 
 			QLocale::setDefault(QLocale(QLocale::English)); // make decimal points == .
 
+#ifdef _WIN32
+			QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering); //Doesn't improve it on anything 'cept windows
+#endif
+
 
 			JASPTIMER_START("JASP");
 			Application a(argc, argv, filePathQ, unitTest, timeOut, save, logToFile);

--- a/JASP-Desktop/qquick/datasetview.cpp
+++ b/JASP-Desktop/qquick/datasetview.cpp
@@ -6,6 +6,7 @@
 #include <queue>
 #include "timers.h"
 #include "log.h"
+#include "gui/preferencesmodel.h"
 
 DataSetView * DataSetView::_lastInstancedDataSetView = nullptr;
 
@@ -35,6 +36,8 @@ DataSetView::DataSetView(QQuickItem *parent) : QQuickItem (parent), _metricsFont
 	connect(this, &DataSetView::itemSizeChanged, this, &DataSetView::reloadTextItems);
 	connect(this, &DataSetView::itemSizeChanged, this, &DataSetView::reloadRowNumbers);
 	connect(this, &DataSetView::itemSizeChanged, this, &DataSetView::reloadColumnHeaders);
+
+	connect(PreferencesModel::prefs(), &PreferencesModel::uiScaleChanged, this, &DataSetView::resetItems);
 
 	setZ(10);
 
@@ -116,6 +119,37 @@ void DataSetView::modelWasReset()
 {
 	setRolenames();
 	calculateCellSizes();
+}
+
+void DataSetView::resetItems()
+{
+	_storedLineFlags.clear();
+	_storedDisplayText.clear();
+
+	for(auto col : _cellTextItems)
+	{
+		for(auto row : col.second)
+			storeTextItem(row.first, col.first, false);
+		col.second.clear();
+	}
+
+	std::list<int> cols, rows;
+
+	for(auto col : _columnHeaderItems)
+		cols.push_back(col.first);
+
+	for(auto col : cols)
+		storeColumnHeader(col);
+
+	for(auto row : _rowNumberItems)
+		rows.push_back(row.first);
+
+	for(auto row : rows)
+		storeRowNumber(row);
+
+	_rowNumberStorage		= {};
+	_columnHeaderStorage	= {};
+	_textItemStorage		= {};
 }
 
 void DataSetView::calculateCellSizes()

--- a/JASP-Desktop/qquick/datasetview.h
+++ b/JASP-Desktop/qquick/datasetview.h
@@ -99,6 +99,8 @@ public:
 	int headerHeight()			{ return _dataRowsMaxHeight; }
 	int rowNumberWidth()		{ return _rowNumberMaxWidth; }
 
+	void resetItems();
+
 
 	GENERIC_SET_FUNCTION(HeaderHeight,		_dataRowsMaxHeight, headerHeightChanged,		double)
 	GENERIC_SET_FUNCTION(RowNumberWidth,	_rowNumberMaxWidth, rowNumberWidthChanged,		double)


### PR DESCRIPTION
- part of the fix for https://github.com/jasp-stats/jasp-test-release/issues/522
Use native text rendering on Windows once more!
Fixes https://github.com/jasp-stats/jasp-test-release/issues/535
Also made sure items in datasetview are reset after uiScaleChanges (stuff looked weird (unevenly size rownumbers etc) after resizing to >300% and going back down)

