### PR TITLE
Enable save as svg

### DIFF
--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -783,18 +783,19 @@ void MainWindow::_analysisSaveImageHandler(Analysis* analysis, QString options)
 	parser.parse(utf8, root);
 
 	QString selectedFilter;
-	QString finalPath = MessageForwarder::browseSaveFile(tr("Save JASP Image"), "", tr("Portable Network Graphics (*.png);;Portable Document Format (*.pdf);;Encapsulated PostScript (*.eps);;300 dpi Tagged Image File (*.tiff);;PowerPoint (*.pptx)"), &selectedFilter);
+	QString finalPath = MessageForwarder::browseSaveFile(tr("Save JASP Image"), "", tr("Portable Network Graphics (*.png);;Portable Document Format (*.pdf);;Encapsulated PostScript (*.eps);;300 dpi Tagged Image File (*.tiff);;PowerPoint (*.pptx);;Scalable Vector Graphics (*.svg)"), &selectedFilter);
 
 	if (!finalPath.isEmpty())
 	{
-		root["type"] = "png";
+		root["type"] = "svg";
 
-		if		(selectedFilter == "Encapsulated PostScript (*.eps)")		root["type"] = "eps";
+		if		(selectedFilter == "Portable Network Graphics (*.png)")		root["type"] = "png";
+		else if	(selectedFilter == "Encapsulated PostScript (*.eps)")		root["type"] = "eps";
 		else if (selectedFilter == "Portable Document Format (*.pdf)")		root["type"] = "pdf";
 		else if (selectedFilter == "300 dpi Tagged Image File (*.tiff)")	root["type"] = "tiff";
 		else if (selectedFilter == "PowerPoint (*.pptx)")					root["type"] = "pptx";
 
-		if(root["type"].asString() != "png")
+		if(root["type"].asString() != "svg")
 		{
 			root["finalPath"] = finalPath.toStdString();
 			analysis->saveImage(root);

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -787,15 +787,15 @@ void MainWindow::_analysisSaveImageHandler(Analysis* analysis, QString options)
 
 	if (!finalPath.isEmpty())
 	{
-		root["type"] = "svg";
+		root["type"] = "png";
 
-		if		(selectedFilter == "Portable Network Graphics (*.png)")		root["type"] = "png";
-		else if	(selectedFilter == "Encapsulated PostScript (*.eps)")		root["type"] = "eps";
+		if		(selectedFilter == "Encapsulated PostScript (*.eps)")		root["type"] = "eps";
 		else if (selectedFilter == "Portable Document Format (*.pdf)")		root["type"] = "pdf";
 		else if (selectedFilter == "300 dpi Tagged Image File (*.tiff)")	root["type"] = "tiff";
 		else if (selectedFilter == "PowerPoint (*.pptx)")					root["type"] = "pptx";
+		else if (selectedFilter == "Scalable Vector Graphics (*.svg)")		root["type"] = "svg";
 
-		if(root["type"].asString() != "svg")
+		if(root["type"].asString() != "png")
 		{
 			root["finalPath"] = finalPath.toStdString();
 			analysis->saveImage(root);

--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -2252,16 +2252,19 @@ as.list.footnotes <- function(footnotes) {
 }
 
 openGrDevice <- function(...) {
-  #if (jaspResultsCalledFromJasp())
-  #  svglite::svglite(...)
-  #else
-  grDevices::png(..., type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
+  if (jaspResultsCalledFromJasp()) {
+    print("using svglite::svglite")
+    svglite::svglite(...)
+  } else {
+    print("using grDevices::png")
+    grDevices::png(..., type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
+  }
 }
 
 .writeImage <- function(width=320, height=320, plot, obj = TRUE, relativePathpng = NULL) {
   # Set values from JASP'S Rcpp when available
   if (exists(".fromRCPP")) {
-    location        <- .fromRCPP(".requestTempFileNameNative", "png")
+    location        <- .fromRCPP(".requestTempFileNameNative", "svg")
     backgroundColor <- .fromRCPP(".imageBackground")
     ppi             <- .fromRCPP(".ppi")
   }
@@ -2281,30 +2284,22 @@ openGrDevice <- function(...) {
   # # convert width & height from pixels to inches. ppi = pixels per inch. 72 is a magic number inherited from the past.
   # # originally, this number was 96 but svglite scales this by (72/96 = 0.75). 0.75 * 96 = 72.
   # # for reference see https://cran.r-project.org/web/packages/svglite/vignettes/scaling.html
-  # width  <- width / 72
-  # height <- height / 72
+  width  <- width / 72
+  height <- height / 72
 
-  width  <- width * (ppi / 96)
-  height <- height * (ppi / 96)
+  # width  <- width * (ppi / 96)
+  # height <- height * (ppi / 96)
   image <- list()
 
   plot2draw <- decodeplot(plot)
 
+  svglite::svglite(filename = relativePathpng, width = width, height = height, bg = backgroundColor)
+  on.exit(dev.off())
+
+  # this should all be plot(plot2draw) and S3 dispatching should handle the rest
   if (ggplot2::is.ggplot(plot2draw) || inherits(plot2draw, c("gtable"))) {
 
-    # TODO: ggsave adds very little when we use a function as device...
-    ggplot2::ggsave(
-      filename  = relativePathpng,
-      plot      = plot2draw,
-      device    = grDevices::png,
-      dpi       = ppi,
-      width     = width,
-      height    = height,
-      bg        = backgroundColor,
-      res       = 72 * (ppi / 96),
-      type      = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"),
-      limitsize = FALSE # only necessary if users make the plot ginormous.
-    )
+    print(plot2draw)
 
     #If we have JASPgraphs available we can get the plotEditingOptions for this plot
     if(requireNamespace("JASPgraphs", quietly = TRUE))
@@ -2313,10 +2308,6 @@ openGrDevice <- function(...) {
   } else {
 
     isRecordedPlot <- inherits(plot2draw, "recordedplot")
-
-    # Open graphics device and plot
-    openGrDevice(file = relativePathpng, width = width, height = height, res = 72 * (ppi / 96), bg = backgroundColor)
-    on.exit(dev.off())
 
     if (is.function(plot2draw) && !isRecordedPlot) {
 

--- a/JASP-R-Interface/jaspResults/R/writeImage.R
+++ b/JASP-R-Interface/jaspResults/R/writeImage.R
@@ -20,20 +20,17 @@ getImageLocation <- function() {
 }
 
 openGrDevice <- function(...) {
-  if (jaspResultsCalledFromJasp()) {
-    print("using svglite::svglite")
-    svglite::svglite(...)
-  } else {
-    print("using grDevices::png")
-    grDevices::png(..., type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
-  }
+  #if (jaspResultsCalledFromJasp())
+  #  svglite::svglite(...)
+  #else
+  grDevices::png(..., type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
 }
 
 writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativePathpng=NULL, ppi=300, backgroundColor="white", location=getImageLocation())
 {
   # Set values from JASP'S Rcpp when available
   if (exists(".fromRCPP")) {
-    location        <- .fromRCPP(".requestTempFileNameNative", "svg")
+    location        <- .fromRCPP(".requestTempFileNameNative", "png")
     backgroundColor <- .fromRCPP(".imageBackground")
     ppi             <- .fromRCPP(".ppi")
   }
@@ -54,30 +51,41 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
   # # convert width & height from pixels to inches. ppi = pixels per inch. 72 is a magic number inherited from the past.
   # # originally, this number was 96 but svglite scales this by (72/96 = 0.75). 0.75 * 96 = 72.
   # # for reference see https://cran.r-project.org/web/packages/svglite/vignettes/scaling.html
-  width  <- width / 72
-  height <- height / 72
-
-  # width  <- width * (ppi / 96)
-  # height <- height * (ppi / 96)
-  image <- list()
+  # width  <- width / 72
+  # height <- height / 72
+  
+  width  <- width * (ppi / 96)
+  height <- height * (ppi / 96)
 
   plot2draw <- decodeplot(plot)
 
-  svglite::svglite(filename = relativePathpng, width = width, height = height, bg = backgroundColor)
-  on.exit(dev.off())
-
-  # this should all be plot(plot2draw) and S3 dispatching should handle the rest
   if (ggplot2::is.ggplot(plot2draw) || inherits(plot2draw, c("gtable"))) {
 
-    print(plot2draw)
+    # TODO: ggsave adds very little when we use a function as device...
+    ggplot2::ggsave(
+      filename  = relativePathpng, 
+      plot      = plot2draw,
+      device    = grDevices::png,
+      dpi       = ppi,
+      width     = width,
+      height    = height,
+      bg        = backgroundColor,
+      res       = 72 * (ppi / 96),
+      type      = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"),
+      limitsize = FALSE # only necessary if users make the plot ginormous.
+    )
 
     #If we have JASPgraphs available we can get the plotEditingOptions for this plot
     if(requireNamespace("JASPgraphs", quietly = TRUE))
       plotEditingOptions <- JASPgraphs::plotEditingOptions(graph=plot, asJSON=TRUE)
 
   } else {
-
+    
     isRecordedPlot <- inherits(plot2draw, "recordedplot")
+
+    # Open graphics device and plot
+    openGrDevice(file = relativePathpng, width = width, height = height, res = 72 * (ppi / 96), bg = backgroundColor)
+    on.exit(dev.off())
 
     if (is.function(plot2draw) && !isRecordedPlot) {
 
@@ -88,7 +96,6 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
     } else if (isRecordedPlot) { # function was called from editImage to resize the plot
 
       .redrawPlot(plot2draw) #(see below)
-
     } else if (inherits(plot2draw, "qgraph")) {
 
       qgraph:::plot.qgraph(plot2draw)

--- a/JASP-R-Interface/jaspResults/R/writeImage.R
+++ b/JASP-R-Interface/jaspResults/R/writeImage.R
@@ -20,17 +20,20 @@ getImageLocation <- function() {
 }
 
 openGrDevice <- function(...) {
-  #if (jaspResultsCalledFromJasp())
-  #  svglite::svglite(...)
-  #else
-  grDevices::png(..., type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
+  if (jaspResultsCalledFromJasp()) {
+    print("using svglite::svglite")
+    svglite::svglite(...)
+  } else {
+    print("using grDevices::png")
+    grDevices::png(..., type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
+  }
 }
 
 writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativePathpng=NULL, ppi=300, backgroundColor="white", location=getImageLocation())
 {
   # Set values from JASP'S Rcpp when available
   if (exists(".fromRCPP")) {
-    location        <- .fromRCPP(".requestTempFileNameNative", "png")
+    location        <- .fromRCPP(".requestTempFileNameNative", "svg")
     backgroundColor <- .fromRCPP(".imageBackground")
     ppi             <- .fromRCPP(".ppi")
   }
@@ -51,41 +54,30 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
   # # convert width & height from pixels to inches. ppi = pixels per inch. 72 is a magic number inherited from the past.
   # # originally, this number was 96 but svglite scales this by (72/96 = 0.75). 0.75 * 96 = 72.
   # # for reference see https://cran.r-project.org/web/packages/svglite/vignettes/scaling.html
-  # width  <- width / 72
-  # height <- height / 72
-  
-  width  <- width * (ppi / 96)
-  height <- height * (ppi / 96)
+  width  <- width / 72
+  height <- height / 72
+
+  # width  <- width * (ppi / 96)
+  # height <- height * (ppi / 96)
+  image <- list()
 
   plot2draw <- decodeplot(plot)
 
+  svglite::svglite(filename = relativePathpng, width = width, height = height, bg = backgroundColor)
+  on.exit(dev.off())
+
+  # this should all be plot(plot2draw) and S3 dispatching should handle the rest
   if (ggplot2::is.ggplot(plot2draw) || inherits(plot2draw, c("gtable"))) {
 
-    # TODO: ggsave adds very little when we use a function as device...
-    ggplot2::ggsave(
-      filename  = relativePathpng, 
-      plot      = plot2draw,
-      device    = grDevices::png,
-      dpi       = ppi,
-      width     = width,
-      height    = height,
-      bg        = backgroundColor,
-      res       = 72 * (ppi / 96),
-      type      = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"),
-      limitsize = FALSE # only necessary if users make the plot ginormous.
-    )
+    print(plot2draw)
 
     #If we have JASPgraphs available we can get the plotEditingOptions for this plot
     if(requireNamespace("JASPgraphs", quietly = TRUE))
       plotEditingOptions <- JASPgraphs::plotEditingOptions(graph=plot, asJSON=TRUE)
 
   } else {
-    
-    isRecordedPlot <- inherits(plot2draw, "recordedplot")
 
-    # Open graphics device and plot
-    openGrDevice(file = relativePathpng, width = width, height = height, res = 72 * (ppi / 96), bg = backgroundColor)
-    on.exit(dev.off())
+    isRecordedPlot <- inherits(plot2draw, "recordedplot")
 
     if (is.function(plot2draw) && !isRecordedPlot) {
 
@@ -96,6 +88,7 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
     } else if (isRecordedPlot) { # function was called from editImage to resize the plot
 
       .redrawPlot(plot2draw) #(see below)
+
     } else if (inherits(plot2draw, "qgraph")) {
 
       qgraph:::plot.qgraph(plot2draw)


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/873
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/620

Plots shown in JASP are still png files. 

This no longer has the error with multiple pages (just refresh [abtestPlotPagingError.jasp.zip](https://github.com/jasp-stats/jasp-desktop/files/5027749/abtestPlotPagingError.jasp.zip)) if you use the development version of svglite (https://github.com/r-lib/svglite).


