### PR TITLE
Add different features/fixes for Mixed Models

### DIFF
--- a/JASP-Common/enumutilities.h
+++ b/JASP-Common/enumutilities.h
@@ -33,6 +33,7 @@
 	std::string		&operator+=(std::string &str, E enumTmp);													\
 	E				operator++(E &enumTmp);																		\
 	E				E##FromString(std::string enumName);														\
+	E				E##FromString(std::string enumName, E devaultValue);										\
 	std::string		E##ToString(E enumVal);																		\
 	bool			valid##E(T value);
 
@@ -71,6 +72,12 @@
 			throw std::runtime_error(#E" enum from string misses requested value \""+enumName+"\"");			\
 		return (E)E##FromNameMap.at(enumName); 																	\
 	}																											\
+	E E##FromString(std::string enumName, E defaultValue)														\
+	{																											\
+		if(E##FromNameMap.count(enumName) == 0) 																\
+			return defaultValue;																				\
+		return (E)E##FromNameMap.at(enumName); 																	\
+	}																											\
 	std::string E##ToString(E enumVal)		{ return ~enumVal; }												\
 	bool		valid##E(T value) { return (E##MapName.find(value) != E##MapName.end()); }
 
@@ -78,6 +85,7 @@
 	#define DECLARE_ENUM_WITH_TYPE_HEADER(E, T, ...)															\
 	DECLARE_ENUM_WITH_TYPE_BASE(E, T, __VA_ARGS__)																\
 	inline E		E##FromQString(QString enumName)	{ return (E)E##FromString(enumName.toStdString()); }	\
+	inline E		E##FromQString(QString enumName, E defaultValue)	{ return (E)E##FromString(enumName.toStdString(), defaultValue); }	\
 	inline QString	E##ToQString(E enumVal)		{ return QString::fromStdString(~enumVal); }					\
 	inline QString	operator+(QString &&str, E enumTmp) { return str + E##ToQString(enumTmp); }					\
 	inline QString	operator+(E enumTmp, QString &&str) { return E##ToQString(enumTmp) + str;	}				\

--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -798,7 +798,9 @@ bool AnalysisForm::runWhenThisOptionIsChanged(Option *option)
 	BoundQMLItem* control = getBoundItem(option);
 	JASPControlBase* item = control ? control->item() : nullptr;
 
-	emit optionChanged(item);
+	emit valueChanged(item);
+	if (item)
+		emit item->valueChanged();
 
 	if (!_runOnChange)
 		return false;

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -87,7 +87,7 @@ signals:
 				void			needsRefreshChanged();
 				void			hasVolatileNotesChanged();
 				void			runOnChangeChanged();
-				void			optionChanged(JASPControlBase* item);
+				void			valueChanged(JASPControlBase* item);
 
 protected:
 				QVariant		requestInfo(const Term &term, VariableInfo::InfoType info) const override;

--- a/JASP-Desktop/analysis/jaspcontrolbase.h
+++ b/JASP-Desktop/analysis/jaspcontrolbase.h
@@ -136,6 +136,7 @@ signals:
 	void runOnChangeChanged();
 	void innerControlChanged();
 	void backgroundChanged();
+	void valueChanged();
 
 protected:
 	void componentComplete() override;

--- a/JASP-Desktop/analysis/options/option.cpp
+++ b/JASP-Desktop/analysis/options/option.cpp
@@ -34,8 +34,9 @@ void Option::blockSignals(bool block, bool notifyOnceUnblocked)
 
 		if (_signalsBlocked == 0 && notifyOnceUnblocked && _shouldSignalChangedOnceUnblocked)
 		{
-			changed(this);
+			changed(_optionToSignalOnceUnblocked ? _optionToSignalOnceUnblocked : this);
 			_shouldSignalChangedOnceUnblocked = false;
+			_optionToSignalOnceUnblocked = nullptr;
 		}
 	}
 }
@@ -48,7 +49,10 @@ bool Option::isTransient() const
 void Option::notifyChanged(Option* option)
 {
 	if (_signalsBlocked)
+	{
+		_optionToSignalOnceUnblocked = option;
 		_shouldSignalChangedOnceUnblocked = true;
+	}
 	else
 		changed(option);
 }

--- a/JASP-Desktop/analysis/options/option.h
+++ b/JASP-Desktop/analysis/options/option.h
@@ -87,6 +87,7 @@ protected:
 private:
 	int			_signalsBlocked						= 0;
 	bool		_shouldSignalChangedOnceUnblocked	= false;
+	Option*		_optionToSignalOnceUnblocked		= nullptr;
 
 };
 

