### PR TITLE
Kill! Kill! Kill!

### DIFF
--- a/JASP-Common/enginedefinitions.cpp
+++ b/JASP-Common/enginedefinitions.cpp
@@ -1,2 +1,10 @@
 #define ENUM_DECLARATION_CPP
 #include "enginedefinitions.h"
+
+const char * unexpectedEngineReply::what() const noexcept{ return std::runtime_error::what(); }
+
+void unexpectedEngineReply::checkIfExpected(engineState expectedReplyState, engineState currentState, int channelNo)
+{
+	if(expectedReplyState != currentState)
+		throw unexpectedEngineReply(expectedReplyState, channelNo, ", in state: " + engineStateToString(currentState));
+}

--- a/JASP-Common/enginedefinitions.h
+++ b/JASP-Common/enginedefinitions.h
@@ -3,10 +3,22 @@
 
 #include "enumutilities.h"
 
-DECLARE_ENUM(engineState,			initializing, idle, analysis, filter, rCode, computeColumn, moduleRequest, pauseRequested, paused, resuming, stopRequested, stopped, logCfg, settings);
+DECLARE_ENUM(engineState,			initializing, idle, analysis, filter, rCode, computeColumn, moduleRequest, pauseRequested, paused, resuming, stopRequested, stopped, logCfg, settings, killed);
 DECLARE_ENUM(performType,			init, run, abort, saveImg, editImg, rewriteImgs);
 DECLARE_ENUM(analysisResultStatus,	validationError, fatalError, imageSaved, imageEdited, imagesRewritten, complete, inited, running, changed, waiting);
 DECLARE_ENUM(moduleStatus,			initializing, installNeeded, installModPkgNeeded, loadingNeeded, unloadingNeeded, readyForUse, error);
 DECLARE_ENUM(engineAnalysisStatus,	empty, toInit, initing, inited, toRun, running, changed, complete, error, exception, aborted, stopped, saveImg, editImg, rewriteImgs, synchingData);
+
+struct unexpectedEngineReply  : public std::runtime_error
+{
+	unexpectedEngineReply(std::string msg)															: std::runtime_error(msg) {}
+	unexpectedEngineReply(engineState unexpectedState, std::string msg = "Engine got unexpected")	: std::runtime_error(msg + ": " + engineStateToString(unexpectedState)) {}
+	unexpectedEngineReply(engineState unexpectedState, int engineNo, std::string extra = "")		: std::runtime_error("Engine " + std::to_string(engineNo) + " got unexpected reply: " + engineStateToString(unexpectedState) + extra) {}
+	const char* what() const noexcept override; //Put that
+
+	static void checkIfExpected(engineState expectedReplyState, engineState currentState, int channelNo);
+};
+
+
 
 #endif // ENGINEDEFINITIONS_H

--- a/JASP-Common/enumutilities.h
+++ b/JASP-Common/enumutilities.h
@@ -17,6 +17,12 @@
 #include <QString>
 #endif
 
+struct missingEnumVal  : public std::runtime_error
+{
+	missingEnumVal(std::string enumName, std::string missingValue)	: std::runtime_error("Enum " + enumName + " does not contain value \"" + missingValue + "\"!") {}
+};
+
+
 #define STRING_REMOVE_CHAR(str, ch) str.erase(std::remove(str.begin(), str.end(), ch), str.end())
 
 
