### PR TITLE
Save figures as *.pptx

### DIFF
--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -713,7 +713,7 @@ void MainWindow::_analysisSaveImageHandler(Analysis* analysis, QString options)
 	parser.parse(utf8, root);
 
 	QString selectedFilter;
-	QString finalPath = MessageForwarder::browseSaveFile(tr("Save JASP Image"), "", tr("Portable Network Graphics (*.png);;Portable Document Format (*.pdf);;Encapsulated PostScript (*.eps);;300 dpi Tagged Image File (*.tiff)"), &selectedFilter);
+	QString finalPath = MessageForwarder::browseSaveFile(tr("Save JASP Image"), "", tr("Portable Network Graphics (*.png);;Portable Document Format (*.pdf);;Encapsulated PostScript (*.eps);;300 dpi Tagged Image File (*.tiff);;PowerPoint (*.pptx)"), &selectedFilter);
 
 	if (!finalPath.isEmpty())
 	{
@@ -722,6 +722,7 @@ void MainWindow::_analysisSaveImageHandler(Analysis* analysis, QString options)
 		if		(selectedFilter == "Encapsulated PostScript (*.eps)")		root["type"] = "eps";
 		else if (selectedFilter == "Portable Document Format (*.pdf)")		root["type"] = "pdf";
 		else if (selectedFilter == "300 dpi Tagged Image File (*.tiff)")	root["type"] = "tiff";
+		else if (selectedFilter == "PowerPoint (*.pptx)")					root["type"] = "pptx";
 
 		if(root["type"].asString() != "png")
 		{


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/888

[Diff without whitespace changes](https://github.com/jasp-stats/jasp-desktop/pull/4106/files?w=1)

New packages:

| Package       | Version       |
| ------------- | ------------- |
| uuid          | 0.1-4         |
| rvg           | 0.2.4         |
| officer       | 0.3.11        |

all from CRAN.


To use, click on a plot, select `Save Image As`. A window opens. Under `Files of type`, select `PowerPoint (*.pptx)`:

![image](https://user-images.githubusercontent.com/21319932/83322667-f25a1380-a259-11ea-9070-1716c2f3d356.png)

This works well for both `ggplot` and `qgraph` objects, but less well for `JASPgraphsPlot`. There the rastering fails and the `.pptx` file just contains an image, which is okay I guess.

I only tested this on Linux but the package authors say it works everywhere and doesn't require any dependencies. Still, I think we should test this on multiple systems to be safe.

@AlexanderLyNL can you test MacOS? 

@TimKDJ can you test Windows?

