### PR TITLE
Bayesian Repeated Measures ANOVA: fix post hoc tests

### DIFF
--- a/JASP-Engine/JASP/R/commonAnovaBayesian.R
+++ b/JASP-Engine/JASP/R/commonAnovaBayesian.R
@@ -1118,7 +1118,7 @@
 
     pairs <- utils::combn(variable.levels, 2)
 
-    allSplits <- split(dataset[[.v(dependent)]], dataset[[.v(posthoc.var)]])
+    allSplits <- split(dataset[[.BANOVAdependentName]], dataset[[.v(posthoc.var)]])
 
     errMessages <- NULL
     for (i in 1:ncol(pairs)) {
@@ -2335,8 +2335,9 @@
   for (term in modelTerms) {
 
     comp <- term$component
-    if (comp != .BANOVAsubjectName)
-      comp <- .v(comp)
+    idx <- comp != .BANOVAsubjectName
+    if (any(idx))
+      comp[idx] <- .v(comp[idx])
 
     if (is.null (effects) & is.null (nuisance)){
       model.formula <- paste0(model.formula, comp, collapse = ":")

--- a/JASP-Engine/JASP/R/commonAnovaBayesian.R
+++ b/JASP-Engine/JASP/R/commonAnovaBayesian.R
@@ -1118,7 +1118,8 @@
 
     pairs <- utils::combn(variable.levels, 2)
 
-    allSplits <- split(dataset[[.BANOVAdependentName]], dataset[[.v(posthoc.var)]])
+    splitname <- if (model[["analysisType"]] == "RM-ANOVA") .BANOVAdependentName else dependent
+    allSplits <- split(dataset[[splitname]], dataset[[.v(posthoc.var)]])
 
     errMessages <- NULL
     for (i in 1:ncol(pairs)) {


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/981

For AN(C)OVAs, we need to use `dependent` (i.e., `options$dependent`). For the RM ANOVA we need `.BANOVAdependentName`.

While fixing the issue above I noticed a warning about:
```
Warning message:
In if (comp != .BANOVAsubjectName):
  the condition has length > 1 and only the first element will be used
```
The component (`comp`) can have length > 1 and I ignored that possibility when I wrote the code. That should be fixed now.


I have no strong feelings as to whether this should go into 0.14 or later.
