### PR TITLE
Add footnote for paired t-tests

### DIFF
--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -219,10 +219,10 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
   )
   bfTitle <- .ttestBayesianGetBFTitle(bfType, hypothesis)
 
-  jaspTable$addColumnInfo(name = "variable1", title = "",      type = "string")
-  jaspTable$addColumnInfo(name = "separator", title = "",      type = "separator")
-  jaspTable$addColumnInfo(name = "variable2", title = "",      type = "string")
-  jaspTable$addColumnInfo(name = "BF",        title = bfTitle, type = "number")
+  jaspTable$addColumnInfo(name = "variable1", title = "Measure 1", type = "string")
+  jaspTable$addColumnInfo(name = "separator", title = "",          type = "separator")
+  jaspTable$addColumnInfo(name = "variable2", title = "Measure 2", type = "string")
+  jaspTable$addColumnInfo(name = "BF",        title = bfTitle,     type = "number")
 
   if (derivedOptions[["wilcoxTest"]]) {
     jaspTable$addColumnInfo(name = "error", type = "number", title = "W")
@@ -236,6 +236,9 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
     }
     jaspTable$addColumnInfo(name = "error", type = "number", format = fmt, title = gettext("error %"))
   }
+
+  if (options[["hypothesis"]] == "groupOneGreater" || options[["hypothesis"]] == "groupTwoGreater")
+    jaspTable$addFootnote(.ttestPairedGetHypothesisFootnote(options[["hypothesis"]], options[["pairs"]]))
 
   return(jaspTable)
 }

