### PR TITLE
Remove QML Connections warnings

### DIFF
--- a/Desktop/components/JASP/Controls/GridLayout.qml
+++ b/Desktop/components/JASP/Controls/GridLayout.qml
@@ -40,8 +40,8 @@ GridLayout
 	{
 		enabled:					checkFormOverflowWhenLanguageChanged
 		target:						preferencesModel
-		onLanguageCodeChanged:		checkFormOverflowTimer.restart()
-		onInterfaceFontChanged:		checkFormOverflowTimer.restart()
+		function onLanguageCodeChanged()		{ checkFormOverflowTimer.restart(); }
+		function onInterfaceFontChanged(font)	{ checkFormOverflowTimer.restart(); }
 	}
 
 	Timer

--- a/Desktop/components/JASP/Controls/GroupBox.qml
+++ b/Desktop/components/JASP/Controls/GroupBox.qml
@@ -73,14 +73,14 @@ JASPControl
 
 	Connections
 	{
-		target:				preferencesModel
-		onUiScaleChanged:	alignTextFieldTimer.restart()
+		target:	preferencesModel
+		function onUiScaleChanged(scale)	{ alignTextFieldTimer.restart(); }
 	}
 
 	Connections
 	{
-		target:					preferencesModel
-		onLanguageCodeChanged:	checkFormOverflowAndAlignTimer.restart()
+		target:	preferencesModel
+		function onLanguageCodeChanged()	{ checkFormOverflowAndAlignTimer.restart(); }
 	}
 
 	Timer

--- a/Desktop/components/JASP/Controls/JASPScrollBar.qml
+++ b/Desktop/components/JASP/Controls/JASPScrollBar.qml
@@ -17,8 +17,8 @@
 //
 // Code based on http://stackoverflow.com/questions/17833103/how-to-create-scrollbar-in-qtquick-2-0
 
-import QtQuick 2.0;
-//import QtQml 2.14;
+import QtQuick	2.0;
+import QtQml	2.15
 
 
 Item
