### PR TITLE
remove some warnings when compiling jaspResults

### DIFF
--- a/JASP-Common/enumutilities.h
+++ b/JASP-Common/enumutilities.h
@@ -133,7 +133,6 @@ template <typename T> std::map<T, std::string> generateEnumMap(std::string strMa
 	{
 		// Token: [EnumName | EnumName=EnumValue]
 		std::string enumName;
-		T enumValue;
 		if (tokenString.find('=') == std::string::npos)
 			enumName = tokenString;
 		else

--- a/JASP-R-Interface/jaspResults/src/jaspResults.h
+++ b/JASP-R-Interface/jaspResults/src/jaspResults.h
@@ -74,6 +74,11 @@ public:
 	static bool				objectExistsInEnv(std::string envName);
 
 private:
+
+	// silences e.g., "./jaspResults.h:36:15: warning: 'jaspResults::dataEntry' hides overloaded virtual function [-Woverloaded-virtual]"
+	Json::Value	metaEntry(jaspObject * )					const	override { throw std::runtime_error("Don't call jaspResults::metaEntry(jaspObject * oldResult)"); };
+	Json::Value	dataEntry(jaspObject *, std::string & )		const	override { throw std::runtime_error("Don't call jaspResults::dataEntry(jaspObject * oldResult, std::string & errorMsg)"); };
+
 	static jaspResults				*	_jaspResults;
 	static Rcpp::Environment		*	_RStorageEnv; //we need this environment to store R objects in a "named" fashion, because then the garbage collector doesn't throw away everything...
 	static Json::Value					_response;


### PR DESCRIPTION
So when you look at [a Travis build](https://travis-ci.com/github/jasp-stats/jaspJags/builds/182427784)  you see the following:

![image](https://user-images.githubusercontent.com/21319932/91993308-80500980-ed35-11ea-9f0a-1695921d3ddd.png)


This PR is an attempt to remove the following three warnings:

1. `../../../JASP-Common/enumutilities.h:136:5: warning: unused variable 'enumValue' [-Wunused-variable]`
2. `./jaspResults.h:34:15: warning: 'jaspResults::metaEntry' hides overloaded virtual function [-Woverloaded-virtual]`
3. `./jaspResults.h:35:15: warning: 'jaspResults::dataEntry' hides overloaded virtual function [-Woverloaded-virtual]`