### PR TITLE
Show folder in window title

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/OSF.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/OSF.qml
@@ -149,7 +149,7 @@ Item
 			id 		: saveFoldernameLabel
 			text	: qsTr("Foldername")
 
-			width	: 80 * preferencesModel.uiScale
+			width	: Math.max(80 * preferencesModel.uiScale, implicitWidth)
 			height	: 30 * preferencesModel.uiScale
 			color 	: jaspTheme.black
 			font	: jaspTheme.font
@@ -258,7 +258,7 @@ Item
 			id 		: saveFilenameLabel
 			text	: qsTr("Filename")
 
-			width	: 80 * preferencesModel.uiScale
+			width	: Math.max(80 * preferencesModel.uiScale, implicitWidth)
 			height	: 30 * preferencesModel.uiScale
 			color 	: jaspTheme.black
 			font	: jaspTheme.font

--- a/JASP-Desktop/data/datasetpackage.cpp
+++ b/JASP-Desktop/data/datasetpackage.cpp
@@ -39,9 +39,9 @@ DataSetPackage::DataSetPackage(QObject * parent) : QAbstractItemModel(parent)
 
 	connect(this, &DataSetPackage::isModifiedChanged,	this, &DataSetPackage::windowTitleChanged);
 	connect(this, &DataSetPackage::loadedChanged,		this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::currentPathChanged,	this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::currentFileChanged,	this, &DataSetPackage::windowTitleChanged);
 	connect(this, &DataSetPackage::folderChanged,		this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::currentPathChanged,	this, &DataSetPackage::nameChanged);
+	connect(this, &DataSetPackage::currentFileChanged,	this, &DataSetPackage::nameChanged);
 }
 
 void DataSetPackage::setEngineSync(EngineSync * engineSync)
@@ -93,7 +93,7 @@ void DataSetPackage::reset()
 
 	setLoaded(false);
 	setModified(false);
-	setCurrentPath("");
+	setCurrentFile("");
 
 	resetEmptyValues();
 	endLoadingData();
@@ -1394,21 +1394,21 @@ std::vector<bool> DataSetPackage::filterVector()
 }
 
 
-void DataSetPackage::setCurrentPath(QString currentPath)
+void DataSetPackage::setCurrentFile(QString currentFile)
 {
-	if (_currentPath == currentPath)
+	if (_currentFile == currentFile)
 		return;
 
-	_currentPath = currentPath;
-	emit currentPathChanged();
+	_currentFile = currentFile;
 	emit currentFileChanged();
 
-	QUrl url(_currentPath);
+	QFileInfo	file(_currentFile);
+	QUrl		url(_currentFile);
 
 #ifdef _WIN32
-	setFolder(currentFile().exists() ? currentFile().absolutePath().replace('/', '\\') : url.isValid() ? "OSF" : "");
+	setFolder(file.exists() ? file.absolutePath().replace('/', '\\')	: url.isValid() ? "OSF" : "");
 #else
-	setFolder(currentFile().exists() ? currentFile().absolutePath() : url.isValid() ? "OSF" : "");
+	setFolder(file.exists() ? file.absolutePath()						: url.isValid() ? "OSF" : "");
 #endif
 }
 
@@ -1439,8 +1439,10 @@ void DataSetPackage::setFolder(QString folder)
 
 QString DataSetPackage::name() const
 {
-	if(currentFile().completeBaseName() != "")
-		return currentFile().completeBaseName();
+	QFileInfo	file(_currentFile);
+
+	if(file.completeBaseName() != "")
+		return file.completeBaseName();
 
 	return "JASP";
 }
@@ -1461,9 +1463,3 @@ QString DataSetPackage::windowTitle() const
 
 	return name + (isModified() ? "*" : "") + folder;
 }
-
-QFileInfo DataSetPackage::currentFile() const
-{
-	return QFileInfo(_currentPath);
-}
-

