### PR TITLE
JASPgraphs gettext

### DIFF
--- a/JASP-Engine/JASPgraphs/DESCRIPTION
+++ b/JASP-Engine/JASPgraphs/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: JASPgraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.4.10
+Version: 0.4.11
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: ...

--- a/JASP-Engine/JASPgraphs/R/PlotPriorAndPosterior.R
+++ b/JASP-Engine/JASPgraphs/R/PlotPriorAndPosterior.R
@@ -224,20 +224,21 @@ makeBFlabels <- function(bfSubscripts, BFvalues, subs = NULL, bfTxt = NULL) {
 hypothesis2BFtxt <- function(hypothesis = c("equal", "smaller", "greater")) {
 
   hypothesis <- match.arg(hypothesis)
+  pizzaTxt <- gettext("data | H0")
   return(
     switch(
       hypothesis,
       "equal" = list(
         bfSubscripts = 0:1,
-        pizzaTxt = c("data | H0", "data | H1")
+        pizzaTxt = c(pizzaTxt, gettext("data | H1"))
       ),
       "smaller" = list(
         bfSubscripts = c(0, "\'-\'"),
-        pizzaTxt = c("data | H0", "data | H-")
+        pizzaTxt = c(pizzaTxt, gettext("data | H-"))
       ),
       "greater" = list(
         bfSubscripts = c(0, "\'+\'"),
-        pizzaTxt = c("data | H0", "data | H+")
+        pizzaTxt = c(pizzaTxt, gettext("data | H+"))
       )
     )
   )
@@ -253,31 +254,21 @@ getBFSubscripts <- function(bfType = c("BF01", "BF10", "LogBF10"), hypothesis = 
   bfType <- match.arg(bfType)
   hypothesis <- match.arg(hypothesis)
 
-  if (bfType == "BF01") {
-    subscripts <- switch (hypothesis,
-                          "equal"   = c("BF[1][0]",   "BF[0][1]"),
-                          "smaller" = c("BF['-'][0]", "BF[0]['-']"),
-                          "greater" = c("BF['+'][0]", "BF[0]['+']")
-    )
-    # subscripts <- switch (hypothesis,
-    #   "equal"   = c("BF[0][1]",   "BF[1][0]"),
-    #   "smaller" = c("BF[0]['-']", "BF['-'][0]"),
-    #   "greater" = c("BF[0]['+']", "BF['+'][0]")
-    # )
-  } else if (bfType == "BF10") {
-    subscripts <- switch (hypothesis,
-                          "equal"   = c("BF[1][0]",   "BF[0][1]"),
-                          "smaller" = c("BF['-'][0]", "BF[0]['-']"),
-                          "greater" = c("BF['+'][0]", "BF[0]['+']")
-    )
-  } else {
-    subscripts <- switch (hypothesis,
-                          "equal"   = c("log(BF[0][1])",   "log(BF[1][0])"    ),
-                          "smaller" = c("log(BF[0]['-'])", "log(BF['-'][0])"),
-                          "greater" = c("log(BF[0]['+'])", "log(BF['+'][0])")
-    )
-  }
-  return(parseThis(subscripts))
+  base <-
+    if (bfType != "LogBF10") gettext("BF%s")
+    else                     gettext("log(BF%s)")
+  base <- fixTranslationForExpression(base)
+
+  subscripts <- switch (hypothesis,
+                        "equal"   = c("[1][0]",   "[0][1]"),
+                        "smaller" = c("['-'][0]", "[0]['-']"),
+                        "greater" = c("['+'][0]", "[0]['+']"))
+  if (bfType == "LogBF10")
+    subscripts <- rev(subscripts)
+
+  ans <- c(sprintf(base, subscripts[1L]), sprintf(base, subscripts[2L]))
+  return(parseThis(ans))
+
 }
 
 makeBFwheelAndText <- function(BF, bfSubscripts, pizzaTxt, drawPizzaTxt = is.null(pizzaTxt), bfType) {

--- a/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
+++ b/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
@@ -433,7 +433,7 @@ fixTranslationForExpression <- function(text) {
   # - whitespace becomes ~
   # - If a line ends or starts with :, the : is pasted to the string.
   #
-  # NOTE: this is 100% safe, words like: "if", "while", "next", "repeat",
+  # NOTE: this is not 100% safe, words like: "if", "while", "next", "repeat",
   # will still crash when parsed.
   #
   # none of this would be necesary if we switch to unicode...

--- a/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
+++ b/JASP-Engine/JASPgraphs/R/PlotRobustnessSequential.R
@@ -425,14 +425,25 @@ PlotRobustnessSequential <- function(
 }
 
 fixTranslationForExpression <- function(text) {
-  # we should really switch to unicode...
-  text <- gsub("\\s+", "~", trimws(text))
+  # Transforms a translated vector of strings into one that a vector that
+  # can safely be parsed as expression.
+  #
+  # Changes:
+  # - the word "for" is escaped to "'for'".
+  # - whitespace becomes ~
+  # - If a line ends or starts with :, the : is pasted to the string.
+  #
+  # NOTE: this is 100% safe, words like: "if", "while", "next", "repeat",
+  # will still crash when parsed.
+  #
+  # none of this would be necesary if we switch to unicode...
+
+  text <- gsub("\\bfor\\b", "'for'", trimws(text))
+  text <- gsub("\\s+", "~", text)
   idx <- endsWith(text, ":")
   text[idx] <- paste0("paste(", substring(text[idx], 1, nchar(text[idx]) - 1L), ", ':')")
   idx <- startsWith(text, ":")
   text[idx] <- paste0("paste(", "':'", substring(text[idx], 1, nchar(text[idx]) - 1L), ")")
-  text <- gsub("~for", "~'for'", text, fixed = TRUE)
-  text <- gsub("for~", "'for'~", text, fixed = TRUE)
   text
 }
 

--- a/JASP-Tests/R/tests/figs/BinomialTestBayesian/binomialtestbayesian-sequential-analysis-1-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/BinomialTestBayesian/binomialtestbayesian-sequential-analysis-1-subplot-3.svg
@@ -28,7 +28,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='505.76' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='510.46' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='519.87' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>l</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/BinomialTestBayesian/binomialtestbayesian-sequential-analysis-2-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/BinomialTestBayesian/binomialtestbayesian-sequential-analysis-2-subplot-3.svg
@@ -28,7 +28,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='505.76' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='510.46' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='519.87' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>l</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/CorrelationBayesian/correlationbayesian-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/CorrelationBayesian/correlationbayesian-sequential-analysis-subplot-3.svg
@@ -26,7 +26,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='490.73' y='378.57' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.14' y='378.57' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='14.09px' lengthAdjust='spacingAndGlyphs'>m</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.57' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='225.03' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='225.03' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.16' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouponegreater-bf01-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouponegreater-bf01-sequential-analysis-subplot-3.svg
@@ -27,7 +27,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='509.53' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouponegreater-bf10-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouponegreater-bf10-sequential-analysis-subplot-3.svg
@@ -27,7 +27,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='509.53' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouponegreater-logbf10-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouponegreater-logbf10-sequential-analysis-subplot-3.svg
@@ -27,7 +27,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='509.53' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-groupsnotequal-bf01-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-groupsnotequal-bf01-sequential-analysis-subplot-3.svg
@@ -27,7 +27,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='509.53' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-groupsnotequal-bf10-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-groupsnotequal-bf10-sequential-analysis-subplot-3.svg
@@ -27,7 +27,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='509.53' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-groupsnotequal-logbf10-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-groupsnotequal-logbf10-sequential-analysis-subplot-3.svg
@@ -27,7 +27,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='509.53' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouptwogreater-bf01-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouptwogreater-bf01-sequential-analysis-subplot-3.svg
@@ -28,7 +28,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='505.76' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='510.46' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='519.87' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>l</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouptwogreater-bf10-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouptwogreater-bf10-sequential-analysis-subplot-3.svg
@@ -28,7 +28,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='505.76' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='510.46' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='519.87' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>l</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouptwogreater-logbf10-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-grouptwogreater-logbf10-sequential-analysis-subplot-3.svg
@@ -28,7 +28,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='505.76' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='510.46' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='519.87' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>l</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianIndependentSamples/ttestbayesianindependentsamples-sequential-analysis-subplot-3.svg
@@ -27,7 +27,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='509.53' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianOneSample/ttestbayesianonesample-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianOneSample/ttestbayesianonesample-sequential-analysis-subplot-3.svg
@@ -28,7 +28,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='505.76' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>t</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='510.46' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>a</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='519.87' y='378.88' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>l</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='224.97' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.10' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='224.97' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/TTestBayesianPairedSamples/ttestbayesianpairedsamples-sequential-analysis-subplot-3.svg
+++ b/JASP-Tests/R/tests/figs/TTestBayesianPairedSamples/ttestbayesianpairedsamples-sequential-analysis-subplot-3.svg
@@ -26,7 +26,17 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='490.73' y='378.57' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.14' y='378.57' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='14.09px' lengthAdjust='spacingAndGlyphs'>m</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='514.23' y='378.57' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='401.36' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='98.77px' lengthAdjust='spacingAndGlyphs'>Evidence for </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='402.29' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='11.28px' lengthAdjust='spacingAndGlyphs'>E</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='413.57' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>v</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='422.04' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='3.77px' lengthAdjust='spacingAndGlyphs'>i</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='425.81' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>d</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='435.21' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='444.62' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>n</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='454.03' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='8.47px' lengthAdjust='spacingAndGlyphs'>c</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='462.50' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='9.41px' lengthAdjust='spacingAndGlyphs'>e</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='471.90' y='225.03' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='476.14' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='19.75px' lengthAdjust='spacingAndGlyphs'>for</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='495.89' y='225.03' style='font-size: 16.93px; font-family: Symbola;' textLength='4.23px' lengthAdjust='spacingAndGlyphs'> </text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='500.12' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>H</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='512.34' y='228.16' style='font-size: 11.85px; font-family: Liberation Sans;' textLength='6.59px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDE3LjI5)'><text x='518.93' y='225.03' style='font-size: 16.93px; font-family: Liberation Sans;' textLength='4.70px' lengthAdjust='spacingAndGlyphs'>:</text></g>

--- a/JASP-Tests/R/tests/figs/jasp-deps.txt
+++ b/JASP-Tests/R/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- JASPgraphs: 0.4.10
+- JASPgraphs: 0.4.11


### PR DESCRIPTION
Part 1 of https://github.com/jasp-stats/jasp-test-release/issues/652

gettexted the horrible expressions inside JASPgraphs. Also cleaned up/ moved some code around in the process to minimize the number of strings to be translated.

There is one expression I couldn't gettext without slightly modifying it, the `"paste('Evidence for ', H[0], ':')"` construction.

Thus all subplot-3s of the sequential plot changed.

Before             |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/21319932/75959867-5bcac000-5ebf-11ea-9f86-cecfcc8c9ca3.png" width="300" />  |  <img src="https://user-images.githubusercontent.com/21319932/75959860-58cfcf80-5ebf-11ea-899c-0127e6d19052.png" width="300" />

screenshots from vdiffr, not jasp.

