### PR TITLE
TableView with FilteredDataEntryModel should display the column values

### DIFF
--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -100,7 +100,7 @@ void ColumnsModel::datasetChanged(	QStringList				changedColumns,
 
 int ColumnsModel::rowCount(const QModelIndex &) const
 {
-	return _tableModel->columnCount();
+	return _tableModel->rowCount();
 }
 
 int ColumnsModel::columnCount(const QModelIndex &) const

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -36,7 +36,8 @@ QVariant ColumnsModel::data(const QModelIndex &index, int role) const
 
 		return tr("The '") + _tableModel->columnTitle(index.row()).toString() + tr("'-column ") + usedIn;
 	}
-	case LabelsRole:	return _tableModel->getColumnLabelsAsStringList(index.row());
+	case LabelsRole:				return _tableModel->getColumnLabelsAsStringList(index.row());
+	case Qt::DisplayRole:			return _tableModel->data(index, Qt::DisplayRole);
 	}
 
 	return QVariant();

--- a/Desktop/data/columnsmodel.h
+++ b/Desktop/data/columnsmodel.h
@@ -33,6 +33,7 @@ public:
 	int						rowCount(	const QModelIndex &parent = QModelIndex())								const	override;
 	int						columnCount(const QModelIndex &parent = QModelIndex())								const	override;
 	QVariant				headerData(	int section, Qt::Orientation orientation, int role = Qt::DisplayRole )	const	override;
+	QModelIndex				index(int row, int column, const QModelIndex &parent = QModelIndex())				const	override	{ return _tableModel->index(row, column, parent); }
 
 	int						getColumnIndex(const std::string& col)												const	{ return _tableModel->getColumnIndex(col);						}
 	size_t					getMaximumColumnWidthInCharacters(int index)										const	{ return _tableModel->getMaximumColumnWidthInCharacters(index);	}

--- a/Desktop/widgets/listmodelfiltereddataentry.cpp
+++ b/Desktop/widgets/listmodelfiltereddataentry.cpp
@@ -267,7 +267,7 @@ void ListModelFilteredDataEntry::fillTable()
 	size_t dataRows = getDataSetRowCount();
 
 	if(_acceptedRows.size() != dataRows)
-		_acceptedRows = std::vector<bool>(true, dataRows);
+		_acceptedRows = std::vector<bool>(dataRows, true);
 
 
 	_values.push_back({});


### PR DESCRIPTION
In the AUDIT Workflows analysis, the Data Entry table does not show anymore the values of the selected columns.
See https://pml-uva.slack.com/archives/CV655R7QS/p1608722351043100