### PR TITLE
Custom R Library on Linux

### DIFF
--- a/JASP-Desktop/engine/enginesync.cpp
+++ b/JASP-Desktop/engine/enginesync.cpp
@@ -389,6 +389,12 @@ QProcess * EngineSync::startSlaveProcess(int no)
 	QDir rHome(rHomePath);
 	Log::log() << "R_HOME set to " << rHomePath.toStdString() << std::endl;
 
+	QString custom_R_library = "";
+#ifdef JASP_DEBUG
+	// allow an environment variables to specify the location of packages
+	if (env.contains("JASP_R_Library"))
+		custom_R_library = ":" + env.value("JASP_R_Library");
+#endif
 #ifdef _WIN32
 	//Windows has *special needs*, so let's make sure it can understand R_HOME later on. Not sure if it is necessary but it couldn't hurt, right?
 	QString rHomeWin = "";
@@ -433,7 +439,7 @@ QProcess * EngineSync::startSlaveProcess(int no)
 #else  // linux
 	env.insert("LD_LIBRARY_PATH",	rHome.absoluteFilePath("lib") + ":" + rHome.absoluteFilePath("library/RInside/lib") + ":" + rHome.absoluteFilePath("library/Rcpp/lib") + ":" + rHome.absoluteFilePath("site-library/RInside/lib") + ":" + rHome.absoluteFilePath("site-library/Rcpp/lib") + ":/app/lib/:/app/lib64/");
 	env.insert("R_HOME",			rHome.absolutePath());
-	env.insert("R_LIBS",			programDir.absoluteFilePath("R/library") + ":" + rHome.absoluteFilePath("library") + ":" + rHome.absoluteFilePath("site-library"));
+	env.insert("R_LIBS",			programDir.absoluteFilePath("R/library") + custom_R_library + ":" + rHome.absoluteFilePath("library") + ":" + rHome.absoluteFilePath("site-library"));
 
 	//Let's just trust linux and *not set* LC_CTYPE at all. It'll be fine.
 #endif

