### PR TITLE
Some small changes to texts in distributions

### DIFF
--- a/JASP-Engine/JASP/R/commonDiscoverDistributions.R
+++ b/JASP-Engine/JASP/R/commonDiscoverDistributions.R
@@ -466,7 +466,7 @@
   allTests <- c("kolmogorovSmirnov", "cramerVonMisses", "andersonDarling", "shapiroWilk", "chiSquare")
   tests <- allTests[allTests %in% names(options)]
   testNames <- c(gettext("Kolmogorov-Smirnov"),
-                 gettext("Cramer von Misses"),
+                 gettext("Cramér-von Mises"),
                  gettext("Anderson-Darling"),
                  gettext("Shapiro-Wilk"),
                  gettext("Chi-square"))[allTests %in% names(options)]

--- a/JASP-Engine/JASP/R/ldBernoulli.R
+++ b/JASP-Engine/JASP/R/ldBernoulli.R
@@ -121,7 +121,7 @@ LDbernoulli <- function(jaspResults, dataset, options, state=NULL){
   if(options$parsSupportMoments && is.null(jaspResults[['parsSupportMoments']])){
     pars <- list()
     pars[[1]] <- gettextf("probability of success: p %s %s: 0 %s p %s 1", "\u2208", "\u211D", "\u2264", "\u2264")
-    support <- gettextf("x %s %s: 0 %s x %s 1", "\u2208", "\u2124", "\u2264", "\u2264")
+    support <- gettextf("x %s {0, 1}", "\u2208")
     
     moments <- list()
     moments$expectation <- gettext("p")

--- a/JASP-Engine/JASP/R/ldBinomial.R
+++ b/JASP-Engine/JASP/R/ldBinomial.R
@@ -125,7 +125,7 @@ LDbinomial <- function(jaspResults, dataset, options, state=NULL){
     pars[[1]] <- gettextf("probability of success: %s", "p \u2208 \u211D: 0 \u2264 p \u2264 1")
     pars[[2]] <- gettextf("number of trials: %s",       "n \u2208 \u2124: n \u2265 0")
     
-    support <- "x \u2208 \u2124: 0 \u2264 x \u2264 n"
+    support <- "x \u2208 {0, 1, ..., n}"
     
     moments <- list()
     moments$expectation <- "np"

--- a/JASP-Engine/JASP/R/ldGaussianunivariate.R
+++ b/JASP-Engine/JASP/R/ldGaussianunivariate.R
@@ -97,9 +97,9 @@ LDgaussianunivariate <- function(jaspResults, dataset, options, state=NULL){
     options$sd <- sqrt(options$varValue)
   } else if(options$parametrization == "sigma"){
     options$sd <- options$varValue
-  } else if(options$parametrization == "tau2"){
-    options$sd <- sqrt(1/options$varValue)
   } else if(options$parametrization == "tau"){
+    options$sd <- sqrt(1/options$varValue)
+  } else if(options$parametrization == "kappa"){
     options$sd <- 1/options$varValue
   }
   
@@ -131,7 +131,7 @@ LDgaussianunivariate <- function(jaspResults, dataset, options, state=NULL){
   options$lowerBound <- c(-Inf, 0)
   options$upperBound <- c(Inf, Inf)
   
-  options$transformations <- c(mu = "mean", sigma2 = "sd^2", sigma = "sd", tau2 = "1/sd^2", tau = "1/sd")
+  options$transformations <- c(mu = "mean", sigma2 = "sd^2", sigma = "sd", tau = "1/sd^2", kappa = "1/sd")
   
   options
 }
@@ -144,8 +144,8 @@ LDgaussianunivariate <- function(jaspResults, dataset, options, state=NULL){
     pars[[2]] <- switch(options[['parametrization']],
                         sigma2 = gettextf("variance: %s",                 "&sigma;<sup>2</sup> \u2208 \u211D<sup>+</sup>"),
                         sigma  = gettextf("standard deviation: %s",       "&sigma; \u2208 \u211D<sup>+</sup>"),
-                        tau2   = gettextf("precision: %s",                "&tau;<sup>2</sup> \u2208 \u211D<sup>+</sup>"),
-                        tau    = gettextf("square root of precision: %s", "&tau; \u2208 \u211D<sup>+</sup>"))
+                        tau    = gettextf("precision: %s",                "&tau; \u2208 \u211D<sup>+</sup>"),
+                        kappa  = gettextf("square root of precision: %s", "&kappa; \u2208 \u211D<sup>+</sup>"))
     
     support <- "x \u2208 \u211D"
     
@@ -154,7 +154,8 @@ LDgaussianunivariate <- function(jaspResults, dataset, options, state=NULL){
     moments$variance <- switch(options[['parametrization']],
                                sigma2 = "&sigma;<sup>2</sup>",
                                sigma  = "&sigma;<sup>2</sup>",
-                                        "1/&tau;<sup>2</sup>")
+                               tau    = "1/&tau;",
+                               kappa  = "1/&kappa;<sup>2</sup>")
 
     jaspResults[['parsSupportMoments']] <- .ldParsSupportMoments(pars, support, moments)
   }
@@ -243,7 +244,7 @@ exp[-(x-<span style='color:red'>&mu;</span>)&sup2; &frasl; 2<span style='color:b
 
   par1 <- c(mu = "\u03BC")
   par2 <- c(sigma2 = "\u03C3\u00B2", sigma = "\u03C3", 
-            tau2   = "\u03C4\u00B2", tau   = "\u03C4")[options$parametrization]
+            tau    = "\u03C4",       kappa   = "\u03BA")[options$parametrization]
   res <- results$structured
   res <- res[res$par %in% names(c(par1, par2)),]
   res$parName <- c(par1, par2)

--- a/JASP-Engine/JASP/R/ldNegbinomial.R
+++ b/JASP-Engine/JASP/R/ldNegbinomial.R
@@ -133,7 +133,7 @@ LDnegbinomial <- function(jaspResults, dataset, options, state=NULL){
                         prob = gettextf("probability of success: %s", "p \u2208 \u211D: 0 \u2264 p \u2264 1"),
                                gettextf("mean: %s",                   "\u03BC \u2208 \u211D: \u03BC \u2265 0"))
     
-    support <- "x \u2208 \u2124: x \u2265 0"
+    support <- "x \u2208 {0, 1, 2, ...}"
     
     moments <- list()
     moments$expectation <- switch(options[['parametrization']],

--- a/JASP-Engine/JASP/R/ldNegbinomial.R
+++ b/JASP-Engine/JASP/R/ldNegbinomial.R
@@ -127,7 +127,7 @@ LDnegbinomial <- function(jaspResults, dataset, options, state=NULL){
   if(options$parsSupportMoments && is.null(jaspResults[['parsSupportMoments']])){
     pars <- list()
     pars[[1]] <- switch(options[['parametrization']],
-                        prob = gettextf("number of successes: %s", "\u03D5 \u2208 \u211D: \u03D5 \u2265 0"),
+                        prob = gettextf("number of successes: %s", "k \u2208 \u211D: \u03D5 \u2265 0"),
                                gettextf("dispersion: %s",          "\u03D5 \u2208 \u211D: \u03D5 \u2265 0"))
     pars[[2]] <- switch(options[['parametrization']],
                         prob = gettextf("probability of success: %s", "p \u2208 \u211D: 0 \u2264 p \u2264 1"),
@@ -137,10 +137,10 @@ LDnegbinomial <- function(jaspResults, dataset, options, state=NULL){
     
     moments <- list()
     moments$expectation <- switch(options[['parametrization']],
-                                  prob = "p\u03D5/(1-p)",
+                                  prob = "pk/(1-p)",
                                          "\u03BC")
     moments$variance <- switch(options[['parametrization']],
-                               prob = "p\u03D5/(1-p)<sup>2</sup>",
+                               prob = "pk/(1-p)<sup>2</sup>",
                                       "\u03BC + \u03BC<sup>2</sup>/\u03D5")
     
     jaspResults[['parsSupportMoments']] <- .ldParsSupportMoments(pars, support, moments)
@@ -196,10 +196,11 @@ LDnegbinomial <- function(jaspResults, dataset, options, state=NULL){
   if(is.null(table)) return()
   
   res <- results$structured
-  res$parName <- c("\u03D5", "p", "\u03BC")
   if(options$parametrization == "prob"){
+    res$parName <- c("k", "p", "\u03BC")
     res <- res[res$par != "mu",,drop=FALSE]
   } else{
+    res$parName <- c("\u03D5", "p", "\u03BC")
     res <- res[res$par != "prob",,drop=FALSE]
   }
   

--- a/JASP-Engine/JASP/R/ldPoisson.R
+++ b/JASP-Engine/JASP/R/ldPoisson.R
@@ -123,7 +123,7 @@ LDpoisson <- function(jaspResults, dataset, options, state=NULL){
     pars <- list()
     pars[[1]] <- gettextf("rate: %s", "\u03BB \u2208 \u211D: \u03BB \u003E 0")
     
-    support <- "x \u2208 \u2124: x \u2265 0"
+    support <- "x \u2208 {0, 1, 2, ...}"
     
     moments <- list()
     moments$expectation <- "\u03BB"

--- a/JASP-Tests/R/tests/testthat/test-ldbeta.R
+++ b/JASP-Tests/R/tests/testthat/test-ldbeta.R
@@ -82,7 +82,7 @@ test_that("Fit Statistics table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_mleFitAssessment"]][["collection"]][["mleContainer_mleFitAssessment_fitStatisticsTable"]][["data"]]
   expect_equal_tables(table,
                       list(0.951877310759137, 0.0517185582096647, "Kolmogorov-Smirnov", 0.909129043884883,
-                           0.0445975101635375, "Cramer von Misses", 0.950741882119664,
+                           0.0445975101635375, "Cram<unicode>r-von Mises", 0.950741882119664,
                            0.28226916064898, "Anderson-Darling"))
 })
 

--- a/JASP-Tests/R/tests/testthat/test-ldchisq.R
+++ b/JASP-Tests/R/tests/testthat/test-ldchisq.R
@@ -80,7 +80,7 @@ test_that("Fit Statistics table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_mleFitAssessment"]][["collection"]][["mleContainer_mleFitAssessment_fitStatisticsTable"]][["data"]]
   expect_equal_tables(table,
                       list(0.987805623863763, 0.0141898736833013, "Kolmogorov-Smirnov", 0.993943245701122,
-                           0.0225598781379213, "Cramer von Misses", 0.999462835577231,
+                           0.0225598781379213, "Cram<unicode>r-von Mises", 0.999462835577231,
                            0.133476420881834, "Anderson-Darling"))
 })
 

--- a/JASP-Tests/R/tests/testthat/test-ldexponential.R
+++ b/JASP-Tests/R/tests/testthat/test-ldexponential.R
@@ -79,7 +79,7 @@ test_that("Fit Statistics table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_mleFitAssessment"]][["collection"]][["mleContainer_mleFitAssessment_fitStatisticsTable"]][["data"]]
   expect_equal_tables(table,
                       list(0.941155629499551, 0.0530359940877157, "Kolmogorov-Smirnov", 0.984237027649063,
-                           0.0274382299574707, "Cramer von Misses", 0.993519259440937,
+                           0.0274382299574707, "Cram<unicode>r-von Mises", 0.993519259440937,
                            0.187251291060505, "Anderson-Darling"))
 })
 