--- a/JASP-Desktop/data/datasetpackage.h
+++ b/JASP-Desktop/data/datasetpackage.h
@@ -47,8 +47,7 @@ class DataSetPackage : public QAbstractItemModel //Not QAbstractTableModel becau
 	Q_PROPERTY(QString		windowTitle				READ windowTitle									NOTIFY windowTitleChanged			)
 	Q_PROPERTY(bool			modified				READ isModified				WRITE setModified		NOTIFY isModifiedChanged			)
 	Q_PROPERTY(bool			loaded					READ isLoaded				WRITE setLoaded			NOTIFY loadedChanged				)
-	Q_PROPERTY(QFileInfo	currentFile				READ currentFile									NOTIFY currentFileChanged			)
-	Q_PROPERTY(QString		currentPath				READ currentPath			WRITE setCurrentPath	NOTIFY currentPathChanged			)
+	Q_PROPERTY(QString		currentFile				READ currentFile			WRITE setCurrentFile	NOTIFY currentFileChanged			)
 
 	typedef std::map<std::string, std::map<int, std::string>> emptyValsType;
 
@@ -113,8 +112,7 @@ public:
 				std::string			dataFilter()						const	{ return _dataFilter;						}
 				std::string			initialMD5()						const	{ return _initialMD5;						 }
 				QString				windowTitle()						const;
-				QFileInfo			currentFile()						const;
-				QString				currentPath()						const	{ return _currentPath;						 }
+				QString				currentFile()						const	{ return _currentFile;						 }
 				bool				hasAnalyses()						const	{ return _analysesData.size() > 0;			  }
 				std::string			dataFilePath()						const	{ return _dataFilePath;						   }
 		const	std::string		&	analysesHTML()						const	{ return _analysesHTML;							}
@@ -260,7 +258,6 @@ signals:
 				void				windowTitleChanged();
 				void				loadedChanged();
 				void				currentFileChanged();
-				void				currentPathChanged();
 
 public slots:
 				void				refresh() { beginResetModel(); endResetModel(); }
@@ -269,7 +266,7 @@ public slots:
 				void				notifyColumnFilterStatusChanged(int columnIndex);
 				void				setColumnsUsedInEasyFilter(std::set<std::string> usedColumns);
 				void				emptyValuesChangedHandler();
-				void				setCurrentPath(QString currentPath);
+				void				setCurrentFile(QString currentFile);
 
 				void setFolder(QString folder);
 
@@ -286,7 +283,7 @@ private:
 	EngineSync				*	_engineSync					= nullptr;
 	emptyValsType				_emptyValuesMap;
 
-	QString						_currentPath,
+	QString						_currentFile,
 								_folder;
 	std::string					_analysesHTML,
 								_id,

--- a/JASP-Desktop/data/fileevent.h
+++ b/JASP-Desktop/data/fileevent.h
@@ -35,8 +35,10 @@ public:
 					FileEvent(const FileEvent&) = default;
 	virtual			~FileEvent();
 
-	bool			setPath(const QString &path);
-	void			setDataFilePath(const QString &path);
+	bool			setPath(		const QString & path);
+	void			setDataFilePath(const QString & path);
+	void			setOsfPath(		const QString & path) { _osfPath = path; }
+
 	void			setComplete(bool success = true, const QString &message = "");
 	void			chain(FileEvent *event);
 
@@ -52,6 +54,7 @@ public:
 	Utils::FileType	type()			const { return _type;			}
 
 	const QString &	path()			const { return _path;			}
+	const QString &	osfPath()		const { return _osfPath;		}
 	const QString &	dataFilePath()	const { return _dataFilePath;	}
 	const QString &	message()		const { return _message;		}
 	const QString & getLastError()	const { return _last_error;		}
@@ -66,6 +69,7 @@ private:
 	FileMode			_operation;
 	Utils::FileType		_type;
 	QString				_path,
