### PR TITLE
Update Package Checks

### DIFF
--- a/JASP-Engine/JASP/R/packagecheck.R
+++ b/JASP-Engine/JASP/R/packagecheck.R
@@ -64,7 +64,7 @@
 	expected <- rbind(expected, c('RcppParallel', '5.0.1'))
 	expected <- rbind(expected, c('Rcsdp', '0.1.57.1'))
 	expected <- rbind(expected, c('Rdpack', '0.11-1'))
-	expected <- rbind(expected, c('RoBMA', '1.2.0.900'))
+	expected <- rbind(expected, c('RoBMA', '1.2.0.902'))
 	expected <- rbind(expected, c('Rsolnp', '1.16'))
 	expected <- rbind(expected, c('Rtsne', '0.15'))
 	expected <- rbind(expected, c('SparseM', '1.77'))

--- a/Tools/flatpak/gather-r-package-info.R
+++ b/Tools/flatpak/gather-r-package-info.R
@@ -66,7 +66,7 @@ defineSpecials <- function()
   specials[['stanova']]      <- list(type='github', commit='3e5635816fb2e4cda06704778e5bcd382f14717d', repo='bayesstuff/stanova'    )
   #specials[['afex']]         <- list(type='github', commit='71e22f0020399de1b35189d7c0dd4e5a2729b843', repo='singmann/afex'         )
   specials[['ggpol']]        <- list(type='github', commit='dea9db2503b04b81dbc746fdeccf92e9849ce64b', repo='jasp-stats/ggpol'      ) # temporary fix for conflicting ggplot2 dependencies in jasp 0.12.2. Should be removed after that release and shit should be fixed!
-  specials[['RoBMA']]        <- list(type='github', commit='ccb82bf2c2c3e7263f3952bc976a230111f9c217', repo='FBartos/RoBMA'         )
+  specials[['RoBMA']]        <- list(type='github', commit='788f678b02bbfbc619425f67c724abc79c9c28b6', repo='FBartos/RoBMA'         )
   
 }
 


### PR DESCRIPTION
Update RoBMA version 1.2.0.902
Request František 16-12-2020
Source :  devtools::install_github("https://github.com/FBartos/RoBMA/commit/788f678b02bbfbc619425f67c724abc79c9c28b6")

