### PR TITLE
Add runAnalysisWhenOptionChanged property to QML and form

### DIFF
--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -380,11 +380,8 @@ void Analysis::optionsChangedHandler(Option *option)
 	if (_refreshBlocked)
 		return;
 
-	if (form())
-	{
-		if (form()->hasError() || !form()->runAnalysisWhenThisOptionIsChanged(option))
-			return;
-	}
+	if (form() && (form()->hasError() || !form()->runWhenThisOptionIsChanged(option)))
+		return;
 
 	setStatus(Empty);
 }

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -380,8 +380,11 @@ void Analysis::optionsChangedHandler(Option *option)
 	if (_refreshBlocked)
 		return;
 
-	if (form() && form()->hasError())
-		return;
+	if (form())
+	{
+		if (form()->hasError() || !form()->runAnalysisWhenThisOptionIsChanged(option))
+			return;
+	}
 
 	setStatus(Empty);
 }

--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -133,8 +133,6 @@ void AnalysisForm::runScriptRequestDone(const QString& result, const QString& co
 
 void AnalysisForm::_addControlWrapper(JASPControlWrapper* controlWrapper)
 {
-	_allItems.push_back(controlWrapper);
-
 	switch(controlWrapper->item()->controlType())
 	{
 	case JASPControlBase::ControlType::Expander:
@@ -782,30 +780,30 @@ void AnalysisForm::setMustContain(std::map<std::string,std::set<std::string>> mu
 
 }
 
-void AnalysisForm::setRunAnalysisWhenOptionChanged(bool change)
+void AnalysisForm::setRunOnChange(bool change)
 {
-	if (change != _runAnalysisWhenOptionChanged)
+	if (change != _runOnChange)
 	{
-		_runAnalysisWhenOptionChanged = change;
+		_runOnChange = change;
 
 		if (_options)
 			_options->blockSignals(change, false);
 
-		emit runAnalysisWhenOptionChangedChanged();
+		emit runOnChangeChanged();
 	}
 }
 
-bool AnalysisForm::runAnalysisWhenThisOptionIsChanged(Option *option)
+bool AnalysisForm::runWhenThisOptionIsChanged(Option *option)
 {
 	BoundQMLItem* control = getBoundItem(option);
 	JASPControlBase* item = control ? control->item() : nullptr;
 
 	emit optionChanged(item);
 
-	if (!_runAnalysisWhenOptionChanged)
+	if (!_runOnChange)
 		return false;
 
-	if (item && !item->runAnalysisWhenOptionChanged())
+	if (item && !item->runOnChange())
 		return false;
 
 	return true;

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -52,7 +52,7 @@ class AnalysisForm : public QQuickItem, public VariableInfoProvider
 	Q_PROPERTY(QQuickItem * errorMessagesItem	READ errorMessagesItem	WRITE setErrorMessagesItem	NOTIFY errorMessagesItemChanged	)
 	Q_PROPERTY(bool			needsRefresh		READ needsRefresh									NOTIFY needsRefreshChanged		)
 	Q_PROPERTY(bool			hasVolatileNotes	READ hasVolatileNotes								NOTIFY hasVolatileNotesChanged	)
-	Q_PROPERTY(bool			runAnalysisWhenOptionChanged	READ runAnalysisWhenOptionChanged	WRITE setRunAnalysisWhenOptionChanged NOTIFY runAnalysisWhenOptionChangedChanged )
+	Q_PROPERTY(bool			runOnChange			READ runOnChange		WRITE setRunOnChange		NOTIFY runOnChangeChanged )
 
 public:
 	explicit					AnalysisForm(QQuickItem * = nullptr);
@@ -66,10 +66,10 @@ public:
 				void			setMustBe(		std::set<std::string>						mustBe);
 				void			setMustContain(	std::map<std::string,std::set<std::string>> mustContain);
 
-				bool			runAnalysisWhenOptionChanged()	{ return _runAnalysisWhenOptionChanged; }
-				void			setRunAnalysisWhenOptionChanged(bool change);
+				bool			runOnChange()	{ return _runOnChange; }
+				void			setRunOnChange(bool change);
 
-				bool			runAnalysisWhenThisOptionIsChanged(Option* option);
+				bool			runWhenThisOptionIsChanged(Option* option);
 					
 public slots:
 				void			runScriptRequestDone(const QString& result, const QString& requestId);
@@ -86,7 +86,7 @@ signals:
 				void			languageChanged();
 				void			needsRefreshChanged();
 				void			hasVolatileNotesChanged();
-				void			runAnalysisWhenOptionChangedChanged();
+				void			runOnChangeChanged();
 				void			optionChanged(JASPControlBase* item);
 
 protected:
@@ -102,8 +102,8 @@ public:
 	QMLExpander			*	nextExpander(QMLExpander* expander)		{ return _nextExpanderMap[expander]; }
 	BoundQMLItem		*	getBoundItem(Option* option)			{ return _optionControlMap[option]; }
 
-	Options*	options() { return _options; }
-	void		addControl(JASPControlBase* control);
+	Options				*	options() { return _options; }
+	void					addControl(JASPControlBase* control);
 
 	Q_INVOKABLE void reset();
     Q_INVOKABLE void exportResults();
@@ -159,7 +159,6 @@ protected:
 	QMap<QString, JASPControlWrapper* >			_controls;
 
 	QVector<JASPControlWrapper*>				_orderedControls;
-	QVector<JASPControlWrapper*>				_allItems;	// get all control items, even the ones without names.
 	QMap<Option*, BoundQMLItem*>				_optionControlMap;
 	QMap<QMLListView*, ListModel* >				_relatedModelMap;
 	QMap<QString, ListModel* >					_modelMap;
@@ -181,7 +180,7 @@ private:
 	QSet<JASPControlBase*>						_jaspControlsWithErrorSet;
 	QSet<JASPControlBase*>						_jaspControlsWithWarningSet;
 	QList<QString>								_computedColumns;
-	bool										_runAnalysisWhenOptionChanged = true;
+	bool										_runOnChange = true;
 };
 
 #endif // ANALYSISFORM_H

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -52,6 +52,7 @@ class AnalysisForm : public QQuickItem, public VariableInfoProvider
 	Q_PROPERTY(QQuickItem * errorMessagesItem	READ errorMessagesItem	WRITE setErrorMessagesItem	NOTIFY errorMessagesItemChanged	)
 	Q_PROPERTY(bool			needsRefresh		READ needsRefresh									NOTIFY needsRefreshChanged		)
 	Q_PROPERTY(bool			hasVolatileNotes	READ hasVolatileNotes								NOTIFY hasVolatileNotesChanged	)
+	Q_PROPERTY(bool			runAnalysisWhenOptionChanged	READ runAnalysisWhenOptionChanged	WRITE setRunAnalysisWhenOptionChanged NOTIFY runAnalysisWhenOptionChangedChanged )
 
 public:
 	explicit					AnalysisForm(QQuickItem * = nullptr);
@@ -59,12 +60,16 @@ public:
 				void			unbind();
 
 				void			runRScript(QString script, QString controlName, bool whiteListedVersion);
-				void			refreshAnalysis();
 				
 				void			itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &value) override;
 
 				void			setMustBe(		std::set<std::string>						mustBe);
 				void			setMustContain(	std::map<std::string,std::set<std::string>> mustContain);
+
+				bool			runAnalysisWhenOptionChanged()	{ return _runAnalysisWhenOptionChanged; }
+				void			setRunAnalysisWhenOptionChanged(bool change);
+
+				bool			runAnalysisWhenThisOptionIsChanged(Option* option);
 					
 public slots:
 				void			runScriptRequestDone(const QString& result, const QString& requestId);
@@ -81,6 +86,8 @@ signals:
 				void			languageChanged();
 				void			needsRefreshChanged();
 				void			hasVolatileNotesChanged();
+				void			runAnalysisWhenOptionChangedChanged();
+				void			optionChanged(JASPControlBase* item);
 
 protected:
 				QVariant		requestInfo(const Term &term, VariableInfo::InfoType info) const override;
@@ -93,6 +100,7 @@ public:
 	void					addListView(QMLListView* listView, QMLListView* sourceListView);
 	void					clearFormErrors();
 	QMLExpander			*	nextExpander(QMLExpander* expander)		{ return _nextExpanderMap[expander]; }
+	BoundQMLItem		*	getBoundItem(Option* option)			{ return _optionControlMap[option]; }
 
 	Options*	options() { return _options; }
 	void		addControl(JASPControlBase* control);
@@ -100,6 +108,8 @@ public:
 	Q_INVOKABLE void reset();
     Q_INVOKABLE void exportResults();
 	Q_INVOKABLE void addFormError(const QString& message);
+	Q_INVOKABLE void refreshAnalysis();
+
 
 	void		addControlError(JASPControlBase* control, QString message, bool temporary = false, bool warning = false);
 	void		clearControlError(JASPControlBase* control);
@@ -149,6 +159,8 @@ protected:
 	QMap<QString, JASPControlWrapper* >			_controls;
 
 	QVector<JASPControlWrapper*>				_orderedControls;
+	QVector<JASPControlWrapper*>				_allItems;	// get all control items, even the ones without names.
+	QMap<Option*, BoundQMLItem*>				_optionControlMap;
 	QMap<QMLListView*, ListModel* >				_relatedModelMap;
 	QMap<QString, ListModel* >					_modelMap;
 	QVector<QMLExpander*>						_expanders;
@@ -169,6 +181,7 @@ private:
 	QSet<JASPControlBase*>						_jaspControlsWithErrorSet;
 	QSet<JASPControlBase*>						_jaspControlsWithWarningSet;
 	QList<QString>								_computedColumns;
+	bool										_runAnalysisWhenOptionChanged = true;
 };
 
 #endif // ANALYSISFORM_H

--- a/JASP-Desktop/analysis/jaspcontrolbase.cpp
+++ b/JASP-Desktop/analysis/jaspcontrolbase.cpp
@@ -49,25 +49,25 @@ void JASPControlBase::setHasWarning(bool hasWarning)
 	}
 }
 
