### PR TITLE
Fix anova labels in 2x2x2 setup

### DIFF
--- a/JASP-Engine/JASP/R/ancova.R
+++ b/JASP-Engine/JASP/R/ancova.R
@@ -356,7 +356,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
   }
 
   # Make sure that the order of the result is same order as reordered modelterms
-  result <- result[.mapAnovaTermsToTerms(rownames(result), c(termsBase64, "Residuals")), ]
+  result <- result[.mapAnovaTermsToTerms(c(termsBase64, "Residuals"), rownames(result)), ]
   result[['cases']] <- c(termsNormal, "Residuals")
   result <- as.data.frame(result)
   result[['.isNewGroup']] <- c(TRUE, rep(FALSE, nrow(result)-2), TRUE)

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -293,6 +293,9 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
       
       sampledDiffsAbs <- abs(diffSamples)
       
+      thisZ <- .decorrelateStepOneSample(diffSamples, oldDeltaProp, sigmaProp = 0.5)
+      diffSamples <- diffSamples + thisZ
+      
       gibbsOutput <- .sampleGibbsOneSampleWilcoxon(diffScores = diffSamples, nIter = nGibbsIterations, rscale = cauchyPriorParameter)
       
       deltaSamples[j] <- oldDeltaProp <- gibbsOutput
@@ -337,4 +340,20 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
     delta <- mu / sqrt(sigmaSq)
   }
   return(delta)
+}
+
+.decorrelateStepOneSample <- function(d, muProp, sigmaProp = 0.5) {
+  
+  thisZ <- rnorm(1, 0, sigmaProp)
+  newD <- d + thisZ
+  
+  denom <- sum(dnorm(d, (muProp-thisZ), log = TRUE))
+  num <- sum(dnorm(newD, muProp, log = TRUE))
+  
+  if(runif(1) < exp(num - denom) ) {
+    return(thisZ)
+  } else {
+    return(0)
+  }
+  
 }

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -301,9 +301,9 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
     }
     
     if (nBurnin > 0) {
-      deltaSamples <- -deltaSamples[-(1:nBurnin)]
+      deltaSamples <- deltaSamples[-(1:nBurnin)]
     } else {
-      deltaSamples <- -deltaSamples
+      deltaSamples <- deltaSamples
     }
     deltaSamplesMatrix[, thisChain] <- deltaSamples
   }

--- a/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
@@ -33,7 +33,7 @@ test_that("Main table results match for Wilcoxon test", {
   options$hypothesis <- "groupOneGreater"
   results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options)
   table <- getTtestTable(results)[["data"]]
-  expect_equal_tables(table, list(0.354513046015919, 1146, 1.00753043165554, "contNormal"))
+  expect_equal_tables(table, list(0.395004853845122, 1146, 0.999374433542238, "contNormal"))
 })
 
 test_that("Inferential and descriptives plots match", {


### PR DESCRIPTION
Fix https://github.com/jasp-stats/jasp-issues/issues/797
now the cases column just stays true to the output of car::Anova instead of attempting to reshuffle