### PR TITLE
Bugfixes networkanalysis

### DIFF
--- a/JASP-Engine/JASP/R/networkanalysis.R
+++ b/JASP-Engine/JASP/R/networkanalysis.R
@@ -17,7 +17,7 @@
 
 NetworkAnalysis <- function(jaspResults, dataset, options) {
 
-  dataset <- .networkAnalysisReadData      (dataset, options)
+  dataset <- .networkAnalysisReadData(dataset, options)
 
   mainContainer <- .networkAnalysisSetupMainContainerAndTable(jaspResults, dataset, options)
   .networkAnalysisErrorCheck(mainContainer, dataset, options)
@@ -110,13 +110,14 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
 
     if (options[["groupingVariable"]] != "") {
       # these cannot be chained unfortunately
-      .hasErrors(dataset = groupingVariable,
-                 type = c("factorLevels", "observations"),
-                 factorLevels.target = groupingVariable,
+      groupingVariableName <- options[["groupingVariable"]]
+      dfGroup <- data.frame(groupingVariable)
+      colnames(dfGroup) <- .v(groupingVariableName)
+      .hasErrors(dataset = dfGroup,
+                 type = c("missingValues", "factorLevels"),
+                 missingValues.target = groupingVariableName,
+                 factorLevels.target = groupingVariableName,
                  factorLevels.amount = "< 2",
-                 observations.target = groupingVariable,
-                 observations.amount = "< 10",
-                 observations.grouping = groupingVariable,
                  exitAnalysisIfErrors = TRUE)
       dataset[[.v(options[["groupingVariable"]])]] <- groupingVariable
       groupingVariable <- options[["groupingVariable"]]

--- a/JASP-Engine/JASP/R/networkanalysis.R
+++ b/JASP-Engine/JASP/R/networkanalysis.R
@@ -729,8 +729,12 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
 
   names(allLegends) <- names(allNetworks) # allows indexing by name
 
+  basePlotSize <- 320
+  legendMultiplier <- 0.4 * basePlotSize
+  width <- height <- basePlotSize + allLegends * legendMultiplier
+
   for (v in names(allNetworks))
-    networkPlotContainer[[v]] <- createJaspPlot(title = v, aspectRatio = aspectRatio)
+    networkPlotContainer[[v]] <- createJaspPlot(title = v, aspectRatio = aspectRatio, width = width[v], height = height[v])
 
   .suppressGrDevice({
 

--- a/JASP-Engine/JASP/R/networkanalysis.R
+++ b/JASP-Engine/JASP/R/networkanalysis.R
@@ -114,6 +114,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
                  type = c("factorLevels", "observations"),
                  factorLevels.target = groupingVariable,
                  factorLevels.amount = "< 2",
+                 observations.target = groupingVariable,
                  observations.amount = "< 10",
                  observations.grouping = groupingVariable,
                  exitAnalysisIfErrors = TRUE)

--- a/JASP-Engine/JASP/R/networkanalysis.R
+++ b/JASP-Engine/JASP/R/networkanalysis.R
@@ -604,7 +604,8 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
       edge.color  = edgeColor,
       nodeNames   = nodeNames,
       label.scale = options[["scaleLabels"]],
-      label.cex   = options[["labelSize"]]
+      label.cex   = options[["labelSize"]],
+      GLratio     = 1 / options[["legendToPlotRatio"]]
     ))
 }
 
@@ -624,9 +625,10 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
     "layout", "edgeColors", "repulsion", "edgeSize", "nodeSize", "colorNodesBy",
     "maxEdgeStrength", "minEdgeStrength", "cut", "showDetails", "nodePalette",
     "showLegend", "legendNumber", "showMgmVariableType", "showVariableNames",
-    "graphSize", "scaleLabels", "labelSize", "abbreviateLabels", "abbreviateNoChars",
+    "scaleLabels", "labelSize", "abbreviateLabels", "abbreviateNoChars",
     "keepLayoutTheSame", "layoutX", "layoutY", "plotNetwork",
-    "groupNames", "groupColors", "variablesForColor", "groupAssigned", "manualColors"
+    "groupNames", "groupColors", "variablesForColor", "groupAssigned", "manualColors",
+    "legendToPlotRatio"
   ))
   plotContainer[["networkPlotContainer"]] <- networkPlotContainer
 
@@ -634,8 +636,6 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
     networkPlotContainer[["dummyPlot"]] <- createJaspPlot(title = gettext("Network Plot"))
     return()
   }
-
-  aspectRatio <- if (options[["graphSize"]] == "graphSizeFree") 0 else 1
 
   layout <- network[["layout"]] # calculated in .networkAnalysisRun()
 
@@ -731,11 +731,11 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   names(allLegends) <- names(allNetworks) # allows indexing by name
 
   basePlotSize <- 320
-  legendMultiplier <- 0.4 * basePlotSize
-  width <- height <- basePlotSize + allLegends * legendMultiplier
-
+  legendMultiplier <- options[["legendToPlotRatio"]] * basePlotSize
+  height <- setNames(rep(basePlotSize, nGraphs), names(allLegends))
+  width  <- basePlotSize + allLegends * legendMultiplier
   for (v in names(allNetworks))
