### PR TITLE
Contingency tables properly reverse column labels

### DIFF
--- a/JASP-Engine/JASP/R/contingencytables.R
+++ b/JASP-Engine/JASP/R/contingencytables.R
@@ -362,7 +362,7 @@ ContingencyTables <- function(jaspResults, dataset, options, ...) {
     else  lvls <- unique(dataset[[ .v(analysis$columns) ]])
       
     if (options$columnOrder == "descending")
-        lvls <- sort(lvls, decreasing = TRUE)
+        lvls <- rev(lvls)
 
     overTitle            <- unlist(analysis$columns)
     useColumnNameAsTitle <- TRUE


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/914

I'm not entirely sure if this a good solution but at least the radio buttons `Row Order` and `Column Order` are now consistent (they both flip the table). I don't know what this has to with "Ascending" or "Descending" though. I also have no idea why the old implementation sorted the column labels.

Furthermore, in my opinion, we should delete these two radio buttons. Reordering a table should be done by clicking on a variable and reordering its levels. This also works already.



