### PR TITLE
Reliability fix

### DIFF
--- a/JASP-Engine/JASP/R/reliabilityAnalysisBayesian.R
+++ b/JASP-Engine/JASP/R/reliabilityAnalysisBayesian.R
@@ -43,12 +43,12 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
                        "Greatest Lower Bound", "Item-rest correlation"),
       plots = list(expression("McDonald's"~omega), expression("Cronbach\'s"~alpha), expression("Guttman's"~lambda[2]), 
                    expression("Guttman's"~lambda[6]), "Greatest Lower Bound")
-    )
+    ),
+    
+    order_end = c(5, 1, 2, 3, 4) # order for plots and such, put omega to the front
 
   )
 
-  # order to show in JASP : check that again when more or different estimators are included
-  derivedOptions[["order"]] <- c(5, 1, 2, 3, 4, 6, 7, 8)
 
   return(derivedOptions)
 }
@@ -204,14 +204,17 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
       relyFit$Bayes$ifitem$samp$mean <- (matrix(NA_real_, ncol(dataset), 2))
       relyFit$Bayes$ifitem$samp$sd <- (matrix(NA_real_, ncol(dataset), 2))
       
-      ops <- .BayesianReliabilityDerivedOptions(options)
-      order <- ops[["order"]]
-      relyFit[["Bayes"]][["samp"]] <- relyFit[["Bayes"]][["samp"]][order]
-      relyFit[["Bayes"]][["chains"]] <- relyFit[["Bayes"]][["chains"]][order]
-      relyFit[["Bayes"]][["est"]] <- relyFit[["Bayes"]][["est"]][order]
+      # reorder for JASP
+      names_est <- names(relyFit$Bayes$est)
+      order_est <- c("Bayes_omega", "Bayes_alpha", "Bayes_lambda2", "Bayes_lambda6", "Bayes_glb", 
+                     "avg_cor", "mean", "sd")
+      order_end <- match(order_est, names_est)
+      relyFit[["Bayes"]][["samp"]] <- relyFit[["Bayes"]][["samp"]][order_end]
+      relyFit[["Bayes"]][["chains"]] <- relyFit[["Bayes"]][["chains"]][order_end]
+      relyFit[["Bayes"]][["est"]] <- relyFit[["Bayes"]][["est"]][order_end]
       
-      relyFit[["Bayes"]][["ifitem"]][["samp"]] <- relyFit[["Bayes"]][["ifitem"]][["samp"]][order]
-      relyFit[["Bayes"]][["ifitem"]][["est"]] <- relyFit[["Bayes"]][["ifitem"]][["est"]][order]
+      relyFit[["Bayes"]][["ifitem"]][["samp"]] <- relyFit[["Bayes"]][["ifitem"]][["samp"]][order_end]
+      relyFit[["Bayes"]][["ifitem"]][["est"]] <- relyFit[["Bayes"]][["ifitem"]][["est"]][order_end]
       
 
       # Consider stripping some of the contents of relyFit to reduce memory load
@@ -328,7 +331,6 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
   relyFit <- model[["relyFit"]]
   derivedOptions <- model[["derivedOptions"]]
   opts     <- derivedOptions[["namesEstimators"]][["tables"]]
-  order    <- derivedOptions[["order"]]
   selected <- derivedOptions[["selectedEstimators"]]
   idxSelected <- which(selected)
   
@@ -495,8 +497,7 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
 
   relyFit <- model[["relyFit"]]
   derivedOptions <- model[["derivedOptions"]]
-  order    <- derivedOptions[["order"]]
-  order <- order[1:(length(order)-3)] # dont need avgCor, mean and sd 
+  order_end    <- derivedOptions[["order_end"]]
   opts     <- derivedOptions[["namesEstimators"]][["tables"]]
   selected <- derivedOptions[["selectedEstimatorsPlots"]]
   idxSelected  <- which(selected)
@@ -506,7 +507,7 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
   if (!is.null(relyFit)) {
     n.item <- dim(relyFit$Bayes$covsamp)[3]
     prior <- Bayesrel:::priors[[as.character(n.item)]] 
-    prior <- prior[order]
+    prior <- prior[order_end]
     end <- length(prior[[1]][["x"]])
     poslow <- end - sum(prior[[1]][["x"]] > options[["probTableValueLow"]]) 
     poshigh <- end - sum(prior[[1]][["x"]] > options[["probTableValueHigh"]]) 
@@ -555,8 +556,7 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
   }
 
   derivedOptions <- model[["derivedOptions"]]
-  order     <- derivedOptions[["order"]]
-  order <- order[1:(length(order)-3)] # dont need avgCor, mean and sd 
+  order_end     <- derivedOptions[["order_end"]]
   indices   <- which(derivedOptions[["selectedEstimatorsPlots"]])
   nmsLabs   <- derivedOptions[["namesEstimators"]][["plots"]]
   nmsObjs   <- derivedOptions[["namesEstimators"]][["tables"]]
