### PR TITLE
RoBMA release fixes

### DIFF
--- a/JASP-Engine/JASP/R/robustbayesianmetaanalysis.R
+++ b/JASP-Engine/JASP/R/robustbayesianmetaanalysis.R
@@ -632,6 +632,12 @@ RobustBayesianMetaAnalysis <- function(jaspResults, dataset, options, state = NU
         columns.as.numeric = var_names,
         columns = if (options[["input_labels"]] != "") options[["input_labels"]]
       )
+
+      if (options[["input_labels"]] != ""){
+        dataset[[.v(options[["input_labels"]])]] <- as.character(dataset[[.v(options[["input_labels"]])]])
+        if (!validUTF8(dataset[[.v(options[["input_labels"]])]]))
+          JASP:::.quitAnalysis(gettext("The study labels contain invalid characters. Please, remove them before running the analysis."))
+      }
     }
     
   }

--- a/Resources/Meta Analysis/qml/RobustBayesianMetaAnalysis.qml
+++ b/Resources/Meta Analysis/qml/RobustBayesianMetaAnalysis.qml
@@ -218,6 +218,11 @@ Form
 		name:					"cohensd_testType"
 		visible:				measures_cohensd.checked
 		radioButtonsOnSameRow:	true
+		onValueChanged:
+		{
+			input_N1.itemDoubleClicked(0)
+			input_N2.itemDoubleClicked(0)
+		}
 
 		RadioButton
 		{


### PR DESCRIPTION
copy of: https://github.com/jasp-stats/jaspMetaAnalysis/pull/18

does not incorporate Lexi's request for formating, because that would affect the whole analysis script and would require detailed testing

fixes: https://github.com/jasp-stats/jasp-test-release/issues/1081
fixes: https://github.com/jasp-stats/jasp-test-release/issues/1082 by this PR https://github.com/FBartos/RoBMA/commit/ce0a37e48ebf79688ebd763785ffdb46067d1113, but updating all the way to https://github.com/FBartos/RoBMA/commit/788f678b02bbfbc619425f67c724abc79c9c28b6 will fix some other potential issues when a model fails to converge
fixes: https://github.com/jasp-stats/jasp-test-release/issues/1083