--- a/JASP-Tests/R/tests/testthat/test-ldf.R
+++ b/JASP-Tests/R/tests/testthat/test-ldf.R
@@ -81,7 +81,7 @@ test_that("Fit Statistics table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_mleFitAssessment"]][["collection"]][["mleContainer_mleFitAssessment_fitStatisticsTable"]][["data"]]
   expect_equal_tables(table,
                       list(0.996070666453852, 0.0129551754522243, "Kolmogorov-Smirnov", 0.988147434223863,
-                           0.0256843281173465, "Cramer von Misses", 0.989633839599013,
+                           0.0256843281173465, "Cram<unicode>r-von Mises", 0.989633839599013,
                            0.202789453225478, "Anderson-Darling"))
 })
 

--- a/JASP-Tests/R/tests/testthat/test-ldgamma.R
+++ b/JASP-Tests/R/tests/testthat/test-ldgamma.R
@@ -81,7 +81,7 @@ test_that("Fit Statistics table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_mleFitAssessment"]][["collection"]][["mleContainer_mleFitAssessment_fitStatisticsTable"]][["data"]]
   expect_equal_tables(table,
                       list(0.992343811838588, 0.0431298791118216, "Kolmogorov-Smirnov", 0.980406756189032,
-                           0.0288078384271124, "Cramer von Misses", 0.982573023214004,
+                           0.0288078384271124, "Cram<unicode>r-von Mises", 0.982573023214004,
                            0.223563309650274, "Anderson-Darling"))
 })
 

