### PR TITLE
More logging in tempfiles and reduce timeout for deleting orphaned files to avoid possible crash

### DIFF
--- a/JASP-Common/tempfiles.cpp
+++ b/JASP-Common/tempfiles.cpp
@@ -123,7 +123,8 @@ void TempFiles::deleteOrphans()
 
 	system::error_code error;
 
-	try {
+	try
+	{
 
 		filesystem::path tempPath		= Utils::osPath(Dirs::tempDir());
 		filesystem::path sessionPath	= Utils::osPath(_sessionDirName);
@@ -132,7 +133,7 @@ void TempFiles::deleteOrphans()
 
 		if (error)
 		{
-			perror(error.message().c_str());
+			Log::log() << error.message() << std::endl;
 			return;
 		}
 
@@ -168,10 +169,7 @@ void TempFiles::deleteOrphans()
 						filesystem::remove(p, error);
 
 						if (error)
-						{
-							Log::log() << "Error when deleting File: " << error.message() << std::endl;
-							perror(error.message().c_str());
-						}
+							Log::log() << "Error when deleting file: " << error.message() << std::endl;
 					}
 				}
 			}
@@ -193,7 +191,7 @@ void TempFiles::deleteOrphans()
 						filesystem::remove_all(p, error);
 
 						if (error)
-							perror(error.message().c_str());
+							Log::log() << "Error when deleting directory: " << error.message() << std::endl;
 					}
 				}
 				else // no status file
@@ -201,7 +199,7 @@ void TempFiles::deleteOrphans()
 					filesystem::remove_all(p, error);
 
 					if (error)
-						perror(error.message().c_str());
+						Log::log() << "Error when deleting directory, had no status file and " << error.message() << std::endl;
 				}
 			}
 		}
@@ -209,8 +207,7 @@ void TempFiles::deleteOrphans()
 	}
 	catch (runtime_error e)
 	{
-		perror("Could not delete orphans");
-		perror(e.what());
+		Log::log() << "Could not delete orphans, error: " << e.what() << std::endl;
 		return;
 	}
 }

--- a/JASP-Desktop/engine/enginesync.cpp
+++ b/JASP-Desktop/engine/enginesync.cpp
@@ -69,7 +69,9 @@ EngineSync::EngineSync(QObject *parent)
 	connect(PreferencesModel::prefs(),	&PreferencesModel::languageCodeChanged,				this,						&EngineSync::haveYouTriedTurningItOffAndOnAgain,	Qt::QueuedConnection);
 #endif
     // delay start so as not to increase program start up time 10sec is better than 100ms, because they are orphaned anyway
-    QTimer::singleShot(10000, this, &EngineSync::deleteOrphanedTempFiles);
+	// Except, that it might somehow cause a crash? If the timer goes off while waiting for a download from OSF than it might remove the files while making them..
+	// So lets put it on 500ms...
+	QTimer::singleShot(500, this, &EngineSync::deleteOrphanedTempFiles);
 
 	DataSetPackage::pkg()->setEngineSync(this);
 

--- a/JASP-Desktop/mainwindow.cpp
+++ b/JASP-Desktop/mainwindow.cpp
@@ -190,6 +190,8 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 
 MainWindow::~MainWindow()
 {
+	Log::log() << "MainWindow::~MainWindow()" << std::endl;
+
 	_singleton = nullptr;
 
 	try


### PR DESCRIPTION
It would be nice if Oliver in https://github.com/jasp-stats/jasp-issues/issues/992 tests his personal nightly first.

On the other hand, I think @vandenman ran into this same bug a while ago.
I think, if my understanding of the problem is correct, that this bug can be triggered by starting JASP and go into a file-loading screen within 10sec and keep it there for at least those first 10sec after startup.

Because if I should believe the logging the "delete orphans" functionality starts running immediately after loading the analyses and I think it might be clashing with that.