### PR TITLE
Refactor the Source Type for QML Controls and more...

### DIFF
--- a/Desktop/Desktop.pro
+++ b/Desktop/Desktop.pro
@@ -461,7 +461,8 @@ HEADERS += \
     widgets/radiobuttonsgroupbase.h \
     widgets/jasplistcontrol.h \
     widgets/radiobuttonbase.h \
-    widgets/repeatedmeasuresfactorslistbase.h
+    widgets/repeatedmeasuresfactorslistbase.h \
+    widgets/sourceitem.h
 
 SOURCES += \
     analysis/analysisform.cpp \
@@ -652,7 +653,8 @@ SOURCES += \
     widgets/radiobuttonsgroupbase.cpp \
     widgets/jasplistcontrol.cpp \
     widgets/radiobuttonbase.cpp \
-    widgets/repeatedmeasuresfactorslistbase.cpp
+    widgets/repeatedmeasuresfactorslistbase.cpp \
+    widgets/sourceitem.cpp
 
 RESOURCES += \
     html/html.qrc \

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -201,6 +201,7 @@ void Analyses::clear()
 	{
 		Analysis* analysis = idAnalysis.second;
 		idAnalysis.second  = nullptr;
+		analysis->remove();
 
 		emit analysisRemoved(analysis);
 		delete analysis;
@@ -514,10 +515,7 @@ void Analyses::refreshAnalysesUsingColumns(	QStringList				changedColumnsQ,
 
 			if (aNameChanged)
 				for (std::string & varname : interChangename)
-				{
-					analysis->replaceVariableName(varname, changeNameColumns[varname]);
 					analysesToRebind.insert(analysis);
-				}
 
 			if (aNameChanged || aColumnRemoved || aColumnChanged)
 				analysesToRefresh.insert(analysis);
@@ -534,15 +532,6 @@ void Analyses::refreshAnalysesUsingColumns(	QStringList				changedColumnsQ,
 		// replaceVariableName and removeUsedVariable just changes the options, not the form
 		// So by rebinding the form with their options, it will update the form
 		analysis->rebind();
-
-	if (hasNewColumns || missingColumns.size() > 0 || changeNameColumns.size() > 0 || changedColumns.size() > 0)
-		applyToAll([&](Analysis * a)
-		{
-			if (analysesToRebind.find(a) == analysesToRebind.end())
-				// rebind already refreshes the available models together with the assigned models in the right way
-				a->refreshAvailableVariablesModels();
-		});
-
 
 	if(rowCountChanged)
 		QTimer::singleShot(0, this, &Analyses::refreshAllAnalyses);
@@ -804,11 +793,6 @@ void Analyses::setChangedAnalysisTitle()
 
     if (analysis != nullptr)
         emit analysisTitleChanged(analysis);
-}
-
-void Analyses::refreshAvailableVariables()
-{
-	applyToAll([](Analysis * a) { a->refreshAvailableVariablesModels();	});
 }
 
 void Analyses::duplicateAnalysis(size_t id)

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -46,7 +46,6 @@ Analyses::Analyses()
 
 	connect(this,					&Analyses::requestComputedColumnDestruction,	this,	&Analyses::dataSetChanged			, Qt::QueuedConnection	);
 	connect(DataSetPackage::pkg(),	&DataSetPackage::dataSetChanged,				this,	&Analyses::dataSetChanged									);
-	connect(DataSetPackage::pkg(),	&DataSetPackage::columnDataTypeChanged,			this,	&Analyses::dataSetColumnsChanged							);
 	connect(DataSetPackage::pkg(),	&DataSetPackage::labelChanged,					this,	&Analyses::dataSetChanged									);
 
 	new KnownIssues(this);
@@ -467,23 +466,12 @@ void Analyses::refreshAnalysesUsingColumns(	QStringList				changedColumnsQ,
 											bool					rowCountChanged,
 											bool					hasNewColumns)
 {
-	std::map<std::string, std::string> changeNameColumns = fq(changeNameColumnsQ);
-
-	std::vector<std::string> oldColumnNames;
-
-	for (auto & keyval : changeNameColumns)
-		oldColumnNames.push_back(keyval.first);
-
 	std::sort(changedColumnsQ.begin(), changedColumnsQ.end()); //Why are we sorting here?
-	std::sort(missingColumnsQ.begin(), missingColumnsQ.end());
-	std::sort(oldColumnNames.begin(),  oldColumnNames.end());
 
 	std::vector<std::string> changedColumns(fq(changedColumnsQ));
-	std::vector<std::string> missingColumns(fq(missingColumnsQ));
 
 
 	std::set<Analysis *> analysesToRefresh;
-	std::set<Analysis *> analysesToRebind;
 
 	for (auto idAnalysis : _analysisMap)
 	{
@@ -493,31 +481,13 @@ void Analyses::refreshAnalysesUsingColumns(	QStringList				changedColumnsQ,
 
 		if (!variables.empty())
 		{
-			std::vector<std::string> interChangecol, interChangename, interMissingcol;
+			std::vector<std::string> interChangecol;
 
 			std::set_intersection(variables.begin(), variables.end(), changedColumns.begin(), changedColumns.end(), std::back_inserter(interChangecol));
-			std::set_intersection(variables.begin(), variables.end(), oldColumnNames.begin(), oldColumnNames.end(), std::back_inserter(interChangename));
-			std::set_intersection(variables.begin(), variables.end(), missingColumns.begin(), missingColumns.end(), std::back_inserter(interMissingcol));
 
-			bool	aNameChanged	= interChangename.size() > 0,
-					aColumnRemoved	= interMissingcol.size() > 0,
-					aColumnChanged	= interChangecol.size() > 0;
+			bool aColumnChanged	= interChangecol.size() > 0;
 
-			if(aNameChanged || aColumnRemoved)
-				analysis->setRefreshBlocked(true);
-
-			if (aColumnRemoved)
-				for (std::string & varname : interMissingcol)
-				{
-					analysis->removeUsedVariable(varname);
-					analysesToRebind.insert(analysis);
-				}
-
-			if (aNameChanged)
-				for (std::string & varname : interChangename)
-					analysesToRebind.insert(analysis);
-
-			if (aNameChanged || aColumnRemoved || aColumnChanged)
+			if (aColumnChanged)
 				analysesToRefresh.insert(analysis);
 		}
 	}
@@ -527,11 +497,6 @@ void Analyses::refreshAnalysesUsingColumns(	QStringList				changedColumnsQ,
 		analysis->setRefreshBlocked(false);
 		analysis->refresh();
 	}
-
-	for (Analysis *analysis : analysesToRebind)
-		// replaceVariableName and removeUsedVariable just changes the options, not the form
-		// So by rebinding the form with their options, it will update the form
-		analysis->rebind();
 
 	if(rowCountChanged)
 		QTimer::singleShot(0, this, &Analyses::refreshAllAnalyses);

--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -128,7 +128,6 @@ public slots:
 	void rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * module);
 	void setChangedAnalysisTitle();
 	void analysisTitleChangedInResults(int id, QString title);
-	void refreshAvailableVariables();
 	void setCurrentFormPrevH(double currentFormPrevH);
 	void move(int fromIndex, int toIndex);
 	void duplicateAnalysis(size_t id);

--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -159,7 +159,6 @@ signals:
 	void movingChanged(					bool		moving);
 	void emptyQMLCache();
 	void dataSetChanged();
-	void dataSetColumnsChanged();
 	void somethingModified();
     void analysesExportResults();
 	bool developerMode();

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -302,8 +302,6 @@ void Analysis::initialized(AnalysisForm* form, bool isNewAnalysis)
 	if(!_isDuplicate && isNewAnalysis)
 		_status = Empty;
 	
-	connect(Analyses::analyses(),	&Analyses::dataSetChanged,			_analysisForm,	&AnalysisForm::dataSetChangedHandler		);
-	connect(Analyses::analyses(),	&Analyses::dataSetColumnsChanged,	_analysisForm,	&AnalysisForm::dataSetColumnsChangedHandler	);
 	connect(_analysisForm,			&AnalysisForm::helpMDChanged,		this,			&Analysis::helpMDChanged					);
 }
 
@@ -488,15 +486,6 @@ std::string Analysis::qmlFormPath() const
 				Dirs::resourcesDir() + "/" + module() + "/qml/"  + qml());
 }
 
-void Analysis::replaceVariableName(const std::string & oldName, const std::string & newName)
-{
-	if (_options)
-		_options->replaceVariableName(oldName, newName);
-
-	if (_analysisForm)
-		_analysisForm->replaceVariableNameInListModels(oldName, newName);
-}
-
 void Analysis::runScriptRequestDone(const QString& result, const QString& controlName)
 {
 	if (_analysisForm)
@@ -577,12 +566,6 @@ void Analysis::emitDuplicationSignals()
 {
 	emit resultsChangedSignal(this);
 	emit titleChanged();
-}
-
-void Analysis::refreshAvailableVariablesModels()
-{
-	if(form() != nullptr)
-		form()->refreshAvailableVariablesModels();
 }
 
 QString	Analysis::fullHelpPath(QString helpFileName)

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -159,7 +159,6 @@ public:
 	std::set<std::string>	usedVariables()																	{ return _options->usedVariables();					}
 	std::set<std::string>	columnsCreated()																{ return _options->columnsCreated();				}
 	void					removeUsedVariable(const std::string & var)										{ _options->removeUsedVariable(var);				}
-	void					replaceVariableName(const std::string & oldName, const std::string & newName);
 	void					runScriptRequestDone(const QString& result, const QString& controlName);
 
 	void					setUpgradeMsgs(const Modules::UpgradeMsgs & msgs);
@@ -204,7 +203,6 @@ public slots:
 	void					setTitle(std::string title) { setTitleQ(tq(title)); }
 	void					setHasVolatileNotes(bool hasVolatileNotes);
 	void					setDynamicModule(Modules::DynamicModule * module);
-	void					refreshAvailableVariablesModels();
 	void					emitDuplicationSignals();
 	void					showDependenciesOnQMLForObject(QString uniqueName); //uniqueName is basically "name" in meta in results.
 	void					setOptionsBound(bool optionsBound);

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -793,7 +793,10 @@ void AnalysisForm::setColumnsModel(QAbstractItemModel *model)
 		{
 			i.next();
 			if (i.value() == "columnName")
+			{
 				_columnsModelRole = i.key();
+				break;
+			}
 		}
 	}
 }

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -50,6 +50,9 @@
 
 using namespace std;
 
+QAbstractItemModel* AnalysisForm::columnsModel =  nullptr;
+int AnalysisForm::columnsModelRole = Qt::DisplayRole;
+
 AnalysisForm::AnalysisForm(QQuickItem *parent) : QQuickItem(parent)
 {
 	setObjectName("AnalysisForm");
@@ -217,35 +220,10 @@ void AnalysisForm::_setUp()
 {
 	QList<JASPControl*> controls = _controls.values();
 
+	// set the order of the BoundItems according to their dependencies (for binding purpose)
 	for (JASPControl* control : controls)
-	{
 		control->setUp();
 
-		JASPListControl* listControl = qobject_cast<JASPListControl*>(control);
-		if (listControl)
-		{
-			TextAreaBase* textArea	= qobject_cast<TextAreaBase*>(listControl);
-			if (textArea)
-			{
-				// TODO : Change this special handling for TextArea
-				ListModelTermsAvailable	* availableModel = qobject_cast<ListModelTermsAvailable*>(textArea->model());
-				if (availableModel && textArea->modelNeedsAllVariables())
-					_allAvailableVariablesModels.push_back(availableModel);
-			}
-			else
-			{
-				ListModelTermsAvailable* availableModel = dynamic_cast<ListModelTermsAvailable*>(listControl->model());
-
-				if (availableModel)
-				{
-					if (!listControl->hasSource())	_allAvailableVariablesModels.push_back(availableModel);
-					else							_allAvailableVariablesModelsWithSource.push_back(availableModel);
-				}
-			}
-		}
-	}
-
-	// set the order of the BoundItems according to their dependencies (for binding purpose)
 	for (JASPControl* control : controls)
 	{
 		std::vector<JASPControl*> depends(control->depends().begin(), control->depends().end());
@@ -341,17 +319,6 @@ QString AnalysisForm::msgsListToString(const QStringList & list) const
 	return text;
 }
 
-void AnalysisForm::replaceVariableNameInListModels(const std::string & oldName, const std::string & newName)
-{
-	for (ListModelTermsAvailable * model : _allAvailableVariablesModels)
-	{
-		model->replaceVariableName(oldName, newName);
-		const QList<ListModelAssignedInterface*>& assignedModels = model->assignedModel();
-		for (ListModelAssignedInterface* modelAssign : assignedModels)
-				modelAssign->replaceVariableName(oldName, newName);
-	}
-}
-
 void AnalysisForm::setInfo(QString info)
 {
 	if (_info == info)
@@ -359,33 +326,6 @@ void AnalysisForm::setInfo(QString info)
 
 	_info = info;
 	emit infoChanged();
-}
-
-void AnalysisForm::_setAllAvailableVariablesModel(bool refreshAssigned)
-{
-	if (_allAvailableVariablesModels.size() == 0)
-		return;
-
-	std::vector<std::string> columnNames = DataSetPackage::pkg()->getColumnNames();
-
-
-	for (ListModelTermsAvailable* model : _allAvailableVariablesModels)
-	{
-		model->initTerms(columnNames);
-
-		if (refreshAssigned)
-		{
-			emit model->allAvailableTermsChanged(nullptr, nullptr);
-			const QList<ListModelAssignedInterface*>& assignedModels = model->assignedModel();
-			for (ListModelAssignedInterface* modelAssign : assignedModels)
-				modelAssign->refresh();
-		}
-	}
-
-	if (refreshAssigned)
-		for (ListModelTermsAvailable * model : _allAvailableVariablesModelsWithSource)
-			model->resetTermsFromSourceModels(true);
-
 }
 
 QString AnalysisForm::_getControlLabel(QString controlName)
@@ -436,14 +376,12 @@ void AnalysisForm::bindTo()
 
 	_options->blockSignals(true);
 	
-	_setAllAvailableVariablesModel();	
-
 	std::set<std::string> controlsJsonWrong;
 	
 	for (JASPControl* control : _dependsOrderedCtrls)
 	{
 		BoundControl* boundControl = dynamic_cast<BoundControl*>(control);
-		if (boundControl && control->isBound())
+		if (control->isBound() && boundControl)
 		{
 			std::string name = control->name().toStdString();
 			Option* option   = _options->get(name);
@@ -498,7 +436,7 @@ void AnalysisForm::bindTo()
 			if (availableModel)
 			{
 				if (optionsFromJASPFile != Json::nullValue || _analysis->isDuplicate())
-					availableModel->resetTermsFromSourceModels(false);
+					availableModel->resetTermsFromSources(false);
 				else
 					availableModelsToBeReset.push_back(availableModel);
 			}
@@ -508,7 +446,7 @@ void AnalysisForm::bindTo()
 	}
 
 	for (ListModelAvailableInterface* availableModel : availableModelsToBeReset)
-		availableModel->resetTermsFromSourceModels(true);
+		availableModel->resetTermsFromSources(true);
 	
 	_addLoadingError(tql(controlsJsonWrong));
 
@@ -540,7 +478,7 @@ void AnalysisForm::unbind()
 	for (JASPControl* control : _dependsOrderedCtrls)
 	{
 		BoundControl* boundControl = dynamic_cast<BoundControl*>(control);
-		if (boundControl)
+		if (control->isBound() && boundControl)
 			boundControl->unbind();
 	}
 
@@ -728,26 +666,6 @@ void AnalysisForm::knownIssuesUpdated()
 		}
 
 		emit warningsChanged();
-	}
-}
-
-void AnalysisForm::dataSetChangedHandler()
-{
-	if (!_removed && DataSetPackage::pkg() && DataSetPackage::pkg()->hasDataSet())
-	{
-		_setAllAvailableVariablesModel(true);
-		emit dataSetChanged();
-	}
-}
-
-void AnalysisForm::dataSetColumnsChangedHandler()
-{
-	if (!_removed && DataSetPackage::pkg() && DataSetPackage::pkg()->hasDataSet())
-	{
-		for (ListModel* model : _modelMap.values())
-			model->refresh();
-
-		emit dataSetChanged();
 	}
 }
 

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -50,8 +50,8 @@
 
 using namespace std;
 
-QAbstractItemModel* AnalysisForm::columnsModel =  nullptr;
-int AnalysisForm::columnsModelRole = Qt::DisplayRole;
+QAbstractItemModel* AnalysisForm::_columnsModel		=  nullptr;
+int					AnalysisForm::_columnsModelRole = Qt::DisplayRole;
 
 AnalysisForm::AnalysisForm(QQuickItem *parent) : QQuickItem(parent)
 {
@@ -780,6 +780,22 @@ QString AnalysisForm::metaHelpMD() const
 	};
 
 	return "---\n# " + tr("Output") + "\n\n" + metaMDer(_analysis->meta(), 2);
+}
+
+void AnalysisForm::setColumnsModel(QAbstractItemModel *model)
+{
+	_columnsModel = model;
+
+	if (model)
+	{
+		QHashIterator<int, QByteArray> i(model->roleNames());
+		while (i.hasNext())
+		{
+			i.next();
+			if (i.value() == "columnName")
+				_columnsModelRole = i.key();
+		}
+	}
 }
 
 QString AnalysisForm::helpMD() const

--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -75,9 +75,6 @@ public:
 					
 public slots:
 				void			runScriptRequestDone(const QString& result, const QString& requestId);
-				void			dataSetChangedHandler();
-				void			dataSetColumnsChangedHandler();
-				void			replaceVariableNameInListModels(const std::string & oldName, const std::string & newName);
 				void			setInfo(QString info);
 				void			setAnalysis(QVariant analysis);
 
@@ -86,7 +83,6 @@ signals:
 				void			sendRScript(QString script, int key);
 				void			formChanged(Analysis* analysis);
 				void			formCompleted();
-				void			dataSetChanged();
 				void			refreshTableViewModels();
 				void			errorMessagesItemChanged();
 				void			languageChanged();
@@ -126,8 +122,6 @@ public:
 	void		addControlError(JASPControl* control, QString message, bool temporary = false, bool warning = false);
 	void		clearControlError(JASPControl* control);
 	void		cleanUpForm();
-	void		refreshAvailableVariablesModels() { _setAllAvailableVariablesModel(true); }
-
 	bool		hasError();
 
 	bool		isOwnComputedColumn(const QString& col)			const	{ return _computedColumns.contains(col); }
@@ -144,8 +138,9 @@ public:
 	QString		warnings()			const { return msgsListToString(_formWarnings);	}
 	QVariant	analysis()			const { return QVariant::fromValue(_analysis);	}
 
+	static QAbstractItemModel*	columnsModel;
+	static int					columnsModelRole;
 protected:
-	void		_setAllAvailableVariablesModel(bool refreshAssigned = false);
 	QString		msgsListToString(const QStringList & list) const;
 
 private:
@@ -185,8 +180,6 @@ protected:
 	std::map<std::string,std::set<std::string>>	_mustContain;
 	
 private:
-	std::vector<ListModelTermsAvailable*>		_allAvailableVariablesModels,
-												_allAvailableVariablesModelsWithSource;
 	QStringList									_formErrors,
 												_formWarnings;
 

--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -138,8 +138,10 @@ public:
 	QString		warnings()			const { return msgsListToString(_formWarnings);	}
 	QVariant	analysis()			const { return QVariant::fromValue(_analysis);	}
 
-	static QAbstractItemModel*	columnsModel;
-	static int					columnsModelRole;
+	static void					setColumnsModel(QAbstractItemModel* model);
+	static QAbstractItemModel*	getColumnsModel()		{ return _columnsModel;		}
+	static int					getColumnsModelRole()	{ return _columnsModelRole;	}
+
 protected:
 	QString		msgsListToString(const QStringList & list) const;
 
@@ -189,6 +191,10 @@ private:
 	bool										_runOnChange	= true,
 												_formCompleted = false;
 	QString										_info;
+
+	static QAbstractItemModel*					_columnsModel;
+	static int									_columnsModelRole;
+
 };
 
 #endif // ANALYSISFORM_H

--- a/Desktop/analysis/jaspcontrol.cpp
+++ b/Desktop/analysis/jaspcontrol.cpp
@@ -233,7 +233,7 @@ void JASPControl::componentComplete()
 			if (!listViewVar.isNull())
 			{
 				_parentListViewKey = context->contextProperty("rowValue").toString();
-				connect(listView->model(), &ListModel::termChanged, this, &JASPControl::parentListViewKeyChanged);
+				connect(listView->model(), &ListModel::oneTermChanged, this, &JASPControl::parentListViewKeyChanged);
 			}
 			else
 				_parentListViewKey = context->contextProperty("rowIndex").toString();
@@ -320,7 +320,7 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item)
 
 bool JASPControl::addDependency(JASPControl *item)
 {
-	if (_depends.count(item) > 0 || this == item)
+	if (_depends.count(item) > 0 || this == item || !item)
 		return false;
 
 	_depends.insert(item);

--- a/Desktop/analysis/jaspcontrol.h
+++ b/Desktop/analysis/jaspcontrol.h
@@ -123,7 +123,7 @@ public:
 	int				alignment()				const	{ return _alignment;			}
 
 	QString			humanFriendlyLabel()	const;
-	void			setInitialized()	{ if (_initialized) { _initialized = true; emit initializedChanged();} }
+	void			setInitialized()	{ if (!_initialized) { _initialized = true; emit initializedChanged();} }
 
 
 	QQmlComponent					*	rowComponent()				const { return _rowComponent;	}

--- a/Desktop/analysis/jaspcontrol.h
+++ b/Desktop/analysis/jaspcontrol.h
@@ -123,7 +123,7 @@ public:
 	int				alignment()				const	{ return _alignment;			}
 
 	QString			humanFriendlyLabel()	const;
-	void			setInitialized()	{ _initialized = true; emit initializedChanged(); }
+	void			setInitialized()	{ if (_initialized) { _initialized = true; emit initializedChanged();} }
 
 
 	QQmlComponent					*	rowComponent()				const { return _rowComponent;	}

--- a/Desktop/analysis/options/term.cpp
+++ b/Desktop/analysis/options/term.cpp
@@ -125,11 +125,17 @@ size_t Term::size() const
 	return _components.size();
 }
 
-void Term::replaceVariableName(const std::string & oldName, const std::string & newName)
+bool Term::replaceVariableName(const std::string & oldName, const std::string & newName)
 {
+	bool changed = false;
 	for(int i=0; i<_components.size(); i++)
 		if(_components[i] == tq(oldName))
+		{
 			_components[i] = tq(newName);
+			changed = true;
+		}
 
 	initFrom(_components);
+
+	return changed;
 }

--- a/Desktop/analysis/options/term.h
+++ b/Desktop/analysis/options/term.h
@@ -56,7 +56,7 @@ public:
 
 	size_t size() const;
 
-	void replaceVariableName(const std::string & oldName, const std::string & newName);
+	bool replaceVariableName(const std::string & oldName, const std::string & newName);
 
 	static const char* separator;
 

--- a/Desktop/analysis/options/terms.cpp
+++ b/Desktop/analysis/options/terms.cpp
@@ -23,7 +23,9 @@
 
 #include <QDataStream>
 #include <QIODevice>
+#include <QSet>
 #include "utilities/qutils.h"
+
 using namespace std;
 
 Terms::Terms(const QList<QList<QString> > &terms, Terms *parent)
@@ -61,12 +63,12 @@ Terms::Terms(Terms *parent)
 	_parent = parent;
 }
 
-void Terms::set(const std::vector<Term> &terms)
+void Terms::set(const std::vector<Term> &terms, bool isUnique)
 {
 	_terms.clear();
 
 	for(const Term &term : terms)
-		add(term);
+		add(term, isUnique);
 }
 
 void Terms::set(const std::vector<string> &terms)