@@ -574,7 +574,7 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
 
   if (!is.null(relyFit)) {
     n.item <- dim(relyFit$Bayes$covsamp)[3]
-    prior <- Bayesrel:::priors[[as.character(n.item)]][order] ##### change this when more estimators are included!!!
+    prior <- Bayesrel:::priors[[as.character(n.item)]][order_end] ##### change this when more estimators are included!!!
     
       for (i in indices) {
         if (is.null(plotContainer[[nmsObjs[i]]])) {
@@ -712,8 +712,6 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
   } 
   
   derivedOptions <- model[["derivedOptions"]]
-  order     <- derivedOptions[["order"]]
-  order <- order[1:(length(order)-3)] # dont need itemrestCor, mean and sd 
   indices   <- which(derivedOptions[["itemDroppedSelectedItem"]])
   nmsLabs   <- derivedOptions[["namesEstimators"]][["plots"]]
   nmsObjs   <- derivedOptions[["namesEstimators"]][["tables_item"]]
@@ -888,8 +886,6 @@ reliabilityBayesian <- function(jaspResults, dataset, options) {
   } 
   
   derivedOptions <- model[["derivedOptions"]]
-  order     <- derivedOptions[["order"]]
-  order <- order[1:(length(order)-3)] # dont need avgCor, mean and sd 
   indices   <- which(derivedOptions[["selectedEstimatorsPlots"]])
   nmsLabs   <- derivedOptions[["namesEstimators"]][["plots"]]
   nmsObjs   <- derivedOptions[["namesEstimators"]][["tables"]]

--- a/JASP-Engine/JASP/R/reliabilityAnalysisFrequentist.R
+++ b/JASP-Engine/JASP/R/reliabilityAnalysisFrequentist.R
@@ -1,5 +1,7 @@
 reliabilityFrequentist <- function(jaspResults, dataset, options) {
 
+  sink("~/Downloads/log_freq.txt")
+  on.exit(sink(NULL))
   
   dataset <- .reliabilityReadData(dataset, options)
   .reliabilityCheckErrors(dataset, options)
@@ -450,9 +452,7 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
           addSingularFootnote <- TRUE
       }
       if (addSingularFootnote) {
-        model[["footnote"]] <- gettextf("%s Some confidence intervals could not be computed because 
-                                        out of the bootstrapped matrices non were invertible. ",
-                                        model[["footnote"]])
+        model[["footnote"]] <- gettextf("%s Some confidence intervals could not be computed because out of the bootstrapped matrices non were invertible. ", model[["footnote"]])
       }
 
     } else {

--- a/JASP-Engine/JASP/R/reliabilityAnalysisFrequentist.R
+++ b/JASP-Engine/JASP/R/reliabilityAnalysisFrequentist.R
@@ -1,5 +1,5 @@
 reliabilityFrequentist <- function(jaspResults, dataset, options) {
-
+  
   
   dataset <- .reliabilityReadData(dataset, options)
   .reliabilityCheckErrors(dataset, options)
@@ -34,9 +34,6 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
     )
   )
 
-  # order to show in JASP
-  derivedOptions[["order"]] <- c(5, 1, 2, 3, 4, 6, 7, 8)
-  
   return(derivedOptions)
 }
 
@@ -144,13 +141,10 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
                                          missing = missing, callback = progressbarTick))
           
           relyFit$freq$est$freq_alpha <- Bayesrel:::applyalpha(model[["dat_cov"]])
-          relyFit[["freq"]][["est"]] <- relyFit[["freq"]][["est"]][c(5, 1, 2, 3, 4)]
-            
+
           Ctmp <- .itemDeletedM(model[["dat_cov"]])
           
           relyFit$freq$ifitem$alpha <- apply(Ctmp, 1, Bayesrel:::applyalpha)
-          relyFit[["freq"]][["ifitem"]] <- relyFit[["freq"]][["ifitem"]][c(5, 1, 2, 3, 4)]
-          
           
           if (!alphaAna) { # when standardized alpha, but bootstrapped alpha interval:
             cors <- array(0, c(options[["noSamples"]], p, p))
@@ -158,10 +152,6 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
               cors[i, , ] <- .cov2cor.callback(relyFit$freq$covsamp[i, , ], progressbarTick)
             }
             relyFit$freq$boot$alpha <- apply(cors, 1, Bayesrel:::applyalpha)
-            if (length(relyFit[["freq"]][["boot"]]) == 4)
-              relyFit[["freq"]][["boot"]] <- relyFit[["freq"]][["boot"]][c(4, 1, 2, 3)]
-            else if (length(relyFit[["freq"]][["boot"]]) == 5)
-              relyFit[["freq"]][["boot"]] <- relyFit[["freq"]][["boot"]][c(5, 1, 2, 3, 4)]
             
           }
           
@@ -197,11 +187,19 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
         }
         relyFit$freq$ifitem$mean <- colMeans(dataset, na.rm = T)
         relyFit$freq$ifitem$sd <- apply(dataset, 2, sd, na.rm = T)  
