### PR TITLE
Update JASP-Desktop.pro: choose language to generate binaries

### DIFF
--- a/Docs/development/translate.md
+++ b/Docs/development/translate.md
@@ -160,7 +160,9 @@ See https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes for the complete list.
 3. Translate the JASPgraphs .po file:	R-xx.po (located in jasp-desktop/JASP-Engine/JASPgraphs/po)
 
 #### *Create the binary .mo and .qm files*
-For translators that might have a complete build environment of JASP: edit JASP-Desktop.pro and the  GENERATE_LANGUAGE_FILES = true. Rebuilding the JASP-Desktop will give you all the binary translation files.<br><br>
+For translators that might have a complete build environment of JASP: edit JASP-Desktop.pro and almost on top set the  GENERATE\_LANGUAGE\_FILES = true. Then you need to specify the target language to translate. You can do this by defining it in the project build environment: Project\->Build Setrings\->Build environment and add the item: <br>
+TARGET\_LANGUAGE\_CODE=nl  (e.g. For a Dutch translation. See the Language Code references below for complete list.)<br>
+Rebuilding the JASP-Desktop will give you all the binary translation files.<br><br>
 Translators who wish to test their translations on an already installed version of JASP:<br>Be sure that the first three items of the Section 4 are installed. The following commands from a terminal in the jasp-desktop folder can be run to create the .mo and .qm files.
 
 1.	The Qt JASP interface .qm file: jasp\_xx.qm<br>From a terminal run: <br> > ~/Qt/5.14.2/clang_64/bin/lrelease ./JASP-Desktop/po/jasp\_xx.po -qm jasp\_xx.qm<br>

--- a/JASP-Desktop/JASP-Desktop.pro
+++ b/JASP-Desktop/JASP-Desktop.pro
@@ -151,6 +151,9 @@ RESOURCES_TRANSLATIONS = $${RESOURCES_PATH}/Translations
 RESOURCES_DESTINATION = $${OUT_PWD}/../Resources
 RESOURCES_DESTINATION_TRANSLATIONS = $$RESOURCES_DESTINATION/Translations
 
+LANGUAGE_CODE= $$(TARGET_LANGUAGE_CODE)
+isEmpty(LANGUAGE_CODE): LANGUAGE_CODE=nl
+
 win32 {
 
   SOURCES_TRANSLATIONS ~= s,/,\\,g
@@ -177,14 +180,14 @@ win32 {
   $$GENERATE_LANGUAGE_FILES {
     maketranslations.commands += $$quote(echo "Generating language Files") &&
 	maketranslations.commands += $$quote($${QTBIN}lupdate.exe -locations none -extensions $${EXTENSIONS} -recursive $${WINPWD} -ts $${SOURCES_TRANSLATIONS}\jasp.po) &&
-	maketranslations.commands += $$quote($${QTBIN}lupdate.exe -locations none -extensions $${EXTENSIONS} -target-language dutch -recursive $${WINPWD} -ts $${SOURCES_TRANSLATIONS}\jasp_nl.po) &&
+	maketranslations.commands += $$quote($${QTBIN}lupdate.exe -locations none -extensions $${EXTENSIONS} -recursive $${WINPWD} -ts $${SOURCES_TRANSLATIONS}\jasp_$${LANGUAGE_CODE}.po) &&
 
 	#cleanup po files
 	maketranslations.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location $${SOURCES_TRANSLATIONS}\jasp.po -o $${SOURCES_TRANSLATIONS}\jasp.po) &&
-	maketranslations.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location $${SOURCES_TRANSLATIONS}\jasp_nl.po -o $${SOURCES_TRANSLATIONS}\jasp_nl.po)  &&
+	maketranslations.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location $${SOURCES_TRANSLATIONS}\jasp_$${LANGUAGE_CODE}.po -o $${SOURCES_TRANSLATIONS}\jasp_$${LANGUAGE_CODE}.po)  &&
 
