### PR TITLE
more tweaks to custom R library

### DIFF
--- a/JASP-Desktop/modules/dynamicmodule.cpp
+++ b/JASP-Desktop/modules/dynamicmodule.cpp
@@ -358,7 +358,7 @@ std::string DynamicModule::generateModuleInstallingR(bool onlyModPkg)
 	std::string typeInstall = "'source'";
 //<< ".runSeparateR(\"{"
 
-	std::string libPathsToUse = "c('" + moduleRLibrary().toStdString()	+ "', .libPaths(.Library))";
+	std::string libPathsToUse = "c('" + moduleRLibrary().toStdString()	+ "', .libPaths())";
 
 	const char * pkgType =
 #ifdef __linux__
@@ -393,7 +393,7 @@ std::string DynamicModule::generateModuleLoadingR(bool shouldReturnSucces)
 
 	setLoadLog("Module " + _name + " is being loaded from " + _moduleFolder.absolutePath().toStdString() + "\n");
 
-	R << _name << _modulePostFix << " <- module({\n" << standardRIndent << ".libPaths('" << moduleRLibrary().toStdString() << "');\n";
+	R << _name << _modulePostFix << " <- module({\n" << standardRIndent << ".libPaths(c('" << moduleRLibrary().toStdString() << "', .libPaths()));\n";
 	R << standardRIndent << "import('" << _name << "');\n\n";
 
 	size_t maxL = 0;

--- a/R_HOME.pri
+++ b/R_HOME.pri
@@ -44,7 +44,6 @@ isEmpty(_RLibrary) {
     message(using R Library of "$$_RLibrary")
 } else {
     message(using custom R library of "$$_RLibrary")
-    DEFINES += _RLibrary
 }
 
 


### PR DESCRIPTION

- removed unnecessary DEFINES in `R_HOME.pri`
- custom r library now works for dynamic modules

after installing a dynamic module I now get the following libPaths in the analysis:
```
[1] "/home/dvdb/.local/share/JASP/JASP/Modules/DevelopmentModule"             
[2] "/home/dvdb/github/build-JASP-Desktop_Qt_5_14_2_GCC_64bit-Debug/R/library"
[3] "/home/dvdb/R/x86_64-pc-linux-gnu-library/3.6_JASP"                       
[4] "/usr/lib/R/library"                                                      
[5] "/usr/lib/R/site-library"                                                 
[6] "/usr/local/lib/R/site-library"                                           
```
for a normal analysis I get the same except for the first path:
```
[1] "/home/dvdb/github/build-JASP-Desktop_Qt_5_14_2_GCC_64bit-Debug/R/library"
[2] "/home/dvdb/R/x86_64-pc-linux-gnu-library/3.6_JASP"                       
[3] "/usr/lib/R/library"                                                      
[4] "/usr/lib/R/site-library"                                                 
[5] "/usr/local/lib/R/site-library"                                           
```