### PR TITLE
Errors and warnings for a form are now a property

### DIFF
--- a/JASP-Desktop/analysis/analysis.cpp
+++ b/JASP-Desktop/analysis/analysis.cpp
@@ -167,9 +167,6 @@ void Analysis::setResults(const Json::Value & results, Status status, const Json
 
 	setStatus(status);
 
-	if (_analysisForm)
-		_analysisForm->clearFormErrors();
-
 	emit resultsChangedSignal(this);
 
 	processResultsForDependenciesToBeShown();

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -111,18 +111,19 @@ public:
 	Options				*	getAnalysisOptions()					{ return _analysis->options(); }
 	JASPControlWrapper	*	getControl(const QString& name)			{ return _controls[name]; }
 	void					addListView(QMLListView* listView, QMLListView* sourceListView);
-	void					clearFormErrors();
 	QMLExpander			*	nextExpander(QMLExpander* expander)		{ return _nextExpanderMap[expander]; }
 	BoundQMLItem		*	getBoundItem(Option* option)			{ return _optionControlMap[option]; }
 
 	Options				*	options() { return _options; }
 	void					addControl(JASPControlBase* control);
 
-	Q_INVOKABLE void reset();
-    Q_INVOKABLE void exportResults();
-	Q_INVOKABLE void addFormError(const QString& message);
-	Q_INVOKABLE void refreshAnalysis();
-	Q_INVOKABLE void runAnalysis();
+	Q_INVOKABLE void		clearFormErrors();
+	Q_INVOKABLE void		clearFormWarnings();
+	Q_INVOKABLE void		reset();
+	Q_INVOKABLE void		exportResults();
+	Q_INVOKABLE void		addFormError(const QString& message);
+	Q_INVOKABLE void		refreshAnalysis();
+	Q_INVOKABLE void		runAnalysis();
 
 	void		addControlError(JASPControlBase* control, QString message, bool temporary = false, bool warning = false);
 	void		clearControlError(JASPControlBase* control);

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -49,12 +49,14 @@ class QMLExpander;
 class AnalysisForm : public QQuickItem, public VariableInfoProvider
 {
 	Q_OBJECT
-	Q_PROPERTY(QQuickItem * errorMessagesItem	READ errorMessagesItem	WRITE setErrorMessagesItem	NOTIFY errorMessagesItemChanged	)
+	Q_PROPERTY(QString		errors				READ errors											NOTIFY errorsChanged			)
+	Q_PROPERTY(QString		warnings			READ warnings										NOTIFY warningsChanged			)
 	Q_PROPERTY(bool			needsRefresh		READ needsRefresh									NOTIFY needsRefreshChanged		)
 	Q_PROPERTY(bool			hasVolatileNotes	READ hasVolatileNotes								NOTIFY hasVolatileNotesChanged	)
 	Q_PROPERTY(bool			runOnChange			READ runOnChange		WRITE setRunOnChange		NOTIFY runOnChangeChanged		)
 	Q_PROPERTY(QString		info				READ info				WRITE setInfo				NOTIFY infoChanged				)
 	Q_PROPERTY(QString		helpMD				READ helpMD											NOTIFY helpMDChanged			)
+	Q_PROPERTY(QVariant		analysis			READ analysis			WRITE setAnalysis			NOTIFY analysisChanged			)
 
 public:
 	explicit					AnalysisForm(QQuickItem * = nullptr);
@@ -79,6 +81,8 @@ public slots:
 				void			dataSetColumnsChangedHandler();
 				void			replaceVariableNameInListModels(const std::string & oldName, const std::string & newName);
 				void			setInfo(QString info);
+				void			setAnalysis(QVariant analysis);
+
 
 signals:
 				void			sendRScript(QString script, int key);
@@ -94,6 +98,9 @@ signals:
 				void			valueChanged(JASPControlBase* item);
 				void			infoChanged();
 				void			helpMDChanged();
+				void			errorsChanged();
+				void			warningsChanged();
+				void			analysisChanged();
 
 protected:
 				QVariant		requestInfo(const Term &term, VariableInfo::InfoType info) const override;
@@ -124,9 +131,6 @@ public:
 	void		addControlWarningSet(JASPControlBase* control, bool add);
 	void		refreshAvailableVariablesModels() { _setAllAvailableVariablesModel(true); }
 
-	QQuickItem*	errorMessagesItem()		{ return _formErrorMessagesItem;	}
-	GENERIC_SET_FUNCTION(ErrorMessagesItem, _formErrorMessagesItem, errorMessagesItemChanged, QQuickItem*)
-
 	bool		hasError() { return _jaspControlsWithErrorSet.size() > 0; }
 
 	bool		isOwnComputedColumn(const QString& col)			const	{ return _computedColumns.contains(col); }
@@ -139,10 +143,13 @@ public:
 	QString		info()				const { return _info; }
 	QString		helpMD()			const;
 	QString		metaHelpMD()		const;
+	QString		errors()			const {	return msgsListToString(_formErrors);	}
+	QString		warnings()			const { return msgsListToString(_formWarnings);	}
+	QVariant	analysis()			const { return QVariant::fromValue(_analysis);	}
 
 protected:
 	void		_setAllAvailableVariablesModel(bool refreshAssigned = false);
-
+	QString		msgsListToString(const QStringList & list) const;
 
 private:
 	void		_addControlWrapper(JASPControlWrapper* controlWrapper);
@@ -150,7 +157,6 @@ private:
 	void		_setUpRelatedModels();
 	void		_setUpItems();
 	void		_orderExpanders();
-	void		_setErrorMessages();
 	QString		_getControlLabel(JASPControlBase* boundControl);
 	void		_addLoadingError();
 	void		setControlIsDependency(QString controlName, bool isDependency);
@@ -158,10 +164,11 @@ private:
 	void		setControlIsDependency(std::string controlName, bool isDependency)					{ setControlIsDependency(tq(controlName), isDependency);	}
 	void		setControlMustContain(std::string controlName, std::set<std::string> containThis)	{ setControlMustContain(tq(controlName), tql(containThis)); }
 	QQuickItem* _getControlErrorMessageUsingThisJaspControl(JASPControlBase* jaspControl);
+	void		setAnalysisUp();
 
 private slots:
-	void		formCompletedHandler();
-	void		_formCompletedHandler();
+	   void		formCompletedHandler();
+	   void		_formCompletedHandler();
 
 protected:
 	Analysis								*	_analysis			= nullptr;
@@ -181,17 +188,18 @@ protected:
 	std::map<std::string,std::set<std::string>>	_mustContain;
 	
 private:
-	QQuickItem								*	_formErrorMessagesItem	= nullptr;
 	std::vector<ListModelTermsAvailable*>		_allAvailableVariablesModels,
 												_allAvailableVariablesModelsWithSource;
-	QList<QString>								_formErrorMessages;
-	long										_lastAddedErrorTimestamp = 0;
+	QStringList									_formErrors,
+												_formWarnings;
+
 	QQmlComponent*								_controlErrorMessageComponent = nullptr;
 	QList<QQuickItem*>							_controlErrorMessageCache;
 	QSet<JASPControlBase*>						_jaspControlsWithErrorSet,
 												_jaspControlsWithWarningSet;
 	QList<QString>								_computedColumns;
-	bool										_runOnChange = true;
+	bool										_runOnChange	= true,
+												_formCompleted = false;
 	QString										_info;
 };
 

--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -127,11 +127,9 @@ public:
 	void		addControlError(JASPControlBase* control, QString message, bool temporary = false, bool warning = false);
 	void		clearControlError(JASPControlBase* control);
 	void		cleanUpForm();
-	void		addControlErrorSet(JASPControlBase* control, bool add);
-	void		addControlWarningSet(JASPControlBase* control, bool add);
 	void		refreshAvailableVariablesModels() { _setAllAvailableVariablesModel(true); }
 
-	bool		hasError() { return _jaspControlsWithErrorSet.size() > 0; }
+	bool		hasError();
 
 	bool		isOwnComputedColumn(const QString& col)			const	{ return _computedColumns.contains(col); }
 	void		addOwnComputedColumn(const QString& col)				{ _computedColumns.push_back(col); }
@@ -157,13 +155,13 @@ private:
 	void		_setUpRelatedModels();
 	void		_setUpItems();
 	void		_orderExpanders();
-	QString		_getControlLabel(JASPControlBase* boundControl);
-	void		_addLoadingError();
-	void		setControlIsDependency(QString controlName, bool isDependency);
-	void		setControlMustContain(QString controlName, QStringList containThis);
-	void		setControlIsDependency(std::string controlName, bool isDependency)					{ setControlIsDependency(tq(controlName), isDependency);	}
-	void		setControlMustContain(std::string controlName, std::set<std::string> containThis)	{ setControlMustContain(tq(controlName), tql(containThis)); }
-	QQuickItem* _getControlErrorMessageUsingThisJaspControl(JASPControlBase* jaspControl);
+	QString		_getControlLabel(QString controlName);
+	void		_addLoadingError(QStringList wrongJson);
+	void		setControlIsDependency(	QString controlName, bool isDependency);
+	void		setControlMustContain(	QString controlName, QStringList containThis);
+	void		setControlIsDependency(	std::string controlName, bool isDependency)					{ setControlIsDependency(tq(controlName), isDependency);	}
+	void		setControlMustContain(	std::string controlName, std::set<std::string> containThis)	{ setControlMustContain(tq(controlName), tql(containThis)); }
+	QQuickItem* _getControlErrorMessageOfControl(JASPControlBase* jaspControl);
 	void		setAnalysisUp();
 
 private slots:
@@ -195,8 +193,6 @@ private:
 
 	QQmlComponent*								_controlErrorMessageComponent = nullptr;
 	QList<QQuickItem*>							_controlErrorMessageCache;
-	QSet<JASPControlBase*>						_jaspControlsWithErrorSet,
-												_jaspControlsWithWarningSet;
 	QList<QString>								_computedColumns;
 	bool										_runOnChange	= true,
 												_formCompleted = false;

--- a/JASP-Desktop/analysis/jaspcontrolbase.h
+++ b/JASP-Desktop/analysis/jaspcontrolbase.h
@@ -26,7 +26,6 @@ class JASPControlBase : public QQuickItem
 	Q_PROPERTY( bool								hasWarning			READ hasWarning			WRITE setHasWarning			NOTIFY hasWarningChanged			)
 	Q_PROPERTY( bool								runOnChange			READ runOnChange		WRITE setRunOnChange		NOTIFY runOnChangeChanged			)
 	Q_PROPERTY( QQuickItem						*	childControlsArea	READ childControlsArea	WRITE setChildControlsArea										)
-	Q_PROPERTY( QQuickItem						*	section				READ section			WRITE setSection												)
 	Q_PROPERTY( QQuickItem						*	parentListView		READ parentListView									NOTIFY parentListViewChanged		)
 	Q_PROPERTY( QQuickItem						*	innerControl		READ innerControl		WRITE setInnerControl		NOTIFY innerControlChanged			)
 	Q_PROPERTY( QQuickItem						*	background			READ background			WRITE setBackground			NOTIFY backgroundChanged			)
@@ -81,17 +80,20 @@ public:
 	bool			isBound()				const	{ return _isBound;				}
 	bool			debug()					const	{ return _debug;				}
 	bool			parentDebug()			const	{ return _parentDebug;			}
-	bool			hasError()				const	{ return _hasError;				}
-	bool			hasWarning()			const	{ return _hasWarning;			}
+	bool			hasError()				const;
+	bool			hasWarning()			const;
+	bool			childHasError()			const;
+	bool			childHasWarning()		const;
 	bool			focusOnTab()			const	{ return activeFocusOnTab();	}
 	AnalysisForm*	form()					const	{ return _form;					}
 	QQuickItem*		childControlsArea()		const	{ return _childControlsArea;	}
 	QQuickItem*		parentListView()		const	{ return _parentListView;		}
 	QString			parentListViewKey()		const	{ return _parentListViewKey;	}
-	QQuickItem*		section()				const	{ return _section;				}
 	QQuickItem*		innerControl()			const	{ return _innerControl;			}
 	QQuickItem*		background()			const	{ return _background;			}
 	bool			runOnChange()			const	{ return _runOnChange;			}
+
+	QString			humanFriendlyLabel()	const;
 
 
 	JASPControlWrapper				*	getWrapper()				const { return _wrapper; }
@@ -108,9 +110,8 @@ public:
 	static QList<JASPControlBase*>	getChildJASPControls(const QQuickItem* item);
 
 public slots:
-	void	setControlType(			ControlType		controlType)		{ _controlType = controlType; }
-	void	setChildControlsArea(	QQuickItem	*	childControlsArea);
-	void	setSection(				QQuickItem	*	section)			{ _section = section; }
+	void	setControlType(			ControlType			controlType)		{ _controlType = controlType; }
+	void	setChildControlsArea(	QQuickItem		*	childControlsArea);
 	void	setFocusOnTab(			bool focus);
 	void	setHasError(			bool hasError);
 	void	setHasWarning(			bool hasWarning);
@@ -182,7 +183,6 @@ protected:
 	JASPControlWrapper	*	_wrapper				= nullptr;
 	QQuickItem			*	_parentListView			= nullptr,
 						*	_childControlsArea		= nullptr,
-						*	_section				= nullptr,
 						*	_innerControl			= nullptr,
 						*	_background				= nullptr;
 	QList<QQmlComponent*>	_rowComponents;

--- a/JASP-Desktop/components/JASP/Controls/ExpanderButton.qml
+++ b/JASP-Desktop/components/JASP/Controls/ExpanderButton.qml
@@ -42,30 +42,6 @@ FocusScope
 	readonly	property string	expanderButtonIcon		: "expander-arrow-up.png"
 				property alias	columns					: expanderArea.columns
 				property alias	runOnChange				: expanderButton.runOnChange
-
-	function addControlWithError(name, add)
-	{
-		if (!name) return;
-
-		var index = expanderButton.controlsWithError.indexOf(name);
-
-		if (add  && index <  0)	expanderButton.controlsWithError.push(name);
-		if (!add && index >= 0) expanderButton.controlsWithError.splice(index, 1);
-
-		expanderButton.nbControlsWithError = expanderButton.controlsWithError.length;
-	}
-
-	function addControlWithWarning(name, add)
-	{
-		if (!name) return;
-
-		var index = expanderButton.controlsWithWarning.indexOf(name);
-
-		if (add  && index <  0)	expanderButton.controlsWithWarning.push(name);
-		if (!add && index >= 0) expanderButton.controlsWithWarning.splice(index, 1);
-
-		expanderButton.nbControlsWithWarning = expanderButton.controlsWithWarning.length;
-	}
 	
 	states: [
 		State
@@ -97,16 +73,9 @@ FocusScope
 		Keys.onSpacePressed		: toggleExpander()
 		Keys.onReturnPressed	: toggleExpander()
 		KeyNavigation.tab		: expanderWrapper.expanded ? firstControl : nextExpander
-		hasError				: nbControlsWithError   > 0 && !expanderWrapper.expanded
-		hasWarning				: nbControlsWithWarning > 0 && !expanderWrapper.expanded
-
 
 		property var nextExpander			: null
 		property var firstControl			: null
-		property int nbControlsWithError	: 0
-		property int nbControlsWithWarning	: 0
-		property var controlsWithError		: []
-		property var controlsWithWarning	: []
 
 		function toggleExpander() { expanderWrapper.expanded = !expanderWrapper.expanded; }
         

--- a/JASP-Desktop/components/JASP/Controls/Form.qml
+++ b/JASP-Desktop/components/JASP/Controls/Form.qml
@@ -30,7 +30,7 @@ AnalysisForm
 	implicitHeight		: formContent.height + (jaspTheme.formMargin * 2)
 	width				: implicitWidth
 	height				: implicitHeight
-	errorMessagesItem	: errorMessagesBox
+	//errorMessagesItem	: errorMessagesBox
 	
 	default property alias	content		: contentArea.children
 	property alias	form				: form
@@ -38,7 +38,7 @@ AnalysisForm
 	property int	majorVersion		: 1
 	property int	minorVersion		: 0
 	property int	availableWidth		: form.width - 2 * jaspTheme.formMargin
-	property var    analysis			: myAnalysis
+					analysis			: myAnalysis
 	property var	backgroundForms		: backgroundFlickable
 	property alias	columns				: contentArea.columns
 	property bool	runAnalysisWhenOptionChange : true
@@ -96,12 +96,9 @@ AnalysisForm
 				
 		Rectangle
 		{
-			property alias text:	errorMessagesText.text
-			
 			id:				errorMessagesBox
-			objectName:		"errorMessagesBox"
-			visible:		false
-			color:			jaspTheme.errorMessagesBackgroundColor
+			visible:		form.errors !== ""
+			color:			jaspTheme.controlErrorBackgroundColor
 			width:			parent.width
 			height:			visible ? errorMessagesText.height : 0
 			anchors.top:	oldFileMessagesBox.bottom
@@ -114,14 +111,37 @@ AnalysisForm
 				wrapMode:			Text.Wrap
 				width:				parent.width - 10 * jaspTheme.uiScale
 				verticalAlignment:	Text.AlignVCenter
-				//Should we maybe set a color here?
+				text:				form.errors
+				color:				jaspTheme.controlErrorTextColor
 			}
 		}
-		
+
+		Rectangle
+		{
+			id:				warningMessagesBox
+			visible:		form.warnings !== ""
+			color:			jaspTheme.controlWarningBackgroundColor
+			width:			parent.width
+			height:			visible ? warningMessagesText.height : 0
+			anchors.top:	errorMessagesBox.bottom
+
+			Text
+			{
+				id:					warningMessagesText
+				anchors.centerIn:	parent
+				padding:			5 * jaspTheme.uiScale
+				wrapMode:			Text.Wrap
+				width:				parent.width - 10 * jaspTheme.uiScale
+				verticalAlignment:	Text.AlignVCenter
+				text:				form.warnings
+				color:				jaspTheme.controlWarningTextColor
+			}
+		}
+
 		GridLayout
 		{
 			id:				contentArea
-			anchors.top:	errorMessagesBox.bottom
+			anchors.top:	warningMessagesBox.bottom
 			width:			parent.width
 		}
 	}

