### PR TITLE
Add values attribute to source property

### DIFF
--- a/Desktop/components/JASP/Controls/ComboBox.qml
+++ b/Desktop/components/JASP/Controls/ComboBox.qml
@@ -27,12 +27,12 @@ JASPControl
 	property alias	currentIndex:			control.currentIndex
 	property alias	indexDefaultValue:		control.currentIndex
 	property alias	model:					control.model
-	property alias	values:					control.model
 	property alias	fieldWidth:				control.modelWidth
 	property string	textRole:				"label"
 	property string	valueRole:				"value"
 	property bool	showVariableTypeIcon:	false
-	property var	source					//defaults would be nice
+	property var	values:					undefined
+	property var	source:					undefined // Do not set a default: if nothing is set, it gets all variables per default.
 	property alias	syncModels:				comboBox.source
 	property bool	addEmptyValue:			false
 	property string	placeholderText:		qsTr("<no choice>")

--- a/Desktop/components/JASP/Controls/ComponentsList.qml
+++ b/Desktop/components/JASP/Controls/ComponentsList.qml
@@ -30,7 +30,7 @@ JASPGridControl
 	implicitHeight		: itemTitle.height + itemGrid.height + 2 * jaspTheme.contentMargin + (showAddIcon ? addIconItem.height : 0)
 
 
-	property bool	addItemManually	: !source
+	property bool	addItemManually	: !source && !values
 	property bool	showAddIcon		: addItemManually
 	property int	minimumItems	: 0
 	property int	maximumItems	: -1

--- a/Desktop/widgets/boundqmlcombobox.h
+++ b/Desktop/widgets/boundqmlcombobox.h
@@ -43,10 +43,8 @@ public:
 	
 protected slots:
 	void modelChangedHandler() override;
-	void valuesChangedHandler();
 	void comboBoxChangeValueSlot(int index);
 	void languageChangedHandler();
-	void resetValues();
 
 protected:
 	OptionList*					_boundTo				= nullptr;
@@ -55,6 +53,7 @@ protected:
 	QString						_currentColumnType;
 	ListModelLabelValueTerms*	_model					= nullptr;
 
+	void _setLabelValues();
 	void _resetItemWidth();
 	void _resetOptions();
 	void _setCurrentValue(int index, bool setComboBoxIndex = true, bool setOption = true);

--- a/Desktop/widgets/boundqmlcomponentslist.cpp
+++ b/Desktop/widgets/boundqmlcomponentslist.cpp
@@ -32,10 +32,8 @@ BoundQMLComponentsList::BoundQMLComponentsList(JASPControlBase *item)
 {
 	_termsModel = new ListModelTermsAssigned(this);
 	setTermsAreNotVariables();
-	_termsModel->readModelProperty(this);
 
 	QQuickItem::connect(_item, SIGNAL(nameChanged(int, QString)), this, SLOT(nameChangedHandler(int, QString)));
-	QQuickItem::connect(_item, SIGNAL(valuesChanged()), this, SLOT(valuesChangedHandler()));
 	QQuickItem::connect(_item, SIGNAL(addItem()), this, SLOT(addItemHandler()));
 	QQuickItem::connect(_item, SIGNAL(removeItem(int)), this, SLOT(removeItemHandler(int)));
 }
@@ -240,12 +238,6 @@ void BoundQMLComponentsList::modelChangedHandler()
 
 		_boundTo->connectOptions(allOptions);
 	}
-}
-
-void BoundQMLComponentsList::valuesChangedHandler()
-{
-	_termsModel->readModelProperty(this);
-	modelChangedHandler();
 }
 
 void BoundQMLComponentsList::addItemHandler()

--- a/Desktop/widgets/boundqmlcomponentslist.h
+++ b/Desktop/widgets/boundqmlcomponentslist.h
@@ -39,7 +39,6 @@ public:
 
 protected slots:
 	void		modelChangedHandler()						override;
-	void		valuesChangedHandler();
 	void		addItemHandler();
 	void		removeItemHandler(int index);
 	void		nameChangedHandler(int index, QString name);

--- a/Desktop/widgets/boundqmllavaantextarea.cpp
+++ b/Desktop/widgets/boundqmllavaantextarea.cpp
@@ -32,7 +32,7 @@ BoundQMLLavaanTextArea::BoundQMLLavaanTextArea(JASPControlBase* item)
 	connect(form(), &AnalysisForm::dataSetChanged,	this, &BoundQMLTextArea::dataSetChangedHandler,	Qt::QueuedConnection	);
 
 	_model = new ListModelTermsAvailable(this);
