### PR TITLE
Corrections of bugs found during the workshop

### DIFF
--- a/Resources/Help/analyses/regressionlinearbayesian.md
+++ b/Resources/Help/analyses/regressionlinearbayesian.md
@@ -77,8 +77,8 @@ Compares each model against the model selected.
   - Models: Predictors contained in the model.
   - P(M): Prior model probabilities.
   - P(M | data): Posterior probabilites of the models considered.
-  - BFM: Posterior model odds.
-  - BF10 (or BF01): Bayes factor.
+  - BFM: The updating factor by which the prior model odds change into the posterior model odds (e.g., when BFM = 2, the posterior model odds are twice as large as the prior model odds).
+  - BF10 (or BF01): Bayes factor comparing a model to either the null model or the model with the highest posterior model probability.
   - R2: Explained variance.
 
 #### Posterior Summary

--- a/Resources/Help/analyses/regressionlinearbayesian_nl.md
+++ b/Resources/Help/analyses/regressionlinearbayesian_nl.md
@@ -78,8 +78,8 @@ Vergelijkt elk model met het geselecteerde model.
   - Modellen: Predictoren in het model.
   - P(M): Prior model kansen.
   - P(M|data): Posterior kansen van de modellen.
-  - BFM: Posterior model odds.
-  - BF10 (of BF01): Bayes factor.
+  - BFM: De update factor waarmee de prior model odds veranderen in de posterior model odds (bv. wanneer BFM = 2, dan is de posterior model odds twee keer zo groot als de prior model odds).
+  - BF10 (of BF01): Bayes factor die een model vergelijkt met ofwel het nulmodel, ofwel het model met de hoogste posterior model kans.
   - R2: Verklaarde variantie.
 
 #### Samenvatting van de posterior

--- a/Resources/Regression/qml/RegressionLinearBayesian.qml
+++ b/Resources/Regression/qml/RegressionLinearBayesian.qml
@@ -241,7 +241,7 @@ Form {
 				}
 				RadioButton
 				{
-					value: "Bernoulli"; label: qsTr("Bernouilli")
+					value: "Bernoulli"; label: qsTr("Bernoulli")
 					childrenOnSameRow: true
 					DoubleField { name: "bernoulliParam"; label: qsTr("p"); defaultValue: 0.5; max: 1; inclusive: JASP.None; decimals: 3 }
 				}

--- a/Resources/Summary Statistics/Description.qml
+++ b/Resources/Summary Statistics/Description.qml
@@ -67,4 +67,10 @@ Description
 		title:	qsTr("S.S. Bayesian Binomial Test")
 		func:	"SummaryStatsBinomialTestBayesian"
 	}
+	Analysis
+	{
+		menu:	qsTr("Bayesian A/B Test")
+		title:	qsTr("S.S. Bayesian A/B Test")
+		func:	"SummaryStatsABTestBayesian"
+	}
 }


### PR DESCRIPTION
Here is a quick fix of some issues we found during the workshop (I am not sure whether this is all of them) and (at least some) should be fixed before the next release

- Adds back Bayesian A/B Test to summary statistics (it dissapeared from the qml for some reason)
- Fixes a typo (Berouilli -> Bernoulli)
- Upgrades a help file for the Bayesian linear regression

I need a hand with the dutch translation of the help file changes, please.

@vandenman feel free to assign someone else if you don't have time. I will make the changes to the jaspModules in the meantime.
