### PR TITLE
Changes to languagemodel and description.json

### DIFF
--- a/JASP-Desktop/gui/columntypesmodel.cpp
+++ b/JASP-Desktop/gui/columntypesmodel.cpp
@@ -26,8 +26,8 @@ QVariant ColumnTypesModel::data(const QModelIndex &index, int role) const
 	if (index.row() >= rowCount())
 		return QVariant();
 
-	static QStringList displayTexts		= { "Scale",				"Ordinal",				"Nominal"				};
-	static QStringList menuImageSources = { "variable-scale.png",	"variable-ordinal.png", "variable-nominal.png"	};
+			QStringList displayTexts		= { tr("Scale"),			tr("Ordinal"),			tr("Nominal")			};
+	static	QStringList menuImageSources	= { "variable-scale.png",	"variable-ordinal.png", "variable-nominal.png"	};
 
 	switch(role)
 	{

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -130,12 +130,7 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 	_ribbonModel			= new RibbonModel(	{ "Descriptives", "T-Tests", "ANOVA", "Regression", "Frequencies", "Factor" },
 												{ "Audit", "BAIN", "Discover Distributions", "Equivalence T-Tests", "JAGS", "Machine Learning", "Meta Analysis", "Network", "SEM", "Summary Statistics", "Visual Modeling"});
 	_ribbonModelFiltered	= new RibbonModelFiltered(this, _ribbonModel);
-
 	_fileMenu				= new FileMenu(this);
-
-	// No good to create Language model here after FileMenu..
-	//_languageModel = new LanguageModel("Resources/Translations", application, _qml, this);
-
 	_helpModel				= new HelpModel(this);
 	_aboutModel				= new AboutModel(this);
 	_resultMenuModel		= new ResultMenuModel(this);

--- a/JASP-Desktop/modules/dynamicmodule.cpp
+++ b/JASP-Desktop/modules/dynamicmodule.cpp
@@ -70,16 +70,6 @@ void DynamicModule::developmentModuleFolderCreate()
 	QDir(AppDirs::modulesDir()).mkdir(QString::fromStdString(defaultDevelopmentModuleName()));
 }
 
-QString DynamicModule::getJsonDescriptionFilename()
-{
-	LanguageInfo li = LanguageModel::CurrentLanguageInfo;
-
-	//Leave help filenames from JASP native language - English - with localname en_US unchanged
-	QString _localname = li.language  == QLocale::English ? "" : ("_" + li.localName);
-
-	return "description" + _localname + ".json";
-}
-
 ///This constructor is meant specifically for the development module and only *it*!
 DynamicModule::DynamicModule(QObject * parent) : QObject(parent), _isDeveloperMod(true)
 {

--- a/JASP-Desktop/modules/dynamicmodule.h
+++ b/JASP-Desktop/modules/dynamicmodule.h
@@ -70,12 +70,12 @@ public:
 	}
 
 
-	static std::string  developmentModuleName()			{ return _developmentModuleName; }
-	static std::string  defaultDevelopmentModuleName()  { return "DevelopmentModule"; }
-	static std::wstring defaultDevelopmentModuleNameW() { return L"DevelopmentModule"; }
+	static std::string  developmentModuleName()			{ return _developmentModuleName;	}
+	static std::string  defaultDevelopmentModuleName()  { return "DevelopmentModule";		}
+	static std::wstring defaultDevelopmentModuleNameW() { return L"DevelopmentModule";		}
+	static QString		getJsonDescriptionFilename()	{ return "description.json";		}
 	static QFileInfo	developmentModuleFolder();
 	static void			developmentModuleFolderCreate();
-	static QString		getJsonDescriptionFilename();
 
 	std::string			name()				const { return _name;									}
 	QString				nameQ()				const { return QString::fromStdString(_name);			}
@@ -143,7 +143,7 @@ public:
 	void initialize(); //returns true if install of package(s) should be done
 	void parseDescriptionFile(std::string descriptionTxt);
 
