### PR TITLE
Install jags on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_install:
   - "git clone --branch=MacOS-Original https://github.com/jasp-stats/jasp-required-files.git ~/pkgs"
   - cd JASP-Tests/R/tests/
 install:
+  - rm '/usr/local/bin/gfortran'
+  - brew install jags
   - R < install.R --no-save
 script:
   - R < testthat.R --no-save


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/651

Travis now installs jags.

`rm '/usr/local/bin/gfortran'` was necessary because without it [Travis failed](https://travis-ci.org/github/vandenman/jasp-desktop/builds/699373173):

![image](https://user-images.githubusercontent.com/21319932/84996027-056f4d80-b14d-11ea-95e2-8565c7a710dc.png)

Luckily the suggestion by brew fixed things.

I did check that `library(rjags)` didn't crash (line 858 [here](https://travis-ci.org/github/vandenman/jasp-desktop/builds/699595871)), but nothing beyond that.


