### PR TITLE
Better handling of Dynamic modules and (re)loading

### DIFF
--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -60,10 +60,8 @@ public:
 	static Analyses *	analyses() { return _singleton; }
 
 	Analysis	*	createFromJaspFileEntry(Json::Value analysisData, RibbonModel* ribbonModel);
-	Analysis	*	create(const QString &module, const QString &name, const QString& qml, const QString &title, size_t id, const Version &version, Json::Value *options = nullptr, Analysis::Status status = Analysis::Initializing, bool notifyAll = true);
-	Analysis	*	create(Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Initializing, bool notifyAll = true, std::string title = "", std::string moduleVersion = "", Json::Value *options = nullptr);
 
-	Analysis	*	create(const QString &module, const QString &name, const QString& qml, const QString &title)	{ return create(module, name, qml, title, _nextId++, AppInfo::version);		}
+	Analysis	*	create(Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Initializing, bool notifyAll = true, std::string title = "", std::string moduleVersion = "", Json::Value *options = nullptr);
 	Analysis	*	create(Modules::AnalysisEntry * analysisEntry)													{ return create(analysisEntry, _nextId++);						}
 
 	Analysis	*	operator[](size_t index)	{ return _analysisMap[_orderedIds[index]]; }

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -63,7 +63,6 @@ public:
 	static Analysis::Status analysisResultsStatusToAnalysisStatus(analysisResultStatus result);
 
 	Analysis(size_t id, Analysis * duplicateMe);
-	Analysis(size_t id, std::string module, std::string name, std::string qml, std::string title, const Version &version, Json::Value *data);
 	Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::string title = "", std::string moduleVersion = "", Json::Value *data = nullptr);
 
 	virtual ~Analysis();
@@ -77,8 +76,8 @@ public:
 	Q_INVOKABLE void	duplicateMe();
 
 	bool needsRefresh()			const;
-	bool isWaitingForModule()	const { return _moduleData == nullptr ? false : !_moduleData->dynamicModule()->readyForUse(); }
-	bool isDynamicModule()		const { return _moduleData == nullptr ? false : _moduleData->dynamicModule() != nullptr; }
+	bool isWaitingForModule();
+	bool isDynamicModule()		const { return bool(_dynamicModule); }
 	void setResults(	const Json::Value & results, analysisResultStatus	status, const Json::Value & progress = Json::nullValue) { setResults(results, analysisResultsStatusToAnalysisStatus(status), progress); }
 	void setResults(	const Json::Value & results, Status					status, const Json::Value & progress = Json::nullValue);
 	void imageSaved(	const Json::Value & results);
@@ -125,7 +124,7 @@ public:
 			bool				isDuplicate()		const	{ return _isDuplicate;						}
 			bool				hasVolatileNotes()	const	{ return _hasVolatileNotes;					}
 			bool				utilityRunAllowed() const	{ return  isSaveImg() || isEditImg() || isRewriteImgs();									}
-			bool				shouldRun()			const	{ return !isWaitingForModule() && ( utilityRunAllowed() || isEmpty() ) && optionsBound();	}
+			bool				shouldRun()					{ return !isWaitingForModule() && ( utilityRunAllowed() || isEmpty() ) && optionsBound();	}
 	const	Json::Value		&	meta()				const	{ return _meta;																				}
 			QString				helpMD()			const;
 			bool				optionsBound()		const	{ return _optionsBound;	}
@@ -225,6 +224,7 @@ private:
 	void					storeUserDataEtc();
 	void					fitOldUserDataEtc();
 	bool					updatePlotSize(const std::string & plotName, int width, int height, Json::Value & root);
+	Modules::AnalysisEntry	*moduleData();
 
 protected:
 	Status					_status			= Initializing;

