### PR TITLE
Add TabView control

### DIFF
--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -174,6 +174,7 @@ void AnalysisForm::_addControlWrapper(JASPControlWrapper* controlWrapper)
 	}
 	case JASPControlBase::ControlType::RepeatedMeasuresFactorsList:
 	case JASPControlBase::ControlType::InputListView:
+	case JASPControlBase::ControlType::TabView:
 	case JASPControlBase::ControlType::ComponentsList:
 	case JASPControlBase::ControlType::FactorsForm:
 	case JASPControlBase::ControlType::TableView:

--- a/JASP-Desktop/analysis/jaspcontrolbase.h
+++ b/JASP-Desktop/analysis/jaspcontrolbase.h
@@ -52,6 +52,7 @@ public:
 		, FactorsForm
 		, ComponentsList
 		, GroupBox
+		, TabView
 	};
 
 	// Be careful not to reuse a name in a enum type: in QML, they are mixed up with a 'JASP' prefix: JASP.DropNone or JASP.None

--- a/JASP-Desktop/components/JASP/Controls/ComponentsList.qml
+++ b/JASP-Desktop/components/JASP/Controls/ComponentsList.qml
@@ -32,24 +32,27 @@ JASPGridControl
 
 	property bool	addItemManually	: !source
 	property bool	showAddIcon		: addItemManually
-	property int	minimumRows		: 0
-	property string	deleteIcon		: "cross.png"
+	property int	minimumItems	: 0
+	property int	maximumItems	: -1
+	property string newItemName		: ""
+	property string	removeIcon		: "cross.png"
 	property string	addIcon			: "duplicate.png"
 	property string addTooltip		: qsTr("Add a row")
 	property string removeTooltip	: qsTr("Remove a row")
 	property var	defaultValues	: []
 
-	signal addRow();
-	signal removeRow(int index);
+	signal addItem();
+	signal removeItem(int index);
+	signal nameChanged(int index, string name)
 
 	MenuButton
 	{
 		id				: addIconItem
 		width			: height
 		radius			: height
-		visible			: showAddIcon
+		visible			: showAddIcon && (maximumItems <= 0 || maximumItems > componentsList.count)
 		iconSource		: jaspTheme.iconPath + addIcon
-		onClicked		: addRow()
+		onClicked		: addItem()
 		toolTip			: addTooltip
 		anchors.bottom	: parent.bottom
 		anchors.horizontalCenter: parent.horizontalCenter
@@ -78,11 +81,11 @@ JASPGridControl
 
 			Image
 			{
-				id						: deleteIconID
-				source					: jaspTheme.iconPath + deleteIcon
+				id						: removeIconID
+				source					: jaspTheme.iconPath + removeIcon
 				anchors.right			: parent.right
 				anchors.verticalCenter	: parent.verticalCenter
-				visible					: itemWrapper.isDeletable && componentsList.count > componentsList.minimumRows
+				visible					: itemWrapper.isDeletable && componentsList.count > componentsList.minimumItems
 				height					: jaspTheme.iconSize
 				width					: jaspTheme.iconSize
 				z						: 2
@@ -97,7 +100,7 @@ JASPGridControl
 				{
 					id					: deleteMouseArea
 					anchors.fill		: parent
-					onClicked			: removeRow(index)
+					onClicked			: removeItem(index)
 				}
 			}
 		}