-    networkPlotContainer[[v]] <- createJaspPlot(title = v, aspectRatio = aspectRatio, width = width[v], height = height[v])
+      networkPlotContainer[[v]] <- createJaspPlot(title = v, width = width[v], height = height[v])
 
   .suppressGrDevice({
 

--- a/Resources/Help/analyses/networkanalysis.md
+++ b/Resources/Help/analyses/networkanalysis.md
@@ -136,18 +136,14 @@ The layout of a network determines where the nodes are placed. By default the la
 - `show details`: If checked, `minimum`, `maximum`, and `cut` will be displayed on the network plot (if they were modified).
 - `color scheme`: What colors should be used for positive and negative edges?
 
-#### Network Size
-When exporting the network, it can be useful to enforce certain sizes on the width or height. You can always resize a network plot by clicking and dragging around in the bottom right corner of the plot. However, some constraints on the width and height might be enforced depending on the option you've selected:
-
-- `Fixed ratio`: Fixes the width/ height ratio. Ensures that the network plot is square. If there is a legend, the width is constrained to be 1.4 times the height of the plot.
-- `Free`: Do not make any constraints on the width or height.
-
 #### Legend
 There are three options:
 
 - Don't show the legend.
 - Show the legend in all networks.
 - Show the legend in a specified plot number.
+
+- `Legend to plot ratio`: Specifies the width of the legend relative to the plot.
 
 #### Labels
 - `Label size`: A multiplier on label size  (i.e. 2 is twice as big).

--- a/Resources/Help/analyses/networkanalysis_nl.md
+++ b/Resources/Help/analyses/networkanalysis_nl.md
@@ -133,17 +133,13 @@ De lay-out van een netwerk bepaalt waar de knopen worden geplaatst. De standaard
 - `details`: Als deze optie wordt aangevinkt, worden `minimum`, `maximum`, en `cut` weergegeven op de netwerkgrafiek (als ze zijn aangepast).
 - `kleuren pallet`: Welke kleuren moeten gebruikt worden voor positieve en negatieve paden?
 
-#### Netwerkgrootte
-Wanneer u het netwerk exporteert, kan het handig zijn om bepaalde breedtes of hoogtes te forceren. U kunt de grootte van een netwerkgrafiek altijd aanpassen door op de rechter onderkant van de grafiek te klikken en uw muis te slepen. Er kunnen echter beperkingen voor de breedte of hoogte zijn op basis van de optie die u heeft geselecteerd:
-- `Vaste ratio`: Zet de breedte/hoogte ratio vast. Zorgt dat de grafiek vierkant is. Als er een legenda is, wordt de breedte vastgezet op 1.4 keer de hoogte van de grafiek.
-- `Free`: Maak geen beperkingen voor de breedte en hoogte van de grafiek.
-
-
 #### Legenda
 Er zijn drie opties:
 - Laat geen legenda zien.
 - Laat de legenda in alle netwerken zien.
 - Laat de legenda in een specifieke grafiek zien.
+
+- `Ratio legenda tot plot`: Specificeert de breedte van de legenda relatief aan het figuur.
 
 #### Labels
 - `Labelgrootte`: Een vermenigvuldiger voor de grootte van labels (bijv., 2 is twee keer zo groot).

--- a/Resources/Network/qml/NetworkAnalysis.qml
+++ b/Resources/Network/qml/NetworkAnalysis.qml
@@ -377,15 +377,6 @@ Form
 			}
 		}
 
-		DoubleField
-		{
-			name: "legendToPlotRatio"
-			label: qsTr("Legend to plot ratio")
-			defaultValue: 0.4
-			min: 0.001
-			max: 1000 // not strictly necessary but let's not take any chances
-		}
-
 		RadioButtonGroup
 		{
 			name: "showVariableNames";
@@ -415,6 +406,14 @@ Form
 				value: "In plot number: "; label: qsTr("In plot number: ")
 				childrenOnSameRow: true
 				IntegerField { name: "legendNumber"; defaultValue: 1 }
+			}
+			DoubleField
+			{
+				name: "legendToPlotRatio"
+				label: qsTr("Legend to plot ratio")
+				defaultValue: 0.4
+				min: 0.001
+				max: 4 // not strictly necessary but png crashes if it gets too big
 			}
 		}
 

--- a/Resources/Network/qml/NetworkAnalysis.qml
+++ b/Resources/Network/qml/NetworkAnalysis.qml
@@ -377,12 +377,13 @@ Form
 			}
 		}
 
-		RadioButtonGroup
+		DoubleField
 		{
-			name: "graphSize";
-			title: qsTr("Network Size")
-			RadioButton { value: "graphSizeFixed";	label: qsTr("Fixed ratio"); checked: true	}
-			RadioButton { value: "graphSizeFree";	label: qsTr("Free")							}
+			name: "legendToPlotRatio"
+			label: qsTr("Legend to plot ratio")
+			defaultValue: 0.4
+			min: 0.001
+			max: 1000 // not strictly necessary but let's not take any chances
 		}
 
 		RadioButtonGroup


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/698
Fixes https://github.com/jasp-stats/jasp-issues/issues/641

Network plots that include a legend are now automatically 1.4 times larger than plots that do not include a legend. The number 1.4 is handpicked by me, other suggestions are welcome.