+
+        # reorder for JASP
+        names_est <- names(relyFit$freq$est)
+        order_est <- c("freq_omega", "freq_alpha", "freq_lambda2", "freq_lambda6", "freq_glb", 
+                       "avg_cor", "mean", "sd")
+        new_order_est <- match(order_est, names_est)
+        relyFit$freq$est <- relyFit$freq$est[new_order_est]
         
-        ops <- .BayesianReliabilityDerivedOptions(options)
-        order <- ops[["order"]]
-        relyFit[["freq"]][["est"]] <- relyFit[["freq"]][["est"]][order]
-        relyFit[["freq"]][["ifitem"]] <- relyFit[["freq"]][["ifitem"]][order]
+        names_item <- names(relyFit$freq$ifitem)
+        order_item <- c("omega", "alpha", "lambda2", "lambda6", "glb", 
+                       "ircor", "mean", "sd")
+        new_order_item <- match(order_item, names_item)
+        relyFit$freq$ifitem <- relyFit$freq$ifitem[new_order_item]
         
         # ------------------------ only point estimates, no intervals: ---------------------------
       } else { 
@@ -306,7 +304,6 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
       if (is.null(cfiState) && !is.null(relyFit)) {
         scaleCfi <- .frequentistReliabilityCalcCfi(relyFit[["freq"]][["boot"]],             
                                                    options[["confidenceIntervalValue"]])
-
         # alpha int is analytical, not from the boot sample, so:
         if (options[["alphaInterval"]] == "alphaAnalytic") {
           
@@ -325,18 +322,13 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
           omegaCfi <- c(om_low, om_up)
           names(omegaCfi) <- c("lower", "upper")
           scaleCfi$omega <- omegaCfi
-          if (options[["alphaInterval"]] == "alphaAnalytic") {
-            scaleCfi <- scaleCfi[c(8, 7, 1, 2, 3, 4, 5, 6)] # check this when more estimators come in
-          } else {
-            scaleCfi <- scaleCfi[c(8, 1, 2, 3, 4, 5, 6, 7)] # check this when more estimators come in
-          }
-        } else {
-          if (options[["alphaInterval"]] == "alphaAnalytic") {
-            scaleCfi <- scaleCfi[c(4, 8, 1, 2, 3, 5, 6, 7)] # check this when more estimators come in
-          } else {
-            scaleCfi <- scaleCfi[c(5, 1, 2, 3, 4, 6, 7, 8)] # check this when more estimators come in
-          }
-        }
+        } 
+        # reorder for JASP:
+        names_cfi <- names(scaleCfi)
+        order_cfi <- c("omega", "alpha", "lambda2", "lambda6", "glb", 
+                        "avg_cor", "mean", "sd")
+        new_order_cfi <- match(order_cfi, names_cfi)
+        scaleCfi <- scaleCfi[new_order_cfi]
         
         cfiState <- list(scaleCfi = scaleCfi)
         jaspCfiState <- createJaspState(cfiState)
@@ -426,7 +418,6 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
   relyFit <- model[["relyFit"]]
   derivedOptions <- model[["derivedOptions"]]
   opts     <- derivedOptions[["namesEstimators"]][["tables"]]
-  order    <- derivedOptions[["order"]]
   selected <- derivedOptions[["selectedEstimatorsF"]]
   idxSelected <- which(selected)
   
@@ -436,6 +427,8 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
   }
 
   if (!is.null(relyFit)) {
+    
+    
     if (options[["intervalOn"]]) {
       addSingularFootnote <- FALSE
       for (i in idxSelected) {
@@ -450,7 +443,9 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
           addSingularFootnote <- TRUE
       }
       if (addSingularFootnote) {
-        model[["footnote"]] <- gettextf("%s Some confidence intervals could not be computed because out of the bootstrapped matrices non were invertible. ", model[["footnote"]])
+        model[["footnote"]] <- gettextf("%s Some confidence intervals could not be computed because 
+                                        out of the bootstrapped matrices non were invertible. ",
+                                        model[["footnote"]])
       }
 
     } else {
@@ -504,7 +499,6 @@ reliabilityFrequentist <- function(jaspResults, dataset, options) {
     }
   }
   itemDroppedSelectedF <- derivedOptions[["itemDroppedSelectedF"]]
-  # order <- derivedOptions[["order_item"]]
   estimators <- derivedOptions[["namesEstimators"]][["tables_item"]]
   overTitle <- gettext("If item dropped")
   

--- a/JASP-Engine/JASP/R/reliabilityAnalysisFrequentist.R
+++ b/JASP-Engine/JASP/R/reliabilityAnalysisFrequentist.R
@@ -1,7 +1,5 @@
 reliabilityFrequentist <- function(jaspResults, dataset, options) {
 
-  sink("~/Downloads/log_freq.txt")
-  on.exit(sink(NULL))
   
   dataset <- .reliabilityReadData(dataset, options)
   .reliabilityCheckErrors(dataset, options)


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-issues/issues/888
This is a major bug, cause the interval columns of two estimators are switched. 
I tested it with two datasets. Maybe a reviewer could also try this again. 
In the future it might be good to fix the unit tests for reliability, so this does not have to be done manually.