### PR TITLE
Special Unicode characters are still not well displayed on Windows

### DIFF
--- a/JASP-Common/utils.cpp
+++ b/JASP-Common/utils.cpp
@@ -429,7 +429,7 @@ void Utils::convertEscapedUnicodeToUTF8(std::string& inputStr)
 	{
 		std::string utf8 = _convertEscapedUnicodeToUTF8(match[1].str()); // match 1 is the first group of the regexp: that is the 4 hexadecimals.
 		auto pos = match.position(0); // position of the whole sequence in str.
-		inputStr.replace(begin + pos, begin + pos + 8, utf8);
+		inputStr.replace(begin + pos, begin + pos + 8, utf8); // 8 is the number of characters of '<U+FFFF>'
 		// str iterators cannot be trusted after replace. They must be recalculated from str.
 		begin = inputStr.begin() + pos;
 	}

--- a/JASP-Common/utils.cpp
+++ b/JASP-Common/utils.cpp
@@ -403,18 +403,20 @@ std::string Utils::doubleToString(double dbl)
 }
 
 // hex should be 4 hexadecimals characters
-std::string Utils::_convertEscapedUnicodeToUTF8(const std::string& hex)
+std::string Utils::_convertEscapedUnicodeToUTF8(std::string hex)
 {
-	std::string result = hex;
 	std::istringstream iss(hex);
 
 	uint32_t bytes;
-	std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
-
+#ifdef _WIN32
+	static std::wstring_convert<std::codecvt_utf8<unsigned int>, unsigned int> conv;
+#else
+	static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
+#endif
 	// Read the 4 hexadecimals as bytes, and convert these bytes into UTF8.
-	if (iss >> std::hex >> bytes) result = conv.to_bytes(char32_t(bytes));
+	if (iss >> std::hex >> bytes) hex = conv.to_bytes(char32_t(bytes));
 
-	return result;
+	return hex;
 }
 
 // Replace all <U+FFFF> in str by their UT8 characters.

--- a/JASP-Common/utils.h
+++ b/JASP-Common/utils.h
@@ -70,7 +70,7 @@ public:
 
 private:
 	static std::string _deEuropeaniseForImport(			const std::string &value);
-	static std::string _convertEscapedUnicodeToUTF8(	const std::string &hex);
+	static std::string _convertEscapedUnicodeToUTF8(	std::string hex);
 
 	static std::vector<std::string>			_currentEmptyValues;
 	static const std::vector<std::string>	_defaultEmptyValues;

--- a/JASP-Common/utils.h
+++ b/JASP-Common/utils.h
@@ -66,9 +66,11 @@ public:
 	static bool			convertValueToIntForImport(		const std::string &strValue, int &intValue);
 	static bool			convertValueToDoubleForImport(	const std::string &strValue, double &doubleValue);
 	static std::string	doubleToString(double dbl);
+	static void			convertEscapedUnicodeToUTF8(	std::string &inputStr);
 
 private:
-	static std::string _deEuropeaniseForImport(		const std::string &value);
+	static std::string _deEuropeaniseForImport(			const std::string &value);
+	static std::string _convertEscapedUnicodeToUTF8(	const std::string &hex);
 
 	static std::vector<std::string>			_currentEmptyValues;
 	static const std::vector<std::string>	_defaultEmptyValues;

--- a/JASP-Engine/engine.cpp
+++ b/JASP-Engine/engine.cpp
@@ -523,6 +523,8 @@ void Engine::_encodeColumnNamesinOptions(Json::Value & options, Json::Value & me
 
 void Engine::sendString(std::string message)
 {
+	Utils::convertEscapedUnicodeToUTF8(message);
+
 	Json::Value msgJson;
 
 	if(Json::Reader().parse(message, msgJson)) //If everything is converted to jaspResults maybe we can do this there?


### PR DESCRIPTION
Fixes jasp-stats/jasp-issues#851

On Windows the gettext R function is apparently depending on the locale of the machine, and sometimes transforms for example a \u03C9 to a <U+03C9> instead of a ω character. This is afterwards considered as an
HTML tag by the WebEngine (and stays invisible). After many attempts to understand why the gettext does not work correctly on Windows (sometimes), a workaround has been decided to be added: transform in the Engine any strings containing such a string ‘<U+FFFF>’ to its UTF8 character.