-void JASPControlBase::setRunAnalysisWhenOptionChangedToChildren(bool change)
+void JASPControlBase::setRunOnChangeToChildren(bool change)
 {
 	if (_childControlsArea)
 	{
 		QList<JASPControlBase*> childControls = getChildJASPControls(_childControlsArea);
 		for (JASPControlBase* childControl : childControls)
-			childControl->setRunAnalysisWhenOptionChanged(change);
+			childControl->setRunOnChange(change);
 	}
 }
 
-void JASPControlBase::setRunAnalysisWhenOptionChanged(bool change)
+void JASPControlBase::setRunOnChange(bool change)
 {
-	if (change != _runAnalysisWhenOptionChanged)
+	if (change != _runOnChange)
 	{
-		_runAnalysisWhenOptionChanged = change;
+		_runOnChange = change;
 
-		setRunAnalysisWhenOptionChangedToChildren(change);
+		setRunOnChangeToChildren(change);
 
-		emit runAnalysisWhenOptionChangedChanged();
+		emit runOnChangeChanged();
 	}
 }
 
@@ -142,9 +142,9 @@ void JASPControlBase::componentComplete()
 	if (_debug)
 		setParentDebugToChildren(_debug);
 
-	// Also, set the runAnalysisWhenOptionChanged property to children items
-	if (!_runAnalysisWhenOptionChanged)
-		setRunAnalysisWhenOptionChangedToChildren(_runAnalysisWhenOptionChanged);
+	// Also, set the runOnChange property to children items
+	if (!_runOnChange)
+		setRunOnChangeToChildren(_runOnChange);
 }
 
 void JASPControlBase::addControlError(QString message)