@@ -69,7 +75,7 @@
 	E E##FromString(std::string enumName)																		\
 	{																											\
 		if(E##FromNameMap.count(enumName) == 0) 																\
-			throw std::runtime_error(#E" enum from string misses requested value \""+enumName+"\"");			\
+			throw missingEnumVal(#E, enumName);																\
 		return (E)E##FromNameMap.at(enumName); 																	\
 	}																											\
 	E E##FromString(std::string enumName, E defaultValue)														\
@@ -82,20 +88,20 @@
 	bool		valid##E(T value) { return (E##MapName.find(value) != E##MapName.end()); }
 
 #ifdef JASP_USES_QT_HERE
-	#define DECLARE_ENUM_WITH_TYPE_HEADER(E, T, ...)															\
-	DECLARE_ENUM_WITH_TYPE_BASE(E, T, __VA_ARGS__)																\
-	inline E		E##FromQString(QString enumName)	{ return (E)E##FromString(enumName.toStdString()); }	\
+	#define DECLARE_ENUM_WITH_TYPE_HEADER(E, T, ...)																						\
+	DECLARE_ENUM_WITH_TYPE_BASE(E, T, __VA_ARGS__)																							\
+	inline E		E##FromQString(QString enumName)					{ return (E)E##FromString(enumName.toStdString()); }				\
 	inline E		E##FromQString(QString enumName, E defaultValue)	{ return (E)E##FromString(enumName.toStdString(), defaultValue); }	\
-	inline QString	E##ToQString(E enumVal)		{ return QString::fromStdString(~enumVal); }					\
-	inline QString	operator+(QString &&str, E enumTmp) { return str + E##ToQString(enumTmp); }					\
-	inline QString	operator+(E enumTmp, QString &&str) { return E##ToQString(enumTmp) + str;	}				\
-	inline QString	&operator+=(QString &str, E enumTmp)														\
-	{																											\
-		str += E##ToQString(enumTmp);																			\
-		return str;																								\
+	inline QString	E##ToQString(E enumVal)								{ return QString::fromStdString(~enumVal); }						\
+	inline QString	operator+(QString &&str, E enumTmp)					{ return str + E##ToQString(enumTmp); }								\
+	inline QString	operator+(E enumTmp, QString &&str)					{ return E##ToQString(enumTmp) + str;	}							\
+	inline QString	&operator+=(QString &str, E enumTmp)																					\
+	{																																		\
+		str += E##ToQString(enumTmp);																										\
+		return str;																															\
 	}
 
-#define DECLARE_ENUM_WITH_TYPE_IMPLEMENTATION(E, T, ...)														\
+#define DECLARE_ENUM_WITH_TYPE_IMPLEMENTATION(E, T, ...)																					\
 	DECLARE_ENUM_METHODS_WITH_TYPE_BASE(E, T, __VA_ARGS__)
 #else
 	#define DECLARE_ENUM_WITH_TYPE_HEADER(E, T, ...)			DECLARE_ENUM_WITH_TYPE_BASE(E, T, __VA_ARGS__)

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -52,9 +52,10 @@ class Analysis : public QObject
 
 public:
 
-	enum Status { Empty, Initing, Inited, Running, Complete, Aborting, Aborted, ValidationError, SaveImg, EditImg, RewriteImgs, FatalError, Initializing };
+	enum Status { Empty, Initing, Inited, Running, Complete, Aborting, Aborted, ValidationError, SaveImg, EditImg, RewriteImgs, FatalError, Initializing, KeepStatus };
 	void setStatus(Status status);
 	static std::string statusToString(Status status);
+	///This function transforms an analysisResultStatus to Analysis::Status so that the Analysis gets the correct status after returning from Engine
 	static Analysis::Status analysisResultsStatusToAnalysisStatus(analysisResultStatus result);
 
 	Analysis(size_t id, Analysis * duplicateMe);
@@ -127,7 +128,6 @@ public:
 			void		reload();
 			void		rebind();
 			void        exportResults();
-	virtual void		abort();
 			void		remove();
 
 			Json::Value asJSON()		const;
@@ -194,6 +194,7 @@ public slots:
 	void					showDependenciesOnQMLForObject(QString uniqueName); //uniqueName is basically "name" in meta in results.
 
 protected:
+	void					abort();
 	void					bindOptionHandlers();
 
 private:

--- a/JASP-Desktop/components/JASP/Widgets/ControlErrorMessage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/ControlErrorMessage.qml
@@ -41,25 +41,13 @@ Rectangle
 	property int paddingWidth	: 10 * jaspTheme.uiScale
 	property int paddingHeight	: 6 * jaspTheme.uiScale
 
-	onContainerWidthChanged: if (visible) showMessage()
-
-	onControlChanged:
+	onContainerWidthChanged:	if (visible)				showMessage()
+	onControlChanged:			if (!control)				controlErrorMessage.opacity = 0
+	onVisibleChanged:			if (!visible && control)
 	{
-		if (!control)
-			controlErrorMessage.opacity = 0
-	}
-
-	onVisibleChanged:
-	{
-		if (!visible)
-		{
-			if (control)
-			{
-				control.hasError = false;
-				control.hasWarning = false;
-				parent = null;
-			}
-		}
+		control.hasError	= false;
+		control.hasWarning	= false;
+		parent				= null;
 	}
 
 	Timer

--- a/JASP-Desktop/engine/enginerepresentation.cpp
+++ b/JASP-Desktop/engine/enginerepresentation.cpp
@@ -2,6 +2,7 @@
 #include "gui/preferencesmodel.h"
 #include "gui/messageforwarder.h"
 #include "utilities/qutils.h"
+#include "utils.h"
 #include "log.h"
 
 EngineRepresentation::EngineRepresentation(IPCChannel * channel, QProcess * slaveProcess, QObject * parent)
@@ -34,6 +35,21 @@ EngineRepresentation::~EngineRepresentation()
 	_channel = nullptr;
 }
 
+void EngineRepresentation::cleanUpAfterClose()
+{
+	_analysisInProgress = nullptr;
+	_analysisAborted	= nullptr;
+	_idRemovedAnalysis	= -1;
+	_lastRequestId		= -1;
+	_abortTime			= -1;
+	_pauseRequested		= false;
+	_stopRequested		= false;
+	_slaveCrashed		= false;
+	_settingsChanged	= true;
+	_abortAndRestart	= false;
+	_lastCompColName	= "???";
+}
+
 void EngineRepresentation::sendString(std::string str)
 {
 #ifdef PRINT_ENGINE_MESSAGES
@@ -44,14 +60,14 @@ void EngineRepresentation::sendString(std::string str)
 
 void EngineRepresentation::processFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
-	Log::log() << "Engine # " << channelNumber() << " finished " << (exitStatus == QProcess::ExitStatus::NormalExit ? "normally" : "crashing") << " and with exitCode " << exitCode << "!" << std::endl;
+	Log::log() << "Engine # " << channelNumber() << " finished while in state '" << _engineState << "' " << (exitStatus == QProcess::ExitStatus::NormalExit ? "normally" : "crashing") << " and with exitCode " << exitCode << "!" << std::endl;
 
 	_slaveProcess->deleteLater();
 	_slaveProcess = nullptr;
-	_slaveCrashed = exitStatus == QProcess::ExitStatus::CrashExit;
+	_slaveCrashed = exitStatus == QProcess::ExitStatus::CrashExit && _engineState != engineState::killed;
 
-	if(exitCode != 0 || _slaveCrashed)
-		handleEngineCrash();
+	if(_engineState == engineState::killed)	_engineState = engineState::initializing;
+	else 	if(exitCode != 0 || _slaveCrashed)		handleEngineCrash();
 }
 
 void EngineRepresentation::handleEngineCrash()
@@ -140,8 +156,15 @@ void EngineRepresentation::process()
 	if (_channel->receive(data))
 	{
 #ifdef PRINT_ENGINE_MESSAGES
-		Log::log() << "message received" <<std::endl;
+		{
+			const int _maxDataChars = 300;//I do not want to keep scrolling forever all the time...
+			if(data != "")	Log::log() << "message received from engine #" << channelNumber() << ": " << (data.size() < _maxDataChars ? data : data.substr(0, _maxDataChars)) + "..." << std::endl;
+			else			Log::log() << "Engine #" << channelNumber() << " cleared its send-buffer." << std::endl;
+		}
 #endif
+
+		if(data == "")
+			return;
 
 		Json::Value json;
 		bool		jsonIsOK = false;
@@ -172,6 +195,12 @@ void EngineRepresentation::process()
 		default:							throw std::logic_error("If you define new engineStates you should add them to the switch in EngineRepresentation::process()!");
 		}
 	}
+
+	if(_analysisAborted && _analysisInProgress && _abortTime + KILLTIME < Utils::currentSeconds()) //We wait a second or two before we kill the engine if it does not want to abort.
+	{
+		killEngine(true);
+		restartAbortedAnalysis(true); //We restart it now because we do want it to continue later. And we refresh it because *maybe* we just killed it in the middle of something important like writing files.
+	}
 }
 
 void EngineRepresentation::runScriptOnProcess(RFilterStore * filterStore)
@@ -196,8 +225,8 @@ void EngineRepresentation::runScriptOnProcess(RFilterStore * filterStore)
 
 void EngineRepresentation::processFilterReply(Json::Value & json)
 {
-	if(_engineState != engineState::filter)
-		throw std::runtime_error("Received an unexpected filter reply!");
+	checkIfExpectedReplyType(engineState::filter);
+
 	_engineState = engineState::idle;
 
 #ifdef PRINT_ENGINE_MESSAGES
@@ -241,8 +270,8 @@ void EngineRepresentation::runScriptOnProcess(RScriptStore * scriptStore)
 
 void EngineRepresentation::processRCodeReply(Json::Value & json)
 {
-	if(_engineState != engineState::rCode)
-		throw std::runtime_error("Received an unexpected rCode reply!");
+	checkIfExpectedReplyType(engineState::rCode);
+
 	_engineState = engineState::idle;
 
 	std::string rCodeResult = json.get("rCodeResult", "").asString();
@@ -273,8 +302,8 @@ void EngineRepresentation::runScriptOnProcess(RComputeColumnStore * computeColum
 
 void EngineRepresentation::processComputeColumnReply(Json::Value & json)
 {
-	if(_engineState != engineState::computeColumn)
-		throw std::runtime_error("Received an unexpected computeColumn reply!");
+	checkIfExpectedReplyType(engineState::computeColumn);
+
 	_engineState = engineState::idle;
 
 
@@ -311,7 +340,7 @@ void EngineRepresentation::analysisRemoved(Analysis * analysis)
 		return;
 
 	_idRemovedAnalysis = analysis->id();
-	abortAnalysisInProgress();
+	abortAnalysisInProgress(false);
 	_analysisInProgress = nullptr; //Because it will be deleted!
 	//But we keep the engineState at analysis to make sure another analysis won't try to run until the aborted one gets the message!
 }
@@ -381,8 +410,6 @@ void EngineRepresentation::processAnalysisReply(Json::Value & json)
 
 		return;
 	}
-
-
 
 	Log::log() << "Resultstatus of analysis was " << analysisResultStatusToString(status) << " and it will now be processed." << std::endl;
 
@@ -471,13 +498,22 @@ void EngineRepresentation::handleRunningAnalysisStatusChanges()
 	if (_engineState != engineState::analysis || _idRemovedAnalysis >= 0)
 		return;
 
-	if((_analysisInProgress->isEmpty() || _analysisInProgress->isAborted()) && _analysisAborted != _analysisInProgress)
-		runAnalysisOnProcess(_analysisInProgress);
+	if(		(_analysisInProgress->isEmpty() || _analysisInProgress->isAborted() )
+			&& _analysisAborted != _analysisInProgress)
+		abortAnalysisInProgress(_analysisInProgress->isEmpty());
 }
 
-void EngineRepresentation::killEngine()
+void EngineRepresentation::killEngine(bool disconnectFinished)
 {
+	_engineState  = engineState::killed;
+
+	if(disconnectFinished)
+		//We must make sure we do not get a popup, and while processFinished checks for "killed" or not it doesnt help that that needs the eventloop to be processed
+		//I want pause and resume all engines to be done in a singly function call without returning to the eventloop, so we just disconnect "finished" if we want to kill the engine.
+		disconnect(_slaveProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),	this, &EngineRepresentation::processFinished);
+
 	_slaveProcess->kill();
+	//The rest will be handled in EngineRepresentation::processFinished
 }
 
 void EngineRepresentation::stopEngine()
@@ -491,33 +527,35 @@ void EngineRepresentation::sendStopEngine()
 	_engineState			= engineState::stopRequested;
 	json["typeRequest"]		= engineStateToString(_engineState);
 
-	Log::log() << "informing engine that it ought to stop" << std::endl;
+	Log::log() << "informing engine #" << channelNumber() << " that it ought to stop" << std::endl;
 
 	sendString(json.toStyledString());
 }
 
 void EngineRepresentation::restartEngine(QProcess * jaspEngineProcess)
 {
-	Log::log() << "informing engine that it ought to restart" << std::endl;
+	Log::log() << "informing engine #" << channelNumber() << " that it ought to restart" << std::endl;
 
 	if(_slaveProcess != nullptr && _slaveProcess != jaspEngineProcess)
 	{
 		_slaveProcess->kill();
 		_slaveProcess->deleteLater();
-		Log::log() << "EngineRepresentation::restartEngine says: Engine already has jaspEngine process!" << std::endl;
+
+		if(_engineState != engineState::killed && _engineState != engineState::stopped)
+			Log::log() << "EngineRepresentation::restartEngine says: Engine already had jaspEngine process that is now replaced!" << std::endl;
 	}
 
 	sendString("");
 	setSlaveProcess(jaspEngineProcess);
-	_stopRequested	= false;
-	resumeEngine(); //We do not want to engine to think it is *resuming* after a crash because it is actually *initializing* then. Because in that case it needs to send the settings again.
+	cleanUpAfterClose();
+
+	_engineState	 = engineState::initializing;
 }
 
 void EngineRepresentation::pauseEngine()
 {
 	_pauseRequested = true;
-	if(_analysisInProgress)
-		_analysisInProgress->abort();
+	abortAnalysisInProgress(true);
 }
 
 void EngineRepresentation::sendPauseEngine()
@@ -526,7 +564,7 @@ void EngineRepresentation::sendPauseEngine()
 	_engineState			= engineState::pauseRequested;
 	json["typeRequest"]		= engineStateToString(_engineState);
 
-	Log::log() << "informing engine that it ought to pause for a bit" << std::endl;
+	Log::log() << "informing engine #" << channelNumber() << " that it ought to pause for a bit" << std::endl;
 
 	sendString(json.toStyledString());
 }
@@ -534,22 +572,23 @@ void EngineRepresentation::sendPauseEngine()
 void EngineRepresentation::resumeEngine()
 {
 	if(_engineState != engineState::paused && _engineState != engineState::stopped && _engineState != engineState::initializing)
-		throw std::runtime_error("Attempt to resume engine made but it isn't paused or stopped");
+		throw unexpectedEngineReply("Attempt to resume engine #" + std::to_string(channelNumber()) + " made but it isn't paused, initializing or stopped");
 
 	_pauseRequested			= false;
 	_engineState			= engineState::resuming;
 	Json::Value json		= Json::Value(Json::objectValue);
 	json["typeRequest"]		= engineStateToString(_engineState);
 
-	Log::log() << "informing engine that it may resume" << std::endl;
+	addSettingsToJson(json);
+
+	Log::log() << "informing engine #" << channelNumber() << " that it may resume." << std::endl;
 
 	sendString(json.toStyledString());
 }
 
 void EngineRepresentation::processEnginePausedReply()
 {
-	if(_engineState != engineState::pauseRequested)
-		throw std::runtime_error("Received an unexpected engine paused reply!");
+	checkIfExpectedReplyType(engineState::pauseRequested);
 
 	_engineState = engineState::paused;
 }
@@ -557,9 +596,9 @@ void EngineRepresentation::processEnginePausedReply()
 void EngineRepresentation::processEngineResumedReply()
 {
 	if(_engineState != engineState::resuming && _engineState != engineState::initializing)
-		throw std::runtime_error("Received an unexpected engine resumed reply!");
+		throw unexpectedEngineReply("Received an unexpected engine #" + std::to_string(channelNumber()) + " resumed reply!");
 
-	_settingsChanged = true; //Make sure we send the settings at least once
+	//_settingsChanged = true; //Make sure we send the settings at least once. We now do this be also sending the settings in the resume request
 
 	_engineState = engineState::idle;
 }
@@ -567,7 +606,7 @@ void EngineRepresentation::processEngineResumedReply()
 void EngineRepresentation::processEngineStoppedReply()
 {
 	if(_engineState != engineState::stopRequested)
-		throw std::runtime_error("Received an unexpected engine stopped reply!");
+		throw unexpectedEngineReply("Received an unexpected engine stopped reply!");
 
 	_engineState = engineState::stopped;
 }
@@ -582,8 +621,8 @@ void EngineRepresentation::runModuleRequestOnProcess(Json::Value request)
 
 void EngineRepresentation::processModuleRequestReply(Json::Value & json)
 {
-	if(_engineState != engineState::moduleRequest)
-		throw std::runtime_error("Received an unexpected moduleRequest reply!");
+	checkIfExpectedReplyType(engineState::moduleRequest);
+
 	_engineState = engineState::idle;
 
 	moduleStatus moduleRequest	= moduleStatusFromString(json["moduleRequest"].asString());
@@ -664,8 +703,7 @@ std::string EngineRepresentation::currentState() const
 	}
 }
 
-//This function is now only used by settingsChanged
-void EngineRepresentation::abortAnalysisInProgress()
+void EngineRepresentation::abortAnalysisInProgress(bool restartAfterwards)
 {
 	if(_engineState == engineState::analysis && _analysisInProgress != nullptr)
 	{
@@ -674,7 +712,9 @@ void EngineRepresentation::abortAnalysisInProgress()
 
 		runAnalysisOnProcess(_analysisInProgress);
 
-		_analysisAborted = _analysisInProgress;
+		_analysisAborted	= _analysisInProgress;
+		_abortTime			= Utils::currentSeconds(); //We'll give it some time to abort, so we need to remember when we gave the order.
+		_abortAndRestart	= restartAfterwards;
 	}
 }
 
@@ -682,7 +722,7 @@ void EngineRepresentation::settingsChanged()
 {
 	Log::log() << "void EngineRepresentation::settingsChanged()" << std::endl;
 	_settingsChanged = true;
-	abortAnalysisInProgress();
+	abortAnalysisInProgress(true);
 }
 
 void EngineRepresentation::sendSettings()
@@ -695,22 +735,33 @@ void EngineRepresentation::sendSettings()
 	_engineState			= engineState::settings;
 	Json::Value msg			= Json::objectValue;
 	msg["typeRequest"]		= engineStateToString(_engineState);
-	msg["ppi"]				= PreferencesModel::prefs()->plotPPI();
-	msg["developerMode"]	= PreferencesModel::prefs()->developerMode();
-	msg["imageBackground"]	= fq(PreferencesModel::prefs()->plotBackground());
-	msg["languageCode"]		= fq(PreferencesModel::prefs()->languageCode());
-
+	addSettingsToJson(msg);
 	sendString(msg.toStyledString());
 
 	_settingsChanged = false;
 }
 
+void EngineRepresentation::addSettingsToJson(Json::Value & msg)
+{
+	msg["ppi"]				= PreferencesModel::prefs()->plotPPI();
+	msg["developerMode"]	= PreferencesModel::prefs()->developerMode();
+	msg["imageBackground"]	= fq(PreferencesModel::prefs()->plotBackground());
+	msg["languageCode"]		= fq(PreferencesModel::prefs()->languageCode());
+}
+
 void EngineRepresentation::processSettingsReply()
 {
 	_engineState = engineState::idle;
+	restartAbortedAnalysis();
+}
 
-	if(_analysisAborted && _analysisAborted->isAborted())
-		_analysisAborted->refresh();
+void EngineRepresentation::restartAbortedAnalysis(bool refreshIt)
+{
+	if(_analysisAborted && _abortAndRestart)
+	{
+		if(refreshIt)	_analysisAborted->refresh();
+		else			_analysisAborted->run();
+	}
 
 	_analysisAborted = nullptr;
 }

--- a/JASP-Desktop/engine/enginerepresentation.cpp
+++ b/JASP-Desktop/engine/enginerepresentation.cpp
@@ -505,6 +505,8 @@ void EngineRepresentation::handleRunningAnalysisStatusChanges()
 
 void EngineRepresentation::killEngine(bool disconnectFinished)
 {
+	Log::log() << "Killing Engine #" << channelNumber() << " and " << (disconnectFinished ? "disconnecting" : "leaving attached") << " it's finished signal." << std::endl;
+
 	_engineState  = engineState::killed;
 
 	if(disconnectFinished)

--- a/JASP-Desktop/engine/enginerepresentation.h
+++ b/JASP-Desktop/engine/enginerepresentation.h
@@ -17,7 +17,7 @@
 #include "modules/dynamicmodules.h"
 
 //How many seconds do we wait for an engine to be killed if it gets stuck in some analysis?
-#define KILLTIME 4
+#define KILLTIME 2
 
 class EngineRepresentation : public QObject
 {
@@ -48,13 +48,13 @@ public:
 	void pauseEngine();
 	void resumeEngine();
 	void restartEngine(QProcess * jaspEngineProcess);
-	bool resumed()				const { return _engineState != engineState::resuming && !paused() && !initializing();			}
-	bool paused()				const { return _engineState == engineState::paused;												}
-	bool initializing()			const { return _engineState == engineState::initializing;										}
-	bool stopped()				const { return _engineState == engineState::stopped;											}
-	bool killed()			const { return _engineState == engineState::killed;										}
-	bool idle()					const { return _engineState == engineState::idle; }
-	bool shouldSendSettings()	const { return idle() && _settingsChanged; }
+	bool resumed()				const { return _engineState != engineState::resuming && !paused() && !initializing();	}
+	bool paused()				const { return _engineState == engineState::paused || initializing();					}
+	bool initializing()			const { return _engineState == engineState::initializing;								}
+	bool stopped()				const { return _engineState == engineState::stopped;									}
+	bool killed()				const { return _engineState == engineState::killed;										}
+	bool idle()					const { return _engineState == engineState::idle;										}
+	bool shouldSendSettings()	const { return idle() && _settingsChanged;												}
 
 	bool jaspEngineStillRunning() { return  _slaveProcess != nullptr && !killed(); }
 

--- a/JASP-Desktop/engine/enginerepresentation.h
+++ b/JASP-Desktop/engine/enginerepresentation.h
@@ -17,7 +17,7 @@
 #include "modules/dynamicmodules.h"
 
 //How many seconds do we wait for an engine to be killed if it gets stuck in some analysis?
-#define KILLTIME 2
+#define KILLTIME 4
 
 class EngineRepresentation : public QObject
 {

--- a/JASP-Desktop/engine/enginesync.cpp
+++ b/JASP-Desktop/engine/enginesync.cpp
@@ -629,7 +629,7 @@ bool EngineSync::allEnginesStopped()
 bool EngineSync::allEnginesPaused()
 {
 	for(auto * engine : _engines)
-		if(!engine->paused())
+		if(!engine->paused() && !engine->initializing()) //Initializing is also sort of paused I guess
 			return false;
 	return true;
 }

--- a/JASP-Desktop/engine/enginesync.cpp
+++ b/JASP-Desktop/engine/enginesync.cpp
@@ -32,6 +32,7 @@
 #include "common.h"
 #include "appinfo.h"
 #include "utilities/qutils.h"
+#include "utils.h"
 #include "tempfiles.h"
 #include "timers.h"
 #include "gui/preferencesmodel.h"
@@ -40,7 +41,6 @@
 
 
 using namespace boost::interprocess;
-
 
 EngineSync::EngineSync(QObject *parent)
 	: QObject(parent)
@@ -80,7 +80,7 @@ EngineSync::~EngineSync()
 	}
 }
 
-void EngineSync::start(int ppi)
+void EngineSync::start(int )
 {
 	JASPTIMER_SCOPE(EngineSync::start);
 
@@ -162,11 +162,28 @@ void EngineSync::restartEngineAfterCrash(int nr)
 	EngineRepresentation * eng = _engines[size_t(nr)];
 
 	eng->restartEngine(startSlaveProcess(nr));
-	setModuleWideCastVars(DynamicModules::dynMods()->getJsonForReloadingActiveModules());
+}
+
+void EngineSync::restartKilledEngines()
+{
+	//Maybe we killed an engine because we wanted to pause or some option changed but the analysis wasn't listening. https://github.com/jasp-stats/INTERNAL-jasp/issues/875
+	bool restartedAnEngine = false;
+
+	for(size_t i=0; i<_engines.size(); i++)
+		if(_engines[i]->killed())
+		{
+			_engines[i]->restartEngine(startSlaveProcess(i));
+			restartedAnEngine = true;
+		}
+
+	if(restartedAnEngine)
+		setModuleWideCastVars(DynamicModules::dynMods()->getJsonForReloadingActiveModules());
 }
 
 void EngineSync::process()
 {
+	restartKilledEngines();
+
 	for (auto engine : _engines)
 		engine->process();
 
@@ -179,6 +196,10 @@ void EngineSync::process()
 	processScriptQueue();
 	processDynamicModules();
 	processAnalysisRequests();
+
+	for (auto engine : _engines)
+		if(engine->idle())
+			engine->restartAbortedAnalysis();
 }
 
 int EngineSync::sendFilter(const QString & generatedFilter, const QString & filter)
@@ -220,21 +241,27 @@ void EngineSync::processFilterScript()
 
 	Log::log() << "Pausing and resuming engines to make sure nothing else is running when we start the filter." << std::endl;
 
-	pause(); //Make sure engines stop
-	_filterRunning = true;
-	resume();
-
-	try
+	//First we make sure nothing else is running before we ask the engine to run the filter
+	if(!_filterRunning)
 	{
-		for (auto *engine : _engines)
-			if (engine->idle())
-			{
-				engine->runScriptOnProcess(_waitingFilter);
-				_waitingFilter = nullptr;
-				return;
-			}
+		pause(); //Make sure engines pause/stop
+		_filterRunning = true;
+		resume();
+	}
+	else //So previous loop we made sure nothing else is running, and maybe we had to kill an engine to make it understand, followed by a restart. Now we are ready to run the filter
+	{
+		try
+		{
+			for (auto *engine : _engines)
+				if (engine->idle())
+				{
+					engine->runScriptOnProcess(_waitingFilter);
+					_waitingFilter = nullptr;
+					return;
+				}
 
-	} catch (...){	Log::log() << "Exception sent in processFilterScript" << std::endl;	}
+		} catch (...){	Log::log() << "Exception sent in processFilterScript" << std::endl;	}
+	}
 }
 
 void EngineSync::filterDone(int requestID)
