### PR TITLE
Fix descriptives table for multinomial test and clean up error handling

### DIFF
--- a/JASP-Engine/JASP/R/multinomialtest.R
+++ b/JASP-Engine/JASP/R/multinomialtest.R
@@ -51,19 +51,21 @@ MultinomialTest <- function(jaspResults, dataset, options, ...) {
     dataset <- .vdf(dataset, columns.as.numeric = asnum, columns.as.factor = fact)
   }
   
-  # Reorder the rows of counts (and expected probabilities) if the user changes the factor level order in JASP
+  # Reorder the rows of the factor and the counts (and expected probabilities) if the user changes the factor level order in JASP.
+  # This ensures the ordering in tables and plots also changes appropriately.
   if (options$factor != "" && options$counts != "") {
-    fact                  <- as.factor(dataset[[.v(options$factor)]])
+    factLevelOrder        <- as.character(dataset[[.v(options$factor)]])
+    levelOrderUserWants   <- options$tableWidget[[1]]$levels
+    whatUserWantsToWhatIs <- match(levelOrderUserWants, factLevelOrder)
+      
+    if (!identical(sort(whatUserWantsToWhatIs), whatUserWantsToWhatIs))
+      dataset[seq_along(factLevelOrder), ] <- dataset[whatUserWantsToWhatIs, ]
     
-    # If we have counts and the number of counts is not equal to the number of levels of the factor, then don't do anything so the error can be caught in .hasErrors()
-    if (nlevels(na.omit(fact)) == length(na.omit(dataset[[.v(options$counts)]]))) {
-      
-      levelOrderUserWants   <- options$tableWidget[[1]]$levels
-      whatUserWantsToWhatIs <- match(levelOrderUserWants, as.character(fact))
-      
-      if (!identical(sort(whatUserWantsToWhatIs), whatUserWantsToWhatIs))
-        dataset <- dataset[whatUserWantsToWhatIs, ]
-    }
+    # For syntax mode the analysis will be called from RStudio and the factor levels may not match the tableWidget.
+    factValues <- as.character(dataset[[.v(options$factor)]])
+    facLevels  <- levels(dataset[[.v(options$factor)]])
+    if (length(facLevels) == length(factValues) && !identical(factValues, facLevels))
+      levels(dataset[[.v(options$factor)]]) <- factValues
   }
   
   return(dataset)

--- a/JASP-Engine/JASP/R/multinomialtestbayesian.R
+++ b/JASP-Engine/JASP/R/multinomialtestbayesian.R
@@ -18,7 +18,7 @@
 
 MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
 
-  dataset            <- .multinomialBayesReadData(dataset, options)
+  dataset            <- .multinomReadData(dataset, options)
 
   .multinomCheckErrors(dataset, options)
 
@@ -63,14 +63,10 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   nlev           <- nlevels(fact)
   prior          <- options$priorCounts[[1]]
   a              <- setNames(prior$values, prior$levels)
-
-  # we want to reorder levels in the tables and plots if the user does that, so here we compute
-  # how to reorder the counts.
-  factNms        <- options$priorCounts[[1]]$levels
-  ord            <- match(factNms, as.character(fact))
+  factNms        <- levels(fact)
 
   if (options$counts != "") {
-    counts <- dataset[[.v(options$counts)]][ord]
+    counts <- dataset[[.v(options$counts)]]
     # omit count entries for which factor variable is NA
     counts <- counts[!is.na(fact)]
     dataTable        <- counts
@@ -455,37 +451,4 @@ MultinomialTestBayesian <- function(jaspResults, dataset, options, ...) {
   }
 
   return(specs)
-}
-
-
-#' Multiomial Bayes - Read dataset
-#'
-#' @param dataset
-#' @param options user input options
-#'
-#' @return dataset
-.multinomialBayesReadData <- function(dataset, options) {
-
-  # First, we load the variables into the R environment
-  asnum <- NULL
-  fact  <- NULL
-
-  if (options$factor != "") {
-    fact <- options$factor
-    if (options$counts != "") {
-      asnum <- options$counts
-      if (options$exProbVar != "") {
-        asnum <- c(asnum, options$exProbVar)
-      }
-    }
-  }
-
-  if (is.null(dataset)) {
-    dataset <- .readDataSetToEnd(columns.as.numeric = asnum, columns.as.factor = fact,
-                                 exclude.na.listwise = NULL)
-  } else {
-    dataset <- .vdf(dataset, columns.as.numeric = asnum, columns.as.factor = fact)
-  }
-
-  return(dataset)
 }