--- a/JASP-Desktop/analysis/jaspcontrolbase.h
+++ b/JASP-Desktop/analysis/jaspcontrolbase.h
@@ -29,7 +29,7 @@ private:
 
 	Q_PROPERTY( QQmlListProperty<QQmlComponent> rowComponents READ rowComponents)
 	Q_PROPERTY( QQmlComponent * rowComponent		READ rowComponent		WRITE setRowComponent		NOTIFY rowComponentChanged			)
-	Q_PROPERTY( bool runAnalysisWhenOptionChanged	READ runAnalysisWhenOptionChanged	WRITE setRunAnalysisWhenOptionChanged	NOTIFY runAnalysisWhenOptionChangedChanged)
+	Q_PROPERTY( bool runOnChange					READ runOnChange		WRITE setRunOnChange		NOTIFY runOnChangeChanged			)
 
 
 public:
@@ -82,9 +82,9 @@ public:
 	QQuickItem*		parentListView()		const	{ return _parentListView;		}
 	QString			parentListViewKey()		const	{ return _parentListViewKey;	}
 	QQuickItem*		section()				const	{ return _section;				}
-	QQuickItem*		innerControl()			const	{ return _innerControl;				}
-	QQuickItem*		background()			const	{ return _background;				}
-	bool			runAnalysisWhenOptionChanged()	const	{ return _runAnalysisWhenOptionChanged; }
+	QQuickItem*		innerControl()			const	{ return _innerControl;			}
+	QQuickItem*		background()			const	{ return _background;			}
+	bool			runOnChange()			const	{ return _runOnChange;			}
 
 
 	void	setControlType(ControlType controlType)				{ _controlType = controlType; }
@@ -93,7 +93,7 @@ public:
 	void	setFocusOnTab(bool focus);
 	void	setHasError(bool hasError);
 	void	setHasWarning(bool hasWarning);
