### PR TITLE
Exploratory factor analysis: improved error message when there are fewer observation than variables

### DIFF
--- a/JASP-Engine/JASP/R/exploratoryfactoranalysis.R
+++ b/JASP-Engine/JASP/R/exploratoryfactoranalysis.R
@@ -16,11 +16,7 @@
 #
 
 ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
-  jaspResults[["optionslist"]] <- createJaspHtml(paste(capture.output(str(options)), collapse = "\n"),
-                                                 class = "jasp-code", position = 7, title = "Options")
-}
 
-ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
   jaspResults$addCitation("Revelle, W. (2018) psych: Procedures for Personality and Psychological Research, Northwestern University, Evanston, Illinois, USA, https://CRAN.R-project.org/package=psych Version = 1.8.12.")
 
   # Read dataset
@@ -82,8 +78,12 @@ ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
         return(gettext("Data not valid: variance is zero in each row"))
       }
     },
-    # Check for correlation anomalies
+    # check for correlation anomalies
     function() {
+      # the checks below also fail when n < p but this provides a more accurate error message
+      if (ncol(dataset) > nrow(dataset))
+        return(gettext("Data not valid: there are more variables than observations"))
+
       P <- ncol(dataset)
       
       # check whether a variable has too many missing values to compute the correlations


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/961

On the left is the old error message and on the right is the new one:
![image](https://user-images.githubusercontent.com/21319932/94784241-2a22c480-03ce-11eb-8f14-24a9b537f5a0.png)

I added the new error check inside the other one because otherwise, a user would see both error messages. The second error message about missing values is also very confusing and inaccurate when n < p. In the linked issue, for example, there aren't any missing variables yet the analysis complains about them!


Also, the analysis used to start with:
```r
ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
  jaspResults[["optionslist"]] <- createJaspHtml(paste(capture.output(str(options)), collapse = "\n"),
                                                 class = "jasp-code", position = 7, title = "Options")
}

ExploratoryFactorAnalysis <- function(jaspResults, dataset, options, ...) {
	...
}
```
defining the same function twice?!

I deleted the first one since the second one always overwrites the first one (I couldn't figure out if the first one had any purpose).