### PR TITLE
Setting an interface font makes data disappears

### DIFF
--- a/JASP-Desktop/analysis/analysisform.cpp
+++ b/JASP-Desktop/analysis/analysisform.cpp
@@ -551,6 +551,8 @@ void AnalysisForm::bindTo()
 				}
 			}
 		}
+
+		control->item()->setInitialized();
 	}
 
 	for (ListModelAvailableInterface* availableModel : availableModelsToBeReset)

--- a/JASP-Desktop/analysis/jaspcontrolbase.cpp
+++ b/JASP-Desktop/analysis/jaspcontrolbase.cpp
@@ -87,7 +87,11 @@ void JASPControlBase::componentComplete()
 	if (!hasContextForm)
 	{
 		if (_form)	_form->addControl(this);
-		else		_wrapper->setUp();
+		else
+		{
+			_wrapper->setUp();
+			setInitialized();
+		}
 	}
 	else
 	{
@@ -95,6 +99,7 @@ void JASPControlBase::componentComplete()
 		if (!noDirectSetup)
 			_wrapper->setUp();
 
+		setInitialized();
 		QMLListView* listView = nullptr;
 
 		QVariant listViewVar = context->contextProperty("listView");

--- a/JASP-Desktop/analysis/jaspcontrolbase.h
+++ b/JASP-Desktop/analysis/jaspcontrolbase.h
@@ -25,6 +25,7 @@ class JASPControlBase : public QQuickItem
 	Q_PROPERTY( bool								hasError			READ hasError			WRITE setHasError			NOTIFY hasErrorChanged				)
 	Q_PROPERTY( bool								hasWarning			READ hasWarning			WRITE setHasWarning			NOTIFY hasWarningChanged			)
 	Q_PROPERTY( bool								runOnChange			READ runOnChange		WRITE setRunOnChange		NOTIFY runOnChangeChanged			)
+	Q_PROPERTY( bool								initialized			READ initialized									NOTIFY initializedChanged			)
 	Q_PROPERTY( QQuickItem						*	childControlsArea	READ childControlsArea	WRITE setChildControlsArea										)
 	Q_PROPERTY( QQuickItem						*	parentListView		READ parentListView									NOTIFY parentListViewChanged		)
 	Q_PROPERTY( QQuickItem						*	innerControl		READ innerControl		WRITE setInnerControl		NOTIFY innerControlChanged			)
@@ -78,6 +79,7 @@ public:
 	QString			info()					const	{ return _info;					}
 	QString			helpMD(int howDeep = 2)	const;
 	bool			isBound()				const	{ return _isBound;				}
+	bool			initialized()			const	{ return _initialized;			}
 	bool			debug()					const	{ return _debug;				}
 	bool			parentDebug()			const	{ return _parentDebug;			}
 	bool			hasError()				const;
@@ -94,6 +96,7 @@ public:
 	bool			runOnChange()			const	{ return _runOnChange;			}
 
 	QString			humanFriendlyLabel()	const;
+	void			setInitialized()	{ _initialized = true; emit initializedChanged(); }
 
 
 	JASPControlWrapper				*	getWrapper()				const { return _wrapper; }
@@ -139,6 +142,7 @@ signals:
 	void setOptionBlockSignal(	bool blockSignal);
 	void nameChanged();
 	void isBoundChanged();
+	void initializedChanged();
 	void debugChanged();
 	void parentDebugChanged();
 	void hasErrorChanged();
@@ -175,6 +179,7 @@ protected:
 							_title,
 							_parentListViewKey;
 	bool					_isBound				= true,
+							_initialized			= false,
 							_debug					= false,
 							_parentDebug			= false,
 							_hasError				= false,

--- a/JASP-Desktop/components/JASP/Controls/ComboBox.qml
+++ b/JASP-Desktop/components/JASP/Controls/ComboBox.qml
@@ -22,6 +22,7 @@ JASPControl
 	property alias	currentLabel:			comboBox.currentText
 	property string currentValue:			"" // This is the current value (what is used by R)
 	property alias	value:					comboBox.currentText
+	property string	startValue:				""
 	property string currentColumnType:		"" // When the values come from column names, this property gives the column type of the current selected column
 	property alias	currentIndex:			control.currentIndex
 	property alias	indexDefaultValue:		control.currentIndex
@@ -35,8 +36,6 @@ JASPControl
 	property alias	syncModels:				comboBox.source
 	property bool	addEmptyValue:			false
 	property string	placeholderText:		qsTr("<no choice>")
-	property bool	isDirectModel:			false
-	property bool	initialized:			isDirectModel
 	property var	enabledOptions:			[]
 	property bool	setLabelAbove:			false
 	property int	controlMinWidth:		0
@@ -156,7 +155,7 @@ JASPControl
 			{
 				anchors.left:				contentIcon.visible ? contentIcon.right : parent.left
 				anchors.leftMargin:			4 * preferencesModel.uiScale
-				text:						control.isEmptyValue ? comboBox.placeholderText : (comboBox.isDirectModel ? control.currentText : comboBox.currentText)
+				text:						control.isEmptyValue ? comboBox.placeholderText : comboBox.currentText
 				font:						control.font
 				anchors.verticalCenter:		parent.verticalCenter
 				anchors.horizontalCenter:	control.showEmptyValueStyle ? parent.horizontalCenter : undefined

--- a/JASP-Desktop/components/JASP/Controls/VariablesForm.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesForm.qml
@@ -150,7 +150,6 @@ Item
 				anchors.leftMargin: (assignButton.width - width - 4) / 2
 				anchors.top:		assignButton.bottom
 				anchors.topMargin:	2
-				isDirectModel:		true
 				currentIndex:		0
 				values: ListModel 
 				{

--- a/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/JASP-Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -57,7 +57,7 @@ ScrollView
 
 				Text { text: qsTr("Interface:") }
 
-				ComboBox
+				DropDown
 				{
 					id						: interfaceFonts
 					values					: preferencesModel.allInterfaceFonts
@@ -66,8 +66,8 @@ ScrollView
 					addLineAfterEmptyValue	: true
 					addScrollBar			: true
 					placeholderText			: qsTr("default: %1").arg(defaultInterfaceFont.fontInfo.family)
-					value					: currentIndex <= 0 ? placeholderText : preferencesModel.interfaceFont
-					onValueChanged			: preferencesModel.interfaceFont = value
+					startValue				: preferencesModel.interfaceFont
+					onValueChanged			: if (initialized) preferencesModel.interfaceFont = (currentIndex <= 0 ? "" : value)
 
 					KeyNavigation.tab		: codeFonts
 					KeyNavigation.down		: codeFonts
@@ -85,7 +85,7 @@ ScrollView
 
 				Text { text: qsTr("R, JAGS or Lavaan code:") }
 
-				ComboBox
+				DropDown
 				{
 					id						: codeFonts
 					values					: preferencesModel.allCodeFonts
@@ -94,8 +94,8 @@ ScrollView
 					addLineAfterEmptyValue	: true
 					addScrollBar			: true
 					placeholderText			: qsTr("default: %1").arg(defaultRCodeFont.fontInfo.family)
-					value					: currentIndex <= 0 ? placeholderText : preferencesModel.codeFont
-					onValueChanged			: preferencesModel.codeFont = value
+					startValue				: preferencesModel.codeFont
+					onValueChanged			: if (initialized) preferencesModel.codeFont = (currentIndex <= 0 ? "" : value)
 
 					KeyNavigation.tab		: resultFonts
 					KeyNavigation.down		: resultFonts
@@ -112,7 +112,7 @@ ScrollView
 
 				Text { text: qsTr("Result & Help:") }
 
-				ComboBox
+				DropDown
 				{
 					id						: resultFonts
 					values					: preferencesModel.allResultFonts
@@ -121,8 +121,8 @@ ScrollView
 					addLineAfterEmptyValue	: true
 					addScrollBar			: true
 					placeholderText			: qsTr("default: %1").arg(defaultResultFont.fontInfo.family)
-					value					: currentIndex <= 0 ? placeholderText : preferencesModel.resultFont
-					onValueChanged			: preferencesModel.resultFont = value
+					startValue				: preferencesModel.resultFont
+					onValueChanged			: if (initialized) preferencesModel.resultFont = (currentIndex <= 0 ? "" : value)
 
 					KeyNavigation.tab		: lightThemeButton
 					KeyNavigation.down		: lightThemeButton

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -470,7 +470,8 @@ void MainWindow::loadQML()
 	Log::log() << "Loading AboutWindow" << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/AboutWindow.qml"));
 	Log::log() << "Loading MainWindow"  << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/MainWindow.qml"));
 
-	connect(_preferences, &PreferencesModel::uiScaleChanged, DataSetView::lastInstancedDataSetView(), &DataSetView::viewportChanged, Qt::QueuedConnection);
+	connect(_preferences, &PreferencesModel::uiScaleChanged,		DataSetView::lastInstancedDataSetView(), &DataSetView::viewportChanged, Qt::QueuedConnection);
+	connect(_preferences, &PreferencesModel::interfaceFontChanged,	DataSetView::lastInstancedDataSetView(), &DataSetView::viewportChanged, Qt::QueuedConnection);
 
 	Log::log() << "QML Initialized!"  << std::endl;
 

--- a/JASP-Desktop/widgets/boundqmlcombobox.cpp
+++ b/JASP-Desktop/widgets/boundqmlcombobox.cpp
@@ -133,7 +133,7 @@ void BoundQMLComboBox::setUp()
 	if (_currentIndex == -1)
 	{
 		// In case a value is given per default, find its index and sets it.
-		QString value = getItemProperty("value").toString();
+		QString value = getItemProperty("startValue").toString();
 		if (!value.isEmpty())
 			_currentIndex = _model->getIndexOfValue(value);
 	}
@@ -251,6 +251,10 @@ void BoundQMLComboBox::_setCurrentValue(int index, bool setComboBoxIndex, bool s
 			_currentColumnType = _model->data(index, ListModel::ColumnTypeRole).toString();			
 		}
 	}
+
+	if (_currentIndex == -1 && getItemProperty("addEmptyValue").toBool())
+		_currentText = getItemProperty("placeholderText").toString();
+
 	setItemProperty("currentText", _currentText);
 	// Cannot use _boundTo to get the current value, because when _boundTo is changed (by setting the current index),
 	// it emits a signal that can be received by a slot that needs already the currentValue.

--- a/JASP-Desktop/widgets/qmlexpander.cpp
+++ b/JASP-Desktop/widgets/qmlexpander.cpp
@@ -62,4 +62,6 @@ void QMLExpander::setUp()
 		if (firstControl)
 			setItemProperty("firstControl", QVariant::fromValue(firstControl));
 	}
+
+	item()->setInitialized();
 }


### PR DESCRIPTION
The main problem was that when the interface font is changed, it should call (like for uiScale change) the viewPort change slot of the DataSetView. 

The DropDown settings in PrefsUI.qml were confusing: the value was set to be the preferencesModel.interfaceFont, but onValueChanged signal sets the preferencesModel.interfaceFont to value.
The value should not be directly set in a DropDown, only the currentIndex. If no currentIndex is known, then a new property is made ‘startValue’ that sets internally the right currentIndex.

Moreover, when an item is being initialised, the properties are changed from empty to the specified value. So onValueChanged is called twice (empty and specified value), without real interaction with the user. These calls should be avoided, so the property ‘initialized’ has been added, and is set to true only when the control is fully initialised, and can be used to avoid these extra onValueChanged calls.

Remove obsolete isDirectModel property in ComboBox