### PR TITLE
Mixed models fit statistics

### DIFF
--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -668,7 +668,7 @@
   
   model <- jaspResults[["mmModel"]]$object$model
   
-  fitStats <- createJaspTable(title = gettext("Fit Statistics"))
+  fitStats <- createJaspTable(title = gettext("Model summary"))
   fitStats$position <- 2
 
   if (type == "LMM") {
@@ -697,7 +697,7 @@
   if (is_REML) {
     fitStats$addColumnInfo(
       name = "devianceREML",
-      title = gettext("REML criterion/deviance"),
+      title = gettext("Deviance (REML)"),
       type = "number"
     )
   }
@@ -714,6 +714,8 @@
   fitStats$addColumnInfo(name = "bic",
                          title = gettext("BIC"),
                          type = "number")
+  
+  jaspResults[["fitStats"]] <- fitStats
   
   
   if (is.list(model$full_model)) {
@@ -746,8 +748,6 @@
   
   fitStats$addRows(temp_row)
   fitStats$addFootnote(.mmMessageFitType(is_REML))
-
-  jaspResults[["fitStats"]] <- fitStats
   
   return()
 }
@@ -2239,10 +2239,12 @@
                          type = "number")
   
 
+  jaspResults[["fitStats"]] <- fitStats
+  
   waic <- loo::waic(model)
   loo  <- loo::loo(model)
 
-  
+
   n_bad_waic <- sum(waic$pointwise[,2] > 0.4)
   n_bad_loo  <- length(loo::pareto_k_ids(loo, threshold = .7))
   
@@ -2263,7 +2265,7 @@
   )
   
   fitStats$addRows(temp_row)