--- a/Desktop/components/JASP/Widgets/LoadingIndicator.qml
+++ b/Desktop/components/JASP/Widgets/LoadingIndicator.qml
@@ -9,7 +9,7 @@ Item
 	Image
 	{
 		id						: img
-		source					: jaspTheme.iconPath + "/loading.svg"
+		source					: visible ? jaspTheme.iconPath + "/loading.svg" : ""
 		sourceSize.width		: width
 		sourceSize.height		: width
 		height					: width
@@ -17,11 +17,25 @@ Item
 		transformOrigin			: Item.Center
 		anchors.centerIn		: parent
 
-		property int	segments: 12
-		property real	duration: 1200
-		property int	run		: 0
+		readonly property int	segments: 12
+		readonly property real	duration: 1200
+				 property int	run		: 0
 
-		onVisibleChanged: if(visible && !anim.running) anim.start()
+		onVisibleChanged: 	startStopIfVisible();
+		ListView.onReused:	startStopIfVisible();
+		ListView.onPooled:	anim.stop()
+
+		function startStopIfVisible()
+		{
+			if ( visible && !anim.running)
+			{
+				run = 0;
+				anim.start();
+			}
+
+			if(!visible && anim.running)
+				anim.stop();
+		}
 
 		SequentialAnimation
 		{

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -20,6 +20,7 @@ import QtQuick				2.11
 import QtQuick.Controls		2.4
 import QtGraphicalEffects	1.12
 import JASP					1.0
+import JASP.Widgets			1.0
 
 Rectangle
 {
@@ -31,8 +32,9 @@ Rectangle
 	objectName      : "ribbonButton"
 
 	property alias	text		: innerText.text
-	property alias	source		: backgroundImage.source
+	property string	source		: ""
 	property bool	enabled		: true
+	property bool	ready		: false
 	property string moduleName	: "???"
 	property string toolTip		: ""
 	property var	menu		: []
@@ -93,6 +95,8 @@ Rectangle
 			smooth:		true
 			mipmap:		true
 			fillMode:	Image.PreserveAspectFit
+			visible:	ribbonButton.ready
+			source:		ribbonButton.source === "" ? jaspTheme.iconPath + "error.png" : ribbonButton.source
 
 			anchors
 			{
@@ -101,6 +105,16 @@ Rectangle
 				horizontalCenter: parent.horizontalCenter
 			}
 
+		}
+
+		LoadingIndicator
+		{
+			anchors.top:		backgroundImage.top
+			anchors.left:		backgroundImage.left
+			width:				backgroundImage.width
+			height:				backgroundImage.height
+			visible:			!ribbonButton.ready
+			z:					backgroundImage.z + 1
 		}
 
 		Image
@@ -114,7 +128,7 @@ Rectangle
 			anchors.top:		backgroundImage.top
 			source:				jaspTheme.iconPath + "/toolbutton-menu-indicator.svg"
 			opacity:			ribbonButton.enabled ? 1 : 0.5
-			visible:			ribbonButton.menu ? ribbonButton.menu.rowCount() > 1 : false
+			visible:			ribbonButton.menu && ribbonButton.menu.rowCount() > 1
 		}
 
 		Text

--- a/Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
@@ -16,8 +16,8 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-import QtQuick 2.11
-import QtQuick.Controls 2.4
+import QtQuick			2.15
+import QtQuick.Controls 2.15
 
 
 Item
@@ -54,6 +54,7 @@ Item
 		interactive:					false
 		highlightFollowsCurrentItem:	true
 		highlightMoveDuration:			20
+		reuseItems:						true
 
 		onDragStarted:					customMenu.hide()
 		onMovementStarted:				customMenu.hide()
@@ -68,13 +69,14 @@ Item
 
 		delegate: RibbonButton
 		{
-			text:			model.moduleTitle
-			moduleName:		model.moduleName
-			source:			!model.ribbonButton ? ""		: (!model.ribbonButton.special ? "file:" : "qrc:/icons/") + model.ribbonButton.iconSource
+			text:			 model.moduleTitle
+			moduleName:		 model.moduleName
+			source:			!model.ribbonButton || model.ribbonButton.iconSource === "" ? ""		: (!model.ribbonButton.special ? "file:" : "qrc:/icons/") + model.ribbonButton.iconSource
 			menu:			!model.ribbonButton ? undefined : model.ribbonButton.analysisMenu
 			toolTip:		!model.ribbonButton ? undefined : model.ribbonButton.toolTip
-			enabled:		!model.ribbonButton ? false		: model.active
-			visible:		!model.ribbonButton ? false		: true
+			enabled:		 model.ribbonButton && model.active
+			visible:		 model.ribbonButton
+			ready:			 model.ribbonButton && (model.ribbonButton.ready || model.ribbonButton.special || model.ribbonButton.error)
 		}
 	}
 	

