### PR TITLE
Juggling Notes!

### DIFF
--- a/Dynamic Modules/TestModule/DESCRIPTION
+++ b/Dynamic Modules/TestModule/DESCRIPTION
@@ -2,7 +2,7 @@ Package: DevelopmentModule
 Type: Package
 Title: Test Module Module for JASP
 Version: 1.0
-Date: 2020-02-04
+Date: 2020-02-27
 Author: Joris Goosen
 Website: 
 Maintainer: Joris Goosen <Joris@JorisGoosen.nl>

--- a/Dynamic Modules/TestModule/NAMESPACE
+++ b/Dynamic Modules/TestModule/NAMESPACE
@@ -2,5 +2,6 @@ export(testTransposedTableFunc)
 export(testFootnotesTableFunc)
 export(testStateFunc)
 export(testHtmlFunc)
+export(testContainerFunc)
 export(customContrasts)
   import('svglite');

--- a/Dynamic Modules/TestModule/R/testContainer.R
+++ b/Dynamic Modules/TestModule/R/testContainer.R
@@ -1,0 +1,18 @@
+testContainerFunc <- function(jaspResults, dataset, options)
+{
+  cnt <- addContainer(addContainer(addContainer(addContainer(jaspResults, name="c0"))))
+  testFootnotesTableFunc(cnt, dataset, options)
+
+  cnt <- addContainer(addContainer(addContainer(addContainer(jaspResults, name="c1")), title="hallo"))
+  testFootnotesTableFunc(cnt, dataset, options)
+
+  cnt <- addContainer(addContainer(addContainer(addContainer(jaspResults, title="hallo", name="c2")), title="er zit er eentje stiekem om me heen"), title="hallo")
+  testFootnotesTableFunc(cnt, dataset, options)
+}
+
+addContainer <- function(inContainer, name="container", title="") 
+{
+  inContainer[[name]] = createJaspContainer(title=title)
+
+  return(inContainer[[name]])
+}

--- a/Dynamic Modules/TestModule/R/testFootnotesTable.R
+++ b/Dynamic Modules/TestModule/R/testFootnotesTable.R
@@ -46,7 +46,7 @@ createFootnotesTable <- function(numFootnotes=3, rowNames=c("b", "c", "c"), colN
 
     if(options$checkbox_0 == notUnique)       tableFootnotes$addFootnote(message = paste0("msg", as.character(msgNum)), rowNames = rowNames[[msgNum]], colNames = colNames[[msgNum]])
     else if(options$checkbox_1 != notUnique)  tableFootnotes$addFootnote(message = "Identical Twins!",                  rowNames = rowNames[[msgNum]], colNames = colNames[[msgNum]])
-    else                                      tableFootnotes$addFootnote(message = "Identical Symbols!",                  rowNames = rowNames[[msgNum]], colNames = colNames[[msgNum]], symbol="?")
+    else                                      tableFootnotes$addFootnote(message = "Identical Symbols!",                rowNames = rowNames[[msgNum]], colNames = colNames[[msgNum]], symbol="?")
   }
 
   return(tableFootnotes);

