### PR TITLE
Ttest Footnote part 2

### DIFF
--- a/JASP-Engine/JASP/R/ttestindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestindependentsamples.R
@@ -239,14 +239,12 @@ TTestIndependentSamples <- function(jaspResults, dataset = NULL, options, ...) {
       if (identical(errors, FALSE)) {
         result <- try(ttestIndependentMainTableRow(variable, dataset, test, testStat, effSize, optionsList, options))
         
-        if (!isTryError(result))
+        if (!isTryError(result)) {
           row <- c(row, result[["row"]])
-        else {
-          errorMessage <- .extractErrorMessage(result)
-
           if (result[["leveneViolated"]])
             table$addFootnote(gettext("Levene's test is significant (p < .05), suggesting a violation of the equal variance assumption"), colNames = "p", rowNames = rowName)
-
+        } else {
+          errorMessage <- .extractErrorMessage(result)
         }
         
       } else {


### PR DESCRIPTION
As noted by @TimKDJ and forgotten by me, the footnote should be created in the `if(!isTryerror(result))` part, not in the `else`.