### PR TITLE
Firefox style ribbon

### DIFF
--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/MenuArrowButton.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/MenuArrowButton.qml
@@ -28,11 +28,25 @@ Rectangle
 	implicitHeight				: jaspTheme.ribbonButtonHeight * 0.6
 	implicitWidth				: implicitHeight
 	// radius					: 5
-	color						: mice.pressed ? jaspTheme.grayLighter : jaspTheme.uiBackground
-
-	property bool	hamburger:	true
-	property bool	showArrow:	false
+	color						: pressed ? jaspTheme.grayLighter : jaspTheme.uiBackground
+	
+	enum ButtonType
+	{
+		Hamburger,
+		Plus,
+		LeftArrow,
+		RightArrow
+	}
+	
+	property int buttonType:	MenuArrowButton.ButtonType.Hamburger 
 	property string	toolTip:	""
+	
+			 property double iconScale:	0.7
+			 property bool showPressed: false
+	readonly property bool pressed:		mice.pressed || showPressed
+	readonly property bool hamburger:	buttonType == MenuArrowButton.ButtonType.Hamburger || buttonType == MenuArrowButton.ButtonType.LeftArrow
+	readonly property bool showArrow:	buttonType == MenuArrowButton.ButtonType.LeftArrow || buttonType == MenuArrowButton.ButtonType.RightArrow 
+	
 
 	ToolTip.text:				toolTip
 	ToolTip.timeout:			jaspTheme.toolTipTimeout
@@ -50,7 +64,7 @@ Rectangle
 		scale:				baseScale * (mice.containsMouse && !mice.pressed ? jaspTheme.ribbonScaleHovered : 1)
 
 
-		property real	baseScale:		0.7 * (parent.height / baseHeight)//Ok changing height doesnt work well for this component so I just scale it when necessary!
+		property real	baseScale:		iconScale * (parent.height / baseHeight)//Ok changing height doesnt work well for this component so I just scale it when necessary!
 
 		property real	baseHeight:		80
 		property real	barThickness:	8 //(jaspTheme.ribbonButtonHeight (2 * jaspTheme.ribbonButtonPadding)) / 7
@@ -131,37 +145,4 @@ Rectangle
 		cursorShape				: Qt.PointingHandCursor
 		//onContainsMouseChanged	: if(containsMouse) itsHoverTime.start(); else itsHoverTime.stop();
 	}
-
-	/* Hmm, hover works a bit weird, disabling it.
-	property bool clickingAllowed: true
-
-	function clickWhenAllowed()
-	{
-		if(clickingAllowed)
-		{
-			clickingAllowed = false;
-			ribbonButton.clicked();
-			blockDoubleClicksTimer.start();
-		}
-	}
-
-	Timer
-	{
-		id:				itsHoverTime
-		interval:		jaspTheme.hoverTime * 2
-		repeat:			false
-		running:		false
-
-		onTriggered:	ribbonButton.clickWhenAllowed();
-	}
-
-	Timer
-	{
-		id:				blockDoubleClicksTimer
-		interval:		jaspTheme.fileMenuSlideDuration * 4
-		repeat:			false
-		running:		false
-
-		onTriggered:	ribbonButton.clickingAllowed = true;
-	}*/
 }

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/MenuArrowButton.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/MenuArrowButton.qml
@@ -61,7 +61,7 @@ Rectangle
 		anchors.centerIn:	parent
 		width:				hamburgerArrow.barWidth//parent.width	- (2 * jaspTheme.ribbonButtonPadding)
 		height:				baseHeight - 20
-		scale:				baseScale * (mice.containsMouse && !mice.pressed ? jaspTheme.ribbonScaleHovered : 1)
+		scale:				baseScale * (mice.containsMouse && !ribbonButton.pressed ? jaspTheme.ribbonScaleHovered : 1)
 
 
 		property real	baseScale:		iconScale * (parent.height / baseHeight)//Ok changing height doesnt work well for this component so I just scale it when necessary!

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/MenuArrowButton.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/MenuArrowButton.qml
@@ -28,7 +28,7 @@ Rectangle
 	implicitHeight				: jaspTheme.ribbonButtonHeight * 0.6
 	implicitWidth				: implicitHeight
 	// radius					: 5