--- a/JASP-Desktop/components/JASP/Controls/Form.qml
+++ b/JASP-Desktop/components/JASP/Controls/Form.qml
@@ -76,6 +76,7 @@ AnalysisForm
 			width:			form.implicitWidth
 			height:			visible ? oldAnalysisText.height : 0
 			anchors.top:	parent.top
+			radius:			jaspTheme.borderRadius
 
 			Text
 			{
@@ -101,6 +102,7 @@ AnalysisForm
 			color:			jaspTheme.controlErrorBackgroundColor
 			width:			parent.width
 			height:			visible ? errorMessagesText.height : 0
+			radius:			jaspTheme.borderRadius
 			anchors.top:	oldFileMessagesBox.bottom
 
 			Text
@@ -114,6 +116,8 @@ AnalysisForm
 				text:				form.errors
 				color:				jaspTheme.controlErrorTextColor
 			}
+
+			CrossButton { onCrossClicked: form.clearFormErrors() }
 		}
 
 		Rectangle
@@ -122,6 +126,7 @@ AnalysisForm
 			visible:		form.warnings !== ""
 			color:			jaspTheme.controlWarningBackgroundColor
 			width:			parent.width
+			radius:			jaspTheme.borderRadius
 			height:			visible ? warningMessagesText.height : 0
 			anchors.top:	errorMessagesBox.bottom
 