@@ -93,12 +95,12 @@ void Terms::set(const QList<Term> &terms)
 		add(term);
 }
 
-void Terms::set(const Terms &terms)
+void Terms::set(const Terms &terms, bool isUnique)
 {
 	_terms.clear();
 
 	for(const Term &term : terms)
-		add(term);
+		add(term, isUnique);
 }
 
 void Terms::set(const QList<QList<QString> > &terms)
@@ -207,6 +209,19 @@ bool Terms::contains(const Term &term) const
 bool Terms::contains(const std::string & component)
 {
 	return contains(tq(component));
+}
+
+int Terms::indexOf(const QString &component) const
+{
+	int i = 0;
+	for(const Term &term : _terms)
+	{
+		if (term.contains(component))
+			return i;
+		i++;
+	}
+
+	return -1;
 }
 
 bool Terms::contains(const QString & component)
@@ -641,9 +656,17 @@ void Terms::remove(const Term &term)
 		_terms.erase(itr);
 }
 
-void Terms::replaceVariableName(const std::string & oldName, const std::string & newName)
+QSet<int> Terms::replaceVariableName(const std::string & oldName, const std::string & newName)
 {
-	for(Term & t : _terms)
-		t.replaceVariableName(oldName, newName);
+	QSet<int> change;
 
+	int i = 0;
+	for(Term & t : _terms)
+	{
+		if (t.replaceVariableName(oldName, newName))
+			change.insert(i);
+		i++;
+	}
+
+	return change;
 }

--- a/Desktop/analysis/options/terms.h
+++ b/Desktop/analysis/options/terms.h
@@ -41,11 +41,11 @@ public:
 
 	void set(const QList<QList<QString> >					& terms);
 	void set(const QList<QString>							& terms);
-	void set(const std::vector<Term>						& terms);
+	void set(const std::vector<Term>						& terms, bool isUnique = true);
 	void set(const std::vector<std::string>					& terms);
 	void set(const std::vector<std::vector<std::string> >	& terms);
 	void set(const QList<Term>								& terms);
-	void set(const Terms									& terms);
+	void set(const Terms									& terms, bool isUnique = true);
 	void set(const QByteArray								& array);
 
 	void removeParent();
@@ -75,14 +75,15 @@ public:
 	bool discardWhatDoesContainTheseTerms(			const Terms &terms);
 	bool discardWhatIsntTheseTerms(					const Terms &terms, Terms *discarded = nullptr);
 
-	void replaceVariableName(const std::string & oldName, const std::string & newName);
+	QSet<int> replaceVariableName(const std::string & oldName, const std::string & newName);
 
 	void clear();
 
-	const Term &at(size_t index) const;
-	bool contains(const Term		&	term) const;
+	const Term &at(size_t index)								const;
+	bool contains(const Term		&	term)					const;
 	bool contains(const QString		&	component);
 	bool contains(const std::string &	component);
+	int	 indexOf(const QString		&	component)				const;
 
 	std::vector<std::string>				asVector()			const;
 	std::set<std::string>					asSet()				const;

--- a/Desktop/components/JASP/Controls/ComboBox.qml
+++ b/Desktop/components/JASP/Controls/ComboBox.qml
@@ -18,9 +18,9 @@ ComboBoxBase
 	property alias	label:					controlLabel.text
 	property alias	currentLabel:			comboBox.currentText
 	property alias	value:					comboBox.currentText
-	property alias	currentIndex:			control.currentIndex
+	property alias	indexDefaultValue:		comboBox.currentIndex
 	property alias	fieldWidth:				control.modelWidth
-	property bool	showVariableTypeIcon:	false
+	property bool	showVariableTypeIcon:	!source && !values
 	property var	enabledOptions:			[]
 	property bool	setLabelAbove:			false
 	property int	controlMinWidth:		0
@@ -32,7 +32,7 @@ ComboBoxBase
 	property bool	showEmptyValueAsNormal:	false
 	property bool	addLineAfterEmptyValue:	false
 
-    signal activated(int index);
+	signal activated(int index);
 
 	onControlMinWidthChanged: _resetWidth(textMetrics.width)
 
@@ -69,7 +69,7 @@ ComboBoxBase
 		comboBox.width = comboBox.implicitWidth; // the width is not automatically updated by the implicitWidth...
     }
 
-	Component.onCompleted: control.activated.connect(activated);
+	Component.onCompleted:	control.activated.connect(activated);
 
 	Rectangle
 	{
@@ -96,7 +96,6 @@ ComboBoxBase
 						anchors.top:	rectangleLabel.visible && comboBox.setLabelAbove ? rectangleLabel.bottom: comboBox.top
 
 						focus:			true
-						currentIndex:	-1
 						padding:		2 * preferencesModel.uiScale //jaspTheme.jaspControlPadding
 
 						width:			modelWidth + extraWidth
@@ -104,7 +103,7 @@ ComboBoxBase
 						font:			jaspTheme.font
 		property int	modelWidth:		30 * preferencesModel.uiScale
 		property int	extraWidth:		5 * padding + dropdownIcon.width
-		property bool	isEmptyValue:	comboBox.addEmptyValue && currentIndex === 0
+		property bool	isEmptyValue:	comboBox.addEmptyValue && comboBox.currentIndex === 0
 		property bool	showEmptyValueStyle:	!comboBox.showEmptyValueAsNormal && isEmptyValue
 
 		TextMetrics
@@ -240,7 +239,7 @@ ComboBoxBase
 				id:								itemRectangle
 				anchors.fill:					parent
 				anchors.rightMargin:			scrollBar.visible ? scrollBar.width + 2 : 0
-				color:							control.currentIndex === index ? jaspTheme.itemSelectedColor : (control.highlightedIndex === index ? jaspTheme.itemHoverColor : jaspTheme.controlBackgroundColor)
+				color:							comboBox.currentIndex === index ? jaspTheme.itemSelectedColor : (control.highlightedIndex === index ? jaspTheme.itemHoverColor : jaspTheme.controlBackgroundColor)
 
 				property bool isEmptyValue:		comboBox.addEmptyValue && index === 0
 				property bool showEmptyValueStyle:	!comboBox.showEmptyValueAsNormal && isEmptyValue
@@ -264,7 +263,7 @@ ComboBoxBase
 					x:							(delegateIcon.visible ? 20 : 4) * preferencesModel.uiScale
 					text:						itemRectangle.isEmptyValue ? comboBox.placeholderText : (model && model.name ? model.name : "")
 					font:						jaspTheme.font
-					color:						itemRectangle.showEmptyValueStyle || !enabled ? jaspTheme.grayDarker : (control.currentIndex === index ? jaspTheme.white : jaspTheme.black)
+					color:						itemRectangle.showEmptyValueStyle || !enabled ? jaspTheme.grayDarker : (comboBox.currentIndex === index ? jaspTheme.white : jaspTheme.black)
 					anchors.verticalCenter:		parent.verticalCenter
 					anchors.horizontalCenter:	itemRectangle.showEmptyValueStyle ? parent.horizontalCenter : undefined
 				}

--- a/Desktop/components/JASP/Controls/TextArea.qml
+++ b/Desktop/components/JASP/Controls/TextArea.qml
@@ -17,7 +17,6 @@ TextAreaBase
 	property alias	text				: control.text
 	property string applyScriptInfo		: Qt.platform.os == "osx" ? qsTr("\u2318 + Enter to apply") : qsTr("Ctrl + Enter to apply")
 	property alias  infoText			: infoText.text
-	property bool   hasScriptError		: false
 	property alias  font				: control.font
 	property alias  textDocument		: control.textDocument
 	property bool   trim				: false

--- a/Desktop/components/JASP/Controls/TextField.qml
+++ b/Desktop/components/JASP/Controls/TextField.qml
@@ -50,7 +50,6 @@ TextInputBase
 	property alias	afterLabel:			afterLabel.text
 	property string	inputType:			"string"
 	property bool	useLastValidValue:	true
-	property bool	hasScriptError:		false
 	property bool	editable:			true
 
 	property double controlXOffset:		0

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -67,7 +67,7 @@ ScrollView
 					addScrollBar			: true
 					placeholderText			: qsTr("default: %1").arg(defaultInterfaceFont.fontInfo.family)
 					startValue				: preferencesModel.interfaceFont
-					onValueChanged			: if (initialized) preferencesModel.interfaceFont = (currentIndex <= 0 ? "" : value)
+					onActivated				: preferencesModel.interfaceFont = (currentIndex <= 0 ? "" : value)
 
 					KeyNavigation.tab		: codeFonts
 					KeyNavigation.down		: codeFonts
@@ -95,7 +95,7 @@ ScrollView
 					addScrollBar			: true
 					placeholderText			: qsTr("default: %1").arg(defaultRCodeFont.fontInfo.family)
 					startValue				: preferencesModel.codeFont
-					onValueChanged			: if (initialized) preferencesModel.codeFont = (currentIndex <= 0 ? "" : value)
+					onActivated				: preferencesModel.codeFont = (currentIndex <= 0 ? "" : value)
 
 					KeyNavigation.tab		: resultFonts
 					KeyNavigation.down		: resultFonts
@@ -122,7 +122,7 @@ ScrollView
 					addScrollBar			: true
 					placeholderText			: qsTr("default: %1").arg(defaultResultFont.fontInfo.family)
 					startValue				: preferencesModel.resultFont
-					onValueChanged			: if (initialized) preferencesModel.resultFont = (currentIndex <= 0 ? "" : value)
+					onActivated				: preferencesModel.resultFont = (currentIndex <= 0 ? "" : value)
 
 					KeyNavigation.tab		: lightThemeButton
 					KeyNavigation.down		: lightThemeButton
@@ -181,18 +181,16 @@ ScrollView
 				fieldWidth:				100
 
 				label:					qsTr("Choose Language  ")
-				valueRole:				"label"
 
 				useModelDefinedIcon:	false
 
 				currentIndex:			languageModel.currentIndex
 				onActivated:			languageModel.changeLanguage(index);
 
-				model:					languageModel
+				source:					languageModel
 
 				KeyNavigation.tab:		uiScaleSpinBox
 				KeyNavigation.down:		uiScaleSpinBox
-
 			}
 
 		}

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -56,6 +56,14 @@ void ColumnsModel::onDataChanged(const QModelIndex &, const QModelIndex &, const
 	endResetModel();
 }
 
+void ColumnsModel::datasetChanged(	QStringList				changedColumns,
+									QStringList				missingColumns,
+									QMap<QString, QString>	changeNameColumns,
+									bool					rowCountChanged,
+									bool					hasNewColumns)
+{
+	emit namesChanged(changeNameColumns);
+}
 
 int ColumnsModel::rowCount(const QModelIndex &) const
 {

--- a/Desktop/data/columnsmodel.h
+++ b/Desktop/data/columnsmodel.h
@@ -31,6 +31,17 @@ public:
 	int						columnCount(const QModelIndex &parent = QModelIndex())								const	override;
 	QVariant				headerData(	int section, Qt::Orientation orientation, int role = Qt::DisplayRole )	const	override;
 
+signals:
+	void namesChanged(QMap<QString, QString> changedNames);
+	void columnTypeChanged(QString colName);
+
+public slots:
+	void datasetChanged(	QStringList				changedColumns,
+							QStringList				missingColumns,
+							QMap<QString, QString>	changeNameColumns,
+							bool					rowCountChanged,
+							bool					hasNewColumns);
+
 private slots:
 	void onHeaderDataChanged(Qt::Orientation orientation, int first, int last);
 	void onDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);

--- a/Desktop/data/computedcolumnsmodel.cpp
+++ b/Desktop/data/computedcolumnsmodel.cpp
@@ -241,22 +241,23 @@ void ComputedColumnsModel::computeColumnFailed(QString columnNameQ, QString erro
 }
 
 ///Called from datatype changed
-void ComputedColumnsModel::recomputeColumn(std::string columnName)
+void ComputedColumnsModel::recomputeColumn(QString columnName)
 {
-	if(!DataSetPackage::pkg()->isColumnComputed(columnName))
+	std::string colName = columnName.toStdString();
+	if(!DataSetPackage::pkg()->isColumnComputed(colName))
 		return;
 
 	//It will be found because we just checked for it in isColumnComputed
-	ComputedColumn * col = &((*computedColumns())[columnName]);
+	ComputedColumn * col = &((*computedColumns())[colName]);
 
 	if(col->codeType() == ComputedColumn::computedType::analysis || col->codeType() == ComputedColumn::computedType::analysisNotComputed)
 		return;
 
-	DataSetPackage::pkg()->columnSetDefaultValues(columnName);
+	DataSetPackage::pkg()->columnSetDefaultValues(colName);
 	computedColumns()->findAllColumnNames();
 
 
-	checkForDependentColumnsToBeSent(columnName, true);
+	checkForDependentColumnsToBeSent(colName, true);
 }
 
 void ComputedColumnsModel::checkForDependentColumnsToBeSent(std::string columnName, bool refreshMe)

--- a/Desktop/data/computedcolumnsmodel.h
+++ b/Desktop/data/computedcolumnsmodel.h
@@ -86,7 +86,7 @@ public slots:
 				ComputedColumn *	requestComputedColumnCreation(QString columnName, Analysis * analysis);
 				void				requestColumnCreation(QString columnName, Analysis * analysis, int columnType);
 				void				requestComputedColumnDestruction(QString columnName);
-				void				recomputeColumn(std::string columnName);
+				void				recomputeColumn(QString columnName);
 				void				setLastCreatedColumn(QString lastCreatedColumn);
 				void				analysisRemoved(Analysis * analysis);
 				void				setShowThisColumn(QString showThisColumn);

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -721,11 +721,11 @@ bool DataSetPackage::setColumnType(int columnIndex, columnType newColumnType)
 
 	if (changed)
 	{
-		std::string colName = _dataSet->column(columnIndex).name();
+		QString colName = tq(_dataSet->column(columnIndex).name());
 
 		emit headerDataChanged(Qt::Orientation::Horizontal, columnIndex, columnIndex);
 		emit columnDataTypeChanged(colName);
-		emit refreshAnalysesWithColumn(tq(colName));
+		emit refreshAnalysesWithColumn(colName);
 	}
 
 	return changed;

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -243,7 +243,7 @@ signals:
 				void				labelFilterChanged();
 				void				labelChanged(QString columnName, QString originalLabel, QString newLabel);
 				void				dataSetChanged();
-				void				columnDataTypeChanged(std::string columnName);
+				void				columnDataTypeChanged(QString columnName);
 				void				refreshAnalysesWithColumn(QString columnName);
 				void				labelsReordered(		  QString columnName);
 				void				isModifiedChanged();

--- a/Desktop/data/labelmodel.cpp
+++ b/Desktop/data/labelmodel.cpp
@@ -127,7 +127,7 @@ void LabelModel::columnAboutToBeRemoved(int column)
 		setVisible(false);
 }
 
-void LabelModel::columnDataTypeChanged(std::string colName)
+void LabelModel::columnDataTypeChanged(QString colName)
 {
 	int colIndex = DataSetPackage::pkg()->getColumnIndex(colName);
 

--- a/Desktop/data/labelmodel.h
+++ b/Desktop/data/labelmodel.h
@@ -41,7 +41,7 @@ public slots:
 	void filteredOutChangedHandler(int col);
 	void setVisible(bool visible);
 	void columnAboutToBeRemoved(int column);
-	void columnDataTypeChanged(std::string colName);
+	void columnDataTypeChanged(QString colName);
 
 signals:
 	void visibleChanged(bool visible);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -160,6 +160,9 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 
 	new MessageForwarder(this); //We do not need to store this
 
+	AnalysisForm::columnsModel = _columnsModel;
+	AnalysisForm::columnsModelRole = ColumnsModel::NameRole;
+
 	startOnlineDataManager();
 
 	makeConnections();
@@ -311,7 +314,6 @@ void MainWindow::makeConnections()
 	connect(_computedColumnsModel,	&ComputedColumnsModel::sendComputeCode,				_engineSync,			&EngineSync::computeColumn,									Qt::QueuedConnection);
 	connect(_computedColumnsModel,	&ComputedColumnsModel::showAnalysisForm,			_analyses,				&Analyses::selectAnalysis									);
 	connect(_computedColumnsModel,	&ComputedColumnsModel::dataColumnAdded,				_fileMenu,				&FileMenu::dataColumnAdded									);
-	connect(_computedColumnsModel,	&ComputedColumnsModel::refreshData,					_analyses,				&Analyses::refreshAvailableVariables,						Qt::QueuedConnection);
 	connect(_computedColumnsModel,	&ComputedColumnsModel::showAnalysisForm,			this,					&MainWindow::showResultsPanel								);
 
 	connect(_resultsJsInterface,	&ResultsJsInterface::packageModified,				this,					&MainWindow::setPackageModified								);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -290,16 +290,18 @@ void MainWindow::makeConnections()
 	connect(_package,				&DataSetPackage::datasetChanged,					_analyses,				&Analyses::refreshAnalysesUsingColumns,						Qt::QueuedConnection);
 	connect(_package,				&DataSetPackage::datasetChanged,					_filterModel,			&FilterModel::datasetChanged,								Qt::QueuedConnection);
 	connect(_package,				&DataSetPackage::datasetChanged,					_computedColumnsModel,	&ComputedColumnsModel::datasetChanged,						Qt::QueuedConnection);
+	connect(_package,				&DataSetPackage::datasetChanged,					_columnsModel,			&ColumnsModel::datasetChanged,								Qt::QueuedConnection);
 	connect(_package,				&DataSetPackage::isModifiedChanged,					this,					&MainWindow::packageChanged									);
 	connect(_package,				&DataSetPackage::windowTitleChanged,				this,					&MainWindow::windowTitleChanged								);
 	connect(_package,				&DataSetPackage::columnDataTypeChanged,				_computedColumnsModel,	&ComputedColumnsModel::recomputeColumn						);
+	connect(_package,				&DataSetPackage::columnDataTypeChanged,				_columnsModel,			&ColumnsModel::columnTypeChanged							);
 	connect(_package,				&DataSetPackage::freeDatasetSignal,					_loader,				&AsyncLoader::free											);
 	connect(_package,				&DataSetPackage::checkDoSync,						_loader,				&AsyncLoader::checkDoSync,									Qt::DirectConnection); //Force DirectConnection because the signal is called from Importer which means it is running in AsyncLoaderThread...
 
 	connect(_engineSync,			&EngineSync::computeColumnSucceeded,				_computedColumnsModel,	&ComputedColumnsModel::computeColumnSucceeded				);
 	connect(_engineSync,			&EngineSync::computeColumnFailed,					_computedColumnsModel,	&ComputedColumnsModel::computeColumnFailed					);
 	connect(_engineSync,			&EngineSync::engineTerminated,						this,					&MainWindow::fatalError,									Qt::QueuedConnection); //To give the process some time to realize it has crashed or something
-	connect(_engineSync,			&EngineSync::columnDataTypeChanged,					_analyses,				&Analyses::dataSetColumnsChanged							);
+	connect(_engineSync,			&EngineSync::columnDataTypeChanged,					_columnsModel,			&ColumnsModel::columnTypeChanged							);
 	connect(_engineSync,			&EngineSync::refreshAllPlotsExcept,					_analyses,				&Analyses::refreshAllPlots									);
 	connect(_engineSync,			&EngineSync::processNewFilterResult,				_filterModel,			&FilterModel::processFilterResult							);
 	connect(_engineSync,			&EngineSync::processFilterErrorMsg,					_filterModel,			&FilterModel::processFilterErrorMsg							);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -160,8 +160,7 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 
 	new MessageForwarder(this); //We do not need to store this
 
-	AnalysisForm::columnsModel = _columnsModel;
-	AnalysisForm::columnsModelRole = ColumnsModel::NameRole;
+	AnalysisForm::setColumnsModel(_columnsModel);
 
 	startOnlineDataManager();
 

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -96,7 +96,6 @@ public:
 	bool	welcomePageVisible()	const	{ return _welcomePageVisible;	}
 	bool	checkAutomaticSync()	const	{ return _checkAutomaticSync;	}
 	QString downloadNewJASPUrl()	const	{ return _downloadNewJASPUrl;	}
-	ColumnsModel *	columnsModel()			{ return _columnsModel;			}
 
 	static MainWindow * singleton() { return _singleton; }
 

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -96,6 +96,7 @@ public:
 	bool	welcomePageVisible()	const	{ return _welcomePageVisible;	}
 	bool	checkAutomaticSync()	const	{ return _checkAutomaticSync;	}
 	QString downloadNewJASPUrl()	const	{ return _downloadNewJASPUrl;	}
+	ColumnsModel *	columnsModel()			{ return _columnsModel;			}
 
 	static MainWindow * singleton() { return _singleton; }
 

--- a/Desktop/utilities/languagemodel.cpp
+++ b/Desktop/utilities/languagemodel.cpp
@@ -102,6 +102,7 @@ QVariant LanguageModel::data(const QModelIndex &index, int role) const
 	switch(role)
 	{
 	case NameRole:			result = getNativeLanguaName(cl); break;
+	case Qt::DisplayRole:
 	case LabelRole:			result = getNativeLanguaName(cl); break;
 	case ValueRole:			result = getNativeLanguaName(cl); break;
 	case NationFlagRole:	result = "qrc:/translations/images/flag_nl.png"; break;

--- a/Desktop/utilities/languagemodel.h
+++ b/Desktop/utilities/languagemodel.h
@@ -102,7 +102,7 @@ private:
 
 	QString		_qmlocation;
 
-	int			_currentIndex;
+	int			_currentIndex = 0;
 	bool		_shouldEmitLanguageChanged = false;
 };
 

--- a/Desktop/widgets/boundcontroljagstextarea.cpp
+++ b/Desktop/widgets/boundcontroljagstextarea.cpp
@@ -160,7 +160,6 @@ void BoundControlJAGSTextArea::checkSyntax()
 
 	ListModelTermsAvailable* model = _textArea->availableModel();
 	model->initTerms(_usedParameters.toList());
-	emit model->termsChanged();
 }
 
 

--- a/Desktop/widgets/boundcontrolsourcetextarea.cpp
+++ b/Desktop/widgets/boundcontrolsourcetextarea.cpp
@@ -47,6 +47,4 @@ void BoundControlSourceTextArea::_setSourceTerms()
 	for (const QString& term : list)
 		terms.append(term.trimmed());
 	_textArea->model()->initTerms(terms);
-
-	emit _textArea->model()->termsChanged();
 }

--- a/Desktop/widgets/boundcontrolsourcetextarea.cpp
+++ b/Desktop/widgets/boundcontrolsourcetextarea.cpp
@@ -48,5 +48,5 @@ void BoundControlSourceTextArea::_setSourceTerms()
 		terms.append(term.trimmed());
 	_textArea->model()->initTerms(terms);
 
-	emit _textArea->model()->termsChanged(nullptr, nullptr);
+	emit _textArea->model()->termsChanged();
 }

