### PR TITLE
Learn Bayes analysis crashes when 2 models is added

### DIFF
--- a/JASP-Desktop/analysis/analysisform.h
+++ b/JASP-Desktop/analysis/analysisform.h
@@ -109,7 +109,7 @@ public:
 	ListModel			*	getRelatedModel(QMLListView* listView)	{ return _relatedModelMap[listView]; }
 	ListModel			*	getModel(const QString& modelName)		{ return _modelMap.count(modelName) > 0 ? _modelMap[modelName] : nullptr; } // Maps create elements if they do not exist yet
 	Options				*	getAnalysisOptions()					{ return _analysis->options(); }
-	JASPControlWrapper	*	getControl(const QString& name)			{ return _controls[name]; }
+	JASPControlWrapper	*	getControl(const QString& name)			{ return _controls.contains(name) ? _controls[name] : nullptr; }
 	void					addListView(QMLListView* listView, QMLListView* sourceListView);
 	QMLExpander			*	nextExpander(QMLExpander* expander)		{ return _nextExpanderMap[expander]; }
 	BoundQMLItem		*	getBoundItem(Option* option)			{ return _optionControlMap[option]; }

--- a/Resources/Learn Bayes/qml/LSbinomialestimation.qml
+++ b/Resources/Learn Bayes/qml/LSbinomialestimation.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick 2.8
-import QtQuick.Layouts 1.3
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.8
+import QtQuick.Layouts	1.3
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
 import "../qml/qml_components" as LS
 
 Form {

--- a/Resources/Learn Bayes/qml/qml_components/LSestimationinference.qml
+++ b/Resources/Learn Bayes/qml/qml_components/LSestimationinference.qml
@@ -20,6 +20,7 @@ import QtQuick.Layouts 1.3
 import JASP.Controls 1.0
 import JASP.Widgets 1.0
 import JASP.Theme 1.0
+import JASP 1.0
 
 Section
 {

--- a/Resources/Learn Bayes/qml/qml_components/LSestimationpredictions.qml
+++ b/Resources/Learn Bayes/qml/qml_components/LSestimationpredictions.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick 2.8
-import QtQuick.Layouts 1.3
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.8
+import QtQuick.Layouts	1.3
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
 
 Section
 {

--- a/Resources/Learn Bayes/qml/qml_components/LSestimationsequential.qml
+++ b/Resources/Learn Bayes/qml/qml_components/LSestimationsequential.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick 2.8
-import QtQuick.Layouts 1.3
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.8
+import QtQuick.Layouts	1.3
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
 
 Section
 {
@@ -106,20 +106,21 @@ Section
 	CheckBox
 	{
 		name: "plotsIterativeInterval"
+		id: plotsIterativeInterval
 		label: qsTr("Interval")
 		checked: false
 
 		RadioButtonGroup
 		{
 			name: "plotsIterativeIntervalType"
-			id: "plotsIterativeIntervalType"
+			id: plotsIterativeIntervalType
 
 			Group
 			{
 				columns: 2
 				DoubleField
 				{
-					enabled: plotsIterativeIntervalType.checked
+					enabled: plotsIterativeInterval.checked
 					name: "plotsIterativeIntervalLower"
 					label: qsTr("lower")
 					id: plotsIterativeIntervalLower
@@ -129,7 +130,7 @@ Section
 
 				DoubleField
 				{
-					enabled: plotsIterativeIntervalType.checked
+					enabled: plotsIterativeInterval.checked
 					name: "plotsIterativeIntervalUpper"
 					label: qsTr("upper")
 					id: plotsIterativeIntervalUpper


### PR DESCRIPTION
. Hopefully this fixes other crashes fount by Franticek
. In Learn Bayes, Binomial Estimation, the model is renamed to its old
value when you add a new model because the value in QML uses the key.
This is a but that will be solved later, but for the time being if you
do not use the key, it will not be updated.