--- a/JASP-Tests/R/tests/testthat/test-ldgammainverse.R
+++ b/JASP-Tests/R/tests/testthat/test-ldgammainverse.R
@@ -81,7 +81,7 @@ test_that("Fit Statistics table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_mleFitAssessment"]][["collection"]][["mleContainer_mleFitAssessment_fitStatisticsTable"]][["data"]]
   expect_equal_tables(table,
                       list(0.475650089652809, 0.0843237690307375, "Kolmogorov-Smirnov", 0.501049563958779,
-                           0.118806731174335, "Cramer von Misses", 0.576804758513749, 0.678332610948303,
+                           0.118806731174335, "Cram<unicode>r-von Mises", 0.576804758513749, 0.678332610948303,
                            "Anderson-Darling"))
 })
 

--- a/JASP-Tests/R/tests/testthat/test-ldgaussianunivariate.R
+++ b/JASP-Tests/R/tests/testthat/test-ldgaussianunivariate.R
@@ -87,7 +87,7 @@ test_that("Fit Statistics table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_mleFitAssessment"]][["collection"]][["mleContainer_mleFitAssessment_fitStatisticsTable"]][["data"]]
   expect_equal_tables(table,
                       list(0.99278432447795, 0.0429230630813024, "Kolmogorov-Smirnov", 0.99519059575295,
-                           0.0217999835633844, "Cramer von Misses", 0.999444838973091,
+                           0.0217999835633844, "Cram<unicode>r-von Mises", 0.999444838973091,
                            0.134303182925592, "Anderson-Darling", 0.994211531885932, 0.996119141722174,
                            "Shapiro-Wilk"))
 })