-	#Create jasp_nl.qm
-	maketranslations.commands += $$quote($${QTBIN}lrelease.exe $${SOURCES_TRANSLATIONS}\jasp_nl.po -qm $${RESOURCES_TRANSLATIONS}\jasp_nl.qm) &&
+	#Create jasp_$${LANGUAGE_CODE}.qm
+	maketranslations.commands += $$quote($${QTBIN}lrelease.exe $${SOURCES_TRANSLATIONS}\jasp_$${LANGUAGE_CODE}.po -qm $${RESOURCES_TRANSLATIONS}\jasp_$${LANGUAGE_CODE}.qm) &&
 	maketranslations.commands += $$quote(copy $${RESOURCES_TRANSLATIONS}\*.qm $${RESOURCES_DESTINATION_TRANSLATIONS}\ ) &&
 
     #Create R-JASP.mo translation file. (Need to add GETTEXT location to PATH environment.)
@@ -201,7 +204,8 @@ unix {
 
   GETTEXT_LOCATION = $$(GETTEXT_PATH)
   isEmpty(GETTEXT_LOCATION): GETTEXT_LOCATION=/usr/local/bin
-  EXTENDED_PATH = $PATH:$$GETTEXT_LOCATION
+
+  EXTENDED_PATH = $$(PATH):$$GETTEXT_LOCATION
 
   delres.commands += rm -rf $$RESOURCES_DESTINATION;
   copyres.commands += $(MKDIR) $$RESOURCES_DESTINATION ;
@@ -210,14 +214,14 @@ unix {
   $$GENERATE_LANGUAGE_FILES {
     maketranslations.commands += $$quote(echo "Generating language Files");
     maketranslations.commands += lupdate -locations none -extensions cpp,qml -recursive $$PWD/.. -ts $$SOURCES_TRANSLATIONS/jasp.po ;
-    maketranslations.commands += lupdate -locations none -extensions cpp,qml -target-language Dutch -recursive $$PWD/.. -ts $$SOURCES_TRANSLATIONS/jasp_nl.po ;
+    maketranslations.commands += lupdate -locations none -extensions cpp,qml -recursive $$PWD/.. -ts $$SOURCES_TRANSLATIONS/jasp_$${LANGUAGE_CODE}.po ;
 
     #cleanup po files
     maketranslations.commands += $$GETTEXT_LOCATION/msgattrib --no-obsolete --no-location $$SOURCES_TRANSLATIONS/jasp.po -o $$SOURCES_TRANSLATIONS/jasp.po ;
-    maketranslations.commands += $$GETTEXT_LOCATION/msgattrib --no-obsolete --no-location $$SOURCES_TRANSLATIONS/jasp_nl.po -o $$SOURCES_TRANSLATIONS/jasp_nl.po ;
+    maketranslations.commands += $$GETTEXT_LOCATION/msgattrib --no-obsolete --no-location $$SOURCES_TRANSLATIONS/jasp_$${LANGUAGE_CODE}.po -o $$SOURCES_TRANSLATIONS/jasp_$${LANGUAGE_CODE}.po ;
 
-    #Create jasp_nl.qm
-    maketranslations.commands += lrelease $$SOURCES_TRANSLATIONS/jasp_nl.po -qm $$RESOURCES_TRANSLATIONS/jasp_nl.qm ;
+    #Create jasp_$${LANGUAGE_CODE}.qm
+    maketranslations.commands += lrelease $$SOURCES_TRANSLATIONS/jasp_$${LANGUAGE_CODE}.po -qm $$RESOURCES_TRANSLATIONS/jasp_$${LANGUAGE_CODE}.qm ;
     maketranslations.commands += cp $$RESOURCES_TRANSLATIONS/*.qm $$RESOURCES_DESTINATION_TRANSLATIONS/ ;
 
     #Create R-JASP.mo translation file. (Need to add GETTEXT location to PATH environment.)
@@ -636,5 +640,4 @@ DISTFILES += \
     modules/upgrader/upgrades.json \
     modules/upgrader/upgrades_template.json \
     po/jasp.po \
-    po/jasp_nl.po \
     resources/CC-Attributions.txt


### PR DESCRIPTION
- Generate language files for a specific language by specifying the TARGET_LANGUAGE_CODE in the project environment.
- Update the translation information.

