### PR TITLE
Allow longer progressbar labels, truncate if necessary

### DIFF
--- a/JASP-Desktop/html/css/darkTheme-jasp.css
+++ b/JASP-Desktop/html/css/darkTheme-jasp.css
@@ -613,6 +613,10 @@ pre {
   color: #5c5c5c;
 }
 
+.jasp-progressbar-label-sep {
+    font-style: italic;
+}
+
 /*.jasp-indent {
   margin-left: .5em ;
   padding-left: 0.8em ;

--- a/JASP-Desktop/html/css/lightTheme-jasp.css
+++ b/JASP-Desktop/html/css/lightTheme-jasp.css
@@ -614,6 +614,10 @@ pre {
 	color: gray;
 }
 
+.jasp-progressbar-label-sep {
+    font-style: italic;
+}
+
 /*.jasp-indent {
 	margin-left: .5em ;
 	padding-left: 0.8em ;

--- a/JASP-Desktop/html/js/jaspwidgets.js
+++ b/JASP-Desktop/html/js/jaspwidgets.js
@@ -963,7 +963,7 @@ JASPWidgets.ProgressbarView = JASPWidgets.View.extend({
 			label = this.model.get("label");
 			value = this.model.get("maxValue");
 		} else {
-			label = this._ellipsify(label);
+			label = this._makePrettyLabel(label);
 			value = Math.min(this.model.get("maxValue"), value)
 		}
 
@@ -1041,7 +1041,21 @@ JASPWidgets.ProgressbarView = JASPWidgets.View.extend({
 		this.$el.append($container);
 	},
 
-	_ellipsify: function(label) {
+	_makePrettyLabel: function(label) {
+		return this._addTrailingEllipsis(this._truncate(label));
+	},
+
+	_truncate: function(label) {
+		var maxChars = 80;
+		var sep = "...";
+		if (maxChars < label.length) {
+			var nCharsPerChunk = Math.floor((maxChars - sep.length) / 2);
+			label = label.substring(0, nCharsPerChunk) + '<span class="jasp-progressbar-label-sep">' + sep + '</span>' + label.substring(label.length - nCharsPerChunk);
+		}
+		return label;
+	},
+
+	_addTrailingEllipsis: function(label) {
 		if (label.length == 0)
 			return label;
 

--- a/JASP-R-Interface/jaspResults/R/zzzWrappers.R
+++ b/JASP-R-Interface/jaspResults/R/zzzWrappers.R
@@ -31,8 +31,8 @@ signalAnalysisAbort <- function(message = "", call = NULL) {
 startProgressbar <- function(expectedTicks, label="") {
 	if (!is.numeric(expectedTicks) || !is.character(label))
 		stop("`expectedTicks` must be numeric and `label` a character")
-	if (nchar(label) > 40)
-		stop("The label must be 40 characters at most")
+	if (nchar(label) > 80) # if you update this value, also update it in the progressbar in jaspwidgets.js
+		warning("The progressbar label is more than 80 characters, label will be truncated")
 		
 	if (jaspResultsCalledFromJasp())
 		jaspResultsModule$cpp_startProgressbar(expectedTicks, label)


### PR DESCRIPTION
This should be a little less strict. 80 is also a completely random value. I just don't want people to write essays in the label, because the progressbar usually only appears for a short while