### PR TITLE
Mixed Models - showing sample sizes

### DIFF
--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -690,9 +690,9 @@
   } else if (type == "GLMM") {
     dependencies <- .mmDependenciesGLMM
   }
-  if (options$method == "PB") {
+  if (options$method == "PB")
     dependencies <- c(dependencies, "seed", "setSeed")
-  }
+
   fitSummary$dependOn(c(dependencies, "fitStats"))
   jaspResults[["fitSummary"]] <- fitSummary
   
@@ -702,9 +702,8 @@
   fitStats$position <- 1
   
   fitStats$addColumnInfo(name = "deviance", title = gettext("Deviance"), type = "number")
-  if (lme4::isREML(full_model)) {
+  if (lme4::isREML(full_model))
     fitStats$addColumnInfo(name = "devianceREML", title = gettext("Deviance (REML)"), type = "number")
-  }
   fitStats$addColumnInfo(name = "loglik", title = gettext("log Lik."), type = "number")
   fitStats$addColumnInfo(name = "df",     title = gettext("df"),       type = "integer")
   fitStats$addColumnInfo(name = "aic",    title = gettext("AIC"),      type = "number")
@@ -735,8 +734,8 @@
   temp_row <- list(
     observations = nrow(full_model@frame)
   )
-  for(n in names(full_model@flist)){
-    fitSizes$addColumnInfo(name = n, title = .unv(n), type = "integer", overtitle = gettext("Random effects grouping factors"))
+  for (n in names(full_model@flist)) {
+    fitSizes$addColumnInfo(name = n, title = .unv(n), type = "integer", overtitle = gettext("Levels of RE grouping factors"))
     temp_row[[n]] <- length(levels(full_model@flist[[n]]))
   }
   fitSizes$addRows(temp_row)
@@ -2239,12 +2238,11 @@
   n_bad_loo  <- length(loo::pareto_k_ids(loo, threshold = .7))
   
   
-  if(n_bad_waic > 0){
+  if (n_bad_waic > 0)
     fitStats$addFootnote(.mmMessageBadWAIC(n_bad_waic), symbol = gettext("Warning:"))   
-  }
-  if(n_bad_loo > 0){
+  if (n_bad_loo > 0)
     fitStats$addFootnote(.mmMessageBadLOO(n_bad_loo), symbol = gettext("Warning:"))    
-  }
+  
   
   temp_row <- list(
     waic   = waic$estimates["waic", "Estimate"],
@@ -2265,8 +2263,8 @@
   temp_row <- list(
     observations = attr(stanova_summary, "nobs")
   )
-  for(n in names(attr(stanova_summary, "ngrps"))){
-    fitSizes$addColumnInfo(name = n, title = .unv(n), type = "integer", overtitle = gettext("Random effects grouping factors"))
+  for (n in names(attr(stanova_summary, "ngrps"))) {
+    fitSizes$addColumnInfo(name = n, title = .unv(n), type = "integer", overtitle = gettext("Levels of RE grouping factors"))
     temp_row[[n]] <- attr(stanova_summary, "ngrps")[[n]]
   }
   fitSizes$addRows(temp_row)

--- a/JASP-Engine/JASP/R/MixedModelsCommon.R
+++ b/JASP-Engine/JASP/R/MixedModelsCommon.R
@@ -734,9 +734,9 @@
   temp_row <- list(
     observations = nrow(full_model@frame)
   )
-  for (n in names(full_model@flist)) {
-    fitSizes$addColumnInfo(name = n, title = .unv(n), type = "integer", overtitle = gettext("Levels of RE grouping factors"))
-    temp_row[[n]] <- length(levels(full_model@flist[[n]]))
+  for (thisName in names(full_model@flist)) {
+    fitSizes$addColumnInfo(name = thisName, title = .unv(thisName), type = "integer", overtitle = gettext("Levels of RE grouping factors"))
+    temp_row[[thisName]] <- length(levels(full_model@flist[[thisName]]))
   }
   fitSizes$addRows(temp_row)
   jaspResults[["fitSummary"]][["fitSizes"]] <- fitSizes
@@ -2234,14 +2234,14 @@
   loo  <- loo::loo(model)
 
 
-  n_bad_waic <- sum(waic$pointwise[,2] > 0.4)
-  n_bad_loo  <- length(loo::pareto_k_ids(loo, threshold = .7))
+  nBadWAIC <- sum(waic$pointwise[,2] > 0.4)
+  nBadLOO  <- length(loo::pareto_k_ids(loo, threshold = .7))
   
   
-  if (n_bad_waic > 0)
-    fitStats$addFootnote(.mmMessageBadWAIC(n_bad_waic), symbol = gettext("Warning:"))   
-  if (n_bad_loo > 0)
-    fitStats$addFootnote(.mmMessageBadLOO(n_bad_loo), symbol = gettext("Warning:"))    
+  if (nBadWAIC > 0)
+    fitStats$addFootnote(.mmMessageBadWAIC(nBadWAIC), symbol = gettext("Warning:"))   
+  if (nBadLOO > 0)
+    fitStats$addFootnote(.mmMessageBadLOO(nBadLOO), symbol = gettext("Warning:"))    
   
   
   temp_row <- list(


### PR DESCRIPTION
`Model summary` checkbox now also shows sample sizes for the Mixed Model analysis (this works for both the Bayesian and frequentist ones)

![image](https://user-images.githubusercontent.com/38475991/88040219-df243f80-cb48-11ea-8278-56edd859b211.png)

![image](https://user-images.githubusercontent.com/38475991/88040020-9a000d80-cb48-11ea-8e09-d75a43165242.png)

fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/987