### PR TITLE
Bayesian Correlation: change DoubleField to FormulaField for the prior

### DIFF
--- a/JASP-Engine/JASP/R/common.R
+++ b/JASP-Engine/JASP/R/common.R
@@ -3028,7 +3028,7 @@ postProcessModuleInstall <- function(moduleLibraryPath)
 .parseAndStoreFormulaOptions <- function(jaspResults, options, names) {
   for (i in seq_along(names)) {
     name <- names[[i]]
-    options[[paste0(name, "Unparsed")]] = options[[name]]
+    options[[paste0(name, "Unparsed")]] <- options[[name]]
 
     if (is.null(jaspResults[[name]])) {
       parsedOption <- .parseRCodeInOptions(options[[name]])

--- a/JASP-Engine/JASP/R/correlationbayesian.R
+++ b/JASP-Engine/JASP/R/correlationbayesian.R
@@ -19,6 +19,7 @@ CorrelationBayesian <- function(jaspResults, dataset=NULL, options, ...) {
   ready <- length(options[["variables"]]) >= 2
   pairs <- unique(options[["pairs"]])
   
+  options <- .parseAndStoreFormulaOptions(jaspResults, options, "kappa")
   # 2. Data retrieval  --------
   #
   if (ready && is.null(dataset))

--- a/JASP-Tests/R/tests/testthat/test-correlationbayesian.R
+++ b/JASP-Tests/R/tests/testthat/test-correlationbayesian.R
@@ -67,6 +67,7 @@ test_that("Bayesian Correlation Matrix Plot matches", {
   options$plotMatrix <- TRUE
   options$plotMatrixDensities <- TRUE
   options$plotMatrixPosteriors <- TRUE
+  options$kappa <- 1.0
   set.seed(1)
   results <- jasptools::run("CorrelationBayesian", "test.csv", options)
   plotName <- results[["results"]][["matrixPlot"]][["data"]]
@@ -116,6 +117,7 @@ options$pairs <- list(c("contcor1", "contcor2"))
 options$plotPriorPosterior <- TRUE
 options$plotBfRobustness <- TRUE
 options$plotBfSequential <- TRUE
+options$kappa <- 1.0
 set.seed(1)
 results <- jasptools::run("CorrelationBayesian", "test.csv", options)
 

--- a/Resources/Regression/qml/CorrelationBayesian.qml
+++ b/Resources/Regression/qml/CorrelationBayesian.qml
@@ -24,119 +24,119 @@ import JASP.Widgets 1.0
 Form
 {
 
-    VariablesForm
-    {
+	VariablesForm
+	{
 		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-        AvailableVariablesList { name: "allVariablesList" }
-        AssignedVariablesList { name: "variables"; suggestedColumns: ["ordinal", "scale"] }
-    }
+		AvailableVariablesList	{	name: "allVariablesList" }
+		AssignedVariablesList	{	name: "variables"; suggestedColumns: ["ordinal", "scale"] }
+	}
 
-    Group
-    {
-        title: qsTr("Population Correlation Coefficient")
-        CheckBox { name: "pearson";         label: qsTr("Pearson's rho"); checked: true       }
-        CheckBox { name: "spearman";        label: qsTr("Spearman's rho"); debug: true		}
-        CheckBox { name: "kendall";         label: qsTr("Kendall's tau-b")				}
-    }
+	Group
+	{
+		title: qsTr("Population Correlation Coefficient")
+		CheckBox {	name: "pearson";		label: qsTr("Pearson's rho");	checked: true	}
+		CheckBox {	name: "spearman";		label: qsTr("Spearman's rho");	debug: true		}
+		CheckBox {	name: "kendall";		label: qsTr("Kendall's tau-b")					}
+	}
 
-    Group
-    {
-        title: qsTr("Additional Options")
-        CheckBox { name: "displayPairwise";		label: qsTr("Display pairwise table")                   }
-        CheckBox { name: "reportBayesFactors";	label: qsTr("Report Bayes factors"); checked: true		}
-        CheckBox { name: "flagSupported";		label: qsTr("Flag supported correlations")				}
-        CheckBox { name: "reportN";             label: qsTr("Sample size")                              }
-        CheckBox { name: "posteriorMedian";     label: qsTr("Posterior median"); debug: true			}
-        CheckBox
-        {
-            name: "ci"; label: qsTr("Credible intervals")
-            CIField { name: "ciValue";	label: qsTr("Interval") }
-        }
-    }
+	Group
+	{
+		title: qsTr("Additional Options")
+		CheckBox {	name: "displayPairwise";		label: qsTr("Display pairwise table")					}
+		CheckBox {	name: "reportBayesFactors";		label: qsTr("Report Bayes factors"); checked: true		}
+		CheckBox {	name: "flagSupported";			label: qsTr("Flag supported correlations")				}
+		CheckBox {	name: "reportN";				label: qsTr("Sample size")								}
+		CheckBox {	name: "posteriorMedian";		label: qsTr("Posterior median"); debug: true			}
+		CheckBox
+		{
+			name: "ci"; label: qsTr("Credible intervals")
+			CIField { name: "ciValue";	label: qsTr("Interval") }
+		}
+	}
 
-    RadioButtonGroup
-    {
-        name: "alternative"
-        title: qsTr("Alt. Hypothesis")
-        RadioButton { value: "two.sided";		label: qsTr("Correlated"); checked: true	}
-        RadioButton { value: "greater";         label: qsTr("Correlated positively")		}
-        RadioButton { value: "less";            label: qsTr("Correlated negatively")		}
-    }
+	RadioButtonGroup
+	{
+		name: "alternative"
+		title: qsTr("Alt. Hypothesis")
+		RadioButton {	value: "two.sided";		label: qsTr("Correlated"); checked: true	}
+		RadioButton {	value: "greater";		label: qsTr("Correlated positively")		}
+		RadioButton {	value: "less";			label: qsTr("Correlated negatively")		}
+	}
 
-    Group
-    {
-        title: qsTr("Plots")
-        CheckBox
-        {
-            name: "plotMatrix"; label: qsTr("Correlation matrix")
-            CheckBox { name: "plotMatrixDensities";                 label: qsTr("Densities for variables")	}
-            CheckBox { name: "plotMatrixPosteriors";				label: qsTr("Posteriors under H\u2081")	}
-        }
-    }
+	Group
+	{
+		title: qsTr("Plots")
+		CheckBox
+		{
+						name: "plotMatrix";				label: qsTr("Correlation matrix")
+			CheckBox {	name: "plotMatrixDensities";	label: qsTr("Densities for variables")	}
+			CheckBox {	name: "plotMatrixPosteriors";	label: qsTr("Posteriors under H\u2081")	}
+		}
+	}
 
-    BayesFactorType {}
+	BayesFactorType {}
 
-    Group
-    {
-        title: qsTr("Prior")
+	Group
+	{
+		title: qsTr("Prior")
 		FormulaField { name: "kappa"; label: qsTr("Stretched beta prior width"); defaultValue: "1.0"; min: 0.003; max: 2}
-    }
+	}
 
-    Section
-    {
-        title: qsTr("Plot Individual Pairs")
-        VariablesForm
-        {
+	Section
+	{
+		title: qsTr("Plot Individual Pairs")
+		VariablesForm
+		{
 			preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-            AvailableVariablesList      { name: "allVariablesList2";     source:"variables" }
-            AssignedPairsVariablesList  { name:  "pairs";                suggestedColumns: ["ordinal", "scale"] }
-        }
+			AvailableVariablesList		{	name: "allVariablesList2";	source:"variables" }
+			AssignedPairsVariablesList	{	name:  "pairs";				suggestedColumns: ["ordinal", "scale"] }
+		}
 
-        RadioButtonGroup
-        {
-            name: "pairsMethod"
-            title: qsTr("Correlation coefficient to plot")
-            RadioButton { value: "pearson";     label: qsTr("Pearson's rho");         checked: true	}
-            RadioButton { value: "spearman";    label: qsTr("Spearman's rho");  debug:   true   }
-            RadioButton { value: "kendall";     label: qsTr("Kendall's tau")                    }
-        }
+		RadioButtonGroup
+		{
+			name: "pairsMethod"
+			title: qsTr("Correlation coefficient to plot")
+			RadioButton {	value: "pearson";		label: qsTr("Pearson's rho");	checked:	true	}
+			RadioButton {	value: "spearman";		label: qsTr("Spearman's rho");	debug:		true	}
+			RadioButton {	value: "kendall";		label: qsTr("Kendall's tau")						}
+		}
 
-        CheckBox
-        {
-            name: "plotScatter";                    label: qsTr("Scatterplot"); checked: true
-            CheckBox { name: "plotScatterAddInfo";  label: qsTr("Robustness check"); debug: true }
+		CheckBox
+		{
+						name: "plotScatter";		label: qsTr("Scatterplot");			checked: true
+			CheckBox {	name: "plotScatterAddInfo";	label: qsTr("Robustness check");	debug: true }
 
-        }
-        CheckBox
-        {
-            name: "plotPriorPosterior";			label: qsTr("Prior and posterior")
-            CheckBox { name: "plotPriorPosteriorAddEstimationInfo";	label: qsTr("Estimation info"); checked: true }
-            CheckBox { name: "plotPriorPosteriorAddTestingInfo";	label: qsTr("Testing info"); checked: true }
-        }
-        CheckBox
-        {
-            name: "plotBfRobustness";		label: qsTr("Bayes factor robustness check")
-            CheckBox { name: "plotBfRobustnessAddInfo"; label: qsTr("Additional info"); checked: true }
-        }
-        CheckBox
-        {
-            name: "plotBfSequential";                   label: qsTr("Sequential analysis")
-            CheckBox { name: "plotBfSequentialAddInfo"; label: qsTr("Additional info"); checked: true}
-        }
-    }
+		}
+		CheckBox
+		{
+						name: "plotPriorPosterior";						label: qsTr("Prior and posterior")
+			CheckBox {	name: "plotPriorPosteriorAddEstimationInfo";	label: qsTr("Estimation info");		checked: true }
+			CheckBox {	name: "plotPriorPosteriorAddTestingInfo";		label: qsTr("Testing info");		checked: true }
+		}
+		CheckBox
+		{
+						name: "plotBfRobustness";			label: qsTr("Bayes factor robustness check")
+			CheckBox {	name: "plotBfRobustnessAddInfo";	label: qsTr("Additional info");					checked: true }
+		}
+		CheckBox
+		{
+						name: "plotBfSequential";			label: qsTr("Sequential analysis")
+			CheckBox {	name: "plotBfSequentialAddInfo";	label: qsTr("Additional info");		checked: true}
+		}
+	}
 
-    Section
-    {
-        title: qsTr("Options")
+	Section
+	{
+		title: qsTr("Options")
 
-        RadioButtonGroup
-        {
-            name: "missingValues"
-            title: qsTr("Missing Values")
-            RadioButton { value: "excludePairwise"; label: qsTr("Exclude cases pairwise"); checked: true	}
-            RadioButton { value: "excludeListwise"; label: qsTr("Exclude cases listwise")                   }
-        }
+		RadioButtonGroup
+		{
+			name: "missingValues"
+			title: qsTr("Missing Values")
+			RadioButton {	value: "excludePairwise";	label: qsTr("Exclude cases pairwise");	checked: true	}
+			RadioButton {	value: "excludeListwise";	label: qsTr("Exclude cases listwise")					}
+		}
 
 		SetSeed{}
-    }
+	}
 }

--- a/Resources/Regression/qml/CorrelationBayesian.qml
+++ b/Resources/Regression/qml/CorrelationBayesian.qml
@@ -79,7 +79,7 @@ Form
     Group
     {
         title: qsTr("Prior")
-        DoubleField { name: "kappa"; label: qsTr("Stretched beta prior width"); defaultValue: 1.0; min: 0.003; max: 2; decimals: 3 }
+		FormulaField { name: "kappa"; label: qsTr("Stretched beta prior width"); defaultValue: "1.0"; min: 0.003; max: 2}
     }
 
     Section


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1085

The first commit contains all actual changes.
The second commit changes the QML file so it consistently uses tabs instead of mixing tabs and spaces.

adding `options$kappa <- 1.0` to the test file is necessary because jasptools doesn't parse the value for a FormulaField.