--- a/JASP-Tests/R/tests/testthat/test-ldnegbinomial.R
+++ b/JASP-Tests/R/tests/testthat/test-ldnegbinomial.R
@@ -56,7 +56,7 @@ test_that("Descriptives table results match", {
 test_that("Estimated Parameters table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_estParametersTable"]][["data"]]
   expect_equal_tables(table,
-                      list(0.840421648116513, 0.206188804688018, "<unicode>", 0.323594131540805,
+                      list(0.840421648116513, 0.206188804688018, "k", 0.323594131540805,
                            1.47465449154501, 0.515462577383601, 0.311965427262039, "p",
                            0.103826984437837, 0.718959727505163))
 })

--- a/JASP-Tests/R/tests/testthat/test-ldt.R
+++ b/JASP-Tests/R/tests/testthat/test-ldt.R
@@ -76,7 +76,7 @@ test_that("Fit Statistics table results match", {
   table <- results[["results"]][["mleContainer"]][["collection"]][["mleContainer_mleFitAssessment"]][["collection"]][["mleContainer_mleFitAssessment_fitStatisticsTable"]][["data"]]
   expect_equal_tables(table,
                       list(0.943712731748752, 0.0527356116236999, "Kolmogorov-Smirnov", 0.936114828474193,
-                           0.039590649123452, "Cramer von Misses", 0.951915789105146, 0.280536039088275,
+                           0.039590649123452, "Cram<unicode>r-von Mises", 0.951915789105146, 0.280536039088275,
                            "Anderson-Darling"))
 })
 