-	color						: pressed ? jaspTheme.grayLighter : jaspTheme.uiBackground
+	color						: pressed ? jaspTheme.grayLighter : "transparent"
 	
 	enum ButtonType
 	{
@@ -118,7 +118,7 @@ Rectangle
 
 			Rectangle
 			{
-				anchors.centerIn:	ribbonButton.showArrow ||   ribbonButton.hamburger	? undefined		: parent
+				anchors.centerIn:	 ribbonButton.showArrow ||  ribbonButton.hamburger	? undefined		: parent
 				anchors.left:		!ribbonButton.showArrow || !ribbonButton.hamburger	? undefined		: parent.left
 				anchors.right:		!ribbonButton.showArrow ||  ribbonButton.hamburger	? undefined		: parent.right
 				transformOrigin:	!ribbonButton.showArrow								? Item.Center	: ribbonButton.hamburger ? Item.Left	: Item.Right
@@ -141,8 +141,36 @@ Rectangle
 		anchors.fill			: parent
 		hoverEnabled			: true
 		acceptedButtons			: Qt.LeftButton
-		onClicked				: ribbonButton.clicked(); //{ itsHoverTime.stop(); ribbonButton.clickWhenAllowed();  }
+		onClicked				: ribbonButton.clicked();
 		cursorShape				: Qt.PointingHandCursor
-		//onContainsMouseChanged	: if(containsMouse) itsHoverTime.start(); else itsHoverTime.stop();
 	}
+	
+	Rectangle
+    {
+        id      : borderLeft
+        width   : 1
+		color   : jaspTheme.uiBorder
+		visible	: pressed
+        anchors
+        {
+            left	: parent.left
+            top		: parent.top
+            bottom	: parent.bottom
+        }
+		
+    }
+
+    Rectangle
+    {
+        id      : borderRight
+        width   : 1
+		color   : jaspTheme.uiBorder
+		visible	: pressed
+        anchors
+        {
+            right	: parent.right
+            top		: parent.top
+            bottom	: parent.bottom
+        }
+    }
 }

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
@@ -35,10 +35,10 @@ FocusScope
 	MenuArrowButton
 	{
 		id			: fileMenuOpenButton
-		width		: height
-		showArrow	: fileMenuModel.visible
-		hamburger	: true
+		showPressed	: fileMenuModel.visible
+		buttonType	: MenuArrowButton.ButtonType.Hamburger
 		z			: 2
+		width		: 0.75 * height
 
 		onClicked:
 		{
@@ -50,9 +50,9 @@ FocusScope
 
 		anchors
 		{
-			top		: parent.top
-			left	: parent.left
-			bottom	: parent.bottom
+			top:			parent.top
+			left:			parent.left
+			bottom:			parent.bottom
 		}
 	}
 
@@ -72,9 +72,11 @@ FocusScope
 	MenuArrowButton
 	{
 		id			: modulesPlusButton
-		width		: height
-		hamburger	: false
 		toolTip		: qsTr("Show Modules Menu")
+		buttonType	: MenuArrowButton.ButtonType.Plus
+		width		: 0.75 * height
+		showPressed	: modulesMenu.opened
+		z			: 2
 
 		onClicked	:
 		{
@@ -83,9 +85,6 @@ FocusScope
 			
 			customMenu.hide()
 		}
-
-		showArrow	: modulesMenu.opened
-		z			: 2
 
 		anchors
 		{

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
@@ -63,9 +63,11 @@ FocusScope
 
 		anchors
 		{
-			top		: parent.top
-			right	: modulesPlusButton.left
-			left	: fileMenuOpenButton.right
+			top			: parent.top
+			left		: fileMenuOpenButton.right
+			right		: modulesPlusButton.left
+			leftMargin	: -1
+			rightMargin	: -1
 		}
 	}
 

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
@@ -33,6 +33,7 @@ Item
 		z:					10
 		anchors.fill:		buttonList
 		acceptedButtons:	Qt.NoButton
+		cursorShape:		Qt.PointingHandCursor
 		onWheel:
 		{
 			var bigWheel = Math.abs(wheel.angleDelta.x) > Math.abs(wheel.angleDelta.y) ? wheel.angleDelta.x : wheel.angleDelta.y;
@@ -50,7 +51,7 @@ Item
 		height:							parent.height
 		boundsBehavior:					Flickable.StopAtBounds
 		clip:							true
-
+		interactive:					false
 		highlightFollowsCurrentItem:	true
 		highlightMoveDuration:			20
 
@@ -69,11 +70,11 @@ Item
 		{
 			text:			model.moduleTitle
 			moduleName:		model.moduleName
-			source:			model.ribbonButton ? ((model.isDynamic ? "file:" : "qrc:/icons/") + model.ribbonButton.iconSource) : ""
-			menu:			model.ribbonButton ? model.ribbonButton.analysisMenu : undefined
-			toolTip:		model.ribbonButton ? model.ribbonButton.toolTip : undefined
-			enabled:		model.ribbonButton ? model.active : false
-			visible:		model.ribbonButton ? true : false
+			source:			!model.ribbonButton ? ""		: (model.isDynamic ? "file:" : "qrc:/icons/") + model.ribbonButton.iconSource
+			menu:			!model.ribbonButton ? undefined : model.ribbonButton.analysisMenu
+			toolTip:		!model.ribbonButton ? undefined : model.ribbonButton.toolTip
+			enabled:		!model.ribbonButton ? false		: model.active
+			visible:		!model.ribbonButton ? false		: true
 		}
 	}
 	

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
@@ -55,7 +55,7 @@ Item
 
 		onDragStarted:					customMenu.hide()
 		onMovementStarted:				customMenu.hide()
-
+		
 		anchors
 		{
 			left:			leftArrow.right
@@ -76,6 +76,38 @@ Item
 		}
 	}
 	
+	property real ribbonFlickSpeed: 400
+	
+	Timer
+	{
+		id:			scrollLikeAChump
+		repeat:		true
+		interval:	300
+		
+		property bool timerWentOffAlready:	false
+		property bool goLeft:				false
+		
+		function anArrowPressed(goLeftPlease)
+		{
+			interval			= 300;
+			goLeft				= goLeftPlease;
+			timerWentOffAlready = false;
+			
+			start();
+		}
+		
+		onTriggered: 
+		{
+			timerWentOffAlready = true;
+			interval			= 10;
+			
+			if(goLeft)	buttonList.flick( ribbonFlickSpeed, 0);
+			else		buttonList.flick(-ribbonFlickSpeed, 0);
+		}
+		
+	}
+	
+	
 	MenuArrowButton
 	{
 		id:				leftArrow
@@ -84,7 +116,11 @@ Item
 		visible:		fadeOutLeft.visible
 		width:			height * 0.4
 		iconScale:		0.4
-		onClicked:		buttonList.flick(jaspTheme.maximumFlickVelocity, 0)
+		onClicked:		if(!scrollLikeAChump.timerWentOffAlready) buttonList.flick(2 * ribbonFlickSpeed, 0)
+		
+		onPressedChanged: 
+			if(pressed)							scrollLikeAChump.anArrowPressed(true);
+			else if(scrollLikeAChump.goLeft)	scrollLikeAChump.stop();
 		
 		anchors
 		{
@@ -94,8 +130,31 @@ Item
 		}	
 		
 	}
+	
+	MenuArrowButton
+	{
+		id:				rightArrow
+		z:				1
+		buttonType:		MenuArrowButton.ButtonType.RightArrow
+		visible:		fadeOutRight.visible
+		width:			leftArrow.width
+		iconScale:		leftArrow.iconScale
+		onClicked:		if(!scrollLikeAChump.timerWentOffAlready) buttonList.flick(-2 * ribbonFlickSpeed, 0)
+		
+		onPressedChanged: 
+			if(pressed)							scrollLikeAChump.anArrowPressed(false);
+			else if(!scrollLikeAChump.goLeft)	scrollLikeAChump.stop();
+		
+		anchors
+		{
+			top:		parent.top
+			bottom:		parent.bottom
+			right:		parent.right
+		}	
+		
+	}
 
-	property real fadeOutMultiplier: 1
+	property real fadeOutMultiplier: 0.15
 
 	Item
 	{
@@ -137,25 +196,6 @@ Item
 			anchors.centerIn:	parent
 			rotation:			-90
 		}
-	}
-	
-	MenuArrowButton
-	{
-		id:				rightArrow
-		z:				1
-		buttonType:		MenuArrowButton.ButtonType.RightArrow
-		visible:		fadeOutRight.visible
-		width:			leftArrow.width
-		iconScale:		leftArrow.iconScale
-		onClicked:		buttonList.flick(-jaspTheme.maximumFlickVelocity, 0)
-		
-		anchors
-		{
-			top:		parent.top
-			bottom:		parent.bottom
-			right:		parent.right
-		}	
-		
 	}
 
 	Item

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
@@ -31,7 +31,7 @@ Item
 	{
 		id:					convertVerticalIntoHorizontalScrolling
 		z:					10
-		anchors.fill:		parent
+		anchors.fill:		buttonList
 		acceptedButtons:	Qt.NoButton
 		onWheel:
 		{
@@ -58,8 +58,8 @@ Item
 
 		anchors
 		{
-			left:			parent.left
-			right:			parent.right
+			left:			leftArrow.right
+			right:			rightArrow.left
 			verticalCenter:	parent.verticalCenter
 		}
 
@@ -75,8 +75,27 @@ Item
 			visible:		model.ribbonButton ? true : false
 		}
 	}