--- a/Desktop/components/JASP/Widgets/qmldir
+++ b/Desktop/components/JASP/Widgets/qmldir
@@ -44,5 +44,5 @@ SetSeed                     1.0 SetSeed.qml
 BasicThreeButtonTableView   1.0 BasicThreeButtonTableView.qml
 ControlErrorMessage         1.0 ControlErrorMessage.qml
 LoadingIndicator            1.0 LoadingIndicator.qml
-CrossButton		    1.0 CrossButton.qml
+CrossButton					1.0 CrossButton.qml
 SimpleTableView             1.0 SimpleTableView.qml

--- a/Desktop/engine/enginerepresentation.h
+++ b/Desktop/engine/enginerepresentation.h
@@ -80,7 +80,7 @@ public:
 	void process();
 	void restartAbortedAnalysis();
 	void checkIfExpectedReplyType(engineState expected) { unexpectedEngineReply::checkIfExpected(expected, _engineState, channelNumber()); }
-	bool willProcessAnalysis(const Analysis * analysis) const;
+	bool willProcessAnalysis(Analysis * analysis) const;
 
 	size_t	channelNumber()		const { return _channel->channelNumber(); }
 
@@ -168,6 +168,8 @@ private:
 					_runsRCmd			= false,	//is this engine meant for the R prompt?
 					_removeEngine		= false;
 	std::string		_lastCompColName	= "???";
+
+	QMetaObject::Connection	_slaveFinishedConnection;
 
 
 };

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -616,7 +616,7 @@ void EngineSync::stopEngines()
 	for(auto engine : _engines)
 		engine->process();
 
-	_engineStarted = false;
+	_engineStarted		= false;
 
 	for(EngineRepresentation * e : _engines)
 		e->stopEngine();
@@ -624,7 +624,7 @@ void EngineSync::stopEngines()
 	while(!allEnginesStopped())
 		if(timeout < QDateTime::currentSecsSinceEpoch())
 		{
-			std::cerr << "Waiting for engine to reply stopRequest took longer than timeout, killing it/them.." << std::endl;
+			Log::log() << "Waiting for engine to reply stopRequest took longer than timeout, killing it/them.." << std::endl;
 			for(EngineRepresentation * e : _engines)
 				if(!e->stopped() && !e->killed())
 					e->killEngine();
@@ -635,10 +635,13 @@ void EngineSync::stopEngines()
 			for (auto * engine : _engines)
 				engine->process();
 
-	timeout = QDateTime::currentSecsSinceEpoch() + 10;
+	//timeout = QDateTime::currentSecsSinceEpoch() + 10;
+
+	/*
+
+	  Log::log() << "Checking if engines are running by using QApplication::processEvents to get answers." << std::endl;
 
 	bool stillRunning;
-
 	do
 	{
 		QApplication::processEvents(); //Otherwise we will not get feedback from QProcess (aka finished)
@@ -658,9 +661,9 @@ void EngineSync::stopEngines()
 		for (auto * engine : _engines)
 			if(engine->jaspEngineStillRunning())
 				engine->killEngine();
-	}
-	else
-		Log::log() << "Engines stopped" << std::endl;
+	}*/
+
+	Log::log() << "Engines stopped(/killed)" << std::endl;
 }
 
 void EngineSync::pause()

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -26,6 +26,8 @@
 #include <boost/filesystem.hpp>
 #include <codecvt>
 #include "appinfo.h"
+#include <iostream>
+#include "timers.h"
 
 const std::string	jaspExtension	= ".jasp",
 					unitTestArg		= "--unitTest",

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -401,6 +401,7 @@ void MainWindow::makeConnections()
 	connect(_languageModel,			&LanguageModel::languageChanged,					_analyses,				&Analyses::languageChangedHandler,							Qt::QueuedConnection);
 	connect(_languageModel,			&LanguageModel::languageChanged,					_helpModel,				&HelpModel::generateJavascript,								Qt::QueuedConnection);
 
+	connect(_qml,					&QQmlApplicationEngine::warnings,					this,					&MainWindow::printQmlWarnings								);
 
 	// Temporary to facilitate plot editing
 	_plotEditingFilePath = QString::fromStdString(Dirs::resourcesDir()) + "PlotEditor.qml";
@@ -408,6 +409,14 @@ void MainWindow::makeConnections()
 		Log::log() << "Cannot watch plot editing file" << _plotEditingFilePath << std::endl;
 	connect(&_plotEditingFileWatcher, &QFileSystemWatcher::fileChanged,					this,					&MainWindow::plotEditingFileChanged							);
 
