### PR TITLE
Use currentValue in place of currentText to check when custom is selected in CustomContrast

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/ComboBox.qml
+++ b/JASP-Desktop/components/JASP/Controls/ComboBox.qml
@@ -16,8 +16,11 @@ JASPControl
 	property alias	control:				control
 	property alias	controlLabel:			controlLabel
 	property alias	label:					controlLabel.text
-	property string	currentText				//Am i empty or what?
-	property string	currentColumnType		//Same here
+	// The 4 following properties should be set only from the backend. Unfortunately they cannot be set readonly
+	property string currentText:			""	// This is the current label displayed. currentText is the official name for a ComboBox in QML
+	property alias	currentLabel:			comboBox.currentText
+	property string currentValue:			"" // This is the current value (what is used by R)
+	property string currentColumnType:		"" // When the values come from column names, this property gives the column type of the current selected column
 	property alias	currentIndex:			control.currentIndex
 	property alias	indexDefaultValue:		control.currentIndex
 	property alias	model:					control.model

--- a/JASP-Desktop/components/JASP/Widgets/ContrastsList.qml
+++ b/JASP-Desktop/components/JASP/Widgets/ContrastsList.qml
@@ -86,7 +86,7 @@ Item
 		cellHeight			: 160 * preferencesModel.uiScale
 		height				: count * cellHeight + 10
 		visible				: count > 0
-		source				: [ { name: "contrasts", condition: "contrastValue == 'custom'", conditionVariables: [{ name: "contrastValue", component: "contrast", property: "currentText"}] }]
+		source				: [ { name: "contrasts", condition: "contrastValue == 'custom'", conditionVariables: [{ name: "contrastValue", component: "contrast", property: "currentValue"}] }]
 
 		rowComponents:
 		[

--- a/JASP-Desktop/modules/upgrader/upgrades.json
+++ b/JASP-Desktop/modules/upgrader/upgrades.json
@@ -175,8 +175,48 @@
 				"homogeneityBrown":	false,
 				"homogeneityWelch":	false
 			}
+		},
+		{
+			"comment": 		"If marginalMeansCIAdjustment was set to None, it must be set in 0.12 to none",
+			"conditional": 	{ "_args": [ { "marginalMeansCIAdjustment": "None" }] },
+			"changes":
+			{
+				"marginalMeansCIAdjustment" : "none"
+			}
 		}
-	]
+		]
+	},
+	{
+		"comment": "For version 0.12 we changed a lot of analyses and this also simplified some forms a bit.",
+		"from": { "module": "ANOVA",			"version": "0.11.1", "function": "AnovaRepeatedMeasures" 	},
+		"to":	{ "module": "ANOVA",			"version": "0.12"							},
+		"options":
+		[
+		{
+			"comment": 		"If marginalMeansCIAdjustment was set to None, it must be set in 0.12 to none",
+			"conditional": 	{ "_args": [ { "marginalMeansCIAdjustment": "None" }] },
+			"changes":
+			{
+				"marginalMeansCIAdjustment" : "none"
+			}
+		}
+		]
+	},
+	{
+		"comment": "For version 0.12 we changed a lot of analyses and this also simplified some forms a bit.",
+		"from": { "module": "ANOVA",			"version": "0.11.1", "function": "Ancova" 	},
+		"to":	{ "module": "ANOVA",			"version": "0.12"							},
+		"options":
+		[
+		{
+			"comment": 		"If marginalMeansCIAdjustment was set to None, it must be set in 0.12 to none",
+			"conditional": 	{ "_args": [ { "marginalMeansCIAdjustment": "None" }] },
+			"changes":
+			{
+				"marginalMeansCIAdjustment" : "none"
+			}
+		}
+		]
 	},
 
 	{

--- a/JASP-Desktop/widgets/boundqmlcombobox.h
+++ b/JASP-Desktop/widgets/boundqmlcombobox.h
@@ -52,8 +52,8 @@ protected:
 	QString						_currentText;
 	QString						_currentColumnType;
 	ListModelTermsAvailable*	_model					= nullptr;
-	QMap<QString, QString>		_keyToValueMap;
-	QMap<QString, QString>		_valueToKeyMap;
+	QMap<QString, QString>		_valueToLabelMap;
+	QMap<QString, QString>		_labelToValueMap;
 
 
 	void _resetItemWidth();

--- a/JASP-Desktop/widgets/qmllistview.cpp
+++ b/JASP-Desktop/widgets/qmllistview.cpp
@@ -203,7 +203,7 @@ void QMLListView::addRowComponentsDefaultOptions(Options *options)
 	}
 }
 
-void QMLListView::readModelProperty(QMap<QString, QString>* keyValueMap)
+void QMLListView::readModelProperty(QMap<QString, QString>* labelToValueMap)
 {
 	QVariant modelVar = getItemProperty("values");
 
@@ -222,16 +222,16 @@ void QMLListView::readModelProperty(QMap<QString, QString>* keyValueMap)
 		{
 			for (const QVariant& itemVariant : list)
 			{
-				QMap<QString, QVariant> labelValueMap = itemVariant.toMap();
-				if (labelValueMap.isEmpty())
+				QMap<QString, QVariant> labelValuePair = itemVariant.toMap();
+				if (labelValuePair.isEmpty())
 					terms.add(itemVariant.toString());
 				else
 				{
-					QString key = labelValueMap[textRole].toString();
-					QString value = labelValueMap[valueRole].toString();
-					terms.add(key);
-					if (keyValueMap)
-						(*keyValueMap)[key] = value;
+					QString label = labelValuePair[textRole].toString();
+					QString value = labelValuePair[valueRole].toString();
+					terms.add(label);
+					if (labelToValueMap)
+						(*labelToValueMap)[label] = value;
 				}
 			}
 			model()->initTerms(terms);
@@ -253,11 +253,11 @@ void QMLListView::readModelProperty(QMap<QString, QString>* keyValueMap)
 				for (int i = 0; i < srcModel->rowCount(); i++)
 				{
 					QModelIndex ind(srcModel->index(i, 0));
-					QString key = srcModel->data(ind, roleMap[textRole]).toString();
+					QString label = srcModel->data(ind, roleMap[textRole]).toString();
 					QString value = srcModel->data(ind, roleMap[valueRole]).toString();
-					terms.add(key);
-					if (keyValueMap)
-						(*keyValueMap)[key] = value;
+					terms.add(label);
+					if (labelToValueMap)
+						(*labelToValueMap)[label] = value;
 				}
 				model()->initTerms(terms);
 			}


### PR DESCRIPTION
In Dutch, selecting handmatig in CustomContrat did not add a
CustomContrast: the condtionValriables in the customContrast
ComponentsList used the currentText, and it should use the currentValue
(which is not translated).

Clean up naming convention between value, label and key, this was too
confusing