### PR TITLE
Make plot behaviour more consistent in descriptives and add error handling

### DIFF
--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -585,10 +585,10 @@ Descriptives <- function(jaspResults, dataset, options) {
   }
 
   plotMat <- matrix(list(), l, l)
-	axisBreaks <- vector("list", l)
+  axisBreaks <- vector("list", l)
 
-	# minor adjustments to plot margin to avoid cutting off the x-axis labels
-	adjMargin <- ggplot2::theme(plot.margin = ggplot2::unit(c(.25, .40, .25, .25), "cm"))
+  # minor adjustments to plot margin to avoid cutting off the x-axis labels
+  adjMargin <- ggplot2::theme(plot.margin = ggplot2::unit(c(.25, .40, .25, .25), "cm"))
 
   oldFontSize <- JASPgraphs::getGraphOption("fontsize")
   JASPgraphs::setGraphOption("fontsize", .85 * oldFontSize)
@@ -598,37 +598,37 @@ Descriptives <- function(jaspResults, dataset, options) {
     if (variable.statuses[[row]]$error != "") {
       plotMat[[row, row]] <- .displayError(errorMessage=variable.statuses[[row]]$error)
     } else {
-    	plotMat[[row, row]] <- .plotMarginalCorDescriptives(dataset[[.v(variables[[row]])]]) + adjMargin
-    	axisBreaks[[row]] <- JASPgraphs::getAxisBreaks(plotMat[[row, row]])
+      plotMat[[row, row]] <- .plotMarginalCorDescriptives(dataset[[.v(variables[[row]])]]) + adjMargin
+      axisBreaks[[row]] <- JASPgraphs::getAxisBreaks(plotMat[[row, row]])
     }
   }
 
   # now do off-diagonal and use the same breaks
   for (row in seq_len(l-1)) {
-  	for (col in seq(row+1, l)) {
-	    if (variable.statuses[[row]]$error != "") {
-	      plotMat[[row, col]] <- .displayError(errorMessage=variable.statuses[[row]]$error)
-	    } else if (variable.statuses[[col]]$error != "") {
-	      plotMat[[row, col]] <- .displayError(errorMessage=variable.statuses[[col]]$error)
-	    } else {
-    		plotMat[[row, col]] <- .plotScatterDescriptives(
-    			xVar    = dataset[[.v(variables[[col]])]],
-    			yVar    = dataset[[.v(variables[[row]])]],
-    			xBreaks = axisBreaks[[col]]$x,
-    			yBreaks = axisBreaks[[row]]$x
-    		) + adjMargin
-	    }
-  	}
+    for (col in seq(row+1, l)) {
+      if (variable.statuses[[row]]$error != "") {
+        plotMat[[row, col]] <- .displayError(errorMessage=variable.statuses[[row]]$error)
+      } else if (variable.statuses[[col]]$error != "") {
+        plotMat[[row, col]] <- .displayError(errorMessage=variable.statuses[[col]]$error)
+      } else {
+        plotMat[[row, col]] <- .plotScatterDescriptives(
+          xVar    = dataset[[.v(variables[[col]])]],
+          yVar    = dataset[[.v(variables[[row]])]],
+          xBreaks = axisBreaks[[col]]$x,
+          yBreaks = axisBreaks[[row]]$x
+        ) + adjMargin
+      }
+    }
   }
 
   JASPgraphs::setGraphOption("fontsize", oldFontSize)
 
-	# slightly adjust the positions of the labels left and above the plots.
+  # slightly adjust the positions of the labels left and above the plots.
   labelPos <- matrix(.5, 4, 2)
   labelPos[1, 1] <- .55
   labelPos[4, 2] <- .65
   p <- JASPgraphs::ggMatrixPlot(plotList = plotMat, leftLabels = variables, topLabels = variables,
-  															scaleXYlabels = NULL, labelPos = labelPos)
+                                scaleXYlabels = NULL, labelPos = labelPos)
 
   return(createJaspPlot(plot=p, width=250 * l + 20, aspectRatio=1, title=name, dependencies=depends))
 }
