### PR TITLE
Implement restrictions on the abtest robustness parameters, update docs

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/DoubleField.qml
+++ b/JASP-Desktop/components/JASP/Controls/DoubleField.qml
@@ -24,6 +24,7 @@ TextField
 {
 	id:									doubleField
 	property double defaultValue:		0
+	property double _prevDefaultValue:	0
 	property alias	doubleValidator:	doubleValidator
 	property bool	negativeValues:		false
 	property double	min:				negativeValues ? -Infinity : 0
@@ -36,4 +37,12 @@ TextField
 					lastValidValue:		defaultValue
 					value:				defaultValue
 					fieldWidth:			jaspTheme.numericFieldWidth
+
+	onDefaultValueChanged:
+	{
+		if (_prevDefaultValue == value)
+			value = defaultValue;
+
+		_prevDefaultValue = defaultValue;
+	}
 }

--- a/JASP-Desktop/components/JASP/Controls/IntegerField.qml
+++ b/JASP-Desktop/components/JASP/Controls/IntegerField.qml
@@ -22,18 +22,27 @@ import JASP				1.0
 
 TextField
 {
-					id:				textField
-	property int	defaultValue:	0
-	property bool	negativeValues:	false
-	property int	min:			negativeValues ? -2147483647 : 0 // 2^32 - 1
-	property int	max:			2147483647
-	property alias	inclusive:		intValidator.inclusive
-	property alias	intValidator:	intValidator
+					id:					textField
+	property int	defaultValue:		0
+	property int	_prevDefaultValue:	0
+	property bool	negativeValues:		false
+	property int	min:				negativeValues ? -2147483647 : 0 // 2^32 - 1
+	property int	max:				2147483647
+	property alias	inclusive:			intValidator.inclusive
+	property alias	intValidator:		intValidator
     
-					inputType:		"integer"
-					validator:		JASPDoubleValidator { id: intValidator; bottom: min; top: max; decimals: 0 }
-					lastValidValue:	defaultValue;
-					value:			defaultValue
-					cursorShape:	Qt.IBeamCursor
-					fieldWidth:		jaspTheme.numericFieldWidth
+					inputType:			"integer"
+					validator:			JASPDoubleValidator { id: intValidator; bottom: min; top: max; decimals: 0 }
+					lastValidValue:		defaultValue;
+					value:				defaultValue
+					cursorShape:		Qt.IBeamCursor
+					fieldWidth:			jaspTheme.numericFieldWidth
+
+	onDefaultValueChanged:
+	{
+		if (_prevDefaultValue == value)
+			value = defaultValue;
+
+		_prevDefaultValue = defaultValue;
+	}
 }

--- a/Resources/Frequencies/qml/ABTestBayesian.qml
+++ b/Resources/Frequencies/qml/ABTestBayesian.qml
@@ -20,6 +20,7 @@ import QtQuick 2.8
 import QtQuick.Layouts 1.3
 import JASP.Controls 1.0
 import JASP.Widgets 1.0
+import JASP 1.0
 
 
 Form
@@ -32,10 +33,10 @@ Form
 		marginBetweenVariablesLists	: 15
 
 		AvailableVariablesList	{ name: "allVariablesList" }
