### PR TITLE
Make sure menu-button in results is hidden for pdf-export

### DIFF
--- a/JASP-Desktop/html/css/printing.css
+++ b/JASP-Desktop/html/css/printing.css
@@ -4,7 +4,9 @@
 
     .jasp-toolbar h1, .jasp-toolbar h2, .jasp-toolbar h3, .jasp-toolbar h4, .jasp-toolbar h5, .jasp-toolbar h6, .jasp-toolbar div , .jasp-toolbar span
 	                                { display:				block !important;	}
-	.toolbar-button					{ display:				none  !important;	}
+	.toolbar-button					{ display:				none  !important;	visibility: hidden; }
+	.jasp-menu						{ display:				none  !important;	visibility: hidden; }
+	.jasp-menu-selected				{ display:				none  !important;	visibility: hidden; }
 	body							{ float:				none  !important;	}
 
     .jasp-toolbar					{ page-break-after:		avoid;	}

--- a/JASP-Desktop/html/js/jaspwidgets.js
+++ b/JASP-Desktop/html/js/jaspwidgets.js
@@ -776,7 +776,7 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 
 			var $self = this.$el.find(">:first-child");
 			$self.tooltip({
-				content: "Damo is awesome",
+				content: "...",
 				items: "*",
 				disabled: true,
 				show: {


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/1010
- Im not sure if all of those hidden/display:none are necessary, but GoogleChrome updated so I can't connect with the debugger...