@@ -637,58 +637,58 @@ Descriptives <- function(jaspResults, dataset, options) {
 #### histogram with density estimator ####
 .plotMarginalCorDescriptives <- function(variable, xName = NULL, yName = gettext("Density")) {
   variable <- na.omit(variable)
-	isNumeric <- !(is.factor(variable) || (is.integer(variable) && length(unique(variable)) <= 10))
-
-	if (isNumeric) {
-		p <- ggplot2::ggplot(data = data.frame(x = variable))
-		h <- hist(variable, plot = FALSE)
-  	hdiff <- h$breaks[2L] - h$breaks[1L]
-		xBreaks <- JASPgraphs::getPrettyAxisBreaks(c(variable, h$breaks), min.n = 3)
-		dens <- h$density
-  	yBreaks <- c(0, 1.2*max(h$density))
-
-  	p <- p + ggplot2::geom_histogram(
-  		mapping  = ggplot2::aes(x = x, y = ..density..),
-  		binwidth = hdiff,
-  		fill     = "grey",
-  		col      = "black",
-  		size     = .3,
-  		center   = hdiff / 2,
-  		stat     = "bin"
-  	) +
-  		ggplot2::scale_x_continuous(name = xName, breaks = xBreaks, limits = range(xBreaks))
-	} else {
-
-		p <- ggplot2::ggplot(data = data.frame(x = factor(variable)))
-		hdiff <- 1L
-		xBreaks <- unique(variable)
-		yBreaks <- c(0, max(table(variable)))
-
-		p <- p + ggplot2::geom_bar(
-			mapping  = ggplot2::aes(x = x),
-			fill     = "grey",
-			col      = "black",
-			size     = .3,
-			stat     = "count"
-		) +
-			ggplot2::scale_x_discrete(name = xName, breaks = xBreaks)
-	}
-
-	yLim <- range(yBreaks)
+  isNumeric <- !(is.factor(variable) || (is.integer(variable) && length(unique(variable)) <= 10))
 
   if (isNumeric) {
-  	density <- density(variable)
-  	p <- p + ggplot2::geom_line(data = data.frame(x = density$x, y = density$y),
-  															mapping = ggplot2::aes(x = x, y = y), lwd = .7, col = "black")
+    p <- ggplot2::ggplot(data = data.frame(x = variable))
+    h <- hist(variable, plot = FALSE)
+    hdiff <- h$breaks[2L] - h$breaks[1L]
+    xBreaks <- JASPgraphs::getPrettyAxisBreaks(c(variable, h$breaks), min.n = 3)
+    dens <- h$density
+    yBreaks <- c(0, 1.2*max(h$density))
+
+    p <- p + ggplot2::geom_histogram(
+      mapping  = ggplot2::aes(x = x, y = ..density..),
+      binwidth = hdiff,
+      fill     = "grey",
+      col      = "black",
+      size     = .3,
+      center   = hdiff / 2,
+      stat     = "bin"
+    ) +
+      ggplot2::scale_x_continuous(name = xName, breaks = xBreaks, limits = range(xBreaks))
+  } else {
+
+    p <- ggplot2::ggplot(data = data.frame(x = factor(variable)))
+    hdiff <- 1L
+    xBreaks <- unique(variable)
+    yBreaks <- c(0, max(table(variable)))
+
+    p <- p + ggplot2::geom_bar(
+      mapping  = ggplot2::aes(x = x),
+      fill     = "grey",
+      col      = "black",
+      size     = .3,
+      stat     = "count"
+    ) +
+      ggplot2::scale_x_discrete(name = xName, breaks = xBreaks)
   }
 
-	thm <- ggplot2::theme(
-		axis.ticks.y = ggplot2::element_blank(),
-		axis.title.y = ggplot2::element_text(margin = ggplot2::margin(t = 0, r = -5, b = 0, l = 0))
-	)
+  yLim <- range(yBreaks)
+
+  if (isNumeric) {
+    density <- density(variable)
+    p <- p + ggplot2::geom_line(data = data.frame(x = density$x, y = density$y),
+                                mapping = ggplot2::aes(x = x, y = y), lwd = .7, col = "black")
+  }
+
+  thm <- ggplot2::theme(
+    axis.ticks.y = ggplot2::element_blank(),
+    axis.title.y = ggplot2::element_text(margin = ggplot2::margin(t = 0, r = -5, b = 0, l = 0))
+  )
   p <- p +
-  	ggplot2::scale_y_continuous(name = yName, breaks = yBreaks, labels = c("", ""), limits = yLim) +
-  	ggplot2::theme()
+    ggplot2::scale_y_continuous(name = yName, breaks = yBreaks, labels = c("", ""), limits = yLim) +
+    ggplot2::theme()
   return(JASPgraphs::themeJasp(p) + thm)
 }
 
@@ -724,17 +724,17 @@ Descriptives <- function(jaspResults, dataset, options) {
 
 .plotScatterDescriptives <- function(xVar, yVar, xBreaks = NULL, yBreaks = NULL, xName = NULL, yName = NULL) {
   
-	isNumericX <- !(is.factor(xVar) || (is.integer(xVar) && length(unique(xVar)) <= 10))
-	isNumericY <- !(is.factor(yVar) || (is.integer(yVar) && length(unique(yVar)) <= 10))
-	bothNumeric <- isNumericX && isNumericY
+  isNumericX <- !(is.factor(xVar) || (is.integer(xVar) && length(unique(xVar)) <= 10))
+  isNumericY <- !(is.factor(yVar) || (is.integer(yVar) && length(unique(yVar)) <= 10))
+  bothNumeric <- isNumericX && isNumericY
   d <- data.frame(x = xVar, y = yVar)
   d <- na.omit(d)
 
   if (!isNumericX)
-  	d$x <- as.factor(d$x)
+    d$x <- as.factor(d$x)
 
   if (!isNumericY)
-  	d$y <- as.factor(d$y)
+    d$y <- as.factor(d$y)
 
   if (is.null(xBreaks))
     xBreaks <- JASPgraphs::getPrettyAxisBreaks(d$x)
@@ -742,37 +742,37 @@ Descriptives <- function(jaspResults, dataset, options) {
   fit <- NULL
   
   if (bothNumeric) {
-  	fit <- lm(y ~ poly(x, 1, raw = TRUE), d)
-  	lineObj <- .poly.predDescriptives(fit, line = FALSE, xMin= xBreaks[1], xMax = xBreaks[length(xBreaks)], lwd = lwd)
-  	rangeLineObj <- c(lineObj[1], lineObj[length(lineObj)])
-  	yLimits <- range(c(pretty(yVar)), rangeLineObj)
+    fit <- lm(y ~ poly(x, 1, raw = TRUE), d)
+    lineObj <- .poly.predDescriptives(fit, line = FALSE, xMin= xBreaks[1], xMax = xBreaks[length(xBreaks)], lwd = lwd)
+    rangeLineObj <- c(lineObj[1], lineObj[length(lineObj)])
+    yLimits <- range(c(pretty(yVar)), rangeLineObj)
 
-  	if (!all(is.na(yLimits))) { # this is NA in case both x and y only contain a single unique value
-    	if (is.null(yBreaks) || yLimits[1L] <= yBreaks[1L] || yLimits[2L] >= yBreaks[length(yBreaks)])
-    		yBreaks <- JASPgraphs::getPrettyAxisBreaks(yLimits)
-  	}
+    if (!all(is.na(yLimits))) { # this is NA in case both x and y only contain a single unique value
+      if (is.null(yBreaks) || yLimits[1L] <= yBreaks[1L] || yLimits[2L] >= yBreaks[length(yBreaks)])
+        yBreaks <- JASPgraphs::getPrettyAxisBreaks(yLimits)
+    }
   } else if (is.null(yBreaks)) {
-  	yBreaks <- JASPgraphs::getPrettyAxisBreaks(d$y)
+    yBreaks <- JASPgraphs::getPrettyAxisBreaks(d$y)
   }
 
   p <- ggplot2::ggplot(data = d, ggplot2::aes(x = x, y = y)) +
     JASPgraphs::geom_point()
 
   if (bothNumeric) {
-  	xr <- range(xBreaks)
-  	dfLine <- data.frame(x = xr, y = rangeLineObj)
+    xr <- range(xBreaks)
+    dfLine <- data.frame(x = xr, y = rangeLineObj)
     p <- p + ggplot2::geom_line(data = dfLine, ggplot2::aes(x = x, y = y), size = .7, inherit.aes = FALSE)
   }
 
   if (isNumericX) {
-  	p <- p + ggplot2::scale_x_continuous(name = xName, breaks = xBreaks, limits = range(xBreaks))
+    p <- p + ggplot2::scale_x_continuous(name = xName, breaks = xBreaks, limits = range(xBreaks))
   } else {
-  	p <- p + ggplot2::scale_x_discrete(name = xName)
+    p <- p + ggplot2::scale_x_discrete(name = xName)
   }
   if (isNumericY) {
-  	p <- p + ggplot2::scale_y_continuous(name = yName, breaks = yBreaks, limits = range(yBreaks))
+    p <- p + ggplot2::scale_y_continuous(name = yName, breaks = yBreaks, limits = range(yBreaks))
   } else {
-  	p <- p + ggplot2::scale_y_discrete(name = yName)
+    p <- p + ggplot2::scale_y_discrete(name = yName)
   }
 
   return(JASPgraphs::themeJasp(p))

--- a/JASP-Tests/R/tests/testthat/test-descriptives.R
+++ b/JASP-Tests/R/tests/testthat/test-descriptives.R
@@ -125,19 +125,26 @@ test_that("Q-QPlot plot matches", {
   expect_equal_plots(testPlot, "qqplot", dir="Descriptives")
 })
 
-test_that("Pie chart and scatter plots matchs", {
+test_that("Scatter plot matches", {
   options <- jasptools::analysisOptions("Descriptives")
-  options$variables <- c("facFive", "contcor1", "contcor2")
-  options$descriptivesPiechart <- TRUE
+  options$variables <- c("contcor1", "contcor2")
   options$scatterPlot <- TRUE
   options$colorPalette <- "ggplot2"
   results <- jasptools::run("Descriptives", "test.csv", options)
 
   testPlot <- results[["state"]][["figures"]][[1]][["obj"]]
-  expect_equal_plots(testPlot, "pieChart", dir="Descriptives")
-
-  testPlot <- results[["state"]][["figures"]][[2]][["obj"]]
   expect_equal_plots(testPlot, "scatterplot", dir="Descriptives")
+})
+
+test_that("Pie chart matches", {
+  options <- jasptools::analysisOptions("Descriptives")
+  options$variables <- "facFive"
+  options$descriptivesPiechart <- TRUE
+  options$colorPalette <- "ggplot2"
+  results <- jasptools::run("Descriptives", "test.csv", options)
+  
+  testPlot <- results[["state"]][["figures"]][[1]][["obj"]]
+  expect_equal_plots(testPlot, "pieChart", dir="Descriptives")
 })
 
 test_that("Analysis handles identical variables", {


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/379, fixes https://github.com/jasp-stats/jasp-test-release/issues/494, fixes https://github.com/jasp-stats/jasp-test-release/issues/498

- Adds error handling where it was either incomplete or absent
- Performs error handling before omitting NA’s
- Plots always omit variables of types that they do not support (rather than sometimes showing an error, sometimes omitting)
- Scatterplots now also work with nominal int data (to be consistent with other plots)
- Removes NA’s from scatterplot data instead of throwing an error
- Adds missing dependency to correlation matrix

