### PR TITLE
[Do not merge for 0.14] Descriptives: added stem and leaf table

### DIFF
--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -1500,9 +1500,9 @@ Descriptives <- function(jaspResults, dataset, options) {
   right <- vapply(text, function(x) if (length(x) == 1L) "" else x[2L], FUN.VALUE = character(1L))
 
   tb <- createJaspTable(title = title)
-  tb$addColumnInfo(name = "left",  title =  "", type = "string")
-  tb$addColumnInfo(name = "sep",   title =  "", type = "separator")
-  tb$addColumnInfo(name = "right", title =  "", type = "string")
+  tb$addColumnInfo(name = "left",  title =  "Stem", type = "integer")
+  tb$addColumnInfo(name = "sep",   title =  "",     type = "separator")
+  tb$addColumnInfo(name = "right", title =  "Leaf", type = "string")
 
   tb[["left"]]  <- left
   tb[["sep"]]   <- rep("|", length(left))

--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -995,6 +995,7 @@ Descriptives <- function(jaspResults, dataset, options) {
   return(thePlot)
 }
 
+
 .plotMarginal <- function(column, variableName,
                           rugs = FALSE, displayDensity = FALSE) {
   column <- as.numeric(column)
@@ -1494,7 +1495,6 @@ Descriptives <- function(jaspResults, dataset, options) {
   footnote <- temp[2L]
   other <- temp[4:(length(temp) - 1L)]
 
-  # The commented out approach below looks fine when copied to word but the spacing is off in JASP.
   text  <- strsplit(other, " | ", fixed = TRUE)
   left  <- vapply(text, `[`, 1L, FUN.VALUE = character(1L))
   right <- vapply(text, function(x) if (length(x) == 1L) "" else x[2L], FUN.VALUE = character(1L))

--- a/JASP-Engine/JASP/R/descriptives.R
+++ b/JASP-Engine/JASP/R/descriptives.R
@@ -206,7 +206,7 @@ Descriptives <- function(jaspResults, dataset, options) {
 
     numericOrFactorVariables <- Filter(function(var) .descriptivesIsNumericColumn(dataset.factors, var), variables)
 
-    .descriptivesStemAndLeaf(
+    .descriptivesStemAndLeafTables(
       container = jaspResults[["stemAndLeaf"]],
       dataset   = if (makeSplit) splitDat.factors else dataset.factors,
       variables = numericOrFactorVariables,
@@ -1449,12 +1449,11 @@ Descriptives <- function(jaspResults, dataset, options) {
     return(FALSE)
 }
 
-.descriptivesStemAndLeaf <- function(container, dataset, variables, options) {
+.descriptivesStemAndLeafTables <- function(container, dataset, variables, options, width = 120, atom = 1e-08) {
 
   # parameters for graphics::stem
   scale <- options[["stemAndLeafScale"]]
-  width <- 120   # we could add this, but the R documentation is unclear as to what it does.
-  atom  <- 1e-08 # we could add this, but the R documentation is unclear as to what it does.
+  # width and atom are set to R's default values. We could allow the user to set them but the R documentation is unclear as to what it does.
 
   if (!is.data.frame(dataset)) { # dataset is split
 
@@ -1469,7 +1468,7 @@ Descriptives <- function(jaspResults, dataset, options) {
       for (split in splitLevels) {
 
         tableName <- paste0("stem_and_leaf_", var, "_", split)
-        subcontainer[[tableName]] <- .descriptivesStemAndLeafToTable(dataset[[split]][[.v(var)]], split, scale, width, atom)
+        subcontainer[[tableName]] <- .descriptivesStemAndLeafCreateSingleTable(dataset[[split]][[.v(var)]], split, scale, width, atom)
         subcontainer[[tableName]]$dependOn(optionContainsValue = list(variables = var))
 
       }
@@ -1479,14 +1478,14 @@ Descriptives <- function(jaspResults, dataset, options) {
 
     for (var in variables) {
       tableName <- paste0("stem_and_leaf_", var)
-      container[[tableName]] <- .descriptivesStemAndLeafToTable(dataset[[.v(var)]], var, scale, width, atom)
+      container[[tableName]] <- .descriptivesStemAndLeafCreateSingleTable(dataset[[.v(var)]], var, scale, width, atom)
       container[[tableName]]$dependOn(optionContainsValue = list(variables = var))
     }
 
   }
 }
 
-.descriptivesStemAndLeafToTable <- function(x, title, scale = 1, width = 80, atom = 1e-08) {
+.descriptivesStemAndLeafCreateSingleTable <- function(x, title, scale = 1, width = 80, atom = 1e-08) {
 
   # NOTE: graphics::stem is fast because it works in C, but it prints directly to the R output and returns NULL...
   # so we resort to capturing the string and manipulating it.

--- a/Resources/Descriptives/qml/Descriptives.qml
+++ b/Resources/Descriptives/qml/Descriptives.qml
@@ -19,6 +19,7 @@
 import QtQuick			2.8
 import JASP.Controls	1.0
 import JASP.Widgets		1.0
+import JASP				1.0
 
 // All Analysis forms must be built with the From QML item
 Form
@@ -32,6 +33,13 @@ Form
 	}
 
 	CheckBox { name: "frequencyTables"; label: qsTr("Frequency tables (nominal and ordinal variables)"); }
+
+	CheckBox
+	{
+		name	: "stemAndLeaf";
+		label	: qsTr("Stem and leaf table")
+		DoubleField	{name: "stemAndLeafScale";	label: qsTr("scale");	negativeValues: false;	inclusive: JASP.MaxOnly;	max: 200;	defaultValue: 1.0; }
+	}
 
 	Section
 	{

--- a/Resources/Descriptives/qml/Descriptives.qml
+++ b/Resources/Descriptives/qml/Descriptives.qml
@@ -37,7 +37,7 @@ Form
 	CheckBox
 	{
 		name	: "stemAndLeaf";
-		label	: qsTr("Stem and leaf table")
+		label	: qsTr("Stem and leaf tables")
 		DoubleField	{name: "stemAndLeafScale";	label: qsTr("scale");	negativeValues: false;	inclusive: JASP.MaxOnly;	max: 200;	defaultValue: 1.0; }
 	}
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/684 and implements stem and leaf tables:

![image](https://user-images.githubusercontent.com/21319932/92398072-2cc03000-f128-11ea-83be-82dd826b414f.png)

Note that the spacing is suboptimal. It looks like this is a limitation in jaspResults at the moment which should probably be fixed in a separate PR (and perhaps more generally than just for these tables).

Considering the dot plots also requested in that issue, perhaps we should reconsider those. The few examples I made of those look exactly like a histogram, so the added value is unclear to me. For example, consider:

```r
ggplot(mtcars, aes(x = mpg)) + geom_dotplot()
ggplot(mtcars, aes(x = mpg)) + geom_histogram()
```
which gives:
![image](https://user-images.githubusercontent.com/21319932/92398179-64c77300-f128-11ea-99ee-9f29db5aacca.png)
and
![image](https://user-images.githubusercontent.com/21319932/92398191-6c871780-f128-11ea-9edb-184774c5c583.png)

There is some smoothing in the histogram that is not in the dot plot, but the differences are rather minimal.