--- a/Desktop/widgets/boundcontrolterms.cpp
+++ b/Desktop/widgets/boundcontrolterms.cpp
@@ -258,7 +258,7 @@ void BoundControlTerms::updateOption()
 				{
 					it.next();
 					BoundControl* boundItem = dynamic_cast<BoundControl*>(it.value());
-					if (boundItem)
+					if (it.value()->isBound() && boundItem)
 					{
 						const QString& name = it.key();
 						Option* option = boundItem->boundTo();

--- a/Desktop/widgets/boundcontroltextarea.cpp
+++ b/Desktop/widgets/boundcontroltextarea.cpp
@@ -64,12 +64,12 @@ void BoundControlTextArea::checkSyntax()
 		try
 		{
 			R_FunctionWhiteList::scriptIsSafe(text.toStdString());
-			_textArea->setProperty("hasScriptError", false);
+			_textArea->setHasScriptError(false);
 			_textArea->setProperty("infoText", QObject::tr("valid R code"));
 		}
 		catch(filterException & e)
 		{
-			_textArea->setProperty("hasScriptError", true);
+			_textArea->setHasScriptError(true);
 			std::string errorMessage(e.what());
 			_textArea->setProperty("infoText", errorMessage.c_str());
 		}

--- a/Desktop/widgets/comboboxbase.h
+++ b/Desktop/widgets/comboboxbase.h
@@ -30,13 +30,11 @@ class ComboBoxBase : public JASPListControl, public BoundControl
 {
 	Q_OBJECT
 
+	Q_PROPERTY( int			currentIndex		READ currentIndex		WRITE setCurrentIndex			NOTIFY currentIndexChanged			)
 	Q_PROPERTY( QString		currentText			READ currentText		WRITE setCurrentText			NOTIFY currentTextChanged			)
 	Q_PROPERTY( QString		currentValue		READ currentValue		WRITE setCurrentValue			NOTIFY currentValueChanged			)
 	Q_PROPERTY( QString		startValue			READ startValue			WRITE setStartValue				NOTIFY startValueChanged			)
 	Q_PROPERTY( QString		currentColumnType	READ currentColumnType	WRITE setCurrentColumnType		NOTIFY currentColumnTypeChanged		)
-	Q_PROPERTY( QString		textRole			READ textRole			WRITE setTextRole				NOTIFY textRoleChanged				)
-	Q_PROPERTY( QString		valueRole			READ valueRole			WRITE setValueRole				NOTIFY valueRoleChanged				)
-	Q_PROPERTY( int			indexDefaultValue	READ indexDefaultValue	WRITE setIndexDefaultValue		NOTIFY indexDefaultValueChanged		)
 
 public:
 	ComboBoxBase(QQuickItem* parent = nullptr);
@@ -50,37 +48,28 @@ public:
 	ListModel*			model()								const	override	{ return _model;				}
 	void				setUpModel()								override;
 
-	void				setLabelValues();
-
 	const QString&		currentText()						const				{ return _currentText;			}
 	const QString&		currentValue()						const				{ return _currentValue;			}
 	const QString&		startValue()						const				{ return _startValue;			}
 	const QString&		currentColumnType()					const				{ return _currentColumnType;	}
-	const QString&		textRole()							const				{ return _textRole;				}
-	const QString&		valueRole()							const				{ return _valueRole;			}
-	int					indexDefaultValue()					const				{ return _indexDefaultValue;	}
+	int					currentIndex()						const				{ return _currentIndex;			}
 
 signals:
 	void currentTextChanged();
 	void currentValueChanged();
 	void startValueChanged();
 	void currentColumnTypeChanged();
-	void indexDefaultValueChanged();
-	void textRoleChanged();
-	void valueRoleChanged();
+	void currentIndexChanged();
 
 protected slots:
 	void termsChangedHandler() override;
-	void comboBoxChangeValueSlot(int index);
-	void languageChangedHandler();
+	void activatedSlot(int index);
 
 	GENERIC_SET_FUNCTION(CurrentText,		_currentText,		currentTextChanged,			QString	)
 	GENERIC_SET_FUNCTION(CurrentValue,		_currentValue,		currentValueChanged,		QString	)
 	GENERIC_SET_FUNCTION(StartValue,		_startValue,		startValueChanged,			QString	)
 	GENERIC_SET_FUNCTION(CurrentColumnType,	_currentColumnType, currentColumnTypeChanged,	QString	)
-	GENERIC_SET_FUNCTION(IndexDefaultValue,	_indexDefaultValue,	indexDefaultValueChanged,	int		)
-	GENERIC_SET_FUNCTION(TextRole,			_textRole,			textRoleChanged,			QString	)
-	GENERIC_SET_FUNCTION(ValueRole,			_valueRole,			valueRoleChanged,			QString	)
+	GENERIC_SET_FUNCTION(CurrentIndex,		_currentIndex,		currentIndexChanged,		int		)
 
 protected:
 	OptionList*					_boundTo				= nullptr;
@@ -88,13 +77,10 @@ protected:
 	QString						_currentText,
 								_currentValue,
 								_startValue,
-								_currentColumnType,
-								_textRole				= "label",
-								_valueRole				= "value";
-	int							_indexDefaultValue		= 0;
+								_currentColumnType;
+	int							_currentIndex			= 0;
 
 	void _resetItemWidth();
-	void _resetOptions();
 	void _setCurrentValue(int index, bool setOption = true);
 
 

--- a/Desktop/widgets/comboboxbase.h
+++ b/Desktop/widgets/comboboxbase.h
@@ -80,6 +80,7 @@ protected:
 								_currentColumnType;
 	int							_currentIndex			= 0;
 
+	int	 _getStartIndex();
 	void _resetItemWidth();
 	void _setCurrentValue(int index, bool setOption = true);
 

--- a/Desktop/widgets/componentslistbase.cpp
+++ b/Desktop/widgets/componentslistbase.cpp
@@ -235,9 +235,12 @@ void ComponentsListBase::termsChangedHandler()
 				{
 					it.next();
 					BoundControl* boundItem = dynamic_cast<BoundControl*>(it.value());
-					const QString& name = it.key();
-					Option* option = boundItem->boundTo();
-					rowOptions->add(name.toStdString(), option);
+					if (it.value()->isBound() && boundItem)
+					{
+						const QString& name = it.key();
+						Option* option = boundItem->boundTo();
+						rowOptions->add(name.toStdString(), option);
+					}
 				}
 			}
 			allOptions.push_back(rowOptions);

--- a/Desktop/widgets/factorsformbase.cpp
+++ b/Desktop/widgets/factorsformbase.cpp
@@ -145,5 +145,7 @@ void FactorsFormBase::addListViewSlot(JASPListControl *listView)
 	JASPListControl* availableListView = dynamic_cast<JASPListControl*>(_availableVariablesListItem);
 	form()->addListView(listView, availableListView);
 	
-	connect(listView->model(), &ListModel::termsChanged, this, &FactorsFormBase::termsChangedHandler);
+	connect(listView->model(), &ListModel::modelReset, this, &FactorsFormBase::termsChangedHandler);
+	connect(listView->model(), &ListModel::rowsRemoved, this, &FactorsFormBase::termsChangedHandler);
+	connect(listView->model(), &ListModel::rowsInserted, this, &FactorsFormBase::termsChangedHandler);
 }

--- a/Desktop/widgets/inputlistbase.cpp
+++ b/Desktop/widgets/inputlistbase.cpp
@@ -188,7 +188,7 @@ void InputListBase::termsChangedHandler()
 				{
 					it.next();
 					BoundControl* boundItem = dynamic_cast<BoundControl*>(it.value());
-					if (boundItem)
+					if (it.value()->isBound() && boundItem)
 						options->add(it.key().toStdString(), boundItem->boundTo());
 				}
 			}

--- a/Desktop/widgets/jasplistcontrol.cpp
+++ b/Desktop/widgets/jasplistcontrol.cpp
@@ -168,17 +168,10 @@ Terms JASPListControl::_getCombinedTerms(SourceItem* sourceToCombine)
 	return result;
 }
 
-QVector<std::pair<SourceItem*, Terms> > JASPListControl::getTermsPerSource()
+void JASPListControl::applyToAllSources(std::function<void(SourceItem *sourceItem, const Terms& terms)> applyThis)
 {
-	QVector<std::pair<SourceItem*, Terms> > result; // Do not use a map in order to keep the order of the sources.
-
 	for (SourceItem* sourceItem : _sourceItems)
-		if (sourceItem->combineWithOtherModels())
-			result.push_back(std::make_pair(sourceItem, _getCombinedTerms(sourceItem)));
-		else
-			result.push_back(std::make_pair(sourceItem, sourceItem->getTerms()));
-
-	return result;
+		applyThis(sourceItem, sourceItem->combineWithOtherModels() ? _getCombinedTerms(sourceItem) : sourceItem->getTerms());
 }
 
 bool JASPListControl::addRowControl(const QString &key, JASPControl *control)

--- a/Desktop/widgets/jasplistcontrol.cpp
+++ b/Desktop/widgets/jasplistcontrol.cpp
@@ -54,11 +54,11 @@ void JASPListControl::setupSources()
 
 	for (SourceItem* sourceItem : _sourceItems)
 	{
-		if (sourceItem->model())
+		if (sourceItem->listModel())
 		{
-			if (!sourceItem->model()->areTermsVariables() || !sourceItem->controlName().isEmpty() || sourceItem->modelUse() == "levels")
+			if (!sourceItem->listModel()->areTermsVariables() || !sourceItem->controlName().isEmpty() || sourceItem->modelUse() == "levels")
 				termsAreVariables = false;
-			if (sourceItem->model()->areTermsInteractions() || sourceItem->combineWithOtherModels())
+			if (sourceItem->listModel()->areTermsInteractions() || sourceItem->combineWithOtherModels())
 				termsAreInteractions = true;
 		}
 	}
@@ -118,7 +118,7 @@ void JASPListControl::setUp()
 
 	connect(this,		&JASPListControl::sourceChanged,	this,	&JASPListControl::sourceChangedHandler);
 	connect(listModel,	&ListModel::termsChanged,			this,	&JASPListControl::termsChangedHandler);
-	connect(listModel,	&ListModel::modelReset,			[this]() { emit countChanged(); });
+	connect(listModel,	&ListModel::termsChanged,			[this]() { emit countChanged(); });
 }
 
 void JASPListControl::cleanUp()
@@ -219,7 +219,7 @@ void JASPListControl::sourceChangedHandler()
 	if (!model())	return;
 
 	setupSources();
-	model()->sourceTermsChanged();
+	model()->sourceTermsReset();
 }
 
 int JASPListControl::_getAllowedColumnsTypes()

--- a/Desktop/widgets/jasplistcontrol.cpp
+++ b/Desktop/widgets/jasplistcontrol.cpp
@@ -23,6 +23,7 @@
 #include "listmodellabelvalueterms.h"
 #include "log.h"
 #include "rowcontrols.h"
+#include "sourceitem.h"
 
 #include <QQmlContext>
 
@@ -39,268 +40,33 @@ void JASPListControl::setUpModel()
 	emit modelChanged();
 }
 
-QList<QVariant> JASPListControl::_getListVariant(QVariant var)
-{
-	QList<QVariant> listVar;
-
-	if (!var.isValid() || var.isNull())
-		return listVar;
-
-	listVar = var.toList();
-
-	if (listVar.isEmpty())
-	{
-		QStringList stringSources = var.toStringList();
-		for (const QString& stringSource : stringSources)
-			listVar.push_back(stringSource);
-	}
-
-	if (listVar.isEmpty())
-	{
-		if (var.canConvert<QMap<QString, QVariant> >())
-		{
-			QMap<QString, QVariant> map = var.toMap();
-			listVar.push_back(map);
-		}
-	}
-
-	if (listVar.isEmpty())
-		listVar.push_back(var);
-
-	return listVar;
-}
-
-QString JASPListControl::_readSourceName(const QString& sourceNameExt, QString& sourceControl, QString& sourceUse)
-{
-	QStringList nameSplit = sourceNameExt.split(".");
-	if (nameSplit.length() > 1)
-	{
-		sourceControl = nameSplit[1];
-		sourceUse = "control=" + nameSplit[1];
-	}
-
-	return nameSplit[0];
-}
-
-QMap<QString, QVariant> JASPListControl::_readSource(const QVariant& source, QString& sourceName, QString& sourceControl, QString& sourceUse, LabelValueMap& sourceValues)
-{
-	QMap<QString, QVariant> map;
-
-	JASPControl* sourceItem = source.value<JASPControl*>();
-	if (sourceItem)
-		sourceName = sourceItem->name();
-	else if (source.type() == QVariant::Type::String)
-		sourceName = _readSourceName(source.toString(), sourceControl, sourceUse);
-	else if (source.canConvert<QMap<QString, QVariant> >())
-	{
-		map = source.toMap();
-		if (map.contains("id"))
-		{
-			JASPControl* sourceItem2 = map["id"].value<JASPControl*>();
-			if (sourceItem2)
-				sourceName = sourceItem2->name();
-		}
-
-		if (map.contains("name"))
-			sourceName = _readSourceName(map["name"].toString(), sourceControl, sourceUse);
-
-		if (map.contains("use"))
-		{
-			if (!sourceUse.isEmpty())
-				sourceUse += ",";
-			sourceUse += map["use"].toString();
-		}
-
-		if (map.contains("values"))
-			sourceValues = _readValues(map["values"]);
-	}
-
-	return map;
-}
-
-JASPListControl::LabelValueMap JASPListControl::_readValues(const QVariant& values)
-{
-	LabelValueMap result;
-
-	bool isInteger = false;
-	int count =  values.toInt(&isInteger);
-
-	if (isInteger)
-	{
-		for (int i = 1; i <= count; i++)
-		{
-			QString number = QString::number(i);
-			result.push_back(std::make_pair(number, number));
-		}
-	}
-	else
-	{
-		QList<QVariant> list = values.toList();
-		if (!list.isEmpty())
-		{
-			QString textRole = property("textRole").toString();
-			QString valueRole = property("valueRole").toString();
-			if (textRole.isEmpty()) textRole = "label";
-			if (valueRole.isEmpty()) valueRole = "value";
-
-
-			for (const QVariant& itemVariant : list)
-			{
-				QMap<QString, QVariant> labelValuePair = itemVariant.toMap();
-				if (labelValuePair.isEmpty())
-				{
-					QString value = itemVariant.toString();
-					result.push_back(std::make_pair(value, value));
-				}
-				else
-				{
-					QString label = labelValuePair[textRole].toString();
-					QString value = labelValuePair[valueRole].toString();
-					result.push_back(std::make_pair(label, value));
-				}
-			}
-		}
-	}
-
-	return result;
-}
-
 void JASPListControl::setupSources()
 {
-	for (SourceType* sourceType : _sourceModels)
-	{
-		if (sourceType->isValuesSource)
-			delete sourceType->model; // In case of values, the model is created just to contain the values, and does not come from another listview.
-		delete sourceType;
-	}
-	_sourceModels.clear();
+	for (SourceItem* sourceItem : _sourceItems)
+		delete sourceItem;
+	_sourceItems.clear();
 
-	if ((!source().isValid() || source().isNull()) && (!values().isValid() || values().isNull()))
-		return;
+	_sourceItems = SourceItem::readAllSources(this);
 
-	if (values().isValid() && !values().isNull())
-		_sourceModels.append(new SourceType(_readValues(values())));
-
-	QList<QVariant> sources = _getListVariant(source());
-	
-	for (const QVariant& source : sources)
-	{
-		QString sourceName, sourceControl, sourceUse;
-		LabelValueMap sourceValues;
-		QMap<QString, QVariant> map = _readSource(source, sourceName, sourceControl, sourceUse, sourceValues);
-
-		QString conditionExpression = map["condition"].toString();
-		QVector<std::tuple<QString, QString, QString, LabelValueMap, bool> > discards;
-		QVector<QMap<QString, QVariant> > conditionVariables;
-		bool combineWithOtherModels = false;
-
-		if (sourceName.isEmpty() && !map.contains("values"))
-		{
-			addControlError(tr("No name given in source attribute of List %1").arg(name()));
-			continue;
-		}
-
-		if (map.contains("discard"))
-		{
-			QList<QVariant> discardSources = _getListVariant(map["discard"]);
-
-			for (const QVariant& discardSource : discardSources)
-			{
-				QString discardName, discardControl, discardUse;
-				LabelValueMap discardValues;
-				QMap<QString, QVariant> discardMap = _readSource(discardSource, discardName, discardControl, discardUse, discardValues);
-
-				if (discardName.isEmpty())
-					addControlError(tr("No name given in discard source attribute of VariableList %1" ).arg(name()));
-
-				discards.push_back(std::make_tuple(discardName, discardControl, discardUse, discardValues, discardMap.contains("values")));
-			}
-		}
-
-		if (map.contains("conditionVariables"))
-		{
-			QList<QVariant> conditionVariablesList = _getListVariant(map["conditionVariables"]);
-
-			for (const QVariant& conditionVariablesVar : conditionVariablesList)
-				if (conditionVariablesVar.canConvert<QMap<QString, QVariant> >())
-					conditionVariables.push_back(conditionVariablesVar.toMap());
-		}
-
-		if (map.contains("combineWithOtherModels"))
-			combineWithOtherModels = map["combineWithOtherModels"].toBool();
-
-		bool isValuesSource = map.contains("values");
-		_sourceModels.append(new SourceType(sourceName, sourceControl, sourceUse, sourceValues, isValuesSource, discards, conditionExpression, conditionVariables, combineWithOtherModels));
-	}
-	
 	ListModel* listModel = model();
+	bool termsAreVariables = true;
+	bool termsAreInteractions = false;
 
-	if (_sourceModels.isEmpty())
+	for (SourceItem* sourceItem : _sourceItems)
 	{
-		if (_needsSourceModels)
-			addControlError(tr("Needs source model for component %1").arg(name()));
-	}
-	else
-	{
-		bool termsAreVariables = true;
-		bool termsAreInteractions = false;
-		for (SourceType* sourceItem : _sourceModels)
+		if (sourceItem->model())
 		{
-			ListModel* sourceModel = nullptr;
-			if (!sourceItem->isValuesSource)
-			{
-				if (form())
-					sourceModel = form()->getModel(sourceItem->name);
-				else
-					Log::log() << "Cannot use a source property outside of an Anlysis Form" << std::endl;
-			}
-			else
-				sourceModel = new ListModelLabelValueTerms(this, sourceItem->values);
-
-			if (sourceModel)
-			{
-				if (!sourceModel->areTermsVariables() || !sourceItem->controlName.isEmpty() || sourceItem->modelUse == "levels")
-					termsAreVariables = false;
-				if (sourceModel->areTermsInteractions() || sourceItem->combineWithOtherModels)
-					termsAreInteractions = true;
-				sourceItem->model = sourceModel;
-				addDependency(sourceModel->listView());
-				connect(sourceModel, &ListModel::termsChanged, listModel, &ListModel::sourceTermsChanged);
-
-				for (SourceType& discardSource : sourceItem->discardModels)
-				{
-					ListModel* discardModel = nullptr;
-					if (!sourceItem->isValuesSource)
-					{
-						if (form())
-							discardModel = form()->getModel(discardSource.name);
-						else
-							Log::log() << "Cannot use a source property outside of an Anlysis Form" << std::endl;
-					}
-
-					else
-						discardModel = new ListModelLabelValueTerms(this, discardSource.values);
-
-					if (discardModel)
-					{
-						discardSource.model = discardModel;
-						addDependency(discardModel->listView());
-						connect(discardModel, &ListModel::termsChanged, listModel, &ListModel::sourceTermsChanged);
-					}
-					else
-						addControlError(tr("Unknown discard model %1 for VariableList %2").arg(discardSource.name).arg(name()));
-				}
-			}
-			else
-				addControlError(tr("Cannot find source %1 for VariablesList %2").arg(sourceItem->name).arg(name()));
+			if (!sourceItem->model()->areTermsVariables() || !sourceItem->controlName().isEmpty() || sourceItem->modelUse() == "levels")
+				termsAreVariables = false;
+			if (sourceItem->model()->areTermsInteractions() || sourceItem->combineWithOtherModels())
+				termsAreInteractions = true;
 		}
-
-		if (!termsAreVariables)
-			listModel->setTermsAreVariables(false); // set it only when it is false
-		if (termsAreInteractions)
-			listModel->setTermsAreInteractions(true); // set it only when it is true
 	}
 
+	if (!termsAreVariables)
+		listModel->setTermsAreVariables(false); // set it only when it is false
+	if (termsAreInteractions)
+		listModel->setTermsAreInteractions(true); // set it only when it is true
 }
 
 void JASPListControl::addRowComponentsDefaultOptions(Options *options)
@@ -323,7 +89,7 @@ void JASPListControl::addRowComponentsDefaultOptions(Options *options)
 		it.next();
 		JASPControl* control = it.value();
 		BoundControl* boundItem = dynamic_cast<BoundControl*>(control);
-		if (boundItem)
+		if (control->isBound() && boundItem)
 		{
 			// The options might depend on properties set by the setup
 			// e.g. setup of BoundQMLListViewTerms sets whether the terms have interactions, which influences the kind of options that will be used.
@@ -352,72 +118,65 @@ void JASPListControl::setUp()
 
 	connect(this,		&JASPListControl::sourceChanged,	this,	&JASPListControl::sourceChangedHandler);
 	connect(listModel,	&ListModel::termsChanged,			this,	&JASPListControl::termsChangedHandler);
-	connect(listModel,	&ListModel::termsChanged,			[this]() { emit countChanged(); });
+	connect(listModel,	&ListModel::modelReset,			[this]() { emit countChanged(); });
 }
 
 void JASPListControl::cleanUp()
 {
-	ListModel* _model = model();
-	if (_model)
-		_model->disconnect();
-	JASPControl::cleanUp();
+	try
+	{
+		ListModel* _model = model();
+		if (_model)
+			_model->disconnect();
+		for (SourceItem* sourceItem : _sourceItems)
+			delete sourceItem;
+
+		for (RowControls* rowControls : _model->getRowControls().values())
+			for (JASPControl* control : rowControls->getJASPControlsMap().values())
+				control->cleanUp();
+
+		if (_defaultRowControls)
+			for (JASPControl* control : _defaultRowControls->getJASPControlsMap().values())
+				control->cleanUp();
+
+		_sourceItems.clear();
+
+		JASPControl::cleanUp();
+	}
+	catch (...) {}
 }
 
-QList<std::pair<JASPListControl::SourceType*, Terms> > JASPListControl::getTermsPerSource()
+Terms JASPListControl::_getCombinedTerms(SourceItem* sourceToCombine)
 {
-	QList<std::pair<SourceType*, Terms> > result; // Do not use a map in order to keep the order of the sources.
+	Terms result = sourceToCombine->getTerms();
+	Terms termsToBeCombinedWith;
+	for (SourceItem* sourceItem : _sourceItems)
+		if (sourceItem != sourceToCombine)
+			termsToBeCombinedWith.add(sourceItem->getTerms());
 
-	for (SourceType* sourceItem : _sourceModels)
+	Terms termsToCombine = sourceToCombine->getTerms();
+	for (const Term& termToCombine : termsToCombine)
 	{
-		ListModel* sourceModel = sourceItem->model;
-		if (sourceModel)
+		for (const Term& termToBeCombined : termsToBeCombinedWith)
 		{
-			Terms sourceTerms = sourceModel->terms(sourceItem->modelUse);
-
-			for (const SourceType& discardModel : sourceItem->getDiscardModels())
-				sourceTerms.discardWhatDoesContainTheseComponents(discardModel.model->terms(discardModel.modelUse));
-
-			if (!sourceItem->conditionExpression.isEmpty())
-			{
-				Terms filteredTerms;
-				QJSEngine* jsEngine = qmlEngine(this);
-
-				for (const Term& term : sourceTerms)
-				{
-					for (const SourceType::ConditionVariable& conditionVariable : sourceItem->conditionVariables)
-					{
-						JASPControl* control = sourceModel->getRowControl(term.asQString(), conditionVariable.controlName);
-						if (control)
-						{
-							QJSValue value;
-							QVariant valueVar = control->property(conditionVariable.propertyName.toStdString().c_str());
-
-							switch (valueVar.type())
-							{
-							case QVariant::Type::Int:
-							case QVariant::Type::UInt:		value = valueVar.toInt();		break;
-							case QVariant::Type::Double:	value = valueVar.toDouble();	break;
-							case QVariant::Type::Bool:		value = valueVar.toBool();		break;
-							default:						value = valueVar.toString();	break;
-							}
-
-							jsEngine->globalObject().setProperty(conditionVariable.name, value);
-						}
-					}
-
-					QJSValue result = jsEngine->evaluate(sourceItem->conditionExpression);
-					if (result.isError())
-							addControlError("Error when evaluating : " + sourceItem->conditionExpression + ": " + result.toString());
-					else if (result.toBool())
-						filteredTerms.add(term);
-				}
-
-				sourceTerms = filteredTerms;
-			}
-
-			result.append(std::make_pair(sourceItem, sourceTerms));
+			QStringList components = termToCombine.components();
+			components.append(termToBeCombined.components());
+			result.add(Term(components));
 		}
 	}
+
+	return result;
+}
+
+QVector<std::pair<SourceItem*, Terms> > JASPListControl::getTermsPerSource()
+{
+	QVector<std::pair<SourceItem*, Terms> > result; // Do not use a map in order to keep the order of the sources.
+
+	for (SourceItem* sourceItem : _sourceItems)
+		if (sourceItem->combineWithOtherModels())
+			result.push_back(std::make_pair(sourceItem, _getCombinedTerms(sourceItem)));
+		else
+			result.push_back(std::make_pair(sourceItem, sourceItem->getTerms()));
 
 	return result;
 }
