### PR TITLE
Adds 'debug' to entries in Description.qml

### DIFF
--- a/Dynamic Modules/TestModule/DESCRIPTION
+++ b/Dynamic Modules/TestModule/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: TestModule
 Type: Package
-Title: Test Module Module for JASP
-Version: 1.0
-Date: 2020-05-28
+Title: Wait for it... Module for JASP
+Version: 1.0.0
+Date: 2020-06-03
 Author: Joris Goosen
 Website: 
 Maintainer: Joris Goosen <Joris@JorisGoosen.nl>

--- a/Dynamic Modules/TestModule/NAMESPACE
+++ b/Dynamic Modules/TestModule/NAMESPACE
@@ -6,5 +6,6 @@ export(testContainerFunc)
 export(testEncodingFunc)
 export(customContrasts)
 export(testSaveLoadButton)
+export(customContrasts)
   import('svglite');
   import('stringi');

--- a/Dynamic Modules/TestModule/inst/Description.qml
+++ b/Dynamic Modules/TestModule/inst/Description.qml
@@ -94,5 +94,20 @@ Description
 		qml:			"testSaveLoadButton.qml"
 		func:			"testSaveLoadButton"
 	}
+
+
+	Separator { debug: true; }
+
+	GroupTitle { title:		"DEBUG QML Widgets"; debug: true; }
+
+	Analysis
+	{
+		title:			"DEBUG Custom Contrasts Widget"
+		qml:			"customContrasts.qml"
+		func:			"customContrasts"
+		requiresData:	true
+		debug:			true
+	}
+
 }
 

--- a/JASP-Desktop/engine/enginesync.cpp
+++ b/JASP-Desktop/engine/enginesync.cpp
@@ -332,6 +332,10 @@ void EngineSync::processDynamicModules()
 			}
 		}
 	}
+	catch(Modules::ModuleException e)
+	{
+		Log::log() << "Exception thrown in processDynamicModules: " <<  e.what() << std::endl;
+	}
 	catch(...)
 	{
 		Log::log() << "Exception thrown in processDynamicModules" << std::endl;

--- a/JASP-Desktop/modules/description/description.cpp
+++ b/JASP-Desktop/modules/description/description.cpp
@@ -218,7 +218,7 @@ std::vector<AnalysisEntry*> Description::menuEntries() const
 	std::vector<AnalysisEntry*> entries;
 
 	for(EntryBase * entry : _entries)
-		if(entry->enabled())
+		if(entry->shouldBeAdded())
 			entries.push_back(entry->convertToAnalysisEntry(requiresData()));
 
 	return entries;

--- a/JASP-Desktop/modules/description/entrybase.h
+++ b/JASP-Desktop/modules/description/entrybase.h
@@ -28,7 +28,8 @@ class EntryBase : public DescriptionChildBase
 	Q_PROPERTY(QString		qml				READ qml			WRITE setQml			NOTIFY qmlChanged			)
 	Q_PROPERTY(EntryType	entryType		READ entryType								NOTIFY entryTypeChanged		) //Entry type can only be set in constructor, to keep things manageable
 	Q_PROPERTY(bool			requiresData	READ requiresData	WRITE setRequiresData	NOTIFY requiresDataChanged	)
-	Q_PROPERTY(bool			enabled			READ enabled		WRITE setEnabled		NOTIFY enabledChanged		)
+	Q_PROPERTY(bool			enabled			READ enabled		WRITE setEnabled		NOTIFY enabledChanged		) //Hmm, this already exists in QQuickItem, maybe a problem?
+	Q_PROPERTY(bool			debug			READ debug			WRITE setDebug			NOTIFY debugChanged			)
 
 public:
 	enum class EntryType {unknown, separator, groupTitle, analysis};
@@ -44,20 +45,25 @@ public:
 	bool		requiresData()	const { return _requiresData;	}
 	bool		enabled()		const { return _enabled;		}
 	QString		qml()			const { return _qml;			}
-
+	bool		debug()			const { return _debug;			}
 	QString		toString()		const;
+	bool		shouldBeAdded()	const;
 
 	///This function is a stopgap and these two classes must be merged together later
 	AnalysisEntry * convertToAnalysisEntry(bool requiresDataDefault) const;
+
+
 
 public slots:
 	void setMenu(			QString menu);
 	void setTitle(			QString title);
 	void setFunction(		QString function);
 	void setIcon(			QString icon);
+	void setQml(			QString qml);
 	void setRequiresData(	bool	requiresData);
 	void setEnabled(		bool	enabled);
-	void setQml(			QString qml);
+	void setDebug(			bool	debug);
+	void devModeChanged(	bool	devMode);
 
 signals:
 	void menuChanged(			QString		menu);
@@ -67,8 +73,8 @@ signals:
 	void entryTypeChanged(		EntryType	entryType);
 	void requiresDataChanged(	bool		requiresData);
 	void enabledChanged(		bool		enabled);
-
-	void qmlChanged(QString qml);
+	void qmlChanged(			QString		qml);
+	void debugChanged(			bool		debug);
 
 private:
 	QString			_menu					= "",
@@ -79,8 +85,8 @@ private:
 	EntryType		_entryType				= EntryType::unknown;
 	bool			_requiresData			= false,
 					_useDefaultRequiresData = true, //will be set to false whenever a value is set through setRequiresData
-					_enabled				= true;
-
+					_enabled				= true,
+					_debug					= false;
 };
 
 #define MAKE_ENTRY_CLASS(CLASS_NAME, ENTRYTYPENAME) class CLASS_NAME : public EntryBase \


### PR DESCRIPTION
- They will only be shown in developer mode
- Implements https://github.com/jasp-stats/INTERNAL-jasp/issues/895
- Also makes sure that any parsing errors and stuff like that in Description.qml are shown in a msgbox to the user...

