### PR TITLE
Fix anova labels in 2x2x2 setup

### DIFF
--- a/JASP-Engine/JASP/R/ancova.R
+++ b/JASP-Engine/JASP/R/ancova.R
@@ -355,9 +355,7 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     
   }
 
-  # Make sure that the order of the result is same order as reordered modelterms
-  result <- result[.mapAnovaTermsToTerms(rownames(result), c(termsBase64, "Residuals")), ]
-  result[['cases']] <- c(termsNormal, "Residuals")
+  result[['cases']] <- gsub(x = rownames(result), pattern = ":", " \u273B ")
   result <- as.data.frame(result)
   result[['.isNewGroup']] <- c(TRUE, rep(FALSE, nrow(result)-2), TRUE)
   if (length(options$covariates) > 0)

--- a/JASP-Engine/JASP/R/ancova.R
+++ b/JASP-Engine/JASP/R/ancova.R
@@ -354,8 +354,10 @@ Ancova <- function(jaspResults, dataset = NULL, options) {
     result['SSt'] <- sum(result["Sum Sq"], na.rm = TRUE)
     
   }
-
-  result[['cases']] <- gsub(x = rownames(result), pattern = ":", " \u273B ")
+  
+  # Make sure that the order of the result is same order as reordered modelterms
+  result <- result[.mapAnovaTermsToTerms(c(termsBase64, "Residuals"), rownames(result) ), ]
+  result[['cases']] <- c(termsNormal, "Residuals")
   result <- as.data.frame(result)
   result[['.isNewGroup']] <- c(TRUE, rep(FALSE, nrow(result)-2), TRUE)
   if (length(options$covariates) > 0)


### PR DESCRIPTION
Fix jasp-stats/jasp-issues#797
now the cases column just stays true to the output of car::Anova instead of attempting to reshuffle