### PR TITLE
Fix helpfile path diagram

### DIFF
--- a/JASP-Engine/JASP/R/exploratoryfactoranalysis.R
+++ b/JASP-Engine/JASP/R/exploratoryfactoranalysis.R
@@ -435,7 +435,7 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   # Create plot object
   n_var <- length(options$variables)
   path <- createJaspPlot(title = gettext("Path Diagram"), width = 480, height = ifelse(n_var < 2, 300, 1 + 299 * (n_var / 5)))
-  path$dependOn("incl_pathDiagram")
+  path$dependOn(c("incl_pathDiagram", "highlightText"))
   path$position <- 7
   modelContainer[["path"]] <- path
   if (!ready || modelContainer$getError()) return()

--- a/JASP-Engine/JASP/R/principalcomponentanalysis.R
+++ b/JASP-Engine/JASP/R/principalcomponentanalysis.R
@@ -332,7 +332,7 @@ PrincipalComponentAnalysis <- function(jaspResults, dataset, options, ...) {
   # Create plot object
   n_var <- length(options$variables)
   path <- createJaspPlot(title = gettext("Path Diagram"), width = 480, height = ifelse(n_var < 2, 300, 1 + 299 * (n_var / 5)))
-  path$dependOn("incl_pathDiagram")
+  path$dependOn(c("incl_pathDiagram", "highlightText"))
   modelContainer[["path"]] <- path
   if (!ready || modelContainer$getError()) return()
 

--- a/Resources/Help/analyses/exploratoryfactoranalysis.md
+++ b/Resources/Help/analyses/exploratoryfactoranalysis.md
@@ -38,7 +38,7 @@ With Exploratory Factor Analysis it is possible to identify one or more factors 
       - cluster: Oblique rotation method cluster. 
 
 ### Output Options 
-- Highlight: This option adjusts the width of the arrows in the path diagram. By default, arrows become wider when their value is 0.4 or higher. 
+- Highlight: This option cuts the scaling of paths in width and color saturation. Paths with absolute weights over this value will have the strongest color intensity and become wider the stronger they are, and paths with absolute weights under this value will have the smallest width and become vaguer the weaker the weight. If set to 0, no cutoff is used and all paths vary in width and color.
 - Include Tables: 
     - Factor correlations: When selecting this option, a table with the correlations between the factors will be displayed. 
     - Additional fit indices: This option displays the Root Mean Squared Error of Approximation (RMSEA) with 90% confidence interval, the Tucker Lewis Index (TLI), and the Bayesian Information Criterion (BIC) to test the fit of the model. 

--- a/Resources/Help/analyses/principalcomponentanalysis.md
+++ b/Resources/Help/analyses/principalcomponentanalysis.md
@@ -36,7 +36,7 @@ Principcal Component Analysis is used to represent the data in smaller component
       - cluster: Oblique rotation method cluster. 
 
 ### Output Options 
-- Highlight: This option adjusts the width of the arrows in the path diagram. By default, arrows become wider when their value is 0.4 or higher. 
+- Highlight: This option cuts the scaling of paths in width and color saturation. Paths with absolute weights over this value will have the strongest color intensity and become wider the stronger they are, and paths with absolute weights under this value will have the smallest width and become vaguer the weaker the weight. If set to 0, no cutoff is used and all paths vary in width and color.
 - Include Tables: 
     - Component correlations: When selecting this option, a table with the correlations between the components will be displayed. 
     - Path diagram: By selecting this option, a visual representation of the direction and strength of the relation between the variable and component will be displayed. 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/684

I changed the helpfile to the following

> Highlight: This option cuts the scaling of paths in width and color saturation. Paths with absolute weights over this value will have the strongest color intensity and become wider the stronger they are, and paths with absolute weights under this value will have the smallest width and become vaguer the weaker the weight. If set to 0, no cutoff is used and all paths vary in width and color.

I need some help with translating this into Dutch though :) @TimKDJ? 