### PR TITLE
Fixes for ml + audit

### DIFF
--- a/JASP-Engine/JASP/R/commonMachineLearningClustering.R
+++ b/JASP-Engine/JASP/R/commonMachineLearningClustering.R
@@ -356,7 +356,7 @@
     colSize <- clusterResult[["clusters"]]
   }
 
-  clusterAssignment <- factor(pred.values)
+  clusterAssignment <- factor(pred.values, levels = sort(unique(pred.values), decreasing = FALSE))
   if(type=="densitybased")
     levels(clusterAssignment)[levels(clusterAssignment)=="0"] <- gettext("Noisepoint")
   tsne_plot <- data.frame(x = tsne_out$Y[,1], y = tsne_out$Y[,2], Cluster = clusterAssignment)

--- a/Resources/Audit/Description.qml
+++ b/Resources/Audit/Description.qml
@@ -12,6 +12,7 @@ Description
 	website:			"www.github.com/koenderks/jfa"
 	license:			"GPL (>= 2)"
 	icon:				"audit-module.svg"
+	requiresData: false
 
 	GroupTitle
 	{


### PR DESCRIPTION
+ Properly sort factor levels in t-sne plot
+ Add requiresData: false to audit module (with https://github.com/jasp-stats/Audit/pull/11)

Attempts to fix the problem described in this e-mail (https://github.com/jasp-stats/INTERNAL-jasp/issues/1005):

Beste heer/mevrouw,

Bij het onderdeel Machine Learning --> Clustering --> K-Means clustering werkt de t-SNE Cluster Plot niet goed. De bolletjes van de clusters komen niet overheen met de aantallen die te zien zijn bij de Cluster information tabel. Ik maak gebruik van een Mac. 
Ik heb een screenshot van mijn analyse toegevoegd. 

![image](https://user-images.githubusercontent.com/25059399/89391987-33165300-d709-11ea-9830-b86e9b1076e1.png)

As can be seen, the dots do not correspond to the appropriate clusters.

**Before:**

Here, cluster 1 and 5 are the largest according to the table, but according to the plot they must be 4 and 2.

![image](https://user-images.githubusercontent.com/25059399/89393609-5510d500-d70b-11ea-84b0-31c0df6f31ec.png)

Now, factor levels are sorted before going into the t-sne plot, which results (on my computer) in good legends:

**After:**

The plot now shows cluster 1 and 5 as the largest clusters.

![image](https://user-images.githubusercontent.com/25059399/89393328-f0ee1100-d70a-11ea-8abd-e8e1623f50dc.png)