+}
+
+void MainWindow::printQmlWarnings(const QList<QQmlError> &warnings)
+{
+	Log::log()		<< "Received QML warnings:\n";
+	for(const QQmlError & warning : warnings)
+		Log::log(false)	<< "\t" << warning.toString() << "\n";
+	Log::log(false) << std::endl;
 }
 
 void MainWindow::loadQML()

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -237,6 +237,8 @@ private slots:
 	void plotEditingFileChanged();
 	void jaspThemeChanged(JaspTheme * newTheme);
 
+	void printQmlWarnings(const QList<QQmlError> &warnings);
+
 private:
 	void _analysisSaveImageHandler(Analysis* analysis, QString options);
 	void makeAppleMenu();

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -684,6 +684,8 @@ void DynamicModule::setLoaded(bool loaded)
 	{
 		_loaded = loaded;
 
+		Log::log() << "DYNMOD " << _name << " changed loaded to " << (loaded ? "YES" : "NO") << std::endl;
+
 		emit loadedChanged(_loaded);
 	}
 }
@@ -717,8 +719,8 @@ void DynamicModule::setInitialized(bool initialized)
 
 void DynamicModule::setStatus(moduleStatus newStatus)
 {
-	//if(_status == newStatus)
-	//	return;
+	if(_status != newStatus && (_status == moduleStatus::error || newStatus == moduleStatus::error))
+		errorChanged(error());
 
 	// if we already need an install then we should only install the modpkg
 	if(_status == moduleStatus::installNeeded && newStatus == moduleStatus::installModPkgNeeded)
@@ -983,7 +985,7 @@ void DynamicModule::setBundled(bool bundled)
 std::string DynamicModule::toString()
 {
 	std::stringstream out;
-	out << "DynamicModule " << _name << "(0x" << std::hex << std::to_string(size_t(static_cast<void *>(this))) << ")" ;
+	out << "DynamicModule " << _name << "(0x" << std::hex << size_t(static_cast<void *>(this)) << ")" ;
 	return out.str();
 }
 

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -58,6 +58,7 @@ class DynamicModule : public QObject
 	Q_PROPERTY(bool			initialized			READ initialized		WRITE setInitialized		NOTIFY initializedChanged		)
 	Q_PROPERTY(bool			isBundled			READ isBundled			WRITE setBundled			NOTIFY bundledChanged			)
 	Q_PROPERTY(QStringList	importsR			READ importsRQ										NOTIFY importsRChanged			)
+	Q_PROPERTY(bool			error				READ error											NOTIFY errorChanged				)
 
 public:
 	//To do make the constructors less misleading (std::string vs QString does not do the same thing at all!) Some kind of a static MakeDynamicModule function and making the constructors private should do the trick
@@ -216,6 +217,7 @@ signals:
 	void		registerForInstallingModPkg(	const std::string & moduleName);
 	void		descriptionReloaded(Modules::DynamicModule * dynMod);
 	void		importsRChanged();
+	void		errorChanged(bool error);
 
 private:
 	QFileInfo			_moduleFolder;
@@ -250,6 +252,7 @@ private:
 	static const std::string	_moduleDirPostfix;
 
 	Description		*	_descriptionObj		= nullptr;
+	bool m_error;
 };
 
 

--- a/Desktop/modules/ribbonbutton.h
+++ b/Desktop/modules/ribbonbutton.h
@@ -46,6 +46,8 @@ class RibbonButton : public QObject
 	Q_PROPERTY(bool		active			READ active											NOTIFY activeChanged		)
 	Q_PROPERTY(QString	toolTip			READ toolTip			WRITE setToolTip			NOTIFY toolTipChanged		)
 	Q_PROPERTY(bool		special			READ isSpecial										NOTIFY isSpecialChanged		)
+	Q_PROPERTY(bool		ready			READ ready				WRITE setReady				NOTIFY readyChanged			)
+	Q_PROPERTY(bool		error			READ error				WRITE setError				NOTIFY errorChanged			)
 
 public:
 
@@ -54,27 +56,30 @@ public:
 	~RibbonButton() {}
 
 
