### PR TITLE
Sequential analysis points vs line

### DIFF
--- a/JASP-Engine/JASP/R/bayesianmetaanalysis.R
+++ b/JASP-Engine/JASP/R/bayesianmetaanalysis.R
@@ -1627,22 +1627,17 @@ BayesianMetaAnalysis <- function(jaspResults, dataset, options) {
     return()
   }
   
-  if(nrow(dataset) < 40) plotLineOrPoint <- "point" else plotLineOrPoint <- "line"
-  
   df <- data.frame(x = 1:nrow(dataset), y = log(BFs))
-  
   
   if(type == "ES"){
     
     plot <- JASPgraphs::PlotRobustnessSequential(dfLines = df,
-                                                 plotLineOrPoint = plotLineOrPoint,
                                                  xName = "Studies",
                                                  BF = BFs[nrow(dataset)],
                                                  bfType = bfType,
                                                  hasRightAxis = TRUE)
   } else if(type == "SE"){
     plot <- JASPgraphs::PlotRobustnessSequential(dfLines = df,
-                                                 plotLineOrPoint = plotLineOrPoint,
                                                  xName = "Studies",
                                                  BF = BFs[nrow(dataset)],
                                                  bfType = bfType,

--- a/JASP-Engine/JASP/R/commonbayesianttest.R
+++ b/JASP-Engine/JASP/R/commonbayesianttest.R
@@ -1751,15 +1751,12 @@
   }
   dfLines$y <- log(dfLines$y)
   
-  plotLineOrPoint <- if (length(BF10) <= 60) "point" else "line"
-
   plot <- JASPgraphs::PlotRobustnessSequential(
     dfLines         = dfLines,
     xName           = gettext("n"),
     BF              = BF,
     bfType          = bftype,
-    hypothesis      = hypothesis,
-    plotLineOrPoint = plotLineOrPoint
+    hypothesis      = hypothesis
   )
   return(plot)
 }

--- a/JASP-Engine/JASP/R/commonequivalencefunctions.R
+++ b/JASP-Engine/JASP/R/commonequivalencefunctions.R
@@ -997,8 +997,6 @@
   }
   dfLines$y <- log(dfLines$y)
   
