### PR TITLE
RoBMA updates

### DIFF
--- a/JASP-Engine/JASP/R/robustbayesianmetaanalysis.R
+++ b/JASP-Engine/JASP/R/robustbayesianmetaanalysis.R
@@ -19,68 +19,68 @@
 RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NULL) {
 
   # clean fitted model if it was changed
-  if(!.RoBMAready(options))
-    .RoBMAcleanModel(jaspResults)
+  if(!.robmaReady(options))
+    .robmaCleanModel(jaspResults)
  
   # load data
-  if (.RoBMAready(options))
-    dataset <- .RoBMAdataGet(options, dataset)
+  if (.robmaReady(options))
+    dataset <- .robmaGetData(options, dataset)
   
   # get the priors
-  .RoBMApriorsGet(jaspResults, options)
+  .robmaGetPriors(jaspResults, options)
   
   # show the model preview
   if (is.null(jaspResults[["model"]]))
-    .RoBMAmodelPreview(jaspResults, options)
+    .robmaModelPreviewTable(jaspResults, options)
 
   # fit model model
-  if (is.null(jaspResults[["model_notifier"]]) && .RoBMAready(options))
-    .RoBMAfitModel(jaspResults, dataset, options)
+  if (is.null(jaspResults[["model_notifier"]]) && .robmaReady(options))
+    .robmaFitModel(jaspResults, dataset, options)
   
   ### Priors plot
   if (options[["priors_plot"]])
-    .RoBMApriorsPlots(jaspResults, options)
+    .robmaPriorsPlots(jaspResults, options)
   
   ### Inference, Plots, and Diagnostics are accessible only if a model is fitted
   if (!is.null(jaspResults[["model"]])) {
     ### Inference
     # defaul summary
-    .RoBMAsummary(jaspResults, options)
+    .robmaSummaryTable(jaspResults, options)
     # models overview
     if (options[["results_models"]])
-      .RoBMAmodelsOverview(jaspResults, options)
+      .robmaModelsOvervievTable(jaspResults, options)
     # models summary
     if (options[["results_individual"]])
-      .RoBMAmodelsSummary(jaspResults, options)
+      .robmaModelsSummaryTable(jaspResults, options)
 
     ### Plots
     # pooled estimates plots
     if (options[["plots_theta"]])
-      .RoBMAplots(jaspResults, options, "theta")
+      .robmaPlots(jaspResults, options, "theta")
     if (options[["plots_mu"]])
-      .RoBMAplots(jaspResults, options, "mu")
+      .robmaPlots(jaspResults, options, "mu")
     if (options[["plots_tau"]])
-      .RoBMAplots(jaspResults, options, "tau")
+      .robmaPlots(jaspResults, options, "tau")
     if (options[["plots_tau"]]                &&
         options[["plots_mu"]]                 &&
         options[["plots_type"]] == "averaged" &&
         !options[["plots_priors"]])
-      .RoBMAplots(jaspResults, options, c("mu", "tau"))
+      .robmaPlots(jaspResults, options, c("mu", "tau"))
     if (options[["plots_omega"]])
-      .RoBMAplots(jaspResults, options, "omega")
+      .robmaPlots(jaspResults, options, "omega")
     
     # individual models
     if (options[["plots_individual_mu"]])
-      .RoBMAindividualPlots(jaspResults, options, "mu")
+      .robmaModelsPlots(jaspResults, options, "mu")
     if (options[["plots_individual_tau"]])
-      .RoBMAindividualPlots(jaspResults, options, "tau")
+      .robmaModelsPlots(jaspResults, options, "tau")
     if (options[["plots_individual_omega"]])
-      .RoBMAindividualPlots(jaspResults, options, "omega")
+      .robmaModelsPlots(jaspResults, options, "omega")
     
     ### Diagnostics
     # overview
     if (options[["diagnostics_overview"]])
-      .RoBMAdiagnosticsOverview(jaspResults, options)
+      .robmaDiagnosticsOverviewTable(jaspResults, options)
     # plots
     if ((
       options[["diagnostics_mu"]]    ||
@@ -93,18 +93,18 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
       options[["diagnostics_autocorrelation"]] ||
       options[["diagnostics_samples"]]
     ))
-      .RoBMAdiagnosticsPlots(jaspResults, options)
+      .robmaDiagnosticsPlots(jaspResults, options)
     
     ### Save the model
     if (options[["save_path"]] != "" &&
         is.null(jaspResults[["model_saved"]]))
-      .RoBMAsaveModel(jaspResults, options)
+      .robmaSaveModel(jaspResults, options)
   }
   
   return()
 }
 