-	void	setRunAnalysisWhenOptionChanged(bool change);
+	void	setRunOnChange(bool change);
 	void	setDebug(bool debug);
 	void	setParentDebug(bool parentDebug);
 
@@ -133,7 +133,7 @@ signals:
 	void focusOnTabChanged();
 	void parentListViewChanged();
 	void rowComponentChanged();
-	void runAnalysisWhenOptionChangedChanged();
+	void runOnChangeChanged();
 	void innerControlChanged();
 	void backgroundChanged();
 
@@ -159,7 +159,7 @@ protected:
 	QQuickItem*			_innerControl			= nullptr;
 	QQuickItem*			_background				= nullptr;
 
-	bool				_runAnalysisWhenOptionChanged = true;
+	bool				_runOnChange = true;
 
 	static void				appendRowComponent(QQmlListProperty<QQmlComponent>*, QQmlComponent*);
 	static int				rowComponentsCount(QQmlListProperty<QQmlComponent>*);
@@ -171,7 +171,7 @@ protected:
 
 	static QList<JASPControlBase*>	getChildJASPControls(QQuickItem* item);
 			void					setParentDebugToChildren(bool debug);
-			void					setRunAnalysisWhenOptionChangedToChildren(bool change);
+			void					setRunOnChangeToChildren(bool change);
 
 };
 

--- a/JASP-Desktop/analysis/options/option.cpp
+++ b/JASP-Desktop/analysis/options/option.cpp
@@ -45,12 +45,12 @@ bool Option::isTransient() const
 	return _isTransient;
 }
 
-void Option::notifyChanged()
+void Option::notifyChanged(Option* option)
 {
 	if (_signalsBlocked)
 		_shouldSignalChangedOnceUnblocked = true;
 	else
-		changed(this);
+		changed(option);
 }
 
 Json::Value Option::defaultMetaEntryContainingColumn(bool containsColumn) const

--- a/JASP-Desktop/analysis/options/option.h
+++ b/JASP-Desktop/analysis/options/option.h
@@ -80,7 +80,7 @@ public:
 	Json::Value			defaultMetaEntryContainingColumn(bool containsColumn = true) const;
 
 protected:
-	void				notifyChanged();
+	void				notifyChanged(Option* option);
 
 	bool		_isTransient;
 

--- a/JASP-Desktop/analysis/options/optioni.h
+++ b/JASP-Desktop/analysis/options/optioni.h
@@ -37,7 +37,7 @@ public:
 
 		_value = value;
 
-		notifyChanged();
+		notifyChanged(this);
 	}
 
 protected:

--- a/JASP-Desktop/analysis/options/options.cpp
+++ b/JASP-Desktop/analysis/options/options.cpp
@@ -81,9 +81,9 @@ void Options::clear()
 	_options.clear();
 }
 
-void Options::optionsChanged(Option *)
+void Options::optionsChanged(Option *option)
 {
-	notifyChanged();
+	notifyChanged(option);
 }
 
 Json::Value Options::asJSON(bool includeTransient) const
@@ -242,7 +242,7 @@ void Options::removeUsedVariable(const std::string & var)
 	for (const OptionNamed& option : _options)
 		option.second->removeUsedVariable(var);
 
-	notifyChanged();
+	notifyChanged(this);
 }
 
 void Options::replaceVariableName(const std::string & oldName, const std::string & newName)
@@ -250,5 +250,5 @@ void Options::replaceVariableName(const std::string & oldName, const std::string
 	for (const OptionNamed& option : _options)
 		option.second->replaceVariableName(oldName, newName);
 
-	notifyChanged();
+	notifyChanged(this);
 }

--- a/JASP-Desktop/analysis/options/options.h
+++ b/JASP-Desktop/analysis/options/options.h
@@ -94,7 +94,7 @@ private:
 	static void insertValue(const std::string &name, Json::Value& value, Json::Value &root);
 	static bool extractValue(const std::string &name, const Json::Value &root, Json::Value &value);
 
-	void optionsChanged(Option *);
+	void optionsChanged(Option *option);
 
 
 };

--- a/JASP-Desktop/analysis/options/optionstable.cpp
+++ b/JASP-Desktop/analysis/options/optionstable.cpp
@@ -123,7 +123,7 @@ void OptionsTable::setValue(const std::vector<Options *> &value)
 	_value = value;
 
 	if(changesFound)
-		notifyChanged();
+		notifyChanged(this);
 }
 
 void OptionsTable::connectOptions(const std::vector<Options *> &value)

