### PR TITLE
Remove successes and failures when changing selected variable in BinomialTesting

### DIFF
--- a/JASP-Desktop/widgets/qmllistview.cpp
+++ b/JASP-Desktop/widgets/qmllistview.cpp
@@ -182,7 +182,7 @@ void QMLListView::setSources()
 			ListModel* sourceModel = form()->getModel(sourceItem->name);
 			if (sourceModel)
 			{
-				if (!sourceModel->areTermsVariables() || !sourceItem->controlName.isEmpty())
+				if (!sourceModel->areTermsVariables() || !sourceItem->controlName.isEmpty() || sourceItem->modelUse == "levels")
 					termsAreVariables = false;
 				if (sourceModel->areTermsInteractions() || sourceItem->combineWithOtherModels)
 					termsAreInteractions = true;

--- a/Resources/Learn Bayes/qml/qml_components/LSbinomialdatainput.qml
+++ b/Resources/Learn Bayes/qml/qml_components/LSbinomialdatainput.qml
@@ -144,6 +144,14 @@ Section
 				title:				qsTr("Selected")
 				singleVariable:		true
 				allowedColumns:		["ordinal", "nominal","nominalText"]
+
+				onCountChanged:
+				{
+					while (keySuccessVar.count > 0)
+						keySuccessVar.itemDoubleClicked(0)
+					while (keyFailureVar.count > 0)
+						keyFailureVar.itemDoubleClicked(0)
+				}
 			}
 		}
 
@@ -160,12 +168,14 @@ Section
 
 			AssignedVariablesList
 			{
+				id:		keySuccessVar
 				name:	"keySuccessVar"
 				title:	qsTr("Successes")
 			}
 
 			AssignedVariablesList
 			{
+				id:		keyFailureVar
 				name:	"keyFailureVar"
 				title:	qsTr("Failures")
 			}


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#988
Remove also the indentation in the levels, Susccesses & Failures Variables box