### PR TITLE
No more scrolling on file load

### DIFF
--- a/JASP-Desktop/analysis/analyses.h
+++ b/JASP-Desktop/analysis/analyses.h
@@ -28,6 +28,7 @@
 #include <QMap>
 #include <QAbstractListModel>
 #include <QFileSystemWatcher>
+#include <sstream>
 
 class RibbonModel;
 
@@ -57,22 +58,22 @@ public:
 						Analyses();
 	static Analyses *	analyses() { return _singleton; }
 
-	Analysis*	createFromJaspFileEntry(Json::Value analysisData, RibbonModel* ribbonModel);
-	Analysis*	create(const QString &module, const QString &name, const QString& qml, const QString &title, size_t id, const Version &version, Json::Value *options = nullptr, Analysis::Status status = Analysis::Initializing, bool notifyAll = true);
-	Analysis*	create(Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Initializing, bool notifyAll = true, std::string title = "", std::string moduleVersion = "", Json::Value *options = nullptr);
+	Analysis	*	createFromJaspFileEntry(Json::Value analysisData, RibbonModel* ribbonModel);
+	Analysis	*	create(const QString &module, const QString &name, const QString& qml, const QString &title, size_t id, const Version &version, Json::Value *options = nullptr, Analysis::Status status = Analysis::Initializing, bool notifyAll = true);
+	Analysis	*	create(Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Initializing, bool notifyAll = true, std::string title = "", std::string moduleVersion = "", Json::Value *options = nullptr);
 
-	Analysis*	create(const QString &module, const QString &name, const QString& qml, const QString &title)	{ return create(module, name, qml, title, _nextId++, AppInfo::version);		}
-	Analysis*	create(Modules::AnalysisEntry * analysisEntry)								{ return create(analysisEntry, _nextId++);						}
+	Analysis	*	create(const QString &module, const QString &name, const QString& qml, const QString &title)	{ return create(module, name, qml, title, _nextId++, AppInfo::version);		}
+	Analysis	*	create(Modules::AnalysisEntry * analysisEntry)													{ return create(analysisEntry, _nextId++);						}
 
-	Analysis*	get(size_t id) const { return _analysisMap.count(id) > 0 ? _analysisMap.at(id) : nullptr;	}
-	void		clear();
-	void		reload(Analysis* analysis, bool logProblem);
-	
-	bool		allFresh() const;
+	Analysis	*	operator[](size_t index)	{ return _analysisMap[_orderedIds[index]]; }
+	Analysis	*	get(size_t id) const		{ return _analysisMap.count(id) > 0 ? _analysisMap.at(id) : nullptr;	}
 
-	void		setAnalysesUserData(Json::Value userData);
+	void			clear();
+	void			reload(Analysis* analysis, bool logProblem);
 
-
+	bool			allFresh() const;
+	void			setAnalysesUserData(Json::Value userData);
+	void			loadAnalysesFromDatasetPackage(bool & errorFound, std::stringstream & errorMsg, RibbonModel * ribbonModel);
 
 	///Applies function to some or all analyses, if applyThis returns false it stops processing.
 	void		applyToSome(std::function<bool(Analysis *analysis)> applyThis);

--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -184,6 +184,7 @@ Item
 				{
 					target:					resultsJsInterface
 					onRunJavaScript:		resultsView.runJavaScript(js)
+					onScrollAtAllChanged:	resultsView.runJavaScript("window.setScrollAtAll("+(scrollAtAll ? "true" : "false")+")");
 				}
 
 				webChannel.registeredObjects:	[ resultsJsInterfaceInterface ]
@@ -197,7 +198,7 @@ Item
 						runJavaScript("window.setAnalysesTitle(\"" + resultsString + "\");");
 				}
 
