### PR TITLE
T-tests: show footnote when the test value is 0

### DIFF
--- a/JASP-Engine/JASP/R/ttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/ttestbayesianonesample.R
@@ -208,25 +208,23 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
 	)
 	bfTitle <- .ttestBayesianGetBFTitle(bfType, hypothesis)
 
-  if (!(options[["hypothesis"]] == "notEqualToTestValue" && options[["testValue"]] == 0)) {
-    testValueFormatted <- format(options[["testValue"]], drop0trailing = TRUE)
-    message <- switch(
-      options[["hypothesis"]],
-      "greaterThanTestValue" = gettextf(
-        "For all tests, the alternative hypothesis specifies that the population mean is greater than %s.", 
-        testValueFormatted
-      ),
-      "lessThanTestValue"    = gettextf(
-        "For all tests, the alternative hypothesis specifies that the population mean is less than %s.", 
-        testValueFormatted
-      ),
-      "notEqualToTestValue"  = gettextf(
-        "For all tests, the alternative hypothesis specifies that the population mean differs from %s.", 
-        testValueFormatted
-      )
+  testValueFormatted <- format(options[["testValue"]], drop0trailing = TRUE)
+  message <- switch(
+    options[["hypothesis"]],
+    "greaterThanTestValue" = gettextf(
+      "For all tests, the alternative hypothesis specifies that the population mean is greater than %s.",
+      testValueFormatted
+    ),
+    "lessThanTestValue"    = gettextf(
+      "For all tests, the alternative hypothesis specifies that the population mean is less than %s.",
+      testValueFormatted
+    ),
+    "notEqualToTestValue"  = gettextf(
+      "For all tests, the alternative hypothesis specifies that the population mean differs from %s.",
+      testValueFormatted
     )
-    jaspTable$addFootnote(message)
-  }
+  )
+  jaspTable$addFootnote(message)
 
   jaspTable$addColumnInfo(name = "variable", title = "",      type = "string")
   jaspTable$addColumnInfo(name = "BF",       title = bfTitle, type = "number")

--- a/JASP-Engine/JASP/R/ttestonesample.R
+++ b/JASP-Engine/JASP/R/ttestonesample.R
@@ -155,7 +155,7 @@ TTestOneSample <- function(jaspResults, dataset = NULL, options, ...) {
     direction <- "two.sided"
   }
   
-  if ((options$testValue != 0 || options$hypothesis != "notEqualToTestValue") && (optionsList$wantsStudents || optionsList$wantsWilcox || optionsList$wantsZtest)) {
+  if (optionsList$wantsStudents || optionsList$wantsWilcox || optionsList$wantsZtest) {
     tMessage <- wMessage <- NULL
 
     if (optionsList$wantsStudents || optionsList$wantsZtest)


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release/issues/842

For consistency, I also changed the Bayesian one-sample so that it shows a footnote when the test value is 0.

@TimKDJ I considered changing the footnote to have more if statements so that `"greater"` and `"smaller"` wouldn't be substituted as you recommended in https://github.com/jasp-stats/jasp-desktop/pull/4119#discussion_r438700524. I'd also like to refactor the footnote into one function for both analyses. 

However, since we're close to a release I didn't do either of that so that the changes are as small as possible. Let me know if you do want that though.