+						_osfPath		= "", //To show the user a friendly path
 						_dataFilePath,
 						_last_error		= "Unknown error",
 						_message;

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -921,7 +921,7 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 		{
 			populateUIfromDataSet();
 
-			_package->setCurrentPath(event->path());
+			_package->setCurrentFile(event->path());
 
 			if(event->osfPath() != "")
 				_package->setFolder("OSF://" + event->osfPath()); //It is also set by setCurrentPath, but then we get some weirdlooking OSF path
@@ -970,7 +970,7 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 
 		if (event->isSuccessful())
 		{
-			_package->setCurrentPath(event->path());
+			_package->setCurrentFile(event->path());
 			if(event->osfPath() != "")
 				_package->setFolder("OSF://" + event->osfPath()); //It is also set by setCurrentPath, but then we get some weirdlooking OSF path
 
@@ -1321,8 +1321,9 @@ void MainWindow::startDataEditorHandler()
 				name = name.replace('#', '_');
 			}
 
-			if (_package->currentFile().dir().exists() && ! _package->currentFile().absolutePath().startsWith(AppDirs::examples())) //If the file was opened from a directory that exists and is not examples we use that as basis to open a csv
-				name = _package->currentFile().dir().absoluteFilePath(_package->name().replace('#', '_') + ".csv");
+			QFileInfo pkgFile(_package->currentFile());
+			if (pkgFile.dir().exists() && ! pkgFile.absolutePath().startsWith(AppDirs::examples())) //If the file was opened from a directory that exists and is not examples we use that as basis to open a csv
+				name = pkgFile.dir().absoluteFilePath(_package->name().replace('#', '_') + ".csv");
 
 			path = MessageForwarder::browseSaveFile(caption, name, filter);
 

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -25,7 +25,7 @@
 #include <QDir>
 
 #include <QFile>
-#include <QFileInfo>
+#include <QUrl>
 #include <QShortcut>
 #include <QStringBuilder>
 #include <QDesktopServices>
@@ -193,6 +193,11 @@ MainWindow::~MainWindow()
 	}
 }
 
