### PR TITLE
Add combineWithOtherModels attribute to source property

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/AvailableVariablesList.qml
+++ b/JASP-Desktop/components/JASP/Controls/AvailableVariablesList.qml
@@ -22,6 +22,4 @@ VariablesList
 {
 	listViewType:	JASP.AvailableVariables
 	showSortMenu:	true
-
-	property bool	mixedModelTerms:	false
 }

--- a/JASP-Desktop/widgets/listmodel.cpp
+++ b/JASP-Desktop/widgets/listmodel.cpp
@@ -114,6 +114,9 @@ Terms ListModel::getSourceTerms()
 	if (sourceItems.size() == 0)
 		return termsAvailable;
 
+	Terms termsToCombine;
+	Terms termsToBeCombinedWith;
+
 	for (QMLListView::SourceType* sourceItem : sourceItems)
 	{
 		ListModel* sourceModel = sourceItem->model;
@@ -163,7 +166,25 @@ Terms ListModel::getSourceTerms()
 				sourceTerms = filteredTerms;
 			}
 
+			if (sourceItem->combineWithOtherModels)
+				termsToCombine = sourceTerms;
+			else
+				termsToBeCombinedWith.add(sourceTerms);
+
 			termsAvailable.add(sourceTerms);
+		}
+	}
+
+	if (termsToCombine.size() > 0)
+	{
+		for (const Term& termToCombine : termsToCombine)
+		{
+			for (const Term& termToBeCombined : termsToBeCombinedWith)
+			{
+				QStringList components = termToCombine.components();
+				components.append(termToBeCombined.components());
+				termsAvailable.add(Term(components));
+			}
 		}
 	}
 	

--- a/JASP-Desktop/widgets/listmodelavailableinterface.h
+++ b/JASP-Desktop/widgets/listmodelavailableinterface.h
@@ -31,8 +31,8 @@ class ListModelAvailableInterface: public ListModelDraggable, public VariableInf
 {
 	Q_OBJECT
 public:
-	ListModelAvailableInterface(QMLListView* listView, bool mixedModelTerms = false)
-		: ListModelDraggable(listView), _mixedModelTerms(mixedModelTerms) {}
+	ListModelAvailableInterface(QMLListView* listView)
+		: ListModelDraggable(listView) {}
 	
 	virtual const Terms& allTerms()																						const { return _allSortedTerms; }
 			void initTerms(const Terms &terms, const RowControlsOptions& _rowControlsOptions = RowControlsOptions())	override;
@@ -54,7 +54,6 @@ protected:
 	bool					_addEmptyValue = false;
 	Terms					_allTerms;
 	Terms					_allSortedTerms;
-	bool					_mixedModelTerms = false;
 
 	Terms					_tempRemovedTerms;
 	Terms					_tempAddedTerms;

--- a/JASP-Desktop/widgets/listmodeltermsavailable.cpp
+++ b/JASP-Desktop/widgets/listmodeltermsavailable.cpp
@@ -21,8 +21,8 @@
 #include "../analysis/analysisform.h"
 #include <QQmlProperty>
 
-ListModelTermsAvailable::ListModelTermsAvailable(QMLListView* listView, bool mixedModelTerms)
-	: ListModelAvailableInterface(listView, mixedModelTerms)
+ListModelTermsAvailable::ListModelTermsAvailable(QMLListView* listView)
+	: ListModelAvailableInterface(listView)
 {
 }
 
@@ -55,34 +55,6 @@ void ListModelTermsAvailable::resetTermsFromSourceModels(bool updateAssigned)
 	beginResetModel();
 
 	Terms termsAvailable = getSourceTerms();
-
-	if (_mixedModelTerms)
-	{
-		QMap<ListModel*, Terms> termsPerSource = getSourceTermsPerModel();
-		QList<Terms> termsPerModel = termsPerSource.values();
-
-		if (termsPerModel.length() > 1)
-		{
-			Terms mixedTerms = termsPerModel[0];
-			mixedTerms.removeParent();
-			for (int i = 1; i < termsPerModel.length(); i++)
-			{
-				const Terms& termsToBeCombined = termsPerModel[i];
-				Terms extraTerms;
-				for (const Term& mixedTerm : mixedTerms)
-				{
-					for (const Term& termToBeCombined : termsToBeCombined)
-					{
-						QStringList components = mixedTerm.components();
-						components.append(termToBeCombined.components());
-						extraTerms.add(Term(components));
-					}
-				}
-				mixedTerms.add(extraTerms);
-			}
-			termsAvailable.add(mixedTerms);
-		}
-	}
 	
 	setChangedTerms(termsAvailable);
 	initTerms(termsAvailable);

--- a/JASP-Desktop/widgets/listmodeltermsavailable.h
+++ b/JASP-Desktop/widgets/listmodeltermsavailable.h
@@ -26,7 +26,7 @@ class ListModelTermsAvailable : public ListModelAvailableInterface
 {
 	Q_OBJECT
 public:
-	ListModelTermsAvailable(QMLListView* listView, bool mixedModelTerms = false);
+	ListModelTermsAvailable(QMLListView* listView);
 		
 	void		sortItems(SortType sortType)							override;
 	void		resetTermsFromSourceModels(bool updateAssigned = true)	override;	

--- a/JASP-Desktop/widgets/qmllistview.cpp
+++ b/JASP-Desktop/widgets/qmllistview.cpp
@@ -96,6 +96,7 @@ void QMLListView::setSources()
 			QString conditionExpression = map["condition"].toString();
 			QVector<QPair<QString, QString> > discards;
 			QVector<QMap<QString, QVariant> > conditionVariables;
+			bool combineWithOtherModels = false;
 
 			if (sourceName.isEmpty())
 			{
@@ -149,7 +150,10 @@ void QMLListView::setSources()
 				}
 			}
 
-			_sourceModels.append(new SourceType(sourceName, modelUse, discards, conditionExpression, conditionVariables));
+			if (map.contains("combineWithOtherModels"))
+				combineWithOtherModels = map["combineWithOtherModels"].toBool();
+
+			_sourceModels.append(new SourceType(sourceName, modelUse, discards, conditionExpression, conditionVariables, combineWithOtherModels));
 		}
 	}
 	
