### PR TITLE
Resizing or rewriting images now set pkg modified

### DIFF
--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -158,7 +158,7 @@ void Analyses::bindAnalysisHandler(Analysis* analysis)
 	connect(analysis, &Analysis::resultsChangedSignal,				this, &Analyses::analysisResultsChanged				);
 	connect(analysis, &Analysis::requestComputedColumnCreation,		this, &Analyses::requestComputedColumnCreation,		Qt::DirectConnection);
 	connect(analysis, &Analysis::requestComputedColumnDestruction,	this, &Analyses::requestComputedColumnDestruction,	Qt::DirectConnection);
-	connect(analysis, &Analysis::titleChanged,						this, &Analyses::somethingModified					);
+	connect(analysis, &Analysis::somethingModified,					this, &Analyses::somethingModified					);
 	connect(analysis, &Analysis::userDataChangedSignal,				this, &Analyses::analysisOverwriteUserdata			);
 
 	

--- a/JASP-Desktop/analysis/analyses.cpp
+++ b/JASP-Desktop/analysis/analyses.cpp
@@ -158,7 +158,8 @@ void Analyses::bindAnalysisHandler(Analysis* analysis)
 	connect(analysis, &Analysis::resultsChangedSignal,				this, &Analyses::analysisResultsChanged				);
 	connect(analysis, &Analysis::requestComputedColumnCreation,		this, &Analyses::requestComputedColumnCreation,		Qt::DirectConnection);
 	connect(analysis, &Analysis::requestComputedColumnDestruction,	this, &Analyses::requestComputedColumnDestruction,	Qt::DirectConnection);
-	connect(analysis, &Analysis::somethingModified,					this, &Analyses::somethingModified					);
+	connect(analysis, &Analysis::titleChanged,						this, &Analyses::somethingModified					);
+	connect(analysis, &Analysis::imageChanged,						this, &Analyses::somethingModified					);
 	connect(analysis, &Analysis::userDataChangedSignal,				this, &Analyses::analysisOverwriteUserdata			);
 
 	

--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -233,7 +233,7 @@ void Analysis::imageEdited(const Json::Value & results)
 	setStatus(Analysis::Complete);
 
 	emit imageEditedSignal(this);
-	emit somethingModified();
+	emit imageChanged();
 }
 
 bool Analysis::updatePlotSize(const std::string & plotName, int width, int height, Json::Value & root)
@@ -272,7 +272,7 @@ void Analysis::imagesRewritten()
 {
 	setStatus(Analysis::Complete);
 	emit resultsChangedSignal(this);
-	emit somethingModified();
+	emit imageChanged();
 
 }
 
@@ -557,14 +557,12 @@ void Analysis::setTitleQ(QString title)
 	_title = strippedTitle;
 	
 	emit titleChanged();
-	emit somethingModified();
 }
 
 void Analysis::emitDuplicationSignals()
 {
 	emit resultsChangedSignal(this);
 	emit titleChanged();
-	emit somethingModified();
 }
 
 void Analysis::refreshAvailableVariablesModels()

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -170,6 +170,7 @@ signals:
 	void				imageEditedSignal(		Analysis * analysis);
 	void				resultsChangedSignal(	Analysis * analysis);
 	void				userDataChangedSignal(	Analysis * analysis);
+	void				somethingModified(); //Possibly not emitted everywhere. But it should be ^^ (well, eventually, but take into account loading stuff etc, thats why it wasnt added everywhere it should be in the first place)
 
 	ComputedColumn *	requestComputedColumnCreation(		QString columnName, Analysis * analysis);
 	void				requestColumnCreation(				QString columnName, Analysis *source, int columnType);
@@ -210,6 +211,7 @@ private:
 	bool					_setEditOptionsOfPlot(Json::Value & results, const std::string & uniqueName, const Json::Value & editOptions);
 	void					storeUserDataEtc();
 	void					fitOldUserDataEtc();
+	bool					updatePlotSize(const std::string & plotName, int width, int height, Json::Value & root);
 
 protected:
 	Status					_status			= Initializing;

--- a/JASP-Desktop/analysis/analysis.h
+++ b/JASP-Desktop/analysis/analysis.h
@@ -170,7 +170,7 @@ signals:
 	void				imageEditedSignal(		Analysis * analysis);
 	void				resultsChangedSignal(	Analysis * analysis);
 	void				userDataChangedSignal(	Analysis * analysis);
-	void				somethingModified(); //Possibly not emitted everywhere. But it should be ^^ (well, eventually, but take into account loading stuff etc, thats why it wasnt added everywhere it should be in the first place)
+	void				imageChanged();
 
 	ComputedColumn *	requestComputedColumnCreation(		QString columnName, Analysis * analysis);
 	void				requestColumnCreation(				QString columnName, Analysis *source, int columnType);

--- a/JASP-Desktop/html/js/image.js
+++ b/JASP-Desktop/html/js/image.js
@@ -84,7 +84,7 @@ JASPWidgets.imagePrimitive = JASPWidgets.View.extend({
 	onResized: function (w, h) {
 		if (this.resizer.isResizing() && !this.resizeEventTriggered) {
 			this.resizeEventTriggered = true;
-			this.model.trigger("EditImage:clicked", this, { data: this.model.get("data"), width: w, height: h, type: "resize" });
+			this.model.trigger("EditImage:clicked", this, { data: this.model.get("data"), width: w, height: h, type: "resize", name: this.model.get("name"), title: this.model.get("title") });
 			
 		}
 	},


### PR DESCRIPTION
- Also updates width&height of plot in results. Otherwise they get squished or stretched after reloading
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/824

