### PR TITLE
Make requiresData sane

### DIFF
--- a/JASP-Desktop/modules/description/description.cpp
+++ b/JASP-Desktop/modules/description/description.cpp
@@ -69,7 +69,7 @@ void Description::connectChangesToDelay()
 	connect(this, &Description::websiteChanged,			this, &Description::delayedUpdate);
 	connect(this, &Description::licenseChanged,			this, &Description::delayedUpdate);
 	connect(this, &Description::nameChanged,			this, &Description::delayedUpdate);
-	connect(this, &Description::requiresDataChanged,	this, &Description::delayedUpdate);
+	connect(this, &Description::requiresDataDefChanged,	this, &Description::delayedUpdate);
 	connect(this, &Description::dynModChanged,			this, &Description::delayedUpdate);
 }
 
@@ -181,13 +181,13 @@ void Description::setLicense(QString license)
 	emit licenseChanged(_license);
 }
 
-void Description::setRequiresData(bool requiresData)
+void Description::setRequiresDataDef(bool requiresData)
 {
-	if (_requiresData == requiresData)
+	if (_requiresDataDef == requiresData)
 		return;
 
-	_requiresData = requiresData;
-	emit requiresDataChanged(_requiresData);
+	_requiresDataDef = requiresData;
+	emit requiresDataDefChanged(_requiresDataDef);
 }
 
 void Description::setDynMod(DynamicModule * dynMod)
@@ -219,7 +219,7 @@ std::vector<AnalysisEntry*> Description::menuEntries() const
 
 	for(EntryBase * entry : _entries)
 		if(entry->shouldBeAdded())
-			entries.push_back(entry->convertToAnalysisEntry(requiresData()));
+			entries.push_back(entry->convertToAnalysisEntry(requiresDataDef()));
 
 	return entries;
 }

