### PR TITLE
Tweaks Wilcoxon tests (freq/Bayes)

### DIFF
--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -162,7 +162,7 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
 
         if (!is.null(ttestResults[["delta"]][[var]]))
           ttestResults[["tValue"]][[var]] <- median(ttestResults[["delta"]][[var]])
-        wValue <- unname(wilcox.test(group2, group1, paired = FALSE)[["statistic"]])
+        wValue <- unname(wilcox.test(group1, group2, paired = FALSE)[["statistic"]])
         error <- wValue
 
       }

--- a/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianindependentsamples.R
@@ -287,10 +287,6 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
         currentVals[i] <- .truncNormSample(currentBounds[["under"]], currentBounds[["upper"]], mu=oldDeltaProp, sd=1)
 
       }
-
-      decorStepResult <- .decorrelateStepTwoSample(currentVals[1:n1], currentVals[(n1+1):(n1+n2)], oldDeltaProp, sigmaProp = 0.5)
-      xVals <- decorStepResult[[1]]
-      yVals <- decorStepResult[[2]]
       
       gibbsResult <- .sampleGibbsTwoSampleWilcoxon(x = xVals, y = yVals, nIter = nGibbsIterations,
                                                    rscale = cauchyPriorParameter)
@@ -376,27 +372,4 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
   bf <- if (isFALSE(oneSided)) priorDensZeroPoint / densZeroPoint else (priorDensZeroPoint / corFactorPrior) / (densZeroPoint / corFactorPosterior)
 
   return(bf)
-}
-
-
-.decorrelateStepTwoSample <- function(x, y, muProp, sigmaProp = 0.5) {
-  # decorrelate step described in Morey, R. D., Rouder, J. N., and Speckman, P. L. (2008). 
-  # A statistical model for dis-criminating between subliminal and near-liminal performance.
-  # and
-  # van Doorn, J., Ly, A., Marsman, M., & Wagenmakers, E. J. (2020). 
-  # Bayesian rank-based hypothesis testing for the rank sum test, the signed rank test, and Spearman's ρ.  
-  thisZ <- rnorm(1, 0, sigmaProp)
-  
-  newX <- x + thisZ
-  newY <- y + thisZ
-  
-  denom <- sum(dnorm(x, (muProp-thisZ) * -0.5, log = TRUE)) + sum(dnorm(y, (muProp-thisZ) * 0.5, log = TRUE))
-  num <- sum(dnorm(newX, muProp * -0.5, log = TRUE)) + sum(dnorm(newY, muProp * 0.5, log = TRUE))
-  
-  if(runif(1) < exp(num - denom) ) {
-    return(list(x = newX, y = newY, accept = TRUE))
-  } else {
-    return(list(x = x, y = y, accept = FALSE))
-  }
-  
 }

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -292,10 +292,6 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
       }
       
       sampledDiffsAbs <- abs(diffSamples)
-      
-      thisZ <- .decorrelateStepOneSample(diffSamples, oldDeltaProp, sigmaProp = 0.5)
-      diffSamples <- diffSamples + thisZ
-      
       gibbsOutput <- .sampleGibbsOneSampleWilcoxon(diffScores = diffSamples, nIter = nGibbsIterations, rscale = cauchyPriorParameter)
       
       deltaSamples[j] <- oldDeltaProp <- gibbsOutput
@@ -340,24 +336,4 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
     delta <- mu / sqrt(sigmaSq)
   }
   return(delta)
-}
-
-.decorrelateStepOneSample <- function(d, muProp, sigmaProp = 0.5) {
-  # decorrelate step described in Morey, R. D., Rouder, J. N., and Speckman, P. L. (2008). 
-  # A statistical model for dis-criminating between subliminal and near-liminal performance.
-  # and
-  # van Doorn, J., Ly, A., Marsman, M., & Wagenmakers, E. J. (2020). 
-  # Bayesian rank-based hypothesis testing for the rank sum test, the signed rank test, and Spearman's ρ.
-  thisZ <- rnorm(1, 0, sigmaProp)
-  newD <- d + thisZ
-  
-  denom <- sum(dnorm(d, (muProp-thisZ), log = TRUE))
-  num <- sum(dnorm(newD, muProp, log = TRUE))
-  
-  if(runif(1) < exp(num - denom) ) {
-    return(thisZ)
-  } else {
-    return(0)
-  }
-  
 }

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -158,7 +158,7 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
           if (!is.null(ttestResults[["delta"]][[var]]))
             ttestResults[["tValue"]][[var]] <- median(ttestResults[["delta"]][[var]])
           ttestResults[["n1"]][var]       <- length(x)
-          wValue <- unname(wilcox.test(y, x, paired = TRUE)[["statistic"]])
+          wValue <- unname(wilcox.test(x, y, paired = TRUE)[["statistic"]])
           error <- wValue
           ttestRows[var, "rHat"] <- rHat
           