--- a/JASP-Engine/JASP/R/ttestpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestpairedsamples.R
@@ -473,9 +473,9 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     pair2 <- pairs[[idx]][[2L]]
     if (onePair) { # one pair, only give example
       ans <- if (isLess) {
-        gettextf("The alternative hypothesis specifies that %1s is less than %2s.", pair1, pair2)
+        gettextf("For all tests, the alternative hypothesis specifies that %1s is less than %2s.", pair1, pair2)
       } else {
-        gettextf("The alternative hypothesis specifies that %1s is greater than %2s.", pair1, pair2)
+        gettextf("For all tests, the alternative hypothesis specifies that %1s is greater than %2s.", pair1, pair2)
       }
     } else { # multiple pairs, general + example
       ans <- if (isLess) {

--- a/JASP-Engine/JASP/R/ttestpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestpairedsamples.R
@@ -457,15 +457,35 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
 }
 
 .ttestPairedGetHypothesisFootnote <- function(hypothesis, pairs) {
-  directionNote <- if (hypothesis == "groupTwoGreater") gettext("less") else gettext("greater")
+
   idx <- .ttestPairedGetIndexOfFirstNonEmptyPair(pairs)
-  return(
-    if (idx != 0L)
-      gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is %1s than Measure 2. For example, %2s is %3s than %4s.",
-               directionNote, pairs[[idx]][[1L]], directionNote, pairs[[idx]][[2L]])
-    else
-      gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is %s than Measure 2.", directionNote)
-  )
+  onePair <- length(pairs) == 1L
+  isLess <- hypothesis == "groupTwoGreater" # greater -> 1 is less than 2
+
+  if (idx == 0L) { # no pairs, no example
+    ans <- if (isLess) {
+      gettext("For all tests, the alternative hypothesis specifies that Measure 1 is less than Measure 2.")
+    } else {
+      gettext("For all tests, the alternative hypothesis specifies that Measure 1 is greater than Measure 2.")
+    }
+  } else {
+    pair1 <- pairs[[idx]][[1L]]
+    pair2 <- pairs[[idx]][[2L]]
+    if (onePair) { # one pair, only give example
+      ans <- if (isLess) {
+        gettextf("the alternative hypothesis specifies that %1s is less than %2s.", pair1, pair2)
+      } else {
+        gettextf("the alternative hypothesis specifies that %1s is greater than %2s.", pair1, pair2)
+      }
+    } else { # multiple pairs, general + example
+      ans <- if (isLess) {
+        gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is less than Measure 2. For example, %1s is less than %2s.", pair1, pair2)
+      } else {
+        gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is greater than Measure 2. For example, %1s is greater than %2s.", pair1, pair2)
+      }
+    }
+  }
+  return(ans)
 }
 
 .ttestPairedGetIndexOfFirstNonEmptyPair <- function(pairs) {

--- a/JASP-Engine/JASP/R/ttestpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestpairedsamples.R
@@ -473,9 +473,9 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     pair2 <- pairs[[idx]][[2L]]
     if (onePair) { # one pair, only give example
       ans <- if (isLess) {
-        gettextf("the alternative hypothesis specifies that %1s is less than %2s.", pair1, pair2)
+        gettextf("The alternative hypothesis specifies that %1s is less than %2s.", pair1, pair2)
       } else {
-        gettextf("the alternative hypothesis specifies that %1s is greater than %2s.", pair1, pair2)
+        gettextf("The alternative hypothesis specifies that %1s is greater than %2s.", pair1, pair2)
       }
     } else { # multiple pairs, general + example
       ans <- if (isLess) {

--- a/JASP-Engine/JASP/R/ttestpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestpairedsamples.R
@@ -49,9 +49,9 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   ttest$showSpecifiedColumnsOnly <- TRUE
   ttest$position <- 1
   
-  ttest$addColumnInfo(name = "v1", type = "string", title = "")
-  ttest$addColumnInfo(name = "sep",  type = "separator", title = "")
-  ttest$addColumnInfo(name = "v2", type = "string", title = "")
+  ttest$addColumnInfo(name = "v1",  type = "string",    title = "Measure 1")
+  ttest$addColumnInfo(name = "sep", type = "separator", title = "")
+  ttest$addColumnInfo(name = "v2",  type = "string",    title = "Measure 2")
   
   if (optionsList$wantsWilcox && optionsList$onlyTest) {
     ttest$addFootnote(gettext("Wilcoxon signed-rank test."))
@@ -114,7 +114,12 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   
   if (options$hypothesis == "groupOneGreater" || options$hypothesis == "groupTwoGreater") {
     directionNote <- ifelse(options$hypothesis == "groupTwoGreater", gettext("less"), gettext("greater"))
-    ttest$addFootnote(gettextf("For all tests, the alternative hypothesis specifies that measurement one is %s than measurement two.", directionNote))
+    idx <- .ttestPairedGetIndexOfFirstNonEmptyPair(options[["pairs"]])
+    if (idx != 0L)
+      ttest$addFootnote(gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is %s than Measure 2. For example, %2s is %3s than %4s.",
+                                 directionNote, options$pairs[[idx]][[1L]], directionNote, options$pairs[[idx]][[2L]]))
+    else
+      ttest$addFootnote(gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is %s than Measure 2.", directionNote))
   }
   
   jaspResults[["ttest"]] <- ttest
@@ -459,4 +464,9 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   return(p)
 }
 
-
+.ttestPairedGetIndexOfFirstNonEmptyPair <- function(pairs) {
+  for (i in seq_along(pairs))
+    if (pairs[[i]][1L] != "" && pairs[[i]][[2L]] != "")
+      return(i)
+  return(0L)
+}

--- a/JASP-Engine/JASP/R/ttestpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestpairedsamples.R
@@ -111,16 +111,8 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
     ttest$addColumnInfo(name = "upperCIeffectSize", type = "number", title = gettext("Upper"), overtitle = title)
   }
   
-  
-  if (options$hypothesis == "groupOneGreater" || options$hypothesis == "groupTwoGreater") {
-    directionNote <- ifelse(options$hypothesis == "groupTwoGreater", gettext("less"), gettext("greater"))
-    idx <- .ttestPairedGetIndexOfFirstNonEmptyPair(options[["pairs"]])
-    if (idx != 0L)
-      ttest$addFootnote(gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is %s than Measure 2. For example, %2s is %3s than %4s.",
-                                 directionNote, options$pairs[[idx]][[1L]], directionNote, options$pairs[[idx]][[2L]]))
-    else
-      ttest$addFootnote(gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is %s than Measure 2.", directionNote))
-  }
+  if (options$hypothesis == "groupOneGreater" || options$hypothesis == "groupTwoGreater")
+    ttest$addFootnote(.ttestPairedGetHypothesisFootnote(options[["hypothesis"]], options[["pairs"]]))
   
   jaspResults[["ttest"]] <- ttest
   
@@ -462,6 +454,18 @@ TTestPairedSamples <- function(jaspResults, dataset = NULL, options, ...) {
   p <- JASPgraphs::themeJasp(p)
   
   return(p)
+}
+
+.ttestPairedGetHypothesisFootnote <- function(hypothesis, pairs) {
+  directionNote <- if (hypothesis == "groupTwoGreater") gettext("less") else gettext("greater")
+  idx <- .ttestPairedGetIndexOfFirstNonEmptyPair(pairs)
+  return(
+    if (idx != 0L)
+      gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is %1s than Measure 2. For example, %2s is %3s than %4s.",
+               directionNote, pairs[[idx]][[1L]], directionNote, pairs[[idx]][[2L]])
+    else
+      gettextf("For all tests, the alternative hypothesis specifies that Measure 1 is %s than Measure 2.", directionNote)
+  )
 }
 
 .ttestPairedGetIndexOfFirstNonEmptyPair <- function(pairs) {


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/758

For both paired t-tests, adds a footnote if the alternative hypothesis is directional. See screenshot below.

![image](https://user-images.githubusercontent.com/21319932/84033444-255a8080-a999-11ea-95d1-26ca9954a889.png)

Only gives an example for the first complete pair (if there is any).