--- a/JASP-Desktop/components/JASP/Controls/GroupBox.qml
+++ b/JASP-Desktop/components/JASP/Controls/GroupBox.qml
@@ -97,7 +97,10 @@ JASPControl
 		{
 			var child = contentArea.children[i];
 			if (child.hasOwnProperty('controlType') && child.controlType === JASPControlBase.TextField)
+			{
+				child.visibleChanged.connect(_alignTextField);
 				_allTextFields.push(child)
+			}
 		}
 
 		alignTextFieldTimer.start()

--- a/JASP-Desktop/components/JASP/Controls/RadioButtonGroup.qml
+++ b/JASP-Desktop/components/JASP/Controls/RadioButtonGroup.qml
@@ -33,6 +33,7 @@ JASPControl
 
 	default property alias	content:				contentArea.children
 			property alias	buttons:				buttonGroup.buttons
+			property alias	checkedButton:			buttonGroup.checkedButton
 			property var	buttonGroup:			buttonGroup
 			property bool	radioButtonsOnSameRow:	false
 			property alias	columns:				contentArea.columns

--- a/JASP-Desktop/components/JASP/Controls/VariablesList.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesList.qml
@@ -53,9 +53,10 @@ JASPListControl
 	property bool	addAvailableVariablesToAssigned	: listViewType === JASP.Interaction
 	property bool	allowAnalysisOwnComputedColumns	: true
 	property bool	allowDuplicatesInMultipleColumns: false // This property is used in the constructor and is not updatable afterwards.
-	
+	property var	columnsTypes					: [] // This is set automatically by the item self each time that the model is changed
+
 	property var	interactionControl
-	property bool	addInteractionOptions			:false
+	property bool	addInteractionOptions			: false
 
 	property int	indexInDroppedListViewOfDraggedItem:	-1
 	