--- a/Resources/Discover Distributions/qml/LDgaussianunivariate.qml
+++ b/Resources/Discover Distributions/qml/LDgaussianunivariate.qml
@@ -40,8 +40,8 @@ Form
 				values: [
 					{ label: "μ, σ²", value: "sigma2"},
 					{ label: "μ, σ",  value: "sigma" },
-					{ label: "μ, τ²", value: "tau2"  },
-					{ label: "μ, τ",  value: "tau"   }
+					{ label: "μ, τ",  value: "tau"   },
+					{ label: "μ, κ",  value: "kappa" }
 				]
 			}
 
@@ -53,7 +53,7 @@ Form
 				{
 					name: "varValue"
 					id:    varValue
-					label: ["σ²", "σ ", "τ²", "τ "][parametrization.currentIndex]
+					label: ["σ²", "σ ", "τ", "κ "][parametrization.currentIndex]
 					negativeValues: false
 					defaultValue: 1
 				}

--- a/Resources/Discover Distributions/qml/LDnegbinomial.qml
+++ b/Resources/Discover Distributions/qml/LDnegbinomial.qml
@@ -38,7 +38,7 @@ Form
 				indexDefaultValue: 0
 				label: qsTr("Parameter")
 				values: [
-					{ label: "φ, p",  value: "prob"},
+					{ label: "k, p",  value: "prob"},
 					{ label: "φ, μ",  value: "mean" }
 				]
 				visible: true
