### PR TITLE
Loading JASP files with RM Anova do not remove columns in Available Variables list when used in Repeated Measures Cells

### DIFF
--- a/JASP-Desktop/widgets/listmodelmeasurescellsassigned.cpp
+++ b/JASP-Desktop/widgets/listmodelmeasurescellsassigned.cpp
@@ -49,6 +49,9 @@ void ListModelMeasuresCellsAssigned::initLevels(const Terms &levels, const Terms
 		_terms = variables;
 
 	_fitTermsWithLevels();
+
+	if (source() != nullptr)
+		source()->removeTermsInAssignedList();
 	
 	endResetModel();
 }


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#858

This bug is at least 1 year old