-	bool							requiresData()												const			{ return _requiresData;									}
-	bool							isCommon()													const			{ return _isCommonModule;								}
-	std::string						title()														const			{ return _title;										}
-	QString							titleQ()													const			{ return QString::fromStdString(_title);				}
-	QString							iconSource()												const			{ return _iconSource;									}
-	bool							enabled()													const			{ return _enabled;					}
-	std::string						moduleName()												const			{ return _moduleName;									}
-	QString							moduleNameQ()												const			{ return QString::fromStdString(_moduleName);			}
+	bool							requiresData()												const			{ return _requiresData;										}
+	bool							isCommon()													const			{ return _isCommonModule;									}
+	std::string						title()														const			{ return _title;											}
+	QString							titleQ()													const			{ return QString::fromStdString(_title);					}
+	QString							iconSource()												const			{ return _iconSource;										}
+	bool							enabled()													const			{ return _enabled;											}
+	std::string						moduleName()												const			{ return _moduleName;										}
+	QString							moduleNameQ()												const			{ return QString::fromStdString(_moduleName);				}
 	Modules::DynamicModule*			dynamicModule();
 	Modules::AnalysisEntry*			getAnalysis(const std::string& name);
-	QVariant						analysisMenu()												const			{ return QVariant::fromValue(_analysisMenuModel); }
+	QVariant						analysisMenu()												const			{ return QVariant::fromValue(_analysisMenuModel);			}
 	std::vector<std::string>		getAllAnalysisNames()										const;
 	bool							dataLoaded()												const			{ return DynamicModules::dynMods() &&  DynamicModules::dynMods()->dataLoaded();	}
-	bool							active()													const			{ return _enabled && (!requiresData() || dataLoaded());	}
-	QString							toolTip()													const			{ return _toolTip;	}
+	bool							active()													const			{ return _enabled && (!requiresData() || dataLoaded());		}
+	QString							toolTip()													const			{ return _toolTip;											}
 	bool							isBundled()													const			{ return _module && _module->isBundled();					}
 	QString							version()													const			{ return !_module ? "?" : _module->versionQ();				}
-
-	//void							reloadMenuFromDescriptionQml();
+	bool							ready()														const			{ return _ready;											}
+	bool							error()														const			{ return _error;											}
 
 	static QString					getJsonDescriptionFilename();
+
+
+
 
 public slots:
 	void setDynamicModule(Modules::DynamicModule * module);
@@ -88,11 +93,15 @@ public slots:
 	void setModuleNameQ(QString moduleName)							{ setModuleName(moduleName.toStdString()); }
 	void somePropertyChanged()										{ emit iChanged(this); }
 	void setToolTip(QString toolTip);
-
+	void setReady(bool ready);
+	void setError(bool error);
 
 	bool isSpecial() const	{ return _specialButtonFunc != nullptr ; }
 	void runSpecial()		{ _specialButtonFunc(); };
 	void reloadDynamicModule(Modules::DynamicModule * dynMod);
+
+
+
 
 signals:
 	void enabledChanged();
@@ -108,6 +117,8 @@ signals:
 	void toolTipChanged(QString toolTip);
 	void analysisMenuChanged();
 	void isSpecialChanged(); //This wont be called it is just here to keep qml from complaining
+	void readyChanged(bool ready);
+	void errorChanged(bool error);
 
 private:
 	void bindYourself();
@@ -118,7 +129,9 @@ private:
 	bool							_requiresData		= true,
 									_isDynamicModule	= true,
 									_isCommonModule		= false,
