### PR TITLE
Added some upgrades for Audit

### DIFF
--- a/JASP-Desktop/modules/upgrader/upgrades.json
+++ b/JASP-Desktop/modules/upgrader/upgrades.json
@@ -137,6 +137,29 @@
 		"to":	{ "module": "Summary Statistics",	"version": "0.10"																} 
 	},
 
+	{	"from": { "module": "Audit",			"version": "0.11.1", 	"function": "bayesianAudit"				},
+		"to":	{ "module": "Audit",			"version": "0.12", 		"function": "auditBayesianWorkflow"		},
+		"options":
+		[	{	"conditional":	{ "_args": [ { 	"planningModel": "beta" 			} ] },
+				"changes":		{ 				"planningModel": "binomial" 			}	},
+			{	"conditional":	{ "_args": [ { 	"planningModel": "beta-binomial" 	} ] },
+				"changes":		{ 				"planningModel": "Poisson" 				}	}	]
+	},
+	{	"from": { "module": "Audit",			"version": "0.11.1", 	"function": "bayesianPlanning"			},
+		"to":	{ "module": "Audit",			"version": "0.12", 		"function": "auditBayesianPlanning"		},
+		"options":
+		[	{	"conditional":	{ "_args": [ { 	"planningModel": "beta" 			} ] },
+				"changes":		{ 				"planningModel": "binomial" 			}	},
+			{	"conditional":	{ "_args": [ { 	"planningModel": "beta-binomial" 	} ] },
+				"changes":		{ 				"planningModel": "Poisson" 				}	}	]
+	},
+	{	"from": { "module": "Audit",			"version": "0.11.1", 	"function": "classicalAudit"			},
+		"to":	{ "module": "Audit",			"version": "0.12", 		"function": "auditClassicalWorkflow"	}},
+	{	"from": { "module": "Audit",			"version": "0.11.1", 	"function": "classicalEstimation"		},
+		"to":	{ "module": "Audit",			"version": "0.12", 		"function": "auditClassicalEstimation"	}},
+	{	"from": { "module": "Audit",			"version": "0.11.1", 	"function": "classicalPlanning"			},
+		"to":	{ "module": "Audit",			"version": "0.12", 		"function": "auditClassicalPlanning"	}},
+
 	{
 		"comment": "For version 0.12 we changed a lot of analyses and this also simplified some forms a bit.",
 		"from": { "module": "ANOVA",			"version": "0.11.1", "function": "Anova" 	},


### PR DESCRIPTION
- Made sure analyses are renamed
- Transfer the set planningsModel to the new names. beta -> binomial and beta-binomial -> hypergeometric
Fixes https://github.com/jasp-stats/jasp-test-release/issues/650

@koenderks Ive made sure that the planningsmodel is properly transferred to the new one. (You changed the names of the radiobuttons).
Are there any other options that were renamed? Because if we do not take them into account anyone who saved some audit in 0.11.1 will get different results in 0.12 after refreshing...
