### PR TITLE
Exact p values setting should only affect p-values

### DIFF
--- a/JASP-Desktop/html/js/utils.js
+++ b/JASP-Desktop/html/js/utils.js
@@ -74,7 +74,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
     for (let i = 0; i < formats.length; i++) {
 
         let f = formats[i];
-        if (f.indexOf("p:") != -1) {
+        if (f.match(/^p:/) !== null) {
             // override APA style if exact p-values wanted
             if (window.globSet.pExact) {
                 sf = 4;


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/613

Stuff like `dp:2` was also matched, which caused the problem above