-	_modelHasAllVariables = true;
+	_modelNeedsAllVariables = true;
 
 	QVariant textDocumentVariant = _item->property("textDocument");
 	QQuickTextDocument* textDocumentQQuick = textDocumentVariant.value<QQuickTextDocument *>();

--- a/Desktop/widgets/boundqmltextarea.h
+++ b/Desktop/widgets/boundqmltextarea.h
@@ -48,6 +48,7 @@ public:
 	bool		isJsonValid(const Json::Value& optionValue) override;
 	Option*		boundTo()									override { return _boundTo; }
 	ListModel*	model()								const	override { return _model; }
+	bool		modelNeedsAllVariables()			const			 { return _modelNeedsAllVariables; }
 
 	void		resetQMLItem(JASPControlBase *item)			override;
 	void		rScriptDoneHandler(const QString &result)	override;
@@ -66,6 +67,7 @@ protected:
 	
 	LavaanSyntaxHighlighter*	_lavaanHighlighter = nullptr;
 	ListModelTermsAvailable*	_model = nullptr;
+	bool						_modelNeedsAllVariables = false;
 	
 };
 

--- a/Desktop/widgets/jaspcontrolwrapper.cpp
+++ b/Desktop/widgets/jaspcontrolwrapper.cpp
@@ -137,7 +137,7 @@ void JASPControlWrapper::addControlError(const QString &error)
 
 bool JASPControlWrapper::addDependency(JASPControlWrapper *item)
 {
-	if (_depends.count(item) > 0)
+	if (_depends.count(item) > 0 || this == item)
 		return false;
 	
 	_depends.insert(item);

--- a/Desktop/widgets/listmodel.h
+++ b/Desktop/widgets/listmodel.h
@@ -72,9 +72,7 @@ public:
 	virtual void					refresh();
 	virtual void					initTerms(const Terms &terms, const RowControlsOptions& allOptionsMap = RowControlsOptions());
 			Terms					getSourceTerms();
-			QMap<ListModel*, Terms> getSourceTermsPerModel();
 			ListModel*				getSourceModelOfTerm(const Term& term);
-	virtual void					readModelProperty(QMLListView* item);
 
 			void					setRowComponents(QList<QQmlComponent*> &rowComponents);
 	virtual void					setUpRowControls();

--- a/Desktop/widgets/listmodelinteractionavailable.cpp
+++ b/Desktop/widgets/listmodelinteractionavailable.cpp
@@ -39,13 +39,10 @@ void ListModelInteractionAvailable::resetTermsFromSourceModels(bool updateAssign
 	Terms randomFactors;
 	Terms covariates;
 
-	QMap<ListModel*, Terms> sourceTerms = getSourceTermsPerModel();
-	QMapIterator<ListModel*, Terms> it(sourceTerms);
-	while (it.hasNext())
+	for (const std::pair<QMLListView::SourceType *, Terms>& source : listView()->getTermsPerSource())
 	{
-		it.next();
-		ListModel* sourceModel = it.key();
-		const Terms& terms = it.value();
+		ListModel* sourceModel = source.first->model;
+		const Terms& terms = source.second;
 		for (const Term& term : terms)
 		{
 			QString itemType = sourceModel->getItemType(term);

--- a/Desktop/widgets/listmodellabelvalueterms.h
+++ b/Desktop/widgets/listmodellabelvalueterms.h
@@ -25,21 +25,22 @@ class ListModelLabelValueTerms : public ListModelTermsAvailable
 {
 	Q_OBJECT
 public:
-	ListModelLabelValueTerms(QMLListView* listView);
+	ListModelLabelValueTerms(QMLListView* listView, const QMLListView::LabelValueMap& values = QMLListView::LabelValueMap());
 
 	QVariant					data(const QModelIndex &index, int role = Qt::DisplayRole)	const override;
-
-	void						readModelProperty(QMLListView* item)						override;
 
 	std::vector<std::string>	getValues();
 	QString						getValue(const QString& label);
 	QString						getLabel(const QString& value);
 	int							getIndexOfValue(const QString& value);
 
+	void						setLabelValues(const QMLListView::LabelValueMap& values);
+
 protected:
 
 	QMap<QString, QString>		_valueToLabelMap;
 	QMap<QString, QString>		_labelToValueMap;
+
 
 };
 

--- a/Desktop/widgets/qmllistview.h
+++ b/Desktop/widgets/qmllistview.h
@@ -23,18 +23,21 @@
 #include "common.h"
 #include <QObject>
 #include <QVector>
+#include <QMap>
 #include <QSet>
 
 class ListModel;
 class BoundQMLItem;
 class Options;
 class RowControls;
+class Terms;
 
 class QMLListView : public QObject, public virtual JASPControlWrapper
 {
 Q_OBJECT
 
 public:
+	typedef QMap<QString, QString> LabelValueMap;
 	struct SourceType
 	{
 		struct ConditionVariable
@@ -54,21 +57,27 @@ public:
 		QString						name,
 									controlName,
 									modelUse;
-		ListModel	*				model;
 		QVector<SourceType>			discardModels;
+		LabelValueMap					values;
+		bool						isValuesSource = false;
+		ListModel	*				model = nullptr;
 		QString						conditionExpression;
 		QVector<ConditionVariable>	conditionVariables;
 		bool						combineWithOtherModels = false;
 		QSet<QString>				usedControls;
 
 		SourceType(
-				  const QString& _name = ""
-				, const QString& _controlName = ""
-				, const QString& _modelUse = ""
-				, const QVector<std::tuple<QString, QString, QString> >& _discardModels = QVector<std::tuple<QString, QString, QString> >()
+				  const QString& _name
+				, const QString& _controlName
+				, const QString& _modelUse
+				, const LabelValueMap& _values
+				, bool isValuesSource
+				, const QVector<std::tuple<QString, QString, QString, LabelValueMap, bool> >& _discardModels = QVector<std::tuple<QString, QString, QString, LabelValueMap, bool> >()
 				, const QString& _conditionExpression = ""
 				, const QVector<QMap<QString, QVariant> >& _conditionVariables = QVector<QMap<QString, QVariant> >()
 				, bool _combineWithOtherModels = false);
+
+		SourceType(const LabelValueMap& _values) : values(_values), isValuesSource(true) {}
 
 		QVector<SourceType> getDiscardModels(bool onlyNotNullModel = true)	const;
 	};
@@ -85,9 +94,8 @@ public:
 			int					variableTypesAllowed()		const	{ return _variableTypesAllowed; }
 
 	const QList<SourceType*>&	sourceModels()				const	{ return _sourceModels; }
+	QList<std::pair<SourceType*, Terms> >	getTermsPerSource();
 			bool				hasSource()					const	{ return _hasSource; }
-			bool				modelHasAllVariables()		const	{ return _modelHasAllVariables; }
-			void				setModelHasAllVariables(bool b)		{ _modelHasAllVariables = b; }
 
 			JASPControlWrapper*	getRowControl(const QString& key, const QString& name)		const;
 			bool				addRowControl(const QString& key, JASPControlWrapper* control);
@@ -101,17 +109,16 @@ protected slots:
 			void				sourceChangedHandler();
 
 protected:
-	virtual void				setSources();
+	virtual void				setupSources();
 			void				addRowComponentsDefaultOptions(Options* optionTable);
 
 protected:
 	QList<SourceType*>	_sourceModels;
 	bool				_hasSource				= false;
-	bool				_needsSourceModels;
+	bool				_needsSourceModels		= false;
 	int					_variableTypesAllowed;
 	bool				_hasRowComponents		= false;
 	std::string			_optionKeyName;
-	bool				_modelHasAllVariables	= false;
 	RowControls*		_defaultRowControls		= nullptr;
 
 	static const QString _defaultKey;
@@ -120,12 +127,9 @@ private:
 	int						_getAllowedColumnsTypes();
 	void					_setAllowedVariables();
 	QString					_readSourceName(const QString& sourceNameExt, QString& sourceControl, QString& sourceUse);
-	QMap<QString, QVariant> _readSource(const QVariant& source, QString& sourceName, QString& sourceControl, QString& sourceUse);
-
-
-
-
-	QList<QVariant> _getListVariant(QVariant var);
+	QMap<QString, QVariant>	_readSource(const QVariant& source, QString& sourceName, QString& sourceControl, QString& sourceUse, LabelValueMap& sourceValues);
+	LabelValueMap				_readValues(const QVariant& values);
+	QList<QVariant>			_getListVariant(QVariant var);
 };
 
 #endif // QMLLISTVIEW_H

--- a/Desktop/widgets/rowcontrols.cpp
+++ b/Desktop/widgets/rowcontrols.cpp
@@ -54,7 +54,9 @@ void RowControls::init(int row, const Term& key, bool isNew)
 		context->setContextProperty("rowValue", key.asQString());
 		context->setContextProperty("rowValueIsInteraction", key.components().size() > 1);
 
-		QQuickItem* obj = qobject_cast<QQuickItem*>(comp->create(context));
+		QVariantMap prop;
+		if (_isDummy)	prop["visible"] = false;
+		QQuickItem* obj = qobject_cast<QQuickItem*>(comp->createWithInitialProperties(prop, context));
 
 		if (obj)
 		{

--- a/Docs/development/jasp-qml-guide.md
+++ b/Docs/development/jasp-qml-guide.md
@@ -343,10 +343,10 @@ For an input with text that can have many lines, use this component. As an `Ente
 Properties:
 - `title`: [optional, default: `""`] title displayed above the TextArea.
 - `textType`: [optional, default: `""`, values: `lavaan`, `JAGS`, `Rcode`, `model`, `source`]: this component is in fact often used in a specialized mode, specified by this property):<br>
-	* `lavaan`, `JAGS` and `Rcode`: the TextArea is used for Lavaan, JAGS or R code: it gets automatically the right syntax check
-	* `model`: the TextArea is used as R model.
-        * `source`: The TextArea can be then used as source for a VariablesList: all unique strings separated by a separator (per default a new line, but can be change via property `separator` will be then the terms of the VariablesList.<br>
-- `separtor`, `separators`: [optional, default: `"\n"`] string or array of strings used to split the string of a `source` TextArea
+  * `lavaan`, `JAGS` and `Rcode`: the TextArea is used for Lavaan, JAGS or R code: it gets automatically the right syntax check
+  * `model`: the TextArea is used as R model.
+  * `source`: The TextArea can be then used as source for a VariablesList: all unique strings separated by a separator (per default a new line, but can be change via property `separator` will be then the terms of the VariablesList.<br>
+- `separator`, `separators`: [optional, default: `"\n"`] string or array of strings used to split the string of a `source` TextArea
 
 ### Variable Specification
 Most analyses are performed on variables. JASP offers a few ways of visualizing these variables in the input form. The general idea is that you get a field of available variables (taken from the dataset) and then one or more fields that the variables can be dragged to. Variable fields should be wrapped in a `VariablesForm`. This makes it possible to automatically align multiple variable fields and add assign-buttons.
@@ -355,7 +355,14 @@ Most analyses are performed on variables. JASP offers a few ways of visualizing 
 Properties
 - `name`: identifier of the variables list, this is never send to R
 - `label`: [optional, default: `""`] text that will be shown above the variable field
-- `source`: [optional, default: `""`] this can be set to the `name` (or a list of names) of an `AssignedVariablesList`. If no source is specified, then all variables of the loaded file is used as source. To specify several sources, you need to use an array: `["source1", "source2"]`. If you have a `singleVariable` Variables List as source, it is possible to specify you want the `levels` of the variable. For this uses: `source: [{name: "splitby", use: "levels"}]`. If a VariablesList source is itself composed by several kinds of sources, you can discard one of them in this way: `source: [{ name: "modelTerms", discard: "covariates" }]`
+- `source`: [optional, default: `""`] this can be set to the `id` or the `name` (or a list of id or names) of one or more Variables Lists. If no source is specified, then all variables of the data file are used as source. To specify several sources, you need to use an array: `["source1", "source2"]`. If you want to specify what you want to read from the source, you can add extra attributes:<br>
+  * `use` attribute: if you want to read the levels of a `singleVariable` Variables List source, type: `source: [{name: "splitby", use: "levels"}]`. If you want only some variables with some types, type: `[{name: "source", use: "type=nominal|ordinal"}]`
+  * `discard` attribute: if a Variables List source is itself composed by several kinds of sources, you can discard one of them in this way: `source: [{ name: "modelTerms", discard: "covariates" }]`
+  * `condition` attribute: if a Variables List source has some components, and you want to retrieve the variables whose components have some specific values, type: `[ { name: "contrasts", condition: "contrast.currentValue == 'custom'" } ]` where `contrast` is the name of a DropDown component (added in the `contrasts` Variables List). In this example only variables with contrast having `custom` as value will be read from the source `contrasts`.
+  * `values` attribute: if you want to add specific values to the list, you can add them in this way `source: [ { values: ["one", "two"] }, "myvariables" ]`. Here the values `one` and `two` are prepend to the names of the variables of the Variables List `myvariables`. If you want to display a label (that can be translated) different from the value used in the analysis, use: `source: [ { values: [ { label: qsTr("One"), value: "one" }, { label: qsTr("Two"), value: "two" } ], "myvariables" ]` (qsTr is the function you need to use if you want the string to be translatable).
+  * if you want to display not the variable names of the source, but the values of some component of this list, use the syntax `name.component`. For example, if the source `myvariables` has a TextField named `field`, a Variables List with source `source: "myvariables.field"` will display all values of the TextField component in place of the variable names.<br>
+
+- `values`: [optional, default: `""`] this is a shortcut: in place of writing `source: [ values: ["one", "two"] ]`, type `values: ["one", "two"]`. If you want to display labels different from the values used by the analysis, use the same syntax as in the `source` property. You can also use an integer n: in this case the values are just [1, 2, ... n]
 - `width`: [optional, default: 2/5 of the VariablesForm width] in pixels how wide should the field be
 
 Note: `height` should be defined on `VariablesForm` itself.
@@ -373,8 +380,15 @@ Note: `height` should be defined on `VariablesForm` itself.
   VariablesForm
   {
     height: 200
-    AvailableVariablesList { name: "postHocTestsAvailable"; source: "fixedFactors" }
+    AvailableVariablesList { name: "postHocTestsAvailable"; source: "fixedFactors"; rowComponent: CheckBox { name: "check" } }
     AssignedVariablesList {  name: "postHocTestsVariables" }
+  }
+
+   VariablesForm
+  {
+    height: 200
+    AvailableVariablesList { name: "checkedPostHocAvailable"; source: [ name: "postHocTestsVariables", condition: "check.checked" ] }
+    AssignedVariablesList { name: "checkedPostHoc" }
   }
   ```
   ![Image example](/Docs/development/img/qml-guide/availableVariablesList_example_1_1.png)
@@ -423,17 +437,17 @@ Properties
 	<summary>Examples</summary>
 
   ```qml
-	VariablesForm
-	{
-		AvailableVariablesList { name: "allVariables" }
-		AssignedVariablesList
-		{
-			name: "dependent"
-			label: qsTr("Dependent Variable")
-			allowedColumns: ["scale"]
-			singleVariable: true
-		}
-	}
+        VariablesForm
+        {
+                AvailableVariablesList { name: "allVariables" }
+                AssignedVariablesList
+                {
+                        name: "dependent"
+                        label: qsTr("Dependent Variable")
+                        allowedColumns: ["scale"]
+                        singleVariable: true
+                }
+        }
   }
   ```
   ![Image example](/Docs/development/img/qml-guide/AssignedVariablesList_example_1.png)
@@ -515,7 +529,7 @@ Properties
 - `optionKey`: [optional, default `"value"`] when using rowComponents, the `name` property indicates the name to use to retrieve all values of this component. These values are specified per row, and each row has different columns. The names of the rowComponents are used to specify the value of each component. The `optionKey` speficies then the name of the value of the Input field.
 
 <details>
-        <summary>Example</summary>
+	<summary>Example</summary>
 
   ```qml
   InputListView
@@ -558,7 +572,7 @@ Properties
 - `source`: [optional, default ``] source of the values the table is based on
 
 <details>
-        <summary>Example</summary>
+	<summary>Example</summary>
 
   ```qml
   TableView
@@ -741,19 +755,19 @@ Any property can be set with an expression. A title of a Section for example:
 
   ```qml
 
-	DropDown
-	{
-		id: estimator
-		name: "estimator"
-		label: qsTr("Estimator")
-		values: ["EBICglasso", "cor", "pcor", "IsingFit", "IsingSampler", "huge", "adalasso", "mgm"]
-	}
+        DropDown
+        {
+                id: estimator
+                name: "estimator"
+                label: qsTr("Estimator")
+                values: ["EBICglasso", "cor", "pcor", "IsingFit", "IsingSampler", "huge", "adalasso", "mgm"]
+        }
 
-	Section
-	{
-		title: qsTr("Analysis Options - ") + estimator.currentText
+        Section
+        {
+                title: qsTr("Analysis Options - ") + estimator.currentText
                 ....
-	}
+        }
 
   ```
 


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp#991
Fixes jasp-stats/INTERNAL-jasp#968
'values' and 'source' properties were handled differently. 'values' is a list of strings (or labels/values), and source is a reference (or a list of references) to other controls. These properties are used in DropDown, VariablesList, ComponentList, InputList, TabView controls.
If we want to be able to mix 'values' with 'sources', 'values' has to be made as a kind of 'source'. This needs a bit of rewrite, so that all these controls use the same code to handle source & values.
One advantage also by handling 'values' as a kind of source is that all the work done to handle changes in the sources, can be used by the values as well: values can also dynamically change, and the model of the control has to be updated as well.