### PR TITLE
Some problems in Learn Bayes analyses

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/TextField.qml
+++ b/JASP-Desktop/components/JASP/Controls/TextField.qml
@@ -37,6 +37,7 @@ JASPControl
 	property alias	label:				beforeLabel.text
 	property alias	text:				beforeLabel.text
 	property alias	value:				control.text
+	property string startValue:			""
 	property string lastValidValue:		""
 	property int	fieldWidth:			jaspTheme.textFieldWidth
 	property int	fieldHeight:		0
@@ -77,7 +78,7 @@ JASPControl
 		control.editingFinished.connect(doEditingFinished);
 		control.textEdited.connect(textEdited);
 		control.pressed.connect(pressed);
-		control.released.connect(released);        
+		control.released.connect(released);
 	}	
 		
 	Rectangle

--- a/JASP-Desktop/widgets/boundqmltextinput.cpp
+++ b/JASP-Desktop/widgets/boundqmltextinput.cpp
@@ -231,7 +231,9 @@ Option *BoundQMLTextInput::createOption()
 	}
 
 	_value = getItemProperty("value").toString();
-	_setOptionValue(option, _value);
+	QString startValue = getItemProperty("startValue").toString();
+
+	_setOptionValue(option, startValue.isEmpty() ? _value : startValue);
 	return option;
 }
 

--- a/JASP-Desktop/widgets/qmllistview.cpp
+++ b/JASP-Desktop/widgets/qmllistview.cpp
@@ -244,7 +244,11 @@ void QMLListView::addRowComponentsDefaultOptions(Options *options)
 			// e.g. setup of BoundQMLListViewTerms sets whether the terms have interactions, which influences the kind of options that will be used.
 			boundItem->setUp();
 			Option* option = boundItem->createOption();
-			options->add(boundItem->name().toStdString(), option);
+			std::string optionName = boundItem->name().toStdString();
+
+			if (form() && (optionName == _optionKeyName))
+				form()->addFormError(tr("The list %1 has a rowComponent with the same name (%2) as its optionKey. Change the optionKey property of the list or the control name.").arg(name()).arg(tq(optionName)));
+			options->add(optionName, option);
 		}
 	}
 }

--- a/JASP-Desktop/widgets/rowcontrols.cpp
+++ b/JASP-Desktop/widgets/rowcontrols.cpp
@@ -33,8 +33,8 @@ RowControls::RowControls(ListModel* parent
 {
 }
 
-// Cannot do this code in the constructor: the Component create function will call the addJASPControl method (JASPControlBase, en ListView),
-// but to call the ListView needs to have already the instance of the RowControls to be able to call addJASPControl.
+// Cannot do this code in the constructor: the Component create function (comp->create(context)) will call the addJASPControl method in JASPControlBase (or ListView),
+// So this RowControls instance needs to exist already.
 void RowControls::init(int row, const Term& key, bool isNew)
 {
 	QMLListView* listView = _parentModel->listView();

--- a/Resources/Learn Bayes/qml/LSbinomialestimation.qml
+++ b/Resources/Learn Bayes/qml/LSbinomialestimation.qml
@@ -52,9 +52,7 @@ Form {
 			ComponentsList
 			{
 				name:					"priors"
-				optionKey:				"type"
 				defaultValues: 			[]
-				preferredHeight: 		90 * preferencesModel.uiScale
 				rowComponent: 			RowLayout
 				{
 					Row
@@ -65,7 +63,7 @@ Form {
 						{
 							label: 				""
 							name: 				"name"
-							value:				"Models " + rowIndex
+							startValue:			"Models " + (rowIndex + 1)
 							fieldWidth:			140 * preferencesModel.uiScale
 							useExternalBorder:	false
 							showBorder:			true

--- a/Resources/Learn Bayes/qml/LSbinomialtesting.qml
+++ b/Resources/Learn Bayes/qml/LSbinomialtesting.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick 2.8
-import QtQuick.Layouts 1.3
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.8
+import QtQuick.Layouts	1.3
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
 import "../qml/qml_components" as LS
 
 Form {
@@ -53,9 +53,7 @@ Form {
 			ComponentsList
 			{
 				name:					"priors"
-				optionKey:				"type"
 				defaultValues: 			[]
-				preferredHeight: 		90 * preferencesModel.uiScale
 				rowComponent: 			RowLayout
 				{
 					Row
@@ -66,7 +64,7 @@ Form {
 						{
 							label: 				""
 							name: 				"name"
-							value:				"Hypothesis " + rowIndex
+							startValue:			"Hypothesis " + (rowIndex + 1)
 							fieldWidth:			140 * preferencesModel.uiScale
 							useExternalBorder:	false
 							showBorder:			true

--- a/Resources/Learn Bayes/qml/qml_components/LStestinginference.qml
+++ b/Resources/Learn Bayes/qml/qml_components/LStestinginference.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick 2.8
-import QtQuick.Layouts 1.3
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.8
+import QtQuick.Layouts	1.3
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
 
 Section
 {
@@ -674,7 +674,7 @@ Section
 						enabled: plotsPosteriorMarginalCI.checked
 						name: "plotsPosteriorMarginalLower"
 						label: qsTr("lower")
-						id: plotsMarginalPosteriorLower
+						id: plotsPosteriorMarginalLower
 						fieldWidth: 50
 						defaultValue: 0.25; min: 0; max: plotsPosteriorMarginalUpper.value; inclusive: JASP.MinMax
 					}

--- a/Resources/Learn Bayes/qml/qml_components/LStestingpredictions.qml
+++ b/Resources/Learn Bayes/qml/qml_components/LStestingpredictions.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick 2.8
-import QtQuick.Layouts 1.3
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.8
+import QtQuick.Layouts	1.3
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
 
 Section
 {
@@ -237,11 +237,11 @@ Section
 
 							DoubleField
 							{
+								id: plotsPredictionPostMarginalLower
 								visible: plotsPredictionPostMarginalTypeCI.currentText == "custom"
 								enabled: plotsPredictionPostMarginalCI.checked
 								name: "plotsPredictionPostMarginalLower"
 								label: qsTr("lower")
-								id: plotsMarginalPredictionPostLower
 								fieldWidth: 50
 								defaultValue: 0; min: 0; max: plotsPredictionPostMarginalUpper.value; inclusive: JASP.MinMax
 							}


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp#1035
Fixes jasp-stats/INTERNAL-jasp#1036

. When a TextField has a binding for its value (e.g TextField { value:
“TEST ” + myCheckBox.checked ? “YES” : “NO” } ), then if you change the
value manually, and then change the value of the binding (in the
example, you click the myCheckBox), then the value of the TextField is
changed according to the binding.
The startValue property has been added in order to avoid this
behaviour: the startValue is used only when the TextField is created,
and the binding will not affect anymore the value of the TextField.

. When a ComponentsList (or a VariablesList) uses a rowComponent having
the same name as the optionKey, no error was thrown (this generates the
problem in issue jasp-stats/INTERNAL-jasp#1036). An error is now
displayed.

. the JASP constants was not imported in the QML analyses (import JASP
1.0)

. A reference to the id plotsPosteriorMarginalLower did not exist in
LStestinginterface.qml