### PR TITLE
Initial some pointers to null.

### DIFF
--- a/JASP-Desktop/widgets/boundqmlcomponentslist.h
+++ b/JASP-Desktop/widgets/boundqmlcomponentslist.h
@@ -45,8 +45,8 @@ protected slots:
 	void		nameChangedHandler(int index, QString name);
 
 private:
-	ListModelTermsAssigned*		_termsModel;
-	OptionsTable*				_boundTo;
+	ListModelTermsAssigned*		_termsModel		= nullptr;
+	OptionsTable*				_boundTo		= nullptr;
 
 protected:
 	QString				_makeUnique(const QString& val, int index = -1);

--- a/JASP-Desktop/widgets/boundqmlfactorsform.h
+++ b/JASP-Desktop/widgets/boundqmlfactorsform.h
@@ -46,11 +46,11 @@ protected slots:
 	void addListViewSlot(BoundQMLListViewTerms* listView);
 	
 private:
-	ListModelFactorsForm*	_factorsModel;
-	OptionsTable*			_boundTo;
+	ListModelFactorsForm*	_factorsModel				= nullptr;
+	OptionsTable*			_boundTo					= nullptr;
 	QString					_availableVariablesListName;
-	JASPControlBase*		_availableVariablesListItem;
-	int						_initNumberFactors;
+	JASPControlBase*		_availableVariablesListItem	= nullptr;
+	int						_initNumberFactors			= 1;
 };
 
 #endif // BOUNDQMLFACTORSFORM_H

--- a/JASP-Desktop/widgets/boundqmlinputlist.h
+++ b/JASP-Desktop/widgets/boundqmlinputlist.h
@@ -42,8 +42,8 @@ protected slots:
 	void		modelChangedHandler()						override;
 
 private:
-	ListModelInputValue*		_inputModel;
-	OptionsTable*				_boundTo;
+	ListModelInputValue*		_inputModel			= nullptr;
+	OptionsTable*				_boundTo			= nullptr;
 	std::vector<std::string>	_defaultValues;
 	
 };

--- a/JASP-Desktop/widgets/boundqmllistviewlayers.h
+++ b/JASP-Desktop/widgets/boundqmllistviewlayers.h
@@ -41,8 +41,8 @@ protected slots:
 	void modelChangedHandler() override;
 	
 private:
-	OptionsTable*				_boundTo;
-	ListModelLayersAssigned*	_layersModel;
+	OptionsTable*				_boundTo		= nullptr;
+	ListModelLayersAssigned*	_layersModel	= nullptr;
 	
 };
 

--- a/JASP-Desktop/widgets/boundqmlrepeatedmeasuresfactors.h
+++ b/JASP-Desktop/widgets/boundqmlrepeatedmeasuresfactors.h
@@ -42,8 +42,8 @@ protected slots:
 	void modelChangedHandler() override;
 	
 private:
-	ListModelRepeatedMeasuresFactors*	_factorsModel;
-	OptionsTable*						_boundTo;
+	ListModelRepeatedMeasuresFactors*	_factorsModel	= nullptr;
+	OptionsTable*						_boundTo		= nullptr;
 	
 };
 


### PR DESCRIPTION
This might help the crash that Frantic encounters with Mixed Models.

I saw in the call stack that it uses a _boundTo pointer which was not initialized