-  jaspResults[["fitStats"]] <- fitStats
+
   
   return()
 }

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -3204,18 +3204,36 @@
   )
 }
 .mmMessageBadWAIC       <- function(n_bad) {
-  gettextf(
-    "There %s %1.0f p_waic %s larger than 0.4. We recommend using LOO instead.",
-    ifelse(n_bad == 1, "was", "were"),
-    n_bad,
-    ifelse(n_bad == 1, "estimate", "estimates")
-  ) 
+  if (n_bad < 2) {
+    return(
+      gettextf(
+        "There was %1.0f p_waic estimate larger than 0.4. We recommend using LOO instead.",
+        n_bad
+      )
+    )
+  } else{
+    return(
+      gettextf(
+        "There were %1.0f p_waic estimates larger than 0.4. We recommend using LOO instead.",
+        n_bad
+      )
+    )
+  }
 }
 .mmMessageBadLOO        <- function(n_bad) {
-  gettextf(
-    "There %s %1.0f %s with the shape parameter of k of the generalized Pareto distribution higher than > .5, indicating convergence problems for the LOO estimate.",
-    ifelse(n_bad == 1, "was", "were"),
-    n_bad,
-    ifelse(n_bad == 1, "observation", "observations")
-  )
+  if (n_bad < 2) {
+    return(
+      gettextf(
+        "There was %1.0f observation with the shape parameter of k of the generalized Pareto distribution higher than > .5, indicating convergence problems for the LOO estimate.",
+        n_bad
+      )
+    )
+  } else{
+    return(
+      gettextf(
+        "There were %1.0f observations with the shape parameter of k of the generalized Pareto distribution higher than > .5, indicating convergence problems for the LOO estimate.",
+        n_bad
+      )
+    )
+  }
 }

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -3204,36 +3204,22 @@
   )
 }
 .mmMessageBadWAIC       <- function(n_bad) {
-  if (n_bad < 2) {
-    return(
-      gettextf(
-        "There was %1.0f p_waic estimate larger than 0.4. We recommend using LOO instead.",
-        n_bad
-      )
-    )
-  } else{
-    return(
-      gettextf(
-        "There were %1.0f p_waic estimates larger than 0.4. We recommend using LOO instead.",
-        n_bad
-      )
-    )
-  }
+  sprintf(
+    ngettext(
+      n_bad < 2,
+      "There was %1.0f p_waic estimate larger than 0.4. We recommend using LOO instead.",
+      "There were %1.0f p_waic estimates larger than 0.4. We recommend using LOO instead."
+    ),
+    n_bad
+  )
 }
 .mmMessageBadLOO        <- function(n_bad) {
-  if (n_bad < 2) {
-    return(
-      gettextf(
-        "There was %1.0f observation with the shape parameter of k of the generalized Pareto distribution higher than > .5, indicating convergence problems for the LOO estimate.",
-        n_bad
-      )
-    )
-  } else{
-    return(
-      gettextf(
-        "There were %1.0f observations with the shape parameter of k of the generalized Pareto distribution higher than > .5, indicating convergence problems for the LOO estimate.",
-        n_bad
-      )
-    )
-  }
+  sprintf(
+    ngettext(
+      n_bad < 2,
+      "There was %1.0f observation with the shape parameter of k of the generalized Pareto distribution higher than > .5, indicating convergence problems for the LOO estimate.",
+      "There were %1.0f observations with the shape parameter of k of the generalized Pareto distribution higher than > .5, indicating convergence problems for the LOO estimate."
+    ),
+    n_bad
+  )
 }

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -692,7 +692,7 @@
   }
   
   fitStats$addColumnInfo(name = "deviance",
-                         title = gettext("deviance"),
+                         title = gettext("Deviance"),
                          type = "number")
   if (is_REML) {
     fitStats$addColumnInfo(

--- a/Resources/Help/analyses/MixedModelsBGLMM.md
+++ b/Resources/Help/analyses/MixedModelsBGLMM.md
@@ -149,5 +149,6 @@ Press the button to run the analysis. Model relevant changes in the settings wil
 - rstan
 - rstanarm
 - emmeans
+- loo
 - ggplot2
 - stats

--- a/Resources/Help/analyses/MixedModelsBGLMM.md
+++ b/Resources/Help/analyses/MixedModelsBGLMM.md
@@ -9,6 +9,8 @@ Bayesian Generalized Linear Mixed Models allow you to model a linear relationshi
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Distribution of errors: The errors are distributed according to the distributional family.
 
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
+
 ### Input
 
 #### Assignment Box

--- a/Resources/Help/analyses/MixedModelsBGLMM.md
+++ b/Resources/Help/analyses/MixedModelsBGLMM.md
@@ -9,7 +9,7 @@ Bayesian Generalized Linear Mixed Models allow you to model a linear relationshi
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Distribution of errors: The errors are distributed according to the distributional family.
 
-The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions. However, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels. For comparing the mean estimates, use the contrasts option.
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interpretability of models with interactions. However, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels. For comparing the mean estimates, use the contrasts option.
 
 The analysis uses a long data format.
 

--- a/Resources/Help/analyses/MixedModelsBGLMM.md
+++ b/Resources/Help/analyses/MixedModelsBGLMM.md
@@ -11,6 +11,8 @@ Bayesian Generalized Linear Mixed Models allow you to model a linear relationshi
 
 The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
 
+The analysis uses a long data format.
+
 ### Input
 
 #### Assignment Box

--- a/Resources/Help/analyses/MixedModelsBGLMM.md
+++ b/Resources/Help/analyses/MixedModelsBGLMM.md
@@ -9,7 +9,7 @@ Bayesian Generalized Linear Mixed Models allow you to model a linear relationshi
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Distribution of errors: The errors are distributed according to the distributional family.
 
-The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions. However, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels. For comparing the mean estimates, use the contrasts option.
 
 The analysis uses a long data format.
 

--- a/Resources/Help/analyses/MixedModelsBLMM.md
+++ b/Resources/Help/analyses/MixedModelsBLMM.md
@@ -10,7 +10,7 @@ Bayesian Linear Mixed Models allow you to model a linear relationship between on
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Normality of errors: The errors are normally distributed with mean zero.
 
-The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interpretability of models with interactions. However, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels. For comparing the mean estimates, use the contrasts option.
 
 The analysis uses a long data format.
 

--- a/Resources/Help/analyses/MixedModelsBLMM.md
+++ b/Resources/Help/analyses/MixedModelsBLMM.md
@@ -10,6 +10,8 @@ Bayesian Linear Mixed Models allow you to model a linear relationship between on
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Normality of errors: The errors are normally distributed with mean zero.
 
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
+
 ### Input
 
 #### Assignment Box

--- a/Resources/Help/analyses/MixedModelsBLMM.md
+++ b/Resources/Help/analyses/MixedModelsBLMM.md
@@ -12,6 +12,8 @@ Bayesian Linear Mixed Models allow you to model a linear relationship between on
 
 The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
 
+The analysis uses a long data format.
+
 ### Input
 
 #### Assignment Box
@@ -139,5 +141,6 @@ Press the button to run the analysis. Model relevant changes in the settings wil
 - rstan
 - rstanarm
 - emmeans
+- loo
 - ggplot2
 - stats

--- a/Resources/Help/analyses/MixedModelsGLMM.md
+++ b/Resources/Help/analyses/MixedModelsGLMM.md
@@ -9,7 +9,7 @@ Generalized Linear Mixed Models allow you to model a linear relationship between
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Distribution of errors: The errors are distributed according to the distributional family.
 
-The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interpretability of models with interactions. However, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels. For comparing the mean estimates, use the contrasts option.
 
 The analysis uses a long data format.
 

--- a/Resources/Help/analyses/MixedModelsGLMM.md
+++ b/Resources/Help/analyses/MixedModelsGLMM.md
@@ -11,6 +11,8 @@ Generalized Linear Mixed Models allow you to model a linear relationship between
 
 The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
 
+The analysis uses a long data format.
+
 ### Input
 
 #### Assignment Box

--- a/Resources/Help/analyses/MixedModelsGLMM.md
+++ b/Resources/Help/analyses/MixedModelsGLMM.md
@@ -9,6 +9,8 @@ Generalized Linear Mixed Models allow you to model a linear relationship between
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Distribution of errors: The errors are distributed according to the distributional family.
 
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
+
 ### Input
 
 #### Assignment Box

--- a/Resources/Help/analyses/MixedModelsLMM.md
+++ b/Resources/Help/analyses/MixedModelsLMM.md
@@ -12,6 +12,8 @@ Linear Mixed Models allow you to model a linear relationship between one or more
 
 The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
 
+The analysis uses a long data format.
+
 ### Input
 
 #### Assignment Box

--- a/Resources/Help/analyses/MixedModelsLMM.md
+++ b/Resources/Help/analyses/MixedModelsLMM.md
@@ -10,6 +10,8 @@ Linear Mixed Models allow you to model a linear relationship between one or more
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Normality of errors: The errors are normally distributed with mean zero.
 
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
+
 ### Input
 
 #### Assignment Box

--- a/Resources/Help/analyses/MixedModelsLMM.md
+++ b/Resources/Help/analyses/MixedModelsLMM.md
@@ -10,7 +10,7 @@ Linear Mixed Models allow you to model a linear relationship between one or more
 - Homoscedasticity: The error variance of each predictor is constant across all values of that predictor.
 - Normality of errors: The errors are normally distributed with mean zero.
 
-The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interoperability of models with interactions, however, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise for using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels and comparing them using the contrasts option.
+The analysis uses sum contrast encoding for categorical (nominal and ordinal) predictors (R uses dummy encoding by default). This scheme is used for better interpretability of models with interactions. However, the fixed and random effects estimates will differ from those obtained from R with default settings. We advise using the 'Estimated marginal means' section for obtaining mean estimates at individual factor levels. For comparing the mean estimates, use the contrasts option.
 
 The analysis uses a long data format.
 

--- a/Resources/MixedModels/qml/common/MixedModelsBOptions.qml
+++ b/Resources/MixedModels/qml/common/MixedModelsBOptions.qml
@@ -86,6 +86,12 @@ Section
 		{
 			CheckBox
 			{
+				name:	"fitStats"
+				label:	qsTr("Model summary")
+			}
+
+			CheckBox
+			{
 				name:	"showFE"
 				label:	qsTr("Fixed effects estimates")
 			}
@@ -96,14 +102,13 @@ Section
 				label:	qsTr("Variance/correlation estimates")
 			}
 		}
+	}
 
-		CIField
-		{
-			name:	"summaryCI"
-			label:	qsTr("Confidence interval")
-		}
+	SetSeed{}
 
-		SetSeed{}
-
+	CIField
+	{
+		name:	"summaryCI"
+		label:	qsTr("Credible interval")
 	}
 }

--- a/Resources/MixedModels/qml/common/MixedModelsOptions.qml
+++ b/Resources/MixedModels/qml/common/MixedModelsOptions.qml
@@ -81,6 +81,12 @@ Section
 	{
 		CheckBox
 		{
+			name:	"fitStats"
+			label:	qsTr("Model summary")
+		}
+
+		CheckBox
+		{
 			name:	"showFE"
 			label:	qsTr("Fixed effects estimates")
 		}


### PR DESCRIPTION
very small change to satisfy this feature request: https://github.com/jasp-stats/INTERNAL-jasp/issues/936

also adds clarifications in help files on:
- the predictors coding
- the dataset type


![image](https://user-images.githubusercontent.com/38475991/85418767-7d84ab80-b571-11ea-9ce0-903532933ac8.png)


even with warning messages for the Bayesian version :)
![image](https://user-images.githubusercontent.com/38475991/85406656-68ece700-b562-11ea-94ae-682746f98fd6.png)
