### PR TITLE
Scrollbars go back to original place

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/JASPScrollBar.qml
+++ b/JASP-Desktop/components/JASP/Controls/JASPScrollBar.qml
@@ -68,7 +68,7 @@ Item
 	
 	Binding
 	{
-		restoreMode: Binding.RestoreBindingOrValue
+		restoreMode: Binding.RestoreBinding
 		target:		handle;
 		property:	scrollbar.vertical ? "y" : "x"
 		when:		!clicker.drag.active
@@ -79,7 +79,7 @@ Item
 
 	Binding
 	{
-		restoreMode: Binding.RestoreBindingOrValue
+		restoreMode: Binding.RestoreBinding
 		target:		flickable
 		property:	scrollbar.vertical ? "contentY" : "contentX"
 		when:		(clicker.drag.active || clicker.pressed)


### PR DESCRIPTION
When you release a scrollbar with the mouse, then it suddenly goes back
to the original place.