### PR TITLE
Adding and then removing an Empty value does not update the analyses

### DIFF
--- a/JASP-Common/dataset.cpp
+++ b/JASP-Common/dataset.cpp
@@ -76,21 +76,19 @@ string DataSet::toString()
 	return ss.str();
 }
 
-vector<string> DataSet::resetEmptyValues(std::map<std::string, std::map<int, std::string> > emptyValuesPerColumnMap)
+std::map<string, std::map<int, string> > DataSet::resetEmptyValues(const std::map<std::string, std::map<int, std::string> >& emptyValuesPerColumnMap)
 {
-	std::vector<std::string> colChanged;
+	std::map<string, std::map<int, string> > colChanged;
 
 	for (Column& col : _columns)
 	{
-		std::map<int, std::string> emptyValuesMap;
+		std::map<int, string> emptyValuesMap;
 
 		if (emptyValuesPerColumnMap.count(col.name()))
-			emptyValuesMap = emptyValuesPerColumnMap[col.name()];
+			emptyValuesMap = emptyValuesPerColumnMap.at(col.name());
 
 		if (col.resetEmptyValues(emptyValuesMap))
-			colChanged.push_back(col.name());
-
-		emptyValuesPerColumnMap[col.name()] = emptyValuesMap;
+			colChanged[col.name()] = emptyValuesMap;
 	}
 
 	return colChanged;

--- a/JASP-Common/dataset.h
+++ b/JASP-Common/dataset.h
@@ -53,7 +53,7 @@ public:
 	void setSharedMemory(boost::interprocess::managed_shared_memory *mem);
 
 	std::string toString();
-	std::vector<std::string> resetEmptyValues(emptyValsType emptyValuesMap);
+	std::map<std::string, std::map<int, std::string> > resetEmptyValues(const emptyValsType& emptyValuesMap);
 
 	bool				setFilterVector(std::vector<bool> filterResult);
 	BoolVector	&		filterVector()				{ return _filterVector; }

--- a/JASP-Desktop/data/datasetpackage.cpp
+++ b/JASP-Desktop/data/datasetpackage.cpp
@@ -1209,9 +1209,16 @@ void DataSetPackage::emptyValuesChangedHandler()
 	if (isLoaded())
 	{
 		beginSynchingData();
+		std::map<std::string, std::map<int, std::string> > emptyValuesChanged;
 		std::vector<std::string> colChanged;
 
-		enlargeDataSetIfNecessary([&](){ colChanged = _dataSet->resetEmptyValues(emptyValuesMap()); }, "emptyValuesChangedHandler");
+		enlargeDataSetIfNecessary([&](){ emptyValuesChanged = _dataSet->resetEmptyValues(emptyValuesMap()); }, "emptyValuesChangedHandler");
+
+		for (auto it : emptyValuesChanged)
+		{
+			colChanged.push_back(it.first);
+			storeInEmptyValues(it.first, it.second);
+		}
 
 		endSynchingDataChangedColumns(colChanged);
 	}


### PR DESCRIPTION
If you add an empty value, and an analysis that uses a column that is
changed by this new empty value, is updated.
When you remove afterwards this empty value, the analysis is not
changed anymore