### PR TITLE
Variables List does not scale in the right way when zooming

### DIFF
--- a/JASP-Desktop/components/JASP/Controls/VariablesForm.qml
+++ b/JASP-Desktop/components/JASP/Controls/VariablesForm.qml
@@ -64,14 +64,9 @@ Item
 		}
 	}
 
-	onListWidthChanged:
-	{
-		if (formInitialized && listWidth > 0 && listWidth != _lastListWidth)
-		{
-			_lastListWidth = listWidth;
-			setControlsSize();
-		}
-	}
+	onListWidthChanged: if (formInitialized && listWidth > 0 && listWidth != _lastListWidth) _lastListWidth = listWidth;
+
+	onHeightChanged:	if (formInitialized )	setControlsSize();
 
 	Repeater
 	{


### PR DESCRIPTION
The calculation of the size of the Variables Lists inside a
VariablesForm depends on the height of the VariablesForm. It was
depending on the istWidth, depending on the width, that was updated
apparently before the height was updated. So the signal that should be
used should be directly the heightChanged.
Fixes jasp-stats/jasp-test-release#1044