### PR TITLE
If Column::resetEmptyValuesChanged it sometimes messes up the data for nom.text

### DIFF
--- a/JASP-Desktop/gui/preferencesmodel.cpp
+++ b/JASP-Desktop/gui/preferencesmodel.cpp
@@ -348,18 +348,8 @@ void PreferencesModel::setThresholdScale(int newThresholdScale)
 
 void PreferencesModel::updateUtilsMissingValues()
 {
-	missingValuesToStdVector(Utils::_currentEmptyValues);
+	Utils::_currentEmptyValues = fq(missingValues());
 	Utils::processEmptyValues();
-}
-
-void PreferencesModel::missingValuesToStdVector(std::vector<std::string> & out)	const
-{
-	QStringList currentValues = missingValues();
-
-	out.resize(size_t(currentValues.size()));
-
-	for(size_t i=0; i<out.size(); i++)
-		out[i] = currentValues[int(i)].toStdString();
 }
 
 void PreferencesModel::setDefaultFont(QFont defaultFont)

--- a/JASP-Desktop/gui/preferencesmodel.h
+++ b/JASP-Desktop/gui/preferencesmodel.h
@@ -85,7 +85,6 @@ public:
 	bool		disableAnimations()			const;
 	bool		animationsOn()				const { return !disableAnimations() && !safeGraphics(); }
 
-	void		missingValuesToStdVector(std::vector<std::string> & out) const;
 	void		zoomIn();
 	void		zoomOut();
 	void		zoomReset();


### PR DESCRIPTION
It only looks at the original values and sees if they can be converted to double or int and if so, does that.
But that means it ignores the labels entirely... WHich were there for a reason.
- fixing https://github.com/jasp-stats/jasp-test-release/issues/744

