### PR TITLE
RM (B)ANOVA: fix names in long format data set

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -1747,7 +1747,7 @@ isTryError <- function(obj){
   return(key)
 }
 
-.shortToLong <- function(dataset, rm.factors, rm.vars, bt.vars) {
+.shortToLong <- function(dataset, rm.factors, rm.vars, bt.vars, dependentName = "dependent", subjectName = "subject") {
 
   f  <- rm.factors[[length(rm.factors)]]
   df <- data.frame(factor(unlist(f$levels), unlist(f$levels)))
@@ -1786,7 +1786,9 @@ isTryError <- function(obj){
   ds <- subset(dataset, select=.v(rm.vars))
   ds <- t(as.matrix(ds))
 
-  df <- cbind(df, dependent=as.numeric(c(ds)))
+  dependentDf <- data.frame(x = as.numeric(c(ds)))
+  colnames(dependentDf) <- dependentName
+  df <- cbind(df, dependentDf)
 
   for (bt.var in bt.vars) {
 
@@ -1800,7 +1802,9 @@ isTryError <- function(obj){
   subjects <- 1:(dim(dataset)[1])
   subjects <- as.factor(rep(subjects, each=row.count))
 
-  df <- cbind(df, subject=subjects)
+  subjectDf <- data.frame(x = subjects)
+  colnames(subjectDf) <- subjectName
+  df <- cbind(df, subjectDf)
 
   df
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/737

Both the repeated measures ANOVAs created a data set in long format with columns `subject` and `dependent`. Both analyses weren't very careful with encoding or decoding the column names and also encoded these names from time to time. The problem: if there's a column in the dataset called `subject` then the new encoding would happily replace this with `JaspColumn.xxx.Encoded`. However, the data set in long format does not have that as a column name. That's the summary of 737.

In addition, bad things happen when you added a covariate called `subject` or `dependent` to the analyses. The `.shortToLong` had the names `subject` and `dependent` hard coded and R "fixes" any duplicate names to become e.g., `subject.1`.

A summary of the fix:

- Made two constants, `.BANOVAdependentName <- "JaspColumn_.dependent._Encoded"` and `.BANOVAsubjectName <- "JaspColumn_.subject._Encoded"`. These particular names can be changed of course.

- adjust `.shortToLong` so that the names for `subject` and `dependent` can be specified through arguments. Rather than `dependent` and `subject` these names are now set to the previously introduced constants in the ANOVAs. Remark: why oh why does `.shortToLong` exists and do we not use a package for this?

- Replaced every instance of `subject` by `.BANOVAsubjectName`, same for `dependent` and `.BANOVAdependentName`. These new names should make it less likely that there are name clashes with the names in the data set.

- Remove any encoding done on these two variables. Note that if the data set contains a variable called `subject`, then `.v("JaspColumn_.subject._Encoded")` returns `"JaspColumn_.JaspColumn.0.Encoded._Encoded"`, i.e., the subject part is decoded. Removing this encoding is necessary to avoid partial encoding of the new subject and dependent names.

@JorisGoosen Are the names `JaspColumn_.dependent._Encoded` and `JaspColumn_.subject._Encoded` ok? These could be customized in any way, I just want to ensure they won't interfere with any column encoding.