--- a/JASP-Desktop/components/JASP/Controls/TabView.qml
+++ b/JASP-Desktop/components/JASP/Controls/TabView.qml
@@ -1,0 +1,217 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+
+import QtQuick			2.11
+import QtQuick.Controls 2.5 as QtControls
+import QtQuick.Layouts	1.3
+import JASP.Widgets		1.0
+import JASP				1.0
+
+JASPControl
+{
+	id						: tabView
+	controlType				: JASPControlBase.TabView
+	background				: rectangleItem
+	implicitWidth 			: parent.width
+	implicitHeight			: itemTitle.height + itemTabBar.height + itemStack.height
+	useControlMouseArea		: false
+	shouldStealHover		: false
+	innerControl			: itemTabBar
+
+	property var	model
+	property var	values
+	property string title
+	property alias	label				: tabView.title
+	property alias	count				: itemRepeater.count
+	property string	optionKey			: "value"
+	property var	source
+	property var	sourceModel
+	property alias	syncModels			: tabView.source
+	property var	defaultValues		: []
+	property bool	addItemManually		: !source
+	property bool	showAddIcon			: addItemManually
+	property bool	showRemoveIcon		: addItemManually
+	property bool	tabNameEditable		: addItemManually
+	property int	minimumItems		: 1
+	property int	maximumItems		: -1
+	property string	removeIcon			: "cross.png"
+	property string	addIcon				: "duplicate.png"
+	property string addTooltip			: qsTr("Add a tab")
+	property string removeTooltip		: qsTr("Remove this tab")
+	property string newItemName			: qsTr("New tab")
+	property alias	newTabName			: tabView.newItemName
+
+	property alias	itemTabBar			: itemTabBar
+	property alias	itemTitle			: itemTitle
+	property alias  content				: tabView.rowComponent
+	property alias	currentIndex		: itemTabBar.currentIndex
+
+	property var	buttonComponent		: defaultButtonButton
+
+	signal addItem();
+	signal removeItem(int index);
+	signal nameChanged(int index, string value)
+
+	Text
+	{
+		id				: itemTitle
+		anchors.top		: parent.top
+		anchors.left	: parent.left
+		text			: title
+		height			: title ? jaspTheme.listTitle : 0
+		font			: jaspTheme.font
+		color			: enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
+	}
+
+	Component
+	{
+		id: defaultButtonButton
+
+		QtControls.TabButton
+		{
+			id		: tabButton
+			width	: Math.min(100, (rectangleItem.width - itemRepeater.count - (showAddIcon ? addIconItem.width : 0)) / itemRepeater.count)
+			contentItem: Text
+			{
+				color				: jaspTheme.black
+				text				: model.name
+				horizontalAlignment	: Text.AlignLeft
+				verticalAlignment	: Text.AlignVCenter
+				elide				: Text.ElideRight
+				width				: parent.width - (removeIconItem.visible ? removeIconItem.width : 0)
+			}
+
+			background: Rectangle
+			{
+				color			: itemTabBar.currentIndex === index ? jaspTheme.analysisBackgroundColor : jaspTheme.buttonColor
+				radius			: jaspTheme.borderRadius
+				border.color	: jaspTheme.borderColor
+				border.width	: itemTabBar.currentIndex === index ? 0 : 1
+			}
+
+			onDoubleClicked:
+			{
+				if (tabNameEditable)
+				{
+					textFieldItem.visible = true
+					textFieldItem.forceActiveFocus();
+				}
+			}
+
+			TextField
+			{
+				id					: textFieldItem
+				z					: 3
+				isBound				: false
+				visible				: false
+				useExternalBorder	: false
+				value				: model.name
+				fieldWidth			: parent.width
+				fieldHeight			: parent.height
+				onEditingFinished	: tabView.nameChanged(index, value)
+
+				onActiveFocusChanged: if (!activeFocus) visible = false
+			}
+
+			Image
+			{
+				id						: removeIconItem
+				source					: jaspTheme.iconPath + tabView.removeIcon
+				anchors.right			: parent.right
+				anchors.verticalCenter	: parent.verticalCenter
+				visible					: tabView.showRemoveIcon && tabView.minimumItems < tabView.count
+				height					: jaspTheme.iconSize * preferencesModel.uiScale
+				width					: jaspTheme.iconSize * preferencesModel.uiScale
+				z						: 2
+
+				QtControls.ToolTip.text			: removeTooltip
+				QtControls.ToolTip.timeout		: jaspTheme.toolTipTimeout
+				QtControls.ToolTip.delay		: jaspTheme.toolTipDelay
+				QtControls.ToolTip.toolTip.font	: jaspTheme.font
+				QtControls.ToolTip.visible		: removeTooltip !== "" && deleteMouseArea.containsMouse
+
+				MouseArea
+				{
+					id				: deleteMouseArea
+					anchors.fill	: parent
+					onClicked		: tabView.removeItem(index)
+				}
+			}
+		}
+	}
+
+	Rectangle
+	{
+		id				: rectangleItem
+
+		anchors.top		: itemTitle.bottom
+		anchors.left	: parent.left
+		height			: itemTabBar.height + itemStack.height
+		width			: parent.width
+
+		color			: "transparent" //debug ? jaspTheme.debugBackgroundColor : jaspTheme.analysisBackgroundColor
+		radius			: jaspTheme.borderRadius
+		border.color	: jaspTheme.borderColor
+		border.width	: 1
+		z				: 2
+	}
+
+	QtControls.TabBar
+	{
+		id				: itemTabBar
+		anchors.top		: itemTitle.bottom
+		anchors.left	: parent.left
+
+		Repeater
+		{
+			id			: itemRepeater
+			model		: tabView.model
+			delegate	: tabView.buttonComponent
+		}
+	}
+
+	MenuButton
+	{
+		id				: addIconItem
+		width			: height
+		radius			: height
+		visible			: tabView.showAddIcon && (tabView.maximumItems <= 0 || tabView.maximumItems >= tabView.count)
+		iconSource		: jaspTheme.iconPath + tabView.addIcon
+		onClicked		: addItem()
+		toolTip			: tabView.addTooltip
+		anchors.left	: itemTabBar.right
+		anchors.top		: parent.top
+	}
+
+	StackLayout
+	{
+		id					: itemStack
+		anchors.top			: itemTabBar.bottom
+		anchors.left		: parent.left
+		anchors.right		: parent.right
+
+		currentIndex		: itemTabBar.currentIndex
+
+		Repeater
+		{
+			model			: tabView.model
+			delegate		: RowComponents { controls : model.rowComponents }
+		}
+	}
+}

