### PR TITLE
RM ANOVA: clear environment of function in referenceGrid before saving it to state

### DIFF
--- a/JASP-Engine/JASP/R/anovarepeatedmeasures.R
+++ b/JASP-Engine/JASP/R/anovarepeatedmeasures.R
@@ -829,6 +829,7 @@ AnovaRepeatedMeasures <- function(jaspResults, dataset = NULL, options) {
   for (var in variables) {
     formula <- as.formula(paste("~", var))
     referenceGrid <- emmeans::emmeans(fullModel, formula)
+    environment(referenceGrid@dffun) <- baseenv()
     referenceGridList[[var]] <- referenceGrid
   }
   


### PR DESCRIPTION
In https://github.com/jasp-stats/jasp-issues/issues/992 we noticed some incredibly large JASP files (+100MB). I looked at one of these files (https://osf.io/bqprn/) and figured out that the state of the repeated measures ANOVA grows incredibly fast as the number of interactions effects in the covariates grows.

#### To Replicate the Problem
- Checkout stable, download the file below, refresh it, and save it under a new name. 
- [bigjaspfile_test_2.jasp.zip](https://github.com/jasp-stats/jasp-desktop/files/5316757/bigjaspfile_test_2.jasp.zip) (rename and drop the .zip).
- For me, the size on disk is then 65.1 MiB (~68.3 MB)!
- Check out this PR, open the big file of 65.1 MiB, refresh it and save it under a new name.
- For me, the size is now 2.2 MiB (~2.3 MB).

There's also another file on that OSF that'seven bigger (> 300 MB) but I didn't look at that one yet. 

Edit: [that file](https://osf.io/5drnk/) is about ~2 GB when unzipped, the largest 12 analyses are also repeated measures ANOVAs (7 over 100 MiB). After that comes flexplot with about 26 MiB, which is a lot but not too bad.

#### Changes
The change looks a bit odd but I could execute that function without its environment without any problems. In fact, it's definition is:

```r
> referenceGrid@dffun
function (k, dfargs) 
{
    emmeans::.aovlist.dffun(k, dfargs)
}
```
`referenceGrid` is an S4 class with another slot called `dfargs`, which is unaffected by this change. I'm not sure where `k` comes from, but it worked for me when I put some values in it (e.g., 2). Since this function only references `emmeans` and nothing in its environment I don't think there can be anything wrong with removing the environment.