@@ -431,7 +190,7 @@ bool JASPListControl::addRowControl(const QString &key, JASPControl *control)
 		if (_defaultRowControls)
 			success = _defaultRowControls->addJASPControl(control);
 	}
-	else
+	else if (model())
 		success = model()->addRowControl(key, control);
 
 	return success;
@@ -449,12 +208,12 @@ JASPControl *JASPListControl::getChildControl(QString key, QString name)
 
 JASPControl *JASPListControl::getRowControl(const QString &key, const QString &name) const
 {
-	return model()->getRowControl(key, name);
+	return model() ? model()->getRowControl(key, name) : nullptr;
 }
 
 QString JASPListControl::getSourceType(QString name)
 {
-	return model()->getItemType(name);
+	return model() ? model()->getItemType(name) : "";
 }
 
 int JASPListControl::count()
@@ -464,24 +223,10 @@ int JASPListControl::count()
 
 void JASPListControl::sourceChangedHandler()
 {
-	ListModel* listModel = model();
-	if (!listModel)
-		return;
-
-	for (SourceType* sourceItem : _sourceModels)
-	{
-		ListModel* sourceModel = sourceItem->model;
-		if (sourceModel)
-		{
-			removeDependency(sourceModel->listView());
-			disconnect(sourceModel, &ListModel::termsChanged, listModel, &ListModel::sourceTermsChanged);
-			for (SourceType& discardModel : sourceItem->getDiscardModels())
-				disconnect(discardModel.model, &ListModel::termsChanged, listModel, &ListModel::sourceTermsChanged);
-		}
-	}
+	if (!model())	return;
 
 	setupSources();
-	listModel->sourceTermsChanged(nullptr, nullptr);
+	model()->sourceTermsChanged();
 }
 
 int JASPListControl::_getAllowedColumnsTypes()
@@ -522,48 +267,5 @@ void JASPListControl::_setAllowedVariables()
 		_variableTypesAllowed = allowedColumnsTypes;
 }
 
-JASPListControl::SourceType::SourceType(
-		  const QString& _name
-		, const QString& _controlName
-		, const QString& _modelUse
-		, const LabelValueMap& _values
-		, bool _isValuesSource
-		, const QVector<std::tuple<QString, QString, QString, LabelValueMap, bool> >& _discardModels
-		, const QString& _conditionExpression
-		, const QVector<QMap<QString, QVariant> >& _conditionVariables
-		, bool _combineWithOtherModels
-		)
-	: name(_name), controlName(_controlName), modelUse(_modelUse), values(_values), isValuesSource(_isValuesSource), model(nullptr), conditionExpression(_conditionExpression), combineWithOtherModels(_combineWithOtherModels)
-{
-	if (!_controlName.isEmpty()) usedControls.insert(_controlName);
 
-	for (const std::tuple<QString, QString, QString, LabelValueMap, bool>& discardModel : _discardModels)
-	{
-		discardModels.push_back(SourceType(std::get<0>(discardModel), std::get<1>(discardModel), std::get<2>(discardModel), std::get<3>(discardModel), std::get<4>(discardModel)));
-		if (!std::get<1>(discardModel).isEmpty()) usedControls.insert(std::get<1>(discardModel));
-	}
 
-	for (const QMap<QString, QVariant>& conditionVariable : _conditionVariables)
-	{
-		conditionVariables.push_back(ConditionVariable(conditionVariable["name"].toString()
-									, conditionVariable["component"].toString()
-									, conditionVariable["property"].toString()
-									, conditionVariable["addQuotes"].toBool())
-					);
-		if (!conditionVariable["component"].toString().isEmpty()) usedControls.insert(conditionVariable["component"].toString());
-	}
-}
-
-QVector<JASPListControl::SourceType> JASPListControl::SourceType::getDiscardModels(bool onlyNotNullModel) const
-{
-	if (!onlyNotNullModel)
-		return discardModels;
-
-	QVector<JASPListControl::SourceType> result;
-
-	for (const JASPListControl::SourceType& discardModel : discardModels)
-		if (discardModel.model)
-			result.push_back(discardModel);
-
-	return result;
-}

--- a/Desktop/widgets/jasplistcontrol.h
+++ b/Desktop/widgets/jasplistcontrol.h
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2013-2018 University of Amsterdam
 //
 // This program is free software: you can redistribute it and/or modify
@@ -25,11 +25,13 @@
 #include <QVector>
 #include <QMap>
 #include <QSet>
+#include <QAbstractItemModel>
 
 class ListModel;
 class Options;
 class RowControls;
 class Terms;
+class SourceItem;
 
 class JASPListControl : public JASPControl
 {
@@ -42,53 +44,13 @@ class JASPListControl : public JASPControl
 	Q_PROPERTY( QString			optionKey			READ optionKey			WRITE setOptionKey											)
 	Q_PROPERTY( bool			addEmptyValue		READ addEmptyValue		WRITE setAddEmptyValue		NOTIFY addEmptyValueChanged		)
 	Q_PROPERTY( QString			placeholderText		READ placeholderText	WRITE setPlaceHolderText	NOTIFY placeHolderTextChanged	)
+	Q_PROPERTY( QString			labelRole			READ labelRole			WRITE setLabelRole			NOTIFY labelRoleChanged			)
+	Q_PROPERTY( QString			valueRole			READ valueRole			WRITE setValueRole			NOTIFY valueRoleChanged			)
+
 
 public:
 	typedef QVector<std::pair<QString, QString> > LabelValueMap;
-	struct SourceType
-	{
-		struct ConditionVariable
-		{
-			QString name,
-					controlName,
-					propertyName;
-			bool	addQuotes = false;
 
-			ConditionVariable(const QString& _name, const QString& _controlName, const QString& _propertyName, bool _addQuotes = false)
-				: name(_name), controlName(_controlName), propertyName(_propertyName), addQuotes(_addQuotes) {}
-			ConditionVariable(const ConditionVariable& source)
-				: name(source.name), controlName(source.controlName), propertyName(source.propertyName), addQuotes(source.addQuotes) {}
-			ConditionVariable() {}
-		};
-
-		QString						name,
-									controlName,
-									modelUse;
-		QVector<SourceType>			discardModels;
-		LabelValueMap				values;
-		bool						isValuesSource = false;
-		ListModel	*				model = nullptr;
-		QString						conditionExpression;
-		QVector<ConditionVariable>	conditionVariables;
-		bool						combineWithOtherModels = false;
-		QSet<QString>				usedControls;
-
-		SourceType(
-				  const QString& _name
-				, const QString& _controlName
-				, const QString& _modelUse
-				, const LabelValueMap& _values
-				, bool isValuesSource
-				, const QVector<std::tuple<QString, QString, QString, LabelValueMap, bool> >& _discardModels = QVector<std::tuple<QString, QString, QString, LabelValueMap, bool> >()
-				, const QString& _conditionExpression = ""
-				, const QVector<QMap<QString, QVariant> >& _conditionVariables = QVector<QMap<QString, QVariant> >()
-				, bool _combineWithOtherModels = false);
-
-		SourceType(const LabelValueMap& _values) : values(_values), isValuesSource(true) {}
-
-		QVector<SourceType> getDiscardModels(bool onlyNotNullModel = true)	const;
-	};
-	
 	JASPListControl(QQuickItem* parent);
 	
 	virtual ListModel		*	model()			const	= 0;
@@ -98,9 +60,9 @@ public:
 	
 			int					variableTypesAllowed()		const	{ return _variableTypesAllowed; }
 
-	const QList<SourceType*>&	sourceModels()				const	{ return _sourceModels; }
-	QList<std::pair<SourceType*, Terms> >	getTermsPerSource();
-			bool				hasSource()					const	{ return !_source.isNull() || !_values.isNull(); }
+	const QVector<SourceItem*>& sourceItems()				const	{ return _sourceItems; }
+	QVector<std::pair<SourceItem*, Terms> >	getTermsPerSource();
+			bool				hasSource()					const	{ return _sourceItems.size() > 0; }
 
 			JASPControl		*	getRowControl(const QString& key, const QString& name)		const;
 			bool				addRowControl(const QString& key, JASPControl* control);
@@ -112,11 +74,14 @@ public:
 
 	Q_INVOKABLE QString			getSourceType(QString name);
 
-			const QVariant&		source()					const	{ return _source;	}
-			const QVariant&		values()					const	{ return _values;	}
+			const QVariant&		source()					const	{ return _source;				}
+			const QVariant&		values()					const	{ return _values;				}
 			int					count();
-			bool				addEmptyValue()				const	{ return _addEmptyValue;				}
-			const QString&		placeholderText()			const	{ return _placeHolderText;				}
+			bool				addEmptyValue()				const	{ return _addEmptyValue;		}
+			const QString&		placeholderText()			const	{ return _placeHolderText;		}
+			const QString&		labelRole()					const	{ return _labelRole;			}
+			const QString&		valueRole()					const	{ return _valueRole;			}
+
 
 signals:
 			void				modelChanged();
@@ -124,6 +89,8 @@ signals:
 			void				countChanged();
 			void				addEmptyValueChanged();
 			void				placeHolderTextChanged();
+			void				labelRoleChanged();
+			void				valueRoleChanged();
 
 
 protected slots:
@@ -134,31 +101,31 @@ protected slots:
 			GENERIC_SET_FUNCTION(Values,			_values,			sourceChanged,				QVariant	)
 			GENERIC_SET_FUNCTION(AddEmptyValue,		_addEmptyValue,		addEmptyValueChanged,		bool		)
 			GENERIC_SET_FUNCTION(PlaceHolderText,	_placeHolderText,	placeHolderTextChanged,		QString		)
+			GENERIC_SET_FUNCTION(LabelRole,			_labelRole,			labelRoleChanged,			QString		)
+			GENERIC_SET_FUNCTION(ValueRole,			_valueRole,			valueRoleChanged,			QString		)
 
 			void				setOptionKey(const QString& optionKey)	{ _optionKey = optionKey; }
 
 protected:
 	virtual void			setupSources();
 
-	QList<SourceType*>		_sourceModels;
-	bool					_needsSourceModels		= false;
+	QVector<SourceItem*>	_sourceItems;
 	int						_variableTypesAllowed;
 	QString					_optionKey				= "value";
 	RowControls*			_defaultRowControls		= nullptr;
 	QVariant				_source;
 	QVariant				_values;
 	bool					_addEmptyValue			= false;
-	QString					_placeHolderText		= tr("<no choice>");
+	QString					_placeHolderText		= tr("<no choice>"),
+							_labelRole				= "label",
+							_valueRole				= "value";
 
 	static const QString	_defaultKey;
 	
 private:
+	Terms					_getCombinedTerms(SourceItem* sourceToCombine);
 	int						_getAllowedColumnsTypes();
 	void					_setAllowedVariables();
-	QString					_readSourceName(const QString& sourceNameExt, QString& sourceControl, QString& sourceUse);
-	QMap<QString, QVariant>	_readSource(const QVariant& source, QString& sourceName, QString& sourceControl, QString& sourceUse, LabelValueMap& sourceValues);
-	LabelValueMap			_readValues(const QVariant& values);
-	QList<QVariant>			_getListVariant(QVariant var);
 };
 
 #endif // JASPLISTCONTROL_H

--- a/Desktop/widgets/jasplistcontrol.h
+++ b/Desktop/widgets/jasplistcontrol.h
@@ -61,7 +61,8 @@ public:
 			int					variableTypesAllowed()		const	{ return _variableTypesAllowed; }
 
 	const QVector<SourceItem*>& sourceItems()				const	{ return _sourceItems; }
-	QVector<std::pair<SourceItem*, Terms> >	getTermsPerSource();
+	void						applyToAllSources(std::function<void(SourceItem *sourceItem, const Terms& terms)> applyThis);
+
 			bool				hasSource()					const	{ return _sourceItems.size() > 0; }
 
 			JASPControl		*	getRowControl(const QString& key, const QString& name)		const;
@@ -123,9 +124,9 @@ protected:
 	static const QString	_defaultKey;
 	
 private:
-	Terms					_getCombinedTerms(SourceItem* sourceToCombine);
-	int						_getAllowedColumnsTypes();
-	void					_setAllowedVariables();
+	Terms									_getCombinedTerms(SourceItem* sourceToCombine);
+	int										_getAllowedColumnsTypes();
+	void									_setAllowedVariables();
 };
 
 #endif // JASPLISTCONTROL_H

--- a/Desktop/widgets/listmodel.cpp
+++ b/Desktop/widgets/listmodel.cpp
@@ -110,13 +110,11 @@ Terms ListModel::getSourceTerms()
 {
 	Terms termsAvailable;
 
-	for (const auto& pair : listView()->getTermsPerSource())
+	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
-		SourceItem* sourceItem = pair.first;
 		_connectSourceControls(sourceItem->model(), sourceItem->usedControls());
-
-		termsAvailable.add(pair.second);
-	}
+		termsAvailable.add(terms);
+	});
 	
 	return termsAvailable;
 }
@@ -125,12 +123,12 @@ ListModel *ListModel::getSourceModelOfTerm(const Term &term)
 {
 	ListModel* result = nullptr;
 
-	for (const auto& pair : listView()->getTermsPerSource())
+	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
-		SourceItem* sourceItem = pair.first;
-		if (pair.second.contains(term) && sourceItem->model())
+		if (terms.contains(term))
 			result = sourceItem->model();
-	}
+	});
+
 	return result;
 }
 

--- a/Desktop/widgets/listmodel.h
+++ b/Desktop/widgets/listmodel.h
@@ -57,11 +57,10 @@ public:
 			int						columnCount(const QModelIndex &parent = QModelIndex())		const override { return 1; }
 			QVariant				data(const QModelIndex &index, int role = Qt::DisplayRole)	const override;
 
-	virtual void					endResetModel();
-
 			JASPListControl*		listView()													const		{ return _listView; }
 			const QString &			name() const;
-	virtual const Terms &			terms(const QString& what = QString())						const;
+	virtual Terms					termsEx(const QString& what);
+			const Terms &			terms()														const		{ return _terms;	}
 			bool					areTermsVariables()											const		{ return _areTermsVariables; }
 			bool					areTermsInteractions()										const		{ return _areTermsInteractions; }
 			bool					needsSource()												const		{ return _needsSource;			}
@@ -91,16 +90,38 @@ public:
 	Q_INVOKABLE QList<QString>		selectedItemsTypes()													{ return _selectedItemsTypes.toList(); }
 	Q_INVOKABLE QList<QString>		itemTypes();
 
-			void					replaceVariableName(const std::string & oldName, const std::string & newName);
-
 
 signals:
-			void termsChanged();
+			void termsChanged();		// Used to signal all kinds of changes in the model. Do not call it directly
+			void namesChanged(QMap<QString, QString> map);
+			void typeChanged(QString name);
 			void selectedItemsChanged();
 			void oneTermChanged(const QString& oldName, const QString& newName);
 
 public slots:	
-	virtual void sourceTermsChanged();
+	virtual void sourceTermsReset();
+	virtual void sourceNamesChanged(QMap<QString, QString> map);
+	virtual int  sourceTypeChanged(QString colName);
+
+protected:
+			void	_setTerms(const Terms& terms, bool isUnique = true);
+			void	_setTerms(const Terms& terms, const Terms& parentTerms);
+			void	_setTerms(const std::vector<Term>& terms, bool isUnique = true);
+			void	_removeTerms(const Terms& terms);
+			void	_removeTerm(int index);
+			void	_removeTerm(const Term& term);
+			void	_addTerms(const Terms& terms);
+			void	_addTerm(const QString& term, bool isUnique = true);
+			void	_replaceTerm(int index, const Term& term);
+
+			QString							_itemType;
+			bool							_needsSource			= true;
+			QMap<QString, RowControls* >	_rowControlsMap;
+			QQmlComponent *					_rowComponent			= nullptr;
+			RowControlsOptions				_rowControlsOptions;
+			QList<BoundControl *>			_rowControlsConnected;
+			QList<int>						_selectedItems;
+			QSet<QString>					_selectedItemsTypes;
 
 private:
 			void	_addSelectedItemType(int _index);
@@ -108,19 +129,10 @@ private:
 			void	_initTerms(const Terms &terms, const RowControlsOptions& allOptionsMap, bool setupRowConnections = true);
 			void	_connectSourceControls(ListModel* sourceModel, const QSet<QString>& controls);
 
-protected:
-	JASPListControl*				_listView = nullptr;
-	QString							_itemType;
-	Terms							_terms;
-	QList<int>						_selectedItems;
-	QSet<QString>					_selectedItemsTypes;
-	bool							_needsSource			= true;
-	bool							_areTermsVariables		= true;
-	bool							_areTermsInteractions	= false;
-	QMap<QString, RowControls* >	_rowControlsMap;
-	QQmlComponent *					_rowComponent = nullptr;
-	RowControlsOptions				_rowControlsOptions;
-	QList<BoundControl *>			_rowControlsConnected;
+			JASPListControl*				_listView = nullptr;
+			Terms							_terms;
+			bool							_areTermsVariables		= true;
+			bool							_areTermsInteractions	= false;
 
 };
 

--- a/Desktop/widgets/listmodel.h
+++ b/Desktop/widgets/listmodel.h
@@ -59,16 +59,18 @@ public:
 
 	virtual void					endResetModel();
 
-			JASPListControl*			listView() const								{ return _listView; }
+			JASPListControl*		listView()													const		{ return _listView; }
 			const QString &			name() const;
-	virtual const Terms &			terms(const QString& what = QString())	const;
-			bool					areTermsVariables() const						{ return _areTermsVariables; }
-			bool					areTermsInteractions() const					{ return _areTermsInteractions; }
-	virtual QString					getItemType(const Term& term) const				{ return _itemType; }
+	virtual const Terms &			terms(const QString& what = QString())						const;
+			bool					areTermsVariables()											const		{ return _areTermsVariables; }
+			bool					areTermsInteractions()										const		{ return _areTermsInteractions; }
+			bool					needsSource()												const		{ return _needsSource;			}
+			void					setNeedsSource(bool needs)												{ _needsSource = needs;			}
+	virtual QString					getItemType(const Term& term)								const		{ return _itemType; }
 	virtual void					setTermsAreVariables(bool areVariables);
-	virtual void					setTermsAreInteractions(bool interactions)		{ _areTermsInteractions = interactions; }
-			void					setItemType(QString type)						{ _itemType = type; }
-			void					addControlError(const QString& error) const;
+	virtual void					setTermsAreInteractions(bool interactions)								{ _areTermsInteractions = interactions; }
+			void					setItemType(QString type)												{ _itemType = type; }
+			void					addControlError(const QString& error)						const;
 	virtual void					refresh();
 	virtual void					initTerms(const Terms &terms, const RowControlsOptions& allOptionsMap = RowControlsOptions());
 			Terms					getSourceTerms();
@@ -77,7 +79,7 @@ public:
 			void					setRowComponent(QQmlComponent* rowComponents);
 	virtual void					setUpRowControls();
 	const rowControlMap	&			getRowControls() const { return _rowControlsMap; }
-	virtual JASPControl	*			getRowControl(const QString& key, const QString& name)			const;
+	virtual JASPControl	*			getRowControl(const QString& key, const QString& name)		const;
 	virtual bool					addRowControl(const QString& key, JASPControl* control);
 
 	Q_INVOKABLE int					searchTermWith(QString searchString);
@@ -85,20 +87,20 @@ public:
 	Q_INVOKABLE void				clearSelectedItems(bool emitSelectedChange = true);
 	Q_INVOKABLE void				setSelectedItem(int _index);
 	Q_INVOKABLE void				selectAllItems();
-	Q_INVOKABLE QList<int>			selectedItems()			{ return _selectedItems; }
-	Q_INVOKABLE QList<QString>		selectedItemsTypes()	{ return _selectedItemsTypes.toList(); }
+	Q_INVOKABLE QList<int>			selectedItems()															{ return _selectedItems; }
+	Q_INVOKABLE QList<QString>		selectedItemsTypes()													{ return _selectedItemsTypes.toList(); }
 	Q_INVOKABLE QList<QString>		itemTypes();
 
 			void					replaceVariableName(const std::string & oldName, const std::string & newName);
 
 
 signals:
-			void termsChanged(const Terms* added = nullptr, const Terms* removed = nullptr);
+			void termsChanged();
 			void selectedItemsChanged();
-			void termChanged(const QString& oldName, const QString& newName);
+			void oneTermChanged(const QString& oldName, const QString& newName);
 
 public slots:	
-	virtual void sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved);
+	virtual void sourceTermsChanged();
 
 private:
 			void	_addSelectedItemType(int _index);
@@ -112,6 +114,7 @@ protected:
 	Terms							_terms;
 	QList<int>						_selectedItems;
 	QSet<QString>					_selectedItemsTypes;
+	bool							_needsSource			= true;
 	bool							_areTermsVariables		= true;
 	bool							_areTermsInteractions	= false;
 	QMap<QString, RowControls* >	_rowControlsMap;

