### PR TITLE
Reset Datalibrary after opening file

### DIFF
--- a/JASP-Desktop/widgets/filemenu/datalibrarylistmodel.cpp
+++ b/JASP-Desktop/widgets/filemenu/datalibrarylistmodel.cpp
@@ -55,4 +55,6 @@ void DataLibraryListModel::openFile(const QString &path)
 	event->setReadOnly();
 
 	emit openFileEvent(event);
+	
+	changePathCrumbIndex(0);  //Reset begin screen datalibrary (the same as with key navigation).
 }


### PR DESCRIPTION
The same behaviour as with key navigation
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/964

