### PR TITLE
Remove warnings

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/JASPControl.qml
+++ b/JASP-Desktop/components/JASP/Controls/JASPControl.qml
@@ -97,7 +97,7 @@ JASPControlBase
 		State
 		{
 			name: "hasError"
-			when: focusIndicator && jaspControl.hasError
+			when: focusIndicator !== null  && jaspControl.hasError
 			PropertyChanges
 			{
 				target:			focusIndicator
@@ -108,7 +108,7 @@ JASPControlBase
 		State
 		{
 			name: "hasWarning"
-			when: focusIndicator && jaspControl.hasWarning && !jaspControl.hasError
+			when: focusIndicator !== null  && jaspControl.hasWarning && !jaspControl.hasError
 			PropertyChanges
 			{
 				target:			focusIndicator
@@ -119,7 +119,7 @@ JASPControlBase
 		State
 		{
 			name: "hasFocus"
-			when: focusIndicator && jaspControl.shouldShowFocus
+			when: focusIndicator !== null  && jaspControl.shouldShowFocus
 			PropertyChanges
 			{
 				target:			focusIndicator
@@ -130,7 +130,7 @@ JASPControlBase
 		State
 		{
 			name: "isDependency"
-			when: focusIndicator && jaspControl.isDependency && !jaspControl.shouldShowFocus
+			when: focusIndicator !== null && jaspControl.isDependency && !jaspControl.shouldShowFocus
 			PropertyChanges
 			{
 				target:			focusIndicator

--- a/JASP-Desktop/components/JASP/Controls/JASPScrollBar.qml
+++ b/JASP-Desktop/components/JASP/Controls/JASPScrollBar.qml
@@ -18,6 +18,7 @@
 // Code based on http://stackoverflow.com/questions/17833103/how-to-create-scrollbar-in-qtquick-2-0
 
 import QtQuick 2.0;
+import QtQml 2.14;
 
 
 Item
@@ -67,6 +68,7 @@ Item
 	
 	Binding
 	{
+		restoreMode: Binding.RestoreBindingOrValue
 		target:		handle;
 		property:	scrollbar.vertical ? "y" : "x"
 		when:		!clicker.drag.active
@@ -77,6 +79,7 @@ Item
 
 	Binding
 	{
+		restoreMode: Binding.RestoreBindingOrValue
 		target:		flickable
 		property:	scrollbar.vertical ? "contentY" : "contentX"
 		when:		(clicker.drag.active || clicker.pressed)

--- a/JASP-Desktop/widgets/jaspcontrolwrapper.cpp
+++ b/JASP-Desktop/widgets/jaspcontrolwrapper.cpp
@@ -137,6 +137,7 @@ AnalysisForm *JASPControlWrapper::form() const
 
 void JASPControlWrapper::addControlError(const QString &error)
 {
+	Log::log() << "JASPControlWrapper::addControlError: " << error << std::endl;
 	if (form())
 		form()->addFormError(error);
 }

--- a/JASP-Desktop/widgets/listmodel.cpp
+++ b/JASP-Desktop/widgets/listmodel.cpp
@@ -121,7 +121,7 @@ Terms ListModel::getSourceTerms()
 		{
 			Terms sourceTerms = sourceModel->terms(sourceItem->modelUse);
 
-			for (const QMLListView::SourceType& discardModel : sourceItem->discardModels)
+			for (const QMLListView::SourceType& discardModel : sourceItem->getDiscardModels())
 				sourceTerms.discardWhatDoesContainTheseComponents(discardModel.model->terms(discardModel.modelUse));
 
 			if (!sourceItem->conditionExpression.isEmpty())
@@ -185,7 +185,7 @@ QMap<ListModel*, Terms> ListModel::getSourceTermsPerModel()
 		{
 			Terms terms = sourceModel->terms(sourceItem->modelUse);
 
-			for (const QMLListView::SourceType& discardModel : sourceItem->discardModels)
+			for (const QMLListView::SourceType& discardModel : sourceItem->getDiscardModels())
 				terms.discardWhatDoesContainTheseComponents(discardModel.model->terms(discardModel.modelUse));
 
 			result[sourceModel] = terms;

--- a/JASP-Desktop/widgets/qmllistview.cpp
+++ b/JASP-Desktop/widgets/qmllistview.cpp
@@ -369,7 +369,7 @@ void QMLListView::sourceChangedHandler()
 		{
 			removeDependency(sourceModel->listView());
 			disconnect(sourceModel, &ListModel::modelChanged, listModel, &ListModel::sourceTermsChanged);
-			for (SourceType& discardModel : sourceItem->discardModels)
+			for (SourceType& discardModel : sourceItem->getDiscardModels())
 				disconnect(discardModel.model, &ListModel::modelChanged, listModel, &ListModel::sourceTermsChanged);
 		}
 	}
@@ -414,4 +414,18 @@ void QMLListView::_setAllowedVariables()
 	
 	if (allowedColumnsTypes >= 0)
 		_variableTypesAllowed = allowedColumnsTypes;
+}
+
+QVector<QMLListView::SourceType> QMLListView::SourceType::getDiscardModels(bool onlyNotNullModel) const
+{
+	if (!onlyNotNullModel)
+		return discardModels;
+
+	QVector<QMLListView::SourceType> result;
+
+	for (const QMLListView::SourceType& discardModel : discardModels)
+		if (discardModel.model)
+			result.push_back(discardModel);
+
+	return result;
 }

--- a/JASP-Desktop/widgets/qmllistview.h
+++ b/JASP-Desktop/widgets/qmllistview.h
@@ -76,6 +76,8 @@ public:
 							);
 			}
 		}
+
+		QVector<SourceType> getDiscardModels(bool onlyNotNullModel = true)	const;
 	};
 	
 	QMLListView(JASPControlBase* item);


### PR DESCRIPTION
With Qt5.14, new warnings are generated.
Repair also a crash when a discard model does not exist.