### PR TITLE
Linear and logistic regression enhancements

### DIFF
--- a/Resources/Help/analyses/regressionlinear.md
+++ b/Resources/Help/analyses/regressionlinear.md
@@ -26,12 +26,12 @@ Linear regression allows the user to model a linear relationship between one or 
 - WLS Weights: The weights used for weighted least square regression.
 
 ### Model
-- Include intercept:
-  - Include the intercept in the regression model.
 - Components and model terms: 
     - Components: All the independent variables that can be included in the model. 
     - Model terms: The independent variables in the model. By default, all the main effects of the specified independent variables are included in the model. To include interactions, click multiple variables (e.g., by holding the ctrl/cmd button on your keyboard while clicking) and drag those into the `Model Terms` box. 
     - Add to null model: The independent variables included in the model can be selected to add to the null model. 
+- Include intercept:
+  - Include the intercept in the regression model.
 
 ### Statistics
 - Regression coefficients:

--- a/Resources/Help/analyses/regressionlinear.md
+++ b/Resources/Help/analyses/regressionlinear.md
@@ -155,7 +155,7 @@ Collinearity Diagnostics:
 
 Casewise Diagnostics:
  - For each flagged case (Case Number) displays:
-    - Standardized (Std.) residual.
+    - Standardized (Std.) residual. Alternatively called also studentized residual. 
     - The value on the dependent variable.
     - Predicted value.
     - Residual.

--- a/Resources/Help/analyses/regressionlinear_nl.md
+++ b/Resources/Help/analyses/regressionlinear_nl.md
@@ -26,12 +26,12 @@ Met een lineaire regressie kan een lineaire relatie tussen een of meer verklaren
 - WLS gewichten: De gewichten die worden gebruikt voor de laagste-kwadratenregressie.
 
 ### Model
