### PR TITLE
Saving a file with a particular extension should always actually add that extension

### DIFF
--- a/Dynamic Modules/TestModule/DESCRIPTION
+++ b/Dynamic Modules/TestModule/DESCRIPTION
@@ -2,7 +2,7 @@ Package: TestModule
 Type: Package
 Title: Test Module Module for JASP
 Version: 1.0
-Date: 2020-05-28
+Date: 2020-06-10
 Author: Joris Goosen
 Website: 
 Maintainer: Joris Goosen <Joris@JorisGoosen.nl>

--- a/JASP-Desktop/engine/enginerepresentation.cpp
+++ b/JASP-Desktop/engine/enginerepresentation.cpp
@@ -579,6 +579,9 @@ void EngineRepresentation::restartEngine(QProcess * jaspEngineProcess)
 
 void EngineRepresentation::pauseEngine()
 {
+	if(initializing())
+		return;
+
 	_pauseRequested = true;
 	abortAnalysisInProgress(true);
 }
@@ -598,6 +601,9 @@ void EngineRepresentation::resumeEngine()
 {
 	if(_engineState != engineState::paused && _engineState != engineState::stopped && _engineState != engineState::initializing)
 		throw unexpectedEngineReply("Attempt to resume engine #" + std::to_string(channelNumber()) + " made but it isn't paused, initializing or stopped");
+
+	if(initializing())
+		return;
 
 	_pauseRequested			= false;
 	_engineState			= engineState::resuming;

--- a/JASP-Desktop/engine/enginesync.cpp
+++ b/JASP-Desktop/engine/enginesync.cpp
@@ -627,7 +627,7 @@ bool EngineSync::allEnginesStopped()
 bool EngineSync::allEnginesPaused()
 {
 	for(auto * engine : _engines)
-		if(!engine->paused() && !engine->initializing()) //Initializing is also sort of paused I guess
+		if(!engine->paused()) //Initializing() is part paused()
 			return false;
 	return true;
 }

--- a/JASP-Desktop/gui/messageforwarder.cpp
+++ b/JASP-Desktop/gui/messageforwarder.cpp
@@ -93,8 +93,26 @@ QString MessageForwarder::browseSaveFileDocuments(QString caption, QString filte
 
 QString MessageForwarder::browseSaveFile(QString caption, QString browsePath, QString filter, QString * selectedFilter)
 {
-	if(Settings::value(Settings::USE_NATIVE_FILE_DIALOG).toBool())	return 	QFileDialog::getSaveFileName(nullptr, caption, browsePath, filter, selectedFilter);
-	else															return 	QFileDialog::getSaveFileName(nullptr, caption, browsePath, filter, selectedFilter, QFileDialog::DontUseNativeDialog);
+
+	QString saveFileName, selectedLocal;
+	if(!selectedFilter) selectedFilter = & selectedLocal;
+
+	if(Settings::value(Settings::USE_NATIVE_FILE_DIALOG).toBool())	saveFileName = 	QFileDialog::getSaveFileName(nullptr, caption, browsePath, filter, selectedFilter);
+	else															saveFileName = 	QFileDialog::getSaveFileName(nullptr, caption, browsePath, filter, selectedFilter, QFileDialog::DontUseNativeDialog);
+
+	Log::log() << "Selected save file: " << saveFileName << " and selected filter: " << *selectedFilter << std::endl;
+
+	//Lets make sure the extension is added:
+	selectedLocal = *selectedFilter; //In case one was actually passed *to* this function
+
+	if(selectedLocal.trimmed().startsWith("*."))
+	{
+		QString ext = selectedLocal.right(selectedLocal.size() - 1);
+		if(!saveFileName.endsWith(ext))
+			saveFileName += ext;
+	}
+
+	return saveFileName;
 }
 
 QString MessageForwarder::browseOpenFolder(QString caption, QString browsePath)


### PR DESCRIPTION
- Also on linux
- Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/903

I also noticed some strange behaviour while loading data and doing some stuff at the same time.
- This was caused as far as I could see by getting a resume response from the initializing engine but not handling that properly.
- However when an engine is initializing you don't need to pause or resume it. Because it hasnt done anything yet anyway.