@@ -171,7 +175,7 @@ void QMLListView::setSources()
 			{
 				if (!sourceModel->areTermsVariables())
 					termsAreVariables = false;
-				if (sourceModel->areTermsInteractions())
+				if (sourceModel->areTermsInteractions() || sourceItem->combineWithOtherModels)
 					termsAreInteractions = true;
 				sourceItem->model = sourceModel;
 				addDependency(sourceModel->listView());

--- a/JASP-Desktop/widgets/qmllistview.h
+++ b/JASP-Desktop/widgets/qmllistview.h
@@ -55,14 +55,16 @@ public:
 		QVector<SourceType>			discardModels;
 		QString						conditionExpression;
 		QVector<ConditionVariable>	conditionVariables;
+		bool						combineWithOtherModels = false;
 
 		SourceType(
 				  const QString& _name = ""
 				, const QString& _modelUse = ""
 				, const QVector<QPair<QString, QString> >& _discardModels = QVector<QPair<QString, QString> >()
 				, const QString& _conditionExpression = ""
-				, const QVector<QMap<QString, QVariant> >& _conditionVariables = QVector<QMap<QString, QVariant> >())
-			: name(_name), modelUse(_modelUse), model(nullptr), conditionExpression(_conditionExpression)
+				, const QVector<QMap<QString, QVariant> >& _conditionVariables = QVector<QMap<QString, QVariant> >()
+				, bool _combineWithOtherModels = false)
+			: name(_name), modelUse(_modelUse), model(nullptr), conditionExpression(_conditionExpression), combineWithOtherModels(_combineWithOtherModels)
 		{
 			for (const QPair<QString, QString>& discardModel : _discardModels)
 				discardModels.push_back(SourceType(discardModel.first, discardModel.second));

--- a/JASP-Desktop/widgets/qmllistviewtermsavailable.cpp
+++ b/JASP-Desktop/widgets/qmllistviewtermsavailable.cpp
@@ -26,11 +26,10 @@ QMLListViewTermsAvailable::QMLListViewTermsAvailable(JASPControlBase* item, bool
 	, QMLListViewDraggable(item)
 
 {
-	bool mixedModelTerms = getItemProperty("mixedModelTerms").toBool();
 	if (isInteraction)
 		_availableModel = new ListModelInteractionAvailable(this);
 	else
-		_availableModel = new ListModelTermsAvailable(this, mixedModelTerms);
+		_availableModel = new ListModelTermsAvailable(this);
 
 	_sortedMenuModel = new SortMenuModel(_availableModel, {Sortable::None, Sortable::SortByName, Sortable::SortByType});
 }

--- a/Resources/ANOVA/qml/AnovaRepeatedMeasures.qml
+++ b/Resources/ANOVA/qml/AnovaRepeatedMeasures.qml
@@ -22,13 +22,13 @@ import JASP.Widgets		1.0
 import JASP				1.0
 
 Form
-{	
+{
 	IntegerField { visible: false; name: "plotHeightDescriptivesPlotLegend"     ; defaultValue: 300 }
 	IntegerField { visible: false; name: "plotHeightDescriptivesPlotNoLegend"   ; defaultValue: 300 }
 	IntegerField { visible: false; name: "plotWidthDescriptivesPlotLegend"      ; defaultValue: 450 }
 	IntegerField { visible: false; name: "plotWidthDescriptivesPlotNoLegend"    ; defaultValue: 350 }
-	
-	
+
+
 	VariablesForm
 	{
 		preferredHeight: 520 * preferencesModel.uiScale
@@ -54,7 +54,7 @@ Form
 			suggestedColumns:	["scale"]
 		}
 	}
-	
+
 	Group
 	{
 		title: qsTr("Display")
@@ -70,25 +70,25 @@ Form
 		}
 		CheckBox { name: "VovkSellkeMPR";					label: qsTr("Vovk-Sellke maximum p-ratio")	}
 	}
-	
+
 	Section
 	{
 		title: qsTr("Model")
-		
+
 		VariablesForm
 		{
 			preferredHeight: 150 * preferencesModel.uiScale
 			AvailableVariablesList	{ name: "withinComponents"; title: qsTr("Repeated Measures Components"); source: ["repeatedMeasuresFactors"] }
 			AssignedVariablesList	{ name: "withinModelTerms"; title: qsTr("Model Terms");	listViewType: JASP.Interaction	}
 		}
-		
+
 		VariablesForm
 		{
 			preferredHeight: 150 * preferencesModel.uiScale
 			AvailableVariablesList	{ name: "betweenComponents"; title: qsTr("Between Subjects Components"); source: ["betweenSubjectFactors", "covariates"] }
 			AssignedVariablesList	{ name: "betweenModelTerms"; title: qsTr("Model terms"); listViewType: JASP.Interaction }
 		}
-		
+
 		DropDown
 		{
 			name: "sumOfSquares"
@@ -101,10 +101,8 @@ Form
 			]
 		}
 		CheckBox { name: "useMultivariateModelFollowup";				label: qsTr("Use multivariate model for follow-up tests");					checked: false }
-
-		
 	}
-	
+
 	Section
 	{
 		title: qsTr("Assumption Checks")
@@ -123,12 +121,12 @@ Form
 			CheckBox { name: "homogeneityTests"; label: qsTr("Homogeneity tests") }
 		}
 	}
