### PR TITLE
Give a bit more time to check whether the data file exist or not

### DIFF
--- a/JASP-Desktop/widgets/filemenu/filemenu.h
+++ b/JASP-Desktop/widgets/filemenu/filemenu.h
@@ -81,7 +81,7 @@ public:
 	bool			isCurrentFileReadOnly() const { return _currentFileReadOnly; }
 
 	void			showPreferences();
-	void			syncDataFile(const QString& path);
+	void			syncDataFile(const QString& path, bool waitForExistence = false);
 
 
 	ActionButtons::FileOperation		fileoperation()				const	{ return _fileoperation;			}
@@ -127,7 +127,7 @@ private slots:
 private:
 			bool checkSyncFileExists(const QString &path, bool waitForExistence = false);
 			void clearSyncData();
-			void setSyncRequest(const QString& path);
+			void setSyncRequest(const QString& path, bool waitForExistence = false);
 
 	static	bool clearOSFFromRecentList(QString path);
 


### PR DESCRIPTION
In https://github.com/jasp-stats/jasp-issues/issues/786, a
synchronisation problem was again encountered.
I have suppressed the check of whether the data file exists during the
loading of a JASP file, and give up to 1 second to check whether the
file exists and is not empty when the watcher signals a change in the data file.