### PR TITLE
Bayesian T-test - Enable sequential and robustness analysis only for default priors

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/SubjectivePriors.qml
+++ b/JASP-Desktop/components/JASP/Widgets/SubjectivePriors.qml
@@ -26,6 +26,7 @@ Section
 {
 	title: qsTr("Prior")
     property alias informedPriorsEnabled: informedPriors.enabled
+	property alias defaultPriorsChecked: defaultPriors.checked
 
 	RadioButtonGroup
 	{
@@ -46,6 +47,7 @@ Section
 			enabled: standardized.checked
 			RadioButton
 			{
+				id: defaultPriors
 				label: qsTr("Default"); name: "default"; checked: true
 				RadioButtonGroup
 				{

--- a/JASP-Desktop/components/JASP/Widgets/SubjectivePriors.qml
+++ b/JASP-Desktop/components/JASP/Widgets/SubjectivePriors.qml
@@ -25,7 +25,7 @@ import JASP				1.0
 Section
 {
 	title: qsTr("Prior")
-    property alias informedPriorsEnabled: informedPriors.enabled
+	property alias informedPriorsEnabled: informedPriors.enabled
 	property alias defaultPriorsChecked: defaultPriors.checked
 
 	RadioButtonGroup

--- a/JASP-Engine/JASP/R/commonbayesianttest.R
+++ b/JASP-Engine/JASP/R/commonbayesianttest.R
@@ -745,8 +745,14 @@
 
 # inferential plots ----
 .ttestBayesianInferentialPlots <- function(jaspResults, dataset, options, ttestResults, errors) {
-
-  opts <- c("plotPriorAndPosterior", "plotBayesFactorRobustness", "plotSequentialAnalysis")
+  
+  # for default priors, we can do prior & posterior, robustness, and sequantial plots
+  # we cannot do robustness and sequential plots for informed priors, hence do only prior & posterior plot:
+  if(options[["effectSizeStandardized"]] == "default")
+    opts <- c("plotPriorAndPosterior", "plotBayesFactorRobustness", "plotSequentialAnalysis")
+  else 
+    opts <- c("plotPriorAndPosterior")
+  
   if (!any(unlist(options[opts])))
     return()
 
@@ -841,7 +847,7 @@
     )
   }
 
-  if (options[["plotBayesFactorRobustness"]]) {
+  if (options[["plotBayesFactorRobustness"]] && options[["effectSizeStandardized"]] == "default") {
     .ttestBayesianPlotRobustness(
       collection             = inferentialPlotsCollection,
       dependents             = dependents,
@@ -862,7 +868,7 @@
     )
   }
 
-  if (options[["plotSequentialAnalysis"]]) {
+  if (options[["plotSequentialAnalysis"]] && options[["effectSizeStandardized"]] == "default") {
     .ttestBayesianPlotSequential(
       collection             = inferentialPlotsCollection,
       dependents             = dependents,

--- a/Resources/T-Tests/qml/TTestBayesianIndependentSamples.qml
+++ b/Resources/T-Tests/qml/TTestBayesianIndependentSamples.qml
@@ -55,14 +55,14 @@ Form {
 
 		CheckBox
 		{
-			enabled: student.checked
+			enabled: student.checked && priors.defaultPriorsChecked
 			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
 			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			enabled: student.checked
+			enabled: student.checked && priors.defaultPriorsChecked
 			name: "plotSequentialAnalysis";		label: qsTr("Sequential analysis")
 			CheckBox { name: "plotSequentialAnalysisRobustness";		label: qsTr("Robustness check") }
 		}
@@ -108,5 +108,5 @@ Form {
 
 	SetSeed{enabled: testWilcoxon.checked}
 
-	SubjectivePriors { informedPriorsEnabled: student.checked }
+	SubjectivePriors { id: priors; informedPriorsEnabled: student.checked }
 }

--- a/Resources/T-Tests/qml/TTestBayesianOneSample.qml
+++ b/Resources/T-Tests/qml/TTestBayesianOneSample.qml
@@ -51,14 +51,14 @@ Form
 
 		CheckBox
 		{
-			enabled: student.checked
+			enabled: student.checked && priors.defaultPriorsChecked
 			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
 			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			enabled: student.checked
+			enabled: student.checked && priors.defaultPriorsChecked
 			name: "plotSequentialAnalysis";		label: qsTr("Sequential analysis")
 			CheckBox { name: "plotSequentialAnalysisRobustness";		label: qsTr("Robustness check") }
 		}
@@ -75,7 +75,7 @@ Form
 	{
 		name: "hypothesis"
 		title: qsTr("Alt. Hypothesis")
-		RadioButton { value: "notEqualToTestValue";		label: qsTr("≠ Test value"); checked: true	}
+		RadioButton { value: "notEqualToTestValue";		label: qsTr("≠ Test value"); checked: true		}
 		RadioButton { value: "greaterThanTestValue";	label: qsTr("> Test value");					}
 		RadioButton { value: "lessThanTestValue";		label: qsTr("< Test value");					}
 	}
@@ -113,6 +113,6 @@ Form
 	}
 	
 
-	SubjectivePriors { }
+	SubjectivePriors { id: priors }
 	
 }

--- a/Resources/T-Tests/qml/TTestBayesianPairedSamples.qml
+++ b/Resources/T-Tests/qml/TTestBayesianPairedSamples.qml
@@ -55,14 +55,14 @@ Form {
 
 		CheckBox
 		{
-			enabled: student.checked
+			enabled: student.checked && priors.defaultPriorsChecked
 			name: "plotBayesFactorRobustness";	label: qsTr("Bayes factor robustness check")
 			CheckBox { name: "plotBayesFactorRobustnessAdditionalInfo";	label: qsTr("Additional info"); checked: true }
 		}
 
 		CheckBox
 		{
-			enabled: student.checked
+			enabled: student.checked && priors.defaultPriorsChecked
 			name: "plotSequentialAnalysis";		label: qsTr("Sequential analysis")
 			CheckBox { name: "plotSequentialAnalysisRobustness";		label: qsTr("Robustness check") }
 		}
@@ -106,6 +106,6 @@ Form {
 		RadioButton { value: "excludeListwise";				label: qsTr("Exclude cases listwise")							}
 	}
 
-	SubjectivePriors { }
+	SubjectivePriors { id: priors }
 
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/845

Pls check if the solution using `property alias` is the way how this should be done.