--- a/Desktop/widgets/listmodelassignedinterface.cpp
+++ b/Desktop/widgets/listmodelassignedinterface.cpp
@@ -55,3 +55,18 @@ void ListModelAssignedInterface::setAvailableModel(ListModelAvailableInterface *
 {
 	_source = source;
 }
+
+int ListModelAssignedInterface::sourceTypeChanged(QString name)
+{
+	int index = ListModelDraggable::sourceTypeChanged(name);
+	VariablesListBase* qmlListView = dynamic_cast<VariablesListBase*>(listView());
+
+	if (qmlListView && index >= 0 && !isAllowed(terms().at(size_t(index))))
+	{
+		QList<int> indexes = {index};
+		qmlListView->moveItems(indexes, _source);
+		ListModelDraggable::refresh();
+	}
+
+	return index;
+}

--- a/Desktop/widgets/listmodelassignedinterface.cpp
+++ b/Desktop/widgets/listmodelassignedinterface.cpp
@@ -23,6 +23,7 @@ ListModelAssignedInterface::ListModelAssignedInterface(JASPListControl* listView
 	: ListModelDraggable(listView)
   , _source(nullptr)
 {
+	_needsSource = false;
 }
 
 void ListModelAssignedInterface::refresh()

--- a/Desktop/widgets/listmodelassignedinterface.h
+++ b/Desktop/widgets/listmodelassignedinterface.h
@@ -34,7 +34,7 @@ public:
 	ListModelAvailableInterface*	source() const												{ return _source; }
 	
 public slots:
-	virtual void availableTermsChanged(const Terms* termsAdded, const Terms* termsRemoved) {}
+	virtual void availableTermsChanged(Terms termsAdded, Terms termsRemoved) {}
 
 protected:
 	ListModelAvailableInterface*			_source;

--- a/Desktop/widgets/listmodelassignedinterface.h
+++ b/Desktop/widgets/listmodelassignedinterface.h
@@ -34,7 +34,10 @@ public:
 	ListModelAvailableInterface*	source() const												{ return _source; }
 	
 public slots:
-	virtual void availableTermsChanged(Terms termsAdded, Terms termsRemoved) {}
+	virtual void availableTermsResetHandler(Terms termsAdded, Terms termsRemoved)	{}
+	virtual void availableNamesChangedHandler(QMap<QString, QString> map)			{ sourceNamesChanged(map); }
+	virtual void availableTypeChangedHandler(QString name)							{ sourceTypeChanged(name); }
+			int  sourceTypeChanged(QString name)									override;
 
 protected:
 	ListModelAvailableInterface*			_source;

--- a/Desktop/widgets/listmodelavailableinterface.cpp
+++ b/Desktop/widgets/listmodelavailableinterface.cpp
@@ -46,8 +46,21 @@ void ListModelAvailableInterface::sortItems(SortType sortType)
 	switch(sortType)
 	{
 	case SortType::None:
+	{
+		Terms allowed, forbidden;
+
+		for (const Term &term : _allTerms)
+		{
+			if ( ! isAllowed(term))	forbidden.add(term);
+			else					allowed.add(term);
+		}
+
+		_allTerms.clear();
+		_allTerms.add(allowed);
+		_allTerms.add(forbidden);
 		_allSortedTerms = _allTerms;
 		break;
+	}
 
 	case SortType::SortByName:
 	{
@@ -94,26 +107,9 @@ void ListModelAvailableInterface::sortItems(SortType sortType)
 	endResetModel();
 }
 
-void ListModelAvailableInterface::sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved)
+void ListModelAvailableInterface::sourceTermsChanged()
 {
-	Q_UNUSED(termsAdded);
-	Q_UNUSED(termsRemoved);
-	
-	resetTermsFromSourceModels();
-}
-
-void ListModelAvailableInterface::setChangedTerms(const Terms &newTerms)
-{
-	_tempRemovedTerms.clear();
-	_tempAddedTerms.clear();
-
-	for (const Term& term : _allTerms)
-		if (!newTerms.contains(term))
-			_tempRemovedTerms.add(term);
-
-	for (const Term& term : newTerms)
-		if (!_allTerms.contains(term))
-			_tempAddedTerms.add(term);
+	resetTermsFromSources();
 }
 
 void ListModelAvailableInterface::removeTermsInAssignedList()

--- a/Desktop/widgets/listmodelavailableinterface.h
+++ b/Desktop/widgets/listmodelavailableinterface.h
@@ -50,10 +50,14 @@ public:
 			void										setTermsAreInteractions(bool interactions)	override;
 
 signals:
-			void allAvailableTermsChanged(Terms termsAdded, Terms termsRemoved);
+			void availableTermsReset(Terms termsAdded, Terms termsRemoved);
+			void availableNamesChanged(QMap<QString, QString>);
+			void availableTypeChanged(QString name);
 
 public slots:
-			void sourceTermsChanged()								override;
+			void sourceTermsReset()										override;
+			void sourceNamesChanged(QMap<QString, QString> map)			override;
+			int  sourceTypeChanged(QString name)						override;
 			void removeAssignedModel(ListModelDraggable* model);
 
 protected:

--- a/Desktop/widgets/listmodelavailableinterface.h
+++ b/Desktop/widgets/listmodelavailableinterface.h
@@ -36,7 +36,7 @@ public:
 	
 	virtual const Terms& allTerms()																						const { return _allSortedTerms; }
 			void initTerms(const Terms &terms, const RowControlsOptions& _rowControlsOptions = RowControlsOptions())	override;
-	virtual void resetTermsFromSourceModels(bool updateAssigned = true)			= 0;
+	virtual void resetTermsFromSources(bool updateAssigned = true)			= 0;
 	virtual void removeTermsInAssignedList();
 	
 			QVariant requestInfo(const Term &term, VariableInfo::InfoType info)			const override;
@@ -50,22 +50,17 @@ public:
 			void										setTermsAreInteractions(bool interactions)	override;
 
 signals:
-			void allAvailableTermsChanged(Terms* termsAdded, Terms* termsRemoved);
+			void allAvailableTermsChanged(Terms termsAdded, Terms termsRemoved);
 
 public slots:
-			void sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved) override;
+			void sourceTermsChanged()								override;
 			void removeAssignedModel(ListModelDraggable* model);
 
 protected:
-	Terms					_allTerms;
-	Terms					_allSortedTerms;
-
-	Terms					_tempRemovedTerms;
-	Terms					_tempAddedTerms;
+	Terms								_allTerms;
+	Terms								_allSortedTerms;
 
 	QList<ListModelAssignedInterface*>	_assignedModels;
-
-	void setChangedTerms(const Terms &newTerms);
 };
 
 #endif // LISTMODELTERMSAVAILABLEINTERFACE_H

--- a/Desktop/widgets/listmodelcustomcontrasts.cpp
+++ b/Desktop/widgets/listmodelcustomcontrasts.cpp
@@ -48,7 +48,7 @@ ListModelCustomContrasts::ListModelCustomContrasts(TableViewBase *parent, QStrin
 	connect(listView(), SIGNAL(scaleFactorChanged()),			this, SLOT(scaleFactorChanged()));
 }
 
-void ListModelCustomContrasts::sourceTermsChanged()
+void ListModelCustomContrasts::sourceTermsReset()
 {
 	_resetValuesEtc();
 }
@@ -224,7 +224,6 @@ void ListModelCustomContrasts::_resetValuesEtc()
 	emit columnCountChanged();
 	emit rowCountChanged();
 	emit variableCountChanged();
-	emit termsChanged();
 }
 
 
@@ -252,8 +251,6 @@ void ListModelCustomContrasts::reset()
 	endResetModel();
 
 	emit columnCountChanged();
-	emit termsChanged();
-
 }
 
 void ListModelCustomContrasts::setup()
@@ -270,7 +267,7 @@ void ListModelCustomContrasts::setup()
 	}
 }
 
-int ListModelCustomContrasts::getMaximumColumnWidthInCharacters(size_t columnIndex) const
+int ListModelCustomContrasts::getMaximumColumnWidthInCharacters(size_t) const
 {
 	return 5;
 }
@@ -436,10 +433,8 @@ void ListModelCustomContrasts::modelChangedSlot() // Should move this to listmod
 
 void ListModelCustomContrasts::labelChanged(QString columnName, QString originalLabel, QString newLabel)
 {
-	bool isChanged = _labelChanged(columnName, originalLabel, newLabel);
-
-	if (isChanged)
-		emit termsChanged();
+	if (_labelChanged(columnName, originalLabel, newLabel))
+		refresh();
 }
 
 bool ListModelCustomContrasts::_labelChanged(const QString& columnName, const QString& originalLabel, const QString& newLabel)
@@ -522,8 +517,6 @@ void ListModelCustomContrasts::scaleFactorChanged()
 				_labelChanged(scaleVariable, QString::number(oldScaleFactor), QString::number(_scaleFactor));
 			}
 			endResetModel();
-
-			emit termsChanged();
 		}
 	}
 

--- a/Desktop/widgets/listmodelcustomcontrasts.cpp
+++ b/Desktop/widgets/listmodelcustomcontrasts.cpp
@@ -34,6 +34,9 @@ ListModelCustomContrasts::ListModelCustomContrasts(TableViewBase *parent, QStrin
 	_values.clear();
 	_colNames.push_back(getDefaultColName(0));
 	_values.push_back({});
+	_loadColumnInfo();
+
+	_needsSource = _colName.isEmpty();
 
 	parent->setProperty("parseDefaultValue", false);
 	parent->setProperty("defaultEmptyValue", _defaultCellVal);
@@ -45,7 +48,7 @@ ListModelCustomContrasts::ListModelCustomContrasts(TableViewBase *parent, QStrin
 	connect(listView(), SIGNAL(scaleFactorChanged()),			this, SLOT(scaleFactorChanged()));
 }
 
-void ListModelCustomContrasts::sourceTermsChanged(const Terms *, const Terms *)
+void ListModelCustomContrasts::sourceTermsChanged()
 {
 	_resetValuesEtc();
 }
@@ -255,8 +258,6 @@ void ListModelCustomContrasts::reset()
 
 void ListModelCustomContrasts::setup()
 {
-	// This cannot be done in the constructor: the form is then not yet known.
-	connect(_tableView->form(), &AnalysisForm::dataSetChanged, this, &ListModelCustomContrasts::dataSetChangedHandler,	Qt::QueuedConnection	);
 	QString factorsSourceName = _tableView->property("factorsSource").toString();
 	if (!factorsSourceName.isEmpty())
 	{
@@ -267,7 +268,6 @@ void ListModelCustomContrasts::setup()
 			connect(factorsSourceModel, &ListModelRepeatedMeasuresFactors::termsChanged, this, &ListModelCustomContrasts::factorsSourceChanged);
 		}
 	}
-	_loadColumnInfo();
 }
 
 int ListModelCustomContrasts::getMaximumColumnWidthInCharacters(size_t columnIndex) const
@@ -537,11 +537,6 @@ void ListModelCustomContrasts::setColName(QString colName)
 	_colName = colName;
 	emit colNameChanged(_colName);
 
-	_resetValuesEtc();
-}
-
-void ListModelCustomContrasts::dataSetChangedHandler()
-{
 	_resetValuesEtc();
 }
 

--- a/Desktop/widgets/listmodelcustomcontrasts.h
+++ b/Desktop/widgets/listmodelcustomcontrasts.h
@@ -48,7 +48,7 @@ public:
 
 
 public slots:
-	void sourceTermsChanged()											override;
+	void sourceTermsReset()											override;
 	void modelChangedSlot()												override;
 	void labelChanged(	 QString columnName, QString originalLabel, QString newLabel);
 	void labelsReordered(QString columnName);

--- a/Desktop/widgets/listmodelcustomcontrasts.h
+++ b/Desktop/widgets/listmodelcustomcontrasts.h
@@ -48,13 +48,12 @@ public:
 
 
 public slots:
-	void sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved)	override;
-	void modelChangedSlot()														override;
+	void sourceTermsChanged()											override;
+	void modelChangedSlot()												override;
 	void labelChanged(	 QString columnName, QString originalLabel, QString newLabel);
 	void labelsReordered(QString columnName);
 	void scaleFactorChanged();
 	void setColName(QString colName);
-	void dataSetChangedHandler();
 	void factorsSourceChanged();
 
 signals:

--- a/Desktop/widgets/listmodeldraggable.cpp
+++ b/Desktop/widgets/listmodeldraggable.cpp
@@ -57,14 +57,12 @@ void ListModelDraggable::removeTerms(const QList<int> &indices)
 	Terms termsToRemove;
 
 	for (int index : indices)
-		if (index < int(_terms.size()))
-			termsToRemove.add(_terms.at(size_t(index)));
+		if (index < int(terms().size()))
+			termsToRemove.add(terms().at(size_t(index)));
 
-	_terms.remove(termsToRemove);
+	_removeTerms(termsToRemove);
 
 	endResetModel();
-
-	emit termsChanged();
 }
 
 
@@ -98,10 +96,8 @@ Terms ListModelDraggable::addTerms(const Terms& terms, int dropItemIndex, JASPCo
 	if (terms.size() > 0)
 	{
 		beginResetModel();
-		_terms.add(terms);
+		_addTerms(terms);
 		endResetModel();
-
-		emit termsChanged();
 	}
 
 	return nullptr;

--- a/Desktop/widgets/listmodeldraggable.cpp
+++ b/Desktop/widgets/listmodeldraggable.cpp
@@ -54,16 +54,17 @@ void ListModelDraggable::removeTerms(const QList<int> &indices)
 {
 	beginResetModel();
 
-	_tempTermsToRemove.clear();
+	Terms termsToRemove;
+
 	for (int index : indices)
 		if (index < int(_terms.size()))
-			_tempTermsToRemove.add(_terms.at(size_t(index)));
+			termsToRemove.add(_terms.at(size_t(index)));
 
-	_terms.remove(_tempTermsToRemove);
+	_terms.remove(termsToRemove);
 
 	endResetModel();
 
-	emit termsChanged(nullptr, &_tempTermsToRemove);
+	emit termsChanged();
 }
 
 
@@ -100,8 +101,7 @@ Terms ListModelDraggable::addTerms(const Terms& terms, int dropItemIndex, JASPCo
 		_terms.add(terms);
 		endResetModel();
 
-		_tempTermsToAdd = terms;
-		emit termsChanged(&_tempTermsToAdd, nullptr);
+		emit termsChanged();
 	}
 
 	return nullptr;

--- a/Desktop/widgets/listmodeldraggable.h
+++ b/Desktop/widgets/listmodeldraggable.h
@@ -52,8 +52,6 @@ protected:
 	bool						_addNewAvailableTermsToAssignedModel	= false;
 	bool						_allowAnalysisOwnComputedColumns		= true;
 	JASPControl::DropMode		_dropMode								= JASPControl::DropMode::DropNone;
-	Terms						_tempTermsToRemove;
-	Terms						_tempTermsToAdd;
 		
 	bool						isAllowed(const Term &term) const;
 };

--- a/Desktop/widgets/listmodelfactorsform.h
+++ b/Desktop/widgets/listmodelfactorsform.h
@@ -40,7 +40,7 @@ public:
 	int						rowCount(const QModelIndex &parent = QModelIndex())			const override { return count(); }
 	QVariant				data(const QModelIndex &index, int role = Qt::DisplayRole)	const override;
 	
-	const Terms&			terms(const QString& what = QString())						const override;
+	Terms					termsEx(const QString& what)									override;
 	void					initFactors(const std::vector<std::tuple<std::string, std::string, std::vector<std::string> > > &factors);
 	int						count() const { return int(_factors.size()); }
 	std::vector<std::tuple<std::string, std::string, std::vector<std::string> > > getFactors() const;

--- a/Desktop/widgets/listmodelfiltereddataentry.cpp
+++ b/Desktop/widgets/listmodelfiltereddataentry.cpp
@@ -24,7 +24,6 @@ ListModelFilteredDataEntry::ListModelFilteredDataEntry(TableViewBase * parent, Q
 	connect(_tableView,			SIGNAL(filterSignal(QString)),					this, SLOT(setFilter(QString))														);
 	connect(_tableView,			SIGNAL(colNameSignal(QString)),					this, SLOT(setColName(QString))														);
 	connect(_tableView,			SIGNAL(extraColSignal(QString)),				this, SLOT(setExtraCol(QString))													);
-	connect(_tableView->form(), &AnalysisForm::dataSetChanged,					this, &ListModelFilteredDataEntry::dataSetChangedHandler,	Qt::QueuedConnection	);
 	connect(this,				&ListModelFilteredDataEntry::filterChanged,		[&](){ _tableView->setProperty("filter",	_filter);	}						);
 	connect(this,				&ListModelFilteredDataEntry::colNameChanged,	[&](){ _tableView->setProperty("colName",	_colName);	}						);
 
@@ -34,12 +33,13 @@ ListModelFilteredDataEntry::ListModelFilteredDataEntry(TableViewBase * parent, Q
 
 }
 
-void ListModelFilteredDataEntry::dataSetChangedHandler()
+//TODO: This is not called anymore, but should be handled by termsChangedHandler
+/*void ListModelFilteredDataEntry::dataSetChangedHandler()
 {
 	//std::cout << "ListModelFilteredDataEntry::dataSetChangedHandler()" << std::endl;
 	setAcceptedRowsTrue();
 	runFilter(_filter);
-}
+}*/
 
 void ListModelFilteredDataEntry::setFilter(QString filter)
 {
@@ -149,7 +149,7 @@ Qt::ItemFlags ListModelFilteredDataEntry::flags(const QModelIndex & index) const
 }
 
 
-void ListModelFilteredDataEntry::sourceTermsChanged(const Terms *, const Terms *)
+void ListModelFilteredDataEntry::sourceTermsChanged()
 {
 	//std::cout << "ListModelFilteredDataEntry::sourceTermsChanged(Terms *, Terms *)" << std::endl;
 

--- a/Desktop/widgets/listmodelfiltereddataentry.cpp
+++ b/Desktop/widgets/listmodelfiltereddataentry.cpp
@@ -111,7 +111,6 @@ void ListModelFilteredDataEntry::setAcceptedRows(std::vector<bool> newRows)
 	{
 		emit acceptedRowsChanged();
 		fillTable();
-		emit termsChanged();
 	}
 }
 
@@ -132,7 +131,6 @@ void ListModelFilteredDataEntry::itemChanged(int column, int row, QVariant value
 			_enteredValues[_filteredRowToData[row]] = value.toDouble();
 
 			emit dataChanged(index(row, column), index(row, column), { Qt::DisplayRole });
-			emit termsChanged();
 
 			if(gotLarger)
 				emit headerDataChanged(Qt::Orientation::Horizontal, column, column);
@@ -149,7 +147,7 @@ Qt::ItemFlags ListModelFilteredDataEntry::flags(const QModelIndex & index) const
 }
 
 
-void ListModelFilteredDataEntry::sourceTermsChanged()
+void ListModelFilteredDataEntry::sourceTermsReset()
 {
 	//std::cout << "ListModelFilteredDataEntry::sourceTermsChanged(Terms *, Terms *)" << std::endl;
 
@@ -172,8 +170,6 @@ void ListModelFilteredDataEntry::sourceTermsChanged()
 	_columnCount		= _colNames.size();
 
 	fillTable();
-
-	emit termsChanged();
 }
 
 OptionsTable * ListModelFilteredDataEntry::createOption()
@@ -204,7 +200,6 @@ void ListModelFilteredDataEntry::initValues(OptionsTable * bindHere)
 	{
 		//addControlError("Not a single row in OptionsTable for ListModelFilteredDataEntry!");
 		fillTable();
-		emit termsChanged();
 		return;
 	}
 
@@ -397,7 +392,7 @@ void ListModelFilteredDataEntry::setColName(QString colName)
 
 	_colName = colName;
 	emit colNameChanged(_colName);
-	emit termsChanged();
+	refresh();
 
 	if (_editableColumn >= 0)
 		emit headerDataChanged(Qt::Horizontal, _editableColumn, _editableColumn);
@@ -459,7 +454,6 @@ void ListModelFilteredDataEntry::setExtraCol(QString extraCol)
 
 	emit columnCountChanged();
 	emit extraColChanged(_extraCol);
-	emit termsChanged();
 }
 
 void ListModelFilteredDataEntry::refreshModel()

--- a/Desktop/widgets/listmodelfiltereddataentry.h
+++ b/Desktop/widgets/listmodelfiltereddataentry.h
@@ -48,7 +48,7 @@ public:
 
 
 public slots:
-	void	sourceTermsChanged()															override;
+	void	sourceTermsReset()															override;
 	void	modelChangedSlot()																override;
 	void	setFilter(QString filter);
 	void	setColName(QString colName);

--- a/Desktop/widgets/listmodelfiltereddataentry.h
+++ b/Desktop/widgets/listmodelfiltereddataentry.h
@@ -48,10 +48,9 @@ public:
 
 
 public slots:
-	void	sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved)			override;
+	void	sourceTermsChanged()															override;
 	void	modelChangedSlot()																override;
 	void	setFilter(QString filter);
-	void	dataSetChangedHandler();
 	void	setColName(QString colName);
 	void	setExtraCol(QString extraCol);
 

--- a/Desktop/widgets/listmodelinputvalue.h
+++ b/Desktop/widgets/listmodelinputvalue.h
@@ -37,7 +37,6 @@ public slots:
 	void itemRemoved(int row);
 		
 protected:
-	void			_removeTerm(int row);
 	QString			_makeUnique(const QString& val, int row = -1);
 	QString			_changeLastNumber(const QString& val);
 

--- a/Desktop/widgets/listmodelinteractionassigned.cpp
+++ b/Desktop/widgets/listmodelinteractionassigned.cpp
@@ -136,17 +136,17 @@ void ListModelInteractionAssigned::_addTerms(const Terms& terms, bool combineWit
 	
 }
 
-void ListModelInteractionAssigned::availableTermsChanged(const Terms *termsAdded, const Terms *termsRemoved)
+void ListModelInteractionAssigned::availableTermsChanged(Terms termsAdded, Terms termsRemoved)
 {
-	if (termsAdded && termsAdded->size() > 0 && _addNewAvailableTermsToAssignedModel)
+	if (termsAdded.size() > 0 && _addNewAvailableTermsToAssignedModel)
 	{
-		_addTerms(*termsAdded, _addInteractionsByDefault);
+		_addTerms(termsAdded, _addInteractionsByDefault);
 		setTerms();
 	}
 	
-	if (termsRemoved && termsRemoved->size() > 0)
+	if (termsRemoved.size() > 0)
 	{
-		removeInteractionTerms(*termsRemoved);
+		removeInteractionTerms(termsRemoved);
 		setTerms();
 	}
 }

--- a/Desktop/widgets/listmodelinteractionassigned.h
+++ b/Desktop/widgets/listmodelinteractionassigned.h
@@ -44,7 +44,7 @@ public:
 
 		
 public slots:
-	void availableTermsChanged(const Terms* termsToAdd, const Terms* termsToRemove) override;
+	void availableTermsChanged(Terms termsToAdd, Terms termsToRemove)								override;
 	
 protected:
 	void addCombinedTerms(const Terms& terms, JASPControl::AssignType assignType);

--- a/Desktop/widgets/listmodelinteractionassigned.h
+++ b/Desktop/widgets/listmodelinteractionassigned.h
@@ -33,18 +33,16 @@ public:
 	ListModelInteractionAssigned(JASPListControl* listView, bool mustContainLowerTerms, bool addInteractionsByDefault);
 
 	void			initTerms(const Terms &terms, const RowControlsOptions& = RowControlsOptions())	override;
-	void			setAvailableModel(ListModelAvailableInterface *source)							override;
 	Terms			termsFromIndexes(const QList<int> &indexes)								const	override;
 	Terms			canAddTerms(const Terms& terms) const override;
 	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, JASPControl::AssignType assignType = JASPControl::AssignType::AssignDefault) override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)					override;
 	void			removeTerms(const QList<int> &indices)											override;
 	QString			getItemType(const Term &term)											const	override;
-	const Terms&	terms(const QString& what = QString())									const	override;
-
+	Terms			termsEx(const QString& what)													override;
 		
 public slots:
-	void availableTermsChanged(Terms termsToAdd, Terms termsToRemove)								override;
+	void availableTermsResetHandler(Terms termsToAdd, Terms termsToRemove)							override;
 	
 protected:
 	void addCombinedTerms(const Terms& terms, JASPControl::AssignType assignType);

--- a/Desktop/widgets/listmodelinteractionavailable.cpp
+++ b/Desktop/widgets/listmodelinteractionavailable.cpp
@@ -37,10 +37,8 @@ void ListModelInteractionAvailable::resetTermsFromSources(bool updateAssigned)
 	Terms randomFactors;
 	Terms covariates;
 
-	for (const auto& pair : listView()->getTermsPerSource())
+	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
-		SourceItem* sourceItem = pair.first;
-		const Terms& terms = pair.second;
 		ListModel* sourceModel = sourceItem->model();
 		for (const Term& term : terms)
 		{
@@ -55,7 +53,7 @@ void ListModelInteractionAvailable::resetTermsFromSources(bool updateAssigned)
 			else if (itemType == "covariates")
 				covariates.add(term);
 		}
-	}
+	});
 		
 	if (fixedFactors.size() > 0)
 		addFixedFactors(fixedFactors);

--- a/Desktop/widgets/listmodelinteractionavailable.cpp
+++ b/Desktop/widgets/listmodelinteractionavailable.cpp
@@ -25,7 +25,7 @@
 ListModelInteractionAvailable::ListModelInteractionAvailable(JASPListControl* listView)
 	: ListModelAvailableInterface(listView), InteractionModel ()
 {
-	_areTermsInteractions = true;
+	setTermsAreInteractions(true);
 }
 
 void ListModelInteractionAvailable::resetTermsFromSources(bool updateAssigned)