-  plotLineOrPoint <- if (length(BF10) <= 60) "point" else "line"
-
   plot <- JASPgraphs::PlotRobustnessSequential(
     dfLines         = dfLines,
     xName           = gettext("n"),
@@ -1006,7 +1004,6 @@
     BF              = BF,
     bfType          = bftype,
     hypothesis      = "equal",
-    plotLineOrPoint = plotLineOrPoint, 
     evidenceLeveltxt = FALSE,
    # evidenceTxt     = JASPgraphs::parseThis("H[phantom()%in%phantom()]"),
     arrowLabel      = JASPgraphs::parseThis(c("H[phantom()%notin%phantom()]", "H[phantom()%in%phantom()]")),

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -1030,13 +1030,14 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
     
   
   plotResult <- try(JASPgraphs::PlotRobustnessSequential(
-    dfLines      = dfLines,
-    xName        = bquote(paste(.(gettext("Stretched beta prior width")), ~kappa)),
-    dfPoints     = dfPoints,
-    bfType       = bfPlotType,
-    pointColors  = pointColors,
-    pointFill    = pointFill, 
-    hypothesis   = hypothesisJASPgraphsName
+    dfLines         = dfLines,
+    xName           = bquote(paste(.(gettext("Stretched beta prior width")), ~kappa)),
+    dfPoints        = dfPoints,
+    bfType          = bfPlotType,
+    pointColors     = pointColors,
+    pointFill       = pointFill,
+    hypothesis      = hypothesisJASPgraphsName,
+    plotLineOrPoint = "line"
   ))
   
   return(plotResult)

--- a/JASP-Engine/JASPgraphs/DESCRIPTION
+++ b/JASP-Engine/JASPgraphs/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: JASPgraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.4.9
+Version: 0.4.10
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: ...

--- a/JASP-Engine/JASPgraphs/R/JASPgraphsPlot.R
+++ b/JASP-Engine/JASPgraphs/R/JASPgraphsPlot.R
@@ -36,7 +36,7 @@ JASPgraphsPlot <- R6::R6Class(
 }
 
 
-reDrawJASPgraphsPlot <- function(subplots, args, grob = FALSE, newpage = !currentDevIsSvg(),
+reDrawJASPgraphsPlot <- function(subplots, args, grob = FALSE, newpage = FALSE,
                                  decodeplotFun = get0("decodeplot"), ...) {
   # redraws plots from PlotPriorAndPosterior, PlotRobustnessSequential, and ggMatrixplot
   g <- gridExtra::arrangeGrob(
@@ -55,7 +55,7 @@ reDrawJASPgraphsPlot <- function(subplots, args, grob = FALSE, newpage = !curren
     return(gridExtra::grid.arrange(g, ..., newpage = newpage))
 }
 
-reDrawAlignedPlot <- function(subplots, args, grob = FALSE, newpage = !currentDevIsSvg(), 
+reDrawAlignedPlot <- function(subplots, args, grob = FALSE, newpage = FALSE,
                               decodeplotFun = get0("decodeplot"), ...) {
   # redraws plots from JASPScatterPlot
   g <- makeGrobAlignedPlots(

--- a/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
+++ b/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
@@ -21,7 +21,7 @@
 #' @param lineTypes String vector, line types if \code{dfLines$g} is not \code{NULL}.
 #' @param addLineAtOne Logical, should a black line be draw at BF = 1?
 #' @param bty List of three elements. Type specifies the box type, ldwX the width of the x-axis, lwdY the width of the y-axis.
-#' @param plotLineOrPoint String, should the main geom in the plot be a line or a point?
+#' @param plotLineOrPoint String, should the main geom in the plot be a line or a point? If set to auto, points are shown whenevever \code{nrow(dfLines) <= 60}.
 #' @param pointShape String, if \code{plotLineOrPoint == "point"} then this controls the shape aesthetic.
 #' @param pointFill String, if \code{plotLineOrPoint == "point"} then this controls the fill aesthetic.
 #' @param pointColor String, if \code{plotLineOrPoint == "point"} then this controls the color aesthetic.
@@ -44,7 +44,7 @@ PlotRobustnessSequential <- function(
   lineColors = c("black", "grey", "black"),
   lineTypes = c("solid", "solid", "dotted"),
   addLineAtOne = TRUE, bty = list(type = "n", ldwX = .5, lwdY = .5),
-  plotLineOrPoint = c("line", "point"),
+  plotLineOrPoint = c("auto", "line", "point"),
   pointShape = rep(21, 3),
   pointFill  = c("grey", "black", "white"),
   pointColor = rep("black", 3),
@@ -56,6 +56,7 @@ PlotRobustnessSequential <- function(
   errCheckPlots(dfLines = dfLines, dfPoints = dfPoints, BF = BF)
   bfType <- match.arg(bfType)
   plotLineOrPoint <- match.arg(plotLineOrPoint)
+  if (plotLineOrPoint == "auto") plotLineOrPoint <- if (nrow(dfLines) <= 60) "point" else "line"
   hypothesis <- match.arg(hypothesis)
   emptyPlot <- list()
   

--- a/JASP-Engine/JASPgraphs/man/PlotRobustnessSequential.Rd
+++ b/JASP-Engine/JASPgraphs/man/PlotRobustnessSequential.Rd
@@ -25,7 +25,7 @@ PlotRobustnessSequential(
   lineTypes = c("solid", "solid", "dotted"),
   addLineAtOne = TRUE,
   bty = list(type = "n", ldwX = 0.5, lwdY = 0.5),
-  plotLineOrPoint = c("line", "point"),
+  plotLineOrPoint = c("auto", "line", "point"),
   pointShape = rep(21, 3),
   pointFill = c("grey", "black", "white"),
   pointColor = rep("black", 3),
@@ -77,7 +77,7 @@ Ignored if \code{!is.null(dfLines$g) && linesLegend}.}
 
 \item{bty}{List of three elements. Type specifies the box type, ldwX the width of the x-axis, lwdY the width of the y-axis.}
 
-\item{plotLineOrPoint}{String, should the main geom in the plot be a line or a point?}
+\item{plotLineOrPoint}{String, should the main geom in the plot be a line or a point? If set to auto, points are shown whenevever \code{nrow(dfLines) <= 60}.}
 
 \item{pointShape}{String, if \code{plotLineOrPoint == "point"} then this controls the shape aesthetic.}
 

--- a/JASP-Tests/R/tests/figs/jasp-deps.txt
+++ b/JASP-Tests/R/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- JASPgraphs: 0.4.9
+- JASPgraphs: 0.4.10


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/616
Fixes https://github.com/jasp-stats/jasp-test-release/issues/620

The choice about points vs lines is made consistent by adding a default to JASPgraphs, and removing the logic from the analyses.

The new pages were intentional, although I have no idea why (everything still worked when I removed them).