--- a/JASP-Tests/R/tests/testthat/test-multinomialtest.R
+++ b/JASP-Tests/R/tests/testthat/test-multinomialtest.R
@@ -47,6 +47,13 @@ test_that("Analysis handles errors - Negative Values", {
   options <- jasptools::analysisOptions("MultinomialTest")
   options$factor <- "facExperim"
   options$counts <- "contNormal"
+  options$tableWidget <- list(
+    list(
+      levels = list("control", "experimental"),
+      name = "H1",
+      values = list(50, 50)
+    )
+  )
   results <- jasptools::run("MultinomialTest", "test.csv", options)
   status <- results[["status"]]
   expect_identical(status, "validationError")
@@ -56,6 +63,13 @@ test_that("Analysis handles errors - wrong levels", {
   options <- jasptools::analysisOptions("MultinomialTest")
   options$factor <- "facExperim"
   options$counts <- "debSame"
+  options$tableWidget <- list(
+    list(
+      levels = list("control", "experimental"),
+      name = "H1",
+      values = list(50, 50)
+    )
+  )
   results <- jasptools::run("MultinomialTest", "test.csv", options)
   status <- results[["status"]]
   expect_identical(status, "validationError")
@@ -65,6 +79,13 @@ test_that("Analysis handles errors - Infinities", {
   options <- jasptools::analysisOptions("MultinomialTest")
   options$factor <- "facExperim"
   options$counts <- "debInf"
+  options$tableWidget <- list(
+    list(
+      levels = list("control", "experimental"),
+      name = "H1",
+      values = list(50, 50)
+    )
+  )
   results <- jasptools::run("MultinomialTest", "test.csv", options)
   status <- results[["status"]]
   expect_identical(status, "validationError")

--- a/JASP-Tests/R/tests/testthat/test-multinomialtestbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-multinomialtestbayesian.R
@@ -50,13 +50,18 @@ test_that("Bayesian Multinomial Test table results match in short data format", 
   options <- jasptools::analysisOptions("MultinomialTestBayesian")
   options$factor <- "Month"
   options$counts <- "Stress.frequency"
-  options$priorCounts <- list(list(values = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
-                                              1, 1, 1, 1), levels = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
-                                                                      1, 1, 1, 1, 1)))
+  options$tableWidget <- list(list(levels = c("1", "2", "3", "4", "5", "6", "7", "8", 
+                                              "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"), name = "H₀ (a)", 
+                                   values = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+                                              1, 1)))
+  options$priorCounts <- list(list(levels = c("1", "2", "3", "4", "5", "6", "7", "8", 
+                                              "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"), name = "Counts", 
+                                   values = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+                                              1, 1)))
   set.seed(1)
   results <- jasptools::run("MultinomialTestBayesian", "Memory of Life Stresses.csv", options)
   table <- results[["results"]][["multinomialTable"]][["data"]]
   expect_equal_tables(table,
-                      list(1.49242615869171e-11, "Multinomial", 18))
+                      list(27.1062505863656, "Multinomial", 18))
 })
 

--- a/JASP-Tests/R/tests/testthat/test-multinomialtestbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-multinomialtestbayesian.R
@@ -65,3 +65,23 @@ test_that("Bayesian Multinomial Test table results match in short data format", 
                       list(27.1062505863656, "Multinomial", 18))
 })
 
+test_that("Descriptives table correctly shows reordered factor levels", {
+  options <- jasptools::analysisOptions("MultinomialTestBayesian")
+  options$factor <- "Month"
+  options$counts <- "Stress.frequency"
+  options$exProbVar <- "Expected.counts"
+  options$descriptives <- TRUE
+  options$tableWidget <- list(list(levels = c("3", "1", "2", "4", "5", "6", "7", "8", 
+                                              "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"), name = "H₀ (a)", 
+                                   values = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+                                              1, 1)))
+  options$priorCounts <- list(list(levels = c("3", "1", "2", "4", "5", "6", "7", "8", 
+                                              "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"), name = "Counts", 
+                                   values = c(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+                                              1, 1)))
+  results <- jasptools::run("MultinomialTestBayesian", "Memory of Life Stresses.csv", options)
+  table <- results[["results"]][["multinomialDescriptivesTable"]][["data"]]
+  expect_equal_tables(table[1:4], list(7, 3, 14, 17, 1, 15, 5, 2, 11, 15, 4, 17))
+})
+
+


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-issues/issues/629

- Cleans up error handling:
Expected counts are now also checked for negative values and infinities and I merged the `.quitAnalysis()` statements into `.hasErrors()`