@@ -39,7 +39,7 @@ void ListModelInteractionAvailable::resetTermsFromSources(bool updateAssigned)
 
 	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
-		ListModel* sourceModel = sourceItem->model();
+		ListModel* sourceModel = sourceItem->listModel();
 		for (const Term& term : terms)
 		{
 			QString itemType = sourceModel ? sourceModel->getItemType(term) : "";
@@ -76,15 +76,14 @@ void ListModelInteractionAvailable::resetTermsFromSources(bool updateAssigned)
 			addedTerms.add(term);
 	
 	_allTerms.set(interactions);
-	_terms.set(interactions);
-	_terms.setSortParent(_allTerms);
+	_setTerms(interactions, _allTerms);
 	
 	removeTermsInAssignedList();
 	
 	endResetModel();
 
 	if (updateAssigned)
-		emit allAvailableTermsChanged(addedTerms, removedTerms);
+		emit availableTermsReset(addedTerms, removedTerms);
 
 }
 

--- a/Desktop/widgets/listmodelinteractionavailable.h
+++ b/Desktop/widgets/listmodelinteractionavailable.h
@@ -29,7 +29,7 @@ class ListModelInteractionAvailable : public ListModelAvailableInterface, public
 public:
 	ListModelInteractionAvailable(JASPListControl* listView);
 	
-	void resetTermsFromSourceModels(bool updateAssigned = true) override;
+	void resetTermsFromSources(bool updateAssigned = true) override;
 };
 
 #endif // LISTMODELINTERACTIONAVAILABLE_H

--- a/Desktop/widgets/listmodeljagsdatainput.cpp
+++ b/Desktop/widgets/listmodeljagsdatainput.cpp
@@ -39,7 +39,7 @@ ListModelJAGSDataInput::ListModelJAGSDataInput(TableViewBase *parent, QString ta
 	parent->setProperty("defaultEmptyValue", _defaultCellVal);
 }
 
-void ListModelJAGSDataInput::sourceTermsChanged()
+void ListModelJAGSDataInput::sourceTermsReset()
 {
 	beginResetModel();
 
@@ -83,7 +83,6 @@ void ListModelJAGSDataInput::sourceTermsChanged()
 
 	emit columnCountChanged();
 	emit rowCountChanged();
-	emit termsChanged();
 }
 
 

--- a/Desktop/widgets/listmodeljagsdatainput.cpp
+++ b/Desktop/widgets/listmodeljagsdatainput.cpp
@@ -39,7 +39,7 @@ ListModelJAGSDataInput::ListModelJAGSDataInput(TableViewBase *parent, QString ta
 	parent->setProperty("defaultEmptyValue", _defaultCellVal);
 }
 
-void ListModelJAGSDataInput::sourceTermsChanged(const Terms *, const Terms *)
+void ListModelJAGSDataInput::sourceTermsChanged()
 {
 	beginResetModel();
 

--- a/Desktop/widgets/listmodeljagsdatainput.h
+++ b/Desktop/widgets/listmodeljagsdatainput.h
@@ -39,8 +39,8 @@ public:
 	bool			isRCodeColumn(int col)						const				{ return col == 1; }
 
 public slots:
-	void sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved)	override;
-	void modelChangedSlot()														override;
+	void sourceTermsChanged()											override;
+	void modelChangedSlot()												override;
 };
 
 #endif // ListModelJAGSDataInput_H

--- a/Desktop/widgets/listmodeljagsdatainput.h
+++ b/Desktop/widgets/listmodeljagsdatainput.h
@@ -39,7 +39,7 @@ public:
 	bool			isRCodeColumn(int col)						const				{ return col == 1; }
 
 public slots:
-	void sourceTermsChanged()											override;
+	void sourceTermsReset()											override;
 	void modelChangedSlot()												override;
 };
 

--- a/Desktop/widgets/listmodellabelvalueterms.cpp
+++ b/Desktop/widgets/listmodellabelvalueterms.cpp
@@ -121,19 +121,16 @@ void ListModelLabelValueTerms::setLabelValuesFromSource()
 	if (_listView->addEmptyValue())
 		labelValuePairs.push_back(std::make_pair(_listView->placeholderText(), ""));
 
-	for (const auto& pair : listView()->getTermsPerSource())
+	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
-		SourceItem* sourceItem = pair.first;
-		const Terms& terms = pair.second;
-		ListModel* sourceModel = sourceItem->model();
-		ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceModel);
+		ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceItem->model());
 		for (const Term& term : terms)
 		{
 			QString label = term.asQString();
 			QString value = labelValueSourceModel ? labelValueSourceModel->getValue(label) : label;
 			labelValuePairs.push_back(std::make_pair(label, value));
 		}
-	}
+	});
 
 	_setLabelValues(labelValuePairs);
 }

--- a/Desktop/widgets/listmodellabelvalueterms.cpp
+++ b/Desktop/widgets/listmodellabelvalueterms.cpp
@@ -54,8 +54,6 @@ void ListModelLabelValueTerms::resetTermsFromSources(bool )
 	setLabelValuesFromSource();
 
 	endResetModel();
-
-	emit termsChanged();
 }
 
 
@@ -88,7 +86,7 @@ int ListModelLabelValueTerms::getIndexOfValue(const QString &value)
 {
 	int index = 0;
 	QString label = getLabel(value);
-	for (const Term& term : _terms)
+	for (const Term& term : terms())
 	{
 		if (term.asQString() == label)
 			return index;
@@ -102,28 +100,30 @@ void ListModelLabelValueTerms::_setLabelValues(const JASPListControl::LabelValue
 {
 	_valueToLabelMap.clear();
 	_labelToValueMap.clear();
-	_terms.clear();
+	Terms newTerms;
 
 	for (const auto& labelValue :labelvalues)
 	{
 		const QString& label = labelValue.first;
 		const QString& value = labelValue.second;
-		_terms.add(label);
+		newTerms.add(label);
 		_valueToLabelMap[value] = label;
 		_labelToValueMap[label] = value;
 	}
+
+	_setTerms(newTerms);
 }
 
 void ListModelLabelValueTerms::setLabelValuesFromSource()
 {
 	JASPListControl::LabelValueMap labelValuePairs;
 
-	if (_listView->addEmptyValue())
-		labelValuePairs.push_back(std::make_pair(_listView->placeholderText(), ""));
+	if (listView()->addEmptyValue())
+		labelValuePairs.push_back(std::make_pair(listView()->placeholderText(), ""));
 
 	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
-		ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceItem->model());
+		ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceItem->listModel());
 		for (const Term& term : terms)
 		{
 			QString label = term.asQString();
@@ -133,5 +133,46 @@ void ListModelLabelValueTerms::setLabelValuesFromSource()
 	});
 
 	_setLabelValues(labelValuePairs);
+}
+
+void ListModelLabelValueTerms::sourceNamesChanged(QMap<QString, QString> map)
+{
+	QMap<QString, QString>	changedNamesMap;
+	QSet<int>				changedIndexes;
+
+	QMapIterator<QString, QString> it(map);
+	while (it.hasNext())
+	{
+		it.next();
+		const QString& oldName = it.key(), newName = it.value();
+		Terms orgTerms = terms();
+		QSet<int> indexes = orgTerms.replaceVariableName(oldName.toStdString(), newName.toStdString());
+		if (indexes.size() > 0)
+		{
+			QString oldValue = _labelToValueMap[oldName];
+			_labelToValueMap.remove(oldName);
+			_valueToLabelMap.remove(oldValue);
+			QString newValue = oldValue;
+			listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
+			{
+				ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceItem->listModel());
+				if (terms.contains(newName) && labelValueSourceModel)
+					newValue = labelValueSourceModel->getValue(newName);
+			});
+			_labelToValueMap[newName] = newValue;
+			_valueToLabelMap[newValue] = newName;
+			changedIndexes += indexes;
+			changedNamesMap[oldName] = newName;
+		}
+	}
+
+	for (int i : changedIndexes)
+	{
+		QModelIndex ind = index(i, 0);
+		emit dataChanged(ind, ind);
+	}
+
+	if (changedNamesMap.size() > 0)
+		emit namesChanged(changedNamesMap);
 }
 

--- a/Desktop/widgets/listmodellabelvalueterms.h
+++ b/Desktop/widgets/listmodellabelvalueterms.h
@@ -20,18 +20,16 @@
 #define LISTMODELLABELVALUETERMS_H
 
 #include "jasplistcontrol.h"
-#include "listmodeltermsavailable.h"
+#include "listmodelavailableinterface.h"
 
-class ListModelLabelValueTerms : public ListModelTermsAvailable
+class ListModelLabelValueTerms : public ListModelAvailableInterface
 {
 	Q_OBJECT
 public:
 	ListModelLabelValueTerms(JASPListControl* listView, const JASPListControl::LabelValueMap& values = JASPListControl::LabelValueMap());
 
 	QVariant					data(const QModelIndex &index, int role = Qt::DisplayRole)	const	override;
-	void						resetTermsFromSourceModels(bool updateAssigned = true)				override;
-	void						initTerms(const Terms &terms, const RowControlsOptions& _rowControlsOptions = RowControlsOptions())	override;
-
+	void						resetTermsFromSources(bool updateAssigned = true)				override;
 
 	std::vector<std::string>	getValues();
 	QString						getValue(const QString& label);

--- a/Desktop/widgets/listmodellabelvalueterms.h
+++ b/Desktop/widgets/listmodellabelvalueterms.h
@@ -38,6 +38,9 @@ public:
 
 	void						setLabelValuesFromSource();
 
+public slots:
+	void						sourceNamesChanged(QMap<QString, QString> map)					override;
+
 protected:
 	void						_setLabelValues(const JASPListControl::LabelValueMap& values);
 

--- a/Desktop/widgets/listmodellayersassigned.cpp
+++ b/Desktop/widgets/listmodellayersassigned.cpp
@@ -90,17 +90,19 @@ int ListModelLayersAssigned::_getLayer(int index, int& indexInLayer, bool inclus
 
 void ListModelLayersAssigned::_setTerms()
 {
-	_terms.clear();
+	Terms newTerms;
 	int layer = 1;
 	for (const QList<QString>& variables : _variables)
 	{
-		_terms.add(tr("Layer %1").arg(layer));
+		newTerms.add(tr("Layer %1").arg(layer));
 		for (const QString& variable : variables)
-			_terms.add(variable);
+			newTerms.add(variable);
 		layer++;
 	}
 
-	_terms.add(tr("Layer %1").arg(layer));
+	newTerms.add(tr("Layer %1").arg(layer));
+
+	ListModel::_setTerms(newTerms);
 }
 
 Terms ListModelLayersAssigned::termsFromIndexes(const QList<int> &indexes) const
@@ -147,8 +149,6 @@ Terms ListModelLayersAssigned::addTerms(const Terms& terms, int dropItemIndex, J
 	_setTerms();
 	
 	endResetModel();
-	
-	emit termsChanged();
 	
 	return result;
 }
@@ -210,9 +210,7 @@ void ListModelLayersAssigned::moveTerms(const QList<int> &indexes, int dropItemI
 
 	_setTerms();
 	
-	endResetModel();
-	
-	emit termsChanged();
+	endResetModel();	
 }
 
 void ListModelLayersAssigned::removeTerms(const QList<int> &indexes)
@@ -242,9 +240,7 @@ void ListModelLayersAssigned::removeTerms(const QList<int> &indexes)
 
 	_setTerms();
 	
-	endResetModel();
-	
-	emit termsChanged();
+	endResetModel();	
 }
 
 QVariant ListModelLayersAssigned::data(const QModelIndex &index, int role) const

--- a/Desktop/widgets/listmodelmeasurescellsassigned.cpp
+++ b/Desktop/widgets/listmodelmeasurescellsassigned.cpp
@@ -28,6 +28,7 @@ using namespace std;
 ListModelMeasuresCellsAssigned::ListModelMeasuresCellsAssigned(JASPListControl* listView)
 	: ListModelAssignedInterface(listView)
 {
+	_needsSource = true;
 }
 
 void ListModelMeasuresCellsAssigned::initLevels(const Terms &levels, const Terms &variables, bool initVariables)
@@ -71,7 +72,7 @@ void ListModelMeasuresCellsAssigned::_fitTermsWithLevels()
 	}
 }
 
-void ListModelMeasuresCellsAssigned::sourceTermsChanged(const Terms *termsAdded, const Terms *termsRemoved)
+void ListModelMeasuresCellsAssigned::sourceTermsChanged()
 {
 	VariablesListBase* measureCellsListView = dynamic_cast<VariablesListBase*>(listView());
 	if (measureCellsListView)
@@ -79,7 +80,7 @@ void ListModelMeasuresCellsAssigned::sourceTermsChanged(const Terms *termsAdded,
 		BoundControlMeasuresCells* boundControl = dynamic_cast<BoundControlMeasuresCells*>(measureCellsListView->boundControl());
 		initLevels(boundControl->getLevels());
 		source()->removeTermsInAssignedList();
-		emit termsChanged(termsAdded, termsRemoved);
+		emit termsChanged();
 	}
 	else
 		Log::log() << "ListView from Measures cells model is not of a Measures Cell type!!";

--- a/Desktop/widgets/listmodelmeasurescellsassigned.h
+++ b/Desktop/widgets/listmodelmeasurescellsassigned.h
@@ -40,7 +40,7 @@ public:
 	void			initLevels(const Terms& levels, const Terms &variables = Terms(), bool initVariables = false);
 
 public slots:	
-	void			sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved) override;
+	void			sourceTermsChanged()																					override;
 	
 private:
 	void			_fitTermsWithLevels();

--- a/Desktop/widgets/listmodelmeasurescellsassigned.h
+++ b/Desktop/widgets/listmodelmeasurescellsassigned.h
@@ -33,14 +33,14 @@ public:
 	QVariant		data(const QModelIndex &index, int role = Qt::DisplayRole)										const	override;
 	Terms			termsFromIndexes(const QList<int> &indexes)														const	override;
 	void			initTerms(const Terms &terms, const RowControlsOptions& allOptionsMap = RowControlsOptions())			override;
-	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault)	override;
+	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault)	override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)											override;
 	void			removeTerms(const QList<int>& indexes) override;
 
 	void			initLevels(const Terms& levels, const Terms &variables = Terms(), bool initVariables = false);
 
 public slots:	
-	void			sourceTermsChanged()																					override;
+	void			sourceTermsReset()																					override;
 	
 private:
 	void			_fitTermsWithLevels();

--- a/Desktop/widgets/listmodelmultinomialchi2test.cpp
+++ b/Desktop/widgets/listmodelmultinomialchi2test.cpp
@@ -35,7 +35,7 @@ ListModelMultinomialChi2Test::ListModelMultinomialChi2Test(TableViewBase * paren
 
 }
 
-void ListModelMultinomialChi2Test::sourceTermsChanged()
+void ListModelMultinomialChi2Test::sourceTermsReset()
 {
 	beginResetModel();
 
@@ -63,7 +63,6 @@ void ListModelMultinomialChi2Test::sourceTermsChanged()
 
 	emit columnCountChanged();
 	emit rowCountChanged();
-	emit termsChanged();
 }
 
 void ListModelMultinomialChi2Test::labelChanged(QString columnName, QString originalLabel, QString newLabel)
@@ -81,8 +80,6 @@ void ListModelMultinomialChi2Test::labelChanged(QString columnName, QString orig
 		}
 
 	endResetModel();
-
-	emit termsChanged();
 }
 
 void ListModelMultinomialChi2Test::labelsReordered(QString columnName)
@@ -107,8 +104,6 @@ void ListModelMultinomialChi2Test::labelsReordered(QString columnName)
 			_values[col].push_back(tempStore[_rowNames[row]][col]);
 
 	endResetModel();
-
-	emit termsChanged();
 }
 
 

--- a/Desktop/widgets/listmodelmultinomialchi2test.cpp
+++ b/Desktop/widgets/listmodelmultinomialchi2test.cpp
@@ -35,7 +35,7 @@ ListModelMultinomialChi2Test::ListModelMultinomialChi2Test(TableViewBase * paren
 
 }
 
-void ListModelMultinomialChi2Test::sourceTermsChanged(const Terms *termsAdded, const Terms *)
+void ListModelMultinomialChi2Test::sourceTermsChanged()
 {
 	beginResetModel();
 
@@ -45,9 +45,10 @@ void ListModelMultinomialChi2Test::sourceTermsChanged(const Terms *termsAdded, c
 	_columnCount = 0;
 	_rowCount    = 0;
 
-	if (termsAdded && termsAdded->size() > 0)
+	Terms newTerms = getSourceTerms();
+	if (newTerms.size() > 0)
 	{
-		_columnBeingTracked	= tq(termsAdded->at(0).asString());
+		_columnBeingTracked	= tq(newTerms.at(0).asString());
 		_rowNames			= DataSetPackage::pkg()->getColumnLabelsAsStringList(fq(_columnBeingTracked)).toVector();
 		_rowCount			= _rowNames.size();
 

--- a/Desktop/widgets/listmodelmultinomialchi2test.h
+++ b/Desktop/widgets/listmodelmultinomialchi2test.h
@@ -32,7 +32,7 @@ public:
 	QString	getDefaultColName(size_t index) const	override;
 
 public slots:
-	void sourceTermsChanged()						override;
+	void sourceTermsReset()						override;
 	void labelChanged(	 QString columnName, QString originalLabel, QString newLabel);
 	void labelsReordered(QString columnName);
 

--- a/Desktop/widgets/listmodelmultinomialchi2test.h
+++ b/Desktop/widgets/listmodelmultinomialchi2test.h
@@ -29,10 +29,10 @@ class ListModelMultinomialChi2Test : public ListModelTableViewBase
 public:
 	explicit ListModelMultinomialChi2Test(TableViewBase * parent, QString tableType);
 
-	QString	getDefaultColName(size_t index) const override;
+	QString	getDefaultColName(size_t index) const	override;
 
 public slots:
-	void sourceTermsChanged(const Terms* termsAdded, const Terms* termsRemoved)	override;
+	void sourceTermsChanged()						override;
 	void labelChanged(	 QString columnName, QString originalLabel, QString newLabel);
 	void labelsReordered(QString columnName);
 

--- a/Desktop/widgets/listmodelmultitermsassigned.cpp
+++ b/Desktop/widgets/listmodelmultitermsassigned.cpp
@@ -134,18 +134,18 @@ void ListModelMultiTermsAssigned::removeTerms(const QList<int> &indexes)
 
 	_setTerms();
 	endResetModel();
-
-	emit termsChanged();
 }
 
 void ListModelMultiTermsAssigned::_setTerms()
 {
-	_terms.clear();
+	Terms newTerms;
 	for (const Terms& terms : _tuples)
 	{
 		for (const Term& term : terms)
-			_terms.add(term, false);
+			newTerms.add(term, false);
 	}
+
+	ListModel::_setTerms(newTerms, false);
 }
 
 
@@ -232,8 +232,6 @@ Terms ListModelMultiTermsAssigned::addTerms(const Terms& termsToAdd, int dropIte
 	
 	_setTerms();
 	endResetModel();
-
-	emit termsChanged();
 
 	return termsToReturn;
 }
@@ -349,6 +347,4 @@ void ListModelMultiTermsAssigned::moveTerms(const QList<int> &indexes, int dropI
 
 	_setTerms();
 	endResetModel();
-	
-	emit termsChanged();
 }

--- a/Desktop/widgets/listmodelrepeatedmeasuresfactors.cpp
+++ b/Desktop/widgets/listmodelrepeatedmeasuresfactors.cpp
@@ -109,9 +109,10 @@ void ListModelRepeatedMeasuresFactors::initFactors(const vector<pair<string, vec
 	Factor extraFactor(tr("RM Factor %1").arg(factorIndex), true, false);
 	_factors.append(extraFactor);
 
+	_setAllLevelsCombinations();
+
 	endResetModel();
 	
-	_setAllLevelsCombinations();	
 }
 
 vector<pair<string, vector<string> > > ListModelRepeatedMeasuresFactors::getFactors() const
@@ -186,7 +187,7 @@ void ListModelRepeatedMeasuresFactors::_updateVirtualFactorIndex()
 void ListModelRepeatedMeasuresFactors::_setAllLevelsCombinations()
 {
 	vector<vector<string> > allLevelsCombinations;
-	_terms.set(_getAllFactorsStringList());
+	_setTerms(_getAllFactorsStringList());
 	
 	vector<vector<string> > allLevels;	
 	vector<string> currentLevels;
@@ -299,13 +300,11 @@ void ListModelRepeatedMeasuresFactors::itemChanged(int row, QVariant value)
 			}
 		}
 
+		_setAllLevelsCombinations();
 		QModelIndex modelIndex = index(row, 0);
 		emit dataChanged(modelIndex, modelIndex);
 	}
 	
-	_setAllLevelsCombinations();
-	
-	emit termsChanged();
 }
 
 QString ListModelRepeatedMeasuresFactors::_removeFactor(int row)
@@ -323,6 +322,7 @@ QString ListModelRepeatedMeasuresFactors::_removeFactor(int row)
 		{
 			beginRemoveRows(QModelIndex(), row, row);
 			_factors.removeAt(row);
+			_setAllLevelsCombinations();
 			endRemoveRows();
 			_updateVirtualLevelIndex(factor.headFactor);
 		}
@@ -346,6 +346,7 @@ QString ListModelRepeatedMeasuresFactors::_removeFactor(int row)
 			beginRemoveRows(QModelIndex(), row, row + countRemoved - 1);
 			for (int i = 0; i < countRemoved; i++)
 				_factors.removeAt(row);
+			_setAllLevelsCombinations();
 			endRemoveRows();
 
 			_updateVirtualFactorIndex();
@@ -360,10 +361,6 @@ QString ListModelRepeatedMeasuresFactors::_removeFactor(int row)
 void ListModelRepeatedMeasuresFactors::itemRemoved(int row)
 {
 	_removeFactor(row);
-	
-	_setAllLevelsCombinations();
-	
-	emit termsChanged();
 }
 
 QStringList ListModelRepeatedMeasuresFactors::_getOtherLevelsStringList(const Factor& item)

--- a/Desktop/widgets/listmodeltableviewbase.h
+++ b/Desktop/widgets/listmodeltableviewbase.h
@@ -67,10 +67,10 @@ public:
 	virtual		OptionsTable *		createOption();
 	virtual		void				modelChangedSlot();
 
-				const QVector<QVector<QVariant>>	&	values()	const { return _values;		}
-				const QVector<QString>				&	rowNames()	const { return _rowNames;	}
-				const QVector<QString>				&	colNames()	const { return _colNames;	}
-				const Terms							&	terms(const QString& what = QString())	const override;
+				const QVector<QVector<QVariant>>	&	values()					const { return _values;		}
+				const QVector<QString>				&	rowNames()					const { return _rowNames;	}
+				const QVector<QString>				&	colNames()					const { return _colNames;	}
+					  Terms								termsEx(const QString& what)	override;
 
 
 				void runRScript(		const QString & script);

--- a/Desktop/widgets/listmodeltermsassigned.cpp
+++ b/Desktop/widgets/listmodeltermsassigned.cpp
@@ -43,29 +43,27 @@ void ListModelTermsAssigned::initTerms(const Terms &terms, const RowControlsOpti
 	}
 }
 