--- a/JASP-Desktop/components/JASP/Controls/qmldir
+++ b/JASP-Desktop/components/JASP/Controls/qmldir
@@ -20,6 +20,7 @@ Group	           1.0 GroupBox.qml
 GroupBox            1.0 GroupBox.qml
 IntegerField         1.0 IntegerField.qml
 JASPControl           1.0 JASPControl.qml
+TabView                1.0 TabView.qml
 JASPGridControl        1.0 JASPGridControl.qml
 JASPGridViewControl    1.0 JASPGridViewControl.qml
 JASPDataView           1.0 JASPDataView.qml

--- a/JASP-Desktop/qml.qrc
+++ b/JASP-Desktop/qml.qrc
@@ -137,5 +137,6 @@
         <file>components/JASP/Controls/JASPGridControl.qml</file>
         <file>components/JASP/Controls/JASPGridViewControl.qml</file>
         <file>components/JASP/Controls/RowLayout.qml</file>
+        <file>components/JASP/Controls/TabView.qml</file>
     </qresource>
 </RCC>

--- a/JASP-Desktop/widgets/boundqmlcomponentslist.h
+++ b/JASP-Desktop/widgets/boundqmlcomponentslist.h
@@ -40,14 +40,19 @@ public:
 protected slots:
 	void		modelChangedHandler()						override;
 	void		valuesChangedHandler();
-	void		addRowHandler();
-	void		removeRowHandler(int index);
+	void		addItemHandler();
+	void		removeItemHandler(int index);
+	void		nameChangedHandler(int index, QString name);
 
 private:
 	ListModelTermsAssigned*		_termsModel;
 	OptionsTable*				_boundTo;
 
-	QString						_incrementCounter();
+protected:
+	QString				_makeUnique(const QString& val, int index = -1);
+	QString				_makeUnique(const QString& val, const QList<QString>& values, int index = -1);
+	QString				_changeLastNumber(const QString& val);
+
 
 };
 

