### PR TITLE
Fix scaling of cells in DataSetViewer

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/JASP-Desktop/components/JASP/Widgets/DataTableView.qml
@@ -28,6 +28,9 @@ FocusScope
 			anchors.right:		parent.right
 			anchors.bottom:		dataStatusBar.top
 
+			itemHorizontalPadding:	8 * jaspTheme.uiScale
+			itemVerticalPadding:	8 * jaspTheme.uiScale
+
 			model:				dataSetModel
 			onDoubleClicked:	__myRoot.doubleClicked()
 

--- a/JASP-Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/JASP-Desktop/components/JASP/Widgets/DataTableView.qml
@@ -28,8 +28,6 @@ FocusScope
 			anchors.right:		parent.right
 			anchors.bottom:		dataStatusBar.top
 
-			font:	jaspTheme.font
-
 			model:				dataSetModel
 			onDoubleClicked:	__myRoot.doubleClicked()
 
@@ -38,7 +36,7 @@ FocusScope
 				{
 					text:				itemText
 					color:				itemActive ? jaspTheme.textEnabled : jaspTheme.textDisabled
-					font:				dataFont
+					font:				jaspTheme.font
 					verticalAlignment:	Text.AlignVCenter
 				}
 
@@ -72,8 +70,8 @@ FocusScope
 					color:	jaspTheme.uiBackground
 					Text {
 						text:				rowIndex + 1
+						font:				jaspTheme.font
 						anchors.centerIn:	parent
-						font:				dataTableView.font
 						color:				jaspTheme.textEnabled
 					}
 
