### PR TITLE
Make .hasErrors() catch columns with only NA's

### DIFF
--- a/JASP-Engine/JASP/R/ancova.R
+++ b/JASP-Engine/JASP/R/ancova.R
@@ -304,9 +304,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
 
     if (contrast$contrast == "custom")
       # Check whether the custom contrast matrix works
-      .hasErrors(dataset = NULL,
-                 allowEmptyDataset = FALSE,
-                 exitAnalysisIfErrors = TRUE,
+      .hasErrors(exitAnalysisIfErrors = TRUE,
                  custom = function() {
                    if (grepl(tryContrMat[1], pattern = "singular contrast matrix")) {
                      return("Singular custom contrast matrix.")

--- a/JASP-Engine/JASP/R/auditCommonFunctions.R
+++ b/JASP-Engine/JASP/R/auditCommonFunctions.R
@@ -382,6 +382,9 @@
 
   if(options[["monetaryVariable"]] != "")
     variables <- c(variables, options[["monetaryVariable"]])
+  
+  if (length(variables) == 0)
+    return()
 
   N <- nrow(dataset)
 

--- a/JASP-Engine/JASP/R/commonAnovaBayesian.R
+++ b/JASP-Engine/JASP/R/commonAnovaBayesian.R
@@ -68,7 +68,6 @@
   if (!noVariables) {
     .hasErrors(
       dataset = dataset,
-      perform = "run",
       type    = c("infinity", "observations", "variance", "factorLevels", "duplicateColumns"),
       infinity.target     = target,
       variance.target     = target,

--- a/JASP-Engine/JASP/R/commonMachineLearningClassification.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningClassification.R
@@ -43,8 +43,11 @@
     target                  <- options[["target"]]
   variables.to.read         <- c(predictors, target)
 
+  if (length(variables.to.read) == 0)
+    return()
+  
   customChecks <- .getCustomErrorChecksKnnBoosting(dataset, options, type)
-  errors <- .hasErrors(dataset, perform, type = c('infinity', 'observations'), custom = customChecks,
+  errors <- .hasErrors(dataset, type = c('infinity', 'observations'), custom = customChecks,
                        all.target = variables.to.read,
                        observations.amount = "< 2",
                        exitAnalysisIfErrors = TRUE)

--- a/JASP-Engine/JASP/R/commonMachineLearningRegression.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningRegression.R
@@ -51,9 +51,12 @@
   if(options[["target"]] != "")
     target                  <- options[["target"]]
   variables.to.read         <- c(predictors, target)
+  
+  if (length(variables.to.read) == 0)
+    return()
 
   customChecks <- .getCustomErrorChecksKnnBoosting(dataset, options, type)
-  errors <- .hasErrors(dataset, perform, type = c('infinity', 'observations'),
+  errors <- .hasErrors(dataset, type = c('infinity', 'observations'),
                        all.target = variables.to.read, custom = customChecks,
                        observations.amount = "< 2",
                        exitAnalysisIfErrors = TRUE)

--- a/JASP-Engine/JASP/R/commonbayesianttest.R
+++ b/JASP-Engine/JASP/R/commonbayesianttest.R
@@ -164,7 +164,7 @@
 
     for (var in dependents) {
 
-      errors[[var]] <- .hasErrors(dataset, perform = "run", message = 'short',
+      errors[[var]] <- .hasErrors(dataset, message = 'short',
                                   type = c('infinity','observations','variance'),
                                   all.target = var, observations.amount = "< 2",
                                   all.grouping = grouping)
@@ -176,7 +176,7 @@
 
     dependents <- unlist(options[["variables"]])
     for (var in dependents) {
-      errors[[var]] <- .hasErrors(dataset, perform = "run", message = 'short',
+      errors[[var]] <- .hasErrors(dataset, message = 'short',
                                   type = c('infinity','observations','variance'),
                                   all.target = var, observations.amount = "< 2")
     }
@@ -199,7 +199,7 @@
 
       } else {
 
-        errors[[var]] <- .hasErrors(dataset, perform = "run", message = 'short',
+        errors[[var]] <- .hasErrors(dataset, message = 'short',
                                     type = c('infinity','observations','variance'),
                                     all.target = c(pair[[1L]],pair[[2L]]), observations.amount = "< 2")
       }

--- a/JASP-Engine/JASP/R/confirmatoryfactoranalysis.R
+++ b/JASP-Engine/JASP/R/confirmatoryfactoranalysis.R
@@ -101,18 +101,18 @@ ConfirmatoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
 
   if (options$groupvar == "") {
 
-    .hasErrors(dataset[, .v(vars)], perform = "run", type = 'varCovData', exitAnalysisIfErrors = TRUE,
+    .hasErrors(dataset[, .v(vars)], type = 'varCovData', exitAnalysisIfErrors = TRUE,
                varCovData.corFun = stats::cov)
 
   } else {
 
-    .hasErrors(dataset, perform, type = "factorLevels", factorLevels.target = options$groupvar,
+    .hasErrors(dataset, type = "factorLevels", factorLevels.target = options$groupvar,
                factorLevels.amount = '< 2', exitAnalysisIfErrors = TRUE)
 
     for (group in levels(dataset[[.v(options$groupvar)]])) {
 
       idx <- dataset[[.v(options$groupvar)]] == group
-      .hasErrors(dataset[idx, .v(vars)], perform = "run", type = 'varCovData', exitAnalysisIfErrors = TRUE,
+      .hasErrors(dataset[idx, .v(vars)], type = 'varCovData', exitAnalysisIfErrors = TRUE,
                  varCovData.corFun = stats::cov)
 
     }

--- a/JASP-Engine/JASP/R/exploratoryfactoranalysis.R
+++ b/JASP-Engine/JASP/R/exploratoryfactoranalysis.R
@@ -26,7 +26,9 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   # Read dataset
   dataset <- .efaReadData(dataset, options)
   ready   <- length(options$variables) > 1
-  .efaCheckErrors(dataset, options)
+  
+  if (ready)
+    .efaCheckErrors(dataset, options)
 
   modelContainer <- .efaModelContainer(jaspResults)
 

--- a/JASP-Engine/JASP/R/mlClassificationLda.R
+++ b/JASP-Engine/JASP/R/mlClassificationLda.R
@@ -80,7 +80,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 # Error handling 
 .classLdaErrorHandling <- function(dataset, options){
   # Error Check 1: There should be at least 5 observations in the target variable
-  .hasErrors(dataset = dataset, perform = "run", type = c('observations', 'variance', 'infinity'),
+  .hasErrors(dataset = dataset, type = c('observations', 'variance', 'infinity'),
              all.target = options$target, observations.amount = '< 5', exitAnalysisIfErrors = TRUE)
   
   # Error Check 2: The target variable should have at least 2 classes

--- a/JASP-Engine/JASP/R/networkanalysis.R
+++ b/JASP-Engine/JASP/R/networkanalysis.R
@@ -110,7 +110,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
 
     if (options[["groupingVariable"]] != "") {
       # these cannot be chained unfortunately
-      .hasErrors(dataset = groupingVariable, perform = perform,
+      .hasErrors(dataset = groupingVariable,
                  type = c("factorLevels", "observations"),
                  factorLevels.target = groupingVariable,
                  factorLevels.amount = "< 2",
@@ -133,7 +133,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
     if (options[["correlationMethod"]] == "cov")
       fun <- cov
 
-    .hasErrors(dataset = dataset, perform = perform,
+    .hasErrors(dataset = dataset,
                type = checks,
                variance.target = options[["variables"]], # otherwise the grouping variable always has variance == 0
                variance.grouping = groupingVariable,

--- a/JASP-Engine/JASP/R/principalcomponentanalysis.R
+++ b/JASP-Engine/JASP/R/principalcomponentanalysis.R
@@ -21,7 +21,9 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
   # Read dataset
   dataset <- .pcaReadData(dataset, options)
   ready   <- length(options$variables) > 1
-  .pcaCheckErrors(dataset, options)
+  
+  if (ready)
+    .pcaCheckErrors(dataset, options)
 
   modelContainer <- .pcaModelContainer(jaspResults)
 

--- a/JASP-Engine/JASP/R/regressionlinear.R
+++ b/JASP-Engine/JASP/R/regressionlinear.R
@@ -121,7 +121,7 @@ RegressionLinear <- function(jaspResults, dataset = NULL, options) {
     )
   }
 
-  .hasErrors(dataset, type = c("infinity", "variance", "observations", "modelInteractions", "varCovData"), allowEmptyDataset = FALSE,
+  .hasErrors(dataset, type = c("infinity", "variance", "observations", "modelInteractions", "varCovData"),
              custom = stepwiseProcedureChecks, all.target = c(options$dependent, unlist(options$covariates)),
              observations.amount = "< 2", modelInteractions.modelTerms = options$modelTerms, varCovData.corFun = stats::cov,
              exitAnalysisIfErrors = TRUE)

--- a/JASP-Engine/JASP/R/regressionlinearbayesian.R
+++ b/JASP-Engine/JASP/R/regressionlinearbayesian.R
@@ -98,7 +98,7 @@ RegressionLinearBayesian <- function(jaspResults, dataset = NULL, options) {
       }
     })
   
-  .hasErrors(dataset = dataset, perform = perform,
+  .hasErrors(dataset = dataset,
              type = c("infinity", "observations", "variance", "modelInteractions"), custom = customChecks,
              infinity.target = c(options$covariates, options$dependent, options$wlsWeight),
              observations.target = options$dependent, observations.amount = paste("<", length(options$modelTerms) + 1),

--- a/JASP-Engine/JASP/R/reliabilityanalysis.R
+++ b/JASP-Engine/JASP/R/reliabilityanalysis.R
@@ -51,7 +51,6 @@ ReliabilityAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
     for (level in levels) {
       .hasErrors(
         dataset              = data[data == level],
-        perform              = "run",
         type                 = "observations",
         observations.amount  = "< 3",
         exitAnalysisIfErrors = TRUE
@@ -61,7 +60,6 @@ ReliabilityAnalysis <- function(jaspResults, dataset = NULL, options, ...) {
 
   # Error check 2: One or more variables has infinity
   .hasErrors(dataset = dataset, 
-             perform = perform,
              type    = "infinity",
              infinity.target = options$variables,
              exitAnalysisIfErrors = TRUE)


### PR DESCRIPTION
Fixes
https://github.com/jasp-stats/jasp-test-release/issues/568 (partially)
https://github.com/jasp-stats/jasp-test-release/issues/562
https://github.com/jasp-stats/jasp-test-release/issues/574
https://github.com/jasp-stats/jasp-test-release/issues/570
https://github.com/jasp-stats/jasp-test-release/issues/559
https://github.com/jasp-stats/jasp-test-release/issues/558

The reason this wasn't changed earlier, is because analyses still used`.readDataSetHeader()` which returned a named zero-row data.frame. And this dataset is identical to what would be provided after calling `na.omit()` on a data.frame with `debNaN` in it. Considering  `readDataSetHeader` is no longer needed after the jaspResults rewrites, I can finally make this change.

I still needed to make some changes to analyses that relied on `.hasErrors()` to deal with  situations in which the analyses didn't actually want to perform any error checking.