-	
+
 	Section
 	{
 		title: qsTr("Contrasts")
-		ContrastsList { source: ["repeatedMeasuresFactors", "betweenSubjectFactors"] }
-		
+		ContrastsList { source: ["withinModelTerms", { name: "betweenModelTerms", discard: "covariates", combineWithOtherModels: true }] }
+
 		CheckBox { name: "contrastAssumeEqualVariance"; label: qsTr("Assume equal variances"); checked: true }
 		CheckBox
 		{
@@ -137,7 +135,7 @@ Form
 			CIField { name: "confidenceIntervalIntervalContrast" }
 		}
 	}
-	
+
 	Section
 	{
 		title: qsTr("Post Hoc Tests")
@@ -146,10 +144,10 @@ Form
 		VariablesForm
 		{
 			preferredHeight: 150 * preferencesModel.uiScale
-			AvailableVariablesList { name: "postHocTestsAvailable"; source: ["withinModelTerms", { name: "betweenModelTerms", discard: "covariates" }]; mixedModelTerms: true }
+			AvailableVariablesList { name: "postHocTestsAvailable"; source: ["withinModelTerms", { name: "betweenModelTerms", discard: "covariates", combineWithOtherModels: true }] }
 			AssignedVariablesList {  name: "postHocTestsVariables" }
 		}
-		
+
 		CheckBox
 		{
 			name: "confidenceIntervalsPostHoc"; label: qsTr("Confidence intervals")
@@ -163,7 +161,7 @@ Form
 			CheckBox { name: "postHocTestEffectSize";	label: qsTr("Effect size")						}
 			CheckBox { name: "postHocTestPooledError";	label: qsTr("Pool error term for RM factors");			checked: true	}
 		}
-		
+
 		Group
 		{
 			title: qsTr("Correction")
@@ -172,19 +170,19 @@ Form
 			CheckBox { name: "postHocTestsTukey";		label: qsTr("Tukey")				}
 			CheckBox { name: "postHocTestsScheffe";		label: qsTr("Scheffe")				}
 		}
-		
+
 		Group
 		{
 			title: qsTr("Display")
 			CheckBox { name: "postHocFlagSignificant";	label: qsTr("Flag Significant Comparisons") }
 		}
 	}