--- a/JASP-Desktop/modules/description/description.h
+++ b/JASP-Desktop/modules/description/description.h
@@ -21,33 +21,34 @@ class DynamicModule;
 class Description : public QQuickItem
 {
 	Q_OBJECT
-	Q_PROPERTY(QString					name			READ name			WRITE setName			NOTIFY nameChanged			)
-	Q_PROPERTY(QString					title			READ title			WRITE setTitle			NOTIFY titleChanged			)
-	Q_PROPERTY(QString					icon			READ icon			WRITE setIcon			NOTIFY iconChanged			)
-	Q_PROPERTY(QString					description		READ description	WRITE setDescription	NOTIFY descriptionChanged	)
-	Q_PROPERTY(QString					version			READ version		WRITE setVersion		NOTIFY versionChanged		)
-	Q_PROPERTY(QString					author			READ author			WRITE setAuthor			NOTIFY authorChanged		)
-	Q_PROPERTY(QString					maintainer		READ maintainer		WRITE setMaintainer		NOTIFY maintainerChanged	)
-	Q_PROPERTY(QUrl						website			READ website		WRITE setWebsite		NOTIFY websiteChanged		)
-	Q_PROPERTY(QString					license			READ license		WRITE setLicense		NOTIFY licenseChanged		)
-	Q_PROPERTY(bool						requiresData	READ requiresData	WRITE setRequiresData	NOTIFY requiresDataChanged	)
-	Q_PROPERTY(Modules::DynamicModule *	dynMod			READ dynMod			WRITE setDynMod			NOTIFY dynModChanged		)
+	Q_PROPERTY(QString					name			READ name				WRITE setName				NOTIFY nameChanged				)
+	Q_PROPERTY(QString					title			READ title				WRITE setTitle				NOTIFY titleChanged				)
+	Q_PROPERTY(QString					icon			READ icon				WRITE setIcon				NOTIFY iconChanged				)
+	Q_PROPERTY(QString					description		READ description		WRITE setDescription		NOTIFY descriptionChanged		)
+	Q_PROPERTY(QString					version			READ version			WRITE setVersion			NOTIFY versionChanged			)
+	Q_PROPERTY(QString					author			READ author				WRITE setAuthor				NOTIFY authorChanged			)
+	Q_PROPERTY(QString					maintainer		READ maintainer			WRITE setMaintainer			NOTIFY maintainerChanged		)
+	Q_PROPERTY(QUrl						website			READ website			WRITE setWebsite			NOTIFY websiteChanged			)
+	Q_PROPERTY(QString					license			READ license			WRITE setLicense			NOTIFY licenseChanged			)
+	//requiresData should really be called defaultRequiresData or something. Because that is what it does. But it would be a lot of work to change all the qmls...
+	Q_PROPERTY(bool						requiresData	READ requiresDataDef	WRITE setRequiresDataDef	NOTIFY requiresDataDefChanged	)
+	Q_PROPERTY(Modules::DynamicModule *	dynMod			READ dynMod				WRITE setDynMod				NOTIFY dynModChanged			)
 
 public:
 	Description(QQuickItem *parent = nullptr);
 	~Description();
 
-	QString			name()			const { return _name;						}
-	QString			title()			const { return _title;						}
-	QString			icon()			const { return _icon;						}
-	QString			description()	const { return _description;				}
-	QString			version()		const { return tq(_version.toString(3));	}
-	QString			author()		const { return _author;						}
-	QString			maintainer()	const { return _maintainer;					}
-	QUrl			website()		const { return _website;					}
-	QString			license()		const { return _license;					}
-	bool			requiresData()	const { return _requiresData;				}
-	DynamicModule * dynMod()		const { return _dynMod;						}
+	QString			name()				const { return _name;						}
+	QString			title()				const { return _title;						}
+	QString			icon()				const { return _icon;						}
+	QString			description()		const { return _description;				}
+	QString			version()			const { return tq(_version.toString(3));	}
+	QString			author()			const { return _author;						}
+	QString			maintainer()		const { return _maintainer;					}
+	QUrl			website()			const { return _website;					}
+	QString			license()			const { return _license;					}
+	bool			requiresDataDef()	const { return _requiresDataDef;			}
+	DynamicModule * dynMod()			const { return _dynMod;						}
 
 	void	addChild(	DescriptionChildBase * child);
 	void	removeChild(DescriptionChildBase * child);
@@ -58,32 +59,32 @@ public:
 
 
 public slots:
-	void setName(			QString			name		);
-	void setTitle(			QString			title		);
-	void setIcon(			QString			icon		);
-	void setDescription(	QString			description	);
-	void setVersion(		QString			version		);
-	void setAuthor(			QString			author		);
-	void setMaintainer(		QString			maintainer	);
-	void setWebsite(		QUrl			website		);
-	void setLicense(		QString			license		);
-	void setRequiresData(	bool			requiresData);
-	void setDynMod(			DynamicModule * dynMod		);
+	void setName(				QString			name		);
+	void setTitle(				QString			title		);
+	void setIcon(				QString			icon		);
+	void setDescription(		QString			description	);
+	void setVersion(			QString			version		);
+	void setAuthor(				QString			author		);
+	void setMaintainer(			QString			maintainer	);
+	void setWebsite(			QUrl			website		);
+	void setLicense(			QString			license		);
+	void setRequiresDataDef(	bool			defRequiresData);
+	void setDynMod(				DynamicModule * dynMod		);
 	void delayedUpdate();
 
 signals:
-	void titleChanged(			QString			title		);
-	void iconChanged(			QString			icon		);
-	void descriptionChanged(	QString			description	);
+	void titleChanged(				QString			title		);
+	void iconChanged(				QString			icon		);
+	void descriptionChanged(		QString			description	);
 	void versionChanged();
-	void authorChanged(			QString			author		);
-	void maintainerChanged(		QString			maintainer	);
-	void websiteChanged(		QUrl			website		);
-	void licenseChanged(		QString			license		);
-	void nameChanged(			QString			name		);
-	void requiresDataChanged(	bool			requiresData);
-	void dynModChanged(			DynamicModule * dynMod		);
-	void iShouldBeUpdated(		Description	  *	desc		);
+	void authorChanged(				QString			author		);
+	void maintainerChanged(			QString			maintainer	);
+	void websiteChanged(			QUrl			website		);
+	void licenseChanged(			QString			license		);
+	void nameChanged(				QString			name		);
+	void requiresDataDefChanged(	bool			defRequiresData);
+	void dynModChanged(				DynamicModule * dynMod		);
+	void iShouldBeUpdated(			Description	  *	desc		);
 
 private slots:
 	void childChanged(DescriptionChildBase * ) { delayedUpdate(); }
@@ -101,7 +102,7 @@ private:
 							_license;
 	QUrl					_website;
 	Version					_version;
-	bool					_requiresData	= true;
+	bool					_requiresDataDef	= true;
 	DynamicModule		*	_dynMod			= nullptr;
 	QList<EntryBase*>		_entries;
 	QList<RequiredPackage*>	_reqPkgs;

--- a/JASP-Desktop/modules/ribbonbutton.cpp
+++ b/JASP-Desktop/modules/ribbonbutton.cpp
@@ -120,6 +120,14 @@ void RibbonButton::setMenu(const Modules::AnalysisEntries& entries)
 	_oldTitles.clear();
 	for(const Modules::AnalysisEntry * entry : _menuEntries)
 		_oldTitles.push_back(entry->title());
+
+	///If any single analysis can run without data the button should be pressible without data
+	bool requiresData = true;
+	for(const Modules::AnalysisEntry * entry : _menuEntries)
+		if(!entry->requiresData())
+			requiresData = false;
+
+	setRequiresData(requiresData);
 }
 
 void RibbonButton::setRequiresData(bool requiresDataset)
@@ -253,13 +261,10 @@ void RibbonButton::reloadMenuFromDescriptionQml()
 	{
 		desc = Modules::DynamicModule::instantiateDescriptionQml(descriptionFile.readAll(), QUrl::fromLocalFile(descriptionFileInfo.absoluteFilePath()), _moduleName);
 
-		setRequiresData(		desc->requiresData());
 		setTitle(			fq(	desc->title()	)	);
 		setIconSource(			desc->icon()		);
 		setToolTip(				desc->description() );
-
-		setMenu(desc->menuEntries());
-
+		setMenu(				desc->menuEntries());
 
 		if(_description)
 			delete _description;
@@ -284,7 +289,6 @@ void RibbonButton::descriptionChanged(Modules::Description * desc)
 
 	Log::log() << "RibbonButton for module " << _moduleName << " will read from Description again!" << std::endl;
 
-	setRequiresData(		_description->requiresData());
 	setTitle(			fq(	_description->title()	)	);
 	setIconSource(			_description->icon()		);
 	setMenu(				_description->menuEntries() );


### PR DESCRIPTION
- "requiresData" on module is now the default value for the "requiresData" property of the  analysis entries in the menu
- The module/ribbonbutton will now be usable without data if at least 1 entry in the menu can be used without data
- fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1004

