### PR TITLE
use same logic as c++ for missing qml files

### DIFF
--- a/Tools/jasptools/DESCRIPTION
+++ b/Tools/jasptools/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jasptools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 0.9.1
+Version: 0.9.2
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/Tools/jasptools/R/options.R
+++ b/Tools/jasptools/R/options.R
@@ -108,6 +108,11 @@ analysisOptions <- function(source) {
   funcToQml <- list()
   for (i in seq_along(descr$menu)) {
     analysisMeta <- descr$menu[[i]]
+
+    # lookup default qml file, same as in c++, but with "???" replaced for a null check
+    if (!("qml" %in% names(analysisMeta)) && "function" %in% names(analysisMeta) && !is.null(analysisMeta[["function"]]))
+      analysisMeta[["qml"]] <- paste0(analysisMeta[["function"]], ".qml")
+
     if (all(c("function", "qml") %in% names(analysisMeta)))
       funcToQml[[tolower(analysisMeta[["function"]])]] <- analysisMeta[["qml"]]
   }


### PR DESCRIPTION
@JohnnyDoorn Can you check if you can now directly load qml files without specifying them in `description.json`?

@JorisGoosen please verify if this is exactly the same logic as in `c++`.