--- a/JASP-Desktop/analysis/options/optionstable.h
+++ b/JASP-Desktop/analysis/options/optionstable.h
@@ -46,7 +46,7 @@ public:
 	void					replaceKey(const std::string& oldKey, const std::string& newKey);
 
 private:
-	void					optionsChanged(Option *) { notifyChanged(); }
+	void					optionsChanged(Option *) { notifyChanged(this); }
 	void					deleteOldValues();
 
 	Options		*_template = nullptr;

--- a/JASP-Desktop/components/JASP/Controls/Button.qml
+++ b/JASP-Desktop/components/JASP/Controls/Button.qml
@@ -29,6 +29,7 @@ JASPControl
 	implicitWidth:		control.implicitWidth
 	isBound:			false
 	shouldStealHover:	false
+	innerControl:		control
 	
 	readonly	property alias control:		control
 				property alias text:		control.text

--- a/JASP-Desktop/components/JASP/Controls/CheckBox.qml
+++ b/JASP-Desktop/components/JASP/Controls/CheckBox.qml
@@ -34,6 +34,7 @@ JASPControl
 							: control.implicitHeight + (childControlsArea.children.length > 0 ? jaspTheme.rowGroupSpacing + childControlsArea.implicitHeight : 0)
 	focusIndicator:		focusIndicator
 	childControlsArea:	childControlsArea
+	innerControl:		control
 
 	default property alias	content:				childControlsArea.children
 			property alias	control:				control

--- a/JASP-Desktop/components/JASP/Controls/ComboBox.qml
+++ b/JASP-Desktop/components/JASP/Controls/ComboBox.qml
@@ -11,6 +11,7 @@ JASPControl
 	implicitHeight:		control.height + ((controlLabel.visible && setLabelAbove) ? rectangleLabel.height : 0)
 	implicitWidth:		control.width + ((controlLabel.visible && !setLabelAbove) ? jaspTheme.labelSpacing + controlLabel.width : 0)
 	background:			useExternalBorder ? externalControlBackground : control.background
+	innerControl:		control
 
 
 	property alias	control:				control

--- a/JASP-Desktop/components/JASP/Controls/ExpanderButton.qml
+++ b/JASP-Desktop/components/JASP/Controls/ExpanderButton.qml
@@ -42,6 +42,7 @@ FocusScope
 	readonly	property string	expanderButtonIcon		: "expander-arrow-up.png"
 				property alias	columns					: expanderArea.columns
 				property alias	alignChildrenTopLeft	: expanderArea.alignChildrenTopLeft
