### PR TITLE
put style in single quotes

### DIFF
--- a/JASP-Desktop/html/js/jaspwidgets.js
+++ b/JASP-Desktop/html/js/jaspwidgets.js
@@ -236,7 +236,7 @@ JASPWidgets.Exporter = {
 		}
 
 		if (style)
-			style = 'style="' + style + '"';
+			style = "style='" + style + "'";
 
 		return style;
 	},


### PR DESCRIPTION
- (maybe) fixes https://github.com/jasp-stats/jasp-test-release/issues/1050 by making sure the html can be parsed properly

If I open @EJWagenmakers 's example in the issue and just save it (not even refresh it) and upload it to OSF it renders fine in any case.
And if I look at the previewhtml at least it is syntactically correct now, which is nice.

