### PR TITLE
Fix typo, "postive" -> "positive".

### DIFF
--- a/JASP-Engine/JASP/R/bayesianmetaanalysis.R
+++ b/JASP-Engine/JASP/R/bayesianmetaanalysis.R
@@ -386,7 +386,7 @@ BayesianMetaAnalysis <- function(jaspResults, dataset, options) {
   }
   
   if(isTryError(p)){
-    .quitAnalysis(gettextf("The model could not be fit. Please check the following: Do you have at least n=2 studies? If the prior is truncated, is it consistent with the data (when most effect sizes are negative, the analysis may not work when the prior is constrained to be postive)?")) 
+    .quitAnalysis(gettextf("The model could not be fit. Please check the following: Do you have at least n=2 studies? If the prior is truncated, is it consistent with the data (when most effect sizes are negative, the analysis may not work when the prior is constrained to be positive)?"))
   }
   
   return(results)

--- a/Resources/Help/analyses/bayesianmetaanalysis.md
+++ b/Resources/Help/analyses/bayesianmetaanalysis.md
@@ -17,7 +17,7 @@ The Bayesian meta-analysis allows the user to estimate an overall effect size es
 - Random effects: performs a random effects Bayesian meta-analysis.
 - Model averaged: performs a model averaged Bayesian meta-analysis. Averages over the fixed and random effects models. Fixed and random effects results are also given. 
 - Constrained random effects
-  - All postive: performs a constrained random effects Bayesian meta-analysis, where the effect size estimates are constrained to be postive. 
+  - All positive: performs a constrained random effects Bayesian meta-analysis, where the effect size estimates are constrained to be positive. 
   - All negative: performs a constrained random effects Bayesian meta-analysis, where the effect size estimates are constrained to be negative. 
 
 #### Bayes Factor


### PR DESCRIPTION
Noticed a typo during translation; hope this fixes the correct files (assuming the `.pot`, and `.po` files are derived, so the change will propagate to those).