--- a/Dynamic Modules/TestModule/inst/description.json
+++ b/Dynamic Modules/TestModule/inst/description.json
@@ -41,6 +41,11 @@
 			"function":							"testHtmlFunc"
 		},
 		{
+			"title":							"Test jaspContainer",
+			"qml":								"test.qml",
+			"function":							"testContainerFunc"
+		},
+		{
 			"title": "-"
 		},
 		{ 

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -59,7 +59,7 @@ public:
 
 	Analysis*	createFromJaspFileEntry(Json::Value analysisData, RibbonModel* ribbonModel);
 	Analysis*	create(const QString &module, const QString &name, const QString& qml, const QString &title, size_t id, const Version &version, Json::Value *options = nullptr, Analysis::Status status = Analysis::Initializing, bool notifyAll = true);
-	Analysis*	create(Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Initializing, bool notifyAll = true, std::string title = "", Json::Value *options = nullptr);
+	Analysis*	create(Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Initializing, bool notifyAll = true, std::string title = "", std::string moduleVersion = "", Json::Value *options = nullptr);
 
 	Analysis*	create(const QString &module, const QString &name, const QString& qml, const QString &title)	{ return create(module, name, qml, title, _nextId++, AppInfo::version);		}
 	Analysis*	create(Modules::AnalysisEntry * analysisEntry)								{ return create(analysisEntry, _nextId++);						}

--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -80,7 +80,7 @@ QVariant AnalysisForm::requestInfo(const Term &term, VariableInfo::InfoType info
 
 void AnalysisForm::runRScript(QString script, QString controlName, bool whiteListedVersion)
 {
-	if(_analysis != nullptr && !_removed)
+	if(_analysis && !_removed)
 		emit _analysis->sendRScript(_analysis, script, controlName, whiteListedVersion);
 }
 
@@ -700,6 +700,9 @@ void AnalysisForm::_formCompletedHandler()
 	{
 		_analysis	= qobject_cast<Analysis *>(analysisVariant.value<QObject *>());
 
+		connect(_analysis, &Analysis::hasVolatileNotesChanged,	this, &AnalysisForm::hasVolatileNotesChanged);
+		connect(_analysis, &Analysis::needsRefreshChanged,		this, &AnalysisForm::needsRefreshChanged	);
+
 		_setUpControls();
 
 		bool isNewAnalysis = _analysis->options()->size() == 0 && _analysis->optionsFromJASPFile().size() == 0;
@@ -755,4 +758,15 @@ void AnalysisForm::setMustContain(std::map<std::string,std::set<std::string>> mu
 	for(const auto & nameContainsPair : _mustContain)
 		setControlMustContain(nameContainsPair.first, nameContainsPair.second); //Its ok if it does it twice, others will only be notified on change
 
+}
+
+
+bool AnalysisForm::needsRefresh() const
+{
+	return _analysis ? _analysis->needsRefresh() : false;
+}
+
+bool AnalysisForm::hasVolatileNotes() const
+{
+	return _analysis ? _analysis->hasVolatileNotes() : false;
 }

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -49,7 +49,9 @@ class QMLExpander;
 class AnalysisForm : public QQuickItem, public VariableInfoProvider
 {
 	Q_OBJECT
-	Q_PROPERTY( QQuickItem * errorMessagesItem	READ errorMessagesItem	WRITE setErrorMessagesItem	NOTIFY errorMessagesItemChanged	)
+	Q_PROPERTY(QQuickItem * errorMessagesItem	READ errorMessagesItem	WRITE setErrorMessagesItem	NOTIFY errorMessagesItemChanged	)
+	Q_PROPERTY(bool			needsRefresh		READ needsRefresh									NOTIFY needsRefreshChanged		)
+	Q_PROPERTY(bool			hasVolatileNotes	READ hasVolatileNotes								NOTIFY hasVolatileNotesChanged	)
 
 public:
 	explicit					AnalysisForm(QQuickItem * = nullptr);
@@ -76,19 +78,20 @@ signals:
 				void			refreshTableViewModels();
 				void			errorMessagesItemChanged();
 				void			languageChanged();
-
+				void			needsRefreshChanged();
+				void			hasVolatileNotesChanged();
 
 protected:
 				QVariant		requestInfo(const Term &term, VariableInfo::InfoType info) const override;
 
 public:
-	ListModel*	getRelatedModel(QMLListView* listView)	{ return _relatedModelMap[listView]; }
-	ListModel*	getModel(const QString& modelName)		{ return _modelMap[modelName]; }
-	Options*	getAnalysisOptions()					{ return _analysis->options(); }
-	JASPControlWrapper*	getControl(const QString& name)			{ return _controls[name]; }
-	void		addListView(QMLListView* listView, QMLListView* sourceListView);
-	void		clearFormErrors();
-	QMLExpander* nextExpander(QMLExpander* expander)	{ return _nextExpanderMap[expander]; }
+	ListModel			*	getRelatedModel(QMLListView* listView)	{ return _relatedModelMap[listView]; }
+	ListModel			*	getModel(const QString& modelName)		{ return _modelMap[modelName]; }
+	Options				*	getAnalysisOptions()					{ return _analysis->options(); }
+	JASPControlWrapper	*	getControl(const QString& name)			{ return _controls[name]; }
+	void					addListView(QMLListView* listView, QMLListView* sourceListView);
+	void					clearFormErrors();
+	QMLExpander			*	nextExpander(QMLExpander* expander)		{ return _nextExpanderMap[expander]; }
 
 	Options*	options() { return _options; }
 	void		addControl(JASPControlBase* control);
@@ -112,6 +115,9 @@ public:
 	bool		isOwnComputedColumn(const QString& col)			const	{ return _computedColumns.contains(col); }
 	void		addOwnComputedColumn(const QString& col)				{ _computedColumns.push_back(col); }
 	void		removeOwnComputedColumn(const QString& col)				{ _computedColumns.removeAll(col); }
+
+	bool		needsRefresh()		const;
+	bool		hasVolatileNotes()	const;
 
 protected:
 	void		_setAllAvailableVariablesModel(bool refreshAssigned = false);
@@ -162,7 +168,6 @@ private:
 	QSet<JASPControlBase*>						_jaspControlsWithErrorSet;
 	QSet<JASPControlBase*>						_jaspControlsWithWarningSet;
 	QList<QString>								_computedColumns;
-
 };
 
 #endif // ANALYSISFORM_H

--- a/JASP-Desktop/components/JASP/Controls/Form.qml
+++ b/JASP-Desktop/components/JASP/Controls/Form.qml
@@ -89,11 +89,36 @@ AnalysisForm
 	{
 		id:				formContent
 		width:			parent.width
-		height:			errorMessagesBox.height + contentArea.implicitHeight
+		height:			oldFileMessagesBox.height + errorMessagesBox.height + contentArea.implicitHeight
 		anchors
 		{
 			top:		form.top
 			left:		form.left
+		}
+
+		Rectangle
+		{
+			id:				oldFileMessagesBox
+			visible:		myAnalysis !== null && myAnalysis.needsRefresh
+			color:			jaspTheme.controlWarningBackgroundColor
+			width:			parent.width
+			height:			visible ? oldAnalysisText.height : 0
+			anchors.top:	parent.top
+
+			Text
+			{
+				id:					oldAnalysisText
+				color:				jaspTheme.controlWarningTextColor
+				anchors.centerIn:	parent
+				padding:			5 * jaspTheme.uiScale
+				wrapMode:			Text.Wrap
+				width:				parent.width - 10 * jaspTheme.uiScale
+				verticalAlignment:	Text.AlignVCenter
+				text:				qsTr("This analysis was created with an older version of JASP (or a dynamic module)") + //I do not want to bother with formatting strings here to be honest
+									( myAnalysis !== null && !myAnalysis.hasVolatileNotes ? qsTr(", refreshing could give a slightly different result.") :
+																	 qsTr(", to keep your notes where they are it is highly recommended to first refresh your analyses!"))
+
+			}
 		}
 				
 		Rectangle
@@ -106,15 +131,17 @@ AnalysisForm
 			color:			jaspTheme.errorMessagesBackgroundColor
 			width:			parent.width
 			height:			visible ? errorMessagesText.height : 0
+			anchors.top:	oldFileMessagesBox.bottom
 
 			Text
 			{
 				id:					errorMessagesText
 				anchors.centerIn:	parent
-				padding:			5
+				padding:			5 * jaspTheme.uiScale
 				wrapMode:			Text.Wrap
-				width:				parent.width - 10
+				width:				parent.width - 10 * jaspTheme.uiScale
 				verticalAlignment:	Text.AlignVCenter
+				//Should we maybe set a color here?
 			}
 		}
 		

--- a/JASP-Desktop/components/JASP/Widgets/HelpWindow.qml
+++ b/JASP-Desktop/components/JASP/Widgets/HelpWindow.qml
@@ -13,7 +13,7 @@ Window
 	minimumHeight:		minimumWidth
 	visible:			helpModel.visible
 	onVisibleChanged:	helpModel.visible = visible
-	title:				"JASP Help"
+	title:				qsTr("JASP Help")
 	color:				jaspTheme.uiBackground
 
 	Shortcut { onActivated: mainWindow.zoomInKeyPressed();		sequences: [Qt.Key_ZoomIn, "Ctrl+Plus", "Ctrl+\+", "Ctrl+\="];	}

--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -212,7 +212,6 @@ Item
 					function analysisSelected(id)						{ resultsJsInterface.analysisSelected(id)                       }
 					function analysisChangedDownstream(id, model)		{ resultsJsInterface.analysisChangedDownstream(id, model)       }
 					function analysisTitleChangedInResults(id, title)	{ resultsJsInterface.analysisTitleChangedInResults(id, title)	}
-					function updateUserData()							{ resultsJsInterface.updateUserData()							}
 					function analysisSaveImage(id, options)				{ resultsJsInterface.analysisSaveImage(id, options)				}
 					function analysisEditImage(id, options)				{ resultsJsInterface.analysisEditImage(id, options)				}
 					function removeAnalysisRequest(id)					{ resultsJsInterface.removeAnalysisRequest(id)					}

--- a/JASP-Desktop/engine/enginerepresentation.h
+++ b/JASP-Desktop/engine/enginerepresentation.h
@@ -109,7 +109,7 @@ private:
 	void abortAnalysisInProgress();
 
 private:
-	Analysis::Status analysisResultStatusToAnalysStatus(analysisResultStatus result, Analysis * analysis);
+	static Analysis::Status analysisResultStatusToAnalysStatus(analysisResultStatus result);
 
 	QProcess	*	_slaveProcess		= nullptr;
 	IPCChannel	*	_channel			= nullptr;

--- a/JASP-Desktop/html/css/darkTheme-jasp.css
+++ b/JASP-Desktop/html/css/darkTheme-jasp.css
@@ -49,15 +49,21 @@ h6, .h6-toolbar .jasp-menu {
   margin-bottom: .5em;
 }
 
-.jasp-display-item {
 
+.jasp-display-item.hidden-collection {
+  margin-top:     0px ;
+  margin-bottom:  0px ;
+  padding-left:   0px ;
+  margin-right:   0px ;
+  padding-right:  0px ;
+}
+
+.jasp-display-item {
         margin-top:       0.1em ;
         margin-bottom:    0.6em ;
-        /*margin-left:    0.6em ;*/
         padding-left:     0.6em ;
         margin-right:     0.6em ;
         padding-right:    0.6em ;
-
 }
 
 .jasp-display-item ~ .jasp-display-item {

--- a/JASP-Desktop/html/css/lightTheme-jasp.css
+++ b/JASP-Desktop/html/css/lightTheme-jasp.css
@@ -53,16 +53,27 @@ h6, .h6-toolbar .jasp-menu {
 	margin-bottom: .5em;
 }
 
+.jasp-display-item.hidden-collection {
+  background-color: rgba(224, 224, 224, 0) ; /*grayLighter*/
+
+  border:         0px none;
+  border-radius:  0px ;
+  margin-top:     0px ;
+  margin-bottom:  0px ;
+  padding-left:   0px ;
+  margin-right:   0px ;
+  padding-right:  0px ;
+}
+
 .jasp-display-item {
   background-color: rgba(224, 224, 224, 0) ; /*grayLighter*/
-  border: 1px solid rgba(105, 105, 105, 0) ; /*grayDarker but not really because this is #696969 */
-	border-radius : 6px ;
-	margin-top: 0.1em ;
-	margin-bottom: 0.6em ;
-	/*margin-left: 0.6em ;*/
-	padding-left: 0.6em ;
-	margin-right: 0.6em ;
-	padding-right: 0.6em ;
+  border:         1px solid rgba(105, 105, 105, 0) ; /*grayDarker but not really because this is #696969 */
+  border-radius:  6px;
+  margin-top:     0.1em;
+  margin-bottom:  0.6em;
+  padding-left:   0.6em;
+  margin-right:   0.6em;
+  padding-right:  0.6em;
 }
 
 .jasp-display-item ~ .jasp-display-item {

--- a/JASP-Desktop/html/js/analysis.js
+++ b/JASP-Desktop/html/js/analysis.js
@@ -411,8 +411,8 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 			return;
 
 		var noteKeys = ['note'];
-		if (itemView.avaliableNoteKeys)
-			noteKeys = itemView.avaliableNoteKeys();
+		//if (itemView.avaliableNoteKeys) //Commented out because it wasn't defined anywhere so it probably isn't functional...
+		//	noteKeys = itemView.avaliableNoteKeys();
 
 		for (var i = 0; i < noteKeys.length; i++) {
 			var noteKey = noteKeys[i];
@@ -515,13 +515,13 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 				continue
 			let data = results[name];
 
-			if (meta.type == 'collection' && data.title == "") {  // remove collections without a title from view
+			/*if (meta.type == 'collection' && data.title == "") {  // remove collections without a title from view
 				let collectionMeta = meta.meta;
 				if (Array.isArray(collectionMeta)) { // the meta comes from a jaspResult analysis
 					this.createResultsViewFromMeta(data["collection"], collectionMeta, $result);
 					continue;
 				}
-			}
+			}*/
 
 			let itemView = this.createChild(data, this.model.get("status"), meta);
 			if (itemView === null)
@@ -633,6 +633,10 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 				this.updateProgressbarInResults();
 			return this;
 		}
+
+		var userdataCPP = this.model.get("userdata"); //This might have been changed by Analysis::fitOldUserDataEtc to accomodate loading old files. And otherwise should be the same as local stored userdata
+		if (userdataCPP !== undefined && userdataCPP !== null)
+			this.userdata = userdataCPP;
 
 		this.imageBeingEdited = null;
 

--- a/JASP-Desktop/html/js/collection.js
+++ b/JASP-Desktop/html/js/collection.js
@@ -137,17 +137,17 @@ JASPWidgets.collectionView = JASPWidgets.View.extend({
 	constructChildren: function (constructor, data) {
 		if (Array.isArray(data.meta)) { // the meta comes from a jaspResult analysis
 			_.each(data.meta, function (meta) {
-				if (meta.type == "collection" && data.collection[meta.name].title == "") { // remove collections without a title from view
+				/*if (meta.type == "collection" && data.collection[meta.name].title == "") { // remove collections without a title from view
 					var dataWithSkip = jQuery.extend(true, {}, data);
 					dataWithSkip.collection = dataWithSkip.collection[meta.name]["collection"];
 					dataWithSkip.meta = meta.meta;
 					this.constructChildren(constructor, dataWithSkip);
-				} else {
+				} else {*/
 					var itemResults = data.collection[meta.name];
 					data.meta = meta;
 					let itemView = constructor.call(this, itemResults, data, true);
 					this.pushViews(itemView);
-				}
+				//}
 			}, this);
 		} else {
 			_.each(data.collection, function (itemResults) {
@@ -230,13 +230,18 @@ JASPWidgets.collectionView = JASPWidgets.View.extend({
 
 		var title = this.model.get("title")
 		var titleFormat = this.model.get("titleFormat")
-		if (title) {
-			this.toolbar.title = title;
-			this.toolbar.titleTag = titleFormat;
-		}
 
-		this.toolbar.render();
-		this.$el.append(this.toolbar.$el);
+
+		if (title) {
+			this.toolbar.title		= title;
+			this.toolbar.titleTag	= titleFormat;
+
+			if(title !== "")
+			{
+				this.toolbar.render();
+				this.$el.append(this.toolbar.$el);
+			}
+		}
 
 		var styleAttr = '';
 		var collapsed = this.model.get("collapsed");

--- a/JASP-Desktop/html/js/jaspwidgets.js
+++ b/JASP-Desktop/html/js/jaspwidgets.js
@@ -426,6 +426,11 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 	},
 
 	isTextboxEmpty: function () {
+
+		//We should probably only be here if we have $quill right?
+		if(this.$quill === undefined)
+			return undefined;
+
 		return this.$quill.getLength() === 0;
 	},
 
@@ -953,27 +958,40 @@ JASPWidgets.ProgressbarView = JASPWidgets.View.extend({
 	},
 
 	render: function() {
-		var label = this.model.getFromAnalysis("progress").label;
-		var value = this.model.getFromAnalysis("progress").value;
-		if (this._blockRequest(value)) {
-			return this;
-		} else if (this._needsToComplete(value)) {
-			label = this.model.get("label");
-			value = this.model.get("maxValue");
-		} else {
-			label = this._makePrettyLabel(label);
-			value = Math.min(this.model.get("maxValue"), value)
-		}
-
-		this.model.set("value", value);
-		this.model.set("label", label);
-
-		this.clear();
-		this._insertBar();
-
-		if (this.isComplete()) {
+		if(this.model.getFromAnalysis("progress") === null)
+		{
 			this._resetModel();
 			this._fadeOut();
+		}
+		else if(this.model.getFromAnalysis("progress") !== undefined)
+		{
+			var label = this.model.getFromAnalysis("progress").label;
+			var value = this.model.getFromAnalysis("progress").value;
+
+			if(label !== undefined && value !== undefined)
+			{
+
+				if (this._blockRequest(value)) {
+					return this;
+				} else if (this._needsToComplete(value)) {
+					label = this.model.get("label");
+					value = this.model.get("maxValue");
+				} else {
+					label = this._makePrettyLabel(label);
+					value = Math.min(this.model.get("maxValue"), value)
+				}
+
+				this.model.set("value", value);
+				this.model.set("label", label);
+			}
+
+			this.clear();
+			this._insertBar();
+
+			if (this.isComplete()) {
+				this._resetModel();
+				this._fadeOut();
+			}
 		}
 
 		return this;

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -403,7 +403,6 @@ $(document).ready(function () {
 
 			analyses.on("analyses:userDataChanged", function () {
 				window.getResultsMeta()
-				jasp.updateUserData();
 			});
 
 			analyses.render();
@@ -440,7 +439,7 @@ $(document).ready(function () {
 			jaspWidget.on("showDependencies",			function (id, optName)	{ jasp.showDependenciesInAnalysis(id, optName);					});
 			jaspWidget.on("analysis:remove",			function (id)			{ jasp.removeAnalysisRequest(id);								});
 			jaspWidget.on("analysis:duplicate",			function (id)			{ jasp.duplicateAnalysis(id);									});
-			jaspWidget.on("analysis:userDataChanged",	function ()				{ jasp.updateUserData(); window.getAllUserData();				});
+			jaspWidget.on("analysis:userDataChanged",	function ()				{ window.getAllUserData();										});
 
 			jaspWidget.on("toolbar:showMenu", function (obj, options) {
 

--- a/JASP-Desktop/html/js/object.js
+++ b/JASP-Desktop/html/js/object.js
@@ -18,6 +18,9 @@ JASPWidgets.objectConstructor = function (results, params, ignoreEvents) {
 	if (metaData.type)
 		type = metaData.type;
 
+	if(_.has(results, "title") && results.title === "" && type === "collection")
+		embeddedLevel--; //to make sure title of whatever inside "hidden-collection"'s aren't shrunk unnecessarily
+
 	if (!_.has(results, "titleFormat"))
 		results.titleFormat = 'h' + (embeddedLevel + 2);
 
@@ -56,6 +59,9 @@ JASPWidgets.objectConstructor = function (results, params, ignoreEvents) {
 
 	if (childOfCollection)
 		otherClasses += ' jasp-collection-item jasp-collection-' + type;
+
+	if (type === "collection" && _.has(results, "title") && results.title === "")
+		otherClasses += ' hidden-collection';
 
 	var itemModel = new JASPWidgets[type](results);
 	var itemView = new JASPWidgets[type + "View"]({ className: "jasp-display-item " + includeNamespace + "jasp-" + type + " jasp-view" + otherClasses, model: itemModel });

--- a/JASP-Desktop/modules/upgrader/upgrader.cpp
+++ b/JASP-Desktop/modules/upgrader/upgrader.cpp
@@ -97,9 +97,8 @@ void Upgrader::removeStepsOfModule(const std::string & module)
 	_allSteps.erase(module);
 }
 
-UpgradeMsgs Upgrader::upgradeAnalysisData(Json::Value & analysis) const
+bool Upgrader::upgradeAnalysisData(Json::Value & analysis, UpgradeMsgs & msgs) const
 {
-	UpgradeMsgs msgs;
 	StepsTaken	stepsTaken;
 
 	try
@@ -114,7 +113,7 @@ UpgradeMsgs Upgrader::upgradeAnalysisData(Json::Value & analysis) const
 		MessageForwarder::showWarning(tq("Analysis Upgrade Failed"), tq("Upgrading analysis failed with error: %1").arg(e.what()));
 	}
 
-	return msgs;
+	return stepsTaken.size() > 0;
 }
 
 void Upgrader::_upgradeOptionsFromJaspFile(Json::Value & analysis, UpgradeMsgs & msgs, StepsTaken & stepsTaken) const

--- a/JASP-Desktop/modules/upgrader/upgrader.h
+++ b/JASP-Desktop/modules/upgrader/upgrader.h
@@ -40,7 +40,7 @@ public:
 	void removeStepsOfModule(const std::string & module);
 	void loadOldSchoolUpgrades();
 
-	UpgradeMsgs upgradeAnalysisData(Json::Value & analysisData) const;
+	bool upgradeAnalysisData(Json::Value & analysisData, UpgradeMsgs & msgs) const;
 
 private:
 	static Upgrader * _singleton;


### PR DESCRIPTION
- QML now knows whether the analysis needs a refresh or not (and this indication now also takes dynamic modules into account)
- It also knows if it has volatile notes (aka coupled with possibly changed names of tables or collections)
- when an analysis status goes from Complete -> something else it stores its userdata
- when it then later gets status Complete again it runs the algorithm in Analysis::fitOldUserDataEtc to try to match the changed names to the old notes
- this changed userData is passed tot the js. And that sometimes handles it correctly
- There is something fishy going on with quill though
-- See JASPWidgets.NoteBox.isTextboxEmpty in jaspWidgets.js
- Also from now on any analysis that was loaded from an old jasp version or dynamic module will state so to the user in polite terms on top of the form

This commit fixes https://github.com/jasp-stats/jasp-test-release/issues/469 (mostly anyway)

