### PR TITLE
Fix one-sided testing bayesian wilcoxon signed rank test

### DIFF
--- a/JASP-Engine/JASP/R/ttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/ttestbayesianonesample.R
@@ -121,7 +121,7 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
           
           .setSeedJASP(options)
           r <- try(.signRankGibbsSampler(
-            x = x, nSamples = options[["wilcoxonSamplesNumber"]], testValue = 0, nBurnin = 0,
+            x = x, nSamples = options[["wilcoxonSamplesNumber"]], testValue = options[["testValue"]], nBurnin = 0,
             cauchyPriorParameter = options[["priorWidth"]]
           ))
           

--- a/JASP-Engine/JASP/R/ttestbayesianonesample.R
+++ b/JASP-Engine/JASP/R/ttestbayesianonesample.R
@@ -134,11 +134,11 @@ TTestBayesianOneSample <- function(jaspResults, dataset, options, state = NULL) 
 
           } else {
             
-            ttestResults[["delta"]][[var]]  <- r[["deltaSamples"]] * -1
+            ttestResults[["delta"]][[var]]  <- r[["deltaSamples"]] * -
             ttestResults[["rHat"]][[var]]  <- r[["rHat"]]
             
             bf.raw <- .computeBayesFactorWilcoxon(
-              deltaSamples         = r[["deltaSamples"]] * -1,
+              deltaSamples         = r[["deltaSamples"]],
               cauchyPriorParameter = options[["priorWidth"]],
               oneSided             = oneSided)
             

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -313,7 +313,7 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
   fullVar <- ((nSamples - 1) / nSamples) * withinChainVar + (betweenChainVar / nSamples)
   rHat <- sqrt(fullVar/withinChainVar)
   
-  return(list(deltaSamples = as.vector(deltaSamplesMatrix), rHat = rHat))
+  return(list(deltaSamples = -as.vector(deltaSamplesMatrix), rHat = rHat))
 }
 
 .sampleGibbsOneSampleWilcoxon <- function(diffScores, nIter = 10, rscale = 1/sqrt(2)){

--- a/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
+++ b/JASP-Engine/JASP/R/ttestbayesianpairedsamples.R
@@ -313,7 +313,7 @@ TTestBayesianPairedSamples <- function(jaspResults, dataset, options) {
   fullVar <- ((nSamples - 1) / nSamples) * withinChainVar + (betweenChainVar / nSamples)
   rHat <- sqrt(fullVar/withinChainVar)
   
-  return(list(deltaSamples = -as.vector(deltaSamplesMatrix), rHat = rHat))
+  return(list(deltaSamples = as.vector(deltaSamplesMatrix), rHat = rHat))
 }
 
 .sampleGibbsOneSampleWilcoxon <- function(diffScores, nIter = 10, rscale = 1/sqrt(2)){


### PR DESCRIPTION
Fix https://github.com/jasp-stats/jasp-issues/issues/1038
Sign rank test now uses testValue as specified by user, as opposed to just setting it to 0