-void ListModelTermsAssigned::availableTermsChanged(const Terms* termsAdded, const Terms* termsRemoved)
+void ListModelTermsAssigned::availableTermsChanged(Terms termsAdded, Terms termsRemoved)
 {
-	if (termsAdded && termsAdded->size() > 0 && _addNewAvailableTermsToAssignedModel)
+	if (termsAdded.size() > 0 && _addNewAvailableTermsToAssignedModel)
 	{
 		beginResetModel();
-		_terms.add(*termsAdded);
+		_terms.add(termsAdded);
 		endResetModel();
 
-		_tempTermsToAdd.set(*termsAdded);
-		emit termsChanged(&_tempTermsToAdd, nullptr);
+		emit termsChanged();
 
 		if (!_copyTermsWhenDropped)
 			source()->removeTermsInAssignedList();
 	}
 
-	if (termsRemoved && termsRemoved->size() > 0)
+	if (termsRemoved.size() > 0)
 	{
 		beginResetModel();
-		_terms.remove(*termsRemoved);
+		_terms.remove(termsRemoved);
 		endResetModel();
 
-		_tempTermsToRemove.set(*termsRemoved);
-		emit termsChanged(nullptr, &_tempTermsToRemove);
+		emit termsChanged();
 	}
 }
 
@@ -104,7 +102,7 @@ Terms ListModelTermsAssigned::addTerms(const Terms& terms, int dropItemIndex, JA
 
 	endResetModel();
 
-	emit termsChanged(&terms, &_tempTermsToSendBack);
+	emit termsChanged();
 
 	return _tempTermsToSendBack;
 }
@@ -133,8 +131,6 @@ void ListModelTermsAssigned::removeTerm(int index)
 {
 	if (index < 0 || index >= int(_terms.size())) return;
 
-	_tempTermsToRemove.clear();
-
 	beginResetModel();
 
 	const Term& term = _terms.at(size_t(index));
@@ -153,11 +149,10 @@ void ListModelTermsAssigned::removeTerm(int index)
 		_rowControlsMap.remove(termQ);
 	}
 	_terms.remove(term);
-	_tempTermsToRemove.add(term);
 
 	endResetModel();
 
-	emit termsChanged(nullptr, &_tempTermsToRemove);
+	emit termsChanged();
 }
 
 void ListModelTermsAssigned::changeTerm(int index, const QString& name)
@@ -171,7 +166,7 @@ void ListModelTermsAssigned::changeTerm(int index, const QString& name)
 		_rowControlsOptions.remove(oldName);
 		_terms.replace(index, Term(name));
 
-		emit termChanged(oldName, name);
+		emit oneTermChanged(oldName, name);
 		emit termsChanged();
 		QModelIndex modelIndex = ListModelTermsAssigned::index(index, 0);
 		emit dataChanged(modelIndex, modelIndex);

--- a/Desktop/widgets/listmodeltermsassigned.h
+++ b/Desktop/widgets/listmodeltermsassigned.h
@@ -31,14 +31,15 @@ public:
 	
 	void			initTerms(const Terms &terms, const RowControlsOptions& allOptionsMap = RowControlsOptions())			override;
 	Terms			canAddTerms(const Terms& terms)																	const	override;
-	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault)	override;
-	const Terms&	terms(const QString& what = QString())															const	override;
+	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault)	override;
+	Terms			termsEx(const QString& what)																			override;
 	void			removeTerm(int index);
 
 	virtual void	changeTerm(int index, const QString& name);
 
 public slots:
-	virtual void availableTermsChanged(Terms termsToAdd, Terms termsToRemove)							override;
+	void availableTermsResetHandler(Terms termsToAdd, Terms termsToRemove)							override;
+
 	
 private:
 	int		_maxRows = -1;

--- a/Desktop/widgets/listmodeltermsassigned.h
+++ b/Desktop/widgets/listmodeltermsassigned.h
@@ -38,7 +38,7 @@ public:
 	virtual void	changeTerm(int index, const QString& name);
 
 public slots:
-	virtual void availableTermsChanged(const Terms* termsToAdd, const Terms* termsToRemove)							override;
+	virtual void availableTermsChanged(Terms termsToAdd, Terms termsToRemove)							override;
 	
 private:
 	int		_maxRows = -1;

--- a/Desktop/widgets/listmodeltermsavailable.cpp
+++ b/Desktop/widgets/listmodeltermsavailable.cpp
@@ -38,8 +38,6 @@ void ListModelTermsAvailable::resetTermsFromSources(bool updateAssigned)
 
 	endResetModel();
 
-	emit termsChanged();
-
 	if (updateAssigned)
-		emit allAvailableTermsChanged(addedTerms, removedTerms);
+		emit availableTermsReset(addedTerms, removedTerms);
 }

--- a/Desktop/widgets/listmodeltermsavailable.cpp
+++ b/Desktop/widgets/listmodeltermsavailable.cpp
@@ -17,50 +17,29 @@
 //
 
 #include "listmodeltermsavailable.h"
-#include "listmodeltermsassigned.h"
-#include "../analysis/analysisform.h"
-#include <QQmlProperty>
 
-ListModelTermsAvailable::ListModelTermsAvailable(JASPListControl* listView)
-	: ListModelAvailableInterface(listView)
-{
-}
-
-void ListModelTermsAvailable::sortItems(SortType sortType)
-{	
-	if (sortType == Sortable::None)
-	{
-		Terms allowed;
-		Terms forbidden;
-
-		for (const Term &term : _allTerms)
-		{
-			if ( ! isAllowed(term))
-				forbidden.add(term);
-			else
-				allowed.add(term);
-		}
-
-		_allTerms.clear();
-		_allTerms.add(allowed);
-		_allTerms.add(forbidden);
-	}
-
-	ListModelAvailableInterface::sortItems(sortType);
-}
-
-void ListModelTermsAvailable::resetTermsFromSourceModels(bool updateAssigned)
+void ListModelTermsAvailable::resetTermsFromSources(bool updateAssigned)
 {
 	
 	beginResetModel();
 
 	Terms termsAvailable = getSourceTerms();
+	Terms removedTerms, addedTerms;
 	
-	setChangedTerms(termsAvailable);
+	for (const Term& term : _allTerms)
+		if (!termsAvailable.contains(term))
+			removedTerms.add(term);
+
+	for (const Term& term : termsAvailable)
+		if (!_allTerms.contains(term))
+			addedTerms.add(term);
+
 	initTerms(termsAvailable);
 
 	endResetModel();
 
+	emit termsChanged();
+
 	if (updateAssigned)
-		emit allAvailableTermsChanged(&_tempAddedTerms, &_tempRemovedTerms);
+		emit allAvailableTermsChanged(addedTerms, removedTerms);
 }

--- a/Desktop/widgets/listmodeltermsavailable.h
+++ b/Desktop/widgets/listmodeltermsavailable.h
@@ -20,16 +20,14 @@
 #define LISTMODELTERMSAVAILABLE_H
 
 #include "listmodelavailableinterface.h"
-#include "common.h"
 
 class ListModelTermsAvailable : public ListModelAvailableInterface
 {
 	Q_OBJECT
 public:
-	ListModelTermsAvailable(JASPListControl* listView);
+	ListModelTermsAvailable(JASPListControl* listView) : ListModelAvailableInterface(listView) {}
 		
-	void		sortItems(SortType sortType)							override;
-	void		resetTermsFromSourceModels(bool updateAssigned = true)	override;	
+	void	resetTermsFromSources(bool updateAssigned = true)	override;
 };
 
 #endif // LISTMODELTERMSAVAILABLE_H

--- a/Desktop/widgets/rowcontrols.cpp
+++ b/Desktop/widgets/rowcontrols.cpp
@@ -92,7 +92,7 @@ bool RowControls::addJASPControl(JASPControl *control)
 		_rowJASPControlMap[control->name()] = control;
 		BoundControl* boundItem = dynamic_cast<BoundControl*>(control);
 
-		if (boundItem && !isDummy)
+		if (control->isBound() && boundItem && !isDummy)
 		{
 			bool hasOption = _rowOptions.contains(control->name());
 			Option* option =  hasOption ? _rowOptions[control->name()] : boundItem->createOption();
@@ -104,7 +104,7 @@ bool RowControls::addJASPControl(JASPControl *control)
 				// If a ListView depends on a source, it has to be initialized by this source
 				// For this just call the sourceTermsChanged handler.
 				if (listView && listView->hasSource())
-					listView->model()->sourceTermsChanged(nullptr, nullptr);
+					listView->model()->sourceTermsChanged();
 			}
 		}
 

--- a/Desktop/widgets/rowcontrols.cpp
+++ b/Desktop/widgets/rowcontrols.cpp
@@ -104,7 +104,7 @@ bool RowControls::addJASPControl(JASPControl *control)
 				// If a ListView depends on a source, it has to be initialized by this source
 				// For this just call the sourceTermsChanged handler.
 				if (listView && listView->hasSource())
-					listView->model()->sourceTermsChanged();
+					listView->model()->sourceTermsReset();
 			}
 		}
 

