### PR TITLE
Scatterplot function inside descriptives shouldn't always use optionContainsValue

### DIFF
--- a/JASP-Engine/JASP/R/commonAnovaBayesian.R
+++ b/JASP-Engine/JASP/R/commonAnovaBayesian.R
@@ -1349,12 +1349,13 @@
         thisPlotName <- paste0(options[["plotHorizontalAxis"]], " - ", options[["dependent"]], ": ", 
                                options[["plotSeparatePlots"]], " = ", thisLevel)
         .descriptivesScatterPlots(descriptivesPlotContainer, subData, c(options[["plotHorizontalAxis"]], options[["dependent"]]), 
-                                  split = options[["plotSeparateLines"]], options = splitScatterOptions, name = thisPlotName)
+                                  split = options[["plotSeparateLines"]], options = splitScatterOptions, name = thisPlotName,
+                                  dependOnVariables = FALSE)
       }
 
     } else {
       .descriptivesScatterPlots(descriptivesPlotContainer, dataset, c(options[["plotHorizontalAxis"]], options[["dependent"]]), 
-                                split = options[["plotSeparateLines"]], options = splitScatterOptions, name = NULL)
+                                split = options[["plotSeparateLines"]], options = splitScatterOptions, dependOnVariables = FALSE)
     }
    
     return()

--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -1330,7 +1330,7 @@ Descriptives <- function(jaspResults, dataset, options) {
   return(plotObj)
 }
 
-.descriptivesScatterPlots <- function(jaspContainer, dataset, variables, split, options, name = NULL) {
+.descriptivesScatterPlots <- function(jaspContainer, dataset, variables, split, options, name = NULL, dependOnVariables = TRUE) {
 
   JASPgraphs::setGraphOption("palette", options[["colorPalette"]])
   if (!is.null(split) && split != "") {
@@ -1366,7 +1366,8 @@ Descriptives <- function(jaspResults, dataset, options) {
     if (is.null(name)) name <- paste(v1, "-", v2)
     if (is.null(jaspContainer[[name]])) {
       scatterPlot <- createJaspPlot(title = name)
-      scatterPlot$dependOn(optionContainsValue = list(variables = c(v1, v2)))
+      if (dependOnVariables)
+        scatterPlot$dependOn(optionContainsValue = list(variables = c(v1, v2)))
       p <- try(JASPgraphs::JASPScatterPlot(
         x                 = dataset[, variablesB64[i]],
         y                 = dataset[, variablesB64[j]],


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/617

The plots disappeared because the ANOVAs don't have something called "variables" in their options list.