### PR TITLE
Cleaned up some unused signals and fixed options ignores

### DIFF
--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -149,15 +149,10 @@ void Analyses::storeAnalysis(Analysis* analysis, size_t id, bool notifyAll)
 
 void Analyses::bindAnalysisHandler(Analysis* analysis)
 {
-	connect(analysis, &Analysis::optionsChanged,					this, &Analyses::analysisOptionsChanged				);
 	connect(analysis, &Analysis::statusChanged,						this, &Analyses::analysisStatusChanged				);
 	connect(analysis, &Analysis::sendRScript,						this, &Analyses::sendRScriptHandler					);
-	connect(analysis, &Analysis::toRefreshSignal,					this, &Analyses::analysisToRefresh					);
 	connect(analysis, &Analysis::titleChanged,						this, &Analyses::setChangedAnalysisTitle			);
-	connect(analysis, &Analysis::saveImageSignal,					this, &Analyses::analysisSaveImage					);
-	connect(analysis, &Analysis::editImageSignal,					this, &Analyses::analysisEditImage					);
 	connect(analysis, &Analysis::imageSavedSignal,					this, &Analyses::analysisImageSaved					);
-	connect(analysis, &Analysis::rewriteImagesSignal,				this, &Analyses::analysisRewriteImages				);
 	connect(analysis, &Analysis::imageEditedSignal,					this, &Analyses::analysisImageEdited				);
 	connect(analysis, &Analysis::requestColumnCreation,				this, &Analyses::requestColumnCreation				);
 	connect(analysis, &Analysis::resultsChangedSignal,				this, &Analyses::analysisResultsChanged				);

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -134,15 +134,10 @@ signals:
 	void countChanged();
 	void analysisAdded(					Analysis *	source);
 	void analysisRemoved(				Analysis *	source);
-	void analysisEditImage(				Analysis *	source);
-	void analysisSaveImage(				Analysis *	source);
-	void analysisToRefresh(				Analysis *	source);
 	void analysisImageSaved(			Analysis *	source);
 	void analysisImageEdited(			Analysis *	source);
-	void analysisRewriteImages(			Analysis *	source);
 	void analysisResultsChanged(		Analysis *	source);
 	void analysisTitleChanged(			Analysis *  source);
-	void analysisOptionsChanged(		Analysis *	source);
 	void analysisStatusChanged(			Analysis *	source);
 	void sendRScript(					QString		script, int requestID, bool whiteListedVersion);
 	void analysisSelectedIndexResults(	int			row);

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -209,7 +209,6 @@ void Analysis::refresh()
 {
 	setStatus(Empty);
 	TempFiles::deleteAll(_id);
-	emit toRefreshSignal(this);
 
 	if(_analysisForm)
 		_analysisForm->refreshTableViewModels();
@@ -219,20 +218,17 @@ void Analysis::saveImage(const Json::Value &options)
 {
 	setStatus(Analysis::SaveImg);
 	_imgOptions = options;
-	emit saveImageSignal(this);
 }
 
 void Analysis::editImage(const Json::Value &options)
 {
 	setStatus(Analysis::EditImg);
 	_imgOptions = options;
-	emit editImageSignal(this);
 }
 
 void Analysis::rewriteImages()
 {
 	setStatus(Analysis::RewriteImgs);
-	emit rewriteImagesSignal(this);
 }
 
 void Analysis::imagesRewritten()
@@ -377,14 +373,17 @@ void Analysis::setStatus(Analysis::Status status)
 
 void Analysis::optionsChangedHandler(Option *option)
 {
+	incrementRevision(); // To make sure we always process all changed options we increment the revision whenever anything changes
+
+	Log::log() << "Option changed for analysis '" << name() << "' and id " << id() << ", revision incremented to: " << _revision << " and options are now: " << option->asJSON().toStyledString() << std::endl;
+
 	if (_refreshBlocked)
 		return;
 
 	if (form() && form()->hasError())
 		return;
 
-	_status = Empty;
-	optionsChanged(this);
+	setStatus(Empty);
 }
 
 ComputedColumn *Analysis::requestComputedColumnCreationHandler(std::string columnName)

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -163,12 +163,8 @@ signals:
 	void				sendRScript(			Analysis * analysis, QString script, QString controlName, bool whiteListedVersion);
 	void				statusChanged(			Analysis * analysis);
 	void				optionsChanged(			Analysis * analysis);
-	void				saveImageSignal(		Analysis * analysis);
-	void				editImageSignal(		Analysis * analysis);
-	void				toRefreshSignal(		Analysis * analysis);
 	void				imageSavedSignal(		Analysis * analysis);
 	void				imageEditedSignal(		Analysis * analysis);
-	void				rewriteImagesSignal(	Analysis * analysis);
 	void				resultsChangedSignal(	Analysis * analysis);
 
 	ComputedColumn *	requestComputedColumnCreation(		QString columnName, Analysis * analysis);

--- a/JASP-Desktop/engine/enginerepresentation.cpp
+++ b/JASP-Desktop/engine/enginerepresentation.cpp
@@ -113,7 +113,6 @@ void EngineRepresentation::clearAnalysisInProgress()
 
 void EngineRepresentation::setAnalysisInProgress(Analysis* analysis)
 {
-	analysis->incrementRevision(); // Increment revision only when the analysis request is about to be sent
 	if(_engineState == engineState::analysis)
 	{
 		if(_analysisInProgress == analysis)	return; //we are already busy with this analysis so everything is fine


### PR DESCRIPTION
Instead of only increasing revision whenever analysis is sent to engine, always increment for each change of options
- fixes https://github.com/jasp-stats/jasp-test-release/issues/688

