### PR TITLE
Bayesian paired t-test: handle duplicate pairs

### DIFF
--- a/JASP-Engine/JASP/R/commonbayesianttest.R
+++ b/JASP-Engine/JASP/R/commonbayesianttest.R
@@ -288,6 +288,21 @@
     derivedOptions[["wilcoxTest"]] <- FALSE
 
     dependents <- sapply(options[["pairs"]], paste, collapse = " - ")
+    duplicatedDependents <- duplicated(dependents)
+    if (any(duplicatedDependents)) {
+
+      derivedOptions[["footnotes"]] <- sprintf(
+        ngettext(sum(duplicatedDependents),
+                 "The following pair is duplicated: %s",
+                 "The following pairs are duplicated: %s"
+        ),
+        paste(dependents[duplicatedDependents], collapse = ", ")
+      )
+      dependents <- unique(dependents)
+
+    }
+
+    derivedOptions[["duplicatedDependents"]] <- duplicatedDependents
     derivedOptions[["variables"]]    <- dependents
     derivedOptions[["pairs"]]        <- options[["pairs"]]
     names(derivedOptions[["pairs"]]) <- dependents
@@ -421,7 +436,7 @@
       ttestRows[, "variable"] <- dependents
   } else {
     ttestRows[, "separator"] <- "-"
-    nms <- unlist(options[["pairs"]])
+    nms <- unlist(options[["pairs"]][!derivedOptions[["duplicatedDependents"]]])
     ttestRows[, "variable1"] <- nms[seq(1, length(nms), 2)]
     ttestRows[, "variable2"] <- nms[seq(2, length(nms), 2)]
   }

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -30,6 +30,10 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
   dependents <- derivedOptions[["variables"]]
   ttestRows <- .ttestBayesianCreateTtestRows(dependents, options, derivedOptions, ttestState)
   ttestTable$setData(ttestRows)
+
+  if (!is.null(derivedOptions[["footnotes"]]))
+    ttestTable$addFootnote(derivedOptions[["footnotes"]])
+
   ttestContainer[["ttestTable"]] <- ttestTable
   if (!derivedOptions[["ready"]])
     return(ttestResults)


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/678

Multiple duplicates:
![image](https://user-images.githubusercontent.com/21319932/76848004-405aa000-6843-11ea-9cc8-b84abed69132.png)

One duplicate:
![image](https://user-images.githubusercontent.com/21319932/76848108-64b67c80-6843-11ea-9173-661e56b3fa90.png)

This behavior differs from the frequentist t-test. That analysis is less computationally demanding, so I suppose it's fine that the analysis is (needlessly) repeated. However, I'd rather not repeat the robustness/ sequential plots for identical variables.