@@ -83,6 +81,7 @@ FocusScope
 			{
 				id:		headerRoot
 				color:	jaspTheme.uiBackground
+
 							property real	iconTextPadding:	10
 				readonly	property int	__iconDim:			baseBlockDim * preferencesModel.uiScale
 
@@ -190,7 +189,7 @@ FocusScope
 					id:				headerTextItem
 
 					text:			headerText
-					font:			dataTableView.font
+					font:			jaspTheme.font
 					color:			jaspTheme.textEnabled
 
 					horizontalAlignment:		Text.AlignHCenter
@@ -312,7 +311,7 @@ FocusScope
 			{
 				id:						datafiltertatusText
 				text:					filterModel.statusBarText
-				font:					dataTableView.font
+				font:					jaspTheme.font
 				color:					jaspTheme.textEnabled
 				anchors.left:			parent.left
 				anchors.verticalCenter:	parent.verticalCenter

--- a/JASP-Desktop/components/JASP/Widgets/JASPDataView.qml
+++ b/JASP-Desktop/components/JASP/Widgets/JASPDataView.qml
@@ -8,23 +8,23 @@ import JASP				1.0
 FocusScope
 {
 	id: __JASPDataViewRoot
-	property alias model: theView.model
 
-	property alias itemDelegate:			theView.itemDelegate
-	property alias rowNumberDelegate:		theView.rowNumberDelegate
-	property alias columnHeaderDelegate:	theView.columnHeaderDelegate
-	property alias leftTopCornerItem:		theView.leftTopCornerItem
-	property alias extraColumnItem:			theView.extraColumnItem
+				property alias model:					theView.model
 
-	property alias itemHorizontalPadding:	theView.itemHorizontalPadding
-	property alias itemVerticalPadding:		theView.itemVerticalPadding
-	property alias font:					theView.font
-	property alias rowNumberWidth:			theView.rowNumberWidth
+				property alias itemDelegate:			theView.itemDelegate
+				property alias rowNumberDelegate:		theView.rowNumberDelegate
+				property alias columnHeaderDelegate:	theView.columnHeaderDelegate
+				property alias leftTopCornerItem:		theView.leftTopCornerItem
+				property alias extraColumnItem:			theView.extraColumnItem
 
-	readonly property alias contentX:		myFlickable.contentX
-	readonly property alias contentY:		myFlickable.contentY
-	readonly property alias contentWidth:	myFlickable.contentWidth
-	readonly property alias contentHeight:	myFlickable.contentHeight
+				property alias itemHorizontalPadding:	theView.itemHorizontalPadding
+				property alias itemVerticalPadding:		theView.itemVerticalPadding
+				property alias rowNumberWidth:			theView.rowNumberWidth
+
+	readonly	property alias contentX:				myFlickable.contentX
+	readonly	property alias contentY:				myFlickable.contentY
+	readonly	property alias contentWidth:			myFlickable.contentWidth
+	readonly	property alias contentHeight:			myFlickable.contentHeight
 
 	JASPMouseAreaToolTipped
 	{

--- a/JASP-Desktop/qquick/datasetview.cpp
+++ b/JASP-Desktop/qquick/datasetview.cpp
@@ -334,9 +334,7 @@ void DataSetView::addLine(float x0, float y0, float x1, float y1)
 
 QSizeF DataSetView::getTextSize(const QString & text) const
 {
-	QFontMetricsF metricsFont(JaspTheme::currentTheme()->font());
-
-	return metricsFont.size(Qt::TextSingleLine, text);
+	return JaspTheme::fontMetrics().size(Qt::TextSingleLine, text);
 }
 
 void DataSetView::buildNewLinesAndCreateNewItems()

--- a/JASP-Desktop/qquick/datasetview.cpp
+++ b/JASP-Desktop/qquick/datasetview.cpp
@@ -37,8 +37,8 @@ DataSetView::DataSetView(QQuickItem *parent) : QQuickItem (parent)
 	connect(this, &DataSetView::itemSizeChanged,				this, &DataSetView::reloadRowNumbers);
 	connect(this, &DataSetView::itemSizeChanged,				this, &DataSetView::reloadColumnHeaders);
 
-	connect(PreferencesModel::prefs(), &PreferencesModel::uiScaleChanged,		this, &DataSetView::resetItems);
-	connect(PreferencesModel::prefs(), &PreferencesModel::interfaceFontChanged,	this, &DataSetView::resetItems);
+	connect(PreferencesModel::prefs(), &PreferencesModel::uiScaleChanged,		this, &DataSetView::resetItems, Qt::QueuedConnection);
+	connect(PreferencesModel::prefs(), &PreferencesModel::interfaceFontChanged,	this, &DataSetView::resetItems, Qt::QueuedConnection);
 
 	setZ(10);
 

--- a/JASP-Desktop/qquick/datasetview.h
+++ b/JASP-Desktop/qquick/datasetview.h
@@ -9,7 +9,6 @@
 #include <QSGFlatColorMaterial>
 
 #include <map>
-#include <QFontMetricsF>
 #include <QtQml>
 #include "utilities/qutils.h"
 #include "gui/preferencesmodel.h"

--- a/JASP-Desktop/qquick/datasetview.h
+++ b/JASP-Desktop/qquick/datasetview.h
@@ -43,7 +43,6 @@ class DataSetView : public QQuickItem
 	Q_PROPERTY( QQmlComponent * columnHeaderDelegate	READ columnHeaderDelegate	WRITE setColumnHeaderDelegate	NOTIFY columnHeaderDelegateChanged	)
 	Q_PROPERTY( QQuickItem * leftTopCornerItem			READ leftTopCornerItem		WRITE setLeftTopCornerItem		NOTIFY leftTopCornerItemChanged		)
 	Q_PROPERTY( QQuickItem * extraColumnItem			READ extraColumnItem		WRITE setExtraColumnItem		NOTIFY extraColumnItemChanged		)
-	Q_PROPERTY( QFont font								READ font					WRITE setFont					NOTIFY fontChanged					)
 	Q_PROPERTY( double headerHeight						READ headerHeight											NOTIFY headerHeightChanged			)
 	Q_PROPERTY( double rowNumberWidth					READ rowNumberWidth			WRITE setRowNumberWidth			NOTIFY rowNumberWidthChanged		)
 	Q_PROPERTY( bool cacheItems							READ cacheItems				WRITE setCacheItems				NOTIFY cacheItemsChanged			)
@@ -75,7 +74,6 @@ public:
 	QQuickItem * tableViewItem()			{ return _tableViewItem; }
 
 	bool cacheItems()						{ return _cacheItems; }
-	QFont font()							{ return _font; }
 
 	GENERIC_SET_FUNCTION(CacheItems, _cacheItems, cacheItemsChanged, bool)
 
@@ -96,8 +94,6 @@ public:
 
 	void setTableViewItem(			QQuickItem * tableViewItem) { _tableViewItem = tableViewItem; }
 
-	void setFont(const QFont& font);
-
 	int headerHeight()			{ return _dataRowsMaxHeight; }
 	int rowNumberWidth()		{ return _rowNumberMaxWidth; }
 
@@ -109,7 +105,6 @@ public:
 
 signals:
 	void modelChanged();
-	void fontPixelSizeChanged();
 	void itemHorizontalPaddingChanged();
 	void itemVerticalPaddingChanged();
 
@@ -126,17 +121,15 @@ signals:
 
 	void itemSizeChanged();
 
-	void fontChanged();
-
 	void headerHeightChanged();
 	void rowNumberWidthChanged();
 
 	void cacheItemsChanged();
 
-public slots:
-	void calculateCellSizes();
 
-	void aContentSizeChanged() { _recalculateCellSizes = true; }
+public slots:
+	void calculateCellSizes()	{ calculateCellSizesAndClear(false); }
+	void aContentSizeChanged()	{ _recalculateCellSizes = true; }
 	void viewportChanged();
 	void myParentChanged(QQuickItem *);
 
@@ -152,6 +145,7 @@ public slots:
 	void setExtraColumnX();
 
 protected:
+	void calculateCellSizesAndClear(bool clearStorage);
 	void setRolenames();
 	void determineCurrentViewPortIndices();
 	void storeOutOfViewItems();
@@ -160,14 +154,14 @@ protected:
 	QSGNode *updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *data) override;
 	float extraColumnWidth() { return _extraColumnItem == nullptr ? 0 : 1 + _extraColumnItem->width(); }
 
-	QQuickItem * createTextItem(int row, int col);
-	void storeTextItem(int row, int col, bool cleanUp = true);
+	QQuickItem *	createTextItem(int row, int col);
+	void			storeTextItem(int row, int col, bool cleanUp = true);
 
-	QQuickItem * createRowNumber(int row);
-	void storeRowNumber(int row);
+	QQuickItem *	createRowNumber(int row);
+	void			storeRowNumber(int row);
 
-	QQuickItem * createColumnHeader(int col);
-	void storeColumnHeader(int col);
+	QQuickItem *	createColumnHeader(int col);
+	void			storeColumnHeader(int col);
 
 	QQuickItem *	createleftTopCorner();
 	void			updateExtraColumnItem();
@@ -178,7 +172,7 @@ protected:
 
 	void addLine(float x0, float y0, float x1, float y1);
 
-	QSizeF getTextSize(const QString& text)	const		{ 	return _metricsFont.size(Qt::TextSingleLine, text) * PreferencesModel::prefs()->uiScale(); }
+	QSizeF getTextSize(const QString& text)	const;
 	QSizeF getColumnSize(int col);
 	QSizeF getRowHeaderSize();
 
@@ -219,8 +213,6 @@ protected:
 
 	QSGFlatColorMaterial material;
 
-	QFont _font;
-
 	double _viewportX=0, _viewportY=0, _viewportW=1, _viewportH=1;
 	int _previousViewportColMin = -1,
 		_previousViewportColMax = -1,
@@ -231,8 +223,6 @@ protected:
 		_currentViewportColMax	= -1,
 		_currentViewportRowMin	= -1,
 		_currentViewportRowMax	= -1;
-
-	QFontMetricsF _metricsFont;
 
 	std::map<std::string, int> _roleNameToRole;
 

--- a/JASP-Desktop/qquick/jasptheme.cpp
+++ b/JASP-Desktop/qquick/jasptheme.cpp
@@ -14,25 +14,25 @@ JaspTheme::JaspTheme(QQuickItem * parent) : QQuickItem(parent)
 	_jaspFont			= PreferencesModel::prefs()->interfaceFont();
 	_jaspCodeFont		= PreferencesModel::prefs()->codeFont();
 
-	connect(this,			&JaspTheme::currentThemeNameChanged,		PreferencesModel::prefs(),	&PreferencesModel::setCurrentThemeName	);
-	connect(this,			&JaspTheme::jaspThemeChanged,				PreferencesModel::prefs(),	&PreferencesModel::jaspThemeChanged		);
-	connect(PreferencesModel::prefs(),	&PreferencesModel::uiScaleChanged,			this,			&JaspTheme::uiScaleChanged				);
-	connect(PreferencesModel::prefs(),	&PreferencesModel::maxFlickVelocityChanged, this,			&JaspTheme::maximumFlickVelocity		);
-	connect(PreferencesModel::prefs(),	&PreferencesModel::interfaceFontChanged,this,				&JaspTheme::setDefaultFont				);
-	connect(PreferencesModel::prefs(),	&PreferencesModel::codeFontChanged,		this,				&JaspTheme::setDefaultCodeFont			);
+	connect(this,						&JaspTheme::currentThemeNameChanged,		PreferencesModel::prefs(),	&PreferencesModel::setCurrentThemeName	);
+	connect(this,						&JaspTheme::jaspThemeChanged,				PreferencesModel::prefs(),	&PreferencesModel::jaspThemeChanged		);
+	connect(PreferencesModel::prefs(),	&PreferencesModel::uiScaleChanged,			this,						&JaspTheme::uiScaleChanged				);
+	connect(PreferencesModel::prefs(),	&PreferencesModel::maxFlickVelocityChanged, this,						&JaspTheme::maximumFlickVelocity		);
+	connect(PreferencesModel::prefs(),	&PreferencesModel::interfaceFontChanged,	this,						&JaspTheme::setDefaultFont				);
+	connect(PreferencesModel::prefs(),	&PreferencesModel::codeFontChanged,			this,						&JaspTheme::setDefaultCodeFont			);
 
 	connectSizeDistancesToUiScaleChanged();
 
 	if(_currentTheme == nullptr)
 		setCurrentTheme(this);
 
-	setFont(_jaspFont);
-	setFontLabel(_jaspFont);
-	setFontRibbon(_jaspFont);
-	setFontGroupTitle(_jaspFont);
-	setFontPrefOptionsGroupTitle(_jaspFont);
-	setFontCode(_jaspCodeFont);
-	setFontRCode(_jaspCodeFont);
+	setFont(						_jaspFont);
+	setFontLabel(					_jaspFont);
+	setFontRibbon(					_jaspFont);
+	setFontGroupTitle(				_jaspFont);
+	setFontPrefOptionsGroupTitle(	_jaspFont);
+	setFontCode(					_jaspCodeFont);
+	setFontRCode(					_jaspCodeFont);
 
 	_fontCode.setStyleHint(QFont::Monospace); // Cannot be set in QML https://bugreports.qt.io/browse/QTBUG-38931
 }

--- a/JASP-Desktop/qquick/jasptheme.cpp
+++ b/JASP-Desktop/qquick/jasptheme.cpp
@@ -139,8 +139,8 @@ void JaspTheme::setCurrentTheme(JaspTheme * theme)
 
 	if(_currentTheme)
 	{
-		emit _currentTheme->jaspThemeChanged(theme);
 		_currentTheme->updateFontMetrics();
+		emit _currentTheme->jaspThemeChanged(theme);
 	}
 
 

--- a/JASP-Desktop/qquick/jasptheme.cpp
+++ b/JASP-Desktop/qquick/jasptheme.cpp
@@ -6,6 +6,7 @@
 JaspTheme			*	JaspTheme::_currentTheme	= nullptr;
 QFont					JaspTheme::_jaspFont		= QFont("SansSerif");
 QFont					JaspTheme::_jaspCodeFont	= QFont("FiraCode-Retina");
+QFontMetricsF			JaspTheme::_fontMetrics		= QFontMetrics(_jaspFont);
 
 std::map<QString, JaspTheme *> JaspTheme::_themes;
 
@@ -35,6 +36,10 @@ JaspTheme::JaspTheme(QQuickItem * parent) : QQuickItem(parent)
 	setFontRCode(					_jaspCodeFont);
 
 	_fontCode.setStyleHint(QFont::Monospace); // Cannot be set in QML https://bugreports.qt.io/browse/QTBUG-38931
+
+	updateFontMetrics();
+
+	connect(this,						&JaspTheme::uiScaleChanged,					this,						&JaspTheme::updateFontMetrics			);
 }
 
 JaspTheme::~JaspTheme()
@@ -133,7 +138,12 @@ void JaspTheme::setCurrentTheme(JaspTheme * theme)
 	_currentTheme = theme;
 
 	if(_currentTheme)
+	{
 		emit _currentTheme->jaspThemeChanged(theme);
+		_currentTheme->updateFontMetrics();
+	}
+
+
 }
 
 void JaspTheme::setCurrentThemeFromName(QString name)