-									_enabled			= false;
+									_enabled			= false,
+									_ready				= false,
+									_error				= false;
 	std::string						_title				= "",
 									_moduleName			= "";
 	Modules::DynamicModule		*	_module				= nullptr;

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -96,25 +96,33 @@ void Engine::initialize()
 {
 	Log::log() << "Engine::initialize()" << std::endl;
 
-	rbridge_init(SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _extraEncodings);
-	
-	Log::log() << "rbridge_init completed" << std::endl;
+	try
+	{
+		rbridge_init(SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _extraEncodings);
+
+		Log::log() << "rbridge_init completed" << std::endl;
 
 #if defined(JASP_DEBUG) || defined(__linux__)
-	if (_slaveNo == 0)
-	{
-		Log::log() << rbridge_check()			<< std::endl;
-		Log::log() << "rbridge_check completed" << std::endl;
-	}
+		if (_slaveNo == 0)
+		{
+			Log::log() << rbridge_check()			<< std::endl;
+			Log::log() << "rbridge_check completed" << std::endl;
+		}
 #endif
 	
-	//Is there maybe already some data? Like, if we just killed and restarted the engine
-	ColumnEncoder::columnEncoder()->setCurrentColumnNames(provideDataSet() == nullptr ? std::vector<std::string>({}) : provideDataSet()->getColumnNames());
+		//Is there maybe already some data? Like, if we just killed and restarted the engine
+		ColumnEncoder::columnEncoder()->setCurrentColumnNames(provideDataSet() == nullptr ? std::vector<std::string>({}) : provideDataSet()->getColumnNames());
 
-	_engineState = engineState::idle;
-	sendEngineResumed(); //Then the desktop knows we've finished init.
-	
-	Log::log() << "Engine::initialize() done" << std::endl;
+		_engineState = engineState::idle;
+		sendEngineResumed(); //Then the desktop knows we've finished init.
+
+		Log::log() << "Engine::initialize() done" << std::endl;
+	}
+	catch(std::exception & e)
+	{
+		Log::log() << "Engine::initialize() failed! The exception caught was: '" << e.what() << "'" << std::endl;
+		throw e;
+	}
 }
 
 Engine::~Engine()

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -66,8 +66,10 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 {
 	JASPTIMER_SCOPE(rbridge_init);
 	
+	Log::log() << "Setting extraEncodings." << std::endl;
 	extraEncodings = extraEncoder;
 
+	Log::log() << "Collecting RBridgeCallBacks." << std::endl;
 	RBridgeCallBacks callbacks = {
 		rbridge_readDataSet,
 		rbridge_readDataColumnNames,
@@ -96,6 +98,7 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 
 	JASPTIMER_START(jaspRCPP_init);
 	
+	Log::log() << "Entering jaspRCPP_init." << std::endl;
 	jaspRCPP_init(	AppInfo::getBuildYear()		.c_str(),
 					AppInfo::version.asString()	.c_str(),
 					&callbacks,

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -82,6 +82,7 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	_systemFunc				= systemFunc;
 	_libraryFixerFunc		= libraryFixerFunc;
 
+	jaspRCPP_logString("Creating RInside.\n");
 	rinside = new RInside();
 
 	RInside &rInside = rinside->instance();
@@ -145,7 +146,7 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	rInside[".readFullFilteredDatasetToEnd"]	= Rcpp::InternalFunction(&jaspRCPP_readFullFilteredDataSet);
 	rInside[".requestSpecificFileNameNative"]	= Rcpp::InternalFunction(&jaspRCPP_requestSpecificFileNameSEXP);
 	
-	
+	jaspRCPP_logString("Creating Output sink.\n");
 	rInside.parseEvalQNT(".outputSink <- .createCaptureConnection(); sink(.outputSink); print('.outputSink initialized!'); sink();");
 
 	static const char *baseCitationFormat	= "JASP Team (%s). JASP (Version %s) [Computer software].";
@@ -157,6 +158,8 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	jaspResults::setPollMessagesFunc(pollMessagesFunction);
 	jaspResults::setBaseCitation(baseCitation);
 	jaspResults::setInsideJASP();
+
+	jaspRCPP_logString("Initializing jaspResultsModule, jaspBase, jaspGraphs and more.\n");
 
 	rInside["jaspResultsModule"]			= givejaspResultsModule();
 


### PR DESCRIPTION
- Removed some stuff from Analysis/Analyses for oldstyle modules, as we don't have them anymore
- Made sure reloading Development Module does not crash anymore
-- fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/1175
-- This was solved by remembering the _slaveFinishedConnection = connect(_slaveProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),	this, &EngineRepresentation::processFinished);
-- And removing it when an engine stopped, a race condition occured whereby the new engine started so fast it got the "closed" signal from the previous one and interpreted it as a crash. While in fact it worked fine.
- Added a loading indicator in the ribbonbar for modules while they are loading
- Added an error indicator, but Im not sure in which situation a module would have an error *and remain installed/loaded*. So not actually sure if it makes sense or not. I guess it would be useful in case an icon is missing. But a then a question mark would make more sense.
- Added a few more logging statements to engine startup
- Removed the "not running analyses on engine 0" define in the constructor of EngineRepresentation...

