### PR TITLE
Bayesian RM ANOVA: properly match names in old state and current run

### DIFF
--- a/JASP-Engine/JASP/R/commonAnovaBayesian.R
+++ b/JASP-Engine/JASP/R/commonAnovaBayesian.R
@@ -1529,11 +1529,28 @@
       oldLevelInfo <- state[["levelInfo"]]$levelNames
       newLevelInfo <- levelInfo$levelNames
 
+      sortTerms <- function(x) {
+        # split b:a to c("b", "a"), sort it, and then paste it back
+        # otherwise posteriors samples between different runs are not correctly retrieved from the state.
+        sapply(strsplit(names(oldLevelInfo), ":", fixed = TRUE), function(x) paste(sort(x), collapse = ":"))
+      }
+
+      tmp_old <- sortTerms(names(oldLevelInfo))
+      tmp_new <- sortTerms(names(newLevelInfo))
+      oldNames <- names(oldLevelInfo)
+      newNames <- names(newLevelInfo)
+      names(oldNames) <- tmp_old
+      names(newNames) <- tmp_new
+
       if (!identical(newLevelInfo, oldLevelInfo)) {
-        for (nm in intersect(names(oldLevelInfo), names(newLevelInfo))) {
-          idx <- !(oldLevelInfo[[nm]] %in% newLevelInfo[[nm]])
-          renameFrom <- c(renameFrom, oldLevelInfo[[nm]][idx])
-          renameTo   <- c(renameTo,   newLevelInfo[[nm]][idx])
+        for (nm in intersect(names(oldNames), names(newNames))) {
+
+          nm_old <- oldNames[nm]
+          nm_new <- newNames[nm]
+
+          idx <- !(oldLevelInfo[[nm_old]] %in% newLevelInfo[[nm_new]])
+          renameFrom <- c(renameFrom, oldLevelInfo[[nm_old]][idx])
+          renameTo   <- c(renameTo,   newLevelInfo[[nm_new]][idx])
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/665

Something probably changed in the way variable names are generated, because the names differed between consecutive runs of the analysis. Maybe this is related to the column encoding, but I'm not entirely sure. To summarize the bug:

In run 1, the interaction effect is called `a:b`, while in run 2, the interaction effect is called `b:a`. In run 2, matching on `a:b` caused an error.