-				Item
+				QtObject
 				{
 					id:				resultsJsInterfaceInterface
 					WebChannel.id:	"jasp"

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -1,6 +1,8 @@
 'use strict'
 
 var jasp = null;
+var scrollAtAll = true;
+
 $(document).ready(function () {
 	var d		= new Date();
 	var month	= d.getMonth();
@@ -174,8 +176,12 @@ $(document).ready(function () {
 	window.getAllUserData = function ()				{ jasp.setAllUserDataFromJavascript(JSON.stringify(analyses.getAllUserData()))	}
 	window.getResultsMeta = function ()				{ jasp.setResultsMetaFromJavascript(JSON.stringify(analyses.getResultsMeta()))	}
 	window.setResultsMeta = function (resultsMeta)	{ analyses.setResultsMeta(resultsMeta);											}
+	window.setScrollAtAll = function (scrollOrNot)  { scrollAtAll = scrollOrNot;													}
 
 	window.scrollIntoView = function (item, complete) {
+
+		if(!scrollAtAll)
+			return;
 
 		var itemTop			= item.offset().top
 		var itemBottom		= itemTop + item.height() + parseInt(item.css('marginBottom')) + parseInt(item.css('marginTop'))
@@ -196,7 +202,15 @@ $(document).ready(function () {
 		}
 	}
 
-	window.scrollToTopView = function (item) {		$("html, body").animate({ scrollTop: item.offset().top  }, { duration: 'slow', easing: 'swing' }); }
+	window.scrollToTopView = function (item)
+	{
+		console.log("window.scrollToTopView called and jasp.scrollAtAll: " + (jasp.scrollAtAll === undefined ? "undefined" : jasp.scrollAtAll ? "true" : "false"))
+
+		if(!scrollAtAll)
+			return;
+
+		$("html, body").animate({ scrollTop: item.offset().top  }, { duration: 'slow', easing: 'swing' });
+	}
 
 	window.slideAlpha = function (item, time, cssProperties, targetAlphas, divisions, clearStyleOnZero, completeCallback) {
 

--- a/JASP-Desktop/results/resultsjsinterface.cpp
+++ b/JASP-Desktop/results/resultsjsinterface.cpp
@@ -81,6 +81,15 @@ void ResultsJsInterface::setResultsLoaded(bool resultsLoaded)
 	}
 }
 
+void ResultsJsInterface::setScrollAtAll(bool scrollAtAll)
+{
+	if (_scrollAtAll == scrollAtAll)
+		return;
+
+	_scrollAtAll = scrollAtAll;
+	emit scrollAtAllChanged(_scrollAtAll);
+}
+
 void ResultsJsInterface::purgeClipboard()
 {
 	TempFiles::purgeClipboard();

--- a/JASP-Desktop/results/resultsjsinterface.h
+++ b/JASP-Desktop/results/resultsjsinterface.h
@@ -35,86 +35,88 @@ class ResultsJsInterface : public QObject
 	Q_PROPERTY(QString			resultsPageUrl	READ resultsPageUrl	WRITE setResultsPageUrl	NOTIFY resultsPageUrlChanged	)
 	Q_PROPERTY(double			zoom			READ zoom			WRITE setZoom			NOTIFY zoomChanged				)
 	Q_PROPERTY(bool				resultsLoaded	READ resultsLoaded	WRITE setResultsLoaded	NOTIFY resultsLoadedChanged		)
-
+	Q_PROPERTY(bool				scrollAtAll		READ scrollAtAll	WRITE setScrollAtAll	NOTIFY scrollAtAllChanged		)
 public:
 	explicit ResultsJsInterface(QObject *parent = 0);
 
-	void setStatus(Analysis *analysis);
-	void changeTitle(Analysis *analysis);
-	void showAnalysis(int id);
-	void analysisChanged(Analysis *analysis);
-	void setResultsMeta(QString str);
+	void setStatus(			Analysis *	analysis);
+	void changeTitle(		Analysis *	analysis);
+	void analysisChanged(	Analysis *	analysis);
+	void overwriteUserdata(	Analysis *	analysis);
+	void showAnalysis(		int			id);
+	void setResultsMeta(	QString		str);
 	void unselect();
 	void showInstruction();
 	void exportPreviewHTML();
 	void exportHTML();
 	void resetResults();
-	void overwriteUserdata(Analysis *analysis);
 
 	QString			resultsPageUrl()	const { return _resultsPageUrl;	}
 	double			zoom()				const { return _webEngineZoom;	}
 	bool			resultsLoaded()		const { return _resultsLoaded;	}
+	bool			scrollAtAll()		const {	return _scrollAtAll;	}
 
 	Q_INVOKABLE void purgeClipboard();
 	Q_INVOKABLE void analysisEditImage(int id, QString options);
 
 	//Callable from javascript through resultsJsInterfaceInterface...
-
-
 signals:
 	Q_INVOKABLE void openFileTab();
 	Q_INVOKABLE void saveTextToFile(const QString &filename, const QString &data);
 	Q_INVOKABLE void analysisUnselected();
-	Q_INVOKABLE void analysisChangedDownstream(int id, QString options);
-	Q_INVOKABLE void analysisSaveImage(int id, QString options);
-				void analysisResizeImage(int id, QString options);
-				void showPlotEditor(int id, QString options);
-	Q_INVOKABLE void analysisSelected(int id);
-	Q_INVOKABLE void analysisTitleChangedInResults(int id, QString title);
-	Q_INVOKABLE void removeAnalysisRequest(int id);
+	Q_INVOKABLE void analysisChangedDownstream(		int id, QString options);
+	Q_INVOKABLE void analysisSaveImage(				int id, QString options);
+				void analysisResizeImage(			int id, QString options);
+				void showPlotEditor(				int id, QString options);
+	Q_INVOKABLE void analysisSelected(				int id);
+	Q_INVOKABLE void analysisTitleChangedInResults(	int id, QString title);
+	Q_INVOKABLE void removeAnalysisRequest(			int id);
+	Q_INVOKABLE void duplicateAnalysis(				int id);
+	Q_INVOKABLE void showDependenciesInAnalysis(	int id, QString optionName);
 	Q_INVOKABLE void packageModified();
 	Q_INVOKABLE void refreshAllAnalyses();
 	Q_INVOKABLE void removeAllAnalyses();
-	Q_INVOKABLE void duplicateAnalysis(int id);
-	Q_INVOKABLE void showDependenciesInAnalysis(int analysis_id, QString optionName);
 
 public slots:
-	void setZoom(double zoom);
-	void resultsDocumentChanged()				{ emit packageModified(); }
-	void saveTempImage(int id, QString path, QByteArray data);
-	void pushImageToClipboard(const QByteArray &base64, const QString &html);
-	void pushToClipboard(const QString &mimeType, const QString &data, const QString &html);
-	void displayMessageFromResults(QString path);
-	void getImageInBase64(int id, const QString &path);
-	void setAllUserDataFromJavascript(QString json);
-	void setResultsMetaFromJavascript(QString json);
-	void removeAnalysis(Analysis *analysis);
+	void resultsDocumentChanged()		{ emit packageModified(); }
+	void setZoom(						double			zoom);
+	void saveTempImage(					int				id,			QString path,			QByteArray data);
+	void getImageInBase64(				int				id,			const QString & path);
+	void pushImageToClipboard(	const	QByteArray	&	base64,		const QString & html);
+	void pushToClipboard(		const	QString		&	mimeType,	const QString & data,	const QString &html);
+	void displayMessageFromResults(		QString			path);
+	void setAllUserDataFromJavascript(	QString			json);
+	void setResultsMetaFromJavascript(	QString			json);
+	void removeAnalysis(				Analysis	*	analysis);
 	void removeAnalyses();
-	void moveAnalyses(quint64 fromId, quint64 toId);
-	void setThemeCss(QString themeName);
+	void moveAnalyses(					quint64 fromId,				quint64 toId);
+	void setThemeCss(					QString themeName);
 
 //end callables
 
 
 signals:
-	void resultsMetaChanged(QString resultsMeta);
-	void allUserDataChanged(QString userData);
-	void resultsPageUrlChanged(QUrl resultsPageUrl);
-	void runJavaScript(QString js);
+	void resultsMetaChanged(	QString resultsMeta);
+	void allUserDataChanged(	QString userData);
+	void resultsPageUrlChanged(	QUrl	resultsPageUrl);
+	void runJavaScript(			QString js);
 	void zoomChanged();
 	void resultsPageLoadedSignal();
 
 	void resultsLoadedChanged(bool resultsLoaded);
 
+	void scrollAtAllChanged(bool scrollAtAll);
+
 public slots:
-	void setExactPValuesHandler(bool exact);
-	void setFixDecimalsHandler(QString numDecimals);
-	void analysisImageEditedHandler(Analysis *analysis);
-	void cancelImageEdit(int id);
-	void exportSelected(const QString &filename);
-	void setResultsPageUrl(QString resultsPageUrl);
+	void setExactPValuesHandler(	bool			exact);
+	void setFixDecimalsHandler(		QString			numDecimals);
+	void analysisImageEditedHandler(Analysis	*	analysis);
+	void cancelImageEdit(			int				id);
+	void exportSelected(	const	QString		&	filename);
+	void setResultsPageUrl(			QString			resultsPageUrl);
 	void setZoomInWebEngine();
-	void setResultsLoaded(bool resultsLoaded);
+	void setResultsLoaded(			bool			resultsLoaded);
+	void setScrollAtAll(			bool			scrollAtAll);
 
 private:
 	void	setGlobalJsValues();
@@ -124,9 +126,10 @@ private slots:
 	void menuHidding();
 
 private:
-	double			_webEngineZoom = 1.0;
+	double			_webEngineZoom	= 1.0;
 	QString			_resultsPageUrl = "qrc:///html/index.html";
-	bool			_resultsLoaded = false;
+	bool			_resultsLoaded	= false,
+					_scrollAtAll	= true;
 };
 
 


### PR DESCRIPTION
- implements https://github.com/jasp-stats/INTERNAL-jasp/issues/878
- Also moved the initializing of analyses on file load to Analyses instead of in MainWindow, because that is where it belongs!
- And by changing the webchannel Item in MainPage.qml to QtObject all those warnings about stuff not being updated on startup are now gone