+				property alias	runAnalysisWhenOptionChanged : expanderButton.runAnalysisWhenOptionChanged
 
 	function addControlWithError(name, add)
 	{

--- a/JASP-Desktop/components/JASP/Controls/ExpanderButton.qml
+++ b/JASP-Desktop/components/JASP/Controls/ExpanderButton.qml
@@ -42,7 +42,7 @@ FocusScope
 	readonly	property string	expanderButtonIcon		: "expander-arrow-up.png"
 				property alias	columns					: expanderArea.columns
 				property alias	alignChildrenTopLeft	: expanderArea.alignChildrenTopLeft
-				property alias	runAnalysisWhenOptionChanged : expanderButton.runAnalysisWhenOptionChanged
+				property alias	runOnChange				: expanderButton.runOnChange
 
 	function addControlWithError(name, add)
 	{

--- a/JASP-Desktop/components/JASP/Controls/Form.qml
+++ b/JASP-Desktop/components/JASP/Controls/Form.qml
@@ -37,42 +37,14 @@ AnalysisForm
 	property bool	usesJaspResults		: true
 	property int	majorVersion		: 1
 	property int	minorVersion		: 0
-	property bool	usesVariablesModel	: false
 	property int	availableWidth		: form.width - 2 * jaspTheme.formMargin
 	property var    analysis			: myAnalysis
 	property var	backgroundForms		: backgroundFlickable
 	property alias	columns				: contentArea.columns
+	property bool	runAnalysisWhenOptionChange : true
 
 	property int    plotHeight			: 320
 	property int    plotWidth			: 480
-
-	function getJASPControls(controls, item, deep)
-	{
-		for (var i = 0; i < item.children.length; ++i)
-		{
-			var child = item.children[i];
-
-			if (child.objectName === "Section")
-			{
-				controls.push(child.button);
-				getJASPControls(controls, child.childControlsArea, deep);
-			}
-			else if (child instanceof JASPControl)
-			{
-				if (child.activeFocusOnTab)
-				{
-					controls.push(child);
-					if (child.childControlsArea && deep)
-						getJASPControls(controls, child.childControlsArea, deep);
-				}
-				else
-					getJASPControls(controls, child, deep);
-
-			}
-			else
-				getJASPControls(controls, child, deep);
-		}
-	}
 
 	MouseArea
 	{

--- a/JASP-Desktop/components/JASP/Controls/GroupBox.qml
+++ b/JASP-Desktop/components/JASP/Controls/GroupBox.qml
@@ -22,22 +22,21 @@ import QtQuick.Layouts	1.3 as L
 import JASP				1.0
 
 
-Rectangle
+JASPControl
 {
-	id:					control
+	id:					groupBox
 	implicitWidth:		Math.max(label.realWidth, jaspTheme.groupContentPadding + contentArea.implicitWidth)
 	implicitHeight:		label.realHeight + jaspTheme.titleBottomMargin + contentArea.implicitHeight	
-	color:				jaspTheme.analysisBackgroundColor // transparent generates sometimes temporary black blocks
 	L.Layout.leftMargin:	indent ? jaspTheme.indentationLength : 0
-	visible:			!debug || DEBUG_MODE
+	controlType				: JASPControlBase.GroupBox
+	isBound					: false
+	childControlsArea		: contentArea
     
 	default property alias	content:			contentArea.children
-			property alias	contentArea:		contentArea
 			property int	rowSpacing:			jaspTheme.rowGroupSpacing
 			property int	columnSpacing:		jaspTheme.columnGroupSpacing
 			property int	columns:			1
 			property string title:				""
-			property bool	debug:				false
 			property bool	indent:				false
 			property bool	alignTextFields:	true
 			property alias	alignChildrenTopLeft: contentArea.alignChildrenTopLeft
@@ -48,12 +47,12 @@ Rectangle
 	Label
 	{
 		id:				label
-		anchors.top:	control.top
-		anchors.left:	control.left
-		text:			control.title
+		anchors.top:	groupBox.top
+		anchors.left:	groupBox.left
+		text:			groupBox.title
 		color:			enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
 		font:			jaspTheme.font
-		visible:		control.title ? true : false
+		visible:		groupBox.title ? true : false
 		
 		property int	realHeight: visible ? implicitHeight : 0
 		property int	realWidth: visible ? implicitWidth : 0
@@ -63,13 +62,13 @@ Rectangle
 	GridLayout
 	{
 		id:					contentArea
-		columns:			control.columns
-		anchors.top:		control.title ? label.bottom : control.top
-		anchors.topMargin:	control.title ? jaspTheme.titleBottomMargin : 0
-		anchors.left:		control.left
-        anchors.leftMargin: control.title ? jaspTheme.groupContentPadding : 0
-		rowSpacing:			control.rowSpacing
-		columnSpacing:		control.columnSpacing
+		columns:			groupBox.columns
+		anchors.top:		groupBox.title ? label.bottom : groupBox.top
+		anchors.topMargin:	groupBox.title ? jaspTheme.titleBottomMargin : 0
+		anchors.left:		groupBox.left
+		anchors.leftMargin: groupBox.title ? jaspTheme.groupContentPadding : 0
+		rowSpacing:			groupBox.rowSpacing
+		columnSpacing:		groupBox.columnSpacing
     }
 
 	Connections
@@ -97,8 +96,6 @@ Rectangle
 		for (var i = 0; i < contentArea.children.length; i++)
 		{
 			var child = contentArea.children[i];
-			if (control.debug && child.hasOwnProperty("debug"))
-				child.setDebugState();
 			if (child.hasOwnProperty('controlType') && child.controlType === JASPControlBase.TextField)
 				_allTextFields.push(child)
 		}
@@ -112,24 +109,24 @@ Rectangle
 		{
 			var i;
 			_allTextFields[0].controlXOffset = 0;
-			var xMax = _allTextFields[0].control.x;
-			var longestControl = _allTextFields[0].control;
+			var xMax = _allTextFields[0].innerControl.x;
+			var longestControl = _allTextFields[0].innerControl;
 			for (i = 1; i < _allTextFields.length; i++)
 			{
 				_allTextFields[i].controlXOffset = 0;
-				if (xMax < _allTextFields[i].control.x)
+				if (xMax < _allTextFields[i].innerControl.x)
 				{
-					longestControl = _allTextFields[i].control;
-					xMax = _allTextFields[i].control.x;
+					longestControl = _allTextFields[i].innerControl;
+					xMax = _allTextFields[i].innerControl.x;
 				}
             }
             
 			for (i = 0; i < _allTextFields.length; i++)
 			{
-				if (_allTextFields[i].control !== longestControl)
-					// Cannot use binding here, since control.x depends on the controlXOffset,
+				if (_allTextFields[i].innerControl !== longestControl)
+					// Cannot use binding here, since innerControl.x depends on the controlXOffset,
 					// that would generate a binding loop
-					_allTextFields[i].controlXOffset = (xMax - _allTextFields[i].control.x);
+					_allTextFields[i].controlXOffset = (xMax - _allTextFields[i].innerControl.x);
 
 			}
 		}

--- a/JASP-Desktop/components/JASP/Controls/JASPListControl.qml
+++ b/JASP-Desktop/components/JASP/Controls/JASPListControl.qml
@@ -30,6 +30,7 @@ JASPControl
 	implicitHeight			: jaspTheme.defaultVariablesFormHeight
 	useControlMouseArea		: false
 	shouldStealHover		: false
+	innerControl			: listGridView
 
 	property var	model
 	property var	values

--- a/JASP-Desktop/components/JASP/Controls/RadioButton.qml
+++ b/JASP-Desktop/components/JASP/Controls/RadioButton.qml
@@ -34,9 +34,10 @@ JASPControl
 							: control.implicitHeight + (childControlsArea.children.length > 0 ? jaspTheme.rowGroupSpacing + childControlsArea.implicitHeight : 0)
 	focusIndicator:			focusIndicator
 	childControlsArea:		childControlsArea
+	innerControl:			control
 
-	default property alias	content:				childControlsArea.children
 	property alias	control:				control
+	default property alias	content:		childControlsArea.children
 
 	property alias	childrenArea:			childControlsArea
 	property alias	text:					control.text

--- a/JASP-Desktop/components/JASP/Controls/Slider.qml
+++ b/JASP-Desktop/components/JASP/Controls/Slider.qml
@@ -10,6 +10,7 @@ JASPControl
 	controlType:		JASPControlBase.Slider
 	implicitHeight:		columnLayout.implicitHeight
 	implicitWidth:		columnLayout.implicitWidth
+	innerControl:		textField
 
 	property alias	control:		textField
 	property int	decimals:		2
@@ -122,7 +123,7 @@ JASPControl
 			}
 			onTextEdited:
 			{
-				if (value && !textField.control.acceptableInput)
+				if (value && !textField.innerControl.acceptableInput)
 					value = control.value
 			}
 		}

--- a/JASP-Desktop/components/JASP/Controls/Switch.qml
+++ b/JASP-Desktop/components/JASP/Controls/Switch.qml
@@ -25,6 +25,7 @@ JASPControl
 	controlType:				JASPControlBase.Switch
 	implicitWidth:				control.indicator.height + (4 * preferencesModel.uiScale)
 	implicitHeight:				control.indicator.width + controlLabel.implicitWidth + control.spacing + (6 * preferencesModel.uiScale)
+	innerControl:				control
 	
 	property alias control:		control
 	property alias label:		control.text

--- a/JASP-Desktop/components/JASP/Controls/TextArea.qml
+++ b/JASP-Desktop/components/JASP/Controls/TextArea.qml
@@ -12,8 +12,9 @@ JASPControl
 	width:				parent.width
 	implicitWidth:		width
 	focusIndicator:		flickableRectangle
+	innerControl:		control
 	
-	property alias  control				: control
+	property alias	control				: control
 	property alias  text				: control.text
     property string textType
 	property string applyScriptInfo		: Qt.platform.os == "osx" ? qsTr("\u2318 + Enter to apply") : qsTr("Ctrl + Enter to apply")

--- a/JASP-Desktop/components/JASP/Controls/TextField.qml
+++ b/JASP-Desktop/components/JASP/Controls/TextField.qml
@@ -30,8 +30,9 @@ JASPControl
 	implicitWidth:		afterLabel.text ? (afterLabelRect.x + afterLabelRect.width) : (control.x + control.width)
 	background:			useExternalBorder ? externalControlBackground : control.background
 	cursorShape:		Qt.IBeamCursor
+	innerControl:		control
 	
-	property alias	control:			control	
+	property alias	control:			control
 	property alias	label:				beforeLabel.text
 	property alias	text:				beforeLabel.text
 	property alias	value:				control.text

--- a/JASP-Desktop/components/JASP/Widgets/ContrastsList.qml
+++ b/JASP-Desktop/components/JASP/Widgets/ContrastsList.qml
@@ -88,37 +88,25 @@ Item
 		visible				: count > 0
 		source				: [ { name: "contrasts", condition: "contrastValue == 'custom'", conditionVariables: [{ name: "contrastValue", component: "contrast", property: "currentValue"}] }]
 
-		rowComponents:
-		[
-			Component
+		rowComponent: Group
+		{
+			Text
 			{
-				FocusScope // This is needed to keep focus working right when reusing the component
-				{
-					Group
-					{
-						id					: group
-						property var control: tableCustomContrasts.control
-
-						Text
-						{
-							height			: 30 * preferencesModel.uiScale
-							text			: qsTr("Custom contrast for %1").arg(rowValue)
-						}
-
-						CustomContrastsTableView
-						{
-							id						: tableCustomContrasts
-							columnName				: rowValue
-							factorsSource			: contrastsList.repeatedMeasureFactors
-							name					: "values"
-							implicitHeight			: 130 * preferencesModel.uiScale
-							implicitWidth			: customContrastsView.cellWidth
-							width					: implicitWidth
-							height					: implicitHeight
-						}
-					}
-				}
+				height			: 30 * preferencesModel.uiScale
+				text			: qsTr("Custom contrast for %1").arg(rowValue)
 			}
-		]
+
+			CustomContrastsTableView
+			{
+				id						: tableCustomContrasts
+				columnName				: rowValue
+				factorsSource			: contrastsList.repeatedMeasureFactors
+				name					: "values"
+				implicitHeight			: 130 * preferencesModel.uiScale
+				implicitWidth			: customContrastsView.cellWidth
+				width					: implicitWidth
+				height					: implicitHeight
+			}
+		}
 	}
 }

--- a/JASP-Desktop/widgets/boundqmlradiobuttons.cpp
+++ b/JASP-Desktop/widgets/boundqmlradiobuttons.cpp
@@ -33,6 +33,7 @@ BoundQMLRadioButtons::BoundQMLRadioButtons(JASPControlBase* item)
 
 void BoundQMLRadioButtons::setUp()
 {
+	JASPControlWrapper::setUp();
 	QList<JASPControlWrapper* > buttons;
 	_getRadioButtons(item(), buttons);
 	QVariant buttonGroup = getItemProperty("buttonGroup");

--- a/JASP-Desktop/widgets/boundqmltextinput.cpp
+++ b/JASP-Desktop/widgets/boundqmltextinput.cpp
@@ -279,6 +279,7 @@ bool BoundQMLTextInput::isJsonValid(const Json::Value &optionValue)
 
 void BoundQMLTextInput::setUp()
 {
+	JASPControlWrapper::setUp();
 	if (form())
 		// For unknown reason, when the language is changed, QML reset the default value.
 		// We have then to set back the value from the option

--- a/JASP-Desktop/widgets/jaspcontrolwrapper.cpp
+++ b/JASP-Desktop/widgets/jaspcontrolwrapper.cpp
@@ -53,7 +53,7 @@ void JASPControlWrapper::setUp()
 		parent = parent->parentItem();
 
 	if (parent && parent->objectName() == "Section")
-		item()->setSection(parent);
+		item()->setSection(parent);	
 }
 
 JASPControlWrapper* JASPControlWrapper::buildJASPControlWrapper(JASPControlBase* control)
@@ -77,6 +77,7 @@ JASPControlWrapper* JASPControlWrapper::buildJASPControlWrapper(JASPControlBase*
 	}
 	case JASPControlBase::ControlType::ComboBox:					controlWrapper		= new BoundQMLComboBox(control);					break;
 	case JASPControlBase::ControlType::Expander:					controlWrapper		= new QMLExpander(control);							break;
+	case JASPControlBase::ControlType::GroupBox:					controlWrapper		= new JASPControlWrapper(control);					break;
 	case JASPControlBase::ControlType::TableView:					controlWrapper		= new BoundQMLTableView(control);					break;
 	case JASPControlBase::ControlType::TextField:					controlWrapper		= new BoundQMLTextInput(control);					break;
 	case JASPControlBase::ControlType::FactorsForm:					controlWrapper		= new BoundQMLFactorsForm(control);					break;

--- a/JASP-Desktop/widgets/qmlexpander.cpp
+++ b/JASP-Desktop/widgets/qmlexpander.cpp
@@ -54,7 +54,7 @@ void QMLExpander::setUp()
 	if (nextExpander)
 		setItemProperty("nextExpander", QVariant::fromValue(nextExpander->item()));
 
-	QObject* childControlsArea = item()->childControlsArea().value<QObject*>();
+	QQuickItem* childControlsArea = item()->childControlsArea();
 
 	if (childControlsArea)
 	{


### PR DESCRIPTION
. Add also optionChanged signal and make refreshAnalysis invokable:
this makes now possible to control from QML when the analysis should be
run when some options are changed.
. Clean up code that set the debug & focus properties: transfer some
handlings from javascript to c++