### PR TITLE
Fix for Note compatibility issue

### DIFF
--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -159,6 +159,7 @@ void Analyses::bindAnalysisHandler(Analysis* analysis)
 	connect(analysis, &Analysis::requestComputedColumnCreation,		this, &Analyses::requestComputedColumnCreation,		Qt::DirectConnection);
 	connect(analysis, &Analysis::requestComputedColumnDestruction,	this, &Analyses::requestComputedColumnDestruction,	Qt::DirectConnection);
 	connect(analysis, &Analysis::titleChanged,						this, &Analyses::somethingModified					);
+	connect(analysis, &Analysis::userDataChangedSignal,				this, &Analyses::analysisOverwriteUserdata			);
 
 	
 	if (Settings::value(Settings::DEVELOPER_MODE).toBool())

--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -140,6 +140,7 @@ signals:
 	void analysisImageEdited(			Analysis *	source);
 	void analysisResultsChanged(		Analysis *	source);
 	void analysisTitleChanged(			Analysis *  source);
+	void analysisOverwriteUserdata(		Analysis *	source);
 	void analysisStatusChanged(			Analysis *	source);
 	void sendRScript(					QString		script, int requestID, bool whiteListedVersion);
 	void analysisSelectedIndexResults(	int			row);

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -856,6 +856,7 @@ void Analysis::fitOldUserDataEtc()
 		if(orphans.size() > 0)
 			_userData["orphanedNotes"] = orphans;
 
+		emit userDataChangedSignal(this);
 		Log::log() << "New userData after attempt to fix is: " << _userData.toStyledString() << std::endl;
 
 	} catch (...) {

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -166,6 +166,7 @@ signals:
 	void				imageSavedSignal(		Analysis * analysis);
 	void				imageEditedSignal(		Analysis * analysis);
 	void				resultsChangedSignal(	Analysis * analysis);
+	void				userDataChangedSignal(	Analysis * analysis);
 
 	ComputedColumn *	requestComputedColumnCreation(		QString columnName, Analysis * analysis);
 	void				requestColumnCreation(				QString columnName, Analysis *source, int columnType);

--- a/JASP-Desktop/html/js/analysis.js
+++ b/JASP-Desktop/html/js/analysis.js
@@ -615,6 +615,20 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		return itemView;
 	},
 
+	overwriteUserData: function(userdata) {
+		this.userdata = userdata;
+		console.log("New userdata: %o", this.userdata);
+		var firstNote = this.viewNotes.firstNoteNoteBox
+		var lastNote = this.viewNotes.lastNoteNoteBox
+		var newList = []
+		for (var i = 0; i < this.viewNotes.list.length; i++) {
+			if (this.viewNotes.list.widget === firstNote || this.viewNotes.list.widget === lastNote)
+				newList.push(this.viewNotes.list[i])
+		}
+
+		this.viewNotes = { list: newList, firstNoteNoteBox: firstNote, lastNoteNoteBox: lastNote };
+	},
+
 	render: function () {
 
 		var results = this.model.get("results");
@@ -633,10 +647,6 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 				this.updateProgressbarInResults();
 			return this;
 		}
-
-		var userdataCPP = this.model.get("userdata"); //This might have been changed by Analysis::fitOldUserDataEtc to accomodate loading old files. And otherwise should be the same as local stored userdata
-		if (userdataCPP !== undefined && userdataCPP !== null)
-			this.userdata = userdataCPP;
 
 		this.imageBeingEdited = null;
 

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -82,6 +82,13 @@ $(document).ready(function () {
 		analysis.toolbar.render();
 	}
 
+	window.overwriteUserdata = function(id, userData) {
+		var analysis = analyses.getAnalysis(id);
+		if (analysis === undefined) return;
+
+		analysis.overwriteUserData(userData)
+	}
+
 	window.setAnalysesTitle = function(newTitle) { analyses.setTitle(newTitle); }
 
 

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -280,6 +280,7 @@ void MainWindow::makeConnections()
 	connect(_analyses,				&Analyses::analysesExportResults,					_fileMenu,				&FileMenu::analysesExportResults							);
 	connect(_analyses,				&Analyses::analysisStatusChanged,					_resultsJsInterface,	&ResultsJsInterface::setStatus								);
 	connect(_analyses,              &Analyses::analysisTitleChanged,                    _resultsJsInterface,    &ResultsJsInterface::changeTitle							);
+	connect(_analyses,				&Analyses::analysisOverwriteUserdata,				_resultsJsInterface,	&ResultsJsInterface::overwriteUserdata						);
 	connect(_analyses,				&Analyses::showAnalysisInResults,					_resultsJsInterface,	&ResultsJsInterface::showAnalysis							);
 	connect(_analyses,				&Analyses::unselectAnalysisInResults,				_resultsJsInterface,	&ResultsJsInterface::unselect								);
 	connect(_analyses,				&Analyses::analysisImageEdited,						_resultsJsInterface,	&ResultsJsInterface::analysisImageEditedHandler				);

--- a/JASP-Desktop/results/resultsjsinterface.cpp
+++ b/JASP-Desktop/results/resultsjsinterface.cpp
@@ -230,6 +230,14 @@ void ResultsJsInterface::changeTitle(Analysis *analysis)
     emit runJavaScript("window.changeTitle(" + QString::number(id) + ", '" + escapeJavascriptString(title) + "')");
 }
 
+void ResultsJsInterface::overwriteUserdata(Analysis *analysis)
+{
+	size_t id = analysis->id();
+	QString userData = tq(analysis->userData().toStyledString());
+
+	emit runJavaScript("window.overwriteUserdata(" + QString::number(id) + ", JSON.parse('" + escapeJavascriptString(userData) + "'))");
+}
+
 void ResultsJsInterface::showAnalysis(int id)
 {
 	emit runJavaScript("window.select(" % QString::number(id) % ")");

--- a/JASP-Desktop/results/resultsjsinterface.h
+++ b/JASP-Desktop/results/resultsjsinterface.h
@@ -49,6 +49,7 @@ public:
 	void exportPreviewHTML();
 	void exportHTML();
 	void resetResults();
+	void overwriteUserdata(Analysis *analysis);
 
 	QString			resultsPageUrl()	const { return _resultsPageUrl;	}
 	double			zoom()				const { return _webEngineZoom;	}


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#653

There were 2 problems:
. when the userdata is changed in fitOldUserDataEtc, it's read in analysis render function, but the noteViews object must be then refreshed to use the new userdata.
. the analyses:userDataChanged event triggers the setResultsMetaFromJavascript function, resetting the userdata in cpp. This event is triggered each time a noteBox is created, that is when the analysis is rendered, but when the analysis is rendered, it reads the userdata from cpp : this explain the concurrency problem between the thread in JavaScript in the main thread in cpp.
That's why I have added a boolean in the userdata, so that it reads it from cpp only when the userdata comes from fitOldUserDataEtc