### PR TITLE
add messages regarding random effects grouping factors

### DIFF
--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -554,8 +554,6 @@
     
     
     if (is.null(model)) {
-      ANOVAsummary$setExpectedSize(1)
-      
       return()
     }
     
@@ -1862,7 +1860,6 @@
           eval(parse(text = x))))
     }
     if (length(contrs) == 0) {
-      EMMCsummary$setExpectedSize(1)
       jaspResults[[paste0("contrasts_", what)]] <- EMMCsummary
       return()
     }
@@ -2434,8 +2431,6 @@
                                type = "number")
       
       if (table_name == "Model summary") {
-        temp_table$setExpectedSize(1)
-        
         return()
       }
       

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -557,7 +557,7 @@
         ANOVAsummary$addFootnote(.mmMessageMissingRE)
       }
       if (type == "GLMM") {
-        if (options$family == "binomial_agg" &
+        if (options$family == "binomial_agg" &&
             options$dependentVariableAggregation == "") {
           ANOVAsummary$addFootnote(.mmMessageMissingAgg)
         }
@@ -2445,7 +2445,7 @@
           temp_table$addFootnote(.mmMessageMissingRE)
         }
         if (type == "BGLMM") {
-          if (options$family == "binomial_agg" &
+          if (options$family == "binomial_agg" &&
               options$dependentVariableAggregation == "") {
             temp_table$addFootnote(.mmMessageMissingAgg)
           }
@@ -2928,15 +2928,22 @@
   gettextf("Type %s Sum of Squares",type)
 }
 .mmMessageREgrouping    <- function(RE_grouping_factors) {
-  gettextf(
-    "The following %s used %s random effects grouping %s: %s.",
-    ifelse(length(RE_grouping_factors) < 2, "variable is", "variables are"),
-    ifelse(length(RE_grouping_factors) < 2, "as a", "as"),
-    ifelse(length(RE_grouping_factors) < 2, "factor", "factors"),
-    ifelse(length(RE_grouping_factors) == 0, "...", paste0("'", RE_grouping_factors, "'", collapse = ", "))
-  )
+  if (length(RE_grouping_factors) < 2) {
+    return(
+      gettextf(
+        "The following variable is used as a random effects grouping factor: %s.",
+        RE_grouping_factors
+      )
+    )
+  } else{
+    return(
+      gettextf(
+        "The following variables are used as random effects grouping factors: %s.",
+        paste0("'", RE_grouping_factors, "'", collapse = ", ")
+      )
+    )
+  }
 }
-
 .mmMessageMissingRE     <- gettext("This analysis requires at least one random effects grouping factor to run.")
 .mmMessageMissingAgg    <- gettext("The 'Binomial (aggregated)' family requires the 'Number of trials' to be specified to run.")
 .mmMessageTestNull      <- function(value) {
@@ -2946,19 +2953,32 @@
   gettextf("Results are averaged over the levels of: %s.",paste(terms, collapse = ", "))
 }
 .mmMessageOmmitedTerms1 <- function(terms, grouping) {
-  gettextf(
-    "%s %s %s not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'.",
-    ifelse(length(terms) == 1, gettext("Factor"), gettext("Factors")),
-    paste0("'", terms, "'", collapse = ", "),
-    ifelse(length(terms) == 1, gettext("does"), gettext("do")),
-    grouping,
-    paste0("'", terms, "'", collapse = ", "),
-    grouping
-  )
+  if(length(terms) < 2){
+    return(
+      gettextf(
+        "Factor %s does not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'.",
+        tpaste0("'", terms, "'", collapse = ", "),
+        grouping,
+        paste0("'", terms, "'", collapse = ", "),
+        grouping
+      )
+    )    
+  }else{
+    return(
+      gettextf(
+        "Factors %s do not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'.",
+        tpaste0("'", terms, "'", collapse = ", "),
+        grouping,
+        paste0("'", terms, "'", collapse = ", "),
+        grouping
+      )
+    ) 
+  }
+
 }
 .mmMessageOmmitedTerms2 <- function(terms, grouping) {
   gettextf(
-    "Number of observations not sufficient for estimating %s random slopes for random effects grouping factor '%s'. Consequently, random slopes for %s have been removed for '%s'.",
+    "Number of observations is not sufficient for estimating %s random slopes for random effects grouping factor '%s'. Consequently, random slopes for %s have been removed for '%s'.",
     paste0("'", terms, "'", collapse = ", "),
     grouping,
     paste0("'", terms, "'", collapse = ", "),
@@ -2966,18 +2986,32 @@
   )
 }
 .mmMessageAddedTerms    <- function(terms, grouping) {
-  gettextf(
-    "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects %s added to the '%s' random effects grouping factor: '%s.'",
-    ifelse(length(terms) == 1,gettext("term was"),gettext("terms were")),
-    grouping,
-    paste0("'", terms, "'", collapse = ", ")
-  )
+  if (length(terms) < 2) {
+    return(
+      gettextf(
+        "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects term was added to the '%s' random effects grouping factor: '%s.'",
+        grouping,
+        paste0("'", terms, "'", collapse = ", ")
+      )
+    )
+  } else{
+    return(
+      gettextf(
+        "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects terms were added to the '%s' random effects grouping factor: '%s.'",
+        grouping,
+        paste0("'", terms, "'", collapse = ", ")
+      )
+    )
+  }
 }
 .mmMessageMissingRows   <- function(value) {
-  gettextf("%i %s removed due to missing values.",
-    value,
-    ifelse(value == 1, gettext("observation was"), gettext("observations were"))
-  )
+  if (value < 2) {
+    return(gettextf("%i observation was removed due to missing values.",
+                    value))
+  } else{
+    return(gettextf("%i observations were removed due to missing values.",
+                    value))
+  }
 }
 .mmMessageGLMMtype      <- function(family, link) {
   family <- switch(family,
@@ -3023,27 +3057,55 @@
   return(gettextf("P-values are adjusted using %s adjustment.",adjustment))
 }
 .mmMessageDivergentIter <- function(iterations) {
-  gettextf(
-    "There %s %i divergent %s after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions.",
-    ifelse(iterations == 1, gettext("was"), gettext("were")),
-    iterations,
-    ifelse(iterations == 1, gettext("transition"), gettext("transitions"))
-  )
+  if (iterations < 2) {
+    return(
+      gettextf(
+        "There was %i divergent transition after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions.",
+        iterations
+      )
+    )
+  } else {
+    return(
+      gettextf(
+        "There were %i divergent transitions after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions.",
+        iterations
+      )
+    )
+  }
 }
 .mmMessageLowBMFI       <- function(nChains) {
-  gettextf(
-    "Bayesian Fraction of Missing Information (BFMI) that was too low in %i %s indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'.",
-    nChains,
-    ifelse(nChains == 1, gettext("chain"), gettext("chains"))
-  )
+  if (nChains < 2) {
+    return(
+      gettextf(
+        "Bayesian Fraction of Missing Information (BFMI) that was too low in %i chain indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'.",
+        nChains
+      )
+    )
+  } else {
+    return(
+      gettextf(
+        "Bayesian Fraction of Missing Information (BFMI) that was too low in %i chains indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'.",
+        nChains
+      )
+    )
+  }
 }
 .mmMessageMaxTreedepth  <- function(iterations) {
-  gettextf(
-    "There %s %i %s exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'.",
-    ifelse(iterations == 1, gettext("was"), gettext("were")),   
-    iterations,
-    ifelse(iterations == 1, gettext("transition"), gettext("transitions"))
-  )
+  if (iterations < 2) {
+    return(
+      gettextf(
+        "There was %i transition exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'.",
+        iterations
+      )
+    )
+  } else{
+    return(
+      gettextf(
+        "There were %i transitions exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'.",
+        iterations
+      )
+    )
+  }
 }
 .mmMessageMaxRhat       <- function(Rhat) {
   gettextf(

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -553,6 +553,14 @@
     
     if (is.null(model)) {
       ANOVAsummary$setExpectedSize(1)
+      
+      # notify user that the random effects grouping factor must be selected if it's the last missing piece
+      if(length(options$dependentVariable) > 0 &&
+         length(options$fixedVariables) > 0 &&
+         length(options$randomVariables) == 0) {
+        ANOVAsummary$setError("At least one random effects grouping factor needs to be selected.")
+      }
+      
       return()
     }
     
@@ -634,7 +642,7 @@
       }
     }
     
-    
+    ANOVAsummary$addFootnote(.mmMessageREgrouping(options$randomVariables))
     ANOVAsummary$addFootnote(.mmMessageANOVAtype(ifelse(options$type == 3, gettext("III"), gettext("II"))))
     if (type == "GLMM") {
       ANOVAsummary$addFootnote(.mmMessageGLMMtype(options$family, options$link))
@@ -976,7 +984,7 @@
     # stop with message if there is no random effects grouping factor selected
     if (length(options$plotsAgregatedOver) == 0) {
       plots$setError(
-        gettext("At least one random effect grouping factor needs to be selected in field 'Background data show'.")
+        gettext("At least one random effects grouping factor needs to be selected in field 'Background data show'.")
       )
       jaspResults[["plots"]] <- plots
       return()
@@ -2430,6 +2438,14 @@
       
       if (table_name == "Model summary") {
         temp_table$setExpectedSize(1)
+        
+        # notify user that the random effects grouping factor must be selected if it's the last missing piece
+        if(length(options$dependentVariable) > 0 &&
+           length(options$fixedVariables) > 0 &&
+           length(options$randomVariables) == 0) {
+          temp_table$setError("At least one random effects grouping factor needs to be selected.")
+        }
+        
         return()
       }
       
@@ -2518,6 +2534,8 @@
       if (type == "BGLMM") {
         temp_table$addFootnote(.mmMessageGLMMtype(options$family, options$link))
       }
+      
+      temp_table$addFootnote(.mmMessageREgrouping(options$randomVariables))
       
     }
     
@@ -2903,6 +2921,15 @@
   gettext("Results are not on the response scale and might be misleading.")
 .mmMessageANOVAtype     <- function(type) {
   gettextf("Type %s Sum of Squares",type)
+}
+.mmMessageREgrouping    <- function(RE_grouping_factors) {
+  gettextf(
+    "The following %s used %s random effects grouping %s: %s.",
+    ifelse(length(RE_grouping_factors) == 1, "variable is", "variables are"),
+    ifelse(length(RE_grouping_factors) == 1, "as a", "as"),
+    ifelse(length(RE_grouping_factors) == 1, "factor", "factors"),
+    paste0("'", RE_grouping_factors, "'", collapse = ", ")
+  )
 }
 .mmMessageTestNull      <- function(value) {
   gettextf("P-values correspond to test of null hypothesis against %s.", value)

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -2930,7 +2930,7 @@
 .mmMessageREgrouping    <- function(RE_grouping_factors) {
   sprintf(
     ngettext(
-      length(RE_grouping_factors) < 2,
+      length(RE_grouping_factors),
       "The following variable is used as a random effects grouping factor: %s.",
       "The following variables are used as random effects grouping factors: %s."
     ),
@@ -2948,7 +2948,7 @@
 .mmMessageOmmitedTerms1 <- function(terms, grouping) {
   sprintf(
     ngettext(
-      length(terms) < 2,
+      length(terms),
       "Factor %s does not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'.",
       "Factors %s do not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'."
     ),
@@ -2970,7 +2970,7 @@
 .mmMessageAddedTerms    <- function(terms, grouping) {
   sprintf(
     ngettext(
-      length(terms) < 2,
+      length(terms),
       "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects term was added to the '%s' random effects grouping factor: '%s.'",
       "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects terms were added to the '%s' random effects grouping factor: '%s.'"
     ),
@@ -2981,7 +2981,7 @@
 .mmMessageMissingRows   <- function(value) {
   sprintf(
     ngettext(
-      value < 2,
+      value,
       "%i observation was removed due to missing values.",
       "%i observations were removed due to missing values."
     ),
@@ -3034,7 +3034,7 @@
 .mmMessageDivergentIter <- function(iterations) {
   sprintf(
     ngettext(
-      iterations < 2,
+      iterations,
       "There was %i divergent transition after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions.",
       "There were %i divergent transitions after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions."
     ),
@@ -3044,7 +3044,7 @@
 .mmMessageLowBMFI       <- function(nChains) {
   sprintf(
     ngettext(
-      nChains < 2,
+      nChains,
       "Bayesian Fraction of Missing Information (BFMI) that was too low in %i chain indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'.",
       "Bayesian Fraction of Missing Information (BFMI) that was too low in %i chains indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'."
     ),
@@ -3054,7 +3054,7 @@
 .mmMessageMaxTreedepth  <- function(iterations) {
   sprintf(
     ngettext(
-      iterations < 2,
+      iterations,
       "There was %i transition exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'.",
       "There were %i transitions exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'."
     ),

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -486,6 +486,8 @@
     }
     ANOVAsummary$dependOn(c(dependencies, seed_dependencies, "pvalVS"))
     
+    # add message about (lack of) random effect grouping factors 
+    ANOVAsummary$addFootnote(.mmMessageREgrouping(options$randomVariables))
     
     # some error managment for GLMMS - and oh boy, they can fail really easily
     if (type %in% c("LMM", "GLMM") && !is.null(model)) {
@@ -553,13 +555,6 @@
     
     if (is.null(model)) {
       ANOVAsummary$setExpectedSize(1)
-      
-      # notify user that the random effects grouping factor must be selected if it's the last missing piece
-      if(length(options$dependentVariable) > 0 &&
-         length(options$fixedVariables) > 0 &&
-         length(options$randomVariables) == 0) {
-        ANOVAsummary$setError("At least one random effects grouping factor needs to be selected.")
-      }
       
       return()
     }
@@ -642,7 +637,6 @@
       }
     }
     
-    ANOVAsummary$addFootnote(.mmMessageREgrouping(options$randomVariables))
     ANOVAsummary$addFootnote(.mmMessageANOVAtype(ifelse(options$type == 3, gettext("III"), gettext("II"))))
     if (type == "GLMM") {
       ANOVAsummary$addFootnote(.mmMessageGLMMtype(options$family, options$link))
@@ -2403,6 +2397,9 @@
       temp_table <- createJaspTable(title = table_name)
       STANOVAsummary[[paste0("summary_", i)]] <- temp_table
       
+      # add message about (lack of) random effects grouping factors
+      temp_table$addFootnote(.mmMessageREgrouping(options$randomVariables))
+      
       if (var_name != "Intercept" && nrow(temp_summary) > 1) {
         temp_table$addColumnInfo(name = "level",
                                  title = gettext("Level"),
@@ -2438,13 +2435,6 @@
       
       if (table_name == "Model summary") {
         temp_table$setExpectedSize(1)
-        
-        # notify user that the random effects grouping factor must be selected if it's the last missing piece
-        if(length(options$dependentVariable) > 0 &&
-           length(options$fixedVariables) > 0 &&
-           length(options$randomVariables) == 0) {
-          temp_table$setError("At least one random effects grouping factor needs to be selected.")
-        }
         
         return()
       }
@@ -2534,8 +2524,6 @@
       if (type == "BGLMM") {
         temp_table$addFootnote(.mmMessageGLMMtype(options$family, options$link))
       }
-      
-      temp_table$addFootnote(.mmMessageREgrouping(options$randomVariables))
       
     }
     
@@ -2925,10 +2913,10 @@
 .mmMessageREgrouping    <- function(RE_grouping_factors) {
   gettextf(
     "The following %s used %s random effects grouping %s: %s.",
-    ifelse(length(RE_grouping_factors) == 1, "variable is", "variables are"),
-    ifelse(length(RE_grouping_factors) == 1, "as a", "as"),
-    ifelse(length(RE_grouping_factors) == 1, "factor", "factors"),
-    paste0("'", RE_grouping_factors, "'", collapse = ", ")
+    ifelse(length(RE_grouping_factors) < 2, "variable is", "variables are"),
+    ifelse(length(RE_grouping_factors) < 2, "as a", "as"),
+    ifelse(length(RE_grouping_factors) < 2, "factor", "factors"),
+    ifelse(length(RE_grouping_factors) == 0, "...", paste0("'", RE_grouping_factors, "'", collapse = ", "))
   )
 }
 .mmMessageTestNull      <- function(value) {

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -2928,21 +2928,14 @@
   gettextf("Type %s Sum of Squares",type)
 }
 .mmMessageREgrouping    <- function(RE_grouping_factors) {
-  if (length(RE_grouping_factors) < 2) {
-    return(
-      gettextf(
-        "The following variable is used as a random effects grouping factor: %s.",
-        RE_grouping_factors
-      )
-    )
-  } else{
-    return(
-      gettextf(
-        "The following variables are used as random effects grouping factors: %s.",
-        paste0("'", RE_grouping_factors, "'", collapse = ", ")
-      )
-    )
-  }
+  sprintf(
+    ngettext(
+      length(RE_grouping_factors) < 2,
+      "The following variable is used as a random effects grouping factor: %s.",
+      "The following variables are used as random effects grouping factors: %s."
+    ),
+    paste0("'", RE_grouping_factors, "'", collapse = ", ")
+  )
 }
 .mmMessageMissingRE     <- gettext("This analysis requires at least one random effects grouping factor to run.")
 .mmMessageMissingAgg    <- gettext("The 'Binomial (aggregated)' family requires the 'Number of trials' to be specified to run.")
@@ -2953,28 +2946,17 @@
   gettextf("Results are averaged over the levels of: %s.",paste(terms, collapse = ", "))
 }
 .mmMessageOmmitedTerms1 <- function(terms, grouping) {
-  if(length(terms) < 2){
-    return(
-      gettextf(
-        "Factor %s does not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'.",
-        tpaste0("'", terms, "'", collapse = ", "),
-        grouping,
-        paste0("'", terms, "'", collapse = ", "),
-        grouping
-      )
-    )    
-  }else{
-    return(
-      gettextf(
-        "Factors %s do not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'.",
-        tpaste0("'", terms, "'", collapse = ", "),
-        grouping,
-        paste0("'", terms, "'", collapse = ", "),
-        grouping
-      )
-    ) 
-  }
-
+  sprintf(
+    ngettext(
+      length(terms) < 2,
+      "Factor %s does not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'.",
+      "Factors %s do not vary within the levels of random effects grouping factor '%s'. All random slopes involving %s have been removed for '%s'."
+    ),
+    paste0("'", terms, "'", collapse = ", "),
+    grouping,
+    paste0("'", terms, "'", collapse = ", "),
+    grouping
+  )
 }
 .mmMessageOmmitedTerms2 <- function(terms, grouping) {
   gettextf(
@@ -2986,32 +2968,25 @@
   )
 }
 .mmMessageAddedTerms    <- function(terms, grouping) {
-  if (length(terms) < 2) {
-    return(
-      gettextf(
-        "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects term was added to the '%s' random effects grouping factor: '%s.'",
-        grouping,
-        paste0("'", terms, "'", collapse = ", ")
-      )
-    )
-  } else{
-    return(
-      gettextf(
-        "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects terms were added to the '%s' random effects grouping factor: '%s.'",
-        grouping,
-        paste0("'", terms, "'", collapse = ", ")
-      )
-    )
-  }
+  sprintf(
+    ngettext(
+      length(terms) < 2,
+      "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects term was added to the '%s' random effects grouping factor: '%s.'",
+      "Lower order random effects terms need to be specified in presence of the higher order random effects terms. Therefore, the following random effects terms were added to the '%s' random effects grouping factor: '%s.'"
+    ),
+    grouping,
+    paste0("'", terms, "'", collapse = ", ")
+  )
 }
 .mmMessageMissingRows   <- function(value) {
-  if (value < 2) {
-    return(gettextf("%i observation was removed due to missing values.",
-                    value))
-  } else{
-    return(gettextf("%i observations were removed due to missing values.",
-                    value))
-  }
+  sprintf(
+    ngettext(
+      value < 2,
+      "%i observation was removed due to missing values.",
+      "%i observations were removed due to missing values."
+    ),
+    value
+  )
 }
 .mmMessageGLMMtype      <- function(family, link) {
   family <- switch(family,
@@ -3057,55 +3032,34 @@
   return(gettextf("P-values are adjusted using %s adjustment.",adjustment))
 }
 .mmMessageDivergentIter <- function(iterations) {
-  if (iterations < 2) {
-    return(
-      gettextf(
-        "There was %i divergent transition after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions.",
-        iterations
-      )
-    )
-  } else {
-    return(
-      gettextf(
-        "There were %i divergent transitions after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions.",
-        iterations
-      )
-    )
-  }
+  sprintf(
+    ngettext(
+      iterations < 2,
+      "There was %i divergent transition after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions.",
+      "There were %i divergent transitions after warmup indicating problems with the validity of Hamiltonian Monte Carlo. Carefully increase 'Adapt delta' until there are no divergent transitions."
+    ),
+    iterations
+  )
 }
 .mmMessageLowBMFI       <- function(nChains) {
-  if (nChains < 2) {
-    return(
-      gettextf(
-        "Bayesian Fraction of Missing Information (BFMI) that was too low in %i chain indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'.",
-        nChains
-      )
-    )
-  } else {
-    return(
-      gettextf(
-        "Bayesian Fraction of Missing Information (BFMI) that was too low in %i chains indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'.",
-        nChains
-      )
-    )
-  }
+  sprintf(
+    ngettext(
+      nChains < 2,
+      "Bayesian Fraction of Missing Information (BFMI) that was too low in %i chain indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'.",
+      "Bayesian Fraction of Missing Information (BFMI) that was too low in %i chains indicating that the posterior distribution was not explored efficiently. Try increasing number of 'Warmup' and 'Iterations'."
+    ),
+    nChains
+  )
 }
 .mmMessageMaxTreedepth  <- function(iterations) {
-  if (iterations < 2) {
-    return(
-      gettextf(
-        "There was %i transition exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'.",
-        iterations
-      )
-    )
-  } else{
-    return(
-      gettextf(
-        "There were %i transitions exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'.",
-        iterations
-      )
-    )
-  }
+  sprintf(
+    ngettext(
+      iterations < 2,
+      "There was %i transition exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'.",
+      "There were %i transitions exceeding maximum treedepth indication problems with the efficiacy of Hamiltonian Monte Carlo. Consider carefully increasing 'Maximum treedepth'."
+    ),
+    iterations
+  )
 }
 .mmMessageMaxRhat       <- function(Rhat) {
   gettextf(

--- a/Resources/MixedModels/qml/MixedModelsBGLMM.qml
+++ b/Resources/MixedModels/qml/MixedModelsBGLMM.qml
@@ -43,7 +43,7 @@ Form {
 
 		AssignedVariablesList
 		{
-			enabled:			family.value === "binomial_agg"
+			enabled:			family.currentText == "Binomial (aggregated)"
 			name:				"dependentVariableAggregation"
 			title:				qsTr("Number of trials")
 			singleVariable:		true


### PR DESCRIPTION
fixes 2/3 of: https://github.com/jasp-stats/jasp-test-release/issues/806

1) sets an error on the empty default table if no random effects grouping factor is selected to notify the user about it.
![image](https://user-images.githubusercontent.com/38475991/85052065-9e778600-b198-11ea-8419-c9399461affb.png)

2) adds a note with the random effects grouping factors specification
![image](https://user-images.githubusercontent.com/38475991/85052214-d5e63280-b198-11ea-85a4-a1420cb82e06.png)