@@ -136,6 +141,8 @@ AnalysisForm
 				text:				form.warnings
 				color:				jaspTheme.controlWarningTextColor
 			}
+
+			CrossButton { onCrossClicked: form.clearFormWarnings(); warning: true; }
 		}
 
 		GridLayout

--- a/JASP-Desktop/components/JASP/Widgets/ControlErrorMessage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/ControlErrorMessage.qml
@@ -112,64 +112,13 @@ Rectangle
 		if (temporary) messageTimer.start();
 	}
 
-	Item
+	CrossButton
 	{
-		id				: crossRectangle
-		width			: 12
-		height			: 12
-		anchors.top		: parent.top
-		anchors.right	: parent.right
-
-		property int crossThickness		: 2
-		property int crossLengthOffset	: -4
-
-		function closeMessage()
+		onCrossClicked:
 		{
 			controlErrorMessage.opacity = 0
 			if (controlErrorMessage.control)
 				controlErrorMessage.control.forceActiveFocus()
-		}
-
-
-		Rectangle
-		{
-			anchors.centerIn	: parent
-			height				: crossRectangle.crossThickness
-			width				: parent.width + crossRectangle.crossLengthOffset
-			rotation			: 45
-			color				: controlErrorMessage.foreCol
-		}
-
-		Rectangle
-		{
-			anchors.centerIn	: parent
-			height				: crossRectangle.crossThickness
-			width				: parent.width + crossRectangle.crossLengthOffset
-			rotation			: -45
-			color				: controlErrorMessage.foreCol
-		}
-
-		states:
-		[
-			State
-			{
-				when: crossArea.containsMouse
-				PropertyChanges
-				{
-					target				: crossRectangle
-					crossThickness		: 3
-					crossLengthOffset	: -2
-				}
-			}
-		]
-
-		MouseArea
-		{
-			id				: crossArea
-			anchors.fill	: parent
-			onClicked		: crossRectangle.closeMessage()
-			hoverEnabled	: true
-			cursorShape		: Qt.PointingHandCursor
 		}
 	}
 