--- a/JASP-Engine/JASP-Engine.pro
+++ b/JASP-Engine/JASP-Engine.pro
@@ -57,12 +57,12 @@ exists(/app/lib/*) {
    # InstallJASPgraphsRPackage.commands	= \"$$R_EXE\" CMD INSTALL --no-multiarch $$PWD/JASPgraphs
 } else {
     win32:RemoveJASPRPkgLock.commands   = IF exist \"$$OUT_PWD/../R/library/00LOCK-JASP/\" (rd /s /q \"$$OUT_PWD/../R/library/00LOCK-JASP/\" && echo Lock removed!) ELSE (echo No lock found!);
-    win32:InstallJASPRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$OUT_PWD/../R/library\'); install.packages(\'$$PWD/JASP\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
-    unix: InstallJASPRPackage.commands  = export JASP_R_HOME=\"$$_R_HOME\" ; \"$$R_EXE\" -e \".libPaths(\'$$_R_HOME/library\'); install.packages(\'$$PWD/JASP\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
+    win32:InstallJASPRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$_R_Library\'); install.packages(\'$$PWD/JASP\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
+    unix: InstallJASPRPackage.commands  = export JASP_R_HOME=\"$$_R_HOME\" ; \"$$R_EXE\" -e \".libPaths(\'$$_R_Library\'); install.packages(\'$$PWD/JASP\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
 
     win32:RemoveJASPgraphsRPkgLock.commands   = IF exist \"$$OUT_PWD/../R/library/00LOCK-JASPgraphs/\" (rd /s /q \"$$OUT_PWD/../R/library/00LOCK-JASPgraphs/\" && echo Lock removed!) ELSE (echo No lock found!);
-    win32:InstallJASPgraphsRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$OUT_PWD/../R/library\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
-    unix: InstallJASPgraphsRPackage.commands  = export JASP_R_HOME=\"$$_R_HOME\" ; \"$$R_EXE\" -e \".libPaths(\'$$_R_HOME/library\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
+    win32:InstallJASPgraphsRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$_R_Library\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
+    unix: InstallJASPgraphsRPackage.commands  = export JASP_R_HOME=\"$$_R_HOME\" ; \"$$R_EXE\" -e \".libPaths(\'$$_R_Library\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
 
 	win32 {
 	InstallJASPgraphsRPackage.depends = RemoveJASPgraphsRPkgLock

--- a/R_HOME.pri
+++ b/R_HOME.pri
@@ -37,6 +37,16 @@ windows {
         R_EXE  = $$_R_HOME/bin/$$ARCH/R
 }
 
+_RLibrary = $$(JASP_R_Library)
+isEmpty(_RLibrary) {
+    win32: _RLibrary =$$OUT_PWD/../R/library
+    unix:  _RLibrary = $$_R_HOME/library
+    message(using R Library of "$$_RLibrary")
+} else {
+    message(using custom R library of "$$_RLibrary")
+    DEFINES += _RLibrary
+}
+
 
 INCLUDEPATH += \
     $$_R_HOME/library/Rcpp/include \

--- a/Tools/flatpak/gather-r-package-info.R
+++ b/Tools/flatpak/gather-r-package-info.R
@@ -127,7 +127,7 @@ giveOrderedDependencies <- function()
   for (i in seq_along(orderedPkgs))
   {
     curPkg  <- orderedPkgs[[i]]
-    
+
     if(!exists(curPkg, where=expEnv, inherits=FALSE)) #if so get the version from available pkgs
     {
       print(paste0("Checking version of pkg ", curPkg, " in available_pkgs"))

--- a/Tools/flatpak/gather-r-package-info.R
+++ b/Tools/flatpak/gather-r-package-info.R
@@ -32,13 +32,10 @@ giveOrderedDependencies <- function()
   expected   <- .expectedPackages()
   pkgs       <- expected[,1]
 
-  i          <- 1L
-  while(i <= length(pkgs))
+  for (curPkg in pkgs)
   {
-    curPkg            <- pkgs[[i]]
     expVersion        <- expected[curPkg, "Version"]
     expEnv[[curPkg]]  <- expVersion
-    i                 <- i + 1L
   }
 
   # use the tools::package_dependencies function to generate an environment with pkg->deps
@@ -74,7 +71,7 @@ giveOrderedDependencies <- function()
   }
 
   print('Now we must make sure that all pkgs are preceded by their dependencies and they by theirs')
-  orderedPkgs   <- list()
+  orderedPkgs   <- character()
   inList        <- new.env(hash = TRUE, parent = parent.frame(), size = length(pkgs))
   lastTime      <- -1
   pkgs_to_order <- sort(names(pkgDeps))
@@ -104,7 +101,7 @@ giveOrderedDependencies <- function()
         if(insert)
         {
           inList[[curPkg]]  <- deps # no point in losing the deps even though we don't really need them after this
-          orderedPkgs       <- append(orderedPkgs, curPkg)
+          orderedPkgs       <- c(orderedPkgs, curPkg)
           remove(list=curPkg, envir=pkgDeps, inherits=FALSE)
           #print(paste0('Pkg ',curPkg,' depends on #', length(deps),' of deps {' ,paste0(deps, collapse='', sep=', '), '} and was added to ordered list'))
         }
@@ -126,20 +123,18 @@ giveOrderedDependencies <- function()
   #print(paste0('Pkgs ordered by dependencies: ', paste0(orderedPkgs, sep=', ', collapse='')))
 
   print('Now make sure also the versions of those packages that were included as a dependency have a version specified in expEnv')
-  i <- 1L
-  while(i <= length(orderedPkgs))
+
+  for (i in seq_along(orderedPkgs))
   {
     curPkg  <- orderedPkgs[[i]]
-
+    
     if(!exists(curPkg, where=expEnv, inherits=FALSE)) #if so get the version from available pkgs
     {
-	  print(paste0("Checking version of pkg ", curPkg, " in available_pkgs"))
+      print(paste0("Checking version of pkg ", curPkg, " in available_pkgs"))
       expEnv[[curPkg]] <- available_pkgs[[curPkg, "Version"]]
       print(paste0("Couldn't find version of ",curPkg," in expected packages so took it from availablePackages: ", expEnv[[curPkg]]))    
     }
-
-    i <- i + 1
-  }  
+  }
 
   return(orderedPkgs);
 }
@@ -276,7 +271,7 @@ createFlatpakJson <- function()
 
 getInstalledPackageEnv <- function()
 {
-  installed           <- as.data.frame(installed.packages()[,c(1,3:4)]);
+  installed           <- as.data.frame(installed.packages(lib.loc = .libPaths()[1])[,c(1,3:4)]);
   rownames(installed) <- NULL
   installed           <- installed[is.na(installed$Priority),1:2,drop=FALSE]
   installEnv          <- new.env(hash = TRUE, parent = parent.frame(), size=length(installed))
@@ -293,17 +288,16 @@ getInstalledPackageEnv <- function()
   return(installEnv)
 }
 
-installRequiredPackages <- function()
+installRequiredPackages <- function(stopOnError = TRUE)
 {
   orderedPkgs   <- giveOrderedDependencies()
   installedPkgs <- getInstalledPackageEnv()
   
   
-  
-  i <- 1L
-  while(i <= length(orderedPkgs))
+  error <- NULL
+  for (pkgName in orderedPkgs)
   {
-    pkgName  <- orderedPkgs[[i]]
+
     version  <- expEnv[[pkgName]]
     isThere  <- exists(pkgName, where=installedPkgs, inherits=FALSE)
     
@@ -318,14 +312,16 @@ installRequiredPackages <- function()
     {
       specialDef <- specials[[pkgName]]
       if(specialDef$type == 'github')
-        devtools::install_github(paste0(specialDef$repo, '@', specialDef$commit))
+        error <- try(devtools::install_github(paste0(specialDef$repo, '@', specialDef$commit)))
       else
         stop(paste0("Found a special that I cannot handle! (",specialDef,")"))
     }
     else
-      devtools::install_version(package=pkgName, version=version, repos=CRAN, dependencies=FALSE, upgrade_dependencies=FALSE)  
+      error <- try(devtools::install_version(package=pkgName, version=version, repos=CRAN, dependencies=FALSE, upgrade_dependencies=FALSE))
+
+    if (stopOnError && inherits(error, "try-error"))
+      stop(error)
       
-    i <- i + 1L
   }
 
 

--- a/Tools/installExpectedPackages.R
+++ b/Tools/installExpectedPackages.R
@@ -1,3 +1,10 @@
 setwd('./flatpak')
 source('gather-r-package-info.R')
 installRequiredPackages()
+
+# For anybody that wants to install all R packages in a custom directory, try the script below:
+#
+# setwd('~/github/jasp-desktop/Tools/flatpak')
+# .libPaths("~/R/x86_64-pc-linux-gnu-library/3.6_JASP/") # <- change this to the directory where you want the packages
+# source('gather-r-package-info.R')
+# installRequiredPackages(stopOnError = FALSE)


### PR DESCRIPTION
Now you can set `JASP_R_Library` to a custom location under projects and use that folder instead. This means that

1. `/usr/R/library` is no longer contaminated by JASP (this folder is available to all R instances, which can make it unclear which package is loaded from where).

2. R packages no longer need to be installed in a folder with root permissions (this is more a convenience thing than strictly necessary).

The only thing you then still need on Linux is Rcpp in the folders with root permission.

I didn't make this work for Windows or Mac because (1) I can't test on those platforms and (2) they didn't have the two problems mentioned above to begin with. 

I also made some small changes to `gather-r-package-info.R`, that should make it easier to install the entire library from source to a custom directory.