-        AssignedVariablesList	{ name: "y1";	title: qsTr("Successes Group 1");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
-        AssignedVariablesList	{ name: "n1";	title: qsTr("Sample Size Group 1");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
-        AssignedVariablesList	{ name: "y2";	title: qsTr("Successes Group 2");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
-        AssignedVariablesList	{ name: "n2";	title: qsTr("Sample Size Group 2");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
+		AssignedVariablesList	{ name: "y1";	title: qsTr("Successes Group 1");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
+		AssignedVariablesList	{ name: "n1";	title: qsTr("Sample Size Group 1");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
+		AssignedVariablesList	{ name: "y2";	title: qsTr("Successes Group 2");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
+		AssignedVariablesList	{ name: "n2";	title: qsTr("Sample Size Group 2");	singleVariable: true;	suggestedColumns: ["scale", "ordinal"] }
 	}
 
 	ColumnLayout
@@ -153,7 +154,7 @@ Form
 
 				Group
 				{
-					title	: qsTr("Step Size")
+					title	: qsTr("No. Steps")
 					IntegerField { label: qsTr("\u03bc:"); name: "mu_stepsize";	defaultValue: 5; min: 3 }
 					IntegerField { label: qsTr("\u03c3:"); name: "sigma_stepsize";	defaultValue: 5; min: 3 }
 				}
@@ -161,19 +162,51 @@ Form
 				Group
 				{
 					title	: qsTr("Step Range")
+					columns : 3
 
-					Row
+					Label { text: "\u03bc:"; Layout.fillHeight: true; verticalAlignment: Text.AlignVCenter }
+					DoubleField
 					{
-						Label { text: qsTr("\u03bc:") }
-						DoubleField { label: qsTr("lower:"); name: "mu_stepsize_lower";	defaultValue: -0.5; negativeValues: true }
-						DoubleField { label: qsTr("upper:"); name: "mu_stepsize_upper";	defaultValue: 0.5 }
+						id				: muLower
+						label			: qsTr("lower:")
+						name			: "mu_stepsize_lower"
+						defaultValue	: plotRobustnessBFType.currentText == "BF+0" ? 0 : -0.5
+						max				: muUpper.value
+						negativeValues	: true
+						inclusive		: JASP.None
+
+					}
+					DoubleField
+					{
+						id				: muUpper
+						label			: qsTr("upper:")
+						name			: "mu_stepsize_upper"
+						defaultValue	: plotRobustnessBFType.currentText == "BF-0" ? 0 : 0.5
+						min				: muLower.value
+						negativeValues	: true
+						inclusive		: JASP.None
 					}
 
-					Row
+					Label { text: "\u03c3:"; Layout.fillHeight: true; verticalAlignment: Text.AlignVCenter }
+					DoubleField
 					{
-						Label { text: qsTr("\u03c3:") }
-						DoubleField { label: qsTr("lower:"); name: "sigma_stepsize_lower"; defaultValue: 0.1; min: 0.0 }
-						DoubleField { label: qsTr("upper:"); name: "sigma_stepsize_upper";	 defaultValue: 1.0; min: 0.0 }
+						id				: sigmaLower
+						label			: qsTr("lower:")
+						name			: "sigma_stepsize_lower"
+						defaultValue	: 0.1
+						max				: sigmaUpper.value
+						negativeValues	: false
+						inclusive		: JASP.None
+					}
+					DoubleField
+					{
+						id				: sigmaUpper
+						label			: qsTr("upper:")
+						name			: "sigma_stepsize_upper"
+						defaultValue	: 1.0
+						min				: sigmaLower.value
+						negativeValues	: false
+						inclusive		: JASP.None
 					}
 				}
 			}

--- a/Resources/Help/analyses/abtestbayesian.md
+++ b/Resources/Help/analyses/abtestbayesian.md
@@ -38,7 +38,7 @@ The input data needs to contain the following elements:
     (In addition, posterior median and central credible interval are also displayed in the plot)
   - Sequential analysis: Displays the development of posterior probabilities as the data come in. The probability wheels visualize prior and posterior probabilities of the hypotheses.
   - Bayes factor robustness check: Displays the prior sensitivity analysis.
-     - Bayes factor type: Specifies which Bayes factor is plotted. Options include - ["BF10", "BF01", "BF+0", "BF0+", "BF-0", "BF-0"]
+     - Bayes factor type: Specifies which Bayes factor is plotted. Options include "BF10", "BF+0" and "BF-0".
   - Prior: Plot parameter prior distributions. Available quantities are the same as mentioned for Prior and posterior plot.
 
 
@@ -72,13 +72,13 @@ Determines the number of importance samples for obtaining log marginal likelihoo
 #### Repeatability
 - Set seed: Gives the option to set a seed for your analysis. Setting a seed will exclude random processes influencing an analysis.
 
-#### Robustness Plot, Step Range
-- mu_range: Specifies the range of mu_psi values to consider
-- sigma_range: Specifies the range of sigma_psi values to consider
+#### Robustness Plot, No. Steps
+- mu: Specifies in how many discrete steps the mu step range is partitioned
+- sigma: Specifies in how many discrete steps the sigma step range is partitioned
 
-#### Robustness Plot, Step Size
-- mu: Specifies how many discrete steps the interval mu_range is partitioned
-- sigma: Specifies how many discrete steps the interval sigma_range is partitioned
+#### Robustness Plot, Step Range
+- mu: Specifies the range of mu values to consider
+- sigma: Specifies the range of sigma values to consider
 
 
 ### Output

--- a/Resources/Help/analyses/abtestbayesian_nl.md
+++ b/Resources/Help/analyses/abtestbayesian_nl.md
@@ -35,12 +35,12 @@ De ingevoerde data moet de volgende elementen bevatten:
 
 	(Aanvullend aan deze opties worden de mediaan en het centrale geloofwaardigheidsinterval van de posterior ook weergegeven in de grafiek.)
   - Sequentiële analyse: Geeft de ontwikkeling van de posterior terwijl de data binnenkomt. De kanswielen geven de prior en posterior kansen op de hypothese weer.
-  - Bayes Factor robuustheid check: Geeft een analyse van de gevoeligheid voor de prior.  
+  - Bayes Factor robuustheidscheck: Geeft een analyse van de gevoeligheid voor de prior.
+    - Bayes factor type: Bepaal het type Bayes factor dat weergegeven wordt in de grafiek. De mogelijkheden zijn "BF10", "BF+0" en "BF-0".
   - Prior: Maakt een grafiek van de prior verdelingen van de parameters. Beschikbare grootheden zijn hetzelfde als voor de prior en posterior grafiek.
 
-
 #### Normale prior op Log Odds Ratio
-Staat toe dat een gemiddelde an standaardafwijking van de normale prior voor test-relevante log odds ratio wordt gespecificeerd. 
+Staat toe dat een gemiddelde an standaardafwijking van de normale prior voor test-relevante log odds ratio wordt gespecificeerd.
 
 
 #### Beschrijvende statistieken
@@ -62,11 +62,19 @@ Specificeert de prior kansen voor de vier hypothesen:
   - Log odds ratio < 0 (H-): Zegt dat de succeskans groter is in de controle dan in de experimentele conditie.
   - Log odds ratio < 0 (H1): Zegt dat de succeskans verschilt tussen condities, maar zegt niet in welke conditie deze groter is.
 
-#### Steekproefen nemen 
+#### Steekproeven nemen 
 Bepaalt het aantal "importance samples" om de log marginale likelihood voor (H+) en (H-) te verkrijgen. Het bepaalt ook het aantal steekproeven van de posterior.
 
 #### Reproduceerbaarheid
 - Gebruik seed: Geeft de mogelijkheid een seed te gebruiken voor je analyse. Een seed gebruiken, zorgt ervoor dat willekeurige processen geen invloed hebben op een analyse.
+
+#### Bayes Factor robuustheidscheck, Aantal Stappen
+- mu: Bepaal het aantal discrete stappen in de stappenreeks van mu 
+- sigma: Bepaal het aantal discrete stappen in de stappenreeks van sigma
+
+#### Bayes Factor robuustheidscheck, Stappenreeks
+- mu: Bepaal de stappenreeks van waarden van mu
+- sigma: Bepaal de stappenreeks van waarden van sigma
 
 ### Uitvoer
 ----------


### PR DESCRIPTION
This PR:

1. Adds Dutch documentation for the features added in https://github.com/jasp-stats/jasp-desktop/pull/3873
2. Imposes some restrictions on the lower <-> upper relationship (otherwise the analysis can crash)
3. Implements the third bullet point in https://github.com/jasp-stats/jasp-test-release/issues/524#issuecomment-585470878
4. Makes it slightly more pretty:

Before:
<img width="204" alt="Screenshot 2020-02-26 at 11 39 14" src="https://user-images.githubusercontent.com/18737241/75337124-abd8cf80-588c-11ea-87d1-431431ce91e5.png">
After:
<img width="231" alt="Screenshot 2020-02-26 at 11 37 38" src="https://user-images.githubusercontent.com/18737241/75337116-aa0f0c00-588c-11ea-8d76-8045bc94f853.png">