@@ -494,7 +521,7 @@ void EngineSync::stopEngines()
 {
 	if(!_engineStarted) return;
 
-	auto timeout = QDateTime::currentSecsSinceEpoch() + 60; //shouldnt take more than a minute
+	auto timeout = QDateTime::currentSecsSinceEpoch() + 10;
 
 	//make sure we process any received messages first.
 	for(auto engine : _engines)
@@ -508,12 +535,18 @@ void EngineSync::stopEngines()
 	while(!allEnginesStopped())
 		if(timeout < QDateTime::currentSecsSinceEpoch())
 		{
-			std::cerr << "Waiting for engine to reply stopRequest took longer than timeout.." << std::endl;
-			return;
+			std::cerr << "Waiting for engine to reply stopRequest took longer than timeout, killing it/them.." << std::endl;
+			for(EngineRepresentation * e : _engines)
+				if(!e->stopped() && !e->killed())
+					e->killEngine();
+
+			break;
 		}
 		else
 		for (auto * engine : _engines)
 			engine->process();
+
+	timeout = QDateTime::currentSecsSinceEpoch() + 10;
 
 	bool stillRunning;
 
@@ -548,23 +581,41 @@ void EngineSync::pause()
 	for(EngineRepresentation * e : _engines)
 		e->pauseEngine();
 
-	while(!allEnginesPaused())
+	long tryTill = Utils::currentSeconds() + KILLTIME; //Ill give the engine 1 sec to respond
+
+	while(!allEnginesPaused() && tryTill >= Utils::currentSeconds())
 		for (auto * engine : _engines)
 			engine->process();
+
+	for (auto * engine : _engines)
+		if(!engine->paused())
+			engine->killEngine(true);
 }
 
 void EngineSync::resume()
 {
 	JASPTIMER_SCOPE(EngineSync::resume);
 
-	if(!_engineStarted) return;
+	if(!_engineStarted)
+		return;
 
-	for(auto * engine : _engines)
-		engine->resumeEngine();
+	bool restartedAnEngine = false;
+
+	for(size_t i=0; i<_engines.size(); i++)
+		if(!_engines[i]->jaspEngineStillRunning())
+		{
+			_engines[i]->restartEngine(startSlaveProcess(i));
+			restartedAnEngine = true;
+		}
+		else
+			_engines[i]->resumeEngine();
 
 	while(!allEnginesResumed())
 		for (auto * engine : _engines)
 			engine->process();
+
+	if(restartedAnEngine)
+		setModuleWideCastVars(DynamicModules::dynMods()->getJsonForReloadingActiveModules());
 }
 
 bool EngineSync::allEnginesStopped()
