### PR TITLE
VariableList property to specify if all interactions are added by default

### DIFF
--- a/Docs/development/jasp-qml-guide.md
+++ b/Docs/development/jasp-qml-guide.md
@@ -395,6 +395,7 @@ Properties
 - `maxRows`: [optional, default: `-1`] maximum number of rows the list can accept. -1 means no limit.
 - `singleVariable`: [optional, default: `false`] if true, set the maxRows to 1
 - `listViewType`: [optional] enumerative that specifies the type of `AssignedVariablesList`, when omitted we get a normal list, options are `JASP.Layers` (see Contingency Tables), `JASP.Interaction` (see ANOVA) and `JASP.RepeatedMeasures` (see Repeated Measures ANOVA)
+- `addInteractionsByDefault`: [optional, default: `true`] Specify if all interactions between factors should be automatically added to the model. Only has an effect if `listViewType == JASP.Interaction`.
 - `width`: [optional, default: 2/5 of the VariablesForm width] in pixels how wide should the field be
 - `height`: [optional] in pixels how heigh should the field be. Per default, it is set so that all AssignedVariablesList's fit the VariablesForm. If you set the height for 1 AssignedVariablesList, it will try to set height of the other AssignedVariablesLists's so that they all fit the heigth of the VariablesForm.
 - `count`: [read-only integer] Gives the number of rows of the list.

--- a/JASP-Desktop/components/JASP/Controls/VariablesList.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesList.qml
@@ -48,6 +48,7 @@ JASPGridViewControl
 	property bool	showVariableTypeIcon			: true
 	property bool	setWidthInForm					: false
 	property bool	setHeightInForm					: false
+	property bool	addInteractionsByDefault		: true
 	property bool	interactionContainLowerTerms	: true
 	property var	interactionHighOrderCheckBox
 	property bool	addAvailableVariablesToAssigned	: listViewType === JASP.Interaction

--- a/JASP-Desktop/widgets/boundqmllistviewterms.cpp
+++ b/JASP-Desktop/widgets/boundqmllistviewterms.cpp
@@ -30,8 +30,6 @@
 #include "log.h"
 #include "rowcontrols.h"
 
-using namespace std;
-
 BoundQMLListViewTerms::BoundQMLListViewTerms(JASPControlBase* item, bool interaction)
 	: JASPControlWrapper(item)
 	, BoundQMLListViewDraggable(item)
