### PR TITLE
Export Results to PDF

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -197,11 +197,20 @@ Item
 
 					onExportToPDF:
 					{
+						if(preferencesModel.currentThemeName !== "lightTheme")
+							resultsJsInterface.setThemeCss("lightTheme");
+
 						resultsJsInterface.unselect(); //Otherwise we get the selected analysis highlighted in the pdf...
 						resultsView.printToPdf(pdfPath);
 					}
 				}
-				onPdfPrintingFinished:	resultsJsInterface.pdfPrintingFinished(filePath);
+				onPdfPrintingFinished:
+				{
+					if(preferencesModel.currentThemeName !== "lightTheme")
+						resultsJsInterface.setThemeCss(preferencesModel.currentThemeName);
+
+					resultsJsInterface.pdfPrintingFinished(filePath);
+				}
 
 				webChannel.registeredObjects:	[ resultsJsInterfaceInterface ]
 

--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -167,8 +167,8 @@ Item
 				Keys.onPressed:
 					switch(event)
 					{
-					case Qt.Key_PageDown:	resultsView.runJavaScript("windows.pageDown();");
-					case Qt.Key_PageUp:		resultsView.runJavaScript("windows.pageUp();");
+					case Qt.Key_PageDown:	resultsView.runJavaScript("windows.pageDown();");	break;
+					case Qt.Key_PageUp:		resultsView.runJavaScript("windows.pageUp();");		break;
 					}
 
 				onNavigationRequested:
@@ -187,12 +187,21 @@ Item
 					setTranslatedResultsString();
 				}
 
+
+
 				Connections
 				{
 					target:					resultsJsInterface
 					onRunJavaScript:		resultsView.runJavaScript(js)
 					onScrollAtAllChanged:	resultsView.runJavaScript("window.setScrollAtAll("+(scrollAtAll ? "true" : "false")+")");
+
+					onExportToPDF:
+					{
+						resultsJsInterface.unselect(); //Otherwise we get the selected analysis highlighted in the pdf...
+						resultsView.printToPdf(pdfPath);
+					}
 				}
+				onPdfPrintingFinished:	resultsJsInterface.pdfPrintingFinished(filePath);
 
 				webChannel.registeredObjects:	[ resultsJsInterfaceInterface ]
 

--- a/JASP-Desktop/components/JASP/Widgets/MainPage.qml
+++ b/JASP-Desktop/components/JASP/Widgets/MainPage.qml
@@ -266,6 +266,7 @@ Item
 							
 							customMenu.hide()
 
+							if (name === 'hasExportResults')				{ fileMenuModel.exportResultsInteractive();		return; }
 							if (name === 'hasRefreshAllAnalyses')			{ resultsJsInterface.refreshAllAnalyses();		return;	}
 							if (name === 'hasRemoveAllAnalyses')			{ resultsJsInterface.removeAllAnalyses();		return; }
 							if (name === 'hasCopy' || name === 'hasCite')	  resultsJsInterface.purgeClipboard();

--- a/JASP-Desktop/data/exporters/dataexporter.cpp
+++ b/JASP-Desktop/data/exporters/dataexporter.cpp
@@ -26,12 +26,13 @@
 using namespace std;
 
 
