### PR TITLE
Fix single column csv wrongfully choosing space as delimiter

### DIFF
--- a/JASP-Desktop/data/importers/csv.h
+++ b/JASP-Desktop/data/importers/csv.h
@@ -54,7 +54,7 @@ private:
 	bool readUtf8();
 
 	void determineEncoding();
-	void determineDelimiters();
+	void determineDelimiters(size_t fromHere = 0);
 
 private:
 


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/1040

The original algorithm only looked at the first line and checked how many spaces, commas, tabs or semicolons there were.
This works reasonably well, only has two problems:
Often users have spaces in columnnames and they are not aware of the need to add "Quotes" to avoid ambiguities.
Normally this is ok, but when there is only 1 column there is no comma, and in that case the algorithm picked spaces
Ive changed it to take into account all lines and it decides that any "delimiter" that does not have the same amount of delimiters on each line cannot be a proper delimiter and ignores it.

