### PR TITLE
Custom fonts for figures

### DIFF
--- a/R-Interface/jaspResults/R/writeImage.R
+++ b/R-Interface/jaspResults/R/writeImage.R
@@ -19,11 +19,21 @@ getImageLocation <- function() {
   )
 }
 
-openGrDevice <- function(...) {
+ openGrDevice <- function(..., dpi) {
   #if (jaspResultsCalledFromJasp())
   #  svglite::svglite(...)
   #else
+
+  # showtext divides by 72 internally, see ?showtext::showtext_opts
+  # 1 + 1 / 3 is a magic number to compensate font size scaling
+  showtext::showtext_opts(dpi = dpi / (1 + 1 / 3))
   grDevices::png(..., type = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"))
+  showtext::showtext_begin()
+}
+
+closeGrDevice <- function() {
+  showtext::showtext_end()
+  dev.off()
 }
 
 writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativePathpng=NULL, ppi=300, backgroundColor="white", location=getImageLocation())
@@ -59,21 +69,12 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
 
   plot2draw <- decodeplot(plot)
 
+  openGrDevice(file = relativePathpng, width = width, height = height, res = 72 * (ppi / 96), bg = backgroundColor, dpi = ppi)
+  on.exit(closeGrDevice())
+
   if (ggplot2::is.ggplot(plot2draw) || inherits(plot2draw, c("gtable"))) {
 
-    # TODO: ggsave adds very little when we use a function as device...
-    ggplot2::ggsave(
-      filename  = relativePathpng, 
-      plot      = plot2draw,
-      device    = grDevices::png,
-      dpi       = ppi,
-      width     = width,
-      height    = height,
-      bg        = backgroundColor,
-      res       = 72 * (ppi / 96),
-      type      = ifelse(Sys.info()["sysname"] == "Darwin", "quartz", "cairo"),
-      limitsize = FALSE # only necessary if users make the plot ginormous.
-    )
+   grid::grid.draw(plot2draw) # inherited from ggplot2::ggsave
 
     #If we have jaspGraphs available we can get the plotEditingOptions for this plot
     if(requireNamespace("jaspGraphs", quietly = TRUE))

--- a/R-Interface/jaspResults/R/writeImage.R
+++ b/R-Interface/jaspResults/R/writeImage.R
@@ -84,10 +84,6 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
     
     isRecordedPlot <- inherits(plot2draw, "recordedplot")
 
-    # Open graphics device and plot
-    openGrDevice(file = relativePathpng, width = width, height = height, res = 72 * (ppi / 96), bg = backgroundColor)
-    on.exit(dev.off())
-
     if (is.function(plot2draw) && !isRecordedPlot) {
 
       if (obj) dev.control('enable') # enable plot recording


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/363 
Continuation of https://github.com/jasp-stats/jasp-desktop/pull/4219

### Message of previous PR

A draft for using different fonts to ensure that we support more Unicode characters. 

The code as is doesn't do anything (and thus the unit tests are happy). To make it work, add:
```r
JASPgraphs::setJASPFont("~/github/jasp-desktop/JASP-Desktop/html/font/Lato-Regular.ttf")
``` 
before creating a plot (or add it once in `runJaspResults` to make the effect global). Then all ggplots that use `themeJasp` or `themeJaspRaw` will use this font automatically (for qgraph we may need adjustments to each plot).

In addition, the following R packages are needed:

- showtext [CRAN](https://cran.r-project.org/package=showtext)
- sysfonts [CRAN](https://cran.r-project.org/package=sysfonts)

Something that may be a dealbreaker is that these packages have dependencies:

SystemRequirements: zlib, libpng, FreeType

I don't know if these dependencies are needed if we just use the binaries or if they are required for the few functions I use from these packages.


Stable                     |  This PR (Lato)
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/21319932/89438761-7f818300-d749-11ea-9ae3-c55cdfc5f9ae.png" width="425"/>  |  <img src="https://user-images.githubusercontent.com/21319932/89438988-d2f3d100-d749-11ea-93ef-cf7a5daa3432.png" width="425"/>

The difference is most clear for the letter g. Note that `ragg` wasn't necessary for this in the end.

Feedback/ comments are welcome! It would also be great if somebody could test this on macOS (I've only tested this on Ubuntu so far).


Edit: in `Makevars.win` inside `sysfonts` there is:

```
PKG_CPPFLAGS = -I./include -I./include/freetype
PKG_LIBS = -L.${R_ARCH} -lfreetype -lpng -lz


.PHONY: all deps clean

all: deps $(SHLIB)

deps: sysfonts-dep-win-biarch.tar.gz
	tar xzf sysfonts-dep-win-biarch.tar.gz

sysfonts-dep-win-biarch.tar.gz:
	${R_HOME}/bin$(R_ARCH_BIN)/Rscript -e "u = 'https://raw.githubusercontent.com/yixuan/sysfonts-dep/master/sysfonts-dep-win-biarch.tar.gz'; utils::download.file(u, basename(u), mode = 'wb')"

clean:
	$(RM) *.o
	$(RM) *.dll
	$(RM) *.so
	$(RM) *.dylib

```

that download looks a little bit fishy but it refers to this repo: https://github.com/yixuan/sysfonts-dep

lucky for us, that repo contains all dependencies.


### To get this to work in Jasp, do
  1. Install `showtext` and `sysfonts`.
  2. Checkout this PR
  3. Checkout https://github.com/jasp-stats/jaspGraphs/pull/2 of jaspGraphs
  4. In `jaspBase/R/common.R` add something like:
```r
  # adjust this to wherever you have a cool font
  jaspGraphs::setJaspFont("~/github/jasp-desktop/Desktop/html/font/Lato-Regular.ttf")
  # other code
  oldGraphOptions <- jaspGraphs::graphOptions()
  on.exit(jaspGraphs::graphOptions(oldGraphOptions), add = TRUE)

```
inside `runJaspResults`.