### PR TITLE
Network analysis: fix jasp-test-release/issues/853, 854, & 855

### DIFF
--- a/JASP-Engine/JASP/R/networkanalysis.R
+++ b/JASP-Engine/JASP/R/networkanalysis.R
@@ -1555,7 +1555,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   dataIssue <- startsWith(errmsg, "y is constant") || endsWith(errmsg, "standardization step")
 
   ans <- if (dataIssue) {
-    gettextf("bootnet crashed with the following error message:\n%s\n\nPlease check if there are variables in the network with little variance or few distinct observations.", errmsg)
+    gettextf("bootnet crashed with the following error message:\n%s. <ul><li>Please check if there are variables in the network with little variance or few distinct observations.</li></ul>", errmsg)
   } else {
     gettextf("bootnet crashed with the following error message:\n%s", errmsg)
   }

--- a/Resources/Network/qml/NetworkAnalysis.qml
+++ b/Resources/Network/qml/NetworkAnalysis.qml
@@ -214,8 +214,8 @@ Form
 			}
 
 			AssignedVariablesList { name: "mgmVariableTypeContinuous";	title: qsTr("Continuous Variables");	suggestedColumns: ["scale"]}
-			AssignedVariablesList { name: "mgmVariableTypeCategorical";	title: qsTr("Categorical Variables");	suggestedColumns: ["ordinal"]}
-			AssignedVariablesList { name: "mgmVariableTypeCount";		title: qsTr("Count Variables");			suggestedColumns: ["nominal"]}
+			AssignedVariablesList { name: "mgmVariableTypeCategorical";	title: qsTr("Categorical Variables");	suggestedColumns: ["nominal"]}
+			AssignedVariablesList { name: "mgmVariableTypeCount";		title: qsTr("Count Variables");			suggestedColumns: ["ordinal"]}
 		}
 	}
 


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release/issues/853
Fixes jasp-stats/jasp-test-release/issues/854
Fixes jasp-stats/jasp-test-release/issues/855

- 853 was a regression from changing the way the input type for mgm is specified. Some old code wasn't adjusted properly (lines 710-728), for example, `options[["mgmVariableType"]]` doesn't exist anymore but I guess I didn't change that.

- 854 is an error where `bootnet` catches an error internally and returns a faulty ggplot2 object (a ggplot object that throws an error when you plot it..). I now check whether the returned object is faulty or not and attribute that to bootnet. This functions are quite unstable, hopefully updating `bootnet` to 1.4.3 fixes this (we're using 1.2.4).


- 855 is an error due to bad data. This is hard to catch beforehand because it happends during cross validation. So there is some bootstrapped dataset that has no variance, even though the overall variable does have variance. I now add something to the error message for this particular case.