-	
+
 	Section
 	{
 		title: qsTr("Descriptives Plots")
 		columns: 1
-		
+
 		VariablesForm
 		{
 			preferredHeight: 150 * preferencesModel.uiScale
@@ -193,7 +191,7 @@ Form
 			AssignedVariablesList {  name: "plotSeparateLines";			title: qsTr("Separate Lines");	singleVariable: true }
 			AssignedVariablesList {  name: "plotSeparatePlots";			title: qsTr("Separate Plots");	singleVariable: true }
 		}
-		
+
 		TextField { name: "labelYAxis"; label: qsTr("Label y-axis"); fieldWidth: 200 }
 		Group
 		{
@@ -215,10 +213,10 @@ Form
 				}
 			}
 			CheckBox { name: "usePooledStandErrorCI";	label: qsTr("Average across unused RM factors")	}
-			
+
 		}
 	}
-	
+
 	Section
 	{
 		title: qsTr("Marginal Means")
@@ -227,14 +225,14 @@ Form
 		Group
 		{
 			title: qsTr("Marginal Means")
-			
+
 			VariablesForm
 			{
 				preferredHeight: 150 * preferencesModel.uiScale
 				AvailableVariablesList { name: "marginalMeansTermsAvailable" ; source: ["withinModelTerms", { name: "betweenModelTerms", discard: "covariates" }] }
 				AssignedVariablesList {  name: "marginalMeansTerms" }
 			}
-			
+
 			CheckBox
 			{
 				name: "marginalMeansBootstrapping"; label: qsTr("From")
@@ -264,13 +262,13 @@ Form
 				}
 			}
 		}
-		
+
 	}
-	
+
 	Section
 	{
 		title: qsTr("Simple Main Effects")
-		
+
 		VariablesForm
 		{
 			preferredHeight: 150 * preferencesModel.uiScale
@@ -279,14 +277,14 @@ Form
 			AssignedVariablesList { name: "moderatorFactorOne";	title: qsTr("Moderator Factor 1");		singleVariable: true }
 			AssignedVariablesList { name: "moderatorFactorTwo";	title: qsTr("Moderator Factor 2");		singleVariable: true }
 		}
-		
+
 		CheckBox { name: "poolErrorTermSimpleEffects"; label: qsTr("Pool error terms") }
 	}
-	
+
 	Section
 	{
 		title: qsTr("Nonparametrics")
-		
+
 		VariablesForm
 		{
 			preferredHeight: 150 * preferencesModel.uiScale
@@ -294,7 +292,7 @@ Form
 			AssignedVariablesList {  name: "friedmanWithinFactor";		title: qsTr("RM Factor") }
 			AssignedVariablesList {  name: "friedmanBetweenFactor";		title: qsTr("Optional Grouping Factor"); singleVariable: true }
 		}
-		
+
 		CheckBox { name: "conoverTest"; label: qsTr("Conover's post hoc tests") }
 	}
 }


### PR DESCRIPTION
The mixedModelTerms property is specific for Available VariablesList. But in case of the ContrastList of the Repeated Anova where an assigned VariablesList is used, such a feature is also needed. 
This property affects in fact the terms given by the source of a VariablesList. So this property is removed and the combineWithOtherModels source attribute is added, making it available for all kind if VariablesList.