### PR TITLE
Fixes several problems with language and refresh

### DIFF
--- a/JASP-Desktop/JASP-Desktop.pro
+++ b/JASP-Desktop/JASP-Desktop.pro
@@ -1,12 +1,13 @@
-QT += webengine webchannel svg network printsupport xml qml quick quickwidgets quickcontrols2
+QT      += webengine webchannel svg network printsupport xml qml quick quickwidgets quickcontrols2
 DEFINES += JASP_USES_QT_HERE
+
 GENERATE_LANGUAGE_FILES = false
 
 QTQUICK_COMPILER_SKIPPED_RESOURCES += html/html.qrc
 
 include(../JASP.pri)
 
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets #We need this for the native dialogs
 
 include(../R_HOME.pri)
 

--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -187,6 +187,9 @@ void Analyses::clear()
 {
 	setCurrentAnalysisIndex(-1);
 	beginResetModel();
+	_resultsMeta = Json::nullValue;
+	_allUserData = Json::nullValue;
+
 	for (auto & idAnalysis : _analysisMap)
 	{
 		Analysis* analysis = idAnalysis.second;
@@ -244,12 +247,16 @@ void Analyses::_analysisQMLFileChanged(Analysis *analysis)
 
 Json::Value Analyses::asJson() const
 {
-	Json::Value analysesDataList = Json::arrayValue;
+	Json::Value analysesJson		= Json::objectValue,
+				analysesDataList	= Json::arrayValue;;
 
 	for(auto idAnalysis : _analysisMap)
 			analysesDataList.append(idAnalysis.second->asJSON());
 
-	return analysesDataList;
+	analysesJson["analyses"]	= analysesDataList;
+	analysesJson["meta"]		= resultsMeta();
+
+	return analysesJson;
 }
 
 
@@ -703,7 +710,6 @@ void Analyses::analysisTitleChangedHandler(string moduleName, string oldTitle, s
 	{
 		if (a->module() == moduleName && a->title() == oldTitle)
 			a->setTitle(newTitle);
-
 	});
 }
 
@@ -714,4 +720,17 @@ void Analyses::languageChangedHandler()
 	{
 		emit a->form()->languageChanged();
 	});
+
+	emit setResultsMeta(tq(_resultsMeta.toStyledString()));
+}
+
+void Analyses::resultsMetaChanged(QString json)
+{
+	Json::Reader().parse(fq(json), _resultsMeta);
+}
+
+void Analyses::allUserDataChanged(QString json)
+{
+	Json::Reader().parse(fq(json), _allUserData);
+	setAnalysesUserData(_allUserData);
 }

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -93,6 +93,8 @@ public:
 	bool					visible()													const			{ return _visible;				}
 	bool					moving()													const			{ return _moving;				}
 	double					currentFormPrevH()											const			{ return _currentFormPrevH;		}
+	Json::Value				resultsMeta()												const			{ return _resultsMeta;			}
+	Json::Value				allUserData()												const			{ return _allUserData;			}
 	Analysis*				getAnalysisBeforeMoving(size_t index);
 
 public slots:
@@ -123,6 +125,8 @@ public slots:
 	void showDependenciesInAnalysis(size_t analysis_id, QString optionName);
 	void analysisTitleChangedHandler(std::string moduleName, std::string oldTitle, std::string newTitle);
 	void languageChangedHandler();
+	void resultsMetaChanged(QString json);
+	void allUserDataChanged(QString json);
 
 signals:
 	void analysesUnselected();
@@ -153,6 +157,7 @@ signals:
 	void somethingModified();
     void analysesExportResults();
 	bool developerMode();
+	void setResultsMeta(QString json);
 
 	ComputedColumn *	requestComputedColumnCreation(QString columnName, Analysis *source);
 	void				requestColumnCreation(QString columnName, Analysis *source, int columnType);
@@ -174,6 +179,9 @@ private:
 private:
 	static Analyses				*	_singleton;
 
+	Json::Value						_resultsMeta, //Stored Notes and custom title
+									_allUserData; //Notes and stuff?
+
 	std::map<size_t, Analysis*>		_analysisMap;
 	std::vector<size_t>				_orderedIds;
 	std::vector<size_t>				_orderedIdsBeforeMoving;
