### PR TITLE
Bayesian RM ANOVA: fix descriptives plot

### DIFF
--- a/JASP-Engine/JASP/R/commonAnovaBayesian.R
+++ b/JASP-Engine/JASP/R/commonAnovaBayesian.R
@@ -1438,8 +1438,8 @@
                                   betweenvars = betweenSubjectFactors,
                                   withinvars = repeatedMeasuresFactors,
                                   idvar = .BANOVAsubjectName,
-                                  conf.interval = options$confidenceIntervalInterval,
-                                  na.rm=TRUE, .drop = FALSE, errorBarType = options$errorBarType,
+                                  conf.interval = conf.interval,
+                                  na.rm=TRUE, .drop = FALSE, errorBarType = errorBarType,
                                   usePooledSE = usePooledSE)
   }
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1019

So this code is used by both the frequentist and the Bayesian ANOVAs, but the names of the options differ. At the beginning of the function we have an if statement to distinguish between the Bayesian and frequentist option names:

https://github.com/jasp-stats/jasp-desktop/blob/a6fc0666fbb909d7a0427a570b0b363ae22456a0/JASP-Engine/JASP/R/commonAnovaBayesian.R#L1394-L1408

but in the old code we later ignore these options and just straight up use the option names of the frequentist ANOVAs:

https://github.com/jasp-stats/jasp-desktop/blob/a6fc0666fbb909d7a0427a570b0b363ae22456a0/JASP-Engine/JASP/R/commonAnovaBayesian.R#L1437-L1443

Changing this to the correct arguments fixes the problem.