+	
+	MenuArrowButton
+	{
+		id:				leftArrow
+		z:				1
+		buttonType:		MenuArrowButton.ButtonType.LeftArrow
+		visible:		fadeOutLeft.visible
+		width:			height * 0.4
+		iconScale:		0.4
+		onClicked:		buttonList.flick(jaspTheme.maximumFlickVelocity, 0)
+		
+		anchors
+		{
+			top:		parent.top
+			bottom:		parent.bottom
+			left:		parent.left
+		}	
+		
+	}
 
-	property real fadeOutMultiplier: 1.5
+	property real fadeOutMultiplier: 1
 
 	Item
 	{
@@ -88,15 +107,29 @@ Item
 		{
 			top:		parent.top
 			bottom:		parent.bottom
-			left:		parent.left
+			left:		leftArrow.right
 			leftMargin:	-2
+		}
+		
+		Rectangle  // a line on the side "under which" ribbonbuttons can dissappear
+		{
+			z		: 3
+			width	: 1
+			color	: jaspTheme.uiBorder
+	
+			anchors
+			{
+				top		: parent.top
+				left	: parent.left
+				bottom	: parent.bottom
+			}
 		}
 
 		Rectangle
 		{
 			gradient: Gradient
 			{
-				GradientStop { position: 0.0; color: jaspTheme.uiBackground	}
+				GradientStop { position: 0.0; color: jaspTheme.shadow	}
 				GradientStop { position: 1.0; color: "transparent"		}
 			}
 			width:				parent.height
@@ -105,26 +138,59 @@ Item
 			rotation:			-90
 		}
 	}
