### PR TITLE
JAGS: Fixed bivariate plot and typo

### DIFF
--- a/JASP-Engine/JASP-Engine.pro
+++ b/JASP-Engine/JASP-Engine.pro
@@ -57,12 +57,12 @@ exists(/app/lib/*) {
    # InstallJASPgraphsRPackage.commands	= \"$$R_EXE\" CMD INSTALL --no-multiarch $$PWD/JASPgraphs
 } else {
     win32:RemoveJASPRPkgLock.commands   = IF exist \"$$OUT_PWD/../R/library/00LOCK-JASP/\" (rd /s /q \"$$OUT_PWD/../R/library/00LOCK-JASP/\" && echo Lock removed!) ELSE (echo No lock found!);
-    win32:InstallJASPRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$_R_Library\'); install.packages(\'$$PWD/JASP\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
-    unix: InstallJASPRPackage.commands  = export JASP_R_HOME=\"$$_R_HOME\" ; \"$$R_EXE\" -e \".libPaths(\'$$_R_Library\'); install.packages(\'$$PWD/JASP\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
+    win32:InstallJASPRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$_RLibrary\'); install.packages(\'$$PWD/JASP\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
+    unix: InstallJASPRPackage.commands  = export JASP_R_HOME=\"$$_R_HOME\" ; \"$$R_EXE\" -e \".libPaths(\'$$_RLibrary\'); install.packages(\'$$PWD/JASP\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
 
     win32:RemoveJASPgraphsRPkgLock.commands   = IF exist \"$$OUT_PWD/../R/library/00LOCK-JASPgraphs/\" (rd /s /q \"$$OUT_PWD/../R/library/00LOCK-JASPgraphs/\" && echo Lock removed!) ELSE (echo No lock found!);
-    win32:InstallJASPgraphsRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$_R_Library\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
-    unix: InstallJASPgraphsRPackage.commands  = export JASP_R_HOME=\"$$_R_HOME\" ; \"$$R_EXE\" -e \".libPaths(\'$$_R_Library\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
+    win32:InstallJASPgraphsRPackage.commands  = \"$$R_EXE\" -e \".libPaths(\'$$_RLibrary\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
+    unix: InstallJASPgraphsRPackage.commands  = export JASP_R_HOME=\"$$_R_HOME\" ; \"$$R_EXE\" -e \".libPaths(\'$$_RLibrary\'); install.packages(\'$$PWD/JASPgraphs\', lib=\'$$OUT_PWD/../R/library\', repos=NULL, type=\'source\', INSTALL_opts=\'--no-multiarch\')\"
 
 	win32 {
 	InstallJASPgraphsRPackage.depends = RemoveJASPgraphsRPkgLock


### PR DESCRIPTION
There was an issue where the x and y axes of the bivariate scatter plot were flipped (mentioned on twitter). This PR fixes that.

In addition, there was a typo in `JASP-Engine.pro`, `_R_library` was never defined `R_HOME.pri` but `_RLibrary` was.

@JorisGoosen the new libPath I added previously is deleted after a dynamic module is installed, probably due to lines 361 and 396 of dynamicmodule.cpp . A fix is to change line 361 from
```
"c('" + moduleRLibrary().toStdString()	+ "', .libPaths(.Library))"
```
into
```
"c('" + moduleRLibrary().toStdString()	+ "', .libPaths())"
```
and line 369 from
```
".libPaths('" << moduleRLibrary().toStdString() << "');\n"
```
into
```
".libPaths(c('" << moduleRLibrary().toStdString() << "', .libPaths()));\n"
```
doing `.libPaths(c('dir', .libPaths()))` adds `'dir'` to the set of existing ones, while `.libPaths('dir')` replaces the first result of `.libPaths()`. 

Any suggestions? If you agree with this approach I can open a separate PR for this.

[diff without whitespace changes](https://github.com/jasp-stats/jasp-desktop/pull/4060/files?w=1)


