### PR TITLE
Fixed Frantisek's problem

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/ComponentsList.qml
+++ b/JASP-Desktop/components/JASP/Controls/ComponentsList.qml
@@ -47,15 +47,18 @@ JASPGridControl
 
 	MenuButton
 	{
-		id				: addIconItem
-		width			: height
-		radius			: height
-		visible			: showAddIcon && (maximumItems <= 0 || maximumItems > componentsList.count)
-		iconSource		: jaspTheme.iconPath + addIcon
-		onClicked		: addItem()
-		toolTip			: addTooltip
-		anchors.bottom	: parent.bottom
-		anchors.horizontalCenter: parent.horizontalCenter
+		id					: addIconItem
+		width				: height
+		radius				: height
+		visible				: showAddIcon && (maximumItems <= 0 || maximumItems > componentsList.count)
+		iconSource			: jaspTheme.iconPath + addIcon
+		onClicked			: addItem()
+		toolTip				: addTooltip
+		anchors
+		{
+			bottom			: parent.bottom
+			horizontalCenter: parent.horizontalCenter
+		}
 	}
 
 	Component

--- a/JASP-Desktop/components/JASP/Controls/JASPGridControl.qml
+++ b/JASP-Desktop/components/JASP/Controls/JASPGridControl.qml
@@ -32,15 +32,6 @@ JASPControl
 	shouldStealHover		: false
 	innerControl			: itemGrid
 
-	onPreferredHeightChanged:
-	{
-		if (preferredHeight != implicitHeight)
-		{
-			// preferredHeight has been specifically set
-			implicitHeight = Qt.binding(function() { return preferredHeight; });
-		}
-	}
-
 	property var	model
 	property var	values
 	property string title


### PR DESCRIPTION
I do not see why we need to bind implicit to preferred, it caused binding loops, in unpredictable situations.

Why did you put it there @boutinb?
Without it @FBartos 's module no longer has the weird height glitch and if I look at JaspControl, JaspGridControl etc I don't see the need for this binding trick.