--- a/JASP-Desktop/components/JASP/Widgets/CrossButton.qml
+++ b/JASP-Desktop/components/JASP/Widgets/CrossButton.qml
@@ -1,0 +1,63 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+import QtQuick			2.11
+import JASP				1.0
+
+Item
+{
+	id				: crossRectangle
+	width			: 12 * jaspTheme.uiScale
+	height			: 12 * jaspTheme.uiScale
+	anchors.top		: parent.top
+	anchors.right	: parent.right
+
+	property int crossThickness		: (crossArea.containsMouse ? 3 : 2) * jaspTheme.uiScale
+	property int crossLengthOffset	: 2 * jaspTheme.uiScale
+
+	property bool warning: false
+
+	signal crossClicked();
+
+	Rectangle
+	{
+		anchors.centerIn	: parent
+		height				: crossRectangle.crossThickness
+		width				: parent.width - crossRectangle.crossLengthOffset
+		rotation			: 45
+		color				: warning ? jaspTheme.controlWarningTextColor : jaspTheme.controlErrorTextColor
+	}
+
+	Rectangle
+	{
+		anchors.centerIn	: parent
+		height				: crossRectangle.crossThickness
+		width				: parent.width - crossRectangle.crossLengthOffset
+		rotation			: -45
+		color				: warning ? jaspTheme.controlWarningTextColor : jaspTheme.controlErrorTextColor
+	}
+
+	MouseArea
+	{
+		id				: crossArea
+		anchors.fill	: parent
+		onClicked		: crossRectangle.crossClicked()
+		hoverEnabled	: true
+		cursorShape		: Qt.PointingHandCursor
+	}
+}
+