-.RoBMAdependencies <- c(
+.robmaDependencies <- c(
   "measures",
   "fitted_path",
   "cohensd_testType",
@@ -147,8 +147,8 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   "advanced_mu_transform"
 )
 # priors related functions
-.RoBMAoptions2priors      <- function(options_prior) {
-  options_prior <- .RoBMAoptions2priorsEval(options_prior)
+.robmaOptions2Priors      <- function(options_prior) {
+  options_prior <- .robmaOptions2PriorsEval(options_prior)
   
   if (options_prior[["type"]] == "normal") {
     return(
@@ -298,7 +298,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     )
   }
 }
-.RoBMAoptions2priorsClean <- function(x) {
+.robmaOptions2PriorsClean <- function(x) {
   
   x <- trimws(x, which = "both")
   x <- trimws(x, which = "both", whitespace = "c")
@@ -315,15 +315,15 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     JASP:::.quitAnalysis(gettext("The priors for publication bias were set incorrectly."))
   return(as.numeric(x))
 }
-.RoBMAoptions2priorsEval  <- function(x) {
+.robmaOptions2PriorsEval  <- function(x) {
   if (x[["type"]] %in% c("Two-sided", "One-sided (mon.)", "One-sided")) {
     x[["priorOdds"]] <- eval(parse(text = x[["priorOdds"]]))
-    x[["parAlpha"]]  <- .RoBMAoptions2priorsClean(x[["parAlpha"]])
+    x[["parAlpha"]]  <- .robmaOptions2PriorsClean(x[["parAlpha"]])
     x[["parAlpha1"]] <-
-      .RoBMAoptions2priorsClean(x[["parAlpha1"]])
+      .robmaOptions2PriorsClean(x[["parAlpha1"]])
     x[["parAlpha2"]] <-
-      .RoBMAoptions2priorsClean(x[["parAlpha2"]])
-    x[["parCuts"]]   <- .RoBMAoptions2priorsClean(x[["parCuts"]])
+      .robmaOptions2PriorsClean(x[["parAlpha2"]])
+    x[["parCuts"]]   <- .robmaOptions2PriorsClean(x[["parCuts"]])
     
   } else if (x[["type"]] == "spike" &&
              any(names(x) %in% c("parAlpha2"))) {
@@ -359,7 +359,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   return(x)
 }
 # table filling functions
-.RoBMAtableFillCoef       <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+.robmaTableFillCoef       <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
   
   CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
   # add columns
@@ -382,7 +382,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   # fill rows
   for (i in c(1:nrow(results_table))[rownames(results_table) %in% c("mu", "tau")]) {
     temp_row <- list(
-      terms    = .RoBMAcoefNames(rownames(results_table)[i], add_info),
+      terms    = .robmaCoefNames(rownames(results_table)[i], add_info),
       mean     = results_table[i, "Mean"],
       median   = results_table[i, "Median"],
       lowerCI  = results_table[i, if(individual) ".025" else as.character(.5 - options[["results_CI"]] / 2)],
@@ -417,7 +417,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return(jasp_table)
 }
-.RoBMAtableFillWeights    <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+.robmaTableFillWeights    <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
   
   p_overtitle  <- gettextf("<em>p</em>-values interval %s","\u002A")
   CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
@@ -476,7 +476,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return(jasp_table)
 }
-.RoBMAtableFillStudies    <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+.robmaTableFillStudies    <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
   
   CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
   # add columns
@@ -523,22 +523,22 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
       gettextf(
         "Estimated studies' effects (%1$s) correspond to effect size %2$s.",
         "\u03B8",
-        .RoBMAcoefLetters(add_info[["effect_size"]])
+        .robmaCoefLetters(add_info[["effect_size"]])
     ))
   }
   
   return(jasp_table)
 }
-.RoBMAcoefNames           <- function(name, add_info) {
+.robmaCoefNames           <- function(name, add_info) {
   if (name == "mu")
     return(gettextf(
       "Effect size (%s)",
-      ifelse(add_info[["effect_size"]] %in% c("r", "d", "OR"), .RoBMAcoefLetters(add_info[["effect_size"]]), "\u03BC")
+      ifelse(add_info[["effect_size"]] %in% c("r", "d", "OR"), .robmaCoefLetters(add_info[["effect_size"]]), "\u03BC")
     ))
   if (name == "tau")
     return(gettextf("Heterogeneity (%s)","\u03C4"))
 }
-.RoBMAcoefLetters         <- function(effect_size){
+.robmaCoefLetters         <- function(effect_size){
   switch(
     effect_size,
     "r"   = "\u03C1",
@@ -546,8 +546,8 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     "OR"  = "OR"
   )
 }
-# main functions
-.RoBMAready               <- function(options) {
+# helper functions
+.robmaReady               <- function(options) {
   
   if (options[["measures"]] == "fitted") {
     return(options[["fitted_path"]] != "")
@@ -586,7 +586,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   return(ready_arg1 && ready_arg2)
   
 }
-.RoBMAmodelNotifier       <- function(jaspResults) {
+.robmaModelNotifier       <- function(jaspResults) {
   # We don't wanna delete the RoBMA modele every time settings is change since RoBMA takes a lot of time to fit.
   # Therefore, we don't create dependencies on the fitted model (in cases when the model can be updated), but 
   # on a notifier that tells us when there was the change. If possible, we don't refit the whole model, 
@@ -594,14 +594,14 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   if (is.null(jaspResults[["model_notifier"]])) {
     model_notifier <- createJaspState()
-    model_notifier$dependOn(.RoBMAdependencies)
+    model_notifier$dependOn(.robmaDependencies)
     jaspResults[["model_notifier"]] <- model_notifier
   }
   
   return()
   
 }
-.RoBMAcleanModel          <- function(jaspResults) {
+.robmaCleanModel          <- function(jaspResults) {
   
   if(!is.null(jaspResults[["model"]])){
     jaspResults[["model"]] <- NULL
@@ -609,7 +609,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAdataGet             <- function(options, dataset) {
+.robmaGetData             <- function(options, dataset) {
   if (options[["measures"]] == "fitted") {
     return(NULL)
   } else{
@@ -638,12 +638,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return(dataset)
 }
-.RoBMApriorsGet           <- function(jaspResults, options) {
+.robmaGetPriors           <- function(jaspResults, options) {
   if (!is.null(jaspResults[["priors"]])) {
     return()
   } else{
     priors <- createJaspState()
-    priors$dependOn(.RoBMAdependencies)
+    priors$dependOn(.robmaDependencies)
     jaspResults[["priors"]] <- priors
   }
   
@@ -654,7 +654,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   for (i in seq_along(prior_elements)) {
     tmp <- NULL
     for (elem in options[[prior_elements[i]]]) {
-      tmp_prior <- tryCatch(.RoBMAoptions2priors(elem), error = function(e)e)
+      tmp_prior <- tryCatch(.robmaOptions2Priors(elem), error = function(e)e)
       if(class(tmp_prior) %in% c("simpleError", "error")){
         JASP:::.quitAnalysis(tmp_prior$message)
       }
@@ -668,7 +668,8 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMApriorsPlots         <- function(jaspResults, options) {
+# main functions
+.robmaPriorsPlots              <- function(jaspResults, options) {
   # create / access the container
   if (!is.null(jaspResults[["prior_plots"]])) {
     return()
@@ -763,13 +764,13 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAmodelPreview        <- function(jaspResults, options) {
+.robmaModelPreviewTable        <- function(jaspResults, options) {
   # create / access the container
   if (!is.null(jaspResults[["prior_plots"]])) {
     return()
   } else{
     model_preview <- createJaspContainer(title = gettext("Model Preview"))
-    model_preview$dependOn(.RoBMAdependencies)
+    model_preview$dependOn(.robmaDependencies)
     model_preview$position <- 1
     jaspResults[["model_preview"]] <- model_preview
   }
@@ -795,7 +796,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   
   # create the setup table
-  s.fit   <- RoBMA::check_setup(
+  fitSummary   <- RoBMA::check_setup(
     priors_mu         = priors[["mu"]],
     priors_tau        = priors[["tau"]],
     priors_omega      = priors[["omega"]],
@@ -816,11 +817,11 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   overall_summary$addColumnInfo(name = "models",    title = gettext("Models"), type = "string")
   overall_summary$addColumnInfo(name = "priorProb", title = gettext("P(M)"),   type = "number")
   
-  for (i in 1:nrow(s.fit[["overview"]])) {
+  for (i in 1:nrow(fitSummary[["overview"]])) {
     temp_row <- list(
       terms     = if (i == 1) gettext("Effect") else if (i == 2) gettext("Heterogeneity") else if (i == 3) gettext("Publication bias"),
-      models    = paste0(s.fit[["overview"]][["Models"]][i], "/", s.fit[["add_info"]][["n_models"]]),
-      priorProb = s.fit[["overview"]][["Prior prob."]][i]
+      models    = paste0(fitSummary[["overview"]][["Models"]][i], "/", fitSummary[["add_info"]][["n_models"]]),
+      priorProb = fitSummary[["overview"]][["Prior prob."]][i]
     )
     
     overall_summary$addRows(temp_row)
@@ -841,13 +842,13 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   models_summary$addColumnInfo(name = "prior_omega", title = gettext("Publication Bias"), type = "string", overtitle = prior_overtitle)
   models_summary$addColumnInfo(name = "priorProb",   title = gettext("P(M)"),             type = "number")
   
-  for (i in 1:nrow(s.fit[["models"]])) {
+  for (i in 1:nrow(fitSummary[["models"]])) {
     temp_row <- list(
-      number       = as.numeric(rownames(s.fit[["models"]]))[i],
-      prior_mu     = s.fit[["models"]][i, "Prior mu"],
-      prior_tau    = s.fit[["models"]][i, "Prior tau"],
-      prior_omega  = s.fit[["models"]][i, "Prior omega"],
-      priorProb    = s.fit[["models"]][i, "Prior prob."]
+      number       = as.numeric(rownames(fitSummary[["models"]]))[i],
+      prior_mu     = fitSummary[["models"]][i, "Prior mu"],
+      prior_tau    = fitSummary[["models"]][i, "Prior tau"],
+      prior_omega  = fitSummary[["models"]][i, "Prior omega"],
+      priorProb    = fitSummary[["models"]][i, "Prior prob."]
     )
     
     models_summary$addRows(temp_row)
@@ -858,7 +859,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAfitModel            <- function(jaspResults, dataset, options) {
+.robmaFitModel                 <- function(jaspResults, dataset, options) {
   
   if (is.null(jaspResults[["model"]])) {
     model <- createJaspState()
@@ -942,7 +943,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
       
     } else{
       debug()
-      fit <- tryCatch(RoBMA::update.RoBMA(
+      fit <- tryCatch(RoBMA::update.robma(
         object  = fit,
         study_names  = if (options[["input_labels"]] != "") dataset[, .v(options[["input_labels"]])],
         chains  = options[["advanced_chains"]],
@@ -980,11 +981,11 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # update the fit and reset notifier
   model[["object"]] <- fit
-  .RoBMAmodelNotifier(jaspResults)
+  .robmaModelNotifier(jaspResults)
   
   return()
 }
-.RoBMAsummary             <- function(jaspResults, options) {
+.robmaSummaryTable             <- function(jaspResults, options) {
   if (!is.null(jaspResults[["main_summary"]])) {
     return()
   } else{
@@ -993,7 +994,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     main_summary$position <- 3
     summary_dependencies <-
       c(
-        .RoBMAdependencies,
+        .robmaDependencies,
         "bayesFactorType",
         "results_CI",
         "results_conditional",
@@ -1010,7 +1011,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   fit   <- jaspResults[["model"]][["object"]]
   
   # some shared info
-  s.fit <- summary(
+  fitSummary <- summary(
     fit,
     logBF    = options[["bayesFactorType"]] == "LogBF10",
     BF01     = options[["bayesFactorType"]] == "BF01",
@@ -1050,19 +1051,19 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     return()
   }
   
-  for (i in 1:nrow(s.fit[["overview"]])) {
+  for (i in 1:nrow(fitSummary[["overview"]])) {
     temp_row <- list(
       terms     = if (i == 1) gettext("Effect") else if (i == 2) gettext("Heterogeneity") else if (i == 3) gettext("Publication bias"),
-      models    = paste0(s.fit[["overview"]][i, "Models"], "/",  s.fit[["add_info"]][["n_models"]] - s.fit[["add_info"]][["failed"]]),
-      priorProb = s.fit[["overview"]][i, "Prior prob."],
-      postProb  = s.fit[["overview"]][i, "Post. prob."],
-      BF        = s.fit[["overview"]][i, 4]
+      models    = paste0(fitSummary[["overview"]][i, "Models"], "/",  fitSummary[["add_info"]][["n_models"]] - fitSummary[["add_info"]][["failed"]]),
+      priorProb = fitSummary[["overview"]][i, "Prior prob."],
+      postProb  = fitSummary[["overview"]][i, "Post. prob."],
+      BF        = fitSummary[["overview"]][i, 4]
     )
     
     overall_summary$addRows(temp_row)
   }
-  if (s.fit[["add_info"]][["failed"]] != 0)
-    overall_summary$addFootnote(symbol = gettext("Warning:"), gettextf("%i models failed to converge.", s.fit[["add_info"]][["failed"]]))
+  if (fitSummary[["add_info"]][["failed"]] != 0)
+    overall_summary$addFootnote(symbol = gettext("Warning:"), gettextf("%i models failed to converge.", fitSummary[["add_info"]][["failed"]]))
   if (!is.null(fit[["add_info"]][["warnings"]])) {
     for (w in fit[["add_info"]][["warnings"]])
       overall_summary$addFootnote(symbol = gettext("Warning:"), w)
@@ -1077,14 +1078,14 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   # estimate table
   averaged_summary <- createJaspTable(title = gettext("Model Averaged Estimates"))
   averaged_summary$position <- 2
-  averaged_summary <- .RoBMAtableFillCoef(averaged_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
+  averaged_summary <- .robmaTableFillCoef(averaged_summary, fitSummary[["averaged"]], fitSummary[["add_info"]], options)
   main_summary[["averaged_summary"]] <- averaged_summary
   
   # weights table
-  if (any(grepl("omega", rownames(s.fit[["averaged"]])))) {
+  if (any(grepl("omega", rownames(fitSummary[["averaged"]])))) {
     averaged_weights <- createJaspTable(title = gettextf("Model Averaged Weights (%s)", "\u03C9"))
     averaged_weights$position <- 3
-    averaged_weights <- .RoBMAtableFillWeights(averaged_weights, s.fit[["averaged"]], s.fit[["add_info"]], options)
+    averaged_weights <- .robmaTableFillWeights(averaged_weights, fitSummary[["averaged"]], fitSummary[["add_info"]], options)
     main_summary[["averaged_weights"]] <- averaged_weights
   }
   
@@ -1092,7 +1093,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   if (options[["results_theta"]]) {
     studies_summary <- createJaspTable(title = gettextf("Model Averaged Estimated Studies' Effects (%s)", "\u03B8"))
     studies_summary$position <- 4
-    studies_summary <- .RoBMAtableFillStudies(studies_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
+    studies_summary <- .robmaTableFillStudies(studies_summary, fitSummary[["averaged"]], fitSummary[["add_info"]], options)
     main_summary[["studies_summary"]] <- studies_summary
   }
   
@@ -1102,15 +1103,15 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     # estimate table
     conditional_summary <- createJaspTable(title = gettext("Conditional Estimates"))
     conditional_summary$position <- 5
-    conditional_summary <-.RoBMAtableFillCoef(conditional_summary, s.fit[["conditional"]], s.fit[["add_info"]], options)
+    conditional_summary <-.robmaTableFillCoef(conditional_summary, fitSummary[["conditional"]], fitSummary[["add_info"]], options)
     conditional_summary$addFootnote(gettext("Estimates are model averaged over models assuming existence of effect / heterogeneity."))
     main_summary[["conditional_summary"]] <- conditional_summary
     
     # weights table
-    if (any(grepl("omega", rownames(s.fit[["conditional"]])))) {
+    if (any(grepl("omega", rownames(fitSummary[["conditional"]])))) {
       conditional_weights <- createJaspTable(title = gettextf("Conditional Weights (%s)", "\u03C9"))
       conditional_weights$position <- 6
-      conditional_weights <- .RoBMAtableFillWeights(conditional_weights, s.fit[["conditional"]], s.fit[["add_info"]], options)
+      conditional_weights <- .robmaTableFillWeights(conditional_weights, fitSummary[["conditional"]], fitSummary[["add_info"]], options)
       conditional_weights$addFootnote(gettextf("Estimated weights (%s) are model averaged over models assuming existence of publication bias.", "\u03C9"))
       main_summary[["conditional_weights"]] <- conditional_weights
     }
@@ -1119,7 +1120,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     if (options[["results_theta"]]) {
       conditional_studies_summary <- createJaspTable(title = gettextf("Conditional Estimated Studies' Effects (%s)","\u03B8"))
       conditional_studies_summary$position <- 7
-      conditional_studies_summary <- .RoBMAtableFillStudies(conditional_studies_summary,s.fit[["conditional"]],fit[["add_info"]], options)
+      conditional_studies_summary <- .robmaTableFillStudies(conditional_studies_summary,fitSummary[["conditional"]],fit[["add_info"]], options)
       conditional_studies_summary$addFootnote(gettextf("Estimated studies effects (%s) are model averaged over models assuming existence of effect.", "\u03B8"))
       main_summary[["conditional_studies_summary"]] <- conditional_studies_summary
     }
@@ -1128,12 +1129,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAmodelsOverview      <- function(jaspResults, options) {
+.robmaModelsOvervievTable      <- function(jaspResults, options) {
   # extract the model
   fit   <- jaspResults[["model"]][["object"]]
   
   # some shared info
-  s.fit <- summary(
+  fitSummary <- summary(
     fit,
     type     = "models",
     logBF    = options[["bayesFactorType"]] == "LogBF10",
@@ -1143,26 +1144,25 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # do ordering
   if (options[["results_models_order"]] == "marglik") {
-    s.fit[["overview"]] <- s.fit[["overview"]][order(s.fit[["overview"]][["log(MargLik)"]], decreasing = TRUE),]
+    fitSummary[["overview"]] <- fitSummary[["overview"]][order(fitSummary[["overview"]][["log(MargLik)"]], decreasing = TRUE),]
   } else if (options[["results_models_order"]] == "posterior") {
-    s.fit[["overview"]] <- s.fit[["overview"]][order(s.fit[["overview"]][["Post. prob."]], decreasing = TRUE),]
+    fitSummary[["overview"]] <- fitSummary[["overview"]][order(fitSummary[["overview"]][["Post. prob."]], decreasing = TRUE),]
   }
   
   # compute the BF requested
   if (options[["results_models_BF"]] == "inclusion") {
-    bf <- s.fit[["overview"]][, 7]
+    bf <- fitSummary[["overview"]][, 7]
   } else if (options[["results_models_BF"]] == "best") {
-    bf <- exp(s.fit[["overview"]][["log(MargLik)"]]) / exp(max(s.fit[["overview"]][["log(MargLik)"]]))
+    bf <- exp(fitSummary[["overview"]][["log(MargLik)"]]) / exp(max(fitSummary[["overview"]][["log(MargLik)"]]))
   } else if (options[["results_models_BF"]] == "previous") {
-    temp_this <- exp(s.fit[["overview"]][["log(MargLik)"]])[-length(s.fit[["overview"]][["log(MargLik)"]])]
-    temp_prev <- exp(s.fit[["overview"]][["log(MargLik)"]])[-1]
+    temp_this <- exp(fitSummary[["overview"]][["log(MargLik)"]])[-length(fitSummary[["overview"]][["log(MargLik)"]])]
+    temp_prev <- exp(fitSummary[["overview"]][["log(MargLik)"]])[-1]
     bf <- c(1, temp_prev / temp_this)
   }
   
   
-  summary_dependencies <-
-    c(
-      .RoBMAdependencies,
+  summary_dependencies <- c(
+      .robmaDependencies,
       "bayesFactorType",
       "results_CI",
       "results_models",
@@ -1210,15 +1210,15 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   models_summary$addColumnInfo(name = "marglik",     title = gettext("log(MargLik)"),     type = "number")
   models_summary$addColumnInfo(name = "BF",          title = BF_title,                    type = "number")
   
-  for (i in 1:nrow(s.fit[["overview"]])) {
+  for (i in 1:nrow(fitSummary[["overview"]])) {
     temp_row <- list(
-      number       = as.numeric(rownames(s.fit[["overview"]]))[i],
-      prior_mu     = s.fit[["overview"]][i, "Prior mu"],
-      prior_tau    = s.fit[["overview"]][i, "Prior tau"],
-      prior_omega  = s.fit[["overview"]][i, "Prior omega"],
-      priorProb    = s.fit[["overview"]][i, "Prior prob."],
-      postProb     = s.fit[["overview"]][i, "Post. prob."],
-      marglik      = s.fit[["overview"]][i, "log(MargLik)"],
+      number       = as.numeric(rownames(fitSummary[["overview"]]))[i],
+      prior_mu     = fitSummary[["overview"]][i, "Prior mu"],
+      prior_tau    = fitSummary[["overview"]][i, "Prior tau"],
+      prior_omega  = fitSummary[["overview"]][i, "Prior omega"],
+      priorProb    = fitSummary[["overview"]][i, "Prior prob."],
+      postProb     = fitSummary[["overview"]][i, "Post. prob."],
+      marglik      = fitSummary[["overview"]][i, "log(MargLik)"],
       BF           = bf[i]
     )
     
@@ -1229,16 +1229,14 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAmodelsSummary       <- function(jaspResults, options) {
+.robmaModelsSummaryTable       <- function(jaspResults, options) {
   if (!is.null(jaspResults[["individual_models"]])) {
     return()
   } else{
-    individual_models <-
-      createJaspContainer(title = gettext("Individual Models Summary"))
+    individual_models <- createJaspContainer(title = gettext("Individual Models Summary"))
     individual_models$position <- 5
-    summary_dependencies <-
-      c(
-        .RoBMAdependencies,
+    summary_dependencies <- c(
+        .robmaDependencies,
         "bayesFactorType",
         "results_individual",
         "results_theta",
@@ -1253,7 +1251,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   fit   <- jaspResults[["model"]][["object"]]
   
   # some shared info
-  s.fit <- summary(
+  fitSummary <- summary(
     fit,
     type     = "individual",
     logBF    = options[["bayesFactorType"]] == "LogBF10",
@@ -1281,8 +1279,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   if (options[["results_individual_single"]]) {
     models_i <- options[["results_individual_single_number"]]
     if (models_i < 1 || models_i > length(fit[["models"]])) {
-      temp_model  <-
-        createJaspContainer(title = gettextf("Model %i", models_i))
+      temp_model  <- createJaspContainer(title = gettextf("Model %i", models_i))
       temp_error  <- createJaspTable(title = "")
       temp_error$setError(gettextf("Model %i does not exist. Select one of the models between 1 and %i.", models_i, length(fit[["models"]])))
       temp_model[["temp_error"]]                      <- temp_error
@@ -1290,7 +1287,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
       return()
     }
   } else{
-    models_i <- 1:length(s.fit[["overview"]])
+    models_i <- 1:length(fitSummary[["overview"]])
   }
   
   
@@ -1301,24 +1298,14 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     
     ### model priors
     temp_priors <- createJaspTable(title = gettext("Priors"))
-    temp_priors$addColumnInfo(name = "prior_mu",
-                              title = gettext("Effect Size"),
-                              type = "string")
-    temp_priors$addColumnInfo(
-      name = "prior_tau",
-      title = gettext("Heterogeneity"),
-      type = "string"
-    )
-    temp_priors$addColumnInfo(
-      name = "prior_omega",
-      title = gettext("Publication Bias"),
-      type = "string"
-    )
+    temp_priors$addColumnInfo(name = "prior_mu",    title = gettext("Effect Size"),      type = "string")    
+    temp_priors$addColumnInfo(name = "prior_tau",   title = gettext("Heterogeneity"),    type = "string")
+    temp_priors$addColumnInfo(name = "prior_omega", title = gettext("Publication Bias"), type = "string")
     
     temp_row <- list(
-      prior_mu     = print(s.fit[["overview"]][[i]][["priors"]][["mu"]], silent = TRUE),
-      prior_tau    = print(s.fit[["overview"]][[i]][["priors"]][["tau"]], silent = TRUE),
-      prior_omega  = print(s.fit[["overview"]][[i]][["priors"]][["omega"]], silent = TRUE)
+      prior_mu     = print(fitSummary[["overview"]][[i]][["priors"]][["mu"]], silent = TRUE),
+      prior_tau    = print(fitSummary[["overview"]][[i]][["priors"]][["tau"]], silent = TRUE),
+      prior_omega  = print(fitSummary[["overview"]][[i]][["priors"]][["omega"]], silent = TRUE)
     )
     temp_priors$addRows(temp_row)
     
@@ -1328,24 +1315,16 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     ### model information
     temp_info <- createJaspTable(title = gettext("Information"))
     
-    temp_info$addColumnInfo(name = "priorProb",
-                            title = gettext("P(M)"),
-                            type = "number")
-    temp_info$addColumnInfo(name = "postProb",
-                            title = gettext("P(M|data)"),
-                            type = "number")
-    temp_info$addColumnInfo(name = "marglik",
-                            title = gettext("log(MargLik)"),
-                            type = "number")
-    temp_info$addColumnInfo(name = "BF",
-                            title = BF_title,
-                            type = "number")
+    temp_info$addColumnInfo(name = "priorProb",   title = gettext("P(M)"),          type = "number")
+    temp_info$addColumnInfo(name = "postProb",    title = gettext("P(M|data)"),     type = "number")
+    temp_info$addColumnInfo(name = "marglik",     title = gettext("log(MargLik)"),  type = "number")
+    temp_info$addColumnInfo(name = "BF",          title = BF_title,                 type = "number")
     
     temp_row <- list(
-      priorProb    = s.fit[["overview"]][[i]][["prior_prob"]],
-      postProb     = s.fit[["overview"]][[i]][["posterior_prob"]],
-      marglik      = s.fit[["overview"]][[i]][["marg_lik"]],
-      BF           = s.fit[["overview"]][[i]][["BF"]]
+      priorProb    = fitSummary[["overview"]][[i]][["prior_prob"]],
+      postProb     = fitSummary[["overview"]][[i]][["posterior_prob"]],
+      marglik      = fitSummary[["overview"]][[i]][["marg_lik"]],
+      BF           = fitSummary[["overview"]][[i]][["BF"]]
     )
     temp_info$addRows(temp_row)
     
@@ -1355,25 +1334,22 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     ### model coeficients
     # estimate table
     temp_coef <- createJaspTable(title = gettext("Model Estimates"))
-    temp_coef <-
-      .RoBMAtableFillCoef(temp_coef,
-                             s.fit[["overview"]][[i]][["tab"]],
-                             s.fit[["overview"]][[i]][["add_info"]],
+    temp_coef <- .robmaTableFillCoef(temp_coef,
+                             fitSummary[["overview"]][[i]][["tab"]],
+                             fitSummary[["overview"]][[i]][["add_info"]],
                              options,
                              individual = TRUE)
     temp_model[["temp_coef"]] <- temp_coef
     
     ### weights and Studies's effects
-    if (!is.null(s.fit[["overview"]][[i]][["tab"]])) {
+    if (!is.null(fitSummary[["overview"]][[i]][["tab"]])) {
       # weights table
-      if (any(grepl("omega", rownames(s.fit[["overview"]][[i]][["tab"]])))) {
-        temp_weights <-
-          createJaspTable(title = gettextf("Estimated Weights (%s)", "\u03C9"))
-        temp_weights <-
-          .RoBMAtableFillWeights(
+      if (any(grepl("omega", rownames(fitSummary[["overview"]][[i]][["tab"]])))) {
+        temp_weights <- createJaspTable(title = gettextf("Estimated Weights (%s)", "\u03C9"))
+        temp_weights <- .robmaTableFillWeights(
             temp_weights,
-            s.fit[["overview"]][[i]][["tab"]],
-            s.fit[["overview"]][[i]][["add_info"]],
+            fitSummary[["overview"]][[i]][["tab"]],
+            fitSummary[["overview"]][[i]][["add_info"]],
             options,
             individual = TRUE
           )
@@ -1381,14 +1357,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
       }
       
       # estimated studies table
-      if (any(grepl("theta", rownames(s.fit[["overview"]][[i]][["tab"]])))) {
-        temp_studies <-
-          createJaspTable(title = gettextf("Estimated Studies' Effects (%s)", "\u03B8"))
-        temp_studies <-
-          .RoBMAtableFillStudies(
+      if (any(grepl("theta", rownames(fitSummary[["overview"]][[i]][["tab"]])))) {
+        temp_studies <- createJaspTable(title = gettextf("Estimated Studies' Effects (%s)", "\u03B8"))
+        temp_studies <- .robmaTableFillStudies(
             temp_studies,
-            s.fit[["overview"]][[i]][["tab"]],
-            s.fit[["overview"]][[i]][["add_info"]],
+            fitSummary[["overview"]][[i]][["tab"]],
+            fitSummary[["overview"]][[i]][["add_info"]],
             options,
             individual = TRUE
           )
@@ -1401,7 +1375,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAplots               <- function(jaspResults, options, parameters) {
+.robmaPlots                    <- function(jaspResults, options, parameters) {
   # create / access the container
   if (is.null(jaspResults[["plots"]])) {
     plots <- createJaspContainer(title = gettext("Plots"))
@@ -1421,7 +1395,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # get overall settings
   dependencies <- c(
-    .RoBMAdependencies,
+    .robmaDependencies,
     "plots_type",
     "plots_priors",
     if (any(parameters %in% "mu"))
@@ -1559,7 +1533,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAindividualPlots     <- function(jaspResults, options, parameters) {
+.robmaModelsPlots              <- function(jaspResults, options, parameters) {
   # create / access the container
   if (is.null(jaspResults[["plots_individual"]])) {
     plots_individual <- createJaspContainer(title = gettext("Individual Models Plots"))
@@ -1579,7 +1553,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # get overall settings
   dependencies <- c(
-    .RoBMAdependencies,
+    .robmaDependencies,
     "plots_type_individual_conditional",
     "plots_type_individual_order",
     "plots_type_individual_by",
@@ -1681,12 +1655,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAdiagnosticsOverview <- function(jaspResults, options) {
+.robmaDiagnosticsOverviewTable <- function(jaspResults, options) {
   # create / access the container
   if (is.null(jaspResults[["diagnostics"]])) {
     diagnostics <- createJaspContainer(title = gettext("Diagnostics"))
     diagnostics$position <- 8
-    diagnostics$dependOn(.RoBMAdependencies)
+    diagnostics$dependOn(.robmaDependencies)
     jaspResults[["diagnostics"]] <- diagnostics
   } else{
     diagnostics <- jaspResults[["diagnostics"]]
@@ -1702,7 +1676,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   
   # some shared info
-  s.fit <- summary(
+  fitSummary <- summary(
     fit,
     type          = "models",
     diagnostics   = TRUE,
@@ -1711,7 +1685,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # do ordering
   diagnostics_dependencies <-
-    c(.RoBMAdependencies,
+    c(.robmaDependencies,
       "diagnostics_overview",
       "diagnostics_overview_theta")
   
@@ -1732,15 +1706,15 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   models_diagnostics$addColumnInfo(name = "ESS",         title = gettext("min(ESS)"),         type = "integer")
   models_diagnostics$addColumnInfo(name = "Rhat",        title = gettext("max(Rhat)"),        type = "number")
   
-  for (i in 1:nrow(s.fit[["diagnostics"]])) {
+  for (i in 1:nrow(fitSummary[["diagnostics"]])) {
     temp_row <- list(
-      number       = as.numeric(rownames(s.fit[["diagnostics"]]))[i],
-      prior_mu     = s.fit[["diagnostics"]][i, "Prior mu"],
-      prior_tau    = s.fit[["diagnostics"]][i, "Prior tau"],
-      prior_omega  = s.fit[["diagnostics"]][i, "Prior omega"],
-      error        = s.fit[["diagnostics"]][i, "max(MCMC error)"],
-      ESS          = s.fit[["diagnostics"]][i, "min(ESS)"],
-      Rhat         = s.fit[["diagnostics"]][i, "max(Rhat)"]
+      number       = as.numeric(rownames(fitSummary[["diagnostics"]]))[i],
+      prior_mu     = fitSummary[["diagnostics"]][i, "Prior mu"],
+      prior_tau    = fitSummary[["diagnostics"]][i, "Prior tau"],
+      prior_omega  = fitSummary[["diagnostics"]][i, "Prior omega"],
+      error        = fitSummary[["diagnostics"]][i, "max(MCMC error)"],
+      ESS          = fitSummary[["diagnostics"]][i, "min(ESS)"],
+      Rhat         = fitSummary[["diagnostics"]][i, "max(Rhat)"]
     )
     
     models_diagnostics$addRows(temp_row)
@@ -1750,12 +1724,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAdiagnosticsPlots    <- function(jaspResults, options) {
+.robmaDiagnosticsPlots         <- function(jaspResults, options) {
   # create / access the container
   if (is.null(jaspResults[["diagnostics"]])) {
     diagnostics <- createJaspContainer(title = gettext("Diagnostics"))
     diagnostics$position <- 8
-    diagnostics$dependOn(.RoBMAdependencies)
+    diagnostics$dependOn(.robmaDependencies)
     jaspResults[["diagnostics"]] <- diagnostics
   } else{
     diagnostics <- jaspResults[["diagnostics"]]
@@ -1998,10 +1972,10 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMAsaveModel           <- function(jaspResults, options) {
+.robmaSaveModel                <- function(jaspResults, options) {
   if (is.null(jaspResults[["model_saved"]])) {
     model_saved <- createJaspState()
-    model_saved$dependOn(c(.RoBMAdependencies, "save_path"))
+    model_saved$dependOn(c(.robmaDependencies, "save_path"))
     jaspResults[["model_saved"]] <- model_saved
     
   }

--- a/JASP-Engine/JASP/R/robustbayesianmetaanalysis.R
+++ b/JASP-Engine/JASP/R/robustbayesianmetaanalysis.R
@@ -16,94 +16,93 @@
 #
 
 
-RobustBayesianMetaAnalysis <-
-  function(jaspResults, dataset, options, state = NULL) {
+RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NULL) {
+
+  # clean fitted model if it was changed
+  if(!.RoBMA_ready(options))
+    .RoBMA_clean_model(jaspResults)
+ 
+  # load data
+  if (.RoBMA_ready(options))
+    dataset <- .RoBMA_data_get(options, dataset)
+  
+  # get the priors
+  .RoBMA_priors_get(jaspResults, options)
+  
+  # show the model preview
+  if (is.null(jaspResults[["model"]]))
+    .RoBMA_model_preview(jaspResults, options)
+
+  # fit model model
+  if (is.null(jaspResults[["model_notifier"]]) && .RoBMA_ready(options))
+    .RoBMA_fit_model(jaspResults, dataset, options)
+  
+  ### Priors plot
+  if (options[["priors_plot"]])
+    .RoBMA_priors_plots(jaspResults, options)
+  
+  ### Inference, Plots, and Diagnostics are accessible only if a model is fitted
+  if (!is.null(jaspResults[["model"]])) {
+    ### Inference
+    # defaul summary
+    .RoBMA_summary(jaspResults, options)
+    # models overview
+    if (options[["results_models"]])
+      .RoBMA_models_overview(jaspResults, options)
+    # models summary
+    if (options[["results_individual"]])
+      .RoBMA_models_summary(jaspResults, options)
+
+    ### Plots
+    # pooled estimates plots
+    if (options[["plots_theta"]])
+      .RoBMA_plots(jaspResults, options, "theta")
+    if (options[["plots_mu"]])
+      .RoBMA_plots(jaspResults, options, "mu")
+    if (options[["plots_tau"]])
+      .RoBMA_plots(jaspResults, options, "tau")
+    if (options[["plots_tau"]] &&
+        options[["plots_mu"]] &&
+        options[["plots_type"]] == "averaged" &&
+        !options[["plots_priors"]])
+      .RoBMA_plots(jaspResults, options, c("mu", "tau"))
+    if (options[["plots_omega"]])
+      .RoBMA_plots(jaspResults, options, "omega")
     
-    # clean fitted model if it was changed
-    if(!.RoBMA_ready(options))
-      .RoBMA_clean_model(jaspResults)
+    # individual models
+    if (options[["plots_individual_mu"]])
+      .RoBMA_individual_plots(jaspResults, options, "mu")
+    if (options[["plots_individual_tau"]])
+      .RoBMA_individual_plots(jaspResults, options, "tau")
+    if (options[["plots_individual_omega"]])
+      .RoBMA_individual_plots(jaspResults, options, "omega")
     
-    # load data
-    if (.RoBMA_ready(options))
-      dataset <- .RoBMA_data_get(options, dataset)
+    ### Diagnostics
+    # overview
+    if (options[["diagnostics_overview"]])
+      .RoBMA_diagnostics_overview(jaspResults, options)
+    # plots
+    if ((
+      options[["diagnostics_mu"]] ||
+      options[["diagnostics_tau"]] ||
+      options[["diagnostics_omega"]] ||
+      options[["diagnostics_theta"]]
+    ) &&
+    (
+      options[["diagnostics_trace"]] ||
+      options[["diagnostics_autocorrelation"]] ||
+      options[["diagnostics_samples"]]
+    ))
+      .RoBMA_diagnostics_plots(jaspResults, options)
     
-    # get the priors
-    .RoBMA_priors_get(jaspResults, options)
-    
-    # show the model preview
-    if (is.null(jaspResults[["model"]]))
-      .RoBMA_model_preview(jaspResults, options)
-    
-    # fit model model
-    if (is.null(jaspResults[["model_notifier"]]) && .RoBMA_ready(options))
-      .RoBMA_fit_model(jaspResults, dataset, options)
-                  
-    ### Priors plot
-    if (options[["priors_plot"]])
-      .RoBMA_priors_plots(jaspResults, options)
-    
-    ### Inference, Plots, and Diagnostics are accessible only if a model is fitted
-    if (!is.null(jaspResults[["model"]])) {
-      ### Inference
-      # defaul summary
-      .RoBMA_summary(jaspResults, options)
-      # models overview
-      if (options[["results_models"]])
-        .RoBMA_models_overview(jaspResults, options)
-      # models summary
-      if (options[["results_individual"]])
-        .RoBMA_models_summary(jaspResults, options)
-      
-      ### Plots
-      # pooled estimates plots
-      if (options[["plots_theta"]])
-        .RoBMA_plots(jaspResults, options, "theta")
-      if (options[["plots_mu"]])
-        .RoBMA_plots(jaspResults, options, "mu")
-      if (options[["plots_tau"]])
-        .RoBMA_plots(jaspResults, options, "tau")
-      if (options[["plots_tau"]] &&
-          options[["plots_mu"]] &&
-          options[["plots_type"]] == "averaged" &&
-          !options[["plots_priors"]])
-        .RoBMA_plots(jaspResults, options, c("mu", "tau"))
-      if (options[["plots_omega"]])
-        .RoBMA_plots(jaspResults, options, "omega")
-      
-      # individual models
-      if (options[["plots_individual_mu"]])
-        .RoBMA_individual_plots(jaspResults, options, "mu")
-      if (options[["plots_individual_tau"]])
-        .RoBMA_individual_plots(jaspResults, options, "tau")
-      if (options[["plots_individual_omega"]])
-        .RoBMA_individual_plots(jaspResults, options, "omega")
-      
-      ### Diagnostics
-      # overview
-      if (options[["diagnostics_overview"]])
-        .RoBMA_diagnostics_overview(jaspResults, options)
-      # plots
-      if ((
-        options[["diagnostics_mu"]] ||
-        options[["diagnostics_tau"]] ||
-        options[["diagnostics_omega"]] ||
-        options[["diagnostics_theta"]]
-      ) &&
-      (
-        options[["diagnostics_trace"]] ||
-        options[["diagnostics_autocorrelation"]] ||
-        options[["diagnostics_samples"]]
-      ))
-        .RoBMA_diagnostics_plots(jaspResults, options)
-      
-      ### Save the model
-      if (options[["save_path"]] != "" &&
-          is.null(jaspResults[["model_saved"]]))
-        .RoBMA_save_model(jaspResults, options)
-    }
-    
-    return()
+    ### Save the model
+    if (options[["save_path"]] != "" &&
+        is.null(jaspResults[["model_saved"]]))
+      .RoBMA_save_model(jaspResults, options)
   }
+  
+  return()
+}
 
 .RoBMA_dependencies <- c(
   "measures",
@@ -117,6 +116,7 @@ RobustBayesianMetaAnalysis <-
   "input_N1",
   "input_N2",
   "input_labels",
+  "effect_direction",
   "priors_mu",
   "priors_tau",
   "priors_omega",
@@ -154,11 +154,13 @@ RobustBayesianMetaAnalysis <-
     return(
       RoBMA::prior(
         distribution = "normal",
-        parameters = list(mean       = options_prior[["parMean"]],
-                          sd         = options_prior[["parScale"]]),
-        truncation = list(
-          lower      = options_prior[["truncationLower"]],
-          upper      = options_prior[["truncationUpper"]]
+        parameters   = list(
+          mean    = options_prior[["parMean"]],
+          sd      = options_prior[["parScale"]]
+        ),
+        truncation   = list(
+          lower   = options_prior[["truncationLower"]],
+          upper   = options_prior[["truncationUpper"]]
         ),
         prior_odds = options_prior[["priorOdds"]]
       )
@@ -198,8 +200,10 @@ RobustBayesianMetaAnalysis <-
     return(
       RoBMA::prior(
         distribution = "gamma",
-        parameters = list(shape      = options_prior[["parAlpha"]],
-                          rate       = options_prior[["parBeta"]]),
+        parameters = list(
+          shape      = options_prior[["parAlpha"]],
+          rate       = options_prior[["parBeta"]]
+        ),
         truncation = list(
           lower      = options_prior[["truncationLower"]],
           upper      = options_prior[["truncationUpper"]]
@@ -211,8 +215,10 @@ RobustBayesianMetaAnalysis <-
     return(
       RoBMA::prior(
         distribution = "gamma",
-        parameters = list(shape      = options_prior[["parShape"]],
-                          scale      = options_prior[["parScale2"]]),
+        parameters = list(
+          shape      = options_prior[["parShape"]],
+          scale      = options_prior[["parScale2"]]
+        ),
         truncation = list(
           lower      = options_prior[["truncationLower"]],
           upper      = options_prior[["truncationUpper"]]
@@ -224,8 +230,10 @@ RobustBayesianMetaAnalysis <-
     return(
       RoBMA::prior(
         distribution = "invgamma",
-        parameters = list(shape      = options_prior[["parAlpha"]],
-                          scale      = options_prior[["parBeta"]]),
+        parameters = list(
+          shape      = options_prior[["parAlpha"]],
+          scale      = options_prior[["parBeta"]]
+        ),
         truncation = list(
           lower      = options_prior[["truncationLower"]],
           upper      = options_prior[["truncationUpper"]]
@@ -237,7 +245,9 @@ RobustBayesianMetaAnalysis <-
     return(
       RoBMA::prior(
         distribution = "point",
-        parameters = list(location   = options_prior[["parLocation"]]),
+        parameters = list(
+          location   = options_prior[["parLocation"]]
+        ),
         prior_odds = options_prior[["priorOdds"]]
       )
     )
@@ -245,8 +255,10 @@ RobustBayesianMetaAnalysis <-
     return(
       RoBMA::prior(
         distribution = "uniform",
-        parameters = list(a          = options_prior[["parA"]],
-                          b          = options_prior[["parB"]]),
+        parameters = list(
+          a = options_prior[["parA"]],
+          b = options_prior[["parB"]]
+        ),
         prior_odds = options_prior[["priorOdds"]]
       )
     )
@@ -254,8 +266,10 @@ RobustBayesianMetaAnalysis <-
     return(
       RoBMA::prior(
         distribution = "two.sided",
-        parameters = list(alpha      = options_prior[["parAlpha"]],
-                          steps      = options_prior[["parCuts"]]),
+        parameters = list(
+          alpha      = options_prior[["parAlpha"]],
+          steps      = options_prior[["parCuts"]]
+        ),
         prior_odds = options_prior[["priorOdds"]]
       )
     )
@@ -263,8 +277,10 @@ RobustBayesianMetaAnalysis <-
     return(
       RoBMA::prior(
         distribution = "one.sided",
-        parameters = list(alpha      = options_prior[["parAlpha"]],
-                          steps      = options_prior[["parCuts"]]),
+        parameters = list(
+          alpha      = options_prior[["parAlpha"]],
+          steps      = options_prior[["parCuts"]]
+        ),
         prior_odds = options_prior[["priorOdds"]]
       )
     )
@@ -283,7 +299,7 @@ RobustBayesianMetaAnalysis <-
   }
 }
 .RoBMA_options2priors_clean <- function(x) {
-
+  
   x <- trimws(x, which = "both")
   x <- trimws(x, which = "both", whitespace = "c")
   x <- trimws(x, which = "both", whitespace = "\\(")
@@ -343,287 +359,228 @@ RobustBayesianMetaAnalysis <-
   return(x)
 }
 # table filling functions
-.RoBMA_table_fill_coef      <-
-  function(jasp_table,
-           results_table,
-           add_info,
-           options,
-           individual = FALSE) {
-    # add columns
-    jasp_table$addColumnInfo(name = "terms",
-                             title = "",
-                             type = "string")
-    jasp_table$addColumnInfo(name = "mean",
-                             title = gettext("Mean"),
-                             type = "number")
-    jasp_table$addColumnInfo(name = "median",
-                             title = gettext("Median") ,
-                             type = "number")
-    jasp_table$addColumnInfo(
-      name = "lowerCI",
-      title = gettext("Lower"),
-      type = "number",
-      overtitle = gettextf("%s%% CI", 100 * options[["results_CI"]])
-    )
-    jasp_table$addColumnInfo(
-      name = "upperCI",
-      title = gettext("Upper"),
-      type = "number",
-      overtitle = gettextf("%s%% CI", 100 * options[["results_CI"]])
+.RoBMA_table_fill_coef      <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+  
+  CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
+  # add columns
+  jasp_table$addColumnInfo(name = "terms",  title = "",                type = "string")
+  jasp_table$addColumnInfo(name = "mean",   title = gettext("Mean"),   type = "number")
+  jasp_table$addColumnInfo(name = "median", title = gettext("Median"), type = "number")
+  jasp_table$addColumnInfo(name = "lowerCI",title = gettext("Lower"),  type = "number", overtitle = CI_overtitle)
+  jasp_table$addColumnInfo(name = "upperCI",title = gettext("Upper"),  type = "number", overtitle = CI_overtitle)
+  
+  if (individual) {
+    jasp_table$addColumnInfo(name = "error", title = gettext("MCMC error"), type = "number")
+    jasp_table$addColumnInfo(name = "ess",   title = gettext("ESS"),        type = "integer")
+    jasp_table$addColumnInfo(name = "rhat",  title = gettext("Rhat"),       type = "number")
+  }
+  
+  
+  if (is.null(results_table)) 
+    return(jasp_table)
+  
+  # fill rows
+  for (i in c(1:nrow(results_table))[rownames(results_table) %in% c("mu", "tau")]) {
+    temp_row <- list(
+      terms    = .RoBMA_coef_names(rownames(results_table)[i], add_info),
+      mean     = results_table[i, "Mean"],
+      median   = results_table[i, "Median"],
+      lowerCI  = results_table[i, if(individual) ".025" else as.character(.5 - options[["results_CI"]] / 2)],
+      upperCI  = results_table[i, if(individual) ".975" else as.character(.5 + options[["results_CI"]] / 2)]
     )
     if (individual) {
-      jasp_table$addColumnInfo(name = "error",
-                               title = gettext("MCMC error"),
-                               type = "number")
-      jasp_table$addColumnInfo(name = "ess",
-                               title = gettext("ESS"),
-                               type = "integer")
-      jasp_table$addColumnInfo(name = "rhat",
-                               title = gettext("Rhat"),
-                               type = "number")
+      temp_row[["error"]] <- results_table[i, "MCMC error"]
+      temp_row[["ess"]]   <- results_table[i, "ESS"]
+      temp_row[["rhat"]]  <- results_table[i, "Rhat"]
     }
     
-    
-    if (is.null(results_table)) 
-      return(jasp_table)
-    
-    # fill rows
-    for (i in c(1:nrow(results_table))[rownames(results_table) %in% c("mu", "tau")]) {
-      temp_row <- list(
-        terms    = .RoBMA_coef_names(rownames(results_table)[i], add_info),
-        mean     = results_table[i, "Mean"],
-        median   = results_table[i, "Median"],
-        lowerCI  = results_table[i, if(individual) ".025" else as.character(.5 - options[["results_CI"]] / 2)],
-        upperCI  = results_table[i, if(individual) ".975" else as.character(.5 + options[["results_CI"]] / 2)]
-      )
-      if (individual) {
-        temp_row[["error"]] <- results_table[i, "MCMC error"]
-        temp_row[["ess"]]   <- results_table[i, "ESS"]
-        temp_row[["rhat"]]  <- results_table[i, "Rhat"]
-      }
-      
-      jasp_table$addRows(temp_row)
-    }
-
-    
-    # add footnote
-    if (any(rownames(results_table) == "tau")) {
-      if (add_info[["effect_size"]] == "r")
-        jasp_table$addFootnote(
-          gettextf("%s is on %s scale.", 
-                   "\u03C4",
-                   if(add_info[["mu_transform"]] == "cohens_d") gettext("Cohen's <em>d</em>") else gettext("Fisher's <em>z</em>")
-          )
+    jasp_table$addRows(temp_row)
+  }
+  
+  
+  # add footnote
+  if (any(rownames(results_table) == "tau")) {
+    if (add_info[["effect_size"]] %in% c("r", "OR")){
+      jasp_table$addFootnote(gettextf(
+        "%1$s is on %2$s scale.", 
+        "\u03C4",
+        switch(
+          add_info[["mu_transform"]],
+          "cohens_d"  = gettext("Cohen's <em>d</em>"),
+          "fishers_z" = gettext("Fisher's <em>z</em>"),
+          "log_OR"    = gettext("log(<em>OR</em>)")
         )
-    }
+      ))
+    } 
     
-    return(jasp_table)
   }
-.RoBMA_table_fill_weights   <-
-  function(jasp_table,
-           results_table,
-           add_info,
-           options,
-           individual = FALSE) {
-    # add columns
-    jasp_table$addColumnInfo(
-      name = "lowerRange",
-      title = gettext("Lower"),
-      type = "number",
-      overtitle = gettextf("<em>p</em>-values interval %s","\u002A")
-    )
-    jasp_table$addColumnInfo(
-      name = "upperRange",
-      title = gettext("Upper"),
-      type = "number",
-      overtitle = gettextf("<em>p</em>-values interval %s", "\u002A")
-    )
-    jasp_table$addColumnInfo(name = "mean",
-                             title = gettext("Mean"),
-                             type = "number")
-    jasp_table$addColumnInfo(name = "median",
-                             title = gettext("Median") ,
-                             type = "number")
-    jasp_table$addColumnInfo(
-      name = "lowerCI",
-      title = gettext("Lower"),
-      type = "number",
-      overtitle = gettextf("%s%% CI", 100 * options[["results_CI"]])
-    )
-    jasp_table$addColumnInfo(
-      name = "upperCI",
-      title = gettext("Upper"),
-      type = "number",
-      overtitle = gettextf("%s%% CI", 100 * options[["results_CI"]])
+  
+  return(jasp_table)
+}
+.RoBMA_table_fill_weights   <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+  
+  p_overtitle  <- gettextf("<em>p</em>-values interval %s","\u002A")
+  CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
+  # add columns
+  jasp_table$addColumnInfo(name = "lowerRange", title = gettext("Lower"),  type = "number", overtitle = p_overtitle)
+  jasp_table$addColumnInfo(name = "upperRange", title = gettext("Upper"),  type = "number", overtitle = p_overtitle)
+  jasp_table$addColumnInfo(name = "mean",       title = gettext("Mean"),   type = "number")
+  jasp_table$addColumnInfo(name = "median",     title = gettext("Median"), type = "number")
+  jasp_table$addColumnInfo(name = "lowerCI",    title = gettext("Lower"),  type = "number", overtitle = CI_overtitle)
+  jasp_table$addColumnInfo(name = "upperCI",    title = gettext("Upper"),  type = "number", overtitle = CI_overtitle)
+  
+  if (individual) {
+    jasp_table$addColumnInfo(name = "error",   title = gettext("MCMC error"), type = "number")
+    jasp_table$addColumnInfo(name = "ess",     title = gettext("ESS"),        type = "integer")
+    jasp_table$addColumnInfo(name = "rhat",    title = gettext("Rhat"),       type = "number")
+  }
+  
+  
+  if (is.null(results_table))
+    return(jasp_table)
+  
+  
+  # fill rows
+  for (i in c(1:nrow(results_table))[grepl("omega", rownames(results_table))]) {
+    temp_row <- list(
+      lowerRange = as.numeric(substr(
+        rownames(results_table)[i],
+        7,
+        regexec(",", rownames(results_table)[i], fixed = TRUE)[[1]] - 1
+      )),
+      upperRange = as.numeric(substr(
+        rownames(results_table)[i],
+        regexec(",", rownames(results_table)[i], fixed = TRUE)[[1]] + 1,
+        nchar(rownames(results_table)[i]) - 1
+      )),
+      mean       = results_table[i, "Mean"],
+      median     = results_table[i, "Median"],
+      lowerCI    = results_table[i, if(individual) ".025" else as.character(.5 - options[["results_CI"]] / 2)],
+      upperCI    = results_table[i, if(individual) ".975" else as.character(.5 + options[["results_CI"]] / 2)]
     )
     if (individual) {
-      jasp_table$addColumnInfo(name = "error",
-                               title = gettext("MCMC error"),
-                               type = "number")
-      jasp_table$addColumnInfo(name = "ess",
-                               title = gettext("ESS"),
-                               type = "integer")
-      jasp_table$addColumnInfo(name = "rhat",
-                               title = gettext("Rhat"),
-                               type = "number")
+      temp_row[["error"]] <- results_table[i, "MCMC error"]
+      temp_row[["ess"]]   <- results_table[i, "ESS"]
+      temp_row[["rhat"]]  <- results_table[i, "Rhat"]
     }
     
-    
-    if (is.null(results_table))
-      return(jasp_table)
-    
-    
-    
-    # fill rows
-    for (i in c(1:nrow(results_table))[grepl("omega", rownames(results_table))]) {
-      temp_row <- list(
-        lowerRange = as.numeric(substr(
-          rownames(results_table)[i],
-          7,
-          regexec(",", rownames(results_table)[i], fixed = TRUE)[[1]] - 1
-        )),
-        upperRange = as.numeric(substr(
-          rownames(results_table)[i],
-          regexec(",", rownames(results_table)[i], fixed = TRUE)[[1]] + 1,
-          nchar(rownames(results_table)[i]) - 1
-        )),
-        mean       = results_table[i, "Mean"],
-        median     = results_table[i, "Median"],
-        lowerCI    = results_table[i, if(individual) ".025" else as.character(.5 - options[["results_CI"]] / 2)],
-        upperCI    = results_table[i, if(individual) ".975" else as.character(.5 + options[["results_CI"]] / 2)]
-      )
-      if (individual) {
-        temp_row[["error"]] <- results_table[i, "MCMC error"]
-        temp_row[["ess"]]   <- results_table[i, "ESS"]
-        temp_row[["rhat"]]  <- results_table[i, "Rhat"]
-      }
-      
-      jasp_table$addRows(temp_row)
+    jasp_table$addRows(temp_row)
+  }
+  
+  
+  # add footnote
+  jasp_table$addFootnote(
+    symbol = "\u002A",
+    gettextf("The weights (%1$s) correspond to %2$s <em>p</em>-values.", "\u03C9", add_info[["weight_type"]])
+  )
+  
+  return(jasp_table)
+}
+.RoBMA_table_fill_studies   <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+  
+  CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
+  # add columns
+  jasp_table$addColumnInfo(name = "terms",   title = "",               type = "string")
+  jasp_table$addColumnInfo(name = "mean",    title = gettext("Mean"),  type = "number")
+  jasp_table$addColumnInfo(name = "median",  title = gettext("Median"),type = "number")
+  jasp_table$addColumnInfo(name = "lowerCI", title = gettext("Lower"), type = "number", overtitle = CI_overtitle)
+  jasp_table$addColumnInfo(name = "upperCI", title = gettext("Upper"), type = "number", overtitle = CI_overtitle)
+  
+  if (individual) {
+    jasp_table$addColumnInfo(name = "error",   title = gettext("MCMC error"), type = "number")
+    jasp_table$addColumnInfo(name = "ess",     title = gettext("ESS"),        type = "integer")
+    jasp_table$addColumnInfo(name = "rhat",    title = gettext("Rhat"),       type = "number")
+  }
+  
+  
+  if (is.null(results_table))
+    return(jasp_table)
+  
+  # fill rows
+  temp_i <- 0
+  for (i in c(1:nrow(results_table))[grepl("theta", rownames(results_table))]) {
+    temp_i <- temp_i + 1
+    temp_row <- list(
+      terms    = add_info[["study_names"]][temp_i],
+      mean     = results_table[i, "Mean"],
+      median   = results_table[i, "Median"],
+      lowerCI  = results_table[i, if(individual) ".025" else as.character(.5 - options[["results_CI"]] / 2)],
+      upperCI  = results_table[i, if(individual) ".975" else as.character(.5 + options[["results_CI"]] / 2)]
+    )
+    if (individual) {
+      temp_row[["error"]] <- results_table[i, "MCMC error"]
+      temp_row[["ess"]]   <- results_table[i, "ESS"]
+      temp_row[["rhat"]]  <- results_table[i, "Rhat"]
     }
     
-    
-    # add footnote
+    jasp_table$addRows(temp_row)
+  }
+  
+  
+  # add footnote
+  if (add_info[["effect_size"]] %in% c("r", "d", "OR")){
     jasp_table$addFootnote(
-      symbol = "\u002A",
-      gettextf("The weights (%s) correspond to %s <em>p</em>-values.", "\u03C9", add_info[["weight_type"]])
-    )
-    
-    return(jasp_table)
+      gettextf(
+        "Estimated studies' effects (%1$s) correspond to effect size %2$s.",
+        "\u03B8",
+        .RoBMA_coef_letters(add_info[["effect_size"]])
+    ))
   }
-.RoBMA_table_fill_studies   <-
-  function(jasp_table,
-           results_table,
-           add_info,
-           options,
-           individual = FALSE) {
-    # add columns
-    jasp_table$addColumnInfo(name = "terms",
-                             title = "",
-                             type = "string")
-    jasp_table$addColumnInfo(name = "mean",
-                             title = gettext("Mean"),
-                             type = "number")
-    jasp_table$addColumnInfo(name = "median",
-                             title = gettext("Median"),
-                             type = "number")
-    jasp_table$addColumnInfo(
-      name = "lowerCI",
-      title = gettext("Lower"),
-      type = "number",
-      overtitle = gettextf("%s%% CI", 100 * options[["results_CI"]])
-    )
-    jasp_table$addColumnInfo(
-      name = "upperCI",
-      title = gettext("Upper"),
-      type = "number",
-      overtitle = gettextf("%s%% CI", 100 * options[["results_CI"]])
-    )
-    if (individual) {
-      jasp_table$addColumnInfo(name = "error",
-                               title = gettext("MCMC error"),
-                               type = "number")
-      jasp_table$addColumnInfo(name = "ess",
-                               title = gettext("ESS"),
-                               type = "integer")
-      jasp_table$addColumnInfo(name = "rhat",
-                               title = gettext("Rhat"),
-                               type = "number")
-    }
-    
-    
-    if (is.null(results_table))
-      return(jasp_table)
-    
-    
-    # fill rows
-    temp_i <- 0
-    for (i in c(1:nrow(results_table))[grepl("theta", rownames(results_table))]) {
-      temp_i <- temp_i + 1
-      temp_row <- list(
-        terms    = add_info[["study_names"]][temp_i],
-        mean     = results_table[i, "Mean"],
-        median   = results_table[i, "Median"],
-        lowerCI  = results_table[i, if(individual) ".025" else as.character(.5 - options[["results_CI"]] / 2)],
-        upperCI  = results_table[i, if(individual) ".975" else as.character(.5 + options[["results_CI"]] / 2)]
-      )
-      if (individual) {
-        temp_row[["error"]] <- results_table[i, "MCMC error"]
-        temp_row[["ess"]]   <- results_table[i, "ESS"]
-        temp_row[["rhat"]]  <- results_table[i, "Rhat"]
-      }
-      
-      jasp_table$addRows(temp_row)
-    }
-
-    
-    # add footnote
-    if (add_info[["effect_size"]] == "r"){
-      jasp_table$addFootnote(
-        gettextf("Estimated studies' effects (%s) correspond to effect size %s.","\u03B8","\u03C1")
-      )
-    }else if (add_info[["effect_size"]] == "d"){
-      jasp_table$addFootnote(
-        gettextf("Estimated studies' effects (%s) correspond to effect size %s.","\u03B8","\u03B4")
-      )
-    }
-    
-    return(jasp_table)
-  }
+  
+  return(jasp_table)
+}
 .RoBMA_coef_names           <- function(name, add_info) {
   if (name == "mu")
-    return(gettextf("Effect size (%s)",if (add_info[["effect_size"]] == "r") "\u03C1" else if (add_info[["effect_size"]] == "d") "\u03B4" else "\u03BC"))
+    return(gettextf(
+      "Effect size (%s)",
+      ifelse(add_info[["effect_size"]] %in% c("r", "d", "OR"), .RoBMA_coef_letters(add_info[["effect_size"]]), "\u03BC")
+    ))
   if (name == "tau")
     return(gettextf("Heterogeneity (%s)","\u03C4"))
 }
+.RoBMA_coef_letters         <- function(effect_size){
+  switch(
+    effect_size,
+    "r"   = "\u03C1",
+    "d"   = "\u03B4",
+    "OR"  = "OR"
+  )
+}
 # main functions
 .RoBMA_ready                <- function(options) {
+  
   if (options[["measures"]] == "fitted") {
     return(options[["fitted_path"]] != "")
   }
   
-  ready_arg1 <- any(c(options[["input_ES"]], options[["input_t"]]) != "")
+  
   if (options[["measures"]] == "cohensd") {
+    ready_arg1 <- any(c(options[["input_ES"]], options[["input_t"]]) != "")
+    
     if (options[["cohensd_testType"]] == "one.sample") {
-      ready_arg2 <-
-        any(c(options[["input_SE"]], options[["input_N"]]) != "",
-            sum(unlist(options[["input_CI"]]) != "") == 2)
+      ready_arg2 <- any(c(
+        options[["input_SE"]] != "",
+        options[["input_N"]]  != "",
+        sum(unlist(options[["input_CI"]]) != "") == 2
+      ))
     } else if (options[["cohensd_testType"]] == "two.sample") {
-      ready_arg2 <-
-        any(
-          c(options[["input_SE"]], options[["input_N"]]) != "",
-          sum(unlist(options[["input_CI"]]) != "") == 2,
-          all(c(
-            options[["input_N1"]], options[["input_N2"]]
-          ) != "")
-        )
+      ready_arg2 <- any(c(
+        options[["input_SE"]] != "",
+        options[["input_N"]]) != "",
+        sum(unlist(options[["input_CI"]]) != "") == 2,
+        all(c(options[["input_N1"]], options[["input_N2"]]) != "")
+      )
     }
   } else if (options[["measures"]] == "correlation") {
-    ready_arg2 <-
-      any(c(options[["input_SE"]], options[["input_N"]]) != "",
-          sum(unlist(options[["input_CI"]]) != "") == 2)
+    ready_arg1 <- options[["input_ES"]] != ""
+    ready_arg2 <- options[["input_N"]]  != ""
+    ready_arg2 <- any(c(options[["input_SE"]], options[["input_N"]]) != "", sum(unlist(options[["input_CI"]]) != "") == 2)
+  } else if (options[["measures"]] == "OR") {
+    ready_arg1 <- options[["input_ES"]] != ""
+    ready_arg2 <- sum(unlist(options[["input_CI"]]) != "") == 2
   } else if (options[["measures"]] == "general") {
-    ready_arg2 <-
-      any(options[["input_SE"]] != "", sum(unlist(options[["input_CI"]]) != "") == 2)
+    ready_arg1 <- options[["input_ES"]] != ""
+    ready_arg2 <- any(options[["input_SE"]] != "", sum(unlist(options[["input_CI"]]) != "") == 2)
   }
   
   return(ready_arg1 && ready_arg2)
@@ -631,8 +588,9 @@ RobustBayesianMetaAnalysis <-
 }
 .RoBMA_model_notifier       <- function(jaspResults) {
   # We don't wanna delete the RoBMA modele every time settings is change since RoBMA takes a lot of time to fit.
-  # Therefore, we don't create dependencies on the fitted model, but on a notifier that tells us when there was
-  # a change. If possible, we don't refit the whole model, just update the neccessary parts.
+  # Therefore, we don't create dependencies on the fitted model (in cases when the model can be updated), but 
+  # on a notifier that tells us when there was the change. If possible, we don't refit the whole model, 
+  # just update the neccessary parts.
   
   if (is.null(jaspResults[["model_notifier"]])) {
     model_notifier <- createJaspState()
@@ -670,16 +628,10 @@ RobustBayesianMetaAnalysis <-
         )
       var_names <- var_names[var_names != ""]
       
-      dataset <-
-        readDataSetToEnd(columns.as.numeric = var_names,
-                         columns = if (options[["input_labels"]] != "")
-                           options[["input_labels"]])
-      
-      # compute SE from CI
-      if (sum(unlist(options[["input_CI"]]) != "") == 2) {
-        dataset$JASP_computed_SE <-
-          abs(dataset[, .v(options[["input_CI"]][[1]][1])] - dataset[, .v(options[["input_CI"]][[1]][2])]) / (2 * 1.96)
-      }
+      dataset <- readDataSetToEnd(
+        columns.as.numeric = var_names,
+        columns = if (options[["input_labels"]] != "") options[["input_labels"]]
+      )
     }
     
   }
@@ -757,15 +709,13 @@ RobustBayesianMetaAnalysis <-
     if (length(priors[[parameter]]) == 0)
       next
     
-    temp_plots <-
-      createJaspContainer(
-        title = if (parameter == "mu")
-          gettext("Effect")
-        else if (parameter == "tau")
-          gettext("Heterogeneity")
-        else if (parameter == "omega")
-          gettext("Weight Function")
-      )
+    temp_plots <- createJaspContainer(
+      title = switch(
+        parameter,
+        "mu"    = gettext("Effect"),
+        "tau"   = gettext("Heterogeneity"),
+        "omega" = gettext("Weight Function")
+      ))
     prior_plots[[parameter]] <- temp_plots
     
     for (i in 1:length(priors[[parameter]])) {
@@ -780,22 +730,26 @@ RobustBayesianMetaAnalysis <-
       if (is.null(jaspResults[["model"]])) {
         p <- plot(
           priors[[parameter]][[i]],
-          plot_type   = "ggplot",
-          par_name    = parameter,
-          samples     = 1e6,
-          mu_transform = if (options[["measures"]] == "correlation" &&
-                             parameter == "mu")
-            options[["advanced_mu_transform"]]
+          plot_type    = "ggplot",
+          par_name     = parameter,
+          effect_size  = if(parameter == "mu") switch(
+            options[["measures"]],
+            "cohensd"     = "d",
+            "correlation" = "r",
+            "OR"          = "OR",
+            "general"     = "y"
+          ),
+          mu_transform = if (options[["measures"]] %in% c("correlation", "OR") && parameter == "mu") options[["advanced_mu_transform"]],
+          samples      = 1e6,
         )
       } else{
         p <- plot(
           priors[[parameter]][[i]],
-          plot_type   = "ggplot",
-          par_name    = parameter,
-          samples     = 1e7,
-          mu_transform = if (!is.null(fit[["add_info"]][["r"]]) &&
-                             parameter == "mu")
-            fit[["add_info"]][["mu_transform"]]
+          plot_type    = "ggplot",
+          par_name     = parameter,
+          effect_size  = if(parameter == "mu") fit[["add_info"]][["effect_size"]],
+          samples      = 1e6,
+          mu_transform = if (fit[["add_info"]][["effect_size"]] %in% c("r", "OR") && parameter == "mu") fit[["add_info"]][["mu_transform"]]
         )
       }
       
@@ -814,8 +768,7 @@ RobustBayesianMetaAnalysis <-
   if (!is.null(jaspResults[["prior_plots"]])) {
     return()
   } else{
-    model_preview <-
-      createJaspContainer(title = gettext("Model Preview"))
+    model_preview <- createJaspContainer(title = gettext("Model Preview"))
     model_preview$dependOn(.RoBMA_dependencies)
     model_preview$position <- 1
     jaspResults[["model_preview"]] <- model_preview
@@ -833,11 +786,9 @@ RobustBayesianMetaAnalysis <-
       (length(priors[["omega"]]) == 0 &&
        length(priors[["omega_null"]]) == 0)) {
     priors_error <- createJaspTable()
-    priors_error$setError(
-      gettext(
+    priors_error$setError(gettext(
         "At least one prior distribution per parameter must be specified (either null or alternative)."
-      )
-    )
+    ))
     model_preview[["priors_error"]] <- priors_error
     return()
   }
@@ -851,7 +802,8 @@ RobustBayesianMetaAnalysis <-
     priors_mu_null    = priors[["mu_null"]],
     priors_tau_null   = priors[["tau_null"]],
     priors_omega_null = priors[["omega_null"]],
-    models            = TRUE
+    models            = TRUE,
+    silent            = TRUE
   )
   
   
@@ -860,24 +812,13 @@ RobustBayesianMetaAnalysis <-
     createJaspTable(title = gettext("Model Summary"))
   overall_summary$position <- 1
   
-  overall_summary$addColumnInfo(name = "terms",
-                                title = "",
-                                type = "string")
-  overall_summary$addColumnInfo(name = "models",
-                                title = gettext("Models"),
-                                type = "string")
-  overall_summary$addColumnInfo(name = "priorProb",
-                                title = gettext("P(M)"),
-                                type = "number")
+  overall_summary$addColumnInfo(name = "terms",     title = "",                type = "string")
+  overall_summary$addColumnInfo(name = "models",    title = gettext("Models"), type = "string")
+  overall_summary$addColumnInfo(name = "priorProb", title = gettext("P(M)"),   type = "number")
   
   for (i in 1:nrow(s.fit[["overview"]])) {
     temp_row <- list(
-      terms     = if (i == 1)
-        gettext("Effect")
-      else if (i == 2)
-        gettext("Heterogeneity")
-      else if (i == 3)
-        gettext("Publication bias"),
+      terms     = if (i == 1) gettext("Effect") else if (i == 2) gettext("Heterogeneity") else if (i == 3) gettext("Publication bias"),
       models    = paste0(s.fit[["overview"]][["Models"]][i], "/", s.fit[["add_info"]][["n_models"]]),
       priorProb = s.fit[["overview"]][["Prior prob."]][i]
     )
@@ -889,34 +830,16 @@ RobustBayesianMetaAnalysis <-
   
   
   ### create models overview table
-  models_summary <-
-    createJaspTable(title = gettext("Models Overview"))
+  models_summary <- createJaspTable(title = gettext("Models Overview"))
   models_summary$position <- 2
   
-  models_summary$addColumnInfo(name = "number",
-                               title = "#",
-                               type = "integer")
-  models_summary$addColumnInfo(
-    name = "prior_mu",
-    title = gettext("Effect Size"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_summary$addColumnInfo(
-    name = "prior_tau",
-    title = gettext("Heterogeneity"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_summary$addColumnInfo(
-    name = "prior_omega",
-    title = gettext("Publication Bias"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_summary$addColumnInfo(name = "priorProb",
-                               title = gettext("P(M)"),
-                               type = "number")
+  prior_overtitle <- gettext("Prior Distribution")
+  
+  models_summary$addColumnInfo(name = "number",      title = "#", type = "integer")
+  models_summary$addColumnInfo(name = "prior_mu",    title = gettext("Effect Size"),      type = "string", overtitle = prior_overtitle)
+  models_summary$addColumnInfo(name = "prior_tau",   title = gettext("Heterogeneity"),    type = "string", overtitle = prior_overtitle)
+  models_summary$addColumnInfo(name = "prior_omega", title = gettext("Publication Bias"), type = "string", overtitle = prior_overtitle)
+  models_summary$addColumnInfo(name = "priorProb",   title = gettext("P(M)"),             type = "number")
   
   for (i in 1:nrow(s.fit[["models"]])) {
     temp_row <- list(
@@ -935,209 +858,132 @@ RobustBayesianMetaAnalysis <-
   
   return()
 }
-.RoBMA_fit_model            <-
-  function(jaspResults, dataset, options) {
-
-    if (is.null(jaspResults[["model"]])) {
-      model <- createJaspState()
-      model$dependOn("measures")
-      jaspResults[["model"]] <- model
-      
-    } else{
-      model <- jaspResults[["model"]]
-      fit   <- model[["object"]]
-      
-    }
+.RoBMA_fit_model            <- function(jaspResults, dataset, options) {
+  
+  if (is.null(jaspResults[["model"]])) {
+    model <- createJaspState()
+    model$dependOn(c(
+      "measures", 
+      "fitted_path", "input_ES", "input_t", "input_SE", "input_CI", "input_N", "input_N1", "input_N2",
+      "effect_direction", "advanced_mu_transform",
+      "priors_mu", "priors_tau", "priors_omega", "priors_mu_null", "priors_tau_null", "priors_omega_null"))
+    jaspResults[["model"]] <- model
+    fit                    <- NULL
+  } else{
+    model <- jaspResults[["model"]]
+    fit   <- model[["object"]]
     
-    if (options[["measures"]] == "fitted") {
-      
-      fit <- tryCatch({
-        fit <- readRDS(file = options[["fitted_path"]])
-        if (!RoBMA::is.RoBMA(fit))
-          JASP:::.quitAnalysis(gettext("The loaded object is not a RoBMA model."))
-        fit
-      },error = function(e)e)
-      
-    } else{
-      
-      # check whether priors whether RoBMA was already fitted - maybe we don't need to refit everything
-      if (!is.null(jaspResults[["model"]]) &&
-          options[["advanced_control"]] %in% c("clever", "no_refit")) {
-        fit     <- jaspResults[["model"]][["object"]]
-        priors  <- jaspResults[["priors"]][["object"]]
-        
-        # this actually saves the priors in the same format as the RoBMA function does, what a coincidence ;)
-        s.fit   <- RoBMA::check_setup(
-          priors_mu         = priors[["mu"]],
-          priors_tau        = priors[["tau"]],
-          priors_omega      = priors[["omega"]],
-          priors_mu_null    = priors[["mu_null"]],
-          priors_tau_null   = priors[["tau_null"]],
-          priors_omega_null = priors[["omega_null"]],
-          models            = TRUE
-        )
-        
-        needs_refit <- !isTRUE(all.equal(fit[["priors"]], s.fit[["priors"]]))
-      } else{
-        needs_refit <- TRUE
-      }
-      
-      if (needs_refit) {
-        # extract priors
-        priors <- jaspResults[["priors"]][["object"]]
-        
-        fit <- tryCatch(RoBMA::RoBMA(
-          t  = if (options[["measures"]] == "cohensd" &&
-                   options[["input_t"]] != "")
-            dataset[, .v(options[["input_t"]])]
-          else
-            NULL,
-          d  = if (options[["measures"]] == "cohensd" &&
-                   options[["input_ES"]] != "")
-            dataset[, .v(options[["input_ES"]])]
-          else
-            NULL,
-          r  = if (options[["measures"]] == "correlation" &&
-                   options[["input_ES"]] != "")
-            dataset[, .v(options[["input_ES"]])]
-          else
-            NULL,
-          y  = if (options[["measures"]] == "general" &&
-                   options[["input_ES"]] != "")
-            dataset[, .v(options[["input_ES"]])]
-          else
-            NULL,
-          se = if (options[["input_SE"]] != "")
-            dataset[, .v(options[["input_SE"]])]
-          else if (sum(unlist(options[["input_CI"]]) != "") == 2)
-            dataset[, "JASP_computed_SE"]
-          else
-            NULL,
-          n  = if (options[["measures"]] %in% c("cohensd", "correlation") &&
-                   options[["input_N"]] != "")
-            dataset[, .v(options[["input_N"]])]
-          else
-            NULL,
-          n1 = if (options[["measures"]] == "cohensd" &&
-                   options[["input_N1"]] != "")
-            dataset[, .v(options[["input_N1"]])]
-          else
-            NULL,
-          n2 = if (options[["measures"]] == "cohensd" &&
-                   options[["input_N2"]] != "")
-            dataset[, .v(options[["input_N2"]])]
-          else
-            NULL,
-          test_type    = if (options[["measures"]] == "cohensd")
-            options[["cohensd_testType"]]
-          else
-            NULL,
-          mu_transform = if (options[["measures"]] == "correlation")
-            options[["advanced_mu_transform"]]
-          else
-            NULL,
-          study_names  = if (options[["input_labels"]] != "")
-            dataset[, .v(options[["input_labels"]])]
-          else
-            NULL,
-          priors_mu         = priors[["mu"]],
-          priors_tau        = priors[["tau"]],
-          priors_omega      = priors[["omega"]],
-          priors_mu_null    = priors[["mu_null"]],
-          priors_tau_null   = priors[["tau_null"]],
-          priors_omega_null = priors[["omega_null"]],
-          chains  = options[["advanced_chains"]],
-          iter    = options[["advanced_iteration"]],
-          burnin  = options[["advanced_burnin"]],
-          thin    = options[["advanced_thin"]],
-          control = list(
-            autofit         = options[["advanced_autofit"]],
-            max_error       = if (options[["advanced_autofit"]])
-              options[["advanced_autofit_error"]],
-            max_time        = if (options[["advanced_autofit"]])
-              paste0(
-                options[["advanced_autofit_time"]],
-                options[["advanced_autofit_time_unit"]]
-              ),
-            adapt           = options[["advanced_adapt"]],
-            bridge_max_iter = options[["advanced_bridge_iter"]],
-            allow_max_error = if (options[["advanced_omit"]] &&
-                                  options[["advanced_omit_error"]])
-              options[["advanced_omit_error_value"]],
-            allow_max_rhat  = if (options[["advanced_omit"]] &&
-                                  options[["advanced_omit_rhat"]])
-              options[["advanced_omit_rhat_value"]],
-            allow_min_ESS   = if (options[["advanced_omit"]] &&
-                                  options[["advanced_omit_ESS"]])
-              options[["advanced_omit_ESS_value"]],
-            allow_inc_theta = options[["advanced_omit_theta"]],
-            balance_prob    = options[["advanced_omit_prior"]] == "conditional",
-            silent          = TRUE,
-            progress_start  = 'startProgressbar(length(object$models))',
-            progress_tick   = 'progressbarTick()'
-          ),
-          save    = "all",
-          seed    = if (options[["setSeed"]])
-            options[["setSeed"]]
-        ),error = function(e)e)
-        
-      } else{
-        
-        fit <- tryCatch(RoBMA::update.RoBMA(
-          object  = fit,
-          study_names  = if (options[["input_labels"]] != "")
-            dataset[, .v(options[["input_labels"]])]
-          else
-            NULL,
-          chains  = options[["advanced_chains"]],
-          iter    = options[["advanced_iteration"]],
-          burnin  = options[["advanced_burnin"]],
-          thin    = options[["advanced_thin"]],
-          control = list(
-            autofit         = options[["advanced_autofit"]],
-            max_error       = if (options[["advanced_autofit"]])
-              options[["advanced_autofit_error"]],
-            max_time        = if (options[["advanced_autofit"]])
-              paste0(
-                options[["advanced_autofit_time"]],
-                options[["advanced_autofit_time_unit"]]
-              ),
-            adapt           = options[["advanced_adapt"]],
-            bridge_max_iter = options[["advanced_bridge_iter"]],
-            allow_max_error = if (options[["advanced_omit"]] &&
-                                  options[["advanced_omit_error"]])
-              options[["advanced_omit_error_value"]],
-            allow_max_rhat  = if (options[["advanced_omit"]] &&
-                                  options[["advanced_omit_rhat"]])
-              options[["advanced_omit_rhat_value"]],
-            allow_min_ESS   = if (options[["advanced_omit_ESS"]])
-              options[["advanced_omit_ESS_value"]],
-            allow_inc_theta = options[["advanced_omit_theta"]],
-            balance_prob    = options[["advanced_omit_prior"]] == "conditional",
-            silent          = TRUE,
-            progress_start  = 'startProgressbar(sum(converged_models))',
-            progress_tick   = 'progressbarTick()'
-          ),
-          refit_failed = options[["advanced_control"]] != "no_refit"
-        ),error = function(e)e)
-        
-      }
-      
-    }
-    
-
-    # error handling
-    if(any(class(fit) %in% c("simpleError", "error"))){
-        JASP:::.quitAnalysis(fit[["message"]])
-    }
-    
-    
-    # update the fit and reset notifier
-    model[["object"]] <- fit
-    .RoBMA_model_notifier(jaspResults)
-    
-    return()
   }
+  
+  if (options[["measures"]] == "fitted") {
+    
+    fit <- tryCatch({
+      fit <- readRDS(file = options[["fitted_path"]])
+      if (!RoBMA::is.RoBMA(fit))
+        JASP:::.quitAnalysis(gettext("The loaded object is not a RoBMA model."))
+      fit
+    },error = function(e)e)
+    
+  } else{
+    
+    if (is.null(fit) || options[["advanced_control"]] == "refit") {
+      # extract priors
+      priors <- jaspResults[["priors"]][["object"]]
+      
+      fit <- tryCatch(RoBMA::RoBMA(
+        # data
+        t   = if (options[["measures"]] == "cohensd" && options[["input_t"]] != "")                     dataset[, .v(options[["input_t"]])],
+        d   = if (options[["measures"]] == "cohensd" && options[["input_ES"]] != "")                    dataset[, .v(options[["input_ES"]])],
+        r   = if (options[["measures"]] == "correlation" && options[["input_ES"]] != "")                dataset[, .v(options[["input_ES"]])],
+        OR  = if (options[["measures"]] == "OR")                                                        dataset[, .v(options[["input_ES"]])],
+        y   = if (options[["measures"]] == "general" && options[["input_ES"]] != "")                    dataset[, .v(options[["input_ES"]])],
+        se  = if (options[["input_SE"]] != "")                                                          dataset[, .v(options[["input_SE"]])],
+        lCI = if (sum(unlist(options[["input_CI"]]) != "") == 2)                                        dataset[, .v(options[["input_CI"]][[1]][1])],
+        uCI = if (sum(unlist(options[["input_CI"]]) != "") == 2)                                        dataset[, .v(options[["input_CI"]][[1]][2])],
+        n   = if (options[["measures"]] %in% c("cohensd", "correlation") && options[["input_N"]] != "") dataset[, .v(options[["input_N"]])],
+        n1  = if (options[["measures"]] == "cohensd" && options[["input_N1"]] != "")                    dataset[, .v(options[["input_N1"]])],
+        n2  = if (options[["measures"]] == "cohensd" && options[["input_N2"]] != "")                    dataset[, .v(options[["input_N2"]])],
+        study_names = if (options[["input_labels"]] != "")                                              dataset[, .v(options[["input_labels"]])],
+        # model settings
+        test_type        = if (options[["measures"]] == "cohensd")                 options[["cohensd_testType"]],
+        mu_transform     = if (options[["measures"]] %in% c("correlation", "OR"))  options[["advanced_mu_transform"]],
+        effect_direction = options[["effect_direction"]],
+        # priors
+        priors_mu         = priors[["mu"]],
+        priors_tau        = priors[["tau"]],
+        priors_omega      = priors[["omega"]],
+        priors_mu_null    = priors[["mu_null"]],
+        priors_tau_null   = priors[["tau_null"]],
+        priors_omega_null = priors[["omega_null"]],
+        # sampling settings
+        chains  = options[["advanced_chains"]],
+        iter    = options[["advanced_iteration"]],
+        burnin  = options[["advanced_burnin"]],
+        thin    = options[["advanced_thin"]],
+        # additional settings
+        control = list(
+          autofit         = options[["advanced_autofit"]],
+          max_error       = if (options[["advanced_autofit"]]) options[["advanced_autofit_error"]],
+          max_time        = if (options[["advanced_autofit"]]) paste0(options[["advanced_autofit_time"]], options[["advanced_autofit_time_unit"]]),
+          adapt           = options[["advanced_adapt"]],
+          bridge_max_iter = options[["advanced_bridge_iter"]],
+          allow_max_error = if (options[["advanced_omit"]] && options[["advanced_omit_error"]]) options[["advanced_omit_error_value"]],
+          allow_max_rhat  = if (options[["advanced_omit"]] && options[["advanced_omit_rhat"]])  options[["advanced_omit_rhat_value"]],
+          allow_min_ESS   = if (options[["advanced_omit"]] && options[["advanced_omit_ESS"]])   options[["advanced_omit_ESS_value"]],
+          allow_inc_theta = options[["advanced_omit_theta"]],
+          balance_prob    = options[["advanced_omit_prior"]] == "conditional",
+          silent          = TRUE,
+          progress_start  = 'startProgressbar(length(object$models))',
+          progress_tick   = 'progressbarTick()'
+        ),
+        save    = "all",
+        seed    = if (options[["setSeed"]]) options[["setSeed"]]
+      ),error = function(e)e)
+      
+    } else{
+      debug()
+      fit <- tryCatch(RoBMA::update.RoBMA(
+        object  = fit,
+        study_names  = if (options[["input_labels"]] != "") dataset[, .v(options[["input_labels"]])],
+        chains  = options[["advanced_chains"]],
+        iter    = options[["advanced_iteration"]],
+        burnin  = options[["advanced_burnin"]],
+        thin    = options[["advanced_thin"]],
+        control = list(
+          autofit         = options[["advanced_autofit"]],
+          max_error       = if (options[["advanced_autofit"]]) options[["advanced_autofit_error"]],
+          max_time        = if (options[["advanced_autofit"]]) paste0(options[["advanced_autofit_time"]], options[["advanced_autofit_time_unit"]]),
+          adapt           = options[["advanced_adapt"]],
+          bridge_max_iter = options[["advanced_bridge_iter"]],
+          allow_max_error = if (options[["advanced_omit"]] && options[["advanced_omit_error"]]) options[["advanced_omit_error_value"]],
+          allow_max_rhat  = if (options[["advanced_omit"]] && options[["advanced_omit_rhat"]])  options[["advanced_omit_rhat_value"]],
+          allow_min_ESS   = if (options[["advanced_omit_ESS"]]) options[["advanced_omit_ESS_value"]],
+          allow_inc_theta = options[["advanced_omit_theta"]],
+          balance_prob    = options[["advanced_omit_prior"]] == "conditional",
+          silent          = TRUE,
+          progress_start  = 'startProgressbar(sum(converged_models))',
+          progress_tick   = 'progressbarTick()'
+        ),
+        refit_failed = options[["advanced_control"]] != "no_refit"
+      ),error = function(e)e)
+      
+    }
+    
+  }
+  
+  
+  # error handling
+  if(any(class(fit) %in% c("simpleError", "error"))){
+    JASP:::.quitAnalysis(fit[["message"]])
+  }
+  
+  
+  # update the fit and reset notifier
+  model[["object"]] <- fit
+  .RoBMA_model_notifier(jaspResults)
+  
+  return()
+}
 .RoBMA_summary              <- function(jaspResults, options) {
   if (!is.null(jaspResults[["main_summary"]])) {
     return()
@@ -1156,7 +1002,7 @@ RobustBayesianMetaAnalysis <-
     main_summary$dependOn(summary_dependencies)
     jaspResults[["main_summary"]] <- main_summary
   }
-
+  
   # remove the model preview
   jaspResults[["model_preview"]] <- NULL
   
@@ -1174,8 +1020,7 @@ RobustBayesianMetaAnalysis <-
   )
   
   ### create overview table
-  overall_summary <-
-    createJaspTable(title = gettext("Model Summary"))
+  overall_summary <- createJaspTable(title = gettext("Model Summary"))
   overall_summary$position <- 1
   
   BF_title <- paste0(
@@ -1192,44 +1037,23 @@ RobustBayesianMetaAnalysis <-
     )
   )
   
-  overall_summary$addColumnInfo(name = "terms",
-                                title = "",
-                                type = "string")
-  overall_summary$addColumnInfo(name = "models",
-                                title = gettext("Models"),
-                                type = "string")
-  overall_summary$addColumnInfo(name = "priorProb",
-                                title = gettext("P(M)"),
-                                type = "number")
-  overall_summary$addColumnInfo(name = "postProb",
-                                title = gettext("P(M|data)"),
-                                type = "number")
-  overall_summary$addColumnInfo(name = "BF",
-                                title = BF_title,
-                                type = "number")
+  overall_summary$addColumnInfo(name = "terms",     title = "",                   type = "string")
+  overall_summary$addColumnInfo(name = "models",    title = gettext("Models"),    type = "string")
+  overall_summary$addColumnInfo(name = "priorProb", title = gettext("P(M)"),      type = "number")
+  overall_summary$addColumnInfo(name = "postProb",  title = gettext("P(M|data)"), type = "number")
+  overall_summary$addColumnInfo(name = "BF",        title = BF_title,             type = "number")
   
   if (!any(fit[["add_info"]][["converged"]])) {
     overall_summary$setError(
-      gettext(
-        "All models failed to converge. Please, consider inspecting the 'MCMC diagnostics' and changing the 'Advanced options'."
-      )
+      gettext("All models failed to converge. Please, consider inspecting the 'MCMC diagnostics' and changing the 'Advanced options'.")
     )
     return()
   }
   
   for (i in 1:nrow(s.fit[["overview"]])) {
     temp_row <- list(
-      terms     = if (i == 1)
-        gettext("Effect")
-      else if (i == 2)
-        gettext("Heterogeneity")
-      else if (i == 3)
-        gettext("Publication bias"),
-      models    = paste0(
-        s.fit[["overview"]][i, "Models"],
-        "/",
-        s.fit[["add_info"]][["n_models"]] - s.fit[["add_info"]][["failed"]]
-      ),
+      terms     = if (i == 1) gettext("Effect") else if (i == 2) gettext("Heterogeneity") else if (i == 3) gettext("Publication bias"),
+      models    = paste0(s.fit[["overview"]][i, "Models"], "/",  s.fit[["add_info"]][["n_models"]] - s.fit[["add_info"]][["failed"]]),
       priorProb = s.fit[["overview"]][i, "Prior prob."],
       postProb  = s.fit[["overview"]][i, "Post. prob."],
       BF        = s.fit[["overview"]][i, 4]
@@ -1238,42 +1062,37 @@ RobustBayesianMetaAnalysis <-
     overall_summary$addRows(temp_row)
   }
   if (s.fit[["add_info"]][["failed"]] != 0)
-    overall_summary$addFootnote(symbol = gettext("Warning:"),
-                                gettextf("%i models failed to converge.", s.fit[["add_info"]][["failed"]]))
+    overall_summary$addFootnote(symbol = gettext("Warning:"), gettextf("%i models failed to converge.", s.fit[["add_info"]][["failed"]]))
   if (!is.null(fit[["add_info"]][["warnings"]])) {
     for (w in fit[["add_info"]][["warnings"]])
       overall_summary$addFootnote(symbol = gettext("Warning:"), w)
   }
+  if (options$measures == "OR")
+    overall_summary$addFootnote(symbol = gettext("Warning:"), gettext("Analyzing odds ratios is an experimental feature. The performance of default prior distributions was not evaluated."))
   
   main_summary[["overall_summary"]] <- overall_summary
   
   
   ### create model averaged results tables
   # estimate table
-  averaged_summary <-
-    createJaspTable(title = gettext("Model Averaged Estimates"))
+  averaged_summary <- createJaspTable(title = gettext("Model Averaged Estimates"))
   averaged_summary$position <- 2
-  averaged_summary <-
-    .RoBMA_table_fill_coef(averaged_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
+  averaged_summary <- .RoBMA_table_fill_coef(averaged_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
   main_summary[["averaged_summary"]] <- averaged_summary
   
   # weights table
   if (any(grepl("omega", rownames(s.fit[["averaged"]])))) {
-    averaged_weights <-
-      createJaspTable(title = gettextf("Model Averaged Weights (%s)", "\u03C9"))
+    averaged_weights <- createJaspTable(title = gettextf("Model Averaged Weights (%s)", "\u03C9"))
     averaged_weights$position <- 3
-    averaged_weights <-
-      .RoBMA_table_fill_weights(averaged_weights, s.fit[["averaged"]], s.fit[["add_info"]], options)
+    averaged_weights <- .RoBMA_table_fill_weights(averaged_weights, s.fit[["averaged"]], s.fit[["add_info"]], options)
     main_summary[["averaged_weights"]] <- averaged_weights
   }
-
+  
   # estimated studies table
   if (options[["results_theta"]]) {
-    studies_summary <-
-      createJaspTable(title = gettextf("Model Averaged Estimated Studies' Effects (%s)", "\u03B8"))
+    studies_summary <- createJaspTable(title = gettextf("Model Averaged Estimated Studies' Effects (%s)", "\u03B8"))
     studies_summary$position <- 4
-    studies_summary <-
-      .RoBMA_table_fill_studies(studies_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
+    studies_summary <- .RoBMA_table_fill_studies(studies_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
     main_summary[["studies_summary"]] <- studies_summary
   }
   
@@ -1281,48 +1100,28 @@ RobustBayesianMetaAnalysis <-
   ### create conditional models results tables
   if (options[["results_conditional"]]) {
     # estimate table
-    conditional_summary <-
-      createJaspTable(title = gettext("Conditional Estimates"))
+    conditional_summary <- createJaspTable(title = gettext("Conditional Estimates"))
     conditional_summary$position <- 5
-    conditional_summary <-
-      .RoBMA_table_fill_coef(conditional_summary,
-                             s.fit[["conditional"]],
-                             s.fit[["add_info"]],
-                             options)
-    conditional_summary$addFootnote(
-      gettext(
-        "Estimates are model averaged over models assuming existence of effect / heterogeneity."
-      )
-    )
+    conditional_summary <-.RoBMA_table_fill_coef(conditional_summary, s.fit[["conditional"]], s.fit[["add_info"]], options)
+    conditional_summary$addFootnote(gettext("Estimates are model averaged over models assuming existence of effect / heterogeneity."))
     main_summary[["conditional_summary"]] <- conditional_summary
     
     # weights table
     if (any(grepl("omega", rownames(s.fit[["conditional"]])))) {
-      conditional_weights <-
-        createJaspTable(title = gettextf("Conditional Weights (%s)", "\u03C9"))
+      conditional_weights <- createJaspTable(title = gettextf("Conditional Weights (%s)", "\u03C9"))
       conditional_weights$position <- 6
-      conditional_weights <-
-        .RoBMA_table_fill_weights(conditional_weights,
-                                  s.fit[["conditional"]],
-                                  s.fit[["add_info"]],
-                                  options)
+      conditional_weights <- .RoBMA_table_fill_weights(conditional_weights, s.fit[["conditional"]], s.fit[["add_info"]], options)
       conditional_weights$addFootnote(gettextf("Estimated weights (%s) are model averaged over models assuming existence of publication bias.", "\u03C9"))
       main_summary[["conditional_weights"]] <- conditional_weights
     }
     
     # add the estimated studies effects
     if (options[["results_theta"]]) {
-      conditional_studies_summary <-
-        createJaspTable(title = gettextf("Conditional Estimated Studies' Effects (%s)","\u03B8"))
+      conditional_studies_summary <- createJaspTable(title = gettextf("Conditional Estimated Studies' Effects (%s)","\u03B8"))
       conditional_studies_summary$position <- 7
-      conditional_studies_summary <-
-        .RoBMA_table_fill_studies(conditional_studies_summary,
-                                  s.fit[["conditional"]],
-                                  fit[["add_info"]],
-                                  options)
+      conditional_studies_summary <- .RoBMA_table_fill_studies(conditional_studies_summary,s.fit[["conditional"]],fit[["add_info"]], options)
       conditional_studies_summary$addFootnote(gettextf("Estimated studies effects (%s) are model averaged over models assuming existence of effect.", "\u03B8"))
-      main_summary[["conditional_studies_summary"]] <-
-        conditional_studies_summary
+      main_summary[["conditional_studies_summary"]] <- conditional_studies_summary
     }
     
   }
@@ -1344,26 +1143,21 @@ RobustBayesianMetaAnalysis <-
   
   # do ordering
   if (options[["results_models_order"]] == "marglik") {
-    s.fit[["overview"]] <-
-      s.fit[["overview"]][order(s.fit[["overview"]][["log(MargLik)"]], decreasing = TRUE),]
+    s.fit[["overview"]] <- s.fit[["overview"]][order(s.fit[["overview"]][["log(MargLik)"]], decreasing = TRUE),]
   } else if (options[["results_models_order"]] == "posterior") {
-    s.fit[["overview"]] <-
-      s.fit[["overview"]][order(s.fit[["overview"]][["Post. prob."]], decreasing = TRUE),]
+    s.fit[["overview"]] <- s.fit[["overview"]][order(s.fit[["overview"]][["Post. prob."]], decreasing = TRUE),]
   }
   
   # compute the BF requested
   if (options[["results_models_BF"]] == "inclusion") {
     bf <- s.fit[["overview"]][, 7]
   } else if (options[["results_models_BF"]] == "best") {
-    bf <-
-      exp(s.fit[["overview"]][["log(MargLik)"]]) / exp(max(s.fit[["overview"]][["log(MargLik)"]]))
+    bf <- exp(s.fit[["overview"]][["log(MargLik)"]]) / exp(max(s.fit[["overview"]][["log(MargLik)"]]))
   } else if (options[["results_models_BF"]] == "previous") {
-    temp_this <-
-      exp(s.fit[["overview"]][["log(MargLik)"]])[-length(s.fit[["overview"]][["log(MargLik)"]])]
+    temp_this <- exp(s.fit[["overview"]][["log(MargLik)"]])[-length(s.fit[["overview"]][["log(MargLik)"]])]
     temp_prev <- exp(s.fit[["overview"]][["log(MargLik)"]])[-1]
     bf <- c(1, temp_prev / temp_this)
   }
-  
   
   
   summary_dependencies <-
@@ -1378,70 +1172,43 @@ RobustBayesianMetaAnalysis <-
   
   
   ### create overview table
-  models_summary <-
-    createJaspTable(title = gettext("Models Overview"))
+  models_summary <- createJaspTable(title = gettext("Models Overview"))
   models_summary$position <- 6
   models_summary$dependOn(summary_dependencies)
   
   if (options[["results_models_BF"]] == "inclusion") {
     BF_title <- paste0(
-      ifelse(
-        options[["bayesFactorType"]] == "BF01",
-        gettext("Exclusion"),
-        gettext("Inclusion")
-      ),
+      ifelse(options[["bayesFactorType"]] == "BF01",    gettext("Exclusion"), gettext("Inclusion")),
       " ",
-      ifelse(
-        options[["bayesFactorType"]] == "LogBF10",
-        gettext("log(BF)"),
-        gettext("BF")
-      )
+      ifelse(options[["bayesFactorType"]] == "LogBF10", gettext("log(BF)"),   gettext("BF"))
     )
   } else{
-    if (options[["bayesFactorType"]] == "BF01") {
-      BF_title <- gettext("BF01")
-      bf       <- 1 / bf
-    } else if (options[["bayesFactorType"]] == "LogBF10") {
-      BF_title <- gettext("log(BF10)")
-      bf       <- log(bf)
-    } else{
-      BF_title <- gettext("BF10")
-    }
+    
+    BF_title <- switch(
+      options[["bayesFactorType"]],
+      "BF10"    = gettextf("BF%s",     "\u2081\u2080"),
+      "BF01"    = gettextf("BF%s",     "\u2080\u2081"),
+      "LogBF10" = gettextf("log(BF%s)","\u2081\u2080")
+    )
+    bf <- switch(
+      options[["bayesFactorType"]],
+      "BF10"    = bf,
+      "BF01"    = 1/bf,
+      "LogBF10" = log(bf)
+    )
+    
   }
   
-  models_summary$addColumnInfo(name = "number",
-                               title = "#",
-                               type = "integer")
-  models_summary$addColumnInfo(
-    name = "prior_mu",
-    title = gettext("Effect Size"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_summary$addColumnInfo(
-    name = "prior_tau",
-    title = gettext("Heterogeneity"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_summary$addColumnInfo(
-    name = "prior_omega",
-    title = gettext("Publication Bias"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_summary$addColumnInfo(name = "priorProb",
-                               title = gettext("P(M)"),
-                               type = "number")
-  models_summary$addColumnInfo(name = "postProb",
-                               title = gettext("P(M|data)"),
-                               type = "number")
-  models_summary$addColumnInfo(name = "marglik",
-                               title = gettext("log(MargLik)"),
-                               type = "number")
-  models_summary$addColumnInfo(name = "BF",
-                               title = BF_title,
-                               type = "number")
+  prior_overtitle <- gettext("Prior Distribution")
+  
+  models_summary$addColumnInfo(name = "number",      title = "#",type = "integer")
+  models_summary$addColumnInfo(name = "prior_mu",    title = gettext("Effect Size"),      type = "string",  overtitle = prior_overtitle)
+  models_summary$addColumnInfo(name = "prior_tau",   title = gettext("Heterogeneity"),    type = "string",  overtitle = prior_overtitle)
+  models_summary$addColumnInfo(name = "prior_omega", title = gettext("Publication Bias"), type = "string",  overtitle = prior_overtitle)
+  models_summary$addColumnInfo(name = "priorProb",   title = gettext("P(M)"),             type = "number")
+  models_summary$addColumnInfo(name = "postProb",    title = gettext("P(M|data)"),        type = "number")
+  models_summary$addColumnInfo(name = "marglik",     title = gettext("log(MargLik)"),     type = "number")
+  models_summary$addColumnInfo(name = "BF",          title = BF_title,                    type = "number")
   
   for (i in 1:nrow(s.fit[["overview"]])) {
     temp_row <- list(
@@ -1458,8 +1225,7 @@ RobustBayesianMetaAnalysis <-
     models_summary$addRows(temp_row)
   }
   
-  jaspResults[["main_summary"]][["models_summary"]] <-
-    models_summary
+  jaspResults[["main_summary"]][["models_summary"]] <-  models_summary
   
   return()
 }
@@ -1635,325 +1401,286 @@ RobustBayesianMetaAnalysis <-
   
   return()
 }
-.RoBMA_plots                <-
-  function(jaspResults, options, parameters) {
-    # create / access the container
-    if (is.null(jaspResults[["plots"]])) {
-      plots <- createJaspContainer(title = gettext("Plots"))
-      plots$position <- 6
-      jaspResults[["plots"]] <- plots
-    } else{
-      plots <- jaspResults[["plots"]]
+.RoBMA_plots                <- function(jaspResults, options, parameters) {
+  # create / access the container
+  if (is.null(jaspResults[["plots"]])) {
+    plots <- createJaspContainer(title = gettext("Plots"))
+    plots$position <- 6
+    jaspResults[["plots"]] <- plots
+  } else{
+    plots <- jaspResults[["plots"]]
+  }
+  
+  if (!is.null(plots[[paste(parameters, collapse = "")]])) {
+    return()
+  }
+  
+  # extract the model
+  fit    <- jaspResults[["model"]][["object"]]
+  temp_s <- summary(fit)
+  
+  # get overall settings
+  dependencies <- c(
+    .RoBMA_dependencies,
+    "plots_type",
+    "plots_priors",
+    if (any(parameters %in% "mu"))
+      "plots_mu",
+    if (any(parameters %in% "tau"))
+      "plots_tau",
+    if (any(parameters %in% "omega"))
+      c("plots_omega", "rescale_weightfunction", "plots_omega_function"),
+    if (any(parameters %in% "theta"))
+      c("plots_theta", "plots_theta_show", "plots_theta_order")
+  )
+  
+  if (all(parameters %in% "mu")) {
+    title    <- gettext("Effect size")
+    position <- 2
+  } else if (all(parameters %in% "tau")) {
+    title    <- gettext("Heterogeneity")
+    position <- 3
+  } else if (all(parameters %in% "omega")) {
+    title    <-
+      if (options[["plots_omega_function"]])
+        gettext("Weight function")
+    else
+      gettext("Weights")
+    position <- 5
+  } else if (all(parameters %in% "theta")) {
+    title    <- gettext("Forest plot")
+    position <- 1
+  } else if (all(parameters %in% c("mu", "tau"))) {
+    title    <- gettext("Effect size vs Heterogeneity")
+    position <- 4
+  }
+  title <- gettextf("%1$s (%2$s)", title, ifelse(options[["plots_type"]] == "conditional", gettext("Conditional"), gettext("Model Averaged")))
+  
+  if (all(parameters %in% "theta")) {
+    height <- 250 + ncol(fit[["RoBMA"]][["samples"]][["averaged"]][["theta"]]) * if (options[["plots_theta_show"]] == "both") 55 else  20
+    width  <- 350 + 9 * if (!is.null(fit[["add_info"]][["study_names"]])) max(nchar(fit[["add_info"]][["study_names"]])) else 10
+    if (options[["plots_theta_show"]] == "both") {
+      pars <- c("forest", "theta")
+    } else if (options[["plots_theta_show"]] == "observed") {
+      pars <- "forest"
+    } else if (options[["plots_theta_show"]] == "estimated") {
+      pars <- "theta"
     }
-    
-    if (!is.null(plots[[paste(parameters, collapse = "")]])) {
-      return()
-    }
-    
-    # extract the model
-    fit    <- jaspResults[["model"]][["object"]]
-    temp_s <- summary(fit)
-    
-    # get overall settings
-    dependencies <- c(
-      .RoBMA_dependencies,
-      "plots_type",
-      "plots_priors",
-      if (any(parameters %in% "mu"))
-        "plots_mu",
-      if (any(parameters %in% "tau"))
-        "plots_tau",
-      if (any(parameters %in% "omega"))
-        "plots_omega",
-      "plots_omega_function",
-      if (any(parameters %in% "theta"))
-        c("plots_theta", "plots_theta_show", "plots_theta_order")
-    )
-    
-    if (all(parameters %in% "mu")) {
-      title    <- gettext("Effect size")
-      position <- 2
-    } else if (all(parameters %in% "tau")) {
-      title    <- gettext("Heterogeneity")
-      position <- 3
-    } else if (all(parameters %in% "omega")) {
-      title    <-
-        if (options[["plots_omega_function"]])
-          gettext("Weight function")
-      else
-        gettext("Weights")
-      position <- 5
-    } else if (all(parameters %in% "theta")) {
-      title    <- gettext("Forest plot")
-      position <- 1
-    } else if (all(parameters %in% c("mu", "tau"))) {
-      title    <- gettext("Effect size vs Heterogeneity")
-      position <- 4
-    }
-    title <-
-      gettextf("%s (%s)", title, ifelse(options[["plots_type"]] == "conditional", gettext("Conditional"), gettext("Model Averaged")))
+  } else{
+    height <- 370
+    width  <- 500
+    pars   <- parameters
+  }
+  
+  
+  # plot
+  p <- tryCatch(
+    plot(
+      fit,
+      parameter = pars,
+      type      = options[["plots_type"]],
+      plot_type = "ggplot",
+      prior     = options[["plots_priors"]],
+      weights   = if (parameters == "omega") !options[["plots_omega_function"]] else  FALSE,
+      order     = if (parameters == "theta") {if (options[["plots_theta_order"]] == "labels") NULL else options[["plots_theta_order"]]},
+      rescale_x = if (parameters == "omega") options[["rescale_weightfunction"]] else  FALSE,
+    ),
+    error = function(e) e
+  )
+  
+  if (any(class(p) %in% "error")) {
+    temp_plot <- createJaspPlot(title = title, width = width, height = height)
+    temp_plot$position <- position
+    temp_plot$dependOn(dependencies)
+    temp_plot$setError(p[["message"]])
+    plots[[paste(parameters, collapse = "")]] <- temp_plot
+    return()
+  }
+  
+  if (ggplot2::is.ggplot(p)) {
+    temp_plot <- createJaspPlot(title = title, width = width, height = height)
+    temp_plot$position <- position
+    temp_plot$dependOn(dependencies)
+    plots[[paste(parameters, collapse = "")]] <- temp_plot
     
     if (all(parameters %in% "theta")) {
-      height <-
-        250 + ncol(fit[["RoBMA"]][["samples"]][["averaged"]][["theta"]]) * if (options[["plots_theta_show"]] == "both")
-          55
-      else
-        20
-      width  <-
-        350 + 9 * if (!is.null(fit[["add_info"]][["study_names"]]))
-          max(nchar(fit[["add_info"]][["study_names"]]))
-      else
-        10
-      if (options[["plots_theta_show"]] == "both") {
-        pars <- c("forest", "theta")
-      } else if (options[["plots_theta_show"]] == "observed") {
-        pars <- "forest"
-      } else if (options[["plots_theta_show"]] == "estimated") {
-        pars <- "theta"
-      }
+      p <- JASPgraphs::themeJasp(p, sides =  "b")
     } else{
-      height <- 370
-      width  <- 500
-      pars   <- parameters
+      if (!is.null(ggplot2::ggplot_build(p)[["layout"]][["panel_params"]][[1]][["y.sec.labels"]])) {
+        p <- JASPgraphs::themeJasp(p, sides =  "blr")
+      } else{
+        p <- JASPgraphs::themeJasp(p, sides =  "bl")
+      }
     }
     
+    # deal with JASPgraphs screwing secondary axis label distance
+    if(! (parameters == "theta" || (parameters == "omega" && options[["plots_omega_function"]]) ) ){
+      if(p$plot_env$any_density && p$plot_env$any_spikes){
+        p <- p + ggplot2::theme(
+          axis.title.y.right = ggplot2::element_text(vjust = 3),
+          plot.margin = ggplot2::margin(t = 3, r = 12, b = 0, l = 1))
+      }
+    }
     
-    # plot
+    plots[[paste(parameters, collapse = "")]][["plotObject"]] <- p
+    
+  } else{
+    temp_plots <- createJaspContainer(title = title)
+    temp_plots$position <- position
+    temp_plots$dependOn(dependencies)
+    plots[[paste(parameters, collapse = "")]] <- temp_plots
+    
+    for (i in 1:length(p)) {
+      temp_plot <- createJaspPlot(width = width, height = height)
+      temp_plots[[paste(parameters, "_", i, collapse = "")]] <- temp_plot
+      
+      if (all(parameters %in% "theta")) {
+        p[[i]] <- JASPgraphs::themeJasp(p[[i]], sides =  "b")
+      } else{
+        if (!is.null(ggplot2::ggplot_build(p[[i]])[["layout"]][["panel_params"]][[1]][["y.sec.labels"]])) {
+          p[[i]] <- JASPgraphs::themeJasp(p[[i]], sides =  "blr")
+        } else{
+          p[[i]] <- JASPgraphs::themeJasp(p[[i]], sides =  "bl")
+        }
+      }
+      
+      # deal with JASPgraphs screwing secondary axis label distance
+      if(p[[i]]$plot_env$any_density && p[[i]]$plot_env$any_spikes){
+        p[[i]] <- p[[i]] + ggplot2::theme(
+          axis.title.y.right = ggplot2::element_text(vjust = 3.25),
+          plot.margin = ggplot2::margin(t = 3, r = 12, b = 0, l = 1))
+      }
+      
+      temp_plots[[paste(parameters, "_", i, collapse = "")]][["plotObject"]] <- p[[i]]
+      
+    }
+  }
+  
+  
+  return()
+}
+.RoBMA_individual_plots     <- function(jaspResults, options, parameters) {
+  # create / access the container
+  if (is.null(jaspResults[["plots_individual"]])) {
+    plots_individual <- createJaspContainer(title = gettext("Individual Models Plots"))
+    plots_individual$position <- 7
+    jaspResults[["plots_individual"]] <- plots_individual
+  } else{
+    plots_individual <- jaspResults[["plots_individual"]]
+  }
+  
+  if (!is.null(plots_individual[[paste(parameters, collapse = "")]])) {
+    return()
+  }
+  
+  # extract the model
+  fit    <- jaspResults[["model"]][["object"]]
+  temp_s <- summary(fit)
+  
+  # get overall settings
+  dependencies <- c(
+    .RoBMA_dependencies,
+    "plots_type_individual_conditional",
+    "plots_type_individual_order",
+    "plots_type_individual_by",
+    if (any(parameters %in% "mu"))    "plots_individual_mu",
+    if (any(parameters %in% "tau"))   "plots_individual_tau",
+    if (any(parameters %in% "omega")) "plots_individual_omega"
+  )
+  
+  if (all(parameters == "mu")) {
+    title    <- gettext("Effect size")
+    position <- 1
+  } else if (parameters == "tau") {
+    title    <- gettext("Heterogeneity")
+    position <- 2
+  } else if (parameters == "omega") {
+    title    <- gettext("Weights")
+    position <- 3
+  }
+  title <- gettextf(
+    "%1$s (%2$s)",
+    title,
+    ifelse(options[["plots_type_individual_conditional"]], gettext("Conditional Models"), gettext("Models")))
+  
+  height <- 250 + 70 * if (options[["plots_type_individual_conditional"]]) {
+    temp_s[["overview"]][["Models"]][if (parameters == "mu") 1 else if (parameters == "tau") 2 else if (parameters == "omega") 3]
+  } else {
+    temp_s[["add_info"]][["n_models"]]
+  }
+  
+  width  <- 750
+  pars   <- parameters
+  
+  
+  # plot
+  if (pars == "omega" && sum(grepl(pars, rownames(temp_s[["averaged"]]))) > 2) {
+    temp_plots <- createJaspContainer(title = title)
+    temp_plots$position <- position
+    temp_plots$dependOn(dependencies)
+    plots_individual[[paste(parameters, collapse = "")]] <- temp_plots
+    
+    # nota that this creates a list of ggplot objects
     p <- tryCatch(
       plot(
         fit,
         parameter = pars,
-        type      = options[["plots_type"]],
+        type      = c("individual", if (options[["plots_type_individual_conditional"]]) "conditional"),
         plot_type = "ggplot",
-        prior     = options[["plots_priors"]],
-        weights   = if (parameters == "omega") {
-          if (options[["plots_omega_function"]])
-            FALSE
-          else
-            TRUE
-        } else
-          FALSE,
-        order     = if (parameters == "theta") {
-          if (options[["plots_theta_order"]] == "labels")
-            NULL
-          else
-            options[["plots_theta_order"]]
-        }
+        order     = c(options[["plots_type_individual_order"]], options[["plots_type_individual_by"]])
       ),
-      error = function(e)
-        e
+      error = function(e) e
     )
     
     if (any(class(p) %in% "error")) {
-      temp_plot <- createJaspPlot(title       = title,
-                                  width       = width,
-                                  height      = height)
+      temp_plot <- createJaspPlot(title = title, width = width, height = height)
       temp_plot$position <- position
       temp_plot$dependOn(dependencies)
       temp_plot$setError(p[["message"]])
-      plots[[paste(parameters, collapse = "")]] <- temp_plot
-      return()
-    }
-    
-    if (ggplot2::is.ggplot(p)) {
-      temp_plot <- createJaspPlot(title       = title,
-                                  width       = width,
-                                  height      = height)
-      temp_plot$position <- position
-      temp_plot$dependOn(dependencies)
-      plots[[paste(parameters, collapse = "")]] <- temp_plot
-      
-      if (all(parameters %in% "theta")) {
-        p <- JASPgraphs::themeJasp(p, sides =  "b")
-      } else{
-        if (!is.null(ggplot2::ggplot_build(p)[["layout"]][["panel_params"]][[1]][["y.sec.labels"]])) {
-          p <- JASPgraphs::themeJasp(p, sides =  "blr")
-        } else{
-          p <- JASPgraphs::themeJasp(p, sides =  "bl")
-        }
-      }
-      
-      plots[[paste(parameters, collapse = "")]][["plotObject"]] <- p
-      
-    } else{
-      temp_plots <- createJaspContainer(title = title)
-      temp_plots$position <- position
-      temp_plots$dependOn(dependencies)
-      plots[[paste(parameters, collapse = "")]] <- temp_plots
-      
-      for (i in 1:length(p)) {
-        temp_plot <- createJaspPlot(width       = width,
-                                    height      = height)
-        temp_plots[[paste(parameters, "_", i, collapse = "")]] <-
-          temp_plot
-        
-        if (all(parameters %in% "theta")) {
-          p[[i]] <- JASPgraphs::themeJasp(p[[i]], sides =  "b")
-        } else{
-          if (!is.null(ggplot2::ggplot_build(p[[i]])[["layout"]][["panel_params"]][[1]][["y.sec.labels"]])) {
-            p[[i]] <- JASPgraphs::themeJasp(p[[i]], sides =  "blr")
-          } else{
-            p[[i]] <- JASPgraphs::themeJasp(p[[i]], sides =  "bl")
-          }
-        }
-        
-        temp_plots[[paste(parameters, "_", i, collapse = "")]][["plotObject"]] <-
-          p[[i]]
-        
-      }
-    }
-    
-    
-    return()
-  }
-.RoBMA_individual_plots     <-
-  function(jaspResults, options, parameters) {
-    # create / access the container
-    if (is.null(jaspResults[["plots_individual"]])) {
-      plots_individual <-
-        createJaspContainer(title = gettext("Individual Models Plots"))
-      plots_individual$position <- 7
-      jaspResults[["plots_individual"]] <- plots_individual
-    } else{
-      plots_individual <- jaspResults[["plots_individual"]]
-    }
-    
-    if (!is.null(plots_individual[[paste(parameters, collapse = "")]])) {
-      return()
-    }
-    
-    # extract the model
-    fit    <- jaspResults[["model"]][["object"]]
-    temp_s <- summary(fit)
-    
-    # get overall settings
-    dependencies <- c(
-      .RoBMA_dependencies,
-      "plots_type_individual_conditional",
-      "plots_type_individual_order",
-      "plots_type_individual_by",
-      if (any(parameters %in% "mu"))
-        "plots_individual_mu",
-      if (any(parameters %in% "tau"))
-        "plots_individual_tau",
-      if (any(parameters %in% "omega"))
-        "plots_individual_omega"
-    )
-    
-    if (all(parameters == "mu")) {
-      title    <- gettext("Effect size")
-      position <- 1
-    } else if (parameters == "tau") {
-      title    <- gettext("Heterogeneity")
-      position <- 2
-    } else if (parameters == "omega") {
-      title    <- gettext("Weights")
-      position <- 3
-    }
-    title <-
-      gettextf("%s (%s)", title, ifelse(options[["plots_type_individual_conditional"]], gettext("Conditional Models"), gettext("Models")))
-    
-    height <-
-      250 + 70 * if (options[["plots_type_individual_conditional"]]) {
-        temp_s[["overview"]][["Models"]][if (parameters == "mu")
-          1
-          else if (parameters == "tau")
-            2
-          else if (parameters == "omega")
-            3]
-      } else
-        temp_s[["add_info"]][["n_models"]]
-    width  <- 750
-    pars   <- parameters
-    
-    
-    # plot
-    if (pars == "omega" &&
-        sum(grepl(pars, rownames(temp_s[["averaged"]]))) > 2) {
-      temp_plots <- createJaspContainer(title = title)
-      temp_plots$position <- position
-      temp_plots$dependOn(dependencies)
-      plots_individual[[paste(parameters, collapse = "")]] <-
-        temp_plots
-      
-      # nota that this creates a list of ggplot objects
-      p <- tryCatch(
-        plot(
-          fit,
-          parameter = pars,
-          type      = c("individual", if (options[["plots_type_individual_conditional"]])
-            "conditional"),
-          plot_type = "ggplot",
-          order     = c(
-            options[["plots_type_individual_order"]],
-            options[["plots_type_individual_by"]]
-          )
-        ),
-        error = function(e)
-          e
-      )
-      
-      if (any(class(p) %in% "error")) {
-        temp_plot <- createJaspPlot(title       = title,
-                                    width       = width,
-                                    height      = height)
-        temp_plot$position <- position
-        temp_plot$dependOn(dependencies)
-        temp_plot$setError(p[["message"]])
-        plots_individual[[paste(parameters, collapse = "")]] <-
-          temp_plot
-        return()
-      }
-      
-      for (i in 1:length(p)) {
-        temp_plot <- createJaspPlot(title       = "",
-                                    width       = width,
-                                    height      = height)
-        temp_plots[[paste0("plot_", i)]] <- temp_plot
-        
-        p[[i]] <- JASPgraphs::themeJasp(p[[i]], sides = "b")
-        
-        temp_plots[[paste0("plot_", i)]][["plotObject"]] <- p[[i]]
-      }
-      
-    } else{
-      temp_plot <- createJaspPlot(title       = title,
-                                  width       = width,
-                                  height      = height)
-      temp_plot$position <- position
-      temp_plot$dependOn(dependencies)
       plots_individual[[paste(parameters, collapse = "")]] <-
         temp_plot
-      
-      p <- tryCatch(
-        plot(
-          fit,
-          parameter = pars,
-          type      = c("individual", if (options[["plots_type_individual_conditional"]])
-            "conditional"),
-          plot_type = "ggplot",
-          order     = c(
-            options[["plots_type_individual_order"]],
-            options[["plots_type_individual_by"]]
-          )
-        ),
-        error = function(e)
-          e
-      )
-      
-      if (any(class(p) %in% "error")) {
-        temp_plot$setError(p[["message"]])
-        return()
-      }
-      
-      p <- JASPgraphs::themeJasp(p, sides = "b")
-      
-      plots_individual[[paste(parameters, collapse = "")]][["plotObject"]] <-
-        p
+      return()
     }
     
-    return()
+    for (i in 1:length(p)) {
+      temp_plot <- createJaspPlot(title = "", width = width, height = height)
+      temp_plots[[paste0("plot_", i)]] <- temp_plot
+      
+      p[[i]] <- JASPgraphs::themeJasp(p[[i]], sides = "b")
+      
+      temp_plots[[paste0("plot_", i)]][["plotObject"]] <- p[[i]]
+    }
+    
+  } else{
+    temp_plot <- createJaspPlot(title = title, width = width, height = height)
+    temp_plot$position <- position
+    temp_plot$dependOn(dependencies)
+    plots_individual[[paste(parameters, collapse = "")]] <- temp_plot
+    
+    p <- tryCatch(
+      plot(
+        fit,
+        parameter = pars,
+        type      = c("individual", if (options[["plots_type_individual_conditional"]]) "conditional"),
+        plot_type = "ggplot",
+        order     = c(options[["plots_type_individual_order"]], options[["plots_type_individual_by"]]
+        )
+      ),
+      error = function(e)e
+    )
+    
+    if (any(class(p) %in% "error")) {
+      temp_plot$setError(p[["message"]])
+      return()
+    }
+    
+    p <- JASPgraphs::themeJasp(p, sides = "b")
+    
+    plots_individual[[paste(parameters, collapse = "")]][["plotObject"]] <- p
   }
+  
+  return()
+}
 .RoBMA_diagnostics_overview <- function(jaspResults, options) {
   # create / access the container
   if (is.null(jaspResults[["diagnostics"]])) {
@@ -1995,37 +1722,15 @@ RobustBayesianMetaAnalysis <-
   models_diagnostics$position <- 1
   models_diagnostics$dependOn(diagnostics_dependencies)
   
-  
-  models_diagnostics$addColumnInfo(name = "number",
-                                   title = "#",
-                                   type = "integer")
-  models_diagnostics$addColumnInfo(
-    name = "prior_mu",
-    title = gettext("Effect Size"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_diagnostics$addColumnInfo(
-    name = "prior_tau",
-    title = gettext("Heterogeneity"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_diagnostics$addColumnInfo(
-    name = "prior_omega",
-    title = gettext("Publication Bias"),
-    type = "string",
-    overtitle = gettext("Prior Distribution")
-  )
-  models_diagnostics$addColumnInfo(name = "error",
-                                   title = gettext("max(MCMC error)"),
-                                   type = "number")
-  models_diagnostics$addColumnInfo(name = "ESS",
-                                   title = gettext("min(ESS)"),
-                                   type = "integer")
-  models_diagnostics$addColumnInfo(name = "Rhat",
-                                   title = gettext("max(Rhat)"),
-                                   type = "number")
+  prior_overtitle <- gettext("Prior Distribution")
+    
+  models_diagnostics$addColumnInfo(name = "number",      title = "#",                         type = "integer")
+  models_diagnostics$addColumnInfo(name = "prior_mu",    title = gettext("Effect Size"),      type = "string", overtitle = prior_overtitle)
+  models_diagnostics$addColumnInfo(name = "prior_tau",   title = gettext("Heterogeneity"),    type = "string", overtitle = prior_overtitle)
+  models_diagnostics$addColumnInfo(name = "prior_omega", title = gettext("Publication Bias"), type = "string", overtitle = prior_overtitle)
+  models_diagnostics$addColumnInfo(name = "error",       title = gettext("max(MCMC error)"),  type = "number")
+  models_diagnostics$addColumnInfo(name = "ESS",         title = gettext("min(ESS)"),         type = "integer")
+  models_diagnostics$addColumnInfo(name = "Rhat",        title = gettext("max(Rhat)"),        type = "number")
   
   for (i in 1:nrow(s.fit[["diagnostics"]])) {
     temp_row <- list(
@@ -2064,12 +1769,11 @@ RobustBayesianMetaAnalysis <-
   if (options[["diagnostics_single"]]) {
     models_i <- options[["diagnostics_single_model"]]
     if (models_i < 1 || models_i > length(fit[["models"]])) {
-      temp_model  <-
-        createJaspContainer(title = gettextf("Model %i", models_i))
+      temp_model  <- createJaspContainer(title = gettextf("Model %i", models_i))
       diagnostics[[paste0("model_", models_i)]] <- temp_model
       temp_error  <- createJaspPlot(title = "")
       temp_error$dependOn("diagnostics_single_model", "diagnostics_single")
-      temp_error$setError(gettextf("Model %i does not exist. Select one of the models between 1 and %i.", models_i, length(fit[["models"]])))
+      temp_error$setError(gettextf("Model %1$i does not exist. Select one of the models between 1 and %2$i.", models_i, length(fit[["models"]])))
       temp_model[["temp_error"]] <- temp_error
       return()
     }
@@ -2091,8 +1795,7 @@ RobustBayesianMetaAnalysis <-
   for (i in models_i) {
     # create / access container for individual models
     if (is.null(diagnostics[[paste0("model_", i)]])) {
-      temp_model <-
-        createJaspContainer(title = gettextf("Model %i", i))
+      temp_model <- createJaspContainer(title = gettextf("Model %i", i))
       temp_model$position <- i
       temp_model$dependOn(c("diagnostics_single_model", "diagnostics_single"))
       diagnostics[[paste0("model_", i)]] <- temp_model
@@ -2100,32 +1803,25 @@ RobustBayesianMetaAnalysis <-
       temp_model <- diagnostics[[paste0("model_", i)]]
     }
     
-    no_pars <-
-      TRUE # tracker for checking whether any parameter was plotted
+    no_pars <- TRUE # tracker for checking whether any parameter was plotted
     
     for (par in parameters) {
       # create / access container for individual parameters
       if (is.null(temp_model[[par]])) {
-        temp_par <-
-          createJaspContainer(
-            title = if (par == "mu")
-              gettext("Effect")
-            else if (par == "tau")
-              gettext("Heterogeneity")
-            else if (par == "omega")
-              gettext("Weights")
-            else if (par == "theta")
-              gettext("Random effects")
-          )
-        temp_par$position <-
-          if (par == "mu")
-            1
-        else if (par == "tau")
-          2
-        else if (par == "omega")
-          3
-        else if (par == "theta")
-          4
+        temp_par <- createJaspContainer(title = switch(
+          par,
+          "mu"    = gettext("Effect"),
+          "tau"   = gettext("Heterogeneity"),
+          "omega" = gettext("Weights"),
+          "theta" = gettext("Random effects")
+        ))
+        temp_par$position <- switch(
+          par,
+          "mu"    = 1,
+          "tau"   = 2,
+          "omega" = 3,
+          "theta" = 4
+        )
         temp_par$dependOn(
           c(
             if (par == "mu")
@@ -2193,8 +1889,7 @@ RobustBayesianMetaAnalysis <-
       if (options[["diagnostics_autocorrelation"]]) {
         # create / access container for trace plots
         if (is.null(temp_par[["autocor"]])) {
-          temp_plots <-
-            createJaspContainer(gettext("Average autocorrelations"))
+          temp_plots <- createJaspContainer(gettext("Average autocorrelations"))
           temp_plots$position <- 2
           temp_plots$dependOn("diagnostics_autocorrelation")
           temp_par[["autocor"]] <- temp_plots
@@ -2239,8 +1934,7 @@ RobustBayesianMetaAnalysis <-
       if (options[["diagnostics_samples"]]) {
         # create / access container for trace plots
         if (is.null(temp_par[["samples"]])) {
-          temp_plots <-
-            createJaspContainer(gettext("Posterior samples densities"))
+          temp_plots <- createJaspContainer(gettext("Posterior samples densities"))
           temp_plots$position <- 3
           temp_plots$dependOn("diagnostics_samples")
           temp_par[["samples"]] <- temp_plots

--- a/JASP-Engine/JASP/R/robustbayesianmetaanalysis.R
+++ b/JASP-Engine/JASP/R/robustbayesianmetaanalysis.R
@@ -19,92 +19,92 @@
 RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NULL) {
 
   # clean fitted model if it was changed
-  if(!.RoBMA_ready(options))
-    .RoBMA_clean_model(jaspResults)
+  if(!.RoBMAready(options))
+    .RoBMAcleanModel(jaspResults)
  
   # load data
-  if (.RoBMA_ready(options))
-    dataset <- .RoBMA_data_get(options, dataset)
+  if (.RoBMAready(options))
+    dataset <- .RoBMAdataGet(options, dataset)
   
   # get the priors
-  .RoBMA_priors_get(jaspResults, options)
+  .RoBMApriorsGet(jaspResults, options)
   
   # show the model preview
   if (is.null(jaspResults[["model"]]))
-    .RoBMA_model_preview(jaspResults, options)
+    .RoBMAmodelPreview(jaspResults, options)
 
   # fit model model
-  if (is.null(jaspResults[["model_notifier"]]) && .RoBMA_ready(options))
-    .RoBMA_fit_model(jaspResults, dataset, options)
+  if (is.null(jaspResults[["model_notifier"]]) && .RoBMAready(options))
+    .RoBMAfitModel(jaspResults, dataset, options)
   
   ### Priors plot
   if (options[["priors_plot"]])
-    .RoBMA_priors_plots(jaspResults, options)
+    .RoBMApriorsPlots(jaspResults, options)
   
   ### Inference, Plots, and Diagnostics are accessible only if a model is fitted
   if (!is.null(jaspResults[["model"]])) {
     ### Inference
     # defaul summary
-    .RoBMA_summary(jaspResults, options)
+    .RoBMAsummary(jaspResults, options)
     # models overview
     if (options[["results_models"]])
-      .RoBMA_models_overview(jaspResults, options)
+      .RoBMAmodelsOverview(jaspResults, options)
     # models summary
     if (options[["results_individual"]])
-      .RoBMA_models_summary(jaspResults, options)
+      .RoBMAmodelsSummary(jaspResults, options)
 
     ### Plots
     # pooled estimates plots
     if (options[["plots_theta"]])
-      .RoBMA_plots(jaspResults, options, "theta")
+      .RoBMAplots(jaspResults, options, "theta")
     if (options[["plots_mu"]])
-      .RoBMA_plots(jaspResults, options, "mu")
+      .RoBMAplots(jaspResults, options, "mu")
     if (options[["plots_tau"]])
-      .RoBMA_plots(jaspResults, options, "tau")
-    if (options[["plots_tau"]] &&
-        options[["plots_mu"]] &&
+      .RoBMAplots(jaspResults, options, "tau")
+    if (options[["plots_tau"]]                &&
+        options[["plots_mu"]]                 &&
         options[["plots_type"]] == "averaged" &&
         !options[["plots_priors"]])
-      .RoBMA_plots(jaspResults, options, c("mu", "tau"))
+      .RoBMAplots(jaspResults, options, c("mu", "tau"))
     if (options[["plots_omega"]])
-      .RoBMA_plots(jaspResults, options, "omega")
+      .RoBMAplots(jaspResults, options, "omega")
     
     # individual models
     if (options[["plots_individual_mu"]])
-      .RoBMA_individual_plots(jaspResults, options, "mu")
+      .RoBMAindividualPlots(jaspResults, options, "mu")
     if (options[["plots_individual_tau"]])
-      .RoBMA_individual_plots(jaspResults, options, "tau")
+      .RoBMAindividualPlots(jaspResults, options, "tau")
     if (options[["plots_individual_omega"]])
-      .RoBMA_individual_plots(jaspResults, options, "omega")
+      .RoBMAindividualPlots(jaspResults, options, "omega")
     
     ### Diagnostics
     # overview
     if (options[["diagnostics_overview"]])
-      .RoBMA_diagnostics_overview(jaspResults, options)
+      .RoBMAdiagnosticsOverview(jaspResults, options)
     # plots
     if ((
-      options[["diagnostics_mu"]] ||
-      options[["diagnostics_tau"]] ||
+      options[["diagnostics_mu"]]    ||
+      options[["diagnostics_tau"]]   ||
       options[["diagnostics_omega"]] ||
       options[["diagnostics_theta"]]
     ) &&
     (
-      options[["diagnostics_trace"]] ||
+      options[["diagnostics_trace"]]           ||
       options[["diagnostics_autocorrelation"]] ||
       options[["diagnostics_samples"]]
     ))
-      .RoBMA_diagnostics_plots(jaspResults, options)
+      .RoBMAdiagnosticsPlots(jaspResults, options)
     
     ### Save the model
     if (options[["save_path"]] != "" &&
         is.null(jaspResults[["model_saved"]]))
-      .RoBMA_save_model(jaspResults, options)
+      .RoBMAsaveModel(jaspResults, options)
   }
   
   return()
 }
 
-.RoBMA_dependencies <- c(
+.RoBMAdependencies <- c(
   "measures",
   "fitted_path",
   "cohensd_testType",
@@ -147,8 +147,8 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   "advanced_mu_transform"
 )
 # priors related functions
-.RoBMA_options2priors       <- function(options_prior) {
-  options_prior <- .RoBMA_options2priors_eval(options_prior)
+.RoBMAoptions2priors      <- function(options_prior) {
+  options_prior <- .RoBMAoptions2priorsEval(options_prior)
   
   if (options_prior[["type"]] == "normal") {
     return(
@@ -298,7 +298,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     )
   }
 }
-.RoBMA_options2priors_clean <- function(x) {
+.RoBMAoptions2priorsClean <- function(x) {
   
   x <- trimws(x, which = "both")
   x <- trimws(x, which = "both", whitespace = "c")
@@ -315,15 +315,15 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     JASP:::.quitAnalysis(gettext("The priors for publication bias were set incorrectly."))
   return(as.numeric(x))
 }
-.RoBMA_options2priors_eval  <- function(x) {
+.RoBMAoptions2priorsEval  <- function(x) {
   if (x[["type"]] %in% c("Two-sided", "One-sided (mon.)", "One-sided")) {
     x[["priorOdds"]] <- eval(parse(text = x[["priorOdds"]]))
-    x[["parAlpha"]]  <- .RoBMA_options2priors_clean(x[["parAlpha"]])
+    x[["parAlpha"]]  <- .RoBMAoptions2priorsClean(x[["parAlpha"]])
     x[["parAlpha1"]] <-
-      .RoBMA_options2priors_clean(x[["parAlpha1"]])
+      .RoBMAoptions2priorsClean(x[["parAlpha1"]])
     x[["parAlpha2"]] <-
-      .RoBMA_options2priors_clean(x[["parAlpha2"]])
-    x[["parCuts"]]   <- .RoBMA_options2priors_clean(x[["parCuts"]])
+      .RoBMAoptions2priorsClean(x[["parAlpha2"]])
+    x[["parCuts"]]   <- .RoBMAoptions2priorsClean(x[["parCuts"]])
     
   } else if (x[["type"]] == "spike" &&
              any(names(x) %in% c("parAlpha2"))) {
@@ -359,7 +359,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   return(x)
 }
 # table filling functions
-.RoBMA_table_fill_coef      <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+.RoBMAtableFillCoef       <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
   
   CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
   # add columns
@@ -382,7 +382,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   # fill rows
   for (i in c(1:nrow(results_table))[rownames(results_table) %in% c("mu", "tau")]) {
     temp_row <- list(
-      terms    = .RoBMA_coef_names(rownames(results_table)[i], add_info),
+      terms    = .RoBMAcoefNames(rownames(results_table)[i], add_info),
       mean     = results_table[i, "Mean"],
       median   = results_table[i, "Median"],
       lowerCI  = results_table[i, if(individual) ".025" else as.character(.5 - options[["results_CI"]] / 2)],
@@ -417,7 +417,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return(jasp_table)
 }
-.RoBMA_table_fill_weights   <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+.RoBMAtableFillWeights    <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
   
   p_overtitle  <- gettextf("<em>p</em>-values interval %s","\u002A")
   CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
@@ -476,7 +476,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return(jasp_table)
 }
-.RoBMA_table_fill_studies   <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
+.RoBMAtableFillStudies    <- function(jasp_table, results_table, add_info, options, individual = FALSE) {
   
   CI_overtitle <- gettextf("%s%% CI", 100 * options[["results_CI"]])
   # add columns
@@ -523,22 +523,22 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
       gettextf(
         "Estimated studies' effects (%1$s) correspond to effect size %2$s.",
         "\u03B8",
-        .RoBMA_coef_letters(add_info[["effect_size"]])
+        .RoBMAcoefLetters(add_info[["effect_size"]])
     ))
   }
   
   return(jasp_table)
 }
-.RoBMA_coef_names           <- function(name, add_info) {
+.RoBMAcoefNames           <- function(name, add_info) {
   if (name == "mu")
     return(gettextf(
       "Effect size (%s)",
-      ifelse(add_info[["effect_size"]] %in% c("r", "d", "OR"), .RoBMA_coef_letters(add_info[["effect_size"]]), "\u03BC")
+      ifelse(add_info[["effect_size"]] %in% c("r", "d", "OR"), .RoBMAcoefLetters(add_info[["effect_size"]]), "\u03BC")
     ))
   if (name == "tau")
     return(gettextf("Heterogeneity (%s)","\u03C4"))
 }
-.RoBMA_coef_letters         <- function(effect_size){
+.RoBMAcoefLetters         <- function(effect_size){
   switch(
     effect_size,
     "r"   = "\u03C1",
@@ -547,7 +547,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   )
 }
 # main functions
-.RoBMA_ready                <- function(options) {
+.RoBMAready               <- function(options) {
   
   if (options[["measures"]] == "fitted") {
     return(options[["fitted_path"]] != "")
@@ -586,7 +586,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   return(ready_arg1 && ready_arg2)
   
 }
-.RoBMA_model_notifier       <- function(jaspResults) {
+.RoBMAmodelNotifier       <- function(jaspResults) {
   # We don't wanna delete the RoBMA modele every time settings is change since RoBMA takes a lot of time to fit.
   # Therefore, we don't create dependencies on the fitted model (in cases when the model can be updated), but 
   # on a notifier that tells us when there was the change. If possible, we don't refit the whole model, 
@@ -594,14 +594,14 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   if (is.null(jaspResults[["model_notifier"]])) {
     model_notifier <- createJaspState()
-    model_notifier$dependOn(.RoBMA_dependencies)
+    model_notifier$dependOn(.RoBMAdependencies)
     jaspResults[["model_notifier"]] <- model_notifier
   }
   
   return()
   
 }
-.RoBMA_clean_model          <- function(jaspResults) {
+.RoBMAcleanModel          <- function(jaspResults) {
   
   if(!is.null(jaspResults[["model"]])){
     jaspResults[["model"]] <- NULL
@@ -609,7 +609,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_data_get             <- function(options, dataset) {
+.RoBMAdataGet             <- function(options, dataset) {
   if (options[["measures"]] == "fitted") {
     return(NULL)
   } else{
@@ -638,12 +638,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return(dataset)
 }
-.RoBMA_priors_get           <- function(jaspResults, options) {
+.RoBMApriorsGet           <- function(jaspResults, options) {
   if (!is.null(jaspResults[["priors"]])) {
     return()
   } else{
     priors <- createJaspState()
-    priors$dependOn(.RoBMA_dependencies)
+    priors$dependOn(.RoBMAdependencies)
     jaspResults[["priors"]] <- priors
   }
   
@@ -654,7 +654,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   for (i in seq_along(prior_elements)) {
     tmp <- NULL
     for (elem in options[[prior_elements[i]]]) {
-      tmp_prior <- tryCatch(.RoBMA_options2priors(elem), error = function(e)e)
+      tmp_prior <- tryCatch(.RoBMAoptions2priors(elem), error = function(e)e)
       if(class(tmp_prior) %in% c("simpleError", "error")){
         JASP:::.quitAnalysis(tmp_prior$message)
       }
@@ -668,7 +668,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_priors_plots         <- function(jaspResults, options) {
+.RoBMApriorsPlots         <- function(jaspResults, options) {
   # create / access the container
   if (!is.null(jaspResults[["prior_plots"]])) {
     return()
@@ -763,13 +763,13 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_model_preview        <- function(jaspResults, options) {
+.RoBMAmodelPreview        <- function(jaspResults, options) {
   # create / access the container
   if (!is.null(jaspResults[["prior_plots"]])) {
     return()
   } else{
     model_preview <- createJaspContainer(title = gettext("Model Preview"))
-    model_preview$dependOn(.RoBMA_dependencies)
+    model_preview$dependOn(.RoBMAdependencies)
     model_preview$position <- 1
     jaspResults[["model_preview"]] <- model_preview
   }
@@ -858,7 +858,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_fit_model            <- function(jaspResults, dataset, options) {
+.RoBMAfitModel            <- function(jaspResults, dataset, options) {
   
   if (is.null(jaspResults[["model"]])) {
     model <- createJaspState()
@@ -980,11 +980,11 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # update the fit and reset notifier
   model[["object"]] <- fit
-  .RoBMA_model_notifier(jaspResults)
+  .RoBMAmodelNotifier(jaspResults)
   
   return()
 }
-.RoBMA_summary              <- function(jaspResults, options) {
+.RoBMAsummary             <- function(jaspResults, options) {
   if (!is.null(jaspResults[["main_summary"]])) {
     return()
   } else{
@@ -993,7 +993,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     main_summary$position <- 3
     summary_dependencies <-
       c(
-        .RoBMA_dependencies,
+        .RoBMAdependencies,
         "bayesFactorType",
         "results_CI",
         "results_conditional",
@@ -1077,14 +1077,14 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   # estimate table
   averaged_summary <- createJaspTable(title = gettext("Model Averaged Estimates"))
   averaged_summary$position <- 2
-  averaged_summary <- .RoBMA_table_fill_coef(averaged_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
+  averaged_summary <- .RoBMAtableFillCoef(averaged_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
   main_summary[["averaged_summary"]] <- averaged_summary
   
   # weights table
   if (any(grepl("omega", rownames(s.fit[["averaged"]])))) {
     averaged_weights <- createJaspTable(title = gettextf("Model Averaged Weights (%s)", "\u03C9"))
     averaged_weights$position <- 3
-    averaged_weights <- .RoBMA_table_fill_weights(averaged_weights, s.fit[["averaged"]], s.fit[["add_info"]], options)
+    averaged_weights <- .RoBMAtableFillWeights(averaged_weights, s.fit[["averaged"]], s.fit[["add_info"]], options)
     main_summary[["averaged_weights"]] <- averaged_weights
   }
   
@@ -1092,7 +1092,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   if (options[["results_theta"]]) {
     studies_summary <- createJaspTable(title = gettextf("Model Averaged Estimated Studies' Effects (%s)", "\u03B8"))
     studies_summary$position <- 4
-    studies_summary <- .RoBMA_table_fill_studies(studies_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
+    studies_summary <- .RoBMAtableFillStudies(studies_summary, s.fit[["averaged"]], s.fit[["add_info"]], options)
     main_summary[["studies_summary"]] <- studies_summary
   }
   
@@ -1102,7 +1102,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     # estimate table
     conditional_summary <- createJaspTable(title = gettext("Conditional Estimates"))
     conditional_summary$position <- 5
-    conditional_summary <-.RoBMA_table_fill_coef(conditional_summary, s.fit[["conditional"]], s.fit[["add_info"]], options)
+    conditional_summary <-.RoBMAtableFillCoef(conditional_summary, s.fit[["conditional"]], s.fit[["add_info"]], options)
     conditional_summary$addFootnote(gettext("Estimates are model averaged over models assuming existence of effect / heterogeneity."))
     main_summary[["conditional_summary"]] <- conditional_summary
     
@@ -1110,7 +1110,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     if (any(grepl("omega", rownames(s.fit[["conditional"]])))) {
       conditional_weights <- createJaspTable(title = gettextf("Conditional Weights (%s)", "\u03C9"))
       conditional_weights$position <- 6
-      conditional_weights <- .RoBMA_table_fill_weights(conditional_weights, s.fit[["conditional"]], s.fit[["add_info"]], options)
+      conditional_weights <- .RoBMAtableFillWeights(conditional_weights, s.fit[["conditional"]], s.fit[["add_info"]], options)
       conditional_weights$addFootnote(gettextf("Estimated weights (%s) are model averaged over models assuming existence of publication bias.", "\u03C9"))
       main_summary[["conditional_weights"]] <- conditional_weights
     }
@@ -1119,7 +1119,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     if (options[["results_theta"]]) {
       conditional_studies_summary <- createJaspTable(title = gettextf("Conditional Estimated Studies' Effects (%s)","\u03B8"))
       conditional_studies_summary$position <- 7
-      conditional_studies_summary <- .RoBMA_table_fill_studies(conditional_studies_summary,s.fit[["conditional"]],fit[["add_info"]], options)
+      conditional_studies_summary <- .RoBMAtableFillStudies(conditional_studies_summary,s.fit[["conditional"]],fit[["add_info"]], options)
       conditional_studies_summary$addFootnote(gettextf("Estimated studies effects (%s) are model averaged over models assuming existence of effect.", "\u03B8"))
       main_summary[["conditional_studies_summary"]] <- conditional_studies_summary
     }
@@ -1128,7 +1128,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_models_overview      <- function(jaspResults, options) {
+.RoBMAmodelsOverview      <- function(jaspResults, options) {
   # extract the model
   fit   <- jaspResults[["model"]][["object"]]
   
@@ -1162,7 +1162,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   summary_dependencies <-
     c(
-      .RoBMA_dependencies,
+      .RoBMAdependencies,
       "bayesFactorType",
       "results_CI",
       "results_models",
@@ -1229,7 +1229,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_models_summary       <- function(jaspResults, options) {
+.RoBMAmodelsSummary       <- function(jaspResults, options) {
   if (!is.null(jaspResults[["individual_models"]])) {
     return()
   } else{
@@ -1238,7 +1238,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     individual_models$position <- 5
     summary_dependencies <-
       c(
-        .RoBMA_dependencies,
+        .RoBMAdependencies,
         "bayesFactorType",
         "results_individual",
         "results_theta",
@@ -1356,7 +1356,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
     # estimate table
     temp_coef <- createJaspTable(title = gettext("Model Estimates"))
     temp_coef <-
-      .RoBMA_table_fill_coef(temp_coef,
+      .RoBMAtableFillCoef(temp_coef,
                              s.fit[["overview"]][[i]][["tab"]],
                              s.fit[["overview"]][[i]][["add_info"]],
                              options,
@@ -1370,7 +1370,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
         temp_weights <-
           createJaspTable(title = gettextf("Estimated Weights (%s)", "\u03C9"))
         temp_weights <-
-          .RoBMA_table_fill_weights(
+          .RoBMAtableFillWeights(
             temp_weights,
             s.fit[["overview"]][[i]][["tab"]],
             s.fit[["overview"]][[i]][["add_info"]],
@@ -1385,7 +1385,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
         temp_studies <-
           createJaspTable(title = gettextf("Estimated Studies' Effects (%s)", "\u03B8"))
         temp_studies <-
-          .RoBMA_table_fill_studies(
+          .RoBMAtableFillStudies(
             temp_studies,
             s.fit[["overview"]][[i]][["tab"]],
             s.fit[["overview"]][[i]][["add_info"]],
@@ -1401,7 +1401,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_plots                <- function(jaspResults, options, parameters) {
+.RoBMAplots               <- function(jaspResults, options, parameters) {
   # create / access the container
   if (is.null(jaspResults[["plots"]])) {
     plots <- createJaspContainer(title = gettext("Plots"))
@@ -1421,7 +1421,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # get overall settings
   dependencies <- c(
-    .RoBMA_dependencies,
+    .RoBMAdependencies,
     "plots_type",
     "plots_priors",
     if (any(parameters %in% "mu"))
@@ -1559,7 +1559,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_individual_plots     <- function(jaspResults, options, parameters) {
+.RoBMAindividualPlots     <- function(jaspResults, options, parameters) {
   # create / access the container
   if (is.null(jaspResults[["plots_individual"]])) {
     plots_individual <- createJaspContainer(title = gettext("Individual Models Plots"))
@@ -1579,7 +1579,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # get overall settings
   dependencies <- c(
-    .RoBMA_dependencies,
+    .RoBMAdependencies,
     "plots_type_individual_conditional",
     "plots_type_individual_order",
     "plots_type_individual_by",
@@ -1681,12 +1681,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_diagnostics_overview <- function(jaspResults, options) {
+.RoBMAdiagnosticsOverview <- function(jaspResults, options) {
   # create / access the container
   if (is.null(jaspResults[["diagnostics"]])) {
     diagnostics <- createJaspContainer(title = gettext("Diagnostics"))
     diagnostics$position <- 8
-    diagnostics$dependOn(.RoBMA_dependencies)
+    diagnostics$dependOn(.RoBMAdependencies)
     jaspResults[["diagnostics"]] <- diagnostics
   } else{
     diagnostics <- jaspResults[["diagnostics"]]
@@ -1711,7 +1711,7 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   # do ordering
   diagnostics_dependencies <-
-    c(.RoBMA_dependencies,
+    c(.RoBMAdependencies,
       "diagnostics_overview",
       "diagnostics_overview_theta")
   
@@ -1750,12 +1750,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_diagnostics_plots    <- function(jaspResults, options) {
+.RoBMAdiagnosticsPlots    <- function(jaspResults, options) {
   # create / access the container
   if (is.null(jaspResults[["diagnostics"]])) {
     diagnostics <- createJaspContainer(title = gettext("Diagnostics"))
     diagnostics$position <- 8
-    diagnostics$dependOn(.RoBMA_dependencies)
+    diagnostics$dependOn(.RoBMAdependencies)
     jaspResults[["diagnostics"]] <- diagnostics
   } else{
     diagnostics <- jaspResults[["diagnostics"]]
@@ -1998,10 +1998,10 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
   
   return()
 }
-.RoBMA_save_model           <- function(jaspResults, options) {
+.RoBMAsaveModel           <- function(jaspResults, options) {
   if (is.null(jaspResults[["model_saved"]])) {
     model_saved <- createJaspState()
-    model_saved$dependOn(c(.RoBMA_dependencies, "save_path"))
+    model_saved$dependOn(c(.RoBMAdependencies, "save_path"))
     jaspResults[["model_saved"]] <- model_saved
     
   }

--- a/Resources/Help/analyses/robustbayesianmetaanalysis.md
+++ b/Resources/Help/analyses/robustbayesianmetaanalysis.md
@@ -7,7 +7,8 @@ The robust Bayesian meta-analysis allows the user to specify a wide range of met
 ---
 #### Input type
 - Cohen's d / t-statistics & (N / SE): Specifying input using either Cohen's d effect sizes and the sample size or standard errors, or reported t-statistics and sample sizes.
-- Correlations & (N / SE): Specifying input using correlations and the sample size. Note that the effect size is internally transformed to Cohen's d scale for model estimation (see Advanced tab for additional options). The prior distributions are specified on the transformed scale, with the provided visualization transforming the priors back to the correlation scale. The output for the mean parameter is transformed back for easier interpretability, however, the heterogeneity parameter is always summarized on the transformed scale.
+- Correlations & N: Specifying input using correlations and the sample size. Note that the effect size is internally transformed to Cohen's d scale for model estimation (see Advanced tab for additional options). The prior distributions are specified on the transformed scale, with the provided visualization transforming the priors back to the correlation scale. The output for the mean parameter is transformed back for easier interpretability, however, the heterogeneity parameter is always summarized on the transformed scale.
+- Odds ratios & CI: Specifying input using odds rations and their confidence intervals. Note that the effect size is internally transformed to log odds ratios for model estimation (see Advanced tab for additional options). The prior distributions are specified on the transformed scale, with the provided visualization transforming the priors back to the correlation scale. Analysing odds ratios is an experimental features and the default prior distribution were not verified to work with them. The output for the mean parameter is transformed back for easier interpretability, however, the heterogeneity parameter is always summarized on the transformed scale.
 - Effect sizes & SE: Specifying input using any other types of effect sizes and standard errors. Note that effect sizes supplied in this way will result in approximating the corresponding test statistics distribution using a normal distribution.
 - Fitted model: Specify a path to already fitted RoBMA model using R. The model must be saved as an RDS file.
 
@@ -111,6 +112,7 @@ Display the estimated effects of individual studies. These correspond to the 'ra
 - Heterogeneity: Display a plot with the estimated heterogeneity parameter tau.
 - Weights: Display a plot with the estimated weights corresponding to the p-values cut-offs.
   - Weight function: Combine the weights into a weight function and display that instead.
+    - Rescale x-axis: Make the differences between the individual ticks on x-axis equal for easier interpretability. 
 
 #### Type
 - Model averaged: Pooled estimates will contain model averaged estimates across all models.

--- a/Resources/Meta Analysis/qml/RobustBayesianMetaAnalysis.qml
+++ b/Resources/Meta Analysis/qml/RobustBayesianMetaAnalysis.qml
@@ -28,6 +28,16 @@ Form
 		name:					"measures"
 		radioButtonsOnSameRow:	true
 		columns:				2
+		onValueChanged:	if(measures_correlation.checked) {
+			advanced_mu_transform.value				= "cohens_d"
+			// TODO: make this work >>
+			advanced_mu_transform_log_OR.enabled	= true
+			advanced_mu_transform_fishers_z.enabled	= false
+		} else if (measures_OR.checked){
+			advanced_mu_transform.value				= "log_OR"
+			advanced_mu_transform_log_OR.enabled	= false
+			advanced_mu_transform_fishers_z.enabled	= true
+		}
 
 		RadioButton
 		{
@@ -36,11 +46,19 @@ Form
 			id: 	measures_cohensd
 			checked:true
 		}
+
 		RadioButton
 		{
-			label: qsTr("Correlations & (N / SE)")
+			label: qsTr("Correlations & N")
 			value: "correlation"
 			id: 	measures_correlation
+		}
+
+		RadioButton
+		{
+			label: qsTr("Odds ratios & CI")
+			value: "OR"
+			id: 	measures_OR
 		}
 
 		RadioButton
@@ -116,7 +134,7 @@ Form
 			title: 			qsTr("95% CI Lower and Upper Bound")
 			singleVariable: true
 			allowedColumns: ["scale"]
-			visible:		measures_cohensd.checked || measures_general.checked
+			visible:		measures_cohensd.checked || measures_general.checked || measures_OR.checked
 			onVisibleChanged: if (!visible && count > 0) itemDoubleClicked(0);
 		}
 
@@ -190,8 +208,27 @@ Form
 	//// Priors ////
 	Section
 	{
-		title: 			qsTr("Priors")
+		title: 			qsTr("Models")
 		columns:		1
+
+		RadioButtonGroup
+		{
+			name:		"effect_direction"
+			title:		qsTr("Expected effect size direction")
+
+			RadioButton
+			{
+				value:		"positive"
+				label:		qsTr("Positive")
+				checked: 	true
+			}
+
+			RadioButton
+			{
+				value:		"negative"
+				label:		qsTr("Negative")
+			}
+		}
 
 		CheckBox
 		{
@@ -1568,6 +1605,12 @@ Form
 					label:	qsTr("Weight function")
 					name:	"plots_omega_function"
 					checked:true
+
+					CheckBox
+					{
+						name:	"rescale_weightfunction"
+						text:	qsTr("Rescale x-axis")
+					}
 				}
 			}
 		}
@@ -1584,7 +1627,7 @@ Form
 				RadioButton
 				{
 					value:	"averaged"
-					label:	qsTr("Model-averaged")
+					label:	qsTr("Model averaged")
 					checked:true
 				}
 				RadioButton
@@ -1809,13 +1852,15 @@ Form
 		DropDown
 		{
 			Layout.columnSpan: 2
-			enabled:	measures_correlation.checked
+			enabled:	measures_correlation.checked || measures_OR.checked
 			label:		qsTr("Transform correlations")
 			name:		"advanced_mu_transform"
+			id:			advanced_mu_transform
 			values:
 			[
 				{ label: qsTr("Cohen's d"),		value: "cohens_d"},
-				{ label: qsTr("Fisher's z"),	value: "fishers_z"}
+				{ label: qsTr("Fisher's z"),	value: "fishers_z"},//,			id: advanced_mu_transform_fishers_z},
+				{ label: qsTr("log(OR)"),		value: "log_OR"}//				id: advanced_mu_transform_log_OR}
 			]
 		}
 


### PR DESCRIPTION
adding a possibility to analyze OR
fixing "too tight" secondary y-axis labels
(most of the code changes are just reformating)

relevant things included in RoBMA 1.04
- more and better error messages

things we might want from RoBMA 1.05 (not released yet, won't get to CRAN in time)
- https://github.com/FBartos/RoBMA/tree/development
- fix for inability to plot a bivariate mu vs tau estimates plot
- range of x-values always cover 0 (or 1 when ORs are analyzed) for individual models parameters plots


**read before testing**
- the development version of the package needs to be installed (https://github.com/FBartos/RoBMA/tree/development)
- fitting models with default settings take long (especially with an increasing number of studies) = using debug dataset is a very bad idea (including the fact that the variables there were not generated by a meta-analytic model, which further impacts estimation time)
- you can use this file instead ([MA_test.txt](https://github.com/jasp-stats/jasp-desktop/files/5070115/MA_test.txt)), it contains all of the data input types, just note that the values in the rows don't correspond, so different columns will lead do different results
- decreasing the MCMC settings number also significantly decreases fitting time 
![image](https://user-images.githubusercontent.com/38475991/90159302-7cf9db80-dd90-11ea-909f-97adf30aaf39.png)
- or load a prefitted [model](https://drive.google.com/file/d/1tc8pu8qp5kOBLjlKhEWQdk8RPLHNFtum/view?usp=sharing) using the "Fitted model" option
- clicking multiple options in short succession can crash JASP engine and the whole model might as a results need refitting





