### PR TITLE
Take non-system missing values from Readstat into account

### DIFF
--- a/JASP-Desktop/data/importers/readstat/readstatimportcolumn.h
+++ b/JASP-Desktop/data/importers/readstat/readstatimportcolumn.h
@@ -5,11 +5,13 @@
 #include "readstat.h"
 #include "../importcolumn.h"
 
+
+
 class ReadStatImportColumn : public ImportColumn
 {
 public:
 
-				ReadStatImportColumn(ImportDataSet* importDataSet, std::string name, std::string labelsID, columnType columnType = columnType::unknown);
+				ReadStatImportColumn(readstat_variable_t * readstat_var, ImportDataSet* importDataSet, std::string name, std::string labelsID, columnType columnType = columnType::unknown);
 				~ReadStatImportColumn()							override;
 
 	size_t						size()									const	override;
@@ -40,7 +42,8 @@ public:
 	void						setType(columnType newType);
 	bool						canConvertToType(columnType newType);
 
-	std::string					valueAsString(size_t row)	const;
+			std::string			valueAsString(size_t row)	const;
+	static	std::string			readstatValueToString(const readstat_value_t & val);
 
 	const std::vector<int>					&	ints()			const { return _ints;		}
 	const std::vector<double>				&	doubles()		const { return _doubles;	}
@@ -52,6 +55,7 @@ public:
 	void						tryNominalMinusText();
 
 private:
+	readstat_variable_t		*	_readstatVariable = nullptr;
 	std::string					_labelsID;
 	columnType					_type;
 	std::vector<int>			_ints;

--- a/JASP-Desktop/data/importers/readstatimporter.cpp
+++ b/JASP-Desktop/data/importers/readstatimporter.cpp
@@ -33,7 +33,7 @@ int handle_variable(int, readstat_variable_t *variable, const char *val_labels, 
 	case READSTAT_MEASURE_SCALE:	colType = columnType::scale;	break;
 	}
 
-	data->addColumn(var_index, new ReadStatImportColumn(data, name, labelsID, colType));
+	data->addColumn(var_index, new ReadStatImportColumn(variable, data, name, labelsID, colType));
 
 	return READSTAT_HANDLER_OK;
 }


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-issues/issues/733

It doesnt add those values to emptyValues or anything, but at least it correctly recognizes them. 
To properly fix this is more work and Ive opened a new issue for it: https://github.com/jasp-stats/INTERNAL-jasp/issues/882
But I think this is better to be postponed a bit.