@@ -1309,4 +1319,10 @@ void JaspTheme::setDarkeningColour(QColor darkeningColour)
 
 	_darkeningColour = darkeningColour;
 	emit darkeningColourChanged(_darkeningColour);
+}
+
+void JaspTheme::updateFontMetrics()
+{
+	if(currentTheme())
+		_fontMetrics = QFontMetrics(currentTheme()->font());
 }

--- a/JASP-Desktop/qquick/jasptheme.h
+++ b/JASP-Desktop/qquick/jasptheme.h
@@ -4,6 +4,7 @@
 #include <QQuickItem>
 #include <QColor>
 #include <QFont>
+#include <QFontMetricsF>
 #include "gui/preferencesmodel.h"
 
 #define theme_distanceType	float
@@ -180,7 +181,8 @@ public:
 	static void setCurrentTheme(JaspTheme * theme);
 	static void setCurrentThemeFromName(QString name);
 
-	static JaspTheme * currentTheme() { return _currentTheme; }
+	static JaspTheme		* currentTheme() { return _currentTheme; }
+	static QFontMetricsF	& fontMetrics()	 { return _fontMetrics;  } //For qml interface font used everywhere (in particular in datasetview though)
 
 	float				uiScale()							const	{ return PreferencesModel::prefs()->uiScale(); }
 	float				ribbonScaleHovered()				const	{ return _ribbonScaleHovered; }