@@ -188,7 +196,6 @@ private:
 
 	static int								_scriptRequestID;
 	QMap<int, QPair<Analysis*, QString> >	_scriptIDMap;
-
 
 };
 

--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -161,9 +161,9 @@ Item
 				width:					giveResultsSomeSpace.width - panelSplit.hackySplitHandlerHideWidth
 
 				url:					resultsJsInterface.resultsPageUrl
-				onLoadingChanged:		resultsJsInterface.resultsPageLoaded(loadRequest.status === WebEngineLoadRequest.LoadSucceededStatus);
 				onContextMenuRequested: request.accepted = true
 				backgroundColor:		jaspTheme.uiBackground
+
 				onNavigationRequested:
 					if(request.navigationType === WebEngineNavigationRequest.ReloadNavigation || request.url == resultsJsInterface.resultsPageUrl)
 						request.action = WebEngineNavigationRequest.AcceptRequest
@@ -174,13 +174,28 @@ Item
 						request.action = WebEngineNavigationRequest.IgnoreRequest;
 					}
 
+				onLoadingChanged:
+				{
+					resultsJsInterface.resultsLoaded = loadRequest.status === WebEngineLoadRequest.LoadSucceededStatus;
+					setTranslatedResultsString();
+				}
+
 				Connections
 				{
 					target:					resultsJsInterface
 					onRunJavaScript:		resultsView.runJavaScript(js)
 				}
 
-				webChannel.registeredObjects: [ resultsJsInterfaceInterface ]
+				webChannel.registeredObjects:	[ resultsJsInterfaceInterface ]
+
+				property string resultsString:	qsTr("Results")
+				onResultsStringChanged:			setTranslatedResultsString();
+
+				function setTranslatedResultsString()
+				{
+					if(resultsJsInterface.resultsLoaded)
+						runJavaScript("window.setAnalysesTitle(\"" + resultsString + "\");");
+				}
 
 				Item
 				{

--- a/JASP-Desktop/html/index.html
+++ b/JASP-Desktop/html/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>

--- a/JASP-Desktop/html/js/analyses.js
+++ b/JASP-Desktop/html/js/analyses.js
@@ -9,8 +9,9 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 		this.toolbar = new JASPWidgets.Toolbar({ className: "jasp-toolbar jasp-title-toolbar jasp_top_level" })
 		this.toolbar.setParent(this);
 
-		this.toolbar.title = 'Results';
-		this.toolbar.titleTag = "h1";
+		this.toolbar.titleDefault	= "Results";
+		this.toolbar.title			= this.toolbar.titleDefault;
+		this.toolbar.titleTag		= "h1";
 
 		this.note = new JASPWidgets.Note();
 		this.noteBox = new JASPWidgets.NoteBox({ className: "jasp-notes jasp-main-note jasp_top_level", model: this.note });
@@ -20,6 +21,15 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 		});
 
 		this.views.push(this.noteBox);
+	},
+
+	setTitle: function(newTitle) {
+		console.log("analyses.setTiltle("+newTitle+") was called and default title= " +this.toolbar.titleDefault + " while the old title is: " + this.toolbar.title);
+		var wasDefault = this.toolbar.title === this.toolbar.titleDefault;
+		this.toolbar.titleDefault = newTitle;
+
+		if(wasDefault)
+			this.toolbar.title = this.toolbar.titleDefault
 	},
 
 	menuName: 'All',
