### PR TITLE
Makes synching an spss file work

### DIFF
--- a/JASP-Desktop/data/datasetloader.cpp
+++ b/JASP-Desktop/data/datasetloader.cpp
@@ -31,6 +31,7 @@
 #include <QFileInfo>
 
 #include "timers.h"
+#include "utils.h"
 
 using namespace std;
 using namespace ods;
@@ -77,6 +78,8 @@ void DataSetLoader::loadPackage(const string &locator, const string &extension, 
 
 void DataSetLoader::syncPackage(const string &locator, const string &extension, boost::function<void(const string &, int)> progress)
 {
+	Utils::sleep(100);
+
 	Importer* importer = getImporter(locator, extension);
 
 	if (importer)

--- a/JASP-Desktop/data/importers/readstat/readstatimportdataset.cpp
+++ b/JASP-Desktop/data/importers/readstat/readstatimportdataset.cpp
@@ -26,13 +26,13 @@ bool operator<(const readstat_value_t & l, const readstat_value_t & r)
 
 	switch(ltype)
 	{
-	case READSTAT_TYPE_STRING:		return std::string(readstat_string_value(l)).compare(readstat_string_value(r));
+	case READSTAT_TYPE_STRING:		return std::string(readstat_string_value(l)) < std::string(readstat_string_value(r));
 	case READSTAT_TYPE_INT8:		return readstat_int8_value(l)	< readstat_int8_value(r);
 	case READSTAT_TYPE_INT16:		return readstat_int16_value(l)	< readstat_int16_value(r);
 	case READSTAT_TYPE_INT32:		return readstat_int32_value(l)	< readstat_int32_value(r);
 	case READSTAT_TYPE_FLOAT:		return readstat_float_value(l)	< readstat_float_value(r);
 	case READSTAT_TYPE_DOUBLE:		return readstat_double_value(l)	< readstat_double_value(r);
-	default:						 return 0;
+	default:						return &l < &r; //If we cannot do anything else just order them based on their pointer to make sure < is well-ordered
 	}
 }
 

--- a/JASP-Desktop/data/importers/readstatimporter.cpp
+++ b/JASP-Desktop/data/importers/readstatimporter.cpp
@@ -104,6 +104,8 @@ ImportDataSet* ReadStatImporter::loadFile(const std::string &locator, boost::fun
 	if (error != READSTAT_OK)
 		throw std::runtime_error("Error processing " + locator + " " + readstat_error_message(error));
 
+	data->buildDictionary(); //Not necessary for opening this file but synching will break otherwise...
+
 	return data;
 }
 


### PR DESCRIPTION
- Added a small sleep to give the os some time to handle stuff, necessary because the sync file is opened twice in rapid succesion clobbering the fopen (on windows anyway).
- Also let a column dictionary be built for spss, not needed for opening a file, but it *is* for synching
- And compare two strings in readstat label with operator< instead of compare because that breaks the std::map...
Fixes https://github.com/jasp-stats/jasp-issues/issues/619

