### PR TITLE
Getting an engine reply for an analysis while closing JASP crashes it

### DIFF
--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -732,6 +732,7 @@ void AnalysisForm::_formCompletedHandler()
 	if (!analysisVariant.isNull())
 	{
 		_analysis	= qobject_cast<Analysis *>(analysisVariant.value<QObject *>());
+		setParent(_analysis); //This object should be destroyed whenever it's Analysis is destroyed.
 
 		connect(_analysis, &Analysis::hasVolatileNotesChanged,	this, &AnalysisForm::hasVolatileNotesChanged);
 		connect(_analysis, &Analysis::needsRefreshChanged,		this, &AnalysisForm::needsRefreshChanged	);

--- a/JASP-Desktop/engine/enginesync.cpp
+++ b/JASP-Desktop/engine/enginesync.cpp
@@ -74,7 +74,7 @@ EngineSync::EngineSync(QObject *parent)
 EngineSync::~EngineSync()
 {
 	if (_engineStarted)
-	{		
+	{
 		try			{ stopEngines(); }
 		catch(...)	{ /* Whatever! */ }
 
@@ -519,7 +519,7 @@ void EngineSync::stopEngines()
 {
 	if(!_engineStarted) return;
 
-	auto timeout = QDateTime::currentSecsSinceEpoch() + 10;
+	auto timeout = QDateTime::currentSecsSinceEpoch() + KILLTIME;
 
 	//make sure we process any received messages first.
 	for(auto engine : _engines)


### PR DESCRIPTION
- This because analysisform tries to set something on a dangling pointer...
- Sovled by giving setting the relevant Analysis as qobject::parent to AnalysisForm, this way it gets destroyed at the same times and connections will be reset, etc!
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/826 (Closing JASP while bootstrapping makes it crash and not kill the engines)