@@ -82,7 +82,7 @@ Item
 	
 	Binding
 	{
-//		restoreMode: Binding.RestoreBinding
+		restoreMode: Binding.RestoreBinding
 		target:		handle;
 		property:	scrollbar.vertical ? "y" : "x"
 		when:		!clicker.drag.active
@@ -93,7 +93,7 @@ Item
 
 	Binding
 	{
-//		restoreMode: Binding.RestoreBinding
+		restoreMode: Binding.RestoreBinding
 		target:		flickable
 		property:	scrollbar.vertical ? "contentY" : "contentX"
 		when:		(clicker.drag.active || clicker.pressed)

--- a/Desktop/components/JASP/Controls/VariablesForm.qml
+++ b/Desktop/components/JASP/Controls/VariablesForm.qml
@@ -53,7 +53,7 @@ Item
 	Connections
 	{
 		target:					preferencesModel
-		onLanguageCodeChanged:
+		function onLanguageCodeChanged()
 		{
 			// Apparently a Qt bug: the height is not always recalculated by the GridLayout when the language is changed.
 			// Force this by changing temporarily the Layout.preferredHeight

--- a/Desktop/components/JASP/Widgets/AboutWindow.qml
+++ b/Desktop/components/JASP/Widgets/AboutWindow.qml
@@ -31,7 +31,7 @@ Window
 	Connections
 	{
 		target:			mainWindow
-		onCloseWindows: aboutModel.visible = false;
+		function onCloseWindows() { aboutModel.visible = false; }
 	}
 
 

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -439,7 +439,7 @@ DropArea
 				Connections
 				{
 					target:				loader.item
-					onHeightChanged:	expanderButton.formHeight = loader.item.height
+					function onHeightChanged() { expanderButton.formHeight = loader.item.height; }
 				}
 
 				Loader

--- a/Desktop/components/JASP/Widgets/AnalysisForms.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisForms.qml
@@ -53,7 +53,7 @@ FocusScope
 		Connections
 		{
 			target:							analysesModel
-			onCurrentAnalysisIndexChanged:	formsBackground.scrollToForm(analysesModel.currentAnalysisIndex);
+			function onCurrentAnalysisIndexChanged(index) { formsBackground.scrollToForm(index); }
 		}
 
 		Rectangle
@@ -143,7 +143,7 @@ FocusScope
 				Connections
 				{
 					target:							analysesModel
-					onCurrentFormHeightChanged:		if(analysesModel.currentFormHeight > analysesModel.currentFormPrevH) reposition(); //If it got larger it probably means an expander opened and we should reposition if possible
+					function onCurrentFormHeightChanged(formHeight) { if (formHeight > analysesModel.currentFormPrevH) reposition(); }//If it got larger it probably means an expander opened and we should reposition if possible
 
 					function reposition()
 					{

--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -37,7 +37,11 @@ FocusScope
 	Connections
 	{
 		target:						computedColumnsInterface
-		onShowThisColumnChanged:	if(!computedColumnContainer.changed && computedColumnsInterface.showThisColumn !== computedColumnsInterface.computeColumnNameSelected) open(computedColumnsInterface.showThisColumn)
+		function onShowThisColumnChanged(columnName)
+		{
+			if (!computedColumnContainer.changed && columnName !== computedColumnsInterface.computeColumnNameSelected)
+				open(columnName);
+		}
 	}
 
 	function close()

--- a/Desktop/components/JASP/Widgets/FileMenu/FileList.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/FileList.qml
@@ -44,8 +44,8 @@ ListView
 
 	Connections
 	{
-		target:				listView.model
-		onModelReset:		listView.currentIndex = 0;
+		target:	listView.model
+		function onModelReset() { listView.currentIndex = 0; }
 	}
 
 	delegate:	ListItem

--- a/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
@@ -33,7 +33,7 @@ FocusScope
 	Connections
 	{
 		target:				fileMenuModel
-		onVisibleChanged:	if(fileMenuModel.visible) actionMenu.forceActiveFocus(); else fileMenu.focus = false;
+		function onVisibleChanged() { if (fileMenuModel.visible) actionMenu.forceActiveFocus(); else fileMenu.focus = false; }
 	}
 
 	Item
@@ -314,10 +314,10 @@ FocusScope
 			Connections
 			{
 				target:	fileMenuModel.resourceButtons
-				onCurrentQMLChanged:
+				function onCurrentQMLChanged(currentQML)
 				{
 					resourceScreen.previousQML = resourceScreen.currentQML
-					resourceScreen.currentQML  = fileMenuModel.resourceButtons.currentQML
+					resourceScreen.currentQML  = currentQML
 				}
 			}
 

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -111,8 +111,8 @@ ScrollView
 
 						Connections
 						{
-							target:					preferencesModel
-							onCustomEditorChanged:	developerFolderText = preferencesModel.developerFolder
+							target:			preferencesModel
+							function onCustomEditorChanged(customEditor) { developerFolderText = preferencesModel.developerFolder; }
 						}
 
 					}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -132,7 +132,7 @@ Item
 							Connections
 							{
 								target:					preferencesModel
-								onCustomEditorChanged:	customEditorText.text = preferencesModel.customEditor
+								function onCustomEditorChanged(customEditor) { customEditorText.text = customEditor; }
 							}
 						}
 					}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -19,14 +19,14 @@ ScrollView
 
 	Connections
 	{
-		target:						preferencesModel
-		onCurrentThemeNameChanged:	scrollPrefs.resetMe();
+		target:				preferencesModel
+		function onCurrentThemeNameChanged(name)	{ scrollPrefs.resetMe(); }
 	}
 
 	Connections
 	{
-		target:						languageModel
-		onCurrentIndexChanged:		scrollPrefs.resetMe();
+		target:				languageModel
+		function onCurrentIndexChanged()			{ scrollPrefs.resetMe(); }
 	}
 
 	Column

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -19,8 +19,8 @@ FocusScope
 	Connections
 	{
 		target:						filterModel
-		onFilterErrorMsgChanged:	if(filterModel.filterErrorMsg.length > 0) open();
-		onRFilterChanged:			absorbModelRFilter();
+		function onFilterErrorMsgChanged()	{ if (filterModel.filterErrorMsg.length > 0) open();	}
+		function onRFilterChanged()			{ absorbModelRFilter();				}
 	}
 
     function toggle()

--- a/Desktop/components/JASP/Widgets/HelpWindow.qml
+++ b/Desktop/components/JASP/Widgets/HelpWindow.qml
@@ -27,7 +27,7 @@ Window
 	Connections
 	{
 		target:			mainWindow
-		onCloseWindows: helpWindowRoot.close()
+		function onCloseWindows() { helpWindowRoot.close(); }
 	}
 
 	UIScaleNotifier { anchors.centerIn:	parent }
@@ -57,7 +57,7 @@ Window
 		Connections
 		{
 			target:				helpModel
-			onRunJavaScriptSignal:
+			function onRunJavaScriptSignal(helpJS)
 			{
 				helpView.runJavaScript(helpJS);
 				searchBar.search();

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -80,10 +80,10 @@ Item
 			Connections
 			{
 				target:						mainWindow
-				onDataPanelVisibleChanged:
+				function onDataPanelVisibleChanged(visible)
 				{
-					if(mainWindow.dataPanelVisible && data.width === 0)		data.maximizeData();
-					else if(!mainWindow.dataPanelVisible && data.width > 0)	data.minimizeData();
+					if (visible && data.width === 0)	data.maximizeData();
+					else if(!visible && data.width > 0)	data.minimizeData();
 				}
 			}
 		}
@@ -130,7 +130,7 @@ Item
 			Connections
 			{
 				target:				analysesModel
-				onAnalysisAdded:
+				function onAnalysisAdded()
 				{
 					//make sure we get to see the results!
 
@@ -191,11 +191,11 @@ Item
 
 				Connections
 				{
-					target:					resultsJsInterface
-					onRunJavaScript:		resultsView.runJavaScript(js)
-					onScrollAtAllChanged:	resultsView.runJavaScript("window.setScrollAtAll("+(scrollAtAll ? "true" : "false")+")");
+					target:		resultsJsInterface
+					function onRunJavaScript(js)				{ resultsView.runJavaScript(js); }
+					function onScrollAtAllChanged(scrollAtAll)	{ resultsView.runJavaScript("window.setScrollAtAll("+(scrollAtAll ? "true" : "false")+")"); }
 
-					onExportToPDF:
+					function onExportToPDF(pdfPath)
 					{
 						if(preferencesModel.currentThemeName !== "lightTheme")
 							resultsJsInterface.setThemeCss("lightTheme");

--- a/Desktop/components/JASP/Widgets/UIScaleNotifier.qml
+++ b/Desktop/components/JASP/Widgets/UIScaleNotifier.qml
@@ -15,9 +15,9 @@ Item
 	Connections
 	{
 		target:				preferencesModel
-		onUiScaleChanged:
+		function onUiScaleChanged(scale)
 		{
-			if(uiScaleNotifier.uiScaleIsLoadedFromSettings)
+			if (uiScaleNotifier.uiScaleIsLoadedFromSettings)
 				uiScaleTimer.restart()
 
 			uiScaleNotifier.uiScaleIsLoadedFromSettings = true;

--- a/Desktop/components/JASP/Widgets/VariablesWindow.qml
+++ b/Desktop/components/JASP/Widgets/VariablesWindow.qml
@@ -32,9 +32,9 @@ FocusScope
 	{
 		target: labelModel
 		
-		onChosenColumnChanged:
+		function onChosenColumnChanged()
 		{
-			if(labelModel.chosenColumn > -1 && labelModel.chosenColumn < dataSetModel.columnCount())
+			if (labelModel.chosenColumn > -1 && labelModel.chosenColumn < dataSetModel.columnCount())
 			{
 				//to prevent the editText in the labelcolumn to get stuck and overwrite the next columns data... We have to remove activeFocus from it
 				levelsTableViewRectangle.focus = true //So we just put it somewhere


### PR DESCRIPTION
QML Connections onFoo properties are deprecated and must be replaced by
a function onFoo() {}