### PR TITLE
Adds a ScrollView around name entry for a computed column

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/JASP-Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -131,7 +131,7 @@ FocusScope
 
 			Rectangle
 			{
-				id: computeColumnEditRectangle
+				id:		computeColumnEditRectangle
 				color: jaspTheme.white
 
 				border.width: 1

--- a/JASP-Desktop/components/JASP/Widgets/CreateComputeColumnDialog.qml
+++ b/JASP-Desktop/components/JASP/Widgets/CreateComputeColumnDialog.qml
@@ -76,7 +76,7 @@ Popup
 			Item
 			{
 				id:		nameItem
-				height:	marge * 2 + (jaspTheme.font.pixelSize * 1.5 * preferencesModel.uiScale)
+				height:	marge * 2 + (nameEdit.implicitHeight * 2)
 
 				property real marge: 10 * preferencesModel.uiScale
 
@@ -117,48 +117,54 @@ Popup
 						bottom:		parent.bottom
 						margins:	6 * preferencesModel.uiScale
 					}
-
-
-					TextEdit
+					
+					ScrollView
 					{
-						property string defaultText:				"..."
-						property string lastCheckedColumnNameInUse: ""
-						property bool	columnNameInUse:			lastCheckedColumnNameInUse !== "" && lastCheckedColumnNameInUse === text
-						property bool	validEntry:					text != defaultText && text.length > 0 && !columnNameInUse
-
-						id:						nameEdit
-						text:					defaultText
-						font:					jaspTheme.font
-						color:					columnNameInUse ? jaspTheme.red : jaspTheme.black
-
-						ToolTip.delay:			0
-						ToolTip.timeout:		10000
-						ToolTip.visible:		columnNameInUse
-						ToolTip.text:			qsTr("Column name is already used, please choose a different one.")
-
-						Keys.onReturnPressed:	rootCreateComputedColumn.createComputedColumn()
-
-						anchors
+						property double textHeightResidual: parent.height - nameEdit.implicitHeight
+						
+						clip:					true
+						anchors.fill:			parent
+						anchors.margins:		4 * preferencesModel.uiScale
+						anchors.topMargin:		textHeightResidual / 2
+						onContentWidthChanged:	if(contentWidth >= width) ScrollBar.horizontal.position = 1 - ScrollBar.horizontal.size
+						
+						TextEdit
 						{
-							left:			parent.left
-							right:			parent.right
-							verticalCenter:	parent.verticalCenter
-							margins:		2
+							property string defaultText:				"..."
+							property string lastCheckedColumnNameInUse: ""
+							property bool	columnNameInUse:			lastCheckedColumnNameInUse !== "" && lastCheckedColumnNameInUse === text
+							property bool	validEntry:					text != defaultText && text.length > 0 && !columnNameInUse
+	
+							id:						nameEdit
+							text:					defaultText
+							font:					jaspTheme.font
+							color:					columnNameInUse ? jaspTheme.red : jaspTheme.black
+							width:					Math.max(implicitWidth, nameBox.width)
+							selectByMouse:			true
+	
+							ToolTip.delay:			0
+							ToolTip.timeout:		10000
+							ToolTip.visible:		columnNameInUse
+							ToolTip.text:			qsTr("Column name is already used, please choose a different one.")
+	
+							Keys.onReturnPressed:	rootCreateComputedColumn.createComputedColumn()
+		
+							onActiveFocusChanged:
+							{
+								if( activeFocus	&& text === defaultText	) text = ""
+								if(!activeFocus && text === ""			) text = defaultText
+							}
 						}
-
-						onActiveFocusChanged:
-						{
-							if( activeFocus	&& text === defaultText	) text = ""
-							if(!activeFocus && text === ""			) text = defaultText
-						}
-
-						MouseArea
-						{
-							anchors.fill:		parent
-							hoverEnabled:		true
-							acceptedButtons:	Qt.NoButton
-							cursorShape:		Qt.IBeamCursor
-						}
+						
+					}
+					
+					MouseArea
+					{
+						z:					1234
+						anchors.fill:		parent
+						hoverEnabled:		true
+						acceptedButtons:	Qt.NoButton
+						cursorShape:		Qt.IBeamCursor
 					}
 				}
 			}


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/1026
- Works quite well, except that it doesn't track the cursor when moving it around in the text
- I added some code to make sure that whenever the text size changes the end (where the user is probably typing) stays in sight
- To fix this would be a bit of a hassle now, possibly using TextArea supports that, but it also enables multiline entry which is not such a good idea for names of columns
- This problem happens in more places in JAPS but I dont think it is too bad, one can scroll here after all.
- Also it uses the default scrollbar but it looks pretty good here, so I didnt bother putting the JASP one.