--- a/Desktop/widgets/sourceitem.cpp
+++ b/Desktop/widgets/sourceitem.cpp
@@ -1,0 +1,406 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#include "sourceitem.h"
+
+#include "analysis/analysisform.h"
+#include "jasplistcontrol.h"
+#include "listmodellabelvalueterms.h"
+#include <QQmlEngine>
+
+SourceItem::SourceItem(
+		  JASPListControl*							listControl
+		, QMap<QString, QVariant>&					map
+		, const JASPListControl::LabelValueMap&		values
+		, QAbstractItemModel*						nativeModel
+		, const QVector<SourceItem*>&				discardSources
+		, const QVector<QMap<QString, QVariant> >&	conditionVariables
+		) : _listControl(listControl)
+{
+	_name					= map["name"].toString();
+	_controlName			= map["controlName"].toString();
+	_modelUse				= map["use"].toString();
+	_conditionExpression	= map["condition"].toString();
+	_values					= values;
+	_nativeModel			= nativeModel;
+	_discardSources			= discardSources;
+
+	_isValuesSource			= map.contains("isValuesSource")			? map["isValuesSource"].toBool()			: false;
+	_isDataSetColumns		= map.contains("isDataSetColumns")			? map["isDataSetColumns"].toBool()			: false;
+	_combineWithOtherModels	= map.contains("combineWithOtherModels")	? map["combineWithOtherModels"].toBool()	: false;
+	_nativeModelRole		= map.contains("nativeModelRole")			? map["nativeModelRole"].toInt()			: Qt::DisplayRole;
+
+	if (!_controlName.isEmpty()) _usedControls.insert(_controlName);
+
+
+	for (const QMap<QString, QVariant>& conditionVariable : conditionVariables)
+	{
+		_conditionVariables.push_back(ConditionVariable(conditionVariable["name"].toString()
+									, conditionVariable["component"].toString()
+									, conditionVariable["property"].toString()
+									, conditionVariable["addQuotes"].toBool())
+					);
+		if (!conditionVariable["component"].toString().isEmpty()) _usedControls.insert(conditionVariable["component"].toString());
+	}
+
+	_setUp();
+}
+
+SourceItem::SourceItem(JASPListControl *listControl, const JASPListControl::LabelValueMap &values)
+	:  _listControl(listControl), _values(values), _isValuesSource(true)
+{
+	_setUp();
+}
+
+SourceItem::SourceItem(JASPListControl *listControl, QAbstractItemModel *nativeModel, int nativeModelRole)
+	 : _listControl(listControl), _nativeModel(nativeModel), _nativeModelRole(nativeModelRole)
+{
+	_setUp();
+}
+
+SourceItem::SourceItem(JASPListControl *listControl)
+	:  _listControl(listControl), _isDataSetColumns(true)
+{
+	_setUp();
+}
+
+
+void SourceItem::_setUp()
+{
+	ListModel* sourceModel = nullptr;
+
+	if (_isDataSetColumns)
+	{
+		_nativeModel = AnalysisForm::columnsModel;
+		_nativeModelRole = AnalysisForm::columnsModelRole;
+	}
+
+	if (_isValuesSource)								sourceModel = new ListModelLabelValueTerms(_listControl, _values);
+	else if (_nativeModel)								sourceModel = qobject_cast<ListModel*>(_nativeModel); // A nativeModel is not always a ListModel
+	else if (_listControl->form() && !_name.isEmpty())	sourceModel = _listControl->form()->getModel(_name);
+
+	if (sourceModel)
+	{
+		_model = sourceModel;
+		_listControl->addDependency(_model->listView());
+		ListModel::connect(_model, &ListModel::termsChanged, _listControl->model(), &ListModel::sourceTermsChanged);
+	}
+	else if (_nativeModel)
+	{
+		connect(_nativeModel, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)),	this,	SLOT(nativeModelChanged()) );
+		connect(_nativeModel, SIGNAL(rowsInserted(const QModelIndex &, int , int )),								this,	SLOT(nativeModelChanged()) );
+		connect(_nativeModel, SIGNAL(rowsRemoved(const QModelIndex &, int , int )),									this,	SLOT(nativeModelChanged()) );
+		connect(_nativeModel, SIGNAL(modelReset()),																	this,	SLOT(nativeModelChanged()) );
+	}
+	else
+	{
+		if (_name.isEmpty())
+		{
+			if (_listControl->form())		_listControl->addControlError(QObject::tr("No name given for the source of %1").arg(_listControl->name()));
+			else							_listControl->addControlError(QObject::tr("No source given for %1").arg(_listControl->name()));
+		}
+		else								_listControl->addControlError(QObject::tr("Cannot find component %1 for the source of %2").arg(_name).arg(_listControl->name()));
+	}
+}
+
+SourceItem::~SourceItem()
+{
+	isAlive = false;
+	if (_isValuesSource)
+		delete _model; // In case of values, the model is created just to contain the values, and does not come from another listview.
+	else if (_model)
+	{
+		_listControl->removeDependency(_model->listView());
+		ListModel::disconnect(_model, &ListModel::termsChanged, _listControl->model(), &ListModel::sourceTermsChanged);
+	}
+
+	for (SourceItem* discardModel : _discardSources)
+		delete discardModel;
+}
+
+void SourceItem::nativeModelChanged()
+{
+	QString name = _listControl->name();
+	_listControl->model()->sourceTermsChanged();
+}
+
+QList<QVariant> SourceItem::_getListVariant(QVariant var)
+{
+	QList<QVariant> listVar;
+
+	if (!var.isValid() || var.isNull())
+		return listVar;
+
+	listVar = var.toList();
+
+	if (listVar.isEmpty())
+	{
+		QStringList stringSources = var.toStringList();
+		for (const QString& stringSource : stringSources)
+			listVar.push_back(stringSource);
+	}
+
+	if (listVar.isEmpty())
+	{
+		if (var.canConvert<QMap<QString, QVariant> >())
+		{
+			QMap<QString, QVariant> map = var.toMap();
+			listVar.push_back(map);
+		}
+	}
+
+	if (listVar.isEmpty())
+		listVar.push_back(var);
+
+	return listVar;
+}
+
+QString SourceItem::_readSourceName(const QString& sourceNameExt, QString& sourceControl, QString& sourceUse)
+{
+	QStringList nameSplit = sourceNameExt.split(".");
+	if (nameSplit.length() > 1)
+	{
+		sourceControl = nameSplit[1];
+		sourceUse = "control=" + nameSplit[1];
+	}
+
+	return nameSplit[0];
+}
+
+QMap<QString, QVariant> SourceItem::_readSource(JASPListControl* listControl, const QVariant& source, JASPListControl::LabelValueMap& sourceValues, QAbstractItemModel*& nativeModel)
+{
+	QMap<QString, QVariant> map;
+	QString sourceName, sourceControl, sourceUse;
+
+	JASPControl* sourceItem = source.value<JASPControl*>();
+	if (sourceItem)										sourceName = sourceItem->name();
+	else if (source.type() == QVariant::Type::String)	sourceName = _readSourceName(source.toString(), sourceControl, sourceUse);
+	else if (source.canConvert<QMap<QString, QVariant> >())
+	{
+		map = source.toMap();
+		if (map.contains("id"))
+		{
+			JASPControl* sourceItem2 = map["id"].value<JASPControl*>();
+			if (sourceItem2)	sourceName = sourceItem2->name();
+		}
+
+		if (map.contains("name"))
+			sourceName = _readSourceName(map["name"].toString(), sourceControl, sourceUse);
+
+		if (map.contains("use"))
+		{
+			if (!sourceUse.isEmpty())
+				sourceUse += ",";
+			sourceUse += map["use"].toString();
+		}
+
+		if (map.contains("values"))
+		{
+			sourceValues = _readValues(listControl, map["values"]);
+			map["isValuesSource"] = true;
+		}
+
+		if (map.contains("model"))
+			nativeModel = source.value<QAbstractItemModel*>();
+	}
+	else
+		nativeModel = source.value<QAbstractItemModel*>();
+
+
+	if (nativeModel)
+	{
+		QString roleName = sourceUse.isEmpty() ? listControl->labelRole() : sourceUse;
+		map["nativeModelRole"] = Qt::DisplayRole;
+
+		if (!roleName.isEmpty())
+		{
+			QHash<int, QByteArray> roles = nativeModel->roleNames();
+			QHashIterator<int, QByteArray> it(roles);
+
+			while (it.hasNext())
+			{
+				it.next();
+				if (it.value() == roleName)
+				{
+					map["nativeModelRole"] = it.key();
+					break;
+				}
+			}
+		}
+	}
+	map["name"]			= sourceName;
+	map["controlName"]	= sourceControl;
+	map["use"]			= sourceUse;
+	return map;
+}
+
+JASPListControl::LabelValueMap SourceItem::_readValues(JASPListControl* listControl, const QVariant& values)
+{
+	JASPListControl::LabelValueMap result;
+
+	bool isInteger = false;
+	int count =  values.toInt(&isInteger);
+
+	if (isInteger)
+	{
+		for (int i = 1; i <= count; i++)
+		{
+			QString number = QString::number(i);
+			result.push_back(std::make_pair(number, number));
+		}
+	}
+	else
+	{
+		QList<QVariant> list = values.toList();
+		if (!list.isEmpty())
+		{
+			for (const QVariant& itemVariant : list)
+			{
+				QMap<QString, QVariant> labelValuePair = itemVariant.toMap();
+				if (labelValuePair.isEmpty())
+				{
+					QString value = itemVariant.toString();
+					result.push_back(std::make_pair(value, value));
+				}
+				else
+				{
+					QString label = labelValuePair[listControl->labelRole()].toString();
+					QString value = labelValuePair[listControl->valueRole()].toString();
+					result.push_back(std::make_pair(label, value));
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
+QVector<SourceItem*> SourceItem::readAllSources(JASPListControl* listControl)
+{
+	QVector<SourceItem*> sources;
+
+	if (listControl->values().isValid() && !listControl->values().isNull())
+		sources.append(new SourceItem(listControl, _readValues(listControl, listControl->values())));
+
+	QList<QVariant> rawSources = _getListVariant(listControl->source());
+
+	for (const QVariant& rawSource : rawSources)
+	{
+		JASPListControl::LabelValueMap sourceValues;
+		QAbstractItemModel* nativeModel = nullptr;
+		QMap<QString, QVariant> map = _readSource(listControl, rawSource, sourceValues, nativeModel);
+		QVector<SourceItem*> discards;
+		QVector<QMap<QString, QVariant> > conditionVariables;
+
+		if (map.contains("discard"))
+		{
+			QList<QVariant> discardSources = _getListVariant(map["discard"]);
+
+			for (const QVariant& discardSource : discardSources)
+			{
+				JASPListControl::LabelValueMap discardValues;
+				QAbstractItemModel* discardNativeModel = nullptr;
+				QMap<QString, QVariant> discardMap = _readSource(listControl, discardSource, discardValues, discardNativeModel);
+
+				discards.push_back(new SourceItem(listControl, discardMap, discardValues, discardNativeModel));
+			}
+		}
+
+		if (map.contains("conditionVariables"))
+		{
+			QList<QVariant> conditionVariablesList = _getListVariant(map["conditionVariables"]);
+
+			for (const QVariant& conditionVariablesVar : conditionVariablesList)
+				if (conditionVariablesVar.canConvert<QMap<QString, QVariant> >())
+					conditionVariables.push_back(conditionVariablesVar.toMap());
+		}
+
+		sources.append(new SourceItem(listControl, map, sourceValues, nativeModel, discards, conditionVariables));
+	}
+
+	if (sources.isEmpty() && listControl->model()->needsSource())
+		sources.append(new SourceItem(listControl)); // Add all columns source
+
+	return sources;
+}
+
+Terms SourceItem::_readAllTerms()
+{
+	Terms terms;
+
+	if (_model)	terms = _model->terms(_modelUse);
+	else if (_nativeModel)
+	{
+		int nbRows = _nativeModel->rowCount();
+		for (int i = 0; i < nbRows; i++)
+		{
+			QModelIndex modelIndex(_nativeModel->index(i, 0));
+			terms.add(_nativeModel->data(modelIndex, _nativeModelRole).toString());
+		}
+	}
+
+	return terms;
+}
+
+Terms SourceItem::getTerms()
+{
+	Terms sourceTerms = _readAllTerms();
+
+	for (SourceItem* discardModel : _discardSources)
+		sourceTerms.discardWhatDoesContainTheseComponents(discardModel->_readAllTerms());
+
+	if (!_conditionExpression.isEmpty() && _model)
+	{
+		Terms filteredTerms;
+		QJSEngine* jsEngine = qmlEngine(_listControl);
+
+		for (const Term& term : sourceTerms)
+		{
+			for (const ConditionVariable& conditionVariable : _conditionVariables)
+			{
+				JASPControl* control = _model->getRowControl(term.asQString(), conditionVariable.controlName);
+				if (control)
+				{
+					QJSValue value;
+					QVariant valueVar = control->property(conditionVariable.propertyName.toStdString().c_str());
+
+					switch (valueVar.type())
+					{
+					case QVariant::Type::Int:
+					case QVariant::Type::UInt:		value = valueVar.toInt();		break;
+					case QVariant::Type::Double:	value = valueVar.toDouble();	break;
+					case QVariant::Type::Bool:		value = valueVar.toBool();		break;
+					default:						value = valueVar.toString();	break;
+					}
+
+					jsEngine->globalObject().setProperty(conditionVariable.name, value);
+				}
+			}
+
+			QJSValue result = jsEngine->evaluate(_conditionExpression);
+			if (result.isError())
+				_listControl->addControlError("Error when evaluating : " + _conditionExpression + ": " + result.toString());
+			else if (result.toBool())
+				filteredTerms.add(term);
+		}
+
+		sourceTerms = filteredTerms;
+	}
+
+	return sourceTerms;
+}

--- a/Desktop/widgets/sourceitem.cpp
+++ b/Desktop/widgets/sourceitem.cpp
@@ -86,8 +86,8 @@ void SourceItem::_setUp()
 
 	if (_isDataSetColumns)
 	{
-		_nativeModel = AnalysisForm::columnsModel;
-		_nativeModelRole = AnalysisForm::columnsModelRole;
+		_nativeModel = AnalysisForm::getColumnsModel();
+		_nativeModelRole = AnalysisForm::getColumnsModelRole();
 	}
 
 	if (_isValuesSource)								sourceModel = new ListModelLabelValueTerms(_listControl, _values);
@@ -102,10 +102,10 @@ void SourceItem::_setUp()
 	}
 	else if (_nativeModel)
 	{
-		connect(_nativeModel, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)),	this,	SLOT(nativeModelChanged()) );
-		connect(_nativeModel, SIGNAL(rowsInserted(const QModelIndex &, int , int )),								this,	SLOT(nativeModelChanged()) );
-		connect(_nativeModel, SIGNAL(rowsRemoved(const QModelIndex &, int , int )),									this,	SLOT(nativeModelChanged()) );
-		connect(_nativeModel, SIGNAL(modelReset()),																	this,	SLOT(nativeModelChanged()) );
+		connect(_nativeModel, &QAbstractItemModel::dataChanged,			this,	&SourceItem::nativeModelChanged);
+		connect(_nativeModel, &QAbstractItemModel::rowsInserted,		this,	&SourceItem::nativeModelChanged);
+		connect(_nativeModel, &QAbstractItemModel::rowsRemoved,			this,	&SourceItem::nativeModelChanged);
+		connect(_nativeModel, &QAbstractItemModel::modelReset,			this,	&SourceItem::nativeModelChanged);
 	}
 	else
 	{

--- a/Desktop/widgets/sourceitem.cpp
+++ b/Desktop/widgets/sourceitem.cpp
@@ -67,12 +67,6 @@ SourceItem::SourceItem(JASPListControl *listControl, const JASPListControl::Labe
 	_setUp();
 }
 
-SourceItem::SourceItem(JASPListControl *listControl, QAbstractItemModel *nativeModel, int nativeModelRole)
-	 : _listControl(listControl), _nativeModel(nativeModel), _nativeModelRole(nativeModelRole)
-{
-	_setUp();
-}
-
 SourceItem::SourceItem(JASPListControl *listControl)
 	:  _listControl(listControl), _isDataSetColumns(true)
 {
@@ -102,10 +96,10 @@ void SourceItem::_setUp()
 	}
 	else if (_nativeModel)
 	{
-		connect(_nativeModel, &QAbstractItemModel::dataChanged,			this,	&SourceItem::nativeModelChanged);
-		connect(_nativeModel, &QAbstractItemModel::rowsInserted,		this,	&SourceItem::nativeModelChanged);
-		connect(_nativeModel, &QAbstractItemModel::rowsRemoved,			this,	&SourceItem::nativeModelChanged);
-		connect(_nativeModel, &QAbstractItemModel::modelReset,			this,	&SourceItem::nativeModelChanged);
+		connect(_nativeModel, &QAbstractItemModel::dataChanged,			this,	[this]() { _listControl->model()->sourceTermsChanged(); });
+		connect(_nativeModel, &QAbstractItemModel::rowsInserted,		this,	[this]() { _listControl->model()->sourceTermsChanged(); });
+		connect(_nativeModel, &QAbstractItemModel::rowsRemoved,			this,	[this]() { _listControl->model()->sourceTermsChanged(); });
+		connect(_nativeModel, &QAbstractItemModel::modelReset,			this,	[this]() { _listControl->model()->sourceTermsChanged(); });
 	}
 	else
 	{
@@ -131,12 +125,6 @@ SourceItem::~SourceItem()
 
 	for (SourceItem* discardModel : _discardSources)
 		delete discardModel;
-}
-
-void SourceItem::nativeModelChanged()
-{
-	QString name = _listControl->name();
-	_listControl->model()->sourceTermsChanged();
 }
 
 QList<QVariant> SourceItem::_getListVariant(QVariant var)
@@ -229,8 +217,7 @@ QMap<QString, QVariant> SourceItem::_readSource(JASPListControl* listControl, co
 
 		if (!roleName.isEmpty())
 		{
-			QHash<int, QByteArray> roles = nativeModel->roleNames();
-			QHashIterator<int, QByteArray> it(roles);
+			QHashIterator<int, QByteArray> it(nativeModel->roleNames());
 
 			while (it.hasNext())
 			{

--- a/Desktop/widgets/sourceitem.h
+++ b/Desktop/widgets/sourceitem.h
@@ -1,0 +1,107 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef SOURCEITEM_H
+#define SOURCEITEM_H
+
+#include <QObject>
+#include <QVector>
+#include <QVariant>
+#include <QMap>
+#include <QSet>
+#include <QAbstractItemModel>
+
+#include "jasplistcontrol.h"
+
+class SourceItem : public QObject
+{
+	Q_OBJECT
+public:
+	struct ConditionVariable
+	{
+		QString name,
+				controlName,
+				propertyName;
+		bool	addQuotes = false;
+
+		ConditionVariable(const QString& _name, const QString& _controlName, const QString& _propertyName, bool _addQuotes = false)
+			: name(_name), controlName(_controlName), propertyName(_propertyName), addQuotes(_addQuotes) {}
+		ConditionVariable(const ConditionVariable& source)
+			: name(source.name), controlName(source.controlName), propertyName(source.propertyName), addQuotes(source.addQuotes) {}
+		ConditionVariable() {}
+	};
+
+	SourceItem(
+			  JASPListControl* _listControl
+			, QMap<QString, QVariant>& map
+			, const JASPListControl::LabelValueMap& _values
+			, QAbstractItemModel* _nativeModel = nullptr
+			, const QVector<SourceItem*>& _discardSources = QVector<SourceItem*>()
+			, const QVector<QMap<QString, QVariant> >& _conditionVariables = QVector<QMap<QString, QVariant> >()
+			);
+
+	SourceItem(JASPListControl* _listControl, const JASPListControl::LabelValueMap& _values);
+
+	SourceItem(JASPListControl* _listControl, QAbstractItemModel* _nativeModel, int _nativeModelRole);
+
+	SourceItem(JASPListControl* _listControl = nullptr);
+
+	virtual ~SourceItem();
+
+	ListModel*				model()								{ return _model;					}
+	const QString&			controlName()				const	{ return _controlName;				}
+	const QString&			modelUse()					const	{ return _modelUse;					}
+	bool					combineWithOtherModels()	const	{ return _combineWithOtherModels;	}
+	const QSet<QString>&	usedControls()				const	{ return _usedControls;				}
+	Terms					getTerms();
+
+	static QVector<SourceItem*>				readAllSources(JASPListControl* _listControl);
+
+private slots:
+
+	void									nativeModelChanged();
+
+private:
+	static QString							_readSourceName(const QString& sourceNameExt, QString& sourceControl, QString& sourceUse);
+	static QMap<QString, QVariant>			_readSource(JASPListControl* _listControl, const QVariant& source, JASPListControl::LabelValueMap& sourceValues, QAbstractItemModel*& _nativeModel);
+	static JASPListControl::LabelValueMap	_readValues(JASPListControl* _listControl, const QVariant& _values);
+	static QList<QVariant>					_getListVariant(QVariant var);
+
+	void									_setUp();
+	Terms									_readAllTerms();
+
+	JASPListControl		*			_listControl			= nullptr;
+	QString							_name,
+									_controlName,
+									_modelUse;
+	QVector<SourceItem*>			_discardSources;
+	JASPListControl::LabelValueMap	_values;
+	bool							_isValuesSource			= false;
+	ListModel			*			_model					= nullptr;
+	QAbstractItemModel	*			_nativeModel			= nullptr;
+	int								_nativeModelRole		= Qt::DisplayRole;
+	bool							_isDataSetColumns		= false;
+	bool							_combineWithOtherModels	= false;
+	QString							_conditionExpression;
+	QVector<ConditionVariable>		_conditionVariables;
+	QSet<QString>					_usedControls;
+
+	bool isAlive = true;
+};
+
+#endif // SOURCEITEM_H

--- a/Desktop/widgets/sourceitem.h
+++ b/Desktop/widgets/sourceitem.h
@@ -57,8 +57,6 @@ public:
 
 	SourceItem(JASPListControl* _listControl, const JASPListControl::LabelValueMap& _values);
 
-	SourceItem(JASPListControl* _listControl, QAbstractItemModel* _nativeModel, int _nativeModelRole);
-
 	SourceItem(JASPListControl* _listControl = nullptr);
 
 	virtual ~SourceItem();
@@ -71,10 +69,6 @@ public:
 	Terms					getTerms();
 
 	static QVector<SourceItem*>				readAllSources(JASPListControl* _listControl);
-
-private slots:
-
-	void									nativeModelChanged();
 
 private:
 	static QString							_readSourceName(const QString& sourceNameExt, QString& sourceControl, QString& sourceUse);

--- a/Desktop/widgets/sourceitem.h
+++ b/Desktop/widgets/sourceitem.h
@@ -61,7 +61,7 @@ public:
 
 	virtual ~SourceItem();
 
-	ListModel*				model()								{ return _model;					}
+	ListModel*				listModel()							{ return _listModel;				}
 	const QString&			controlName()				const	{ return _controlName;				}
 	const QString&			modelUse()					const	{ return _modelUse;					}
 	bool					combineWithOtherModels()	const	{ return _combineWithOtherModels;	}
@@ -79,6 +79,10 @@ private:
 	void									_setUp();
 	Terms									_readAllTerms();
 
+private slots:
+	void									_connectModels();
+
+private:
 	JASPListControl		*			_listControl			= nullptr;
 	QString							_name,
 									_controlName,
@@ -86,7 +90,7 @@ private:
 	QVector<SourceItem*>			_discardSources;
 	JASPListControl::LabelValueMap	_values;
 	bool							_isValuesSource			= false;
-	ListModel			*			_model					= nullptr;
+	ListModel			*			_listModel				= nullptr;
 	QAbstractItemModel	*			_nativeModel			= nullptr;
 	int								_nativeModelRole		= Qt::DisplayRole;
 	bool							_isDataSetColumns		= false;
@@ -94,8 +98,6 @@ private:
 	QString							_conditionExpression;
 	QVector<ConditionVariable>		_conditionVariables;
 	QSet<QString>					_usedControls;
-
-	bool isAlive = true;
 };
 
 #endif // SOURCEITEM_H

--- a/Desktop/widgets/tableviewbase.cpp
+++ b/Desktop/widgets/tableviewbase.cpp
@@ -157,3 +157,8 @@ void TableViewBase::refreshMe()
 	if(_tableModel)
 		_tableModel->refreshModel();
 }
+
+void TableViewBase::termsChangedHandler()
+{
+	_tableModel->modelChangedSlot();
+}

--- a/Desktop/widgets/tableviewbase.cpp
+++ b/Desktop/widgets/tableviewbase.cpp
@@ -56,7 +56,8 @@ void TableViewBase::setUpModel()
 	if (modelType == "JAGSDataInputModel")		_tableModel	= new ListModelJAGSDataInput(		this, tableType	);
 	if (modelType == "FilteredDataEntryModel")	_tableModel = new ListModelFilteredDataEntry(	this, tableType	);
 	if (modelType == "CustomContrasts")			_tableModel = new ListModelCustomContrasts(		this, tableType	);
-	if (!_tableModel)                            _tableModel = new ListModelTableViewSimple(     this, tableType );
+	if (!_tableModel)							_tableModel = new ListModelTableViewSimple(     this, tableType );
+
 	JASPListControl::setUpModel();
 
 	_tableModel->setItemType(itemType);

--- a/Desktop/widgets/tableviewbase.h
+++ b/Desktop/widgets/tableviewbase.h
@@ -45,6 +45,9 @@ public:
 public slots:
 	void		refreshMe();
 
+protected slots:
+	void				termsChangedHandler()							override;
+
 protected:
 	OptionsTable				* _boundTo		= nullptr;
 	ListModelTableViewBase		* _tableModel	= nullptr;

--- a/Desktop/widgets/textareabase.cpp
+++ b/Desktop/widgets/textareabase.cpp
@@ -36,9 +36,31 @@ TextAreaBase::TextAreaBase(QQuickItem* parent)
 	_controlType = ControlType::TextArea;
 }
 
-
 void TextAreaBase::setUpModel()
 {
+	if (_textType == TextType::TextTypeSource || _textType == TextType::TextTypeJAGSmodel || _textType == TextType::TextTypeLavaan)
+	{
+		_model = new ListModelTermsAvailable(this);
+
+		if (_textType == TextType::TextTypeLavaan)
+		{
+			_model->setNeedsSource(true);
+			connect(_model, &ListModel::termsChanged, [this] () { if (form()) form()->refreshAnalysis(); } );
+		}
+		else
+		{
+			_model->setNeedsSource(false);
+			_model->setTermsAreVariables(false);
+		}
+
+		JASPListControl::setUpModel();
+	}
+}
+
+void TextAreaBase::setUp()
+{
+	JASPListControl::setUp();
+
 	switch (_textType)
 	{
 	case TextType::TextTypeSource:		_boundControl = new BoundControlSourceTextArea(this);	break;
@@ -56,39 +78,15 @@ void TextAreaBase::setUpModel()
 			_separators.push_back(separator.toString());
 	}
 
-	if (_textType == TextType::TextTypeSource || _textType == TextType::TextTypeJAGSmodel || _textType == TextType::TextTypeLavaan)
-	{
-		_model = new ListModelTermsAvailable(this);
-
-		if (_textType == TextType::TextTypeLavaan)
-		{
-			connect(form(), &AnalysisForm::dataSetChanged,	this, &TextAreaBase::dataSetChangedHandler,	Qt::QueuedConnection	);
-			_modelNeedsAllVariables = true;
-		}
-		else
-			_model->setTermsAreVariables(false);
-
-		JASPListControl::setUpModel();
-	}
-
 	QQuickItem::connect(this, SIGNAL(applyRequest()), this, SLOT(checkSyntaxHandler()));
-
 }
-
-
-void TextAreaBase::dataSetChangedHandler()
-{
-	form()->refreshAnalysis();
-}
-
-
 
 void TextAreaBase::rScriptDoneHandler(const QString & result)
 {
 	//This is for the lavaan model, but can be used by other type
 	if (result.length() == 0)
 	{
-		setProperty("hasScriptError", false);
+		setHasScriptError(false);
 		setProperty("infoText", tr("Model applied"));
 		OptionString* option = dynamic_cast<OptionString*>(boundTo());
 		if (option != nullptr)
@@ -96,7 +94,7 @@ void TextAreaBase::rScriptDoneHandler(const QString & result)
 	}
 	else
 	{
-		setProperty("hasScriptError", true);
+		setHasScriptError(true);
 		setProperty("infoText", result);
 	}
 }

--- a/Desktop/widgets/textareabase.cpp
+++ b/Desktop/widgets/textareabase.cpp
@@ -43,10 +43,7 @@ void TextAreaBase::setUpModel()
 		_model = new ListModelTermsAvailable(this);
 
 		if (_textType == TextType::TextTypeLavaan)
-		{
 			_model->setNeedsSource(true);
-			connect(_model, &ListModel::termsChanged, [this] () { if (form()) form()->refreshAnalysis(); } );
-		}
 		else
 		{
 			_model->setNeedsSource(false);
@@ -107,4 +104,11 @@ QString TextAreaBase::text()
 void TextAreaBase::setText(const QString& text)
 {
 	setProperty("text", text);
+}
+
+void TextAreaBase::termsChangedHandler()
+{
+	if (_textType == TextType::TextTypeLavaan && form())
+		form()->refreshAnalysis();
+
 }

--- a/Desktop/widgets/textareabase.h
+++ b/Desktop/widgets/textareabase.h
@@ -65,12 +65,14 @@ public slots:
 	GENERIC_SET_FUNCTION(TextType,			_textType,			textTypeChanged,		TextType	)
 	GENERIC_SET_FUNCTION(HasScriptError,	_hasScriptError,	hasScriptErrorChanged,	bool		)
 
-	void checkSyntaxHandler()						{ _boundControl->checkSyntax(); }
+	void	checkSyntaxHandler()						{ _boundControl->checkSyntax(); }
 
 signals:
-	void textTypeChanged();
-	void hasScriptErrorChanged();
+	void	textTypeChanged();
+	void	hasScriptErrorChanged();
 
+protected slots:
+	void	termsChangedHandler()		override;
     
 protected:
 

--- a/Desktop/widgets/textareabase.h
+++ b/Desktop/widgets/textareabase.h
@@ -37,7 +37,8 @@ class TextAreaBase : public JASPListControl, public BoundControl
 {
 	Q_OBJECT
 
-	Q_PROPERTY( TextType	textType	READ textType		WRITE setTextType		NOTIFY textTypeChanged)
+	Q_PROPERTY( TextType	textType			READ textType				WRITE setTextType			NOTIFY textTypeChanged				)
+	Q_PROPERTY( bool		hasScriptError		READ hasScriptError			WRITE setHasScriptError		NOTIFY hasScriptErrorChanged		)
 
 public:
 	TextAreaBase(QQuickItem* parent = nullptr);
@@ -49,34 +50,36 @@ public:
 	Option*						boundTo()									override	{ return _boundControl->boundTo();				}
 	ListModel*					model()								const	override	{ return _model; }
 	ListModelTermsAvailable*	availableModel()					const				{ return _model; }
+	void						setUp()										override;
 	void						setUpModel()								override;
-	bool						modelNeedsAllVariables()			const				{ return _modelNeedsAllVariables; }
 
 	void						rScriptDoneHandler(const QString &result)	override;
 
-	TextType					textType()							const	{ return _textType; }
-	const QList<QString>&		separators()						const	{ return _separators; }
+	TextType					textType()							const	{ return _textType;				}
+	bool						hasScriptError()					const	{ return _hasScriptError;		}
+	const QList<QString>&		separators()						const	{ return _separators;			}
 	QString						text();
 	void						setText(const QString& text);
 
 public slots:
-	GENERIC_SET_FUNCTION(TextType,	_textType,	textTypeChanged,	TextType)
+	GENERIC_SET_FUNCTION(TextType,			_textType,			textTypeChanged,		TextType	)
+	GENERIC_SET_FUNCTION(HasScriptError,	_hasScriptError,	hasScriptErrorChanged,	bool		)
 
-	void dataSetChangedHandler();
 	void checkSyntaxHandler()						{ _boundControl->checkSyntax(); }
 
 signals:
 	void textTypeChanged();
+	void hasScriptErrorChanged();
 
     
 protected:
 
 	BoundControlTextArea*		_boundControl			= nullptr;
 	TextType					_textType				= TextType::TextTypeDefault;
+	bool						_hasScriptError			= false;
 	QList<QString>				_separators;
 	
 	ListModelTermsAvailable*	_model					= nullptr;
-	bool						_modelNeedsAllVariables = false;
 	
 };
 

--- a/Desktop/widgets/textinputbase.cpp
+++ b/Desktop/widgets/textinputbase.cpp
@@ -315,7 +315,7 @@ void TextInputBase::rScriptDoneHandler(const QString &result)
 		if (!succes)
 		{
 			addControlError(tr("The expression did not return a number."));
-			setProperty("hasScriptError", true);
+			setHasScriptError(true);
 			break;
 		}
 
@@ -376,11 +376,11 @@ bool TextInputBase::_formulaResultInBounds(double result)
 		if (tooSmall)	end = (includeMin ? "&ge; " : "&gt; ") + property("min").toString();
 		else			end = (includeMax ? "&le; " : "&lt; ") + property("max").toString();
 		addControlError(tr("The value (%1) must be %2").arg(result).arg(end));
-		setProperty("hasScriptError", true);
+		setHasScriptError(true);
 	}
 	else
 	{
-		setProperty("hasScriptError", false);
+		setHasScriptError(false);
 		clearControlError();
 	}
 

--- a/Desktop/widgets/textinputbase.h
+++ b/Desktop/widgets/textinputbase.h
@@ -36,6 +36,8 @@ class TextInputBase : public JASPControl, public BoundControl
 {
 	Q_OBJECT
 
+	Q_PROPERTY( bool		hasScriptError		READ hasScriptError			WRITE setHasScriptError		NOTIFY hasScriptErrorChanged		)
+
 public:
 	enum TextInputType { IntegerInputType = 0, StringInputType, NumberInputType, PercentIntputType, IntegerArrayInputType, DoubleArrayInputType, ComputedColumnType, AddColumnType, FormulaType, FormulaArrayType};
 
@@ -51,9 +53,14 @@ public:
 
 	TextInputType	inputType()	{ return _inputType; }
 	QString			friendlyName() const override;
+	bool			hasScriptError()						const	{ return _hasScriptError;		}
 
 signals:
 	void		formulaCheckSucceeded();
+	void		hasScriptErrorChanged();
+
+public slots:
+	GENERIC_SET_FUNCTION(HasScriptError,	_hasScriptError,	hasScriptErrorChanged,	bool		)
 
 private slots:
 	void		textChangedSlot();
@@ -80,6 +87,7 @@ private:
 
 	bool					_parseDefaultValue	= true;
 	QString					_defaultValue		= "";
+	bool					_hasScriptError		= false;
 
 };
 

--- a/Desktop/widgets/variableslistbase.cpp
+++ b/Desktop/widgets/variableslistbase.cpp
@@ -30,6 +30,7 @@
 #include "boundcontrolmultiterms.h"
 #include "../analysis/analysisform.h"
 #include "../analysis/jaspcontrol.h"
+#include "sourceitem.h"
 #include <QTimer>
 #include <QQmlProperty>
 #include "log.h"
@@ -47,9 +48,9 @@ void VariablesListBase::setUp()
 
 	if (listViewType() == ListViewType::RepeatedMeasures)
 	{
-		for (SourceType* sourceItem : _sourceModels)
+		for (SourceItem* sourceItem : _sourceItems)
 		{
-			ListModelRepeatedMeasuresFactors* factorsModel = dynamic_cast<ListModelRepeatedMeasuresFactors*>(sourceItem->model);
+			ListModelRepeatedMeasuresFactors* factorsModel = dynamic_cast<ListModelRepeatedMeasuresFactors*>(sourceItem->model());
 			if (!factorsModel)
 				addControlError(tr("Source model of %1 must be from a Factor List").arg(name()));
 			addDependency(factorsModel->listView());
@@ -66,7 +67,7 @@ void VariablesListBase::setUp()
 
 		if (!relatedModel)
 		{
-			if (sourceModels().empty() && !property("debug").toBool())
+			if (sourceItems().empty() && !property("debug").toBool())
 				addControlError(tr("Cannot find source for VariableList %1").arg(name()));
 		}
 		else
@@ -123,7 +124,6 @@ void VariablesListBase::setUpModel()
 	}
 	case ListViewType::RepeatedMeasures:
 	{
-		_needsSourceModels = true;
 		 ListModelMeasuresCellsAssigned* measuresCellsModel = new ListModelMeasuresCellsAssigned(this);
 		_boundControl	= new BoundControlMeasuresCells(measuresCellsModel);
 		_draggableModel = measuresCellsModel;

--- a/Desktop/widgets/variableslistbase.cpp
+++ b/Desktop/widgets/variableslistbase.cpp
@@ -50,7 +50,7 @@ void VariablesListBase::setUp()
 	{
 		for (SourceItem* sourceItem : _sourceItems)
 		{
-			ListModelRepeatedMeasuresFactors* factorsModel = dynamic_cast<ListModelRepeatedMeasuresFactors*>(sourceItem->model());
+			ListModelRepeatedMeasuresFactors* factorsModel = dynamic_cast<ListModelRepeatedMeasuresFactors*>(sourceItem->listModel());
 			if (!factorsModel)
 				addControlError(tr("Source model of %1 must be from a Factor List").arg(name()));
 			addDependency(factorsModel->listView());
@@ -80,7 +80,9 @@ void VariablesListBase::setUp()
 				assignedModel->setAvailableModel(availableModel);
 				availableModel->addAssignedModel(assignedModel);
 				addDependency(availableModel->listView());
-				connect(availableModel, &ListModelAvailableInterface::allAvailableTermsChanged, assignedModel, &ListModelAssignedInterface::availableTermsChanged);
+				connect(availableModel, &ListModelAvailableInterface::availableTermsReset, assignedModel, &ListModelAssignedInterface::availableTermsResetHandler);
+				connect(availableModel, &ListModelAvailableInterface::availableNamesChanged, assignedModel, &ListModelAssignedInterface::availableNamesChangedHandler);
+				connect(availableModel, &ListModelAvailableInterface::availableTypeChanged, assignedModel, &ListModelAssignedInterface::availableTypeChangedHandler);
 			}
 		}
 	}


### PR DESCRIPTION
- Fixes some problems with ComboBox. It should also accepts source as LanguageModel.
- Refactor the SourceType so that it becomes an apart class.
- If the source of a control is the variable names, then this case should be treated as a normal kind of source. All special codes that handled the changes of dataset, can be then removed.
- Start making the QML controls independent of the MainWindow. Reference to MainWindow and DataSetPackage should be removed.
- Some code cleaning