### PR TITLE
Independent samples T-Test: fix "result not found" bug

### DIFF
--- a/JASP-Engine/JASP/R/ttestindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestindependentsamples.R
@@ -241,8 +241,13 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
         
         if (!isTryError(result))
           row <- c(row, result[["row"]])
-        else
+        else {
           errorMessage <- .extractErrorMessage(result)
+
+          if (result[["leveneViolated"]])
+            table$addFootnote(gettext("Levene's test is significant (p < .05), suggesting a violation of the equal variance assumption"), colNames = "p", rowNames = rowName)
+
+        }
         
       } else {
         errorMessage <- errors$message
@@ -252,9 +257,6 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
         row[[testStat]] <- NaN
         table$addFootnote(errorMessage, colNames = testStat, rowNames = rowName)
       }
-      
-      if (result[["leveneViolated"]])
-        table$addFootnote(gettext("Levene's test is significant (p < .05), suggesting a violation of the equal variance assumption"), colNames = "p", rowNames = rowName)
       
       table$addRows(row, rowNames = rowName)
     }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/724

The bug is the following (the diff doesn't show all relevant code). Starting from https://github.com/jasp-stats/jasp-desktop/blob/stable/JASP-Engine/JASP/R/ttestindependentsamples.R#L239, we have:

```r
if (identical(errors, FALSE)) {
  result <- try(ttestIndependentMainTableRow(variable, dataset, test, testStat, effSize, optionsList, options))

  # more stuff 
}

if (result[["leveneViolated"]])
  table$addFootnote(gettext("Levene's test is significant (p < .05), suggesting a violation of the equal variance assumption"), colNames = "p", rowNames = rowName)
```
The bug is that when `identical(errors, FALSE)` returns `FALSE`, `result` is never created and `if (result[["leveneViolated"]])` causes an error. 

The fix is to put the `if (result[["leveneViolated"]])` part inside of the `if (identical(errors, FALSE))`. 

To replicate the error, run an independent samples t-test with `debInf` as variable and `contBinom` as grouping variable. 
Stable returns the same error as the linked issue, this PR shows what's wrong with `debInf` as a footnote in the main table (the intended behavior).