@@ -40,11 +38,12 @@ BoundQMLListViewTerms::BoundQMLListViewTerms(JASPControlBase* item, bool interac
 	_optionVariables = nullptr;
 	_maxRows = getItemProperty("maxRows").toInt();
 	_columns = getItemProperty("columns").toInt();
-	bool interactionContainLowerTerms = getItemProperty("interactionContainLowerTerms").toBool();
-	_interactionHighOrderCheckBoxName = getItemProperty("interactionHighOrderCheckBox").toString();
+	bool interactionContainLowerTerms	= getItemProperty("interactionContainLowerTerms").toBool();
+	_interactionHighOrderCheckBoxName	= getItemProperty("interactionHighOrderCheckBox").toString();
+	bool addInteractionsByDefault		= getItemProperty("addInteractionsByDefault").toBool();
 		
 	if (interaction)
-		_termsModel = new ListModelInteractionAssigned(this, interactionContainLowerTerms);
+		_termsModel = new ListModelInteractionAssigned(this, interactionContainLowerTerms, addInteractionsByDefault);
 	else if (_columns > 1)
 		_termsModel = new ListModelMultiTermsAssigned(this, _columns);
 	else
@@ -229,7 +228,7 @@ void BoundQMLListViewTerms::modelChangedHandler()
 
 	if (_optionsTable)
 	{
-		vector<Options*> allOptions;
+		std::vector<Options*> allOptions;
 		const Terms& terms = _termsModel->terms();
 		const QMap<QString, RowControls*>& allControls = _termsModel->getRowControls();
 		for (const Term& term : terms)

--- a/JASP-Desktop/widgets/listmodelinteractionassigned.cpp
+++ b/JASP-Desktop/widgets/listmodelinteractionassigned.cpp
@@ -25,12 +25,13 @@
 
 using namespace std;
 
-ListModelInteractionAssigned::ListModelInteractionAssigned(QMLListView* listView, bool mustContainLowerTerms)
+ListModelInteractionAssigned::ListModelInteractionAssigned(QMLListView* listView, bool mustContainLowerTerms, bool addInteractionsByDefault)
 	: ListModelAssignedInterface(listView), InteractionModel ()
 {
-	_areTermsInteractions = true;
-	_copyTermsWhenDropped = true;
-	_mustContainLowerTerms = mustContainLowerTerms;
+	_areTermsInteractions		= true;
+	_copyTermsWhenDropped		= true;
+	_mustContainLowerTerms		= mustContainLowerTerms;
+	_addInteractionsByDefault	= addInteractionsByDefault;
 }
 
 void ListModelInteractionAssigned::initTerms(const Terms &terms, const RowControlsOptions& allOptionsMap)
@@ -140,7 +141,7 @@ void ListModelInteractionAssigned::availableTermsChanged(const Terms *termsAdded
 {
 	if (termsAdded && termsAdded->size() > 0 && _addNewAvailableTermsToAssignedModel)
 	{
-		_addTerms(*termsAdded, true);
+		_addTerms(*termsAdded, _addInteractionsByDefault);
 		setTerms();
 	}
 	

--- a/JASP-Desktop/widgets/listmodelinteractionassigned.h
+++ b/JASP-Desktop/widgets/listmodelinteractionassigned.h
@@ -30,7 +30,7 @@ class ListModelInteractionAssigned : public ListModelAssignedInterface, public I
 	Q_OBJECT
 	
 public:
-	ListModelInteractionAssigned(QMLListView* listView, bool mustContainLowerTerms);
+	ListModelInteractionAssigned(QMLListView* listView, bool mustContainLowerTerms, bool addInteractionsByDefault);
 
 	void			initTerms(const Terms &terms, const RowControlsOptions& = RowControlsOptions())	override;
 	void			setAvailableModel(ListModelAvailableInterface *source)							override;
@@ -51,6 +51,8 @@ protected:
 	void _addTerms(const Terms& terms, bool combineWithExistingTerms);
 	
 	void setTerms();
+
+	bool _addInteractionsByDefault;
 };
 
 

--- a/Resources/Frequencies/qml/RegressionLogLinear.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinear.qml
@@ -37,7 +37,7 @@ Form
 		{
 			preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
 			AvailableVariablesList	{ name: "availableTerms";	title: qsTr("Components");	width: parent.width / 4;		source: ['factors'] }
-			AssignedVariablesList	{ name: "modelTerms";		title: qsTr("Model Terms");	width: parent.width * 5 / 9;	listViewType: JASP.Interaction }
+			AssignedVariablesList	{ name: "modelTerms";		title: qsTr("Model Terms");	width: parent.width * 5 / 9;	listViewType: JASP.Interaction;	addInteractionsByDefault: false}
 		}
 	}
 	

--- a/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
+++ b/Resources/Frequencies/qml/RegressionLogLinearBayesian.qml
@@ -56,7 +56,7 @@ Form
 			preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
 			
 			AvailableVariablesList { name: "availableTerms"; title: qsTr("Components"); width: parent.width / 4; source: ['factors'] }
-			AssignedVariablesList {  name: "modelTerms";	 title: qsTr("Model Terms"); width: parent.width * 5 / 9; listViewType: JASP.Interaction }
+			AssignedVariablesList {  name: "modelTerms";	 title: qsTr("Model Terms"); width: parent.width * 5 / 9; listViewType: JASP.Interaction; addInteractionsByDefault: false }
 		}
 	}
 	

--- a/Resources/Regression/qml/RegressionLogistic.qml
+++ b/Resources/Regression/qml/RegressionLogistic.qml
@@ -61,7 +61,7 @@ Form
 				source: ['covariates', 'factors']
 				width: parent.width / 4
 			}
-			ModelTermsList { width: parent.width * 5 / 9; 	addInteractionsByDefault: falses }
+			ModelTermsList { width: parent.width * 5 / 9; 	addInteractionsByDefault: false }
 		}
 		
 	}

--- a/Resources/Regression/qml/RegressionLogistic.qml
+++ b/Resources/Regression/qml/RegressionLogistic.qml
@@ -61,7 +61,7 @@ Form
 				source: ['covariates', 'factors']
 				width: parent.width / 4
 			}
-			ModelTermsList { width: parent.width * 5 / 9 }
+			ModelTermsList { width: parent.width * 5 / 9; 	addInteractionsByDefault: falses }
 		}
 		
 	}


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/894

Introduces the QML property `addInteractionsByDefault` so that `_addTerms(*termsAdded, true)` becomes `_addTerms(*termsAdded, _addInteractionsByDefault)`. `_addTerms` already had a bool to decide if interactions should be generated.

Here, I've only implemented this for `RegressionLogLinear.qml` (hence the draft PR). @boutinb let me know if this is the right approach. If so I'll also implement this for the other analyses discussed.