+	
+	MenuArrowButton
+	{
+		id:				rightArrow
+		z:				1
+		buttonType:		MenuArrowButton.ButtonType.RightArrow
+		visible:		fadeOutRight.visible
+		width:			leftArrow.width
+		iconScale:		leftArrow.iconScale
+		onClicked:		buttonList.flick(-jaspTheme.maximumFlickVelocity, 0)
+		
+		anchors
+		{
+			top:		parent.top
+			bottom:		parent.bottom
+			right:		parent.right
+		}	
+		
+	}
 
 	Item
 	{
 		id:			fadeOutRight
-		width:		height * Math.min(fadeOutMultiplier, (((buttonList.originX + buttonList.contentWidth) - (buttonList.contentX + buttonList.width)) / height))
+		width:		height * Math.min(fadeOutMultiplier, (((buttonList.originX + buttonList.contentWidth) - (buttonList.contentX + buttonList.width + 1)) / height))
 		visible:	width > 0
 		z:			1
 		anchors
 		{
 			top:			parent.top
 			bottom:			parent.bottom
-			right:			parent.right
+			right:			rightArrow.left
 			rightMargin:	-2
+		}
+		
+		Rectangle  // a line on the side "under which" ribbonbuttons can dissappear
+		{
+			z		: 3
+			width	: 1
+			color	: jaspTheme.uiBorder
+	
+			anchors
+			{
+				top		: parent.top
+				right	: parent.right
+				bottom	: parent.bottom
+			}
 		}
 
 		Rectangle
 		{
 			gradient: Gradient
 			{
-				GradientStop { position: 0.0; color: jaspTheme.uiBackground	}
+				GradientStop { position: 0.0; color: jaspTheme.shadow	}
 				GradientStop { position: 1.0; color: "transparent"		}
 			}
 			width:				parent.height

--- a/JASP-Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
+++ b/JASP-Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
@@ -49,6 +49,7 @@ Item
 		currentIndex:					ribbonModelFiltered.highlightedModuleIndex
 		height:							parent.height
 		boundsBehavior:					Flickable.StopAtBounds
+		clip:							true
 
 		highlightFollowsCurrentItem:	true
 		highlightMoveDuration:			20
@@ -167,7 +168,6 @@ Item
 			top:		parent.top
 			bottom:		parent.bottom
 			left:		leftArrow.right
-			leftMargin:	-2
 		}
 		
 		Rectangle  // a line on the side "under which" ribbonbuttons can dissappear
@@ -178,9 +178,10 @@ Item
 	
 			anchors
 			{
-				top		: parent.top
-				left	: parent.left
-				bottom	: parent.bottom
+				top			: parent.top
+				left		: parent.left
+				bottom		: parent.bottom
+				leftMargin	: -1
 			}
 		}
 