--- a/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
@@ -33,7 +33,7 @@ test_that("Main table results match for Wilcoxon test", {
   options$hypothesis <- "groupOneGreater"
   results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options)
   table <- getTtestTable(results)[["data"]]
-  expect_equal_tables(table, list(0.277730185316155, 1146, 1.00447417926979, "contNormal"))
+  expect_equal_tables(table, list(0.277730185316155, 1290, 1.00447417926979, "contNormal"))
 })
 
 test_that("Inferential and descriptives plots match", {

--- a/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
+++ b/JASP-Tests/R/tests/testthat/test-ttestbayesianindependentsamples.R
@@ -33,7 +33,7 @@ test_that("Main table results match for Wilcoxon test", {
   options$hypothesis <- "groupOneGreater"
   results <- jasptools::run("TTestBayesianIndependentSamples", "test.csv", options)
   table <- getTtestTable(results)[["data"]]
-  expect_equal_tables(table, list(0.395004853845122, 1146, 0.999374433542238, "contNormal"))
+  expect_equal_tables(table, list(0.277730185316155, 1146, 1.00447417926979, "contNormal"))
 })
 
 test_that("Inferential and descriptives plots match", {

--- a/Resources/Help/analyses/ttestbayesianindependentsamples.md
+++ b/Resources/Help/analyses/ttestbayesianindependentsamples.md
@@ -72,7 +72,7 @@ The independent samples t-test allows the user to estimate the effect size and t
   - BF0+: Bayes factor that quantifies evidence for the null hypothesis, relative to the one-sided alternative hypothesis that group one > group two.
   - BF0-: Bayes factor that quantifies evidence for the null hypothesis, relative to the one-sided alternative hypothesis that group one < group two.
 - error %: The error of the Gaussian quadrature integration routine used for the computation of the Bayes factor.
-- W: The test statistic of the Wilcoxon test.
+- W: The test statistic of the Wilcoxon test. The two most common definitions correspond to the sum of the ranks of the first sample with the minimum value subtracted or not. JASP uses the definition with the subtraction (also used by R).
 - Rhat: A measure of MCMC convergence for the Wilcoxon test. A ratio comparing the between- and within-chain variance of the MCMC estimates for the delta parameter. Values less than or equal to 1 indicate convergence.
 
 #### Group Descriptives

--- a/Resources/Help/analyses/ttestbayesianindependentsamples_nl.md
+++ b/Resources/Help/analyses/ttestbayesianindependentsamples_nl.md
@@ -72,7 +72,7 @@ Met de t-toets voor onafhankelijke steekproeven kan de gebruiker de effectgroott
   - BF0+: De Bayes factor die bewijs geeft voor de nulhypothese, ten opzichte van de eenzijdige alternatieve hypothese dat groep een > groep twee.
   - BF0-: De Bayes factor die bewijs geeft voor de nulhypothese, ten opzichte van de eenzijdige alternatieve hypothese dat groep een < groep twee.
 - error %: De fout van de Gaussiaanse kwadratuur intergratie methode die wordt gebruikt op de Bayes factor te berekenen.
-- W: De toets statistiek van de Wilcoxon toets.
+- W: De toets statistiek van de Wilcoxon toets. Deze wordt berekend door de rangordes van de eerste groep op te tellen (dezelfde procedure als door R wordt gebruikt). 
 - R-dakje: Mate van convergentie voor de MCMC procedure van de Wilcoxon toets. Een ratio die de varianties vergelijkt binnen en tussen de MCMC ketens voor de delta parameter. Waarden minder dan, of gelijk aan, 1 duiden op convergentie.
 
 

--- a/Resources/Help/analyses/ttestindependentsamples.md
+++ b/Resources/Help/analyses/ttestindependentsamples.md
@@ -54,6 +54,7 @@ The independent samples t-test allows the user to estimate the effect size and t
 - The first column contains the dependent variable. 
 - Test: The type of t-test that is selected. If only one test is selected, this column will not be displayed. In this scenario, the table only displays the results for the selected test. 
 - t: The value of the t-value. 
+- W: The test statistic of the Wilcoxon test. The two most common definitions correspond to the sum of the ranks of the first sample with the minimum value subtracted or not. JASP uses the definition with the subtraction (also used by R).
 - df: Degrees of freedom. 
 - p: The p-value. 
 - Mean difference: Difference in sample means. This column is only named 'Mean difference' when the tests `Student` or `Welch` are selected. When the test `Mann-Whitney` is selected, this column is called 'Location parameter'. 

--- a/Resources/Help/analyses/ttestindependentsamples_nl.md
+++ b/Resources/Help/analyses/ttestindependentsamples_nl.md
@@ -54,6 +54,7 @@ Met de t-toets voor onafhankelijke steekproeven kan de gebruiker de effectgroott
 - De eerste kolom bevat de variabelen waarvoor de analyse is uitgevoerd.
 - Toets: Het type toets dat is geselecteerd. Als er maar een toets is geselecteerd wordt deze kolom niet weergegeven. In dit geval geeft de tabel alleen de resultaten van de geselecteerde toets weer. 
 - t: De waarde van de t-waarde. 
+- W: De toets statistiek van de Wilcoxon toets. Deze wordt berekend door de rangordes van de eerste groep op te tellen (dezelfde procedure als door R wordt gebruikt). 
 - vg: Vrijheidsgraden.
 - p: De p-waarde.
 - Gemiddelde verschil: Gemiddeld verschil tussen de steekproefgemiddelden. Deze kolom heet alleen 'Gemiddelde verschil' wanneer de toets `Student` of `Welch` is geselecteerd. Wanneer de toets `Mann-Whitney` is geselecteerd, heet deze kolom 'Locatieparameter'. 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/887
Fixes https://github.com/jasp-stats/jasp-issues/issues/868
Fixes https://github.com/jasp-stats/jasp-issues/issues/828

- Adjust the helpfiles to clarify how we obtain Wilcoxon test statistic
- Remove decorrelation steps Wilcoxon (@vandenman was right in the end!)

Fixes the issues reporting on the one-sample Wilcoxon inconsistencies:

Edit: changed so GitHub picks up on the linked issues.