-- Neem intercept mee:
-  - Neem het intercept mee in het model.
 - Componenten en model termen:
 	- Componenten: Alle onafhankelijke variabelen die in het model worden meegenomen.
 	- Model termen: De onafhankelijke variabelen in het model. De standaardoptie is om de hoofdeffecten van de gespecificeerde onafhankelijke variabelen in het model te betrekken. Vink meerdere variabelen aan om interacties mee te nemen (bijv., door de ctrl/cmd knop op uw toetsenbord ingedrukt te houden terwijl u klikt, en sleep de variabelen naar het `Model Termen` veld.
 	- Voeg toe aan nul model: De onafhankelijke variabelen in het model kunnen ook aan het nulmodel worden toegevoegd. 
+- Neem intercept mee:
+  - Neem het intercept mee in het model.
 
 ### Statistieken
 - Regressiecoëfficiënten:

--- a/Resources/Help/analyses/regressionlinear_nl.md
+++ b/Resources/Help/analyses/regressionlinear_nl.md
@@ -153,7 +153,7 @@ Collineariteit Diagnostieken:
 
 Stapsgewijze Diagnostieken: 
   - Voor elk gemarkeerd geval (Geval nummer) geeft dit het volgende weer:
-	- Gestandaardiseerd residu.
+	- Gestandaardiseerd residu. Ook bekend als het gestudentiseerd residue.
 	- De waarde van de afhankelijke variabele.
 	- De voorspelde waarde.
 	- Residu 

--- a/Resources/Help/analyses/regressionlogistic.md
+++ b/Resources/Help/analyses/regressionlogistic.md
@@ -24,11 +24,11 @@ Logistic regression allows the user to model a linear relationship between one o
 - Factors: The variables that are manipulated/define the different groups. These are also called the independent variables.
  
 ### Model
-- Include intercepts: Ticking this box will add a coefficient estimate of the intercept as well. This corresponds to the first (=reference) level for the independent variable.
 - Components and model terms:
     - Components: All the independent variables and covariates that can be included in the model.
     - Model terms: The independent variables and covariates included in the model. By default, all the main effects and interaction effects of the specified independent variables, and the covariates are included in the model. 
     - Add to null model: The independent variables included in the model can be selected to add to the null model. 
+- Include intercepts: Ticking this box will add a coefficient estimate of the intercept as well. This corresponds to the first (=reference) level for the independent variable.
 
  
 ### Statistics

--- a/Resources/Help/analyses/regressionlogistic.md
+++ b/Resources/Help/analyses/regressionlogistic.md
@@ -28,7 +28,7 @@ Logistic regression allows the user to model a linear relationship between one o
     - Components: All the independent variables and covariates that can be included in the model.
     - Model terms: The independent variables and covariates included in the model. By default, all the main effects and interaction effects of the specified independent variables, and the covariates are included in the model. 
     - Add to null model: The independent variables included in the model can be selected to add to the null model. 
-- Include intercepts: Ticking this box will add a coefficient estimate of the intercept as well. This corresponds to the first (=reference) level for the independent variable.
+- Include intercept: Ticking this box will add a coefficient estimate of the intercept as well. This corresponds to the first (=reference) level for the independent variable.
 
  
 ### Statistics

--- a/Resources/Help/analyses/regressionlogistic_nl.md
+++ b/Resources/Help/analyses/regressionlogistic_nl.md
@@ -25,12 +25,12 @@ Met logistische regressie kan men een lineaire relatie tussen een of meer verkla
 
  
 ### Model
-- Neem intercept mee:
-  - Neem het intercept mee in het model.
 - Componenten en model termen:
 	- Componenten: Alle onafhankelijke variabelen die in het model worden meegenomen.
 	- Model termen: De onafhankelijke variabelen en covariaten in het model. De standaardoptie is om de hoofdeffecten en interactie-effecten van de geselecteerde onafhankelijke variabelen mee te nemen in het model, net zoals de covariaten.
 	- Voeg toe aan nul model: De onafhankelijke variabelen in het model kunnen ook aan het nulmodel worden toegevoegd. 
+- Neem intercept mee:
+  - Neem het intercept mee in het model.
 
  
 ### Statistieken

--- a/Resources/Help/analyses/regressionlogistic_nl.md
+++ b/Resources/Help/analyses/regressionlogistic_nl.md
@@ -30,7 +30,7 @@ Met logistische regressie kan men een lineaire relatie tussen een of meer verkla
 	- Model termen: De onafhankelijke variabelen en covariaten in het model. De standaardoptie is om de hoofdeffecten en interactie-effecten van de geselecteerde onafhankelijke variabelen mee te nemen in het model, net zoals de covariaten.
 	- Voeg toe aan nul model: De onafhankelijke variabelen in het model kunnen ook aan het nulmodel worden toegevoegd. 
 - Neem intercept mee:
-  - Neem het intercept mee in het model.
+  - Neem intercept mee: Als u deze optie selecteert, dan wordt de schatting van het coëfficiënt van het intercept ook weergegeven. Dit komt overeen met het eerste (=referentie) niveau van de onafhankelijke variabele.
 
  
 ### Statistieken

--- a/Resources/Regression/qml/RegressionLinear.qml
+++ b/Resources/Regression/qml/RegressionLinear.qml
@@ -48,8 +48,6 @@ Form
 	{
 		title: qsTr("Model")
 		
-		CheckBox { name: "includeConstant"; label: qsTr("Include intercept"); checked: true }
-		
 		VariablesForm
 		{
 			preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
@@ -62,6 +60,8 @@ Form
 			}
 			ModelTermsList { width: parent.width * 5 / 9 }
 		}
+
+		CheckBox { name: "includeConstant"; label: qsTr("Include intercept"); checked: true }
 		
 	}
 	

--- a/Resources/Regression/qml/RegressionLogistic.qml
+++ b/Resources/Regression/qml/RegressionLogistic.qml
@@ -48,8 +48,6 @@ Form
 	{
 		title: qsTr("Model")
 		
-		CheckBox { name: "includeIntercept"; label: qsTr("Include intercept"); checked: true }
-		
 		VariablesForm
 		{
 			preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
@@ -63,6 +61,8 @@ Form
 			}
 			ModelTermsList { width: parent.width * 5 / 9; 	addInteractionsByDefault: false }
 		}
+
+		CheckBox { name: "includeIntercept"; label: qsTr("Include intercept"); checked: true }
 		
 	}
 	


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/820
Fixes https://github.com/jasp-stats/jasp-issues/issues/819

Would anyone (@JohnnyDoorn perhaps) be so kind to help me translate the change in the help files?
Specifically:

```
Standardized (Std.) residual. Alternatively called also studentized residual. 
```
and complete the translation of

```
Include intercept: Ticking this box will add a coefficient estimate of the intercept as well. This corresponds to the first (=reference) level for the independent variable.
```
(which somehow was not directly translated yet it seems.