@@ -47,7 +47,11 @@ Form
 			Group
 			{
 				columns: 1
-				DoubleField{ name: "size"; label: qsTr("φ"); id: size; defaultValue: 1; negativeValues: false }
+				DoubleField
+				{
+					name: "size"; label: ["k", "φ"][parametrization.currentIndex]; id: size;
+					defaultValue: 1; negativeValues: false
+				}
 				DoubleField
 				{
 					name:  "par"; label: ["p", "μ"][parametrization.currentIndex]; id: par
@@ -117,7 +121,7 @@ Form
 	LD.LDGenerateDisplayData
 	{
 		distributionName		: "NBinomial"
-		formula					: "φ = " + size.value + [",p = ", ",μ = "][parametrization.currentIndex] + par.value
+		formula					: ["k = ", "φ = "][parametrization.currentIndex] + size.value + [",p = ", ",μ = "][parametrization.currentIndex] + par.value
 		histogramIsBarPlot		: true
 		allowOnlyScaleColumns	: false
 		suggestScaleColumns		: true

--- a/Resources/Help/analyses/ldbeta.md
+++ b/Resources/Help/analyses/ldbeta.md
@@ -59,5 +59,5 @@ Displays theoretical beta distribution, given specified parameter values.
 
 ### Statistics
 - Kolmogorov-Smirnov: Displays the Kolmogorov-Smirnov test
-- Cramer von Misses: Displays the Cramer von Misses test
+- Cramér-von Mises: Displays the Cramér-von Mises test
 - Anderson-Darling: Displays the Anderson-Darling test

--- a/Resources/Help/analyses/ldbeta_nl.md
+++ b/Resources/Help/analyses/ldbeta_nl.md
@@ -56,5 +56,5 @@ Geeft de theoretische beta verdeling weer, met opgegeven parameterwaarden.
 
 ### Statistieken
 - Kolmogorov-Smirnov: Geeft de pasmaat en p-waarde van de Kolmogorov-Smirnov toets weer.
-- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramer-von Misses toets weer.
+- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramér-von Mises toets weer.
 - Anderson-Darling: Geeft de pasmaat en p-waarde van de Anderson-Darling toets weer.

--- a/Resources/Help/analyses/ldchisq.md
+++ b/Resources/Help/analyses/ldchisq.md
@@ -57,5 +57,5 @@ Displays theoretical chi-squared distribution, given specified parameter values.
 
 ### Statistics
 - Kolmogorov-Smirnov: Displays the Kolmogorov-Smirnov test
-- Cramer von Misses: Displays the Cramer von Misses test
+- Cramér-von Mises: Displays the Cramér-von Mises test
 - Anderson-Darling: Displays the Anderson-Darling test

--- a/Resources/Help/analyses/ldchisq_nl.md
+++ b/Resources/Help/analyses/ldchisq_nl.md
@@ -56,5 +56,5 @@ Geeft de theoretische chi-kwadraatverdeling weer, met opgegeven parameterwaarden
 
 ### Statistieken
 - Kolmogorov-Smirnov: Geeft de pasmaat en p-waarde van de Kolmogorov-Smirnov toets weer.
-- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramer-von Misses toets weer.
+- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramér-von Mises toets weer.
 - Anderson-Darling: Geeft de pasmaat en p-waarde van de Anderson-Darling toets weer.

--- a/Resources/Help/analyses/ldexponential.md
+++ b/Resources/Help/analyses/ldexponential.md
@@ -60,5 +60,5 @@ Displays theoretical exponential distribution, given specified parameter values.
 
 ### Statistics
 - Kolmogorov-Smirnov: Displays the Kolmogorov-Smirnov test
-- Cramer von Misses: Displays the Cramer von Misses test
+- Cramér-von Mises: Displays the Cramér-von Mises test
 - Anderson-Darling: Displays the Anderson-Darling test

--- a/Resources/Help/analyses/ldexponential_nl.md
+++ b/Resources/Help/analyses/ldexponential_nl.md
@@ -56,5 +56,5 @@ Geeft de theoretische exponentiële verdeling weer, met opgegeven parameterwaard
 
 ### Statistieken
 - Kolmogorov-Smirnov: Geeft de pasmaat en p-waarde van de Kolmogorov-Smirnov toets weer.
-- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramer-von Misses toets weer.
+- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramér-von Mises toets weer.
 - Anderson-Darling: Geeft de pasmaat en p-waarde van de Anderson-Darling toets weer.

--- a/Resources/Help/analyses/ldf.md
+++ b/Resources/Help/analyses/ldf.md
@@ -61,5 +61,5 @@ Displays theoretical F distribution, given specified parameter values.
 
 ### Statistics
 - Kolmogorov-Smirnov: Displays the Kolmogorov-Smirnov test
-- Cramer von Misses: Displays the Cramer von Misses test
+- Cramér-von Mises: Displays the Cramér-von Mises test
 - Anderson-Darling: Displays the Anderson-Darling test

--- a/Resources/Help/analyses/ldf_nl.md
+++ b/Resources/Help/analyses/ldf_nl.md
@@ -57,5 +57,5 @@ Geeft de theoretische F-verdeling weer, met opgegeven parameterwaarden.
 
 ### Statistieken
 - Kolmogorov-Smirnov: Geeft de pasmaat en p-waarde van de Kolmogorov-Smirnov toets weer.
-- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramer-von Misses toets weer.
+- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramér-von Mises toets weer.
 - Anderson-Darling: Geeft de pasmaat en p-waarde van de Anderson-Darling toets weer.

--- a/Resources/Help/analyses/ldgamma.md
+++ b/Resources/Help/analyses/ldgamma.md
@@ -59,5 +59,5 @@ Displays theoretical gamma distribution, given specified parameter values.
 
 ### Statistics
 - Kolmogorov-Smirnov: Displays the Kolmogorov-Smirnov test
-- Cramer von Misses: Displays the Cramer von Misses test
+- Cramér-von Mises: Displays the Cramér-von Mises test
 - Anderson-Darling: Displays the Anderson-Darling test

--- a/Resources/Help/analyses/ldgamma_nl.md
+++ b/Resources/Help/analyses/ldgamma_nl.md
@@ -57,5 +57,5 @@ Geeft de theoretische gammaverdeling weer, met opgegeven parameterwaarden.
 
 ### Statistieken
 - Kolmogorov-Smirnov: Geeft de pasmaat en p-waarde van de Kolmogorov-Smirnov toets weer.
-- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramer-von Misses toets weer.
+- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramér-von Mises toets weer.
 - Anderson-Darling: Geeft de pasmaat en p-waarde van de Anderson-Darling toets weer.

--- a/Resources/Help/analyses/ldgammainverse.md
+++ b/Resources/Help/analyses/ldgammainverse.md
@@ -59,5 +59,5 @@ Displays theoretical inverse gamma distribution, given specified parameter value
 
 ### Statistics
 - Kolmogorov-Smirnov: Displays the Kolmogorov-Smirnov test
-- Cramer von Misses: Displays the Cramer von Misses test
+- Cramér-von Mises: Displays the Cramér-von Mises test
 - Anderson-Darling: Displays the Anderson-Darling test

--- a/Resources/Help/analyses/ldgammainverse_nl.md
+++ b/Resources/Help/analyses/ldgammainverse_nl.md
@@ -57,5 +57,5 @@ Geeft de theoretische gammaverdeling weer, met opgegeven parameterwaarden.
 
 ### Statistieken
 - Kolmogorov-Smirnov: Geeft de pasmaat en p-waarde van de Kolmogorov-Smirnov toets weer.
-- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramer-von Misses toets weer.
+- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramér-von Mises toets weer.
 - Anderson-Darling: Geeft de pasmaat en p-waarde van de Anderson-Darling toets weer.

--- a/Resources/Help/analyses/ldgaussianunivariate.md
+++ b/Resources/Help/analyses/ldgaussianunivariate.md
@@ -11,8 +11,8 @@ Displays theoretical Normal distribution, given specified parameter values.
 
 - &mu;, &sigma;<sup>2</sup>: The Normal distribution is specified using the mean and variance parameters
 - &mu;, &sigma;: The Normal distribution is specified using the mean and standard deviation parameters
-- &mu;, &tau;<sup>2</sup>: The Normal distribution is specified using the mean and precision parameters
-- &mu;, &tau;: The Normal distribution is specified using the mean and square root of precision parameters
+- &mu;, &tau;: The Normal distribution is specified using the mean and precision parameters
+- &mu;, &kappa;: The Normal distribution is specified using the mean and square root of precision parameters
 
 ### Display
 
@@ -63,6 +63,6 @@ Displays theoretical Normal distribution, given specified parameter values.
 
 ### Statistics
 - Kolmogorov-Smirnov: Displays the Kolmogorov-Smirnov test
-- Cramer von Misses: Displays the Cramer von Misses test
+- Cramér-von Mises: Displays the Cramér-von Mises test
 - Anderson-Darling: Displays the Anderson-Darling test
 - Shapiro-Wilk: Displays the Shapiro-Wilk test of normality

--- a/Resources/Help/analyses/ldgaussianunivariate_nl.md
+++ b/Resources/Help/analyses/ldgaussianunivariate_nl.md
@@ -9,8 +9,8 @@ Geeft de theoretische normale verdeling weer, met opgegeven parameterwaarden.
 ### Parameters
 - &mu;, &sigma;<sup> 2 </sup>: De normale verdeling geparametriseerd met behulp van de parameters voor de gemiddelde en variantie.
 - &mu;, &sigma;: De normale verdeling geparametriseerd met behulp van de gemiddelde en standaarddeviatieparameters.
-- &mu;, &tau;<<sup> 2 </sup>: De normale verdeling geparametriseerd met behulp van de gemiddelde en precisieparameters.
-- &mu;, &tau;: De normale verdeling geparametriseerd met behulp van de gemiddelde en vierkantswortel van de precisieparameters.
+- &mu;, &tau;: De normale verdeling geparametriseerd met behulp van de gemiddelde en precisieparameters.
+- &mu;, &kappa;: De normale verdeling geparametriseerd met behulp van de gemiddelde en vierkantswortel van de precisieparameters.
 
 ### Weergeven
 - Toelichtende tekst: Toont toelichtende tekst.
@@ -58,6 +58,6 @@ Geeft de theoretische normale verdeling weer, met opgegeven parameterwaarden.
 
 ### Statistieken
 - Kolmogorov-Smirnov: Geeft de pasmaat en p-waarde van de Kolmogorov-Smirnov toets weer.
-- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramer-von Misses toets weer.
+- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramér-von Mises toets weer.
 - Anderson-Darling: Geeft de pasmaat en p-waarde van de Anderson-Darling toets weer.
 - Shapiro-Wilk: Geeft de pasmaat en p-waarde van de Shapiro-Wilk toets voor normaliteit weer.

--- a/Resources/Help/analyses/ldnegbinomial.md
+++ b/Resources/Help/analyses/ldnegbinomial.md
@@ -9,7 +9,7 @@ Displays theoretical Negative binomial distribution, given specified parameter v
 
 ### Parameters
 
-- &phi;, p: The negative binomial distribution is parametrized with the number of successes and chance of success parameters.
+- k, p: The negative binomial distribution is parametrized with the number of successes and chance of success parameters.
 - &phi;, &mu;: The negative binomial distribution is parametrized using the dispersion and mean parameters.
 
 ### Display

--- a/Resources/Help/analyses/ldnegbinomial_nl.md
+++ b/Resources/Help/analyses/ldnegbinomial_nl.md
@@ -7,7 +7,7 @@ Expositie van de negatief-binomiale verdeling.
 Geeft de theoretische negatief-binominale verdeling weer, met opgegeven parameterwaarden.
 
 ### Parameters
-- &phi;, p: De negatief-binominale verdeling geparametriseerd op basis van het aantal successen en de kans op een success parameters.
+- k, p: De negatief-binominale verdeling geparametriseerd op basis van het aantal successen en de kans op een success parameters.
 - &phi;, &mu;: De negatief-binominale verdeling geparametriseerd met behulp van de spreiding en gemiddelde parameters.
 
 ### Weergeven

--- a/Resources/Help/analyses/ldt.md
+++ b/Resources/Help/analyses/ldt.md
@@ -57,5 +57,5 @@ Displays theoretical Student's t distribution, given specified parameter values.
 
 ### Statistics
 - Kolmogorov-Smirnov: Displays the Kolmogorov-Smirnov test
-- Cramer von Misses: Displays the Cramer von Misses test
+- Cramér-von Mises: Displays the Cramér-von Mises test
 - Anderson-Darling: Displays the Anderson-Darling test

--- a/Resources/Help/analyses/ldt_nl.md
+++ b/Resources/Help/analyses/ldt_nl.md
@@ -56,5 +56,5 @@ Geeft de theoretische t-verdeling van Student weer, met opgegeven parameterwaard
 
 ### Statistieken
 - Kolmogorov-Smirnov: Geeft de pasmaat en p-waarde van de Kolmogorov-Smirnov toets weer.
-- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramer-von Misses toets weer.
+- Cramér-von Mises: Geeft de pasmaat en p-waarde van de Cramér-von Mises toets weer.
 - Anderson-Darling: Geeft de pasmaat en p-waarde van de Anderson-Darling toets weer.


### PR DESCRIPTION
- from https://github.com/jasp-stats/jasp-test-release/issues/736 renames precision  and square root of precision parameters to \tau and \kappa respectively
- from https://github.com/jasp-stats/jasp-test-release/issues/736 fixes Crames-von Misses to Cramér von Mises in all texts and helpfiles
- from https://github.com/jasp-stats/jasp-test-release/issues/732, https://github.com/jasp-stats/jasp-test-release/issues/735, https://github.com/jasp-stats/jasp-test-release/issues/733, and https://github.com/jasp-stats/jasp-test-release/issues/734 fixes notation of support for the random variable to the style: x \in {0, 1}, x \in {0, 1, ...}, x \in {0, 1, ..., n} , etc.
- from https://github.com/jasp-stats/jasp-test-release/issues/734 renames number of successes parameter to k