--- a/JASP-Desktop/components/JASP/Widgets/qmldir
+++ b/JASP-Desktop/components/JASP/Widgets/qmldir
@@ -44,3 +44,4 @@ SetSeed                     1.0 SetSeed.qml
 BasicThreeButtonTableView   1.0 BasicThreeButtonTableView.qml
 ControlErrorMessage         1.0 ControlErrorMessage.qml
 LoadingIndicator            1.0 LoadingIndicator.qml
+CrossButton					1.0 CrossButton.qml

--- a/JASP-Desktop/qml.qrc
+++ b/JASP-Desktop/qml.qrc
@@ -140,5 +140,6 @@
         <file>components/JASP/Controls/TabView.qml</file>
         <file>components/JASP/Controls/FileSelector.qml</file>
         <file>components/JASP/Widgets/RCommanderWindow.qml</file>
+        <file>components/JASP/Widgets/CrossButton.qml</file>
     </qresource>
 </RCC>

--- a/JASP-Desktop/widgets/jaspcontrolwrapper.cpp
+++ b/JASP-Desktop/widgets/jaspcontrolwrapper.cpp
@@ -46,16 +46,6 @@ JASPControlWrapper::JASPControlWrapper(JASPControlBase *item)
 {
 }
 
-void JASPControlWrapper::setUp()
-{
-	QQuickItem* parent = item();
-	while (parent && parent->objectName() != "Section")
-		parent = parent->parentItem();
-
-	if (parent && parent->objectName() == "Section")
-		item()->setSection(parent);	
-}
-
 JASPControlWrapper* JASPControlWrapper::buildJASPControlWrapper(JASPControlBase* control)
 {
 	JASPControlWrapper* controlWrapper = nullptr;
@@ -78,7 +68,7 @@ JASPControlWrapper* JASPControlWrapper::buildJASPControlWrapper(JASPControlBase*
 	case JASPControlBase::ControlType::TextArea:
 	{
 		QString textType = control->property("textType").toString();
-		if (textType == "lavaan")									controlWrapper		= new BoundQMLLavaanTextArea(control);
+		if		(textType == "lavaan")								controlWrapper		= new BoundQMLLavaanTextArea(control);
 		else if (textType == "JAGSmodel")							controlWrapper		= new BoundQMLJAGSTextArea(control);
 		else														controlWrapper		= new BoundQMLTextArea(control);
 		break;

--- a/JASP-Desktop/widgets/jaspcontrolwrapper.h
+++ b/JASP-Desktop/widgets/jaspcontrolwrapper.h
@@ -35,7 +35,7 @@ public:
 			 JASPControlWrapper(JASPControlBase* item);
 	virtual ~JASPControlWrapper() {}
 
-	virtual void				setUp();
+	virtual void				setUp() {}
 	virtual void				cleanUp();
 	virtual void				resetQMLItem(JASPControlBase* item);
 

--- a/JASP-Desktop/widgets/listmodelavailableinterface.cpp
+++ b/JASP-Desktop/widgets/listmodelavailableinterface.cpp
@@ -27,24 +27,19 @@ void ListModelAvailableInterface::initTerms(const Terms &terms, const RowControl
 	
 	_allTerms = _allSortedTerms = _terms = terms;
 	_terms.setSortParent(_allSortedTerms);
+
 	if (currentSortType() != SortType::None)
 		Sortable::sortItems();
 
-	if (_addEmptyValue)
+	if (_addEmptyValue && _allSortedTerms.size() > 0 && !_allSortedTerms[0].asQString().isEmpty())
 	{
-		if (_allSortedTerms.size() > 0 && !_allSortedTerms[0].asQString().isEmpty())
-		{
-			_allSortedTerms.insert(0, QString());
-			_allTerms.insert(0, QString());
-			_terms.add(QString());
-		}
+		_allSortedTerms.insert(0, QString());
+		_allTerms.insert(0, QString());
+		_terms.add(QString());
 	}
 
 	removeTermsInAssignedList();
-	
 	endResetModel();
-
-
 }
 
 QVariant ListModelAvailableInterface::requestInfo(const Term &term, VariableInfo::InfoType info) const
@@ -61,6 +56,7 @@ void ListModelAvailableInterface::sortItems(SortType sortType)
 	case SortType::None:
 		_allSortedTerms = _allTerms;
 		break;
+
 	case SortType::SortByName:
 	{
 		QList<QString> sortedTerms = _allSortedTerms.asQList();
@@ -71,24 +67,32 @@ void ListModelAvailableInterface::sortItems(SortType sortType)
 		_allSortedTerms = Terms(sortedTerms);
 		break;
 	}
+
 	case SortType::SortByType:
 	{
-		QList<QString> termsList = _allSortedTerms.asQList();
+		QList<QString>				termsList = _allSortedTerms.asQList();
 		QList<QPair<QString, int> > termsTypeList;
+
 		for (const QString& term : termsList)
 			termsTypeList.push_back(QPair<QString, int>(term, requestInfo(term, VariableInfo::VariableType).toInt()));
+
 		std::sort(termsTypeList.begin(), termsTypeList.end(),
 				  [&](const QPair<QString, int>& a, const QPair<QString, int>& b) {
 						return a.second - b.second > 0;
 					});
+
 		QList<QString> sortedTerms;
+
 		for (const auto& term : termsTypeList)
 			sortedTerms.push_back(term.first);
+
 		_allSortedTerms = Terms(sortedTerms);
 		break;
 	}
+
 	default:
-		Log::log() << "Unimplemented sort!";
+		Log::log() << "Unimplemented sort in ListModelAvailableInterface::sortItems!";
+		break;
 	}
 
 	Terms orgTerms = _terms;
@@ -110,17 +114,14 @@ void ListModelAvailableInterface::setChangedTerms(const Terms &newTerms)
 {
 	_tempRemovedTerms.clear();
 	_tempAddedTerms.clear();
+
 	for (const Term& term : _allTerms)
-	{
 		if (!newTerms.contains(term))
 			_tempRemovedTerms.add(term);
-	}
-	
+
 	for (const Term& term : newTerms)
-	{
 		if (!_allTerms.contains(term))
 			_tempAddedTerms.add(term);
-	}
 }
 
 void ListModelAvailableInterface::removeTermsInAssignedList()
@@ -131,10 +132,9 @@ void ListModelAvailableInterface::removeTermsInAssignedList()
 	_terms.setSortParent(_allSortedTerms);
 	
 	QMLListViewTermsAvailable* qmlAvailableListView = dynamic_cast<QMLListViewTermsAvailable*>(listView());
+
 	if (qmlAvailableListView)
-	{
-		const QList<ListModelAssignedInterface*>& assignedModels = qmlAvailableListView->assignedModel();	
-		for (ListModelAssignedInterface* modelAssign : assignedModels)
+		for (ListModelAssignedInterface* modelAssign : qmlAvailableListView->assignedModel())
 		{
 			Terms assignedTerms = modelAssign->terms();
 			if (assignedTerms.discardWhatIsntTheseTerms(_allSortedTerms))
@@ -145,7 +145,7 @@ void ListModelAvailableInterface::removeTermsInAssignedList()
 			else if (!modelAssign->copyTermsWhenDropped())
 				_terms.remove(assignedTerms);
 		}
-	}
+
 	
 	endResetModel();
 }


### PR DESCRIPTION
- No more need for directly manipulating QQuickItem*...
- Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/757
- Refactored some code a bit
- Added a property for Analysis * as well