-	static QString		getFileFromFolder(const QString &  filepath, const QString & searchMe);
+	static QString		getFileFromFolder(				const QString &  filepath,		const QString & searchMe);
 	static std::string	getFileFromFolder(				const std::string & folderPath, const std::string & searchMe);
 	static std::string	getDESCRIPTIONFromArchive(		const std::string & archivePath);
 	static std::string	getDescriptionJsonFromArchive(	const std::string & archivePath);

--- a/JASP-Desktop/modules/ribbonbutton.cpp
+++ b/JASP-Desktop/modules/ribbonbutton.cpp
@@ -20,6 +20,7 @@
 #include "enginedefinitions.h"
 #include "modules/dynamicmodule.h"
 #include "modules/analysisentry.h"
+#include "utilities/languagemodel.h"
 
 RibbonButton::RibbonButton(QObject *parent, Json::Value descriptionJson, bool isCommon)  : QObject(parent)
 {
@@ -227,7 +228,7 @@ void RibbonButton::reloadMenuFromDescriptionJson()
 	}
 
 	//Check existence of the description.json
-	QFile descriptionFile(modulepath.absoluteFilePath() + "/" + Modules::DynamicModule::getJsonDescriptionFilename());
+	QFile descriptionFile(modulepath.absoluteFilePath() + "/" + getJsonDescriptionFilename());
 	if(!descriptionFile.exists())
 	{
 		Log::log() << "Could not find the json description file : " << descriptionFile.fileName().toStdString() << std::endl;
@@ -283,3 +284,9 @@ void RibbonButton::reloadMenuFromDescriptionJson()
 
 }
 
+QString RibbonButton::getJsonDescriptionFilename()
+{
+	LanguageInfo li = LanguageModel::CurrentLanguageInfo();
+
+	return "description" + (li.language  == QLocale::English ? "" : ("_" + li.localName)) + ".json";
+}

--- a/JASP-Desktop/modules/ribbonbutton.h
+++ b/JASP-Desktop/modules/ribbonbutton.h
@@ -68,6 +68,8 @@ public:
 	bool							active()													const			{ return _enabled && (!requiresData() || dataLoaded());	}
 	void							reloadMenuFromDescriptionJson();
 
+	static QString					getJsonDescriptionFilename();
+
 public slots:
 	void setRequiresData(bool requiresData);
 	void setIsDynamic(bool isDynamicModule);
@@ -98,6 +100,7 @@ signals:
 
 private:
 	void bindYourself();
+
 
 private:
 	AnalysisMenuModel*				_analysisMenuModel;

