### PR TITLE
Fixes bCor

### DIFF
--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -783,17 +783,16 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
         }
         # Note(Alexander): Not stored
         # 
-        ciValue <- options[["ciValue"]]
         lowerCi <- sidedBfWithoutPost[["lowerCi"]]
         upperCi <- sidedBfWithoutPost[["upperCi"]]
         medianPoint <- sidedBfWithoutPost[["posteriorMedian"]]
       }  else {
-        ciValue <- postPlotValues[["ciValue"]]
         lowerCi <- postPlotValues[["lowerCi"]]
         upperCi <- postPlotValues[["upperCi"]]
         medianPoint <- postPlotValues[["posteriorMedian"]]
       }
       
+      ciValue <- options[["ciValue"]]
       CRI <- c(lowerCi, upperCi)
       CRItxt <- gettextf("%s%% CI:", ciValue * 100)
     }

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -39,15 +39,16 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 
   # 5. PairsPlot Container: (Optional) ------
   #
-  if (options[["plotScatter"]] || options[["plotPriorPosterior"]] || options[["plotBfRobustness"]] || options[["plotBfSequential"]]) {
+  if (options[["plotScatter"]] || options[["plotPriorPosterior"]] || options[["plotBfRobustness"]] || 
+      options[["plotBfSequential"]]) {
     pairsPlotCollection <- .getPairPlotsContainerCorBayes(jaspResults, options)
+    
     if (!is.null(pairsPlotCollection)) {
       pairsPlotCollection <- .initPlotContainerSubStructureCorBayes(pairsPlotCollection, options)
   
       .fillPairsPlotsCorBayes(jaspResults, pairsPlotCollection, corModel, dataset, options)
     }
   }
-
 }
 
 .computeCorBayes <- function(jaspResults, dataset, options, ready = TRUE) {
@@ -61,7 +62,9 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
     .hasErrors(dataset, type="observations", observations.amount='< 2', exitAnalysisIfErrors=TRUE)
   
   result <- list()
+  
   pairs <- combn(options[["variables"]], 2, simplify=FALSE)
+  
   for (pair in pairs) {
     var1 <- pair[1]
     var2 <- pair[2]
@@ -71,10 +74,12 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
     pairName <- paste(sort(c(var1, var2)), collapse="-")
     
     result[[pairName]] <- list()
+    
     for (method in c("pearson", "kendall")) {
       
       errorMsg <- NULL
       dataCheck <- .corBayesCheckPairsErrors(dataset, var1, var2)
+      
       if (!identical(dataCheck, FALSE)) {
         errorMsg <- dataCheck[["message"]]
         v1 <- NA
@@ -95,7 +100,6 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
         ci <- .computeCorCredibleInterval(bfObject, options[["ciValue"]], method)
         bfObject <- modifyList(bfObject, ci)
       }
-      
       result[[pairName]][[method]] <- bfObject
     }
   }
@@ -155,10 +159,11 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 }
 
 .addTableColumnMarkupCorBayes <- function(table, methodItems, options) {
-  if (options[["displayPairwise"]])
+  if (options[["displayPairwise"]]) {
     .addPairwiseTableColumnMarkupCorBayes(table, methodItems, options)
-  else
+  } else {
     .addMatrixTableColumnMarkupCorBayes(table, methodItems, options)
+  }
 }
 
 .addPairwiseTableColumnMarkupCorBayes <- function(table, methodItems, options) {
@@ -234,14 +239,21 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
   table$addColumnInfo(name="itemColumn", title="", type="string")
   
   nVariables <- length(options[["variables"]])
+  
   if (nVariables < 2) {
-    if (nVariables == 0) title <- "..."
-    else                 title <- options[["variables"]][1]
+    
+    if (nVariables == 0) {
+      title <- "..."
+    } else {
+      title <- options[["variables"]][1]
+    }
+    
     table$addColumnInfo(name="firstPlaceholder", type="number", title=title)
     table$addColumnInfo(name="secondPlaceholder", type="number", title="...")
   } else {
-    for (variable in options[["variables"]])
+    for (variable in options[["variables"]]) {
       table$addColumnInfo(name=variable, type="number",title=variable)
+    }
   }
   
   if (length(methodItems)==0) {
@@ -272,25 +284,29 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 
 .fillTableCorBayes <- function(table, options, corModel) {
   if (is.null(corModel)) {
-    if (options[["displayPairwise"]])
+    if (options[["displayPairwise"]]) {
       .insertPairwiseDefaultEmptyTableCellsCorBayes(table, options)
-    else
+    } else {
       .insertMatrixDefaultEmptyTableCellsCorBayes(table, options)
+    }
   } else {
-    if (options[["displayPairwise"]])
+    if (options[["displayPairwise"]]) {
       .fillPairwiseTableCorBayes(table, options, corModel)
-    else
+    } else {
       .fillMatrixTableCorBayes(table, options, corModel)
+    }
   }
 }
 
 .insertPairwiseDefaultEmptyTableCellsCorBayes <- function(table, options) {
   nVariables <- length(options[["variables"]])
   if (nVariables < 2) {
-    if (nVariables == 0)
+    if (nVariables == 0) {
       var1 <- "..."
-    else
+    } else {
       var1 <- options[["variables"]][1]
+    }
+      
     var2 <- "..."
     table$addRows(list(variable1=var1, separator="\u2014", variable2=var2))
   }
@@ -298,14 +314,19 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 
 .insertMatrixDefaultEmptyTableCellsCorBayes <- function(table, options) {
   variables <- unlist(options[["variables"]])
-  if (length(variables) == 1)
-    variables <- c(paste("1.", variables), "2. ...")
-  else
-    variables <- c("1. ...", "2. ...")
   
+  if (length(variables) == 1) {
+    variables <- c(paste("1.", variables), "2. ...")
+  } else {
+    variables <- c("1. ...", "2. ...")
+  }
+    
   methodItems <- .getCorMethods(options)
   itemNames <- .bSelectItems(options)
+  
+  # TODO(Alexander): fix length is better
   statColumnPerVar <- c()
+  
   for (methodItem in methodItems) {
     statsToReport <- unlist(.bCorRowNames(options, itemNames, method=methodItem))
     statsToReport <- statsToReport[statsToReport != gettext("n")] # we want to only report this once per variable. probably better solved in .bCorRowNames() tho
@@ -315,21 +336,22 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
   if (options[["reportN"]])
     statColumnPerVar <- c(gettext("n"), statColumnPerVar)
   
-  emptyCells <- matrix(c("\u2014", "",
-                         ".", "\u2014"), nrow=2, byrow=TRUE)
+  emptyCells <- matrix(c("\u2014", "", ".", "\u2014"), nrow=2, byrow=TRUE)
   
-  for (i in seq_along(variables))
-    for (j in seq_along(statColumnPerVar))
+  for (i in seq_along(variables)) {
+    for (j in seq_along(statColumnPerVar)) {
       table$addRows(list(.isNewGroup = (i == 2 && j == 1),
                          variable = variables[i],
                          itemColumn = statColumnPerVar[j],
                          firstPlaceholder = emptyCells[i, 1],
                          secondPlaceholder = emptyCells[i, 2]))
-  
+    }
+  }
 }
 
 .fillPairwiseTableCorBayes <- function(table, options, corModel) {
   pairs <- combn(options[["variables"]], 2, simplify=FALSE)
+  
   for (pair in pairs) {
     var1 <- pair[1]
     var2 <- pair[2]
@@ -338,6 +360,7 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
     tempRow <- list("variable1"=var1, "separator"="-", "variable2"=var2)
     
     itemNames <- .bSelectItems(options)
+    
     for (method in .getCorMethods(options)) {
       bfObject <- corModel[[pairName]][[method]]
       
@@ -349,10 +372,11 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
       reportBf <- rowObject[["bf"]]
       
       if (options[["reportBayesFactors"]]) {
-        if (options[["bayesFactorType"]] == "BF01")
+        if (options[["bayesFactorType"]] == "BF01") {
           rowObject[["bf"]] <- 1/reportBf
-        else if (options[["bayesFactorType"]] == "LogBF10")
+        } else if (options[["bayesFactorType"]] == "LogBF10") {
           rowObject[["bf"]] <- log(reportBf)
+        }
       }
       
       names(rowObject) <- paste0(method, itemNames)
@@ -361,10 +385,12 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
         rowObject[["n"]] <- sampleSize
       
       errorMessage <- bfObject[["error"]]
-      if (!is.null(errorMessage))
+      
+      if (!is.null(errorMessage)) {
         table$addFootnote(errorMessage, rowNames = pairName, colNames = paste0(method, "stat"))
-      else if (options[["reportBayesFactors"]] && options[["flagSupported"]] && !is.na(reportBf))
+      } else if (options[["reportBayesFactors"]] && options[["flagSupported"]] && !is.na(reportBf)) {
         .addSupportedBfIndicators(table, reportBf, rowNames = pairName, colNames = paste0(method, "stat"))
+      }
       
       tempRow <- modifyList(tempRow, rowObject)
     }
@@ -374,6 +400,7 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 
 .fillMatrixTableCorBayes <- function(table, options, corModel) {
   nVariables <- length(options[["variables"]])
+  
   for (i in 1:nVariables) {
     emptyCellInfo <- vector("list", length=i)
 
@@ -386,6 +413,7 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
     
     itemNames <- .bSelectItems(options)
     methodItems <- .getCorMethods(options)
+    
     for (m in seq_along(.getCorMethods(options))) {
       # Row info collected here
       #
@@ -411,11 +439,12 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
                                                 itemNames=itemNames)
           reportBf <- sidedObject[["bf"]]
           
-          if (options[["bayesFactorType"]] == "BF01")
+          if (options[["bayesFactorType"]] == "BF01") {
             sidedObject[["bf"]] <- 1/reportBf
-          else if (options[["bayesFactorType"]] == "LogBF10")
+          } else if (options[["bayesFactorType"]] == "LogBF10") {
             sidedObject[["bf"]] <- log(reportBf)
-          
+          }
+            
           # Here add to info to the collection
           # 
           for (item in itemNames) 
@@ -423,11 +452,12 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
           
           errorMessage <- bfObject[["error"]]
           rowName <- paste0(var1, methodName, "stat")
-          if (!is.null(errorMessage))
+          
+          if (!is.null(errorMessage)) {
             table$addFootnote(errorMessage, rowNames = rowName, colNames = var2)
-          else if (options[["reportBayesFactors"]] && options[["flagSupported"]] && !is.na(reportBf))
+          } else if (options[["reportBayesFactors"]] && options[["flagSupported"]] && !is.na(reportBf)) {
             .addSupportedBfIndicators(table, reportBf, rowNames = rowName, colNames = var2)
-
+          }
         }
       }
       
@@ -453,10 +483,11 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
       rowItemNames <- .bCorRowNames(options, itemNames, method = methodName)
       
       for (k in seq_along(itemNames)) {
-        if (k == 1 && m == 1)
+        if (k == 1 && m == 1) {
           tempRow <- list(variable = paste0(i, ". ", var1), itemColumn = rowItemNames[[k]], .isNewGroup = TRUE) # First item gets the variable name
-        else
+        } else {
           tempRow <- list(variable = "", itemColumn = rowItemNames[[k]], .isNewGroup = FALSE)
+        }
         
         itemInfo <- as.list(allItemInfo[[k]])
 
@@ -471,12 +502,13 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 .addSupportedBfIndicators <- function(table, bf, rowNames, colNames) {
   symbol <- NULL
   
-  if (bf >= 100)
+  if (bf >= 100) {
     symbol <- "***"
-  else if (bf >= 30)
+  } else if (bf >= 30) {
     symbol <- "**"
-  else if (bf >= 10)
+  } else if (bf >= 10) {
     symbol <- "*"
+  }
   
   if (!is.null(symbol))
     table$addFootnote(symbol = symbol, rowNames=rowNames, colNames=colNames)
@@ -500,6 +532,7 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
   matrixPlot$position <- 2
   
   matrixDependencies <- c("variables", "plotMatrix", "plotMatrixDensities", "plotMatrixPosteriors", "missingValues", "setSeed", "seed")
+  
   if (options[["plotMatrixPosteriors"]])
     matrixDependencies <- c(matrixDependencies, "pearson", "spearman", "kendall", "alternative", "kappa")
   
@@ -543,7 +576,8 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
         if (!options[["plotMatrixPosteriors"]]) {
           posteriorPlot <- list()
         } else {
-          posteriorPlot <- .drawPosteriorPlotCorBayes(jaspResults, corModel, options, methodItems, purpose="matrix", pairName)
+          posteriorPlot <- .drawPosteriorPlotCorBayes(jaspResults, corModel, options, methodItems, purpose="matrix", 
+                                                      pairName)
         }
         plotMat[[col, row]] <- posteriorPlot
         
@@ -661,9 +695,9 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
   # a. No data errors, try to plot ----
   #
   postPlotValuesPerMethod <- .getPosteriorPlotValuesCorBayes(jaspResults, pairStats, options, pairName)
+  
   for (i in seq_along(postPlotValuesPerMethod)) {
     postPlotValues <- postPlotValuesPerMethod[[i]]
-    
     error <- postPlotValues[["error"]]
     
     if (postPlotValues[["tooPeaked"]]) {
@@ -724,7 +758,12 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
       )
     }
   } else if (purpose %in% c("pairs", "sumStat")) {
-    postPlotValues <- postPlotValuesPerMethod[[1]]
+    if (purpose=="sumStat") {
+      postPlotValues <- postPlotValuesPerMethod[[1]]
+    } else if (purpose=="pairs") {
+      postPlotValues <- postPlotValuesPerMethod[[options[["pairsMethod"]]]]
+    }
+    
     xName <- unlist(.corXNames[[methodItems]], recursive = FALSE)
     gLegend <- c(gettext("Prior"), gettext("Posterior"))
     dfLines <- data.frame(
@@ -732,11 +771,31 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
       y = c(postPlotValues[["priorLine"]], postPlotValues[["posteriorLine"]]),
       g = rep(gLegend, each=domainLength)
     )
-
+    
     if (isTRUE(options[["plotPriorPosteriorAddEstimationInfo"]])) {
-      CRI <- c(postPlotValues[["lowerCi"]], postPlotValues[["upperCi"]])
-      CRItxt <- gettextf("%s%% CI:", postPlotValues[["ciValue"]] * 100)
-      medianPoint <- postPlotValues[["posteriorMedian"]]
+      if (postPlotValues[["ciValue"]] != options[["ciValue"]]) {
+        if (purpose=="pairs") {
+          methodName <- options[["pairsMethod"]]
+          sidedBfWithoutPost <- corModel[[pairName]][[methodName]][[options[["alternative"]]]]
+        } else if (purpose=="sumStat") {
+          methodName <- options[["method"]]
+          sidedBfWithoutPost <- corModel[[options[["alternative"]]]]
+        }
+        # Note(Alexander): Not stored
+        # 
+        ciValue <- options[["ciValue"]]
+        lowerCi <- sidedBfWithoutPost[["lowerCi"]]
+        upperCi <- sidedBfWithoutPost[["upperCi"]]
+        medianPoint <- sidedBfWithoutPost[["posteriorMedian"]]
+      }  else {
+        ciValue <- postPlotValues[["ciValue"]]
+        lowerCi <- postPlotValues[["lowerCi"]]
+        upperCi <- postPlotValues[["upperCi"]]
+        medianPoint <- postPlotValues[["posteriorMedian"]]
+      }
+      
+      CRI <- c(lowerCi, upperCi)
+      CRItxt <- gettextf("%s%% CI:", ciValue * 100)
     }
 
     if (isTRUE(options[["plotPriorPosteriorAddTestingInfo"]])) {
@@ -755,24 +814,37 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
                        "less"="smaller"
   )
   plotResult <- try(JASPgraphs::PlotPriorAndPosterior(
-    dfLines, dfPoints, BF10, "CRI"=CRI, "CRItxt"=CRItxt, "median"=medianPoint, "xName"=xName, "hypothesis"=hypothesis, bfType = "BF10")
+    dfLines, dfPoints, BF10, "CRI" = CRI, "CRItxt" = CRItxt, "median" = medianPoint, "xName" = xName, 
+    "hypothesis" = hypothesis, bfType = "BF10")
   )
   return(plotResult)
 }
 
 .getPosteriorPlotValuesCorBayes <- function(jaspResults, bfObject, options, pair = NULL) {
   indexName <- paste0("posteriorLine-", pair)
+  
   if (!is.null(jaspResults[[indexName]]))
     return(jaspResults[[indexName]]$object)
 
   results <- list()
+  
   for (method in names(bfObject)){
     .setSeedJASP(options)
-    results[[method]] <- bstats::computeCorPosteriorLine(bfObject = bfObject[[method]], method = method, alternative = options[["alternative"]])
+    results[[method]] <- bstats::computeCorPosteriorLine(bfObject = bfObject[[method]], 
+                                                         alternative = options[["alternative"]])
   }
   
   jaspResults[[indexName]] <- createJaspState(results)
-  jaspResults[[indexName]]$dependOn(c("missingValues", "alternative", "kappa", "setSeed", "seed"))
+  
+  if (is.null(pair)) {
+    # sumStats
+    qmlInputElements <- c("hypothesis", "priorWidth", "setSeed", "seed")
+  } else {
+    # pairs
+    qmlInputElements <- c("missingValues", "alternative", "kappa", "setSeed", "seed")
+  }
+  
+  jaspResults[[indexName]]$dependOn(qmlInputElements)
   
   return(results)
 }
@@ -910,7 +982,8 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
         } else if (item == "plotBfRobustness") {
           plot <- .drawBfRobustnessPlotCorBayes(pairStats[[thisMethod]], options, thisMethod)
         } else if (item == "plotBfSequential") {
-          plot <- .drawBfSequentialPlotCorBayes(dataset[[.v(var1)]], dataset[[.v(var2)]], pairStats[[thisMethod]], options)
+          plot <- .drawBfSequentialPlotCorBayes(dataset[[.v(var1)]], dataset[[.v(var2)]], pairStats[[thisMethod]], 
+                                                options)
         }
         .checkAndSetPlotCorBayes(plot, jaspPlotResult)
       }
@@ -921,7 +994,7 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 
 .drawBfRobustnessPlotCorBayes <- function(bfObject, options, method) {
   .setSeedJASP(options)
-  robustnessValuesPerHypothesis <- bstats::computeCorRobustnessLine(bfObject, method=method)
+  robustnessValuesPerHypothesis <- bstats::computeCorRobustnessLine(bfObject)
   robustnessValues <- bstats::getSidedObject(robustnessValuesPerHypothesis, alternative=options[["alternative"]], 
                                         itemNames=c("kappaDomain", "kappa"))
   robustnessLine <- robustnessValues[["robustnessLine"]]
@@ -995,19 +1068,15 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
     
     for (i in seq_along(xPoint)) {
       if (i==1) {
-
         legendText1[i] <- gettextf("max %s", bfLegendLabel)
         legendText1[i] <- gsub(pattern = "\\s+", "~", legendText1[i])
         legendText2[i] <- gettextf("%s at kappa==%s", format(yPoint[i], digits=nDigits), format(xPoint[i], digits=nDigits))
         legendText2[i] <- gsub(pattern = "\\s+", "~", legendText2[i])
-
       } else if (i==2) {
-
         legendText1[i] <- gettext("user prior")
         legendText1[i] <- paste0("\"", legendText1[i], "\"")
         legendText2[i] <- gettextf("%s at kappa==%s", format(yPoint[i], digits=nDigits), format(xPoint[i], digits=nDigits))
         legendText2[i] <- gsub(pattern = "\\s+", "~", legendText2[i])
-
       }
       # TODO(Alexander): Do something here, with user-prior, wide etc etc. Also loop over colours
     }
@@ -1043,8 +1112,9 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
 
 .drawBfSequentialPlotCorBayes <- function(v1, v2, bfObject, options) {
   .setSeedJASP(options)
-  sequentialValuesPerHyp <- bstats::computeCorSequentialLine(x=v1, y=v2, bfObject=bfObject, method=options[["pairsMethod"]])
-  sequentialValues <- bstats::getSidedObject(sequentialValuesPerHyp, alternative=options[["alternative"]], itemNames="nDomain")
+  sequentialValuesPerHyp <- bstats::computeCorSequentialLine(x=v1, y=v2, bfObject=bfObject)
+  sequentialValues <- bstats::getSidedObject(sequentialValuesPerHyp, alternative=options[["alternative"]], 
+                                             itemNames="nDomain")
 
   sequentialLine <- sequentialValues[["sequentialLine"]]
 

--- a/JASP-Engine/JASP/R/summarystatscorrelationbayesianpairs.R
+++ b/JASP-Engine/JASP/R/summarystatscorrelationbayesianpairs.R
@@ -48,7 +48,8 @@ SummaryStatsCorrelationBayesianPairs <- function(jaspResults, dataset=NULL, opti
                     spearman = options[["rhoSObs"]])
   
   corResults <- bstats::bcor.testSumStat(n=options[["n"]], stat=statObs, alternative=options[["alternative"]],
-                                       method=options[["method"]], ciValue=options[["ciValue"]], kappa=options[["kappa"]])
+                                         method=options[["method"]], ciValue=options[["ciValue"]], 
+                                         kappa=options[["kappa"]])
   pValue <- bstats::pValueFromCor(n=options[["n"]], stat=statObs, method=options[["method"]])
   results <- modifyList(corResults, pValue)
   

--- a/Resources/Help/analyses/correlation.md
+++ b/Resources/Help/analyses/correlation.md
@@ -19,8 +19,8 @@ The Correlation analysis allows estimation of the population correlation, as wel
 ### Input
 ---
 
-#### Correlation Coefficient
-- Pearson's rho: Pearson's product moment correlation coefficient. 
+#### Sample Correlation Coefficient
+- Pearson's r: Pearson's product moment correlation coefficient.
 - Spearman: Spearman's rank-order correlation coefficient to quantify the monotonic association between two variables.
 - Kendall's tau-b: Kendall's tau-b rank-order correlation coefficient to quantify the monotonic association between two variables.
 
@@ -35,7 +35,7 @@ The Correlation analysis allows estimation of the population correlation, as wel
 - Flag significant correlations: Mark statistically significant correlations.
 - Confidence Intervals: Confidence intervals for the population correlation (only available for the Pearson correlation).
   - Interval: Coverage of the confidence interval in percentages.
-- Vovk-Selke maximum p-ratio: The bound 1/(-e p log(p)) is derived from the shape of the p-value distribution. Under the null hypothesis (H<sub>0</sub>) it is uniform (0,1), and under the alternative (H<sub>1</sub>) it is decreasing in p, e.g., a beta (α, 1) distribution, where 0 < α < 1. The Vovk-Sellke MPR is obtained by choosing the shape α of the distribution under H1 such that the obtained p-value is maximally diagnostic. The value is then the ratio of the densities at point p under H<sub>0</sub> and H<sub>1</sub>. For example, if the two-sided p-value equals .05, the Vovk-Sellke MPR equals 2.46, indicating that this p-value is at most 2.46 times more likely to occur under H1 than under H<sub>0</sub>. 
+- Vovk-Selke maximum p-ratio: The bound 1/(-e p log(p)) is derived from the shape of the p-value distribution. Under the null hypothesis (H<sub>0</sub>) it is uniform (0,1), and under the alternative (H<sub>1</sub>) it is decreasing in p, e.g., a beta (α, 1) distribution, where 0 < α < 1. The Vovk-Sellke MPR is obtained by choosing the shape α of the distribution under H1 such that the obtained p-value is maximally diagnostic. The value is then the ratio of the densities at point p under H<sub>0</sub> and H<sub>1</sub>. For example, if the two-sided p-value equals .05, the Vovk-Sellke MPR equals 2.46, indicating that this p-value is at most 2.46 times more likely to occur under H1 than under H<sub>0</sub>.
 - Sample size: The number of complete observations for a given pair of variables.
 
 #### Plots
@@ -48,16 +48,16 @@ The Correlation analysis allows estimation of the population correlation, as wel
 
 - Multivariate normality
   - Shapiro: Computes the Shapiro-Wilk statistic to test the null hypothesis that the selected variables have multivariate normal distribution.
-  
+
 - Pairwise normality
   - Shapiro: For each possible combination of the selected variables, computes the Shapiro-Wilk statistic to test the null hypothesis that the variable pair has a bivariate normal distribution.
-  
+
 #### Options
 
 - Missing values
   - Exclude cases pairwise: Uses all complete observations for each individual pair of variables.
   - Exclude cases listwise: Uses only complete cases across all variables.
-  
+
 ### Output
 ---
 #### Correlation Table
@@ -69,7 +69,7 @@ The Correlation analysis allows estimation of the population correlation, as wel
     - *p < .05 if the correlation is significant at alpha=.05 level.
     - **p < .01 if the correlation is significant at alpha=.01 level.
     - ***p < .001 if the correlation is significant at alpha=.001 level.
-- Vovk-Sellke Maximum *p*-Ratio: For an explanation, see Vovk-Sellke under `Options`. 
+- Vovk-Sellke Maximum *p*-Ratio: For an explanation, see Vovk-Sellke under `Options`.
 - Upper x% CI: Upper bound of the x% confidence interval for the population correlation.
 - Lower x% CI: Lower bound of the x% confidence interval for the population correlation.
 - n: Sample size.

--- a/Resources/Help/analyses/correlation_nl.md
+++ b/Resources/Help/analyses/correlation_nl.md
@@ -19,8 +19,8 @@ De Correlatie Matrix maakt het mogelijk de populatiecorrelatie te schatten en de
 ### Invoer
 ---
 
-#### Correlatiecoëfficiënt
-- Pearson's rho: Pearson's productmoment correlatiecoëfficiënt. 
+#### Steekproef Correlatiecoëfficiënt
+- Pearson's r: Pearson's productmoment correlatiecoëfficiënt.
 - Spearman: Spearman's rangorde correlatiecoëfficiënt om de monotone associatie tussen twee variabelen te kwantificeren.
 - Kendall's tau-b: Kendall's tau-b rangorde correlatiecoëfficiënt om de monotone associatie tussen twee variabelen te kwantificeren.
 
@@ -35,7 +35,7 @@ De Correlatie Matrix maakt het mogelijk de populatiecorrelatie te schatten en de
 - Markeer significante correlaties: Markeer statistisch significante correlaties.
 - Betrouwbaarheidsintervallen: Betrouwbaarheidsintervallen voor de populatiecorrelatie (enkel beschikbaar voor de Pearson correlatie).
   - Interval: Dekking van het betrouwbaarheidsinterval in percentages.
-- Vovk-Selke maximum p-ratio: De grens 1/(-e p log(p)) is berekend aan de hand van de p-waarde verdeling. Onder de nullhypothese (H<sub>0</sub>) is het uniform (0,1), en onder de alternatieve (H<sub>1</sub>) verlaagt de p-waarde, e.g., een beta (α, 1) verdeling, met 0 < α < 1. De Vovk-Sellke MPR is verkregen door de vorm α van de verdeling te kiezen onder H1 zodat de behaalde p-waarde diagnostisch gemaximaliseerd is. De waarde is dan de ratio van de verdelingen op punt p onder H<sub>0</sub> en H<sub>1</sub>. Bijvoorbeeld, als de tweezijdige p-waarde gelijk is aan .05, de Vovk-Sellke MPR gelijk is aam 2.46, dit geeft aan dat deze p-waarde is hoogstens 2.46 keer meer aannemelijk is voor H<sub>1</sub> dan voor H<sub>0</sub>. 
+- Vovk-Selke maximum p-ratio: De grens 1/(-e p log(p)) is berekend aan de hand van de p-waarde verdeling. Onder de nullhypothese (H<sub>0</sub>) is het uniform (0,1), en onder de alternatieve (H<sub>1</sub>) verlaagt de p-waarde, e.g., een beta (α, 1) verdeling, met 0 < α < 1. De Vovk-Sellke MPR is verkregen door de vorm α van de verdeling te kiezen onder H1 zodat de behaalde p-waarde diagnostisch gemaximaliseerd is. De waarde is dan de ratio van de verdelingen op punt p onder H<sub>0</sub> en H<sub>1</sub>. Bijvoorbeeld, als de tweezijdige p-waarde gelijk is aan .05, de Vovk-Sellke MPR gelijk is aam 2.46, dit geeft aan dat deze p-waarde is hoogstens 2.46 keer meer aannemelijk is voor H<sub>1</sub> dan voor H<sub>0</sub>.
 - Steekproefgrootte: Het aantal volledige observaties voor een gegeven paar variabelen.
 
 #### Grafieken
@@ -48,19 +48,19 @@ De Correlatie Matrix maakt het mogelijk de populatiecorrelatie te schatten en de
 
 - Multivariate normaliteit
   - Shapiro: Berekend de Shapiro-Wilk statistiek om de nulhypothese dat de geselecteerde variabelen een multivariate normale verdeling hebben, te toetsen.
-  
+
 - Paarsgewijze normaliteit
   - Shapiro: Voor elke mogelijke combinatie van de geselecteerde variabelen berekent de Shapiro-Wilk statistiek om de nulhypothese te toetsen dat de paar variabelen een bivariate normale verdeling hebben.
-  
+
 #### Opties
 
 - Ontbrekende waarden
   - Sluit paarsgewijs waarnemingen uit: Gebruik alle complete observaties for elk individuele paar van variabelen.
   - Sluit lijstgewijs waarnemingen uit: Gebruik enkel volledige waarnemingen van alle variabelen.
-  
+
 ### Uitvoer
 ---
-#### Correlatietabel 
+#### Correlatietabel
 - Pearson r: Pearson's product-moment correlatiecoëfficiënt.
 - Spearman rho: Spearman's rank correlatiecoëfficiënt.
 - Kendall tau:  Kendall's tau b rank correlatiecoëfficiënt.
@@ -69,7 +69,7 @@ De Correlatie Matrix maakt het mogelijk de populatiecorrelatie te schatten en de
 	- *p < 0.05 als de correlatie significant is op het alfa=.05 niveau.
 	- **p < .01 als de correlatie significant is op het alfa=.01 niveau.
 	- ***p < .001 als de correlatie significant is op het alfa=.001 niveau.
-- Vovk-Sellke Maximum *p*-Ratio: Voor een uitleg, zie Vovk-Sellke onder `Opties`. 
+- Vovk-Sellke Maximum *p*-Ratio: Voor een uitleg, zie Vovk-Sellke onder `Opties`.
 - Boven x% BI: Bovenste grens van de x% betrouwbaarheidsinterval voor de populatiecorrelatie.
 - Onder x% BI: Onderste grens of the x% betrouwbaarheidsinterval voor de populatiecorrelatie.
 - n: Steekproefgrootte.

--- a/Resources/Help/analyses/correlationbayesian.md
+++ b/Resources/Help/analyses/correlationbayesian.md
@@ -17,8 +17,8 @@ The Bayesian Correlation analysis allows for the estimation of the population co
 ### Input
 ---
 
-#### Correlation Coefficient
-- Pearson's rho: Pearson's product moment correlation coefficient. 
+#### Population Correlation Coefficient
+- Pearson's rho: Pearson's product moment correlation coefficient.
 - Kendall's tau-b: Kendall's tau-b rank-order correlation coefficient to quantify the monotonic association between two variables.
 
 #### Alt. Hypothesis
@@ -42,31 +42,31 @@ The Bayesian Correlation analysis allows for the estimation of the population co
 - Correlation matrix: Display a grid of scatterplots for each possible combination of the selected variables. These are placed above the diagonal.
   - Densities for variables: Display histogram and the corresponding density plot for each variable. These are placed on the diagonal.
   - Posteriors under H<sub>1</sub>: Display posterior distribution of the correlation coefficient for each possible combination of the selected variables. These are placed below the diagonal.
-  
+
 #### Prior
 - Stretched beta prior width: Width of the scaled beta distribution on the correlation under the alterative hypothesis; default is 1. The lower this value, the more concentrated the prior density is around 0. Value must be between 0 and 2.
 
 ### Plot Individual Pairs
 - Correlation coefficient to plot:
-  - Pearson's rho: Pearson's product moment correlation coefficient. 
+  - Pearson's rho: Pearson's product moment correlation coefficient.
   - Kendall's tau-b: Kendall's tau-b rank-order correlation coefficient to quantify the monotonic association between two variables.
-  
+
 - Scatterplot: Displays scatterplots for each specified pair of variables.
-  
+
 - Prior and posterior: Displays the prior and posterior distribution of the correlation under the alternative hypothesis for each specified pair of variables.
   - Estimation info: Adds the median and the 95% credible interval of the posterior distribution of the effect size.
   - Testing info: Adds the Bayes factor computed with the user-defined prior; adds a probability wheel depicting the odds of the data under the null vs. alternative hypothesis (under the assumption that the null and alternative hypotheses were equal probable a priori, i.e., P(H0)=P(H1)=1/2); adds indicators representing the prior and posterior at the test point (e.g., rho=0), the ratio between these two values equals the Bayes factor.
-  
+
 - Bayes factor robustness check: Displays the Bayes factor as a function of the width of the stretched beta prior on the correlation for each specified pair of variables. The width of the kappa prior is varied between 0 and 2.
-  - Additional info: Adds the Bayes factor computed with the user-defined prior and the maximum obtainable Bayes factor. 
-  
+  - Additional info: Adds the Bayes factor computed with the user-defined prior and the maximum obtainable Bayes factor.
+
 - Sequential analysis: Displays the development of the Bayes factor as the data come in using the user-defined prior for each specified pair of variables.
   - Additional info: Adds the Bayes factor computed with the user-defined prior; adds a probability wheel depicting the odds of the data under the null vs. alternative hypothesis; shows the decisiveness of the evidence in terms of Jeffreys' (1961) evidence categories.
 
 ### Options
-- Missing values: 
+- Missing values:
   - Exclude cases pairwise
-  - Exclude cases listwise 
+  - Exclude cases listwise
 - Repeatability:
   - Set seed: Gives the option to set a seed for your analysis. Setting a seed will exclude random processes influencing an analysis.
 
@@ -104,11 +104,11 @@ The Bayesian Correlation analysis allows for the estimation of the population co
     - Estimation info: Displays the median and the 95% credible interval of the posterior distribution of the effect size.
     - Testing info: Displays the Bayes factor computed with the user-defined prior; displays a probability wheel depicting the odds of the data under the null vs. alternative hypothesis (under the assumption that the null and alternative hypotheses were equal probable a priori, i.e., P(H0)=P(H1)=1/2); displays indicators (gray circles) representing the prior and posterior at the test point (e.g., rho=0), the ratio between these two values equals the Bayes factor.
 
-- Bayes factor robustness check: 
-  - Displays the Bayes factor as a function of the width of the beta prior on the correlation. 
+- Bayes factor robustness check:
+  - Displays the Bayes factor as a function of the width of the beta prior on the correlation.
     - Additional info: The red circle represents the maximum obtainable Bayes factor; the gray circle represents the Bayes factor computed with the user-defined prior.
 
-- Sequential analysis: 
+- Sequential analysis:
   - Displays the development of the Bayes factor as a function of the number of observations (n) using the user-defined prior.
     - Additional info: Displays the Bayes factor computed with the user-defined prior; displays a probability wheel depicting the odds of the data under the null vs. alternative hypothesis; shows the decisiveness of the evidence in terms of Jeffreys' (1961) evidence categories.
 

--- a/Resources/Help/analyses/correlationbayesian_nl.md
+++ b/Resources/Help/analyses/correlationbayesian_nl.md
@@ -17,8 +17,8 @@ De Bayesiaanse Correlatie analyse maakt het mogelijk om de populatiecorrelatie t
 ### Invoer
 ---
 
-#### Correlatiecoëfficiënt
-- Pearson's rho: Pearson's productmoment correlatiecoëfficiënt. 
+#### Populatie Correlatiecoëfficiënt
+- Pearson's rho: Pearson's productmoment correlatiecoëfficiënt.
 - Kendall's tau-b: Kendall's tau-b rangorde correlatiecoëfficiënt om de monotone associatie tussen twee variabelen te kwantificeren.
 
 #### Alt. Hypotheses
@@ -27,7 +27,7 @@ De Bayesiaanse Correlatie analyse maakt het mogelijk om de populatiecorrelatie t
 - Negatieve correlatie: Eénzijdige alternatieve hypothese dat de populatiecorrelatie lager is dan 0.
 
 #### Bayes Factor  
-- BF<sub>10</sub>: Als u deze optie selecteert, geeft de Bayes factor bewijs voor de alternatieve hypothese ten opzichte van de nulhypothese. Dit is de standaardoptie. 
+- BF<sub>10</sub>: Als u deze optie selecteert, geeft de Bayes factor bewijs voor de alternatieve hypothese ten opzichte van de nulhypothese. Dit is de standaardoptie.
 - BF<sub>01</sub>: Als u deze optie selecteert, geeft de Bayes factor bewijs voor de nulhypothese ten opzichte van de alternatieve hypothese. Dit is gelijk aan 1/BF<sub>10</sub>.
 - Log(BF<sub>10</sub>) : Als u deze optie selecteert, wordt het natuurlijke logaritme <sub>10</sub>, BF<sub>m</sub>, BF<sub>Inclusie</sub>, BF<sub>10, U</sub> weergegeven in de uitvoer.
 
@@ -39,26 +39,26 @@ De Bayesiaanse Correlatie analyse maakt het mogelijk om de populatiecorrelatie t
 - Geloofwaardigheidsinterval: Geeft het geloofwaardigheidsinterval weer voor de correlatiecoëfficiënt.
 
 #### Grafieken
-- Correlatie matrix: Geeft correlatiematrices weer voor iedere mogelijke combinatie van de geselecteerde variabelen. Deze staan boven de diagonaal. 
-  - Verdelingen van variabelen: Geeft een histogram en de overeenkomende verdelingsgrafieken weer voor elke variabele. Deze staan op de diagonaal. 
-  - Posteriors onder H<sub>1</sub>: Geeft posterior vergelijkingen van de correlatiecoëfficiënt weer voor iedere mogelijke combinatie van de geselecteerde variabelen. Deze staan onder de diagonaal. 
-  
+- Correlatie matrix: Geeft correlatiematrices weer voor iedere mogelijke combinatie van de geselecteerde variabelen. Deze staan boven de diagonaal.
+  - Verdelingen van variabelen: Geeft een histogram en de overeenkomende verdelingsgrafieken weer voor elke variabele. Deze staan op de diagonaal.
+  - Posteriors onder H<sub>1</sub>: Geeft posterior vergelijkingen van de correlatiecoëfficiënt weer voor iedere mogelijke combinatie van de geselecteerde variabelen. Deze staan onder de diagonaal.
+
 #### Prior
-- Gespreide beta prior breedte: Breedte van de geschaalde beta verdeling op de correlatie onder de alternatieve hypothese; de standaardwaarde is 1. Hoe lager deze waarde, hoe meer de prior verdeling is geconcentreerd rond 0. De waarde moet tussen de 0 en de 2 liggen. 
+- Gespreide beta prior breedte: Breedte van de geschaalde beta verdeling op de correlatie onder de alternatieve hypothese; de standaardwaarde is 1. Hoe lager deze waarde, hoe meer de prior verdeling is geconcentreerd rond 0. De waarde moet tussen de 0 en de 2 liggen.
 
 ### Maak Grafieken Van Losse Paren
 - Correlatiecoëfficiënt in grafieken
-  - Pearson's rho: Pearson's productmoment correlatiecoëfficiënt. 
+  - Pearson's rho: Pearson's productmoment correlatiecoëfficiënt.
   - Kendall's tau-b: Kendall's tau-b rangorde correlatiecoëfficiënt om de monotone associatie tussen twee variabelen te kwantificeren.
-  
+
 - Spreidingsdiagram: Geef een spreidingsdiagram weer voor elk paar geselecteerde variabelen.
-  
+
 - Prior en posterior: Geeft de dichtheid van de prior en de posterior van de effectgrootte onder de alternatieve hypothese.
   - Schatting info: Geeft de mediaan en het 95% geloofwaardigheidsinterval van de posterior weer.
   - Toetsing info: Voegt de Bayes factor berekend met de door de gebruiker gedefinieerde prior toe; voegt een kanswiel toe die de kans van de data onder de nulhypothese vs. de alternatieve hypothese laat zien; voegt twee cirkels toe voor de prior en posterior op het toetsingspunt (rho=0), de ratio van de twee punten is gelijk aan de Bayes factor.
 - Bayes factor robuustheidsgrafiek: Geeft de Bayes factor weer als een functie van de gerekte beta prior breedte voor de correlatie tussen de paren. De schaal van kappa varieert tussen 0 en 2.
   - Aanvullende informatie: Voegt de Bayes factor berekend met de door de gebruiker gedefinieerde prior toe en de maximaal haalbare Bayes factor.
-  
+
 - Sequentiële analyse: Geeft de ontwikkeling van de Bayes factor weer terwijl de data binnenkomen, gebruik makende van de door de gebruiker gedefinieerde prior.
   - Aanvullende info: Voegt de Bayes factor berekend met de door de gebruiker gedefinieerde prior toe; voegt een kanswiel toe die de kans van de data onder de nulhypothese vs. de alternatieve hypothese laat zien; geeft de interpretatie van het bewijs in termen van Jeffreys' (1961) bewijscategorieën.
 
@@ -77,21 +77,21 @@ De Bayesiaanse Correlatie analyse maakt het mogelijk om de populatiecorrelatie t
 - Pearson r: Pearson's product-moment correlatiecoëfficiënt.
 - Kendall tau:  Kendall's tau b rank correlatiecoëfficiënt.
 - BF10 (of BF01): Bayes factor. Als een eenzijdige toets wordt opgevraagd:
-  - BF+0: Bayes factor die bewijs geeft voor de eenzijdige alternatieve hypothese dat de populatiecorrelatie hoger is dan 0. 
-  - BF-0: Bayes factor die bewijs geeft voor de eenzijdige alternatieve hypothese dat de populatiecorrelatie lager is dan 0. 
-  - BF0+: Bayes factor die bewijs geeft voor de nulhypothese ten opzichte van de eenzijdige alternatieve hypothese dat de populatiecorrelatie hoger is dan 0. 
-  - BF0-: Bayes factor die bewijs geeft voor de nulhypothese ten opzichte van de eenzijdige alternatieve hypothese dat de populatiecorrelatie lager is dan 0. 
-- Geloofwaardigheidsinterval: Centrale geloofwaardigheidsinterval voor de correlatiecoëfficiënt. 
+  - BF+0: Bayes factor die bewijs geeft voor de eenzijdige alternatieve hypothese dat de populatiecorrelatie hoger is dan 0.
+  - BF-0: Bayes factor die bewijs geeft voor de eenzijdige alternatieve hypothese dat de populatiecorrelatie lager is dan 0.
+  - BF0+: Bayes factor die bewijs geeft voor de nulhypothese ten opzichte van de eenzijdige alternatieve hypothese dat de populatiecorrelatie hoger is dan 0.
+  - BF0-: Bayes factor die bewijs geeft voor de nulhypothese ten opzichte van de eenzijdige alternatieve hypothese dat de populatiecorrelatie lager is dan 0.
+- Geloofwaardigheidsinterval: Centrale geloofwaardigheidsinterval voor de correlatiecoëfficiënt.
 
 - Markeer ondersteunde correlaties: Correlaties die worden ondersteund door de Bayes factor zijn gemarkeerd met (zie Jeffreys (1961) voor bewijscategorieën):
-	- *BF < 10 als de data minimaal 10 keer aannemelijker zijn onder de gekozen hypothese (zie Hypothese). 
-	- **BF < 30 als de data minimaal 30 keer aannemelijker zijn onder de gekozen hypothese (zie Hypothese). 
-	- ***BF < 100 als de data minimaal 100 keer aannemelijker zijn onder de gekozen hypothese (zie Hypothese). 
+	- *BF < 10 als de data minimaal 10 keer aannemelijker zijn onder de gekozen hypothese (zie Hypothese).
+	- **BF < 30 als de data minimaal 30 keer aannemelijker zijn onder de gekozen hypothese (zie Hypothese).
+	- ***BF < 100 als de data minimaal 100 keer aannemelijker zijn onder de gekozen hypothese (zie Hypothese).
 
 #### Bayesiaanse Correlatie Grafiek
 - Correlatiematrix: Geeft een (matrix van) spreidingsdiagram(men) weer tussen de variabelen (in de bovenste niet-diagonale vakken van de matrix). De zwarte lijn is de kleinste-kwadraten regressielijn.
-    - Verdeling van variabelen: Geeft een histogram en de bijbehorende verdelingsgrafiek weer voor elke variabele in de diagonale delen van de matrix. 
-    - Posteriors onder H1: Geeft (een) verdelingsgrafiek(en) weer van de posterior van de correlatie(s) onder de alternatieve hypothese in de lagere niet-diagonale delen van de matrix. 
+    - Verdeling van variabelen: Geeft een histogram en de bijbehorende verdelingsgrafiek weer voor elke variabele in de diagonale delen van de matrix.
+    - Posteriors onder H1: Geeft (een) verdelingsgrafiek(en) weer van de posterior van de correlatie(s) onder de alternatieve hypothese in de lagere niet-diagonale delen van de matrix.
 
 #### Paarsgewijze Bayesiaanse Correlatie Grafieken
 - Spreidingsdiagram:
@@ -107,7 +107,7 @@ De Bayesiaanse Correlatie analyse maakt het mogelijk om de populatiecorrelatie t
   - Geeft de Bayes factor weer als een functie van de beta prior breedte voor de correlatie tussen de paren.
     - Aanvullende informatie: De rode cirkel is de maximaal haalbare Bayes factor; de grijze cirkel is de Bayes factor berekend met de door de gebruiker gedefinieerde prior.
 
-- Sequentiële analyse: 
+- Sequentiële analyse:
   - Geeft de ontwikkeling van de Bayes factor weer als een functie van het aantal observaties (n) op basis van de door de gebruiker gedefinieerde prior.
     - Aanvullende info: Voegt de Bayes factor berekend met de door de gebruiker gedefinieerde prior toe; voegt een kanswiel toe die de kans van de data onder de nulhypothese vs. de alternatieve hypothese laat zien; geeft de interpretatie van het bewijs in termen van Jeffreys' (1961) bewijscategorieën.
 

--- a/Resources/Help/analyses/summarystatscorrelationbayesianpairs.md
+++ b/Resources/Help/analyses/summarystatscorrelationbayesianpairs.md
@@ -9,9 +9,9 @@ The Bayesian Correlation analysis allows you to test the null hypothesis that th
 #### Assignment Box
 - *n*: Sample size (minimum: 2)
 
-#### Correlation coefficient
-  - *Pearson's r*:  Pearson product-moment correlation coefficient
-  - *Kendall's tau-b*
+#### Sample Correlation coefficient
+  - *Pearson's r*: The observed Pearson product-moment correlation coefficient
+  - *Kendall's tau-b*: The observed Kendall's tau-b rank-order correlation coefficient.
 
 #### Alt. Hypothesis
 - *Correlated*: Two-sided alternative hypothesis that the population correlation does not equal 0.

--- a/Resources/Help/analyses/summarystatscorrelationbayesianpairs_nl.md
+++ b/Resources/Help/analyses/summarystatscorrelationbayesianpairs_nl.md
@@ -1,7 +1,7 @@
 Samenvatting statistiek Bayesiaanse Correlatie
 ==========
 
-Met Bayesiaanse correlatie analyse kan men de nulhypothese testen dat de populatiecorrelatie (Pearson product-moment correlatie) tussen twee variabelen 0 is. 
+Met Bayesiaanse correlatie analyse kan men de nulhypothese testen dat de populatiecorrelatie (Pearson product-moment correlatie) tussen twee variabelen 0 is.
 
 ### Invoer
 ---
@@ -10,18 +10,18 @@ Met Bayesiaanse correlatie analyse kan men de nulhypothese testen dat de populat
 - *n*: Steekproefgrootte (minimaal 2).
 
 #### Correlatiecoëfficiënt
-  - *Pearson's r*: Pearson's product-moment correlatie coëfficiënt.
-  - *Kendall's tau-b*
+  - *Pearson's r*: De geöbserveerde Pearson's product-moment correlatie coëfficiënt.
+  - *Kendall's tau-b*: De geöbserveerde Kendall's tau-b rangorde correlatiecoëfficiënt.
 
 #### Alt. Hypothese
-- *gecorreleerd*: Tweezijdige alternatieve hypothese dat de populatiecorrelatie niet 0 is. 
+- *gecorreleerd*: Tweezijdige alternatieve hypothese dat de populatiecorrelatie niet 0 is.
 - *positief gecorreleerd*: Eenzijdige alternatieve hypothese dat de populatiecorrelatie hoger is dan 0.
 - *negatief gecorreleerd*: Eenzijdige alternatieve hypothese dat de populatiecorrelatie lager is dan 0.
 
 - *Geloofwaardigheidsinterval*: Geeft het geloofwaardigheidsinterval weer voor de correlatiecoëfficiënt.
-- 
+-
 #### Bayes Factor
-- BF<sub>10</sub>: Als u deze optie selecteert geeft de Bayes factor bewijs voor de alternatieve hypothese ten opzichte van de nulhypothese. Dit is de standaardoptie. 
+- BF<sub>10</sub>: Als u deze optie selecteert geeft de Bayes factor bewijs voor de alternatieve hypothese ten opzichte van de nulhypothese. Dit is de standaardoptie.
 - BF<sub>01</sub>: Als u deze optie selecteert geeft de Bayes factor bewijs voor de nulhypothese ten opzichte van de alternatieve hypothese. Dit is gelijk aan 1/BF<sub>10</sub>.
 - Log(BF<sub>10</sub>) : Natuurlijk logaritme van BF10.
 
@@ -38,7 +38,7 @@ Met Bayesiaanse correlatie analyse kan men de nulhypothese testen dat de populat
 ### Uitvoer
 ---
 #### Bayesiaanse Pearson Correlaties
-- **Bayes factor**: Als er een eenzijdige toets is geselecteerd: 
+- **Bayes factor**: Als er een eenzijdige toets is geselecteerd:
   - BF+0: De Bayes factor die bewijs geeft voor de eenzijdige hypothese dat de populatiecorrelatie hoger is dan 0.
   - BF-0: De Bayes factor die bewijs geeft voor de eenzijdige hypothese dat de populatiecorrelatie lager is dan 0.
   - BF0+: De Bayes factor de bewijs geeft voor de nulhypothese ten opzichte van de eenzijdige hypothese dat de populatiecorrelatie hoger is dan 0.

--- a/Resources/Help/analyses/summarystatscorrelationbayesianpairs_nl.md
+++ b/Resources/Help/analyses/summarystatscorrelationbayesianpairs_nl.md
@@ -10,8 +10,8 @@ Met Bayesiaanse correlatie analyse kan men de nulhypothese testen dat de populat
 - *n*: Steekproefgrootte (minimaal 2).
 
 #### Correlatiecoëfficiënt
-  - *Pearson's r*: De geöbserveerde Pearson's product-moment correlatie coëfficiënt.
-  - *Kendall's tau-b*: De geöbserveerde Kendall's tau-b rangorde correlatiecoëfficiënt.
+  - *Pearson's r*: De geobserveerde Pearson's product-moment correlatie coëfficiënt.
+  - *Kendall's tau-b*: De geobserveerde Kendall's tau-b rangorde correlatiecoëfficiënt.
 
 #### Alt. Hypothese
 - *gecorreleerd*: Tweezijdige alternatieve hypothese dat de populatiecorrelatie niet 0 is.

--- a/Resources/Regression/qml/Correlation.qml
+++ b/Resources/Regression/qml/Correlation.qml
@@ -34,9 +34,9 @@ Form
 
 	Group
 	{
-		title: qsTr("Correlation Coefficient")
-		CheckBox { name: "pearson";			label: qsTr("Pearson"); checked: true	}
-		CheckBox { name: "spearman";		label: qsTr("Spearman")					}
+        title: qsTr("Sample Correlation Coefficient")
+        CheckBox { name: "pearson";			label: qsTr("Pearson's r"); checked: true	}
+        CheckBox { name: "spearman";		label: qsTr("Spearman's rho")					}
 		CheckBox { name: "kendallsTauB";	label: qsTr("Kendall's tau-b")			}
 	}
 

--- a/Resources/Regression/qml/CorrelationBayesian.qml
+++ b/Resources/Regression/qml/CorrelationBayesian.qml
@@ -33,9 +33,9 @@ Form
 
     Group
     {
-        title: qsTr("Correlation Coefficient")
-        CheckBox { name: "pearson";         label: qsTr("Pearson"); checked: true       }
-        CheckBox { name: "spearman";        label: qsTr("Spearman"); debug: true		}
+        title: qsTr("Population Correlation Coefficient")
+        CheckBox { name: "pearson";         label: qsTr("Pearson's rho"); checked: true       }
+        CheckBox { name: "spearman";        label: qsTr("Spearman's rho"); debug: true		}
         CheckBox { name: "kendall";         label: qsTr("Kendall's tau-b")				}
     }
 
@@ -96,7 +96,7 @@ Form
         {
             name: "pairsMethod"
             title: qsTr("Correlation coefficient to plot")
-            RadioButton { value: "pearson";     label: qsTr("Pearson");         checked: true	}
+            RadioButton { value: "pearson";     label: qsTr("Pearson's rho");         checked: true	}
             RadioButton { value: "spearman";    label: qsTr("Spearman's rho");  debug:   true   }
             RadioButton { value: "kendall";     label: qsTr("Kendall's tau")                    }
         }

--- a/Resources/Summary Statistics/qml/SummaryStatsCorrelationBayesianPairs.qml
+++ b/Resources/Summary Statistics/qml/SummaryStatsCorrelationBayesianPairs.qml
@@ -33,11 +33,11 @@ Form
 	RadioButtonGroup
 	{
         name: "correlationCoefficient"
-		title: qsTr("Correlation Coefficient")
+        title: qsTr("Sample Correlation Coefficient")
 		Layout.columnSpan: 2
 		RadioButton
 		{
-            value: "pearsonRho"; label: qsTr("Pearson's rho"); checked: true; childrenOnSameRow: true
+            value: "pearsonRho"; label: qsTr("Pearson's r"); checked: true; childrenOnSameRow: true
             DoubleField { name: "pearsonRhoValue"; defaultValue: 0; min: -1; max: 1 }
 		}
 		RadioButton


### PR DESCRIPTION
Requires Frans' update on jasp-required-files. Already implemented on mac. Windows is work in progress.

- Changed QML labels:
* Fixes: https://github.com/jasp-stats/jasp-test-release/issues/702
- Changes in '.getPosteriorPlotValuesCorBayes()', so dependencies are added to for pairs and sumStat accordingly
* Fixes: https://github.com/jasp-stats/jasp-test-release/issues/703
- Changed in bstats and getSidedObject to grab the ciValue as well, which is now passed through properly
* Fixes https://github.com/jasp-stats/jasp-test-release/issues/704
- Changed so there's a check on options[["ciValue"]] and postPlotValues[["ciValue"]]. If not, then take ciValue from corModel
* Fixes: https://github.com/jasp-stats/jasp-test-release/issues/711
- Changed in '.drawPosteriorPlotCorBayes()' so that for pairs, the posterior values for options[["pairsMethod"] is chosen instead of postPlotValuesPerMethod[[1]]
* Fixes: https://github.com/jasp-stats/jasp-test-release/issues/716