-DataExporter::DataExporter(bool includeComputeColumns) : _includeComputeColumns(includeComputeColumns) {
-	_defaultFileType = Utils::FileType::csv;
-	_allowedFileTypes.push_back(Utils::FileType::csv);
-	_allowedFileTypes.push_back(Utils::FileType::txt);
-	_allowedFileTypes.push_back(Utils::FileType::tsv);
+DataExporter::DataExporter(bool includeComputeColumns) : _includeComputeColumns(includeComputeColumns)
+{
+	_defaultFileType  = Utils::FileType::csv;
+	_allowedFileTypes = { Utils::FileType::csv, Utils::FileType::txt, Utils::FileType::tsv };
 }
+
+DataExporter::~DataExporter() {}
 
 void DataExporter::saveDataSet(const std::string &path, boost::function<void(int)> progressCallback)
 {

--- a/JASP-Desktop/data/exporters/dataexporter.h
+++ b/JASP-Desktop/data/exporters/dataexporter.h
@@ -24,6 +24,7 @@ class DataExporter : public Exporter
 {
 public:
 	DataExporter(bool includeComputeColumns);
+	~DataExporter() override;
 	void saveDataSet(const std::string &path, boost::function<void (int)> progressCallback) override;
 
 	bool _includeComputeColumns;

--- a/JASP-Desktop/data/exporters/exporter.cpp
+++ b/JASP-Desktop/data/exporters/exporter.cpp
@@ -17,13 +17,7 @@
 
 #include "exporter.h"
 
-Exporter::Exporter()
-{
-}
-
-Exporter::~Exporter() {
-
-}
+Exporter::~Exporter() {}
 
 Utils::FileType Exporter::getDefaultFileType()
 {

--- a/JASP-Desktop/data/exporters/exporter.h
+++ b/JASP-Desktop/data/exporters/exporter.h
@@ -18,6 +18,7 @@
 #ifndef EXPORTER_H
 #define EXPORTER_H
 
+#include <QObject>
 #include <string>
 #include "../datasetpackage.h"
 #include <boost/function.hpp>
@@ -31,13 +32,13 @@
 class Exporter
 {
 protected:
+	Exporter(){}
+
 	Utils::FileType			_defaultFileType;
 	Utils::FileTypeVector	_allowedFileTypes;
 	Utils::FileType			_currentFileType;
-	Exporter();
 
 public:
-
 	virtual ~Exporter();
 	virtual void saveDataSet(const std::string &path, boost::function<void (int)> progressCallback) = 0;
 

--- a/JASP-Desktop/data/exporters/jaspexporter.cpp
+++ b/JASP-Desktop/data/exporters/jaspexporter.cpp
@@ -38,7 +38,8 @@ const Version JASPExporter::dataArchiveVersion = Version("1.0.2");
 const Version JASPExporter::jaspArchiveVersion = Version("3.1.0");
 
 
-JASPExporter::JASPExporter() {
+JASPExporter::JASPExporter()
+{
 	_defaultFileType = Utils::FileType::jasp;
 	_allowedFileTypes.push_back(Utils::FileType::jasp);
 }

--- a/JASP-Desktop/data/exporters/resultexporter.h
+++ b/JASP-Desktop/data/exporters/resultexporter.h
@@ -19,13 +19,20 @@
 #define RESULTEXPORTER_H
 
 #include "exporter.h"
+#include <QMutex>
+#include <QWaitCondition>
 
 class ResultExporter: public Exporter
 {
-
 public:
 	ResultExporter();
 	void saveDataSet(const std::string &path, boost::function<void (int)> progressCallback) OVERRIDE;
+
+private:
+	QString			_pdfPath;
+	QMutex			_writingToPdfMutex;
+	QWaitCondition	_writingToPdf;
+
 
 	JASPTIMER_CLASS(ResultExporter);
 };

--- a/JASP-Desktop/data/fileevent.cpp
+++ b/JASP-Desktop/data/fileevent.cpp
@@ -39,8 +39,8 @@ FileEvent::FileEvent(QObject *parent, FileEvent::FileMode fileMode)
 
 FileEvent::~FileEvent()
 {
-	delete _exporter;
-	_exporter = nullptr;
+	   delete _exporter;
+	   _exporter = nullptr;
 }
 
 void FileEvent::setDataFilePath(const QString &path)

--- a/JASP-Desktop/gui/messageforwarder.cpp
+++ b/JASP-Desktop/gui/messageforwarder.cpp
@@ -94,6 +94,8 @@ QString MessageForwarder::browseSaveFileDocuments(QString caption, QString filte
 
 QString MessageForwarder::browseSaveFile(QString caption, QString browsePath, QString filter, QString * selectedExtension)
 {
+	Log::log() << "MessageForwarder::browseSaveFile(\"" << caption.toStdString() << "\", \"" << browsePath.toStdString() << "\", \"" << filter.toStdString() << "\")" << std::endl;
+
 	QString saveFileName, selectedFilter;
 
 	if(Settings::value(Settings::USE_NATIVE_FILE_DIALOG).toBool())	saveFileName = 	QFileDialog::getSaveFileName(nullptr, caption, browsePath, filter, &selectedFilter);
@@ -120,6 +122,9 @@ QString MessageForwarder::browseSaveFile(QString caption, QString browsePath, QS
 		if(saveFileName.lastIndexOf('.') >= 0)	*selectedExtension = saveFileName.mid(saveFileName.lastIndexOf('.') + 1);
 		else									*selectedExtension = ""; //???
 	}
+
+	if(selectedExtension)
+		Log::log() << "Selected extension: '" << *selectedExtension << "'" << std::endl;
 
 	return saveFileName;
 }

--- a/JASP-Desktop/html/css/darkTheme-jasp.css
+++ b/JASP-Desktop/html/css/darkTheme-jasp.css
@@ -57,12 +57,13 @@ h6, .h6-toolbar .jasp-menu {
   padding-right:  0px ;
 }
 
-.jasp-display-item {
-        margin-top:       0.1em ;
-        margin-bottom:    0.6em ;
-        padding-left:     0.6em ;
-        margin-right:     0.6em ;
-        padding-right:    0.6em ;
+.jasp-display-item
+{
+    margin-top:			0.1em ;
+	margin-bottom:		0.6em ;
+	padding-left:		0.6em ;
+	margin-right:		0.6em ;
+	padding-right:		0.6em ;
 }
 
 .jasp-display-item ~ .jasp-display-item {
@@ -78,17 +79,17 @@ h6, .h6-toolbar .jasp-menu {
 }
 
 .jasp-collapsed {
-  max-width: 70em;
-  min-width: 40em;
-        background-color: #404040; /*grayLighter*/
-        border: 1px solid #747677  ; /*grayDarker but not really because this is #696969 */
+    max-width:			70em;
+	min-width:			40em;
+	background-color:	#404040; /*grayLighter*/
+	border:				1px solid #747677  ; /*grayDarker but not really because this is #696969 */
 }
 
 table {
-  font-style: normal ;
-  border-collapse: collapse ;
-  margin-bottom: 2em ;
-  cursor: default;
+  font-style:			normal ;
+  border-collapse:		collapse ;
+  margin-bottom:		2em ;
+  cursor:				default;
 }
 
 th {
@@ -145,39 +146,38 @@ tbody th {
 }
 
 tbody th,
-tbody td {
-
-  border-bottom : none ;
-  border-top : none;
-  white-space: nowrap;
+tbody td
+{
+  border-bottom:	none ;
+  border-top:		none;
+  white-space:		nowrap;
 }
 
 thead tr th {
-
-  border-bottom: thin solid ;
+    border-bottom: thin solid ;
 }
 
 thead tr.over-title th:empty {
-  border-bottom: none;
+    border-bottom:	none;
 }
 
 thead tr.over-title-space th {
-  border-bottom: none;
-  padding: 0 .25em 0 .25em;
+    border-bottom:	none;
+	padding:		0 .25em 0 .25em;
 }
 
 thead tr.over-title-space th:last-child {
-  border-bottom: none;
-  padding: 0 0 0 .25em;
+    border-bottom:	none;
+	padding:		0 0 0 .25em;
 }
 
 div.over-title-space {
-  padding-top: .25em;
-  padding-bottom: .25em;
-  vertical-align: middle;
-  margin: 0 0 0 0;
-  text-align: center;
-  border-bottom: thin solid;
+    padding-top:	.25em;
+	padding-bottom:	.25em;
+	vertical-align:	middle;
+	margin:			0 0 0 0;
+	text-align:		center;
+	border-bottom:	thin solid;
 }
 
 div.over-title-space:empty {
@@ -217,21 +217,21 @@ tr:nth-child(odd) td {
 
 tr:nth-child(even) th,
 tr:nth-child(even) td {
-        background: #555
+    background: #555
 }
 
 .jasp-analysis.selected {
-        color: #EEE;
+    color: #EEE;
 }
 
 .jasp-analysis.unselected:not(.jasp-menu-selected) {
 
-        background-color: #404040 ;
+    background-color: #404040 ;
 }
 
 .jasp-analysis.selected:not(.jasp-menu-selected) {
 
-        background-color: #222 ;
+    background-color: #222 ;
 }
 
 td.text {
@@ -253,14 +253,14 @@ svg > text
 }
 
 .jasp-collection-image {
-  display:            inline-block;
-  background-color:   #000;
+  display:				block;
+  background-color:		#000;
 }
 
 .jasp-image {
-  position:           relative ;
-  background-color:   #000;
-  border-radius:      2px;
+  position:				relative ;
+  background-color:		#000;
+  border-radius:		2px;
 }
 
 .jasp-image-image {
@@ -287,22 +287,16 @@ svg > text
 
 .jasp-image-resizable {
 
-  border: 2px solid #5F89A7 ;
-  border-radius : 2px ;
+  border:			2px solid #5F89A7 ;
+  border-radius:	2px ;
 }
 
 .jasp_top_level {
 
-  margin-left: 1.7em ;
+  margin-left:	1.7em ;
   margin-right: 1.7em ;
 }
 
-:not(.error-state) > .jasp-analysis {
-
-  margin: 0 .7em .7em .7em ;
-  padding: 0 1em 1em 1em ;
-  position: relative;
-}
 
 #instructions {
 
@@ -313,31 +307,31 @@ svg > text
 
 div.toolbar {
 
-  display: block ;
+  display:	block ;
   position: relative;
 }
 
 div.image-status {
 
-  position: absolute ;
-  top : 0 ;
-  left: 0 ;
-  width: 100% ;
-  height: 100% ;
-  background-repeat:no-repeat;
-  background-position: center center;
-  visibility: hidden ;
-  z-index: 50 ;
+  position:				absolute ;
+  top :					0 ;
+  left:					0 ;
+  width:				100% ;
+  height:				100% ;
+  background-repeat:	no-repeat;
+  background-position:	center center;
+  visibility:			hidden ;
+  z-index:				50 ;
 }
 
 div.status {
 
-  width: 16px ;
-  height: 16px ;
-  background-size : 100% ;
-  display: inline-block ;
-  margin-left : 6px ;
-  visibility: hidden ;
+  width:			16px ;
+  height:			16px ;
+  background-size:	100% ;
+  display:			inline-block ;
+  margin-left:		6px ;
+  visibility:		hidden ;
 }
 
 div.status.running {
@@ -365,16 +359,16 @@ div.image-status.waiting {
 }
 
 div.jasp-image-image.no-data {
-        background-image: url('images/darkTheme/empty-plot.png') ;
-  background-repeat: no-repeat;
-  background-size: contain;
-  position: relative;
-  max-height: 480px;
-  max-width: 480px;
+    background-image:	url('images/darkTheme/empty-plot.png') ;
+	background-repeat:	no-repeat;
+	background-size:	contain;
+	position:			relative;
+	max-height:			480px;
+	max-width:			480px;
 }
 
 div.jasp-image-image.no-data.error {
-        background-image: linear-gradient(rgba(0,0,0,0.67), rgba(0,0,0,0.67)), url('images/darkTheme/empty-plot.png');
+    background-image: linear-gradient(rgba(0,0,0,0.67), rgba(0,0,0,0.67)), url('images/darkTheme/empty-plot.png');
 }
 
 .jasp-analysis.error-state div.jasp-image-image {
@@ -386,9 +380,18 @@ div.jasp-image-image.no-data.error {
 }
 
 .jasp-analysis.error-state {
-  min-width: 500px;
-  min-height: 200px;
+  min-width:			500px;
+  min-height:			200px;
 }
+
+
+:not(.error-state) > .jasp-analysis {
+
+    margin:				0 .7em .7em .7em ;
+	padding:			0 1em 1em 1em ;
+	position:			relative;
+}
+
 
 .fatalError.error-message-box {
   border: 3px double  #faa;
@@ -400,57 +403,57 @@ div.jasp-image-image.no-data.error {
   min-width: 400px;
   max-width: 1000px;
   position: absolute;
-  top: 60px;
-  left: 50px;
+  top:			60px;
+  left:			50px;
   margin-right: 50px;
 }
 
 .error-message-positioner {
 
-  height: 0px ;
-  overflow: visible ;
-  position: relative;
-  top: 10px ;
-  float: left ;
-  z-index: 100 ;
+  height:	0px ;
+  overflow:	visible ;
+  position:	relative;
+  top:		10px ;
+  float:	left ;
+  z-index:	100 ;
 }
 
 .jasp-image-image .error-message-positioner {
 
   position: absolute ;
-  top: 25% ;
+  top:		25% ;
 }
 
 .error-message-symbol {
 
-  float: left;
+  float:		left;
   margin-right: .3em;
 }
 
 .error-message-box {
 
-  z-index: 100 ;
-  padding: 1em ;
-  border-radius: .4em ;
-  min-width: 300px ;
-  white-space: normal;
+  z-index:			100 ;
+  padding:			1em ;
+  border-radius:	.4em ;
+  min-width:		300px ;
+  white-space:		normal;
 }
 
 .stack-trace-selector div,
 .stack-trace-selector span {
 
-  cursor: pointer ;
-  display: inline-block ;
-  vertical-align: middle ;
+  cursor:			pointer ;
+  display:			inline-block ;
+  vertical-align:	middle ;
 }
 
 .stack-trace-arrow {
 
-  background: center no-repeat url("images/darkTheme/expand.png") ;
-  background-size: 70% ;
-  width: 16px ;
-  height: 16px ;
-  margin-left: 2px ;
+  background:		center no-repeat url("images/darkTheme/expand.png") ;
+  background-size:	70% ;
+  width:			16px ;
+  height:			16px ;
+  margin-left:		2px ;
 }
 
 .stack-trace {
@@ -465,20 +468,20 @@ td.squash-left
 
 #intro {
 
-  padding: 1em 2em ;
-  margin: 50px auto ;
-  min-width: 300px ;
-  max-width: 500px ;
-  width: 50% ;
-  border: 3px dashed #3CAAE7 ;
-  border-radius: 10px ;
-  color: #3CAAE7 ;
+  padding:			1em 2em ;
+  margin:			50px auto ;
+  min-width:		300px ;
+  max-width:		500px ;
+  width:			50% ;
+  border:			3px dashed #3CAAE7 ;
+  border-radius:	10px ;
+  color:			#3CAAE7 ;
 
 }
 
 .jasp-hide {
-    display: none;
-  visibility: hidden ;
+    display:	none;
+	visibility: hidden ;
 }
 
 .jasp-image-holder {
@@ -488,36 +491,37 @@ td.squash-left
 
 .jasp-resize {
     background: top left no-repeat url(images/darkTheme/resizer.png);
-    right: 2px;
-    cursor: nw-resize;
-  bottom: 2px;
-  position: absolute;
-    width: 16px;
-    height: 16px;
+	right:		2px;
+	cursor:		nw-resize;
+	bottom:		2px;
+	position:	absolute;
+	width:		16px;
+	height:		16px;
 }
 
 .jasp-closer {
-    background: top left no-repeat url(images/darkTheme/closer.png);
-    background-size: 16px;
-    position: absolute;
-    right: 5px;
-    top: 5px;
-    width: 16px;
-    height: 16px;
-    bottom: 1px;
-    float: right;
-    border: 8px solid;
-    border-color: transparent;
-    z-index: 1;
+    background:			top left no-repeat url(images/darkTheme/closer.png);
+	background-size:	16px;
+	position:			absolute;
+	right:				5px;
+	top:				5px;
+	width:				16px;
+	height:				16px;
+	bottom:				1px;
+	float:				right;
+	border:				8px solid;
+	border-color:		transparent;
+	z-index:			1;
 }
 
-.jasp-toolbar h1, .jasp-toolbar h2, .jasp-toolbar h3, .jasp-toolbar h4, .jasp-toolbar h5, .jasp-toolbar h6, .jasp-toolbar div , .jasp-toolbar span {
-  display: inline-block;
-  vertical-align: middle;
+.jasp-toolbar h1, .jasp-toolbar h2, .jasp-toolbar h3, .jasp-toolbar h4, .jasp-toolbar h5, .jasp-toolbar h6, .jasp-toolbar div , .jasp-toolbar span
+{
+    display:			inline-block;
+	vertical-align:		middle;
 }
 
-.jasp-menu {
-
+.jasp-menu
+{
   background: center no-repeat url(images/darkTheme/menu-indicator.svg);
   background-size: 70% ;
   width:  16px ;
@@ -526,15 +530,15 @@ td.squash-left
 }
 
 .jasp-collapsed .jasp-menu {
-  background: center no-repeat url(images/darkTheme/expand.png);
-  background-size: 70% ;
-  width:  16px ;
-  height: 16px ;
-  margin-left: 4px ;
+  background:		center no-repeat url(images/darkTheme/expand.png);
+  background-size:	70% ;
+  width:			16px ;
+  height:			16px ;
+  margin-left:		4px ;
 }
 
 .jasp-toolbar {
-  display: block ;
+  display:				block ;
 }
 
 .toolbar-clickable {
@@ -542,9 +546,9 @@ td.squash-left
 }
 
 .toolbar-editing {
-  cursor: text;
-  border-top: 1px solid 	#5c5c5c;	/*rgb(205, 205, 205); #CDCDCD gray*/
-  border-bottom: 1px solid #5c5c5c;
+  cursor:			text;
+  border-top:		1px solid #5c5c5c;	/*rgb(205, 205, 205); #CDCDCD gray*/
+  border-bottom:	1px solid #5c5c5c;
 }
 
 .jasp-menu-selected {
@@ -552,10 +556,10 @@ td.squash-left
 }
 
 .jasp-editable {
-  padding-top: .5em ;
-  padding-bottom: .5em ;
-  background-color : inherit ;
-  word-wrap: break-word;
+  padding-top:		.5em ;
+  padding-bottom:	.5em ;
+  background-color:	inherit ;
+  word-wrap:		break-word;
 }
 
 .jasp-editable, .jasp-editable * {
@@ -564,15 +568,15 @@ td.squash-left
 
 
 .jasp-notes {
-  border-bottom:  1px solid #5c5c5c;
-  border-radius:  0;
-  color:          #000;
-  max-width:      70em;
-  min-width:      40em;
-  position:       relative ;
-  margin-top:     0.6em ;
-  margin-bottom:  0.6em ;
-  filter:         invert(1);
+  border-bottom:		1px solid #5c5c5c;
+  border-radius:		0;
+  color:				#000;
+  max-width:			70em;
+  min-width:			40em;
+  position:				relative ;
+  margin-top:			0.6em ;
+  margin-bottom:		0.6em ;
+  filter:				invert(1);
 }
 
 .jasp-notes-border {
@@ -592,11 +596,11 @@ td.squash-left
 
 
 .jasp-ghost-text {
-  font-weight: bold ;
-  color: #212121;
-  cursor: text;
-  padding-top: .5em ;
-  padding-bottom: .5em ;
+  font-weight:		bold ;
+  color:			#212121;
+  cursor:			text;
+  padding-top:		.5em ;
+  padding-bottom:	.5em ;
 }
 
 pre {
@@ -608,7 +612,7 @@ pre {
 }
 
 .jasp-progressbar-container {
-  min-height: 1.25em;
+  min-height:			1.25em;
 }
 
 .jasp-progressbar {
@@ -616,10 +620,10 @@ pre {
 }
 
 .jasp-progressbar-label {
-  display: table-cell;
-  vertical-align: middle;
-  padding-left: 15px;
-  color: #5c5c5c;
+  display:			table-cell;
+  vertical-align:	middle;
+  padding-left:		15px;
+  color:			#5c5c5c;
 }
 
 .jasp-progressbar-label-sep {

--- a/JASP-Desktop/html/css/printing.css
+++ b/JASP-Desktop/html/css/printing.css
@@ -1,0 +1,19 @@
+@media only print
+{
+    .jasp-toolbar h1, .jasp-toolbar h2, .jasp-toolbar h3, .jasp-toolbar h4, .jasp-toolbar h5, .jasp-toolbar h6, .jasp-toolbar div , .jasp-toolbar span
+	                                { display:				block !important;	}
+	.toolbar-button					{ display:				none  !important;	}
+	body							{ float:				none  !important;	}
+
+    .jasp-toolbar					{ page-break-after:		avoid;	}
+	.jasp-analysis					{ page-break-after:		always; }
+	.jasp-collection				{ page-break-inside:	avoid;	}
+	.hidden-collection				{ page-break-inside:	auto;	}
+	.object-body					{ page-break-inside:	auto;	}
+	.object-body .hidden-collection	{ page-break-inside:	auto;	}
+	.jasp-image						{ page-break-inside:	avoid;	}
+	.jasp-notes						{ page-break-inside:	avoid;	}
+	.jasp-table-primitive			{ page-break-inside:	avoid;	}
+}
+
+@page { margin:		1cm; }

--- a/JASP-Desktop/html/html.qrc
+++ b/JASP-Desktop/html/html.qrc
@@ -73,5 +73,6 @@
         <file>css/images/lightTheme/closer.png</file>
         <file>css/images/lightTheme/expand.png</file>
         <file>css/images/lightTheme/collapse.png</file>
+        <file>css/printing.css</file>
     </qresource>
 </RCC>

--- a/JASP-Desktop/html/index.html
+++ b/JASP-Desktop/html/index.html
@@ -1,38 +1,39 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-  <meta name="viewport"           content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+	<meta name="viewport"           content="width=device-width, initial-scale=1"/>
 
-  <title>JASP</title>
+    <title>JASP</title>
 
-  <link rel="stylesheet" href="css/jquery-ui-1.10.1.custom.css"       type="text/css" />
-  <link rel="stylesheet" href="css/etch.css"                          type="text/css" />
-  <link rel="stylesheet" href="css/quill.snow.css"              type="text/css" />
+    <link rel="stylesheet" href="css/jquery-ui-1.10.1.custom.css"			type="text/css" />
+	<link rel="stylesheet" href="css/etch.css"								type="text/css" />
+	<link rel="stylesheet" href="css/quill.snow.css"						type="text/css" />
+	<link rel="stylesheet" href="css/printing.css"							type="text/css" />
 
-  <link rel="stylesheet" href="css/lightTheme-jasp.css"  type="text/css" id="style"/>
+    <link rel="stylesheet" href="css/lightTheme-jasp.css"					type="text/css" id="style"/>
 
 
 
-  <script type="text/javascript" src="js/jquery-1.9.1.js">              </script>
-  <script type="text/javascript" src="js/jquery-ui-1.10.1.custom.js">  </script>
-  <script type="text/javascript" src="js/underscore-min.js">          </script>
-  <script type="text/javascript" src="js/backbone-1.1.2.js">         </script>
-  <script type="text/javascript" src="js/etch.js">                  </script>
-  <script type="text/javascript" src="js/quill.js">                 </script>
-  <script type="text/javascript" src="js/mrkdwn.js">               </script>
-  <script type="text/javascript" src="js/jaspwidgets.js">         </script>
-  <script type="text/javascript" src="js/object.js">             </script>
-  <script type="text/javascript" src="js/utils.js">             </script>
-  <script type="text/javascript" src="js/table.js">            </script>
-  <script type="text/javascript" src="js/image.js">           </script>
-  <script type="text/javascript" src="js/collection.js">     </script>
-  <script type="text/javascript" src="js/qwebchannel.js">   </script>
-  <script type="text/javascript" src="js/analysis.js">     </script>
-  <script type="text/javascript" src="js/analyses.js">    </script>
-  <script type="text/javascript" src="js/htmlNode.js">   </script>
-  <script type="text/javascript" src="js/column.js">    </script>
-  <script type="text/javascript" src="js/main.js">     </script>
+    <script type="text/javascript" src="js/jquery-1.9.1.js">              </script>
+	<script type="text/javascript" src="js/jquery-ui-1.10.1.custom.js">  </script>
+	<script type="text/javascript" src="js/underscore-min.js">          </script>
+	<script type="text/javascript" src="js/backbone-1.1.2.js">         </script>
+	<script type="text/javascript" src="js/etch.js">                  </script>
+	<script type="text/javascript" src="js/quill.js">                 </script>
+	<script type="text/javascript" src="js/mrkdwn.js">               </script>
+	<script type="text/javascript" src="js/jaspwidgets.js">         </script>
+	<script type="text/javascript" src="js/object.js">             </script>
+	<script type="text/javascript" src="js/utils.js">             </script>
+	<script type="text/javascript" src="js/table.js">            </script>
+	<script type="text/javascript" src="js/image.js">           </script>
+	<script type="text/javascript" src="js/collection.js">     </script>
+	<script type="text/javascript" src="js/qwebchannel.js">   </script>
+	<script type="text/javascript" src="js/analysis.js">     </script>
+	<script type="text/javascript" src="js/analyses.js">    </script>
+	<script type="text/javascript" src="js/htmlNode.js">   </script>
+	<script type="text/javascript" src="js/column.js">    </script>
+	<script type="text/javascript" src="js/main.js">     </script>
 
 </head>
 <body>
@@ -44,7 +45,7 @@
           <p>When you have the analysis set up the way you want, you can click the OK button to return to the spreadsheet view.</p>
           <p>If you decide you want to change the analysis later, you can simply click the results table again, and this will bring back the options.</p>
 	</div>
-	<div id="results" style="display:inline-block">
+	<div id="results" style="display:block">
           <div id="spacer" style="height: 1px;"></div>
 	</div>
 

--- a/JASP-Desktop/html/js/jaspwidgets.js
+++ b/JASP-Desktop/html/js/jaspwidgets.js
@@ -965,13 +965,15 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 			hasLaTeXCode:			(parent.hasLaTeXCode	=== undefined || parent.hasLaTeXCode())		&& parent.latexCodeMenuClicked		!== undefined,
 			hasRemoveAllAnalyses:	parent.menuName			=== 'All',
 			hasRefreshAllAnalyses:	parent.menuName			=== 'All',
+			hasExportResults:		parent.menuName			=== 'All',
 
 			objectName:				parent.menuName
 		};
 
-		this.hasMenu =	this.options.hasCopy		|| this.options.hasCite		|| this.options.hasSaveImg		|| this.options.hasEditImg		||
-						this.options.hasDuplicate	|| this.options.hasNotes	|| this.options.hasRemove		|| this.options.hasRemoveAll	||
-						this.options.hasEditTitle	|| this.options.hasCollapse || this.options.hasLaTeXCode	|| this.options.hasShowDeps		 ;
+		this.hasMenu =	this.options.hasCopy			|| this.options.hasCite		|| this.options.hasSaveImg		|| this.options.hasEditImg		||
+						this.options.hasDuplicate		|| this.options.hasNotes	|| this.options.hasRemove		|| this.options.hasRemoveAll	||
+						this.options.hasEditTitle		|| this.options.hasCollapse || this.options.hasLaTeXCode	|| this.options.hasShowDeps		||
+						this.options.hasExportResults	 ;
 	},
 
 	selectionElement: function() {	return this.parent.$el;	},

--- a/JASP-Desktop/html/js/jaspwidgets.js
+++ b/JASP-Desktop/html/js/jaspwidgets.js
@@ -951,7 +951,7 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 	setParent: function (parent) {
 		this.parent = parent;
 		this.options = {
-			//If you add something here don't forget to do the same in resultmenuentry.cpp
+			//If you add something here don't forget to do the same in resultmenumodel.cpp
 			hasCopy:				(parent.hasCopy			=== undefined || parent.hasCopy())			&& parent.copyMenuClicked			!== undefined,
 			hasCite:				(parent.hasCitation		=== undefined || parent.hasCitation())		&& parent.citeMenuClicked			!== undefined,
 			hasNotes:				(parent.hasNotes		=== undefined || parent.hasNotes())			&& parent.notesMenuClicked			!== undefined,
@@ -966,28 +966,23 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 			hasRemoveAllAnalyses:	parent.menuName			=== 'All',
 			hasRefreshAllAnalyses:	parent.menuName			=== 'All',
 
-			objectName: parent.menuName,
+			objectName:				parent.menuName
 		};
 
 		this.hasMenu =	this.options.hasCopy		|| this.options.hasCite		|| this.options.hasSaveImg		|| this.options.hasEditImg		||
 						this.options.hasDuplicate	|| this.options.hasNotes	|| this.options.hasRemove		|| this.options.hasRemoveAll	||
-						this.options.hasEditTitle	|| this.options.hasCollapse || this.options.hasLaTeXCode	|| this.options.hasShowDeps		;
+						this.options.hasEditTitle	|| this.options.hasCollapse || this.options.hasLaTeXCode	|| this.options.hasShowDeps		 ;
 	},
 
-	selectionElement: function() {
-		return this.parent.$el;
-	},
+	selectionElement: function() {	return this.parent.$el;	},
 
 	setSelected: function (value) {
-		this.selected = value;
+		this.selected			= value;
+		var $selectionElement	= this.selectionElement();
 
-		var $selectionElement = this.selectionElement();
-		if (value) {
-			$selectionElement.addClass("jasp-menu-selected")
-		}
-		else {
-			$selectionElement.removeClass("jasp-menu-selected")
-		}
+		if (value)	$selectionElement.addClass(		"jasp-menu-selected")
+		else		$selectionElement.removeClass(	"jasp-menu-selected")
+
 	},
 
 	displayMessage: function (msg) {

--- a/JASP-Desktop/html/js/main.js
+++ b/JASP-Desktop/html/js/main.js
@@ -204,7 +204,7 @@ $(document).ready(function () {
 
 	window.scrollToTopView = function (item)
 	{
-		console.log("window.scrollToTopView called and jasp.scrollAtAll: " + (jasp.scrollAtAll === undefined ? "undefined" : jasp.scrollAtAll ? "true" : "false"))
+		//console.log("window.scrollToTopView called and scrollAtAll: " + (scrollAtAll === undefined ? "undefined" : scrollAtAll ? "true" : "false"))
 
 		if(!scrollAtAll)
 			return;

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -875,7 +875,8 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 	{
 		connectFileEventCompleted(event);
 
-		_resultsJsInterface->exportHTML();
+		if(!event->path().endsWith(".pdf"))
+			_resultsJsInterface->exportHTML();
 
 		_loader->io(event);
 		showProgress();
@@ -935,7 +936,6 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 		closeVariablesPage();
 	}
 }
-
 
 ///Returns true if the caller can go ahead and close up shop.
 bool MainWindow::checkPackageModifiedBeforeClosing()

--- a/JASP-Desktop/results/resultmenumodel.cpp
+++ b/JASP-Desktop/results/resultmenumodel.cpp
@@ -23,7 +23,7 @@
 #include "gui/preferencesmodel.h"
 
 ResultMenuModel::ResultMenuModel(QObject *parent) : QAbstractListModel(parent),
-	_entriesOrder({"hasCollapse", "hasEditTitle", "hasCopy", "hasLaTeXCode", "hasCite", "hasSaveImg",
+	_entriesOrder({"hasCollapse", "hasEditTitle", "hasCopy", "hasLaTeXCode", "hasCite", "hasSaveImg", "hasExportResults",
 				"hasEditImg", "hasNotes", "hasDuplicate", "hasRemove", "hasRemoveAllAnalyses", "hasRefreshAllAnalyses", "hasShowDeps"})
 {
 	_generateCorrectlyTranslatedResultEntries();
@@ -47,7 +47,8 @@ void ResultMenuModel::_generateCorrectlyTranslatedResultEntries()
 		{	"hasRemove",				ResultMenuEntry(tr("Remove"),				"hasRemove",				"close-button.png",			"window.removeMenuClicked();")		},
 		{	"hasRemoveAllAnalyses",		ResultMenuEntry(tr("Remove All"),			"hasRemoveAllAnalyses",		"close-button.png",			"")									},
 		{	"hasRefreshAllAnalyses",	ResultMenuEntry(tr("Refresh All"),			"hasRefreshAllAnalyses",	"",							"")									},
-		{	"hasShowDeps",				ResultMenuEntry(tr("Show Dependencies"),	"hasShowDeps",				"",							"window.showDependenciesClicked()")	}
+		{	"hasShowDeps",				ResultMenuEntry(tr("Show Dependencies"),	"hasShowDeps",				"",							"window.showDependenciesClicked()")	},
+		{	"hasExportResults",			ResultMenuEntry(tr("Export Results"),		"hasExportResults",			"",							"")									}
    };
 }
 

--- a/JASP-Desktop/results/resultmenumodel.cpp
+++ b/JASP-Desktop/results/resultmenumodel.cpp
@@ -35,19 +35,19 @@ void ResultMenuModel::_generateCorrectlyTranslatedResultEntries()
 {
 	_allResultEntries =
 	{
-	   {	"hasCollapse",				ResultMenuEntry(tr("Collapse"),				"hasCollapse",				"collapse.png",				"window.collapseMenuClicked();")	},
-	   {	"hasEditTitle",				ResultMenuEntry(tr("Edit Title"),			"hasEditTitle",				"edit-pencil.png",			"window.editTitleMenuClicked();")	},
-	   {	"hasCopy",					ResultMenuEntry(tr("Copy"),					"hasCopy",					"copy.png",					"window.copyMenuClicked();")		},
-	   {	"hasLaTeXCode",				ResultMenuEntry(tr("Copy LaTeX"),			"hasLaTeXCode",				"code-icon.png",			"window.latexCodeMenuClicked();")	},
-	   {	"hasCite",					ResultMenuEntry(tr("Copy Citations"),		"hasCite",					"cite.png",					"window.citeMenuClicked();")		},
-	   {	"hasSaveImg",				ResultMenuEntry(tr("Save Image As"),		"hasSaveImg",				"document-save-as.png",		"window.saveImageClicked();")		},
-	   {	"hasEditImg",				ResultMenuEntry(tr("Edit Image"),			"hasEditImage",				"editImage.png",			"window.editImageClicked();")		},
-	   {	"hasNotes",					ResultMenuEntry(tr("Add Note"),				"hasNotes",					"",							"")									},
-	   {	"hasDuplicate",				ResultMenuEntry(tr("Duplicate"),			"hasDuplicate",				"duplicate.png",			"window.duplicateMenuClicked();")	},
-	   {	"hasRemove",				ResultMenuEntry(tr("Remove"),				"hasRemove",				"close-button.png",			"window.removeMenuClicked();")		},
-	   {	"hasRemoveAllAnalyses",		ResultMenuEntry(tr("Remove All"),			"hasRemoveAllAnalyses",		"close-button.png",			"")									},
-	   {	"hasRefreshAllAnalyses",	ResultMenuEntry(tr("Refresh All"),			"hasRefreshAllAnalyses",	"",							"")									},
-	   {	"hasShowDeps",				ResultMenuEntry(tr("Show Dependencies"),	"hasShowDeps",				"",							"window.showDependenciesClicked()")	}
+		{	"hasCollapse",				ResultMenuEntry(tr("Collapse"),				"hasCollapse",				"collapse.png",				"window.collapseMenuClicked();")	},
+		{	"hasEditTitle",				ResultMenuEntry(tr("Edit Title"),			"hasEditTitle",				"edit-pencil.png",			"window.editTitleMenuClicked();")	},
+		{	"hasCopy",					ResultMenuEntry(tr("Copy"),					"hasCopy",					"copy.png",					"window.copyMenuClicked();")		},
+		{	"hasLaTeXCode",				ResultMenuEntry(tr("Copy LaTeX"),			"hasLaTeXCode",				"code-icon.png",			"window.latexCodeMenuClicked();")	},
+		{	"hasCite",					ResultMenuEntry(tr("Copy Citations"),		"hasCite",					"cite.png",					"window.citeMenuClicked();")		},
+		{	"hasSaveImg",				ResultMenuEntry(tr("Save Image As"),		"hasSaveImg",				"document-save-as.png",		"window.saveImageClicked();")		},
+		{	"hasEditImg",				ResultMenuEntry(tr("Edit Image"),			"hasEditImage",				"editImage.png",			"window.editImageClicked();")		},
+		{	"hasNotes",					ResultMenuEntry(tr("Add Note"),				"hasNotes",					"",							"")									},
+		{	"hasDuplicate",				ResultMenuEntry(tr("Duplicate"),			"hasDuplicate",				"duplicate.png",			"window.duplicateMenuClicked();")	},
+		{	"hasRemove",				ResultMenuEntry(tr("Remove"),				"hasRemove",				"close-button.png",			"window.removeMenuClicked();")		},
+		{	"hasRemoveAllAnalyses",		ResultMenuEntry(tr("Remove All"),			"hasRemoveAllAnalyses",		"close-button.png",			"")									},
+		{	"hasRefreshAllAnalyses",	ResultMenuEntry(tr("Refresh All"),			"hasRefreshAllAnalyses",	"",							"")									},
+		{	"hasShowDeps",				ResultMenuEntry(tr("Show Dependencies"),	"hasShowDeps",				"",							"window.showDependenciesClicked()")	}
    };
 }
 

--- a/JASP-Desktop/results/resultsjsinterface.cpp
+++ b/JASP-Desktop/results/resultsjsinterface.cpp
@@ -37,10 +37,15 @@
 #include "gui/messageforwarder.h"
 #include <QApplication>
 #include "gui/preferencesmodel.h"
+#include <QThread>
+
+ResultsJsInterface * ResultsJsInterface::_singleton = nullptr;
 
 ResultsJsInterface::ResultsJsInterface(QObject *parent) : QObject(parent)
 {
-	connect(this, &ResultsJsInterface::zoomChanged,				this, &ResultsJsInterface::setZoomInWebEngine);
+	_singleton = this;
+
+	connect(this, &ResultsJsInterface::zoomChanged,					this, &ResultsJsInterface::setZoomInWebEngine);
 
 	setZoom(Settings::value(Settings::UI_SCALE).toDouble());
 }

--- a/JASP-Desktop/results/resultsjsinterface.h
+++ b/JASP-Desktop/results/resultsjsinterface.h
@@ -39,13 +39,14 @@ class ResultsJsInterface : public QObject
 public:
 	explicit ResultsJsInterface(QObject *parent = 0);
 
+	static ResultsJsInterface * singleton() { return _singleton; }
+
 	void setStatus(			Analysis *	analysis);
 	void changeTitle(		Analysis *	analysis);
 	void analysisChanged(	Analysis *	analysis);
 	void overwriteUserdata(	Analysis *	analysis);
 	void showAnalysis(		int			id);
 	void setResultsMeta(	QString		str);
-	void unselect();
 	void showInstruction();
 	void exportPreviewHTML();
 	void exportHTML();
@@ -56,6 +57,7 @@ public:
 	bool			resultsLoaded()		const { return _resultsLoaded;	}
 	bool			scrollAtAll()		const {	return _scrollAtAll;	}
 
+	Q_INVOKABLE void unselect();
 	Q_INVOKABLE void purgeClipboard();
 	Q_INVOKABLE void analysisEditImage(int id, QString options);
 
@@ -76,6 +78,8 @@ signals:
 	Q_INVOKABLE void packageModified();
 	Q_INVOKABLE void refreshAllAnalyses();
 	Q_INVOKABLE void removeAllAnalyses();
+	Q_INVOKABLE void pdfPrintingFinished(	QString pdfPath);
+	Q_INVOKABLE void exportToPDF(			QString pdfPath);
 
 public slots:
 	void resultsDocumentChanged()		{ emit packageModified(); }
@@ -103,10 +107,9 @@ signals:
 	void runJavaScript(			QString js);
 	void zoomChanged();
 	void resultsPageLoadedSignal();
-
 	void resultsLoadedChanged(bool resultsLoaded);
-
 	void scrollAtAllChanged(bool scrollAtAll);
+
 
 public slots:
 	void setExactPValuesHandler(	bool			exact);
@@ -123,6 +126,7 @@ private:
 	void	setGlobalJsValues();
 	QString escapeJavascriptString(const QString &str);
 
+
 private slots:
 	void menuHidding();
 
@@ -131,6 +135,8 @@ private:
 	QString			_resultsPageUrl = "qrc:///html/index.html";
 	bool			_resultsLoaded	= false,
 					_scrollAtAll	= true;
+
+	static ResultsJsInterface * _singleton;
 };
 
 

--- a/JASP-Desktop/widgets/filemenu/actionbuttons.cpp
+++ b/JASP-Desktop/widgets/filemenu/actionbuttons.cpp
@@ -21,12 +21,12 @@ void ActionButtons::loadButtonData(std::vector<ActionButtons::DataRow> &data)
 {
 	_data =
 	{
-		{FileOperation::Open,			tr("Open"),				true,	{ResourceButtons::RecentFiles,	ResourceButtons::Computer,	ResourceButtons::DataLibrary, ResourceButtons::OSF }		},
+		{FileOperation::Open,			tr("Open"),				true,	{ResourceButtons::Computer, ResourceButtons::OSF, ResourceButtons::RecentFiles,	ResourceButtons::DataLibrary }		},
 		{FileOperation::Save,			tr("Save"),				false,	{}																														},
 		{FileOperation::SaveAs,			tr("Save As"),			false,	{ResourceButtons::Computer, ResourceButtons::OSF }																		},
 		{FileOperation::ExportResults,	tr("Export Results"),	false,	{ResourceButtons::Computer, ResourceButtons::OSF }																		},
 		{FileOperation::ExportData,		tr("Export Data"),		false,	{ResourceButtons::Computer, ResourceButtons::OSF }																		},
-		{FileOperation::SyncData,		tr("Sync Data"),		false,	{ResourceButtons::CurrentFile, ResourceButtons::Computer, ResourceButtons::OSF }										},
+		{FileOperation::SyncData,		tr("Sync Data"),		false,	{ResourceButtons::Computer, ResourceButtons::OSF, ResourceButtons::CurrentFile}										},
 		{FileOperation::Close,			tr("Close"),			false,	{}																														},
 		{FileOperation::Preferences,	tr("Preferences"),		true,	{ResourceButtons::PrefsData, ResourceButtons::PrefsResults, ResourceButtons::PrefsUI, ResourceButtons::PrefsAdvanced}	},
 		{FileOperation::About,			tr("About"),			true,	{}																														}

--- a/JASP-Desktop/widgets/filemenu/computer.cpp
+++ b/JASP-Desktop/widgets/filemenu/computer.cpp
@@ -77,14 +77,8 @@ FileEvent *Computer::browseSave(const QString &path, FileEvent::FileMode mode)
 	switch(mode)
 	{
 	case FileEvent::FileExportResults:
-		caption = "Export Result as HTML";
-#ifdef JASP_DEBUG
-		// In debug mode enable pdf export
-		filter = "HTML Files (*.html *.pdf)";
-#else
-		// For future use of pdf export switch to line above
-		filter = "HTML Files (*.html)";
-#endif
+		caption = "Export Result as HTML or PDF";
+		filter = "HTML Files (*.html);;Portable Document Format (*.pdf)";
 		break;
 
 	case FileEvent::FileGenerateData:
@@ -105,9 +99,9 @@ FileEvent *Computer::browseSave(const QString &path, FileEvent::FileMode mode)
 		throw std::runtime_error("Wrong FileEvent type for saving!");
 	}
 
-	Log::log() << "Now calling MessageForwarder::browseSaveFile(\"" << caption.toStdString() << "\", \"" << browsePath.toStdString() << "\", \"" << filter.toStdString() << "\")" << std::endl;
-	QString finalPath = MessageForwarder::browseSaveFile(caption, browsePath, filter);
-	Log::log() << "Chosen path: \"" << finalPath.toStdString() << "\"" << std::endl;
+
+	QString extension,
+			finalPath = MessageForwarder::browseSaveFile(caption, browsePath, filter, &extension);
 
 	FileEvent *event = new FileEvent(this, mode);
 

--- a/JASP-Desktop/widgets/filemenu/computer.h
+++ b/JASP-Desktop/widgets/filemenu/computer.h
@@ -54,7 +54,7 @@ signals:
 
 private:
 	// these two variables are a hack!
-	bool _hasFileName;
+	bool	_hasFileName;
 	QString _fileName;	
 	
 	ComputerListModel *_computerListModel = nullptr;

--- a/JASP-Desktop/widgets/filemenu/filemenu.cpp
+++ b/JASP-Desktop/widgets/filemenu/filemenu.cpp
@@ -475,3 +475,9 @@ void FileMenu::showPreferences()
 	setVisible(true);
 	_actionButtons->setSelectedAction(ActionButtons::Preferences);
 }
+
+void FileMenu::exportResultsInteractive()
+{
+	actionButtonClicked(ActionButtons::ExportResults);
+	_computer->browseMostRecent();
+}

--- a/JASP-Desktop/widgets/filemenu/filemenu.h
+++ b/JASP-Desktop/widgets/filemenu/filemenu.h
@@ -95,6 +95,8 @@ public:
 	ResourceButtons					*	resourceButtons()			const	{ return _resourceButtons;			}
 	ResourceButtonsVisible			*	resourceButtonsVisible()	const	{ return _resourceButtonsVisible;	}
 
+	Q_INVOKABLE void exportResultsInteractive();
+
 signals:
 	void fileoperationChanged();
 	void dataSetIORequest(FileEvent *event);
@@ -119,6 +121,7 @@ public slots:
     void analysesExportResults();
 	void refresh();
 	void close();
+
 
 
 private slots:

--- a/JASP-Desktop/widgets/filemenu/filemenuobject.h
+++ b/JASP-Desktop/widgets/filemenu/filemenuobject.h
@@ -32,8 +32,6 @@ public:
 
 signals:
 	void dataSetIORequest(FileEvent *event);
-	void closeDataSetSelected();
-	void exportSelected(QString filename);
 
 protected:
 	FileEvent::FileMode _mode;


### PR DESCRIPTION
- Implements https://github.com/jasp-stats/INTERNAL-jasp/issues/173
- For some reason runs ***very slow*** in dark mode, and leads to ridiculous filesizes.
-- Example 6 page export in light theme: ~280kb rendered in seconds
-- The same in dark theme: 6MB and rendered in minutes...
-- But it *does* work in dark theme, so whatever I guess? We have very little control over how QWebEngine/Chromium prints to pdf
- Only small problem remaining is that very wide tables or images do no fit on a page, but Im not sure what would be the best way around that
- All (pdf)printing related css settings are in "printing.css"
- Also refactored/restyled darkTheme.css a little bit