--- a/JASP-Desktop/widgets/boundqmltextinput.cpp
+++ b/JASP-Desktop/widgets/boundqmltextinput.cpp
@@ -415,11 +415,17 @@ void BoundQMLTextInput::_setOptionValue(Option* option, QString& text)
 
 void BoundQMLTextInput::textChangedSlot()
 {
+	if (!isBound() && _inputType != TextInputType::FormulaType)
+		// In a TabView, if the name of the tab is edited and, before validating, a new tab is added, the model is first changed because of adding a tab,
+		// making possibly the QML item of the TextField invalid (as this TextField depends on the TabView model).
+		// But as this TextField is anyway not bound (_option is null), and is not a Formula, we don't need anyway to fetch the value of the item.
+		return;
+
 	_value = getItemProperty("value").toString();
 
 	if (_inputType == TextInputType::FormulaType)
 	{
-		// _formula might be empty (in TableView the FormulaType is not directly bound, and has it own model).
+		// _formula might be empty (in TableView the FormulaType is not directly bound, and has its own model).
 		if (!_formula || (_formula->value() != _value.toStdString()))
 		{
 			if (!_parseDefaultValue && _defaultValue == _value)

--- a/JASP-Desktop/widgets/jaspcontrolwrapper.cpp
+++ b/JASP-Desktop/widgets/jaspcontrolwrapper.cpp
@@ -82,6 +82,7 @@ JASPControlWrapper* JASPControlWrapper::buildJASPControlWrapper(JASPControlBase*
 	case JASPControlBase::ControlType::TextField:					controlWrapper		= new BoundQMLTextInput(control);					break;
 	case JASPControlBase::ControlType::FactorsForm:					controlWrapper		= new BoundQMLFactorsForm(control);					break;
 	case JASPControlBase::ControlType::InputListView:				controlWrapper		= new BoundQMLInputList(control);					break;
+	case JASPControlBase::ControlType::TabView:						controlWrapper		= new BoundQMLComponentsList(control);				break;
 	case JASPControlBase::ControlType::ComponentsList:				controlWrapper		= new BoundQMLComponentsList(control);				break;
 	case JASPControlBase::ControlType::RadioButtonGroup:			controlWrapper		= new BoundQMLRadioButtons(control);				break;
 	case JASPControlBase::ControlType::RepeatedMeasuresFactorsList:	controlWrapper		= new BoundQMLRepeatedMeasuresFactors(control);		break;

--- a/JASP-Desktop/widgets/listmodeltermsassigned.cpp
+++ b/JASP-Desktop/widgets/listmodeltermsassigned.cpp
@@ -100,7 +100,7 @@ Terms ListModelTermsAssigned::addTerms(const Terms& terms, int dropItemIndex, JA
 
 	_terms.set(newTerms);
 
-	endResetModel();	
+	endResetModel();
 
 	emit modelChanged(&terms, &_tempTermsToSendBack);
 	
@@ -126,3 +126,21 @@ const Terms &ListModelTermsAssigned::terms(const QString &what) const
 	else
 		return ListModelAssignedInterface::terms(what);
 }
+
+void ListModelTermsAssigned::changeTerm(int index, const QString& name)
+{
+	QString oldName = _terms[size_t(index)].asQString();
+	if (oldName != name)
+	{
+		_rowControlsMap[name] = _rowControlsMap[oldName];
+		_rowControlsOptions[name] = _rowControlsOptions[oldName];
+		_rowControlsMap.remove(oldName);
+		_rowControlsOptions.remove(oldName);
+		_terms.replace(index, Term(name));
+
+		emit modelChanged();
+		QModelIndex modelIndex = ListModelTermsAssigned::index(index, 0);
+		emit dataChanged(modelIndex, modelIndex);
+	}
+}
+

--- a/JASP-Desktop/widgets/listmodeltermsassigned.h
+++ b/JASP-Desktop/widgets/listmodeltermsassigned.h
@@ -34,6 +34,7 @@ public:
 	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, JASPControlBase::AssignType assignOption = JASPControlBase::AssignType::AssignDefault)	override;
 	const Terms&	terms(const QString& what = QString())															const	override;
 
+	virtual void	changeTerm(int index, const QString& name);
 
 public slots:
 	virtual void availableTermsChanged(const Terms* termsToAdd, const Terms* termsToRemove)							override;


### PR DESCRIPTION
This control reuse the BoundQMLComponentList
ComponentList, TabView & InputListView should be better integrated
together. This will be done after 0.13 release. For the time being I
have just added new functionality so that this does not interfere with
existing
controls.