@@ -579,6 +581,9 @@ public slots:
 private:
 	void connectSizeDistancesToUiScaleChanged();
 
+private slots:
+	void updateFontMetrics();
+
 private:
 	static JaspTheme		* _currentTheme;
 
@@ -715,10 +720,12 @@ private:
 	static QFont		_jaspFont,
 						_jaspCodeFont;
 
+
 	QString				_iconPath,
 						_themeName;
 
-	static std::map<QString, JaspTheme *> _themes;
+	static QFontMetricsF					_fontMetrics;
+	static std::map<QString, JaspTheme *>	_themes;
 };
 
 

--- a/JASP-Desktop/qquick/jasptheme.h
+++ b/JASP-Desktop/qquick/jasptheme.h
@@ -180,6 +180,8 @@ public:
 	static void setCurrentTheme(JaspTheme * theme);
 	static void setCurrentThemeFromName(QString name);
 
+	static JaspTheme * currentTheme() { return _currentTheme; }
+
 	float				uiScale()							const	{ return PreferencesModel::prefs()->uiScale(); }
 	float				ribbonScaleHovered()				const	{ return _ribbonScaleHovered; }
 	QColor				white()								const	{ return _white; }


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/914
- Removed "font" from datasetview because it wasn't being used consistently anyway, and is unnecessary with JaspTheme being available
- getTextSize was mistakenly multiplying a size by uiScale that already had it's pixelSize multiplied by that, leading to ridiculously large cells when zoomed in far