--- a/JASP-Desktop/modules/ribbonmodel.cpp
+++ b/JASP-Desktop/modules/ribbonmodel.cpp
@@ -60,19 +60,19 @@ void RibbonModel::addRibbonButtonModelFromModulePath(QFileInfo modulePath, bool 
 {
 	if(!modulePath.exists())
 	{
-		Log::log() << "Path " << modulePath.absoluteFilePath().toStdString() << " does not exist!" << std::flush;
+		Log::log() << "Path " << modulePath.absoluteFilePath().toStdString() << " does not exist!" << std::endl;
 		return;
 	}
 
-	QFile descriptionFile(modulePath.absoluteFilePath() + "/" + Modules::DynamicModule::getJsonDescriptionFilename());
+	QFile descriptionFile(modulePath.absoluteFilePath() + "/" + RibbonButton::getJsonDescriptionFilename());
 	if(!descriptionFile.exists())
 	{
-		Log::log() << "Could not find "  << Modules::DynamicModule::getJsonDescriptionFilename() << " file in " << modulePath.absoluteFilePath().toStdString() << std::endl << std::flush;
-		Log::log() << "Try to fall back to original description.json. " << std::endl << std::flush;
+		Log::log()	<< "Could not find "  << RibbonButton::getJsonDescriptionFilename() << " file in " << modulePath.absoluteFilePath().toStdString()
+					<< "\nTry to fall back to original description.json. " << std::endl;
 		descriptionFile.setFileName(modulePath.absoluteFilePath() + "/" + "description.json");
 		if(!descriptionFile.exists())
 		{
-			Log::log() << "No description.json file found for this module." << std::endl << std::flush;
+			Log::log() << "No description.json file found for this module." << std::endl; //Shouldn't this give an error?
 			return;
 		}
 	}
@@ -87,11 +87,11 @@ void RibbonModel::addRibbonButtonModelFromModulePath(QFileInfo modulePath, bool 
 		if(Json::Reader().parse(descriptionTxt, descriptionJson))
 			addRibbonButtonModel(new RibbonButton(this, descriptionJson, isCommon));
 		else
-			Log::log() << "Error when reading description.json of " << modulePath.filePath().toStdString() << std::flush;
+			Log::log() << "Error while reading description.json of " << modulePath.filePath().toStdString() << std::endl;
 	}
 	catch(std::runtime_error e)
 	{
-		Log::log() << e.what() << std::flush;
+		Log::log() << e.what() << std::endl;
 	}
 }
 

--- a/JASP-Desktop/utilities/helpmodel.cpp
+++ b/JASP-Desktop/utilities/helpmodel.cpp
@@ -127,7 +127,7 @@ bool HelpModel::loadHelpContent(const QString &pagePath, bool ignorelanguage, QS
 	//Leave help filenames from JASP native language - English - with localname en_US unchanged
 	if (!ignorelanguage)
 	{
-		LanguageInfo li = LanguageModel::CurrentLanguageInfo;
+    LanguageInfo li = LanguageModel::CurrentLanguageInfo();
 		_localname = li.language  == QLocale::English ? "" : ("_" + li.localName);
 	}
 

--- a/JASP-Desktop/utilities/languagemodel.h
+++ b/JASP-Desktop/utilities/languagemodel.h
@@ -57,8 +57,7 @@ public:
 	int		currentIndex()			const { return _currentIndex; }
 	QString currentLanguageCode()	const { return getLocalName(_languages[currentIndex()]); } //Here we use currentIndex instead of CurrentLanguageInfo? Why not everywhere else?
 
-	static LanguageInfo CurrentLanguageInfo() { return _singleton->_currentLanguageInfo; } //A function so that we know for sure noone can edit it outside this class, OO-style. Sort of. Better would be to use _currentIndex and the list directly.
-	static QString		getCurrentLanguageFileExtension();
+	static const LanguageInfo & CurrentLanguageInfo() { return _singleton->_currentLanguageInfo; } //A function so that we know for sure noone can edit it outside this class, OO-style. Sort of. Better would be to use _currentIndex and the list directly.
 
 	void setApplicationEngine(QQmlApplicationEngine	 * ae) { _qml = ae; }
 	void initialize();

--- a/JASP-Desktop/utilities/languagemodel.h
+++ b/JASP-Desktop/utilities/languagemodel.h
@@ -12,34 +12,21 @@
 
 struct LanguageInfo {
 
-	LanguageInfo(QLocale::Language lang, QString name, QString nativeName, QString local, QString qmfile, QString qmfolder)
+
+	LanguageInfo() {}
+
+	LanguageInfo(QLocale::Language language, QString languageName, QString nativeLanguageName, QString localName, QString qmFilename, QString qmFolder)
+		: language(language), languageName(languageName), nativeLanguageName(nativeLanguageName), localName(localName), qmFolder(qmFolder), qmFilenames({qmFilename})
 	{
-		language = lang;
-		languageName = name; //Language Name
-		nativeLanguageName = nativeName; //Name of the language in native language
-		localName = local; //QLocale::system().name(); // e.g. "nl_NL" then truncated to "nl"
-		qmFilenames.push_back(qmfile) ;		
-		qmFolder = qmfolder; //QTranslator::load(const QString &filename, const QString &directory = QString()
 	}
 
-	LanguageInfo()
-	{
-		language = QLocale::English;
-		languageName = ""; //Language Name
-		nativeLanguageName = ""; //Name of the language in native language
-		localName = ""; //QLocale::system().name(); // e.g. "nl_NL" then truncated to "nl"
-		qmFilenames.clear();
-		qmFolder = ""; //QTranslator::load(const QString &filename, const QString &directory = QString()
 
-	}
-
-	QLocale::Language language; //e.g. QLocale::English
-	QString languageName;
-	QString nativeLanguageName; //e.g. English
-	QString localName; //e.g. en_US
-	QVector<QString> qmFilenames; //e.g. jasp_en.qm	
-	QString qmFolder;
-
+	QLocale::Language	language			= QLocale::English; //e.g. QLocale::English
+	QString				languageName		= "",
+						nativeLanguageName	= "",	//e.g. English
+						localName			= "",
+						qmFolder			= "";	//e.g. en_US
+	QVector<QString>	qmFilenames;				//e.g. jasp_en.qm
 };
 
 class LanguageModel : public QAbstractListModel
@@ -61,22 +48,21 @@ public:
 
 	explicit LanguageModel(QString qsources, QApplication *app = nullptr, QQmlApplicationEngine *qml = nullptr, QObject *parent = nullptr) ;
 
-	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-	int	columnCount(const QModelIndex &parent = QModelIndex())		const override { return 1; }
+	int						rowCount(const QModelIndex &parent = QModelIndex())			const override;
+	int						columnCount(const QModelIndex & = QModelIndex())			const override { return 1; }
+	QVariant				data(const QModelIndex &index, int role = Qt::DisplayRole)	const override;
 
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	QHash<int, QByteArray>	roleNames() const override;
 
-	QHash<int, QByteArray>			roleNames() const override;	
+	int		currentIndex()			const { return _currentIndex; }
+	QString currentLanguageCode()	const { return getLocalName(_languages[currentIndex()]); } //Here we use currentIndex instead of CurrentLanguageInfo? Why not everywhere else?
 
-	int currentIndex() const;
+	static LanguageInfo CurrentLanguageInfo() { return _singleton->_currentLanguageInfo; } //A function so that we know for sure noone can edit it outside this class, OO-style. Sort of. Better would be to use _currentIndex and the list directly.
+	static QString		getCurrentLanguageFileExtension();
 
-	static LanguageInfo CurrentLanguageInfo;
-	static QString getCurrentLanguageFileExtension();
-
-	void setApplicationEngine(QQmlApplicationEngine	 * ae);	
+	void setApplicationEngine(QQmlApplicationEngine	 * ae) { _qml = ae; }
 	void initialize();
 
-	QString currentLanguageCode() const;
 
 public slots:
 	void changeLanguage(int index);
@@ -105,11 +91,12 @@ private:
 	bool isJaspSupportedLanguage(QLocale::Language lang);
 
 	static LanguageModel	* _singleton;
-	QApplication			* _mApp = nullptr;
-	QTranslator				* _mTransLator = nullptr;
-	QQmlApplicationEngine	* _qml = nullptr;
-	QObject					* _parent = nullptr;
+	QApplication			* _mApp			= nullptr;
+	QTranslator				* _mTransLator	= nullptr;
+	QQmlApplicationEngine	* _qml			= nullptr;
+	QObject					* _parent		= nullptr;
 
+	LanguageInfo							_currentLanguageInfo; //I am quite unhappy with the fact that we store this info twice, is there a scenario where they need to be different or are in fact allowed to be? Why does it need to be inside this (previously static, publicyly accessible) copy of the info and *also* store the _currentIndex in a list... But I won't change it now as we are about to release.
 	QMap<QLocale::Language, LanguageInfo>	_languagesInfo;
 	QVector<QLocale::Language>				_languages;
 	QVector<QTranslator *>					_translators;

--- a/JASP-Desktop/widgets/filemenu/datalibraryfilesystem.cpp
+++ b/JASP-Desktop/widgets/filemenu/datalibraryfilesystem.cpp
@@ -187,7 +187,7 @@ QJsonDocument *DataLibraryFileSystem::getJsonDocument()
 
 	QString filename = "index";
 
-	LanguageInfo li = LanguageModel::CurrentLanguageInfo;
+  LanguageInfo li = LanguageModel::CurrentLanguageInfo();
 
 	//Leave help filenames from JASP native language - English - with localname en_US unchanged
 	QString translation_suffix = li.language  == QLocale::English ? "" : ("_" + li.localName);


### PR DESCRIPTION
Added tr() to Scale/Ordinal/Nominal in change columnType in data
Dynamic Modules no longer try to find a localized description, because there are too many places where they do so and it will be removed soon anyway
- Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/776
Also cleaned up languagemodel sources and added some thoughts

