### PR TITLE
Closing JASP while bootstrapping makes it crash

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -170,7 +170,8 @@ void Analyses::bindAnalysisHandler(Analysis* analysis)
 	connect(analysis,	&Analysis::titleChanged,						this, &Analyses::somethingModified					);
 	connect(analysis,	&Analysis::imageChanged,						this, &Analyses::somethingModified					);
 	connect(analysis,	&Analysis::userDataChangedSignal,				this, &Analyses::analysisOverwriteUserdata			);
-
+	connect(analysis,	&Analysis::destructionSignal,					this, &Analyses::analysisRemoved					);
+	
 	if (Settings::value(Settings::DEVELOPER_MODE).toBool())
 	{
 		QString filePath = tq(analysis->qmlFormPath());
@@ -199,7 +200,6 @@ void Analyses::clear()
 		idAnalysis.second  = nullptr;
 
 		emit analysisRemoved(analysis);
-		delete analysis;
 	}
 
 	_analysisMap.clear();
@@ -275,6 +275,9 @@ void Analyses::removeAnalysis(Analysis *analysis)
 			break;
 		}
 
+	if (indexAnalysis == -1)
+		return;
+
 	QList<int> toRemove;
 	QMapIterator<int, QPair<Analysis*, QString> > it(_scriptIDMap);
 	while (it.hasNext())
@@ -294,10 +297,7 @@ void Analyses::removeAnalysis(Analysis *analysis)
 
 	emit countChanged();
 	emit analysisRemoved(analysis);
-
-	delete analysis;
 }
-
 
 void Analyses::removeAnalysesOfDynamicModule(Modules::DynamicModule * module)
 {

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -300,10 +300,13 @@ void Analysis::initialized(AnalysisForm* form, bool isNewAnalysis)
 {
 						_analysisForm	= form;
 	if(!_isDuplicate)	_status			= isNewAnalysis ? Empty : Complete;
-	
+
+	setParent(_analysisForm);
+
 	connect(Analyses::analyses(),	&Analyses::dataSetChanged,			_analysisForm,	&AnalysisForm::dataSetChangedHandler		);
 	connect(Analyses::analyses(),	&Analyses::dataSetColumnsChanged,	_analysisForm,	&AnalysisForm::dataSetColumnsChangedHandler	);
 	connect(_analysisForm,			&AnalysisForm::helpMDChanged,		this,			&Analysis::helpMDChanged					);
+	connect(_analysisForm,			&AnalysisForm::formDestruction,		[=]() { emit this->destructionSignal(this);	}				);
 }
 
 

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -181,6 +181,7 @@ signals:
 	void				imageEditedSignal(		Analysis * analysis);
 	void				resultsChangedSignal(	Analysis * analysis);
 	void				userDataChangedSignal(	Analysis * analysis);
+	void				destructionSignal(		Analysis * analysis);
 	void				imageChanged();
 
 	ComputedColumn *	requestComputedColumnCreation(		QString columnName, Analysis * analysis);

--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -88,6 +88,7 @@ signals:
 				void			sendRScript(QString script, int key);
 				void			formChanged(Analysis* analysis);
 				void			formCompleted();
+				void			formDestruction();
 				void			dataSetChanged();
 				void			refreshTableViewModels();
 				void			errorMessagesItemChanged();

--- a/Desktop/components/JASP/Controls/Form.qml
+++ b/Desktop/components/JASP/Controls/Form.qml
@@ -190,4 +190,5 @@ AnalysisForm
 	}
 	
 	Component.onCompleted:	bindingTimer.start()
+	Component.onDestruction: formDestruction();
 }

--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -20,8 +20,15 @@ PlotEditorModel::PlotEditorModel()
 
 void PlotEditorModel::showPlotEditor(int id, QString options)
 {
+	Analysis* analysis = Analyses::analyses()->get(id);
+	if (_analysis != analysis)
+	{
+		if (_analysis)	disconnect(_analysis, &Analysis::destructionSignal, this, &PlotEditorModel::reset);
+		if (analysis)	connect(_analysis, &Analysis::destructionSignal, this, &PlotEditorModel::reset);
+	}
+
 	_analysisId	= id;
-	_analysis	= Analyses::analyses()->get(id);
+	_analysis = analysis;
 	_imgOptions	= Json::objectValue;
 
 	Json::Reader().parse(fq(options), _imgOptions);
@@ -38,6 +45,7 @@ void PlotEditorModel::showPlotEditor(int id, QString options)
 void PlotEditorModel::reset()
 {
 	_analysisId		=	-1;
+
 	_analysis		=	nullptr;
 	_imgOptions		=	Json::nullValue;
 	_editOptions	=	Json::nullValue;


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#826

. Make the Analysis object as child of the AnalysisForm
. Do not destroy the Analysis object from Analyses: as child of
AnalysisForm, it will be destroyed automatically.
. When the AnalysisForm starts to be destroyed, signal it to all
objects that have a pointer to an analysis (EngineRepresentation and
PlotEditorModel), so that this pointer should not be used anymore.