### PR TITLE
Fixes for JAGS

### DIFF
--- a/JASP-Engine/JASP/R/jagsModule.R
+++ b/JASP-Engine/JASP/R/jagsModule.R
@@ -501,28 +501,20 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
   return(g)
 }
 
-.JAGSIsParameterDiscrete <- function(samples, param) {
-  
-  u <- c()
-  for (i in seq_along(samples))
-    u <- c(u, unique(samples[[i]][, param]))
-  
-  # if a parameter has 25 unique values or less, we assume the parameter is discrete
-  return(length(u) > 25L)
-}
-
 .JAGSGetHistogramBreaks <- function(samples, param) {
 
   n <- nrow(samples[[1L]])
+  # all unique values for this paramer
   u <- sort(unique(unlist(lapply(samples, `[`, i = 1:n, j = param), use.names = FALSE)))
 
   # if a parameter has 25 unique values or less, we assume the parameter is discrete
   isDiscrete <- length(u) <= 25L
 
   if (isDiscrete) {
-    # this works because by default, hist makes the first category using e.g., [0, 1], but the next using (1, 2]. 
-    # the resulting histogram may be heavily misleading. Hist only does this for particular frequencies, but unfortunately,
-    # the default number of samples can lead to this when sampling from the prior predictive of binomial(theta) with theta ~ dbeta(1, 1).
+    # This works because by default, graphics::hist makes the first category using e.g., [0, 1], but the next
+    # using (1, 2]. The resulting histogram may be heavily misleading, as the first bar can lump two categories 
+    # together. This only for particular frequencies, but unfortunately, the default number of samples can lead
+    # to this when sampling from the prior predictive of binomial(theta) with theta ~ dbeta(1, 1).
     return(list(breaks = c(u[1L], 0.999 + u), unique = u))
   } else {
     return(list(breaks = "Sturges")) # the default of hist

--- a/JASP-Engine/JASP/R/jagsModule.R
+++ b/JASP-Engine/JASP/R/jagsModule.R
@@ -371,7 +371,7 @@ JAGS <- function(jaspResults, dataset, options, state = NULL) {
     add <- list("function" = ".JAGSPlotDensity")
     if (is.null(plotContainer[["plotDensity"]])) {
       add[["container"]] <- createJaspContainer(title = gettext("Marginal Density"),  position = 1,
-                                                dependencies = c("plotDensity", "aggregateChains"))
+                                                dependencies = c("plotDensity", "aggregateChains", "showLegend"))
       plotContainer[["plotDensity"]] <- add[["container"]]
     } else {
       add[["container"]] <- plotContainer[["plotDensity"]]


### PR DESCRIPTION
A lot of the issues in https://github.com/jasp-stats/jasp-test-release/issues/392 are fixed by this. Not all, so don't close that issue with this PR.

Tested with the model:
```r
model{
  theta ~ dbeta(1, 1)
  k ~ dbinom(theta, 10)
}
```

Below an overview of the fixed things.


Easy issues, all changed:

- In the output table, can we have "Posterior" on top of the "mean, sd, median" group?
- Same table: can we have the order "mean, median, sd"? (mean and median kinda go together)
- In JASP, is "sd" the way we always denote standard deviation? (I changed this to SD, like in Bayesian Linear Regression)
- The histogram is constructed by a series of vertical lines. Is this a histogram? Why not a histogram the way we do our other histograms?
- The option "Show legends" should be active for all plots -- right now it does not work for the ACF plot (I did not check the bivariate plot, but I'm guessing it does not work there either)
- The header of the main output table: should "summary" be "Summary", to be consistent with other JASP output (I checked one other analysis and there it was caps)
- The ACF plot -- maybe worthwhile to plot a horizontal dotted line on a correlation of zero? This is what people usually have as a comparison standard

More complicated issues that need some explanation:

> The option "Show Deviance" under "Advanced" does not appear to do anything.

My guess is that you tried a model without data? Because then the deviance cannot be computed. I've added a footnote to inform the user of this.

> Right now, clicking several display options (that merely control the cosmetics) cause the model to be rerun. This is completely unnecessary and prevents users from freely exploring the options. Imagine running the model takes 5 minutes. 

> ticking "Show Deviations" should not make the model rerun. Only options that require a rerun should trigger that.

Deviance is explictly not sampled unless someone asks for it. We could change that of course.

> So changing "thinning" should not cause a rerun, but entering a new seed should cause a rerun. I think this is a general concern for other analyses also.

There are two choices here.
1. We set the thinning in JAGS to 1 and then do the thinning ourselves. In that case, we don't have to resample whenever we change the thinning. However, if someone runs a large model with many samples and high thinning, this will be rather memory inefficient. 
2. We let JAGS do the thinning (current situation). This is more memory efficient because intermediate samples are never stored. At the same time, it does mean that we need to resample whenever the thinning value changes.

> The the binomial model, I am monitoring theta as well as k (so it is a predictive value). I was doing this to explore the bivariate plots. Then I discovered that the histogram of k looks funky, as the values of k=0 and k=1 seem to be added to one another, making the histogram there twice as high. Is this true?

This was a numerical artefact in the way `hist` computes breaks. It disappears when the number of mcmc samples increases. Nevertheless I've improved the logic a bit for things that can be detected as discrete (parameters with 25 or less unique values across all chains). Now this artefact should be gone. I've also prevented the x-axis labels from taking on non integer labels when there is a discrete parameter.

> The bivariate scatter also shows the anomaly near k=0. 

Same as the previous issue, the code to make these plots is identical.