@@ -56,7 +66,7 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 	},
 
 	editTitleClicked: function () {
-		this.toolbar.startEdit();
+		this.toolbar.startEdit(function(){ window.getResultsMeta(); });
 	},
 
 	events: {
@@ -152,13 +162,13 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
         // format: 'markdown',
 
 		return {
-			title: this.toolbar.title,
+			title:	this.toolbar.title,
 			notes: {
 				first: {
-                    text: this.note.get('text'),
-                    format: this.note.get('format'),
-					visible: this.noteBox.visible,
-					delta: this.note.get('delta'),
+					text:			this.note.get('text'),
+					format:			this.note.get('format'),
+					visible:		this.noteBox.visible,
+					delta:			this.note.get('delta'),
 					deltaAvailable: this.note.get('deltaAvailable'),
 				}
 			}
@@ -196,7 +206,10 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 	},
 
 
-	setResultsMeta: function (resultsNotes) {
+	setResultsMeta: function (resultsNotes)
+	{
+		if(resultsNotes === null)
+			return; //null is default value in Analyses class
 
 		var notes = resultsNotes['notes'];
 		var title = resultsNotes['title'];

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -82,6 +82,10 @@ $(document).ready(function () {
 		analysis.toolbar.render();
 	}
 
+	window.setAnalysesTitle = function(newTitle) { analyses.setTitle(newTitle); }
+
+
+
 	window.setAppVersion	= function(version) { $(".app-version").text("Version " + version);	}
 	window.noInstructions	= function()		{ $('#instructions').text("");					}
 	window.noPatchinfo		= function()		{ $('#patchinfo').text("");						}
@@ -398,6 +402,7 @@ $(document).ready(function () {
 			});
 
 			analyses.on("analyses:userDataChanged", function () {
+				window.getResultsMeta()
 				jasp.updateUserData();
 			});
 
@@ -435,7 +440,7 @@ $(document).ready(function () {
 			jaspWidget.on("showDependencies",			function (id, optName)	{ jasp.showDependenciesInAnalysis(id, optName);					});
 			jaspWidget.on("analysis:remove",			function (id)			{ jasp.removeAnalysisRequest(id);								});
 			jaspWidget.on("analysis:duplicate",			function (id)			{ jasp.duplicateAnalysis(id);									});
-			jaspWidget.on("analysis:userDataChanged",	function ()				{ jasp.updateUserData();										});
+			jaspWidget.on("analysis:userDataChanged",	function ()				{ jasp.updateUserData(); window.getAllUserData();				});
 
 			jaspWidget.on("toolbar:showMenu", function (obj, options) {
 

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -163,7 +163,6 @@ private:
 	void saveTextToFileHandler(const QString &filename, const QString &data);
 
 	void		removeAnalysis(Analysis *analysis);
-	void		getAnalysesUserData();
 	void		analysesCountChangedHandler();
 	void		analysisChangedDownstreamHandler(int id, QString options);
 	void		analysisSaveImageHandler(int id, QString options);

--- a/JASP-Desktop/results/resultsjsinterface.h
+++ b/JASP-Desktop/results/resultsjsinterface.h
@@ -34,6 +34,7 @@ class ResultsJsInterface : public QObject
 	Q_OBJECT
 	Q_PROPERTY(QString			resultsPageUrl	READ resultsPageUrl	WRITE setResultsPageUrl	NOTIFY resultsPageUrlChanged	)
 	Q_PROPERTY(double			zoom			READ zoom			WRITE setZoom			NOTIFY zoomChanged				)
+	Q_PROPERTY(bool				resultsLoaded	READ resultsLoaded	WRITE setResultsLoaded	NOTIFY resultsLoadedChanged		)
 
 public:
 	explicit ResultsJsInterface(QObject *parent = 0);
@@ -49,16 +50,15 @@ public:
 	void exportHTML();
 	void resetResults();
 
-	Json::Value &getResultsMeta();
-	QVariant	&getAllUserData();
-
 	QString			resultsPageUrl()	const { return _resultsPageUrl;	}
 	double			zoom()				const { return _webEngineZoom;	}
+	bool			resultsLoaded()		const { return _resultsLoaded;	}
 
 	Q_INVOKABLE void purgeClipboard();
 	Q_INVOKABLE void analysisEditImage(int id, QString options);
 
 	//Callable from javascript through resultsJsInterfaceInterface...
+
 
 signals:
 	Q_INVOKABLE void openFileTab();
@@ -97,12 +97,14 @@ public slots:
 
 
 signals:
-	void getResultsMetaCompleted();
-	void getAllUserDataCompleted();
+	void resultsMetaChanged(QString resultsMeta);
+	void allUserDataChanged(QString userData);
 	void resultsPageUrlChanged(QUrl resultsPageUrl);
 	void runJavaScript(QString js);
 	void zoomChanged();
 	void resultsPageLoadedSignal();
+
+	void resultsLoadedChanged(bool resultsLoaded);
 
 public slots:
 	void setExactPValuesHandler(bool exact);
@@ -111,8 +113,8 @@ public slots:
 	void cancelImageEdit(int id);
 	void exportSelected(const QString &filename);
 	void setResultsPageUrl(QString resultsPageUrl);
-	void resultsPageLoaded(bool success);
 	void setZoomInWebEngine();
+	void setResultsLoaded(bool resultsLoaded);
 
 private:
 	void	setGlobalJsValues();
@@ -123,9 +125,8 @@ private slots:
 
 private:
 	double			_webEngineZoom = 1.0;
-	Json::Value		_resultsMeta;
-	QVariant		_allUserData;
 	QString			_resultsPageUrl = "qrc:///html/index.html";
+	bool			_resultsLoaded = false;
 };
 
 

--- a/JASP-Desktop/utilities/languagemodel.cpp
+++ b/JASP-Desktop/utilities/languagemodel.cpp
@@ -149,8 +149,16 @@ void LanguageModel::changeLanguage(int index)
 	_qml->retranslate();
 	Settings::setValue(Settings::PREFERRED_LANGUAGE, cl);
 	setCurrentIndex(index);
-	emit languageChanged();
+	_shouldEmitLanguageChanged = true;
+}
 
+void LanguageModel::resultsPageLoaded()
+{
+	if(!_shouldEmitLanguageChanged)
+		return;
+
+	_shouldEmitLanguageChanged = false;
+	emit languageChanged();
 }
 
 QString LanguageModel::getLocalName(QLocale::Language cl) const

--- a/JASP-Desktop/utilities/languagemodel.h
+++ b/JASP-Desktop/utilities/languagemodel.h
@@ -81,7 +81,8 @@ public:
 public slots:
 	void changeLanguage(int index);
 	void setCurrentIndex(int currentIndex);
-	void loadModuleTranslationFile(Modules::DynamicModule *dyn);	
+	void loadModuleTranslationFile(Modules::DynamicModule *dyn);
+	void resultsPageLoaded();
 
 signals:
 	void currentIndexChanged();
@@ -103,20 +104,20 @@ private:
 	bool isValidLocalName(QString filename, QLocale & loc);
 	bool isJaspSupportedLanguage(QLocale::Language lang);
 
-	static LanguageModel * _singleton;
+	static LanguageModel	* _singleton;
+	QApplication			* _mApp = nullptr;
+	QTranslator				* _mTransLator = nullptr;
+	QQmlApplicationEngine	* _qml = nullptr;
+	QObject					* _parent = nullptr;
 
-	QApplication *_mApp = nullptr;
-	QTranslator *_mTransLator = nullptr;
-	QQmlApplicationEngine *_qml = nullptr;
-	QObject *_parent = nullptr;
+	QMap<QLocale::Language, LanguageInfo>	_languagesInfo;
+	QVector<QLocale::Language>				_languages;
+	QVector<QTranslator *>					_translators;
 
-	QMap<QLocale::Language, LanguageInfo> _languagesInfo;
-	QVector<QLocale::Language> _languages;
-	QVector<QTranslator *> _translators;
+	QString		_qmlocation;
 
-	QString _qmlocation;
-
-	int _currentIndex;
+	int			_currentIndex;
+	bool		_shouldEmitLanguageChanged = false;
 };
 
 


### PR DESCRIPTION
- Keep notes and changed title after language change
-- fixes https://github.com/jasp-stats/jasp-test-release/issues/500
- Removes QEventloop calls from resultsJsInterface because they really ought not be there
- Makes sure "Results" in results is translatable but, only when the user hasn't changed it.
-- fixes https://github.com/jasp-stats/jasp-test-release/issues/626
- Makes GENERATE_LANGUAGE_FILES a boolean instead of an integer because it is nicer