@@ -209,7 +210,6 @@ Item
 			top:			parent.top
 			bottom:			parent.bottom
 			right:			rightArrow.left
-			rightMargin:	-2
 		}
 		
 		Rectangle  // a line on the side "under which" ribbonbuttons can dissappear
@@ -220,9 +220,10 @@ Item
 	
 			anchors
 			{
-				top		: parent.top
-				right	: parent.right
-				bottom	: parent.bottom
+				top			: parent.top
+				right		: parent.right
+				bottom		: parent.bottom
+				rightMargin	: -1
 			}
 		}
 


### PR DESCRIPTION
So the code didn't get simplified but the UI seems clearest now
- I still like the glass look more than this, but this way at least it is glaringly obvious there are more buttons left or right
- Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1086 differently from https://github.com/jasp-stats/jasp-desktop/pull/4330

![image](https://user-images.githubusercontent.com/29062713/95210694-0f948500-07ec-11eb-95b8-559d7784ec49.png)

![image](https://user-images.githubusercontent.com/29062713/95210717-13c0a280-07ec-11eb-82b7-7889392e484b.png)

![image](https://user-images.githubusercontent.com/29062713/95210733-17ecc000-07ec-11eb-9ba2-e7336d59d60c.png)

![image](https://user-images.githubusercontent.com/29062713/95210799-263adc00-07ec-11eb-9d91-8e6cc5e77d96.png)

I'll make some nightlies as well, they will be called `firefoxRibbon` 