--- a/JASP-Desktop/widgets/boundqmllistviewterms.cpp
+++ b/JASP-Desktop/widgets/boundqmllistviewterms.cpp
@@ -40,12 +40,11 @@ BoundQMLListViewTerms::BoundQMLListViewTerms(JASPControlBase* item, bool interac
 	_optionVariables = nullptr;
 	_maxRows = getItemProperty("maxRows").toInt();
 	_columns = getItemProperty("columns").toInt();
-	bool addAvailableTermsToAssigned = getItemProperty("addAvailableVariablesToAssigned").toBool();
 	bool interactionContainLowerTerms = getItemProperty("interactionContainLowerTerms").toBool();
 	_interactionHighOrderCheckBoxName = getItemProperty("interactionHighOrderCheckBox").toString();
 		
 	if (interaction)
-		_termsModel = new ListModelInteractionAssigned(this, addAvailableTermsToAssigned, interactionContainLowerTerms);
+		_termsModel = new ListModelInteractionAssigned(this, interactionContainLowerTerms);
 	else if (_columns > 1)
 		_termsModel = new ListModelMultiTermsAssigned(this, _columns);
 	else
@@ -226,6 +225,8 @@ bool BoundQMLListViewTerms::isJsonValid(const Json::Value &optionValue)
 
 void BoundQMLListViewTerms::modelChangedHandler()
 {
+	setItemProperty("columnsTypes", QVariant(_termsModel->itemTypes()));
+
 	if (_optionsTable)
 	{
 		vector<Options*> allOptions;

--- a/JASP-Desktop/widgets/boundqmltextinput.cpp
+++ b/JASP-Desktop/widgets/boundqmltextinput.cpp
@@ -426,6 +426,7 @@ void BoundQMLTextInput::textChangedSlot()
 			{
 				if (_formula)
 					_formula->setValue(_value.toStdString());
+				emit formulaCheckSucceeded();
 			}
 			else
 				runRScript("as.character(" + _value + ")", true);

--- a/JASP-Desktop/widgets/listmodel.cpp
+++ b/JASP-Desktop/widgets/listmodel.cpp
@@ -481,17 +481,18 @@ const QString &ListModel::name() const
 
 const Terms &ListModel::terms(const QString &what) const
 {
-	if (what.startsWith("type="))
+	const QString typeIs = "type=";
+
+	if (what.startsWith(typeIs))
 	{
 		static Terms terms;
 
-		QStringList typesStr = what.right(what.length() - 5).toLower().split("|");
+		QStringList typesStr = what.right(what.length() - typeIs.length()).toLower().split("|");
 		QList<columnType> types;
 
 		for (const QString& typeStr : typesStr)
 		{
-			columnType type = columnType::unknown;
-			try { type = columnTypeFromQString(typeStr); } catch (...) {}
+			columnType type = columnTypeFromQString(typeStr, columnType::unknown);
 			if (type != columnType::unknown)
 				types.push_back(type);
 		}

--- a/JASP-Desktop/widgets/listmodel.h
+++ b/JASP-Desktop/widgets/listmodel.h
@@ -60,7 +60,7 @@ public:
 
 			QMLListView*			listView() const								{ return _listView; }
 			const QString &			name() const;
-	virtual const Terms &			terms(const QString& what = QString())	const	{ return _terms; }
+	virtual const Terms &			terms(const QString& what = QString())	const;
 			bool					areTermsVariables() const						{ return _areTermsVariables; }
 			bool					areTermsInteractions() const					{ return _areTermsInteractions; }
 	virtual QString					getItemType(const Term& term) const				{ return _itemType; }
@@ -87,6 +87,7 @@ public:
 	Q_INVOKABLE void				selectAllItems();
 	Q_INVOKABLE QList<int>			selectedItems()			{ return _selectedItems; }
 	Q_INVOKABLE QList<QString>		selectedItemsTypes()	{ return _selectedItemsTypes.toList(); }
+	Q_INVOKABLE QList<QString>		itemTypes();
 
 			void					replaceVariableName(const std::string & oldName, const std::string & newName);
 

--- a/JASP-Desktop/widgets/listmodeldraggable.cpp
+++ b/JASP-Desktop/widgets/listmodeldraggable.cpp
@@ -24,6 +24,7 @@ ListModelDraggable::ListModelDraggable(QMLListView* listView)
 	, _copyTermsWhenDropped(false)	
 {
 	_allowAnalysisOwnComputedColumns = listView->getItemProperty("allowAnalysisOwnComputedColumns").toBool();
+	_addNewAvailableTermsToAssignedModel = listView->getItemProperty("addAvailableVariablesToAssigned").toBool();
 }
 
 Terms ListModelDraggable::termsFromIndexes(const QList<int> &indexes) const

--- a/JASP-Desktop/widgets/listmodelinteractionassigned.cpp
+++ b/JASP-Desktop/widgets/listmodelinteractionassigned.cpp
@@ -25,12 +25,11 @@
 
 using namespace std;
 
-ListModelInteractionAssigned::ListModelInteractionAssigned(QMLListView* listView, bool addAvailableTermsToAssigned, bool mustContainLowerTerms)
+ListModelInteractionAssigned::ListModelInteractionAssigned(QMLListView* listView, bool mustContainLowerTerms)
 	: ListModelAssignedInterface(listView), InteractionModel ()
 {
 	_areTermsInteractions = true;
 	_copyTermsWhenDropped = true;
-	_addNewAvailableTermsToAssignedModel = addAvailableTermsToAssigned;
 	_mustContainLowerTerms = mustContainLowerTerms;
 }
 
@@ -38,6 +37,23 @@ void ListModelInteractionAssigned::initTerms(const Terms &terms, const RowContro
 {
 	_addTerms(terms, false);
 	ListModelAssignedInterface::initTerms(interactionTerms(), allOptionsMap);
+}
+
+const Terms &ListModelInteractionAssigned::terms(const QString &what) const
+{
+	if (what == "noInteraction")
+	{
+		static Terms terms;
+
+		terms.clear();
+		terms.add(_fixedFactors);
+		terms.add(_randomFactors);
+		terms.add(_covariates);
+
+		return terms;
+	}
+	else
+		return ListModelAssignedInterface::terms(what);
 }
 
 void ListModelInteractionAssigned::setAvailableModel(ListModelAvailableInterface *source)

--- a/JASP-Desktop/widgets/listmodelinteractionassigned.h
+++ b/JASP-Desktop/widgets/listmodelinteractionassigned.h
@@ -30,17 +30,18 @@ class ListModelInteractionAssigned : public ListModelAssignedInterface, public I
 	Q_OBJECT
 	
 public:
-	ListModelInteractionAssigned(QMLListView* listView, bool addAvailableTermsToAssigned, bool mustContainLowerTerms);
+	ListModelInteractionAssigned(QMLListView* listView, bool mustContainLowerTerms);
 
-	void	initTerms(const Terms &terms, const RowControlsOptions& = RowControlsOptions())	override;
-	void	setAvailableModel(ListModelAvailableInterface *source)							override;
-	Terms	termsFromIndexes(const QList<int> &indexes)								const	override;
-	Terms	canAddTerms(const Terms& terms) const override;
-	Terms	addTerms(const Terms& terms, int dropItemIndex = -1, JASPControlBase::AssignType assignType = JASPControlBase::AssignType::AssignDefault) override;
-	void	moveTerms(const QList<int>& indexes, int dropItemIndex = -1)					override;
-	void	removeTerms(const QList<int> &indices)											override;
-	QString getItemType(const Term &term)											const	override;
-	
+	void			initTerms(const Terms &terms, const RowControlsOptions& = RowControlsOptions())	override;
+	void			setAvailableModel(ListModelAvailableInterface *source)							override;
+	Terms			termsFromIndexes(const QList<int> &indexes)								const	override;
+	Terms			canAddTerms(const Terms& terms) const override;
+	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, JASPControlBase::AssignType assignType = JASPControlBase::AssignType::AssignDefault) override;
+	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)					override;
+	void			removeTerms(const QList<int> &indices)											override;
+	QString			getItemType(const Term &term)											const	override;
+	const Terms&	terms(const QString& what = QString())									const	override;
+
 		
 public slots:
 	void availableTermsChanged(const Terms* termsToAdd, const Terms* termsToRemove) override;

--- a/JASP-Desktop/widgets/listmodeltermsassigned.cpp
+++ b/JASP-Desktop/widgets/listmodeltermsassigned.cpp
@@ -43,9 +43,19 @@ void ListModelTermsAssigned::initTerms(const Terms &terms, const RowControlsOpti
 
 void ListModelTermsAssigned::availableTermsChanged(const Terms* termsAdded, const Terms* termsRemoved)
 {
-	// Only remove the terms that are not available anymore
-	Q_UNUSED(termsAdded);
-	
+	if (termsAdded && termsAdded->size() > 0 && _addNewAvailableTermsToAssignedModel)
+	{
+		beginResetModel();
+		_terms.add(*termsAdded);
+		endResetModel();
+
+		_tempTermsToAdd.set(*termsAdded);
+		emit modelChanged(&_tempTermsToAdd, nullptr);
+
+		if (!_copyTermsWhenDropped)
+			source()->removeTermsInAssignedList();
+	}
+
 	if (termsRemoved && termsRemoved->size() > 0)
 	{
 		beginResetModel();


### PR DESCRIPTION
. addNewAvailableTermsToAssignedModel property should work for all
VariablesList
. Alignment of TextField in a Group should work even if some of the
TextField becomes visible/invisible
. Add “noInteraction” in the source property to discard interaction
terms.
. Add “type=scale|ordinale|ordinal| in the source property to select
only some column types
. Add itemTypes property in VariablesList that contain all column types
. MarginalMeansContrast does not update if value is set back to 0
(default value)