@@ -728,8 +779,9 @@ void EngineSync::processLogCfgRequests()
 
 void EngineSync::cleanUpAfterClose()
 {
-	//stopEngines(); //Seems to break stuff
-	pause();
+	//try { stopEngines(); } //Tends to go wrong when the engine was already killed (for instance because it didnt want to pause)
+	try {	pause(); }
+	catch(unexpectedEngineReply e) {} // If we are cleaning up after close we can get all sorts of things, lets just ignore them.
 
 	while(_waitingScripts.size() > 0)
 	{
@@ -743,9 +795,14 @@ void EngineSync::cleanUpAfterClose()
 
 	TempFiles::clearSessionDir();
 
-	resume();
+	for(EngineRepresentation * e : _engines)
+		e->cleanUpAfterClose();
 
-	//restartEngines();
+	try { resume(); }
+	//try { restartEngines(); }
+	catch(unexpectedEngineReply e) {}
+
+
 }
 
 std::string	EngineSync::currentState() const

--- a/JASP-Desktop/engine/enginesync.h
+++ b/JASP-Desktop/engine/enginesync.h
@@ -110,6 +110,7 @@ private slots:
 
 	void	restartEngines();
 	void	restartEngineAfterCrash(int nr);
+	void	restartKilledEngines();
 
 	void	logCfgReplyReceived(size_t channelNr);
 

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -177,6 +177,20 @@ MainWindow::~MainWindow()
 {
 	try
 	{
+		//Clean up all QML to get rid of warnings and stuff
+		QList<QObject *> rootObjs = _qml->rootObjects();
+
+		//Going backwards to make sure the theme isnt deleted before everything that depends on it
+		for(int i=rootObjs.size() - 1; i >= 0; i--)
+			delete rootObjs[i];
+
+		delete _qml;
+
+	}
+	catch(...)	{}
+
+	try
+	{
 		_engineSync->stopEngines();
 		_odm->clearAuthenticationOnExit(OnlineDataManager::OSF);
 

--- a/JASP-Desktop/modules/upgrader/upgrader.cpp
+++ b/JASP-Desktop/modules/upgrader/upgrader.cpp
@@ -131,7 +131,7 @@ void Upgrader::_upgradeOptionsFromJaspFile(Json::Value & analysis, UpgradeMsgs &
 
 	if(_searcher.count(module) == 0)
 	{
-		Log::log() << "No such upgrade options was found, keeping it as is." << std::endl;
+		Log::log() << "No such upgrade options were found, keeping it as is." << std::endl;
 		return;
 	}
 

--- a/JASP-Engine/engine.h
+++ b/JASP-Engine/engine.h
@@ -38,6 +38,7 @@ public:
 	void run();
 	bool receiveMessages(int timeout = 0);
 	void setSlaveNo(int no);
+	int	 slaveNo() const { return _slaveNo; }
 	void sendString(std::string message);
 
 
@@ -72,6 +73,7 @@ private: // Methods:
 	void receiveModuleRequestMessage(	const Json::Value & jsonRequest);
 	void receiveLogCfg(					const Json::Value & jsonRequest);
 	void receiveSettings(				const Json::Value & jsonRequest);
+	void absorbSettings(				const Json::Value & json);
 
 	void runAnalysis();
 	void runComputeColumn(	const std::string & computeColumnName,	const std::string & computeColumnCode,	columnType computeColumnType);
@@ -81,7 +83,7 @@ private: // Methods:
 
 	void stopEngine();
 	void pauseEngine();
-	void resumeEngine();
+	void resumeEngine(const Json::Value & jsonRequest); //It is practical if resume also gets the settings
 	void sendEnginePaused();
 	void sendEngineResumed();
 	void sendEngineStopped();


### PR DESCRIPTION

![BuschemiTheKiller](https://user-images.githubusercontent.com/29062713/82552738-fb185e80-9b62-11ea-9722-0b1e3f01d1e7.gif)

If the engine takes too long to pause just kill it instead of crashing the entire GUI

- implements https://github.com/jasp-stats/INTERNAL-jasp/issues/875
- Small tweak to also kill the engine if it doesnt respond to a stopRequest
- Implemented a "abort analysis if no response" on option changes
- Make sure engines pause gracefully and do not kill the desktop for each little unexpected reply.
-- Some of them are unexpected but not that bad, so it is nice to be able to differentiate those errors from others (new exception added)
- Added an exception to enumutilities to be able to catch the "missing enum val problem" specifically (aka entered a string that isnt an enumval)
- Resume engine now also sends the settings, this avoids another send->reply cycle afterwards
- Split the filter pause-resume from running the filter so that a process loop can be made in between and let the desktop possibly respond to something
- Engine now also reads in columnnames on startup, because maybe it just started after being killed (or just plain crashing ofc)
- We might be on a killing spree but it would be nice if the desktop also responds well to an engine that *does* respond properly to option changes.
-- For this Ive added a KeepStatus Analysis::Status that tells the Analysis it should, well duh, keep it's current status instead of changing it to something new.
- Taken some code for ~MainWindow from stablish branch that destroys all the loaded qml in reverse order
-- this should avoid a bunch of qml warnings/errors were the qml was dependent on other objects that are already deleted by MainWindow