+QString MainWindow::windowTitle() const
+{
+	return _package->windowTitle();
+}
+
 bool MainWindow::checkDoSync()
 {
 	if (checkAutomaticSync() && !MessageForwarder::showYesNo(tr("Datafile changed"), tr("The datafile that was used by this JASP file was modified. Do you want to reload the analyses with this new data?")))
@@ -228,6 +233,7 @@ void MainWindow::makeConnections()
 	connect(_package,				&DataSetPackage::datasetChanged,					_filterModel,			&FilterModel::datasetChanged,									Qt::QueuedConnection);
 	connect(_package,				&DataSetPackage::datasetChanged,					_computedColumnsModel,	&ComputedColumnsModel::datasetChanged,							Qt::QueuedConnection);
 	connect(_package,				&DataSetPackage::isModifiedChanged,					this,					&MainWindow::packageChanged									);
+	connect(_package,				&DataSetPackage::windowTitleChanged,				this,					&MainWindow::windowTitleChanged								);
 	connect(_package,				&DataSetPackage::columnDataTypeChanged,				_computedColumnsModel,	&ComputedColumnsModel::recomputeColumn						);
 	connect(_package,				&DataSetPackage::freeDatasetSignal,					_loader,				&AsyncLoader::free											);
 	connect(_package,				&DataSetPackage::checkDoSync,						_loader,				&AsyncLoader::checkDoSync,									Qt::DirectConnection); //Force DirectConnection because the signal is called from Importer which means it is running in AsyncLoaderThread...
@@ -624,15 +630,7 @@ void MainWindow::syncKeyPressed()
 
 void MainWindow::packageChanged()
 {
-	QString title = windowTitle();
-	if (title.isEmpty())
-		title = "JASP";
-
-	if (_package->isModified())	title += '*';
-	else						title.chop(1);
-
-
-	setWindowTitle(title);
+	emit windowTitleChanged();
 }
 
 
@@ -922,9 +920,11 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 		if (event->isSuccessful())
 		{
 			populateUIfromDataSet();
-			QString name = QFileInfo(event->path()).completeBaseName();
-			setWindowTitle(name);
-			_currentFilePath = event->path();
+
+			_package->setCurrentPath(event->path());
+
+			if(event->osfPath() != "")
+				_package->setFolder("OSF://" + event->osfPath()); //It is also set by setCurrentPath, but then we get some weirdlooking OSF path
 
 			if (event->type() == Utils::FileType::jasp && !_package->dataFilePath().empty() && !_package->dataFileReadOnly() && strncmp("http", _package->dataFilePath().c_str(), 4) != 0)
 			{
@@ -970,10 +970,11 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 
 		if (event->isSuccessful())
 		{
-			QString name = QFileInfo(event->path()).completeBaseName();
+			_package->setCurrentPath(event->path());
+			if(event->osfPath() != "")
+				_package->setFolder("OSF://" + event->osfPath()); //It is also set by setCurrentPath, but then we get some weirdlooking OSF path
 
 			_package->setModified(false);
-			setWindowTitle(name);
 
 			if(testingAndSaving)
 				std::cerr << "Tested and saved " << event->path().toStdString() << " succesfully!" << std::endl;
@@ -989,8 +990,7 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 			if(testingAndSaving)
 				std::cerr << "Tested " << event->path().toStdString() << " but saving failed because of: " << event->message().toStdString() << std::endl;
 
-			if(_savingForClose)
-				_savingForClose = false; //User should get to try again.
+			_savingForClose = false; //User should get to try again.
 		}
 
 		if(testingAndSaving)
@@ -1005,8 +1005,6 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 			_package->reset();
 
 			setWelcomePageVisible(true);
-			setWindowTitle("JASP");
-
 			_engineSync->cleanUpAfterClose();
 
 			if (_applicationExiting)	QApplication::exit();
@@ -1031,9 +1029,9 @@ void MainWindow::populateUIfromDataSet()
 
 	if (_package->hasAnalyses())
 	{
-		int corruptAnalyses = 0;
-		stringstream corruptionStrings;
-		Analysis* currentAnalysis = nullptr;
+		int				corruptAnalyses = 0;
+		stringstream	corruptionStrings;
+		Analysis	*	currentAnalysis = nullptr;
 
 		//This really should all be moved to Analyses!
 
@@ -1322,11 +1320,9 @@ void MainWindow::startDataEditorHandler()
 				name.truncate(name.length() - 1);
 				name = name.replace('#', '_');
 			}
-			if (!_currentFilePath.isEmpty())
-			{
-				QFileInfo file(_currentFilePath);
-				name = file.absolutePath() + QDir::separator() + file.completeBaseName().replace('#', '_') + ".csv";
-			}
+
+			if (_package->currentFile().dir().exists() && ! _package->currentFile().absolutePath().startsWith(AppDirs::examples())) //If the file was opened from a directory that exists and is not examples we use that as basis to open a csv
+				name = _package->currentFile().dir().absoluteFilePath(_package->name().replace('#', '_') + ".csv");
 
 			path = MessageForwarder::browseSaveFile(caption, name, filter);
 
@@ -1566,16 +1562,6 @@ void MainWindow::setDataPanelVisible(bool dataPanelVisible)
 
 	_dataPanelVisible = dataPanelVisible;
 	emit dataPanelVisibleChanged(_dataPanelVisible);
-}
-
-
-void MainWindow::setWindowTitle(QString windowTitle)
-{
-	if (_windowTitle == windowTitle)
-		return;
-
-	_windowTitle = windowTitle;
-	emit windowTitleChanged(_windowTitle);
 }
 
 void MainWindow::removeAnalysis(Analysis *analysis)

--- a/JASP-Desktop/mainwindow.h
+++ b/JASP-Desktop/mainwindow.h
@@ -68,7 +68,7 @@ class MainWindow : public QObject
 	Q_PROPERTY(int		progressBarProgress	READ progressBarProgress	WRITE setProgressBarProgress	NOTIFY progressBarProgressChanged	)
 	Q_PROPERTY(QString	progressBarStatus	READ progressBarStatus		WRITE setProgressBarStatus		NOTIFY progressBarStatusChanged		)
 	Q_PROPERTY(bool		dataPanelVisible	READ dataPanelVisible		WRITE setDataPanelVisible		NOTIFY dataPanelVisibleChanged		)
-	Q_PROPERTY(QString	windowTitle			READ windowTitle			WRITE setWindowTitle			NOTIFY windowTitleChanged			)
+	Q_PROPERTY(QString	windowTitle			READ windowTitle											NOTIFY windowTitleChanged			)
 	Q_PROPERTY(int		screenPPI			READ screenPPI				WRITE setScreenPPI				NOTIFY screenPPIChanged				)
 	Q_PROPERTY(bool		dataAvailable		READ dataAvailable											NOTIFY dataAvailableChanged			)
 	Q_PROPERTY(bool		analysesAvailable	READ analysesAvailable										NOTIFY analysesAvailableChanged		)
@@ -87,7 +87,7 @@ public:
 	int		progressBarProgress()	const	{ return _progressBarProgress;	}
 	QString	progressBarStatus()		const	{ return _progressBarStatus;	}
 	bool	dataPanelVisible()		const	{ return _dataPanelVisible;		}
-	QString	windowTitle()			const	{ return _windowTitle;			}
+	QString	windowTitle()			const;
 	int		screenPPI()				const	{ return _screenPPI;			}
 	bool	dataAvailable()			const	{ return _dataAvailable;		}
 	bool	analysesAvailable()		const	{ return _analysesAvailable;	}
@@ -105,8 +105,6 @@ public slots:
 	void setAnalysesAvailable(bool analysesAvailable);
 	void setDataPanelVisible(bool dataPanelVisible);
 	void setDataAvailable(bool dataAvailable);
-	//void setDatasetLoaded(bool datasetLoaded);
-	void setWindowTitle(QString windowTitle);
 	void setScreenPPI(int screenPPI);
 
 	bool checkPackageModifiedBeforeClosing();
@@ -183,21 +181,21 @@ private:
 
 signals:
 	void saveJaspFile();
-	void editImageCancelled(int id);
-	void updateAnalysesUserData(QString userData);
-	void runButtonTextChanged(QString runButtonText);
-	void runButtonEnabledChanged(bool runButtonEnabled);
-	void progressBarVisibleChanged(bool progressBarVisible);
-	void progressBarProgressChanged(int progressBarProgress);
-	void progressBarStatusChanged(QString progressBarStatus);
-	void dataPanelVisibleChanged(bool dataPanelVisible);
-	void analysesVisibleChanged(bool analysesVisible);
-	void windowTitleChanged(QString windowTitle);
-	void screenPPIChanged(int screenPPI);
-	void dataAvailableChanged(bool dataAvailable);
-	void analysesAvailableChanged(bool analysesAvailable);
-	void welcomePageVisibleChanged(bool welcomePageVisible);
-	void downloadNewJASPUrlChanged(QString downloadNewJASPUrl);
+	void editImageCancelled(		int			id);
+	void updateAnalysesUserData(	QString		userData);
+	void runButtonTextChanged(		QString		runButtonText);
+	void runButtonEnabledChanged(	bool		runButtonEnabled);
+	void progressBarVisibleChanged(	bool		progressBarVisible);
+	void progressBarProgressChanged(int			progressBarProgress);
+	void progressBarStatusChanged(	QString		progressBarStatus);
+	void dataPanelVisibleChanged(	bool		dataPanelVisible);
+	void analysesVisibleChanged(	bool		analysesVisible);
+	void windowTitleChanged();
+	void screenPPIChanged(			int			screenPPI);
+	void dataAvailableChanged(		bool		dataAvailable);
+	void analysesAvailableChanged(	bool		analysesAvailable);
+	void welcomePageVisibleChanged(	bool		welcomePageVisible);
+	void downloadNewJASPUrlChanged	(QString	downloadNewJASPUrl);
 
 private slots:
 	void resultsPageLoaded();
@@ -271,9 +269,7 @@ private:
 
 	QString							_openOnLoadFilename,
 									_fatalError				= "The engine crashed...",
-									_currentFilePath,
 									_progressBarStatus,
-									_windowTitle,
 									_downloadNewJASPUrl		= "";
 
 	AsyncLoader					*	_loader					= nullptr;

--- a/JASP-Desktop/widgets/filemenu/osf.h
+++ b/JASP-Desktop/widgets/filemenu/osf.h
@@ -31,30 +31,29 @@ class OSF: public FileMenuObject
 {
 	Q_OBJECT
 
-	Q_PROPERTY(	bool	loggedin		READ loggedin		WRITE setLoggedin		NOTIFY loggedinChanged)
-	Q_PROPERTY(	bool	processing		READ processing		WRITE setProcessing		NOTIFY processingChanged)
-	Q_PROPERTY(	bool	showfiledialog	READ showfiledialog WRITE setShowfiledialog NOTIFY showfiledialogChanged)
-	Q_PROPERTY(	QString	savefilename	READ savefilename	WRITE setSavefilename	NOTIFY savefilenameChanged)
-	Q_PROPERTY(	QString savefoldername	READ savefoldername	WRITE setSavefoldername	NOTIFY savefoldernameChanged)
-	Q_PROPERTY(	bool	rememberme		READ rememberme		WRITE setRememberme		NOTIFY remembermeChanged)
-	Q_PROPERTY(	QString	username		READ username		WRITE setUsername		NOTIFY usernameChanged)
-	Q_PROPERTY(	QString	password		READ password		WRITE setPassword		NOTIFY passwordChanged)
-
-	Q_PROPERTY(OSFListModel * listModel					READ listModel		WRITE setListModel		NOTIFY listModelChanged)
-	Q_PROPERTY(OSFBreadCrumbsListModel * breadCrumbs	READ breadCrumbs	WRITE setBreadCrumbs	NOTIFY breadCrumbsChanged)
-	Q_PROPERTY(SortMenuModel * sortedMenuModel			READ sortedMenuModel						NOTIFY sortedMenuModelChanged)
+	Q_PROPERTY(bool							loggedin		READ loggedin			WRITE setLoggedin		NOTIFY loggedinChanged			)
+	Q_PROPERTY(bool							processing		READ processing			WRITE setProcessing		NOTIFY processingChanged		)
+	Q_PROPERTY(bool							showfiledialog	READ showfiledialog		WRITE setShowfiledialog NOTIFY showfiledialogChanged	)
+	Q_PROPERTY(QString						savefilename	READ savefilename		WRITE setSavefilename	NOTIFY savefilenameChanged		)
+	Q_PROPERTY(QString						savefoldername	READ savefoldername		WRITE setSavefoldername	NOTIFY savefoldernameChanged	)
+	Q_PROPERTY(bool							rememberme		READ rememberme			WRITE setRememberme		NOTIFY remembermeChanged		)
+	Q_PROPERTY(QString						username		READ username			WRITE setUsername		NOTIFY usernameChanged			)
+	Q_PROPERTY(QString						password		READ password			WRITE setPassword		NOTIFY passwordChanged			)
+	Q_PROPERTY(OSFListModel				*	listModel		READ listModel			WRITE setListModel		NOTIFY listModelChanged			)
+	Q_PROPERTY(OSFBreadCrumbsListModel	*	breadCrumbs		READ breadCrumbs		WRITE setBreadCrumbs	NOTIFY breadCrumbsChanged		)
+	Q_PROPERTY(SortMenuModel			*	sortedMenuModel	READ sortedMenuModel							NOTIFY sortedMenuModelChanged	)
 
 public:
 	explicit OSF(QObject *parent = nullptr);
 
-	bool loggedin();
-	bool rememberme();
-	bool processing();
-	bool showfiledialog();
-	QString savefilename();
-	QString savefoldername();
-	QString username();
-	QString password();
+	bool loggedin()				const { return _mLoggedin;			}
+	bool rememberme()			const { return _mRememberMe;		}
+	bool processing()			const { return _mProcessing;		}
+	bool showfiledialog()		const { return _mShowFileDialog;	}
+	QString savefilename()		const { return _mSaveFileName;		}
+	QString savefoldername()	const { return _mSaveFolderName;	}
+	QString username()			const { return _mUserName;			}
+	QString password()			const { return _mPassword;			}
 
 	void setLoggedin(const bool loggedin);
 	void setRememberme(const bool rememberme);
@@ -89,7 +88,6 @@ signals:
 	void openFileRequest(QString path);
 	void listModelChanged(OSFListModel * listModel);
 	void breadCrumbsChanged(OSFBreadCrumbsListModel * breadCrumbs);
-
 	void sortedMenuModelChanged(SortMenuModel * sortedMenuModel);
 
 private slots:
@@ -97,9 +95,9 @@ private slots:
 	void notifyDataSetOpened(QString path);
 	void authenticationeFailed(QString message);
 	void saveClicked();
-	void openSaveFile(const QString &nodePath, const QString &filename);
+	void openSaveFile(const QString & nodePath, const QString & filename, const QString & osfpath = "");
 	void userDetailsReceived();
-	void openSaveCompleted(FileEvent* event);
+	void openSaveCompleted(FileEvent * event);
 	void updateUserDetails();
 	void newFolderCreated();
 	void resetOSFListModel();
@@ -138,7 +136,7 @@ private:
 			_mUserName,
 			_mPassword;
 
-	SortMenuModel * m_sortedMenuModel;
+	SortMenuModel * _sortedMenuModel;
 };
 
 

--- a/JASP-Desktop/widgets/filemenu/osffilesystem.h
+++ b/JASP-Desktop/widgets/filemenu/osffilesystem.h
@@ -38,20 +38,21 @@ public:
 	~OSFFileSystem() override;
 	void refresh() override;
 
-	typedef struct {
+	struct OnlineNodeData
+	{
 		QString name;
-		bool isFolder;
-		bool isComponent;
-		bool isProvider;
-		QString contentsPath;
-		QString childrenPath;
-		QString uploadPath;
-		QString downloadPath;
-		QString nodePath;
-		bool canCreateFolders;
-		bool canCreateFiles;
-		int level = 0;
-	} OnlineNodeData;
+		bool	isFolder,
+				isComponent,
+				isProvider;
+		QString	contentsPath,
+				childrenPath,
+				uploadPath,
+				downloadPath,
+				nodePath;
+		bool	canCreateFolders,
+				canCreateFiles;
+		int		level = 0;
+	};
 	
 	static const QString rootelementname; //Root element in the OSF
 


### PR DESCRIPTION
Window Title is now a property of DataSetPackage
- It also shows the folder where the file is stored
- Implements https://github.com/jasp-stats/INTERNAL-jasp/issues/730
- Also moves "current file" to DataSetPackage
- Added a small extra field to FileEvent to store browse path of OSF
-- This works pretty good except for when an OSF file is loaded from recent files, because the info isnt available then. But oh well, it then just says "(OSF)" as folder as fallback.
- Made sure OSF labels for filename and dirname aren't too small
- Some fixes and changes to make title look nice on Windows
- Also made sure that whenever a file is loaded from data library they do not get a folder behind them, because we do not want to make people scared with things like "Program Files" or "/usr/..."
- And finally, when a csv needs to be generated JASP will check if the directory it loaded the file from exists and if so open a save dialog positioned there. Unless it is the Data Library, then it will show documents.

