### PR TITLE
use QUrl::fromLocalFile to open dataset

### DIFF
--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -1422,7 +1422,7 @@ void MainWindow::startDataEditor(QString path)
 	}
 	else
 #endif
-		if (!QDesktopServices::openUrl(QUrl("file:///" + path, QUrl::TolerantMode)))
+		if (!QDesktopServices::openUrl(QUrl::fromLocalFile(path)))
 			MessageForwarder::showWarning(tr("Start Spreadsheet Editor"), tr("No default spreadsheet editor for file %1. Use Preferences to set the right editor.").arg(fileInfo.completeBaseName()));
 
 }

--- a/JASP-Desktop/utilities/appdirs.cpp
+++ b/JASP-Desktop/utilities/appdirs.cpp
@@ -123,7 +123,7 @@ QString AppDirs::rHome()
 		rHomePath = "/usr/lib/R/";
 #endif
 #else
-	QString rHomePath = QDir::isRelativePath(R_HOME) ? programDir.absoluteFilePath(R_HOME) : R_HOME;
+	QString rHomePath = QDir::isRelativePath(R_HOME) ? programDir().absoluteFilePath(R_HOME) : R_HOME;
 #endif
 #endif
 	


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/916, although I'm not entirely sure why.

Also fixes a compilation error on Linux with a custom R home introduced by https://github.com/jasp-stats/jasp-desktop/pull/4311 (missing parentheses after `programDir`):

https://github.com/jasp-stats/jasp-desktop/blob/46d21a76022f6cb3a3d93cc0fbbee33b826e0604/JASP-Desktop/utilities/appdirs.cpp#L108-L131
