### PR TITLE
Load generated markdown for analysis help if there is no helpfile in the module

### DIFF
--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -775,8 +775,7 @@ QString AnalysisForm::metaHelpMD() const
 
 QString AnalysisForm::helpMD() const
 {
-	if (!PreferencesModel::prefs()->generateMarkdown())
-		return ""; // It should not come here, but when debugging QML, it crashes here because apparently _analysis is not set yet. Weird...
+	if(!_analysis) return "";
 
 	QStringList markdown =
 	{

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -359,7 +359,7 @@ DropArea
 					opacity:			editButton.opacity
 					//visible:			expanderButton.expanded || hovered || mouseArea.containsMouse
 					enabled:			expanderButton.expanded
-					onClicked:			if(preferencesModel.generateMarkdown)
+					onClicked:			if(preferencesModel.generateMarkdown || !helpModel.pageExists(loader.myAnalysis.helpFile))
 											helpModel.markdown = Qt.binding(function(){ return myAnalysis.helpMD; });
 										else
 										{

--- a/Desktop/utilities/helpmodel.cpp
+++ b/Desktop/utilities/helpmodel.cpp
@@ -150,7 +150,19 @@ void HelpModel::setFont()
 	runJavaScript("window.setFont", fontFamily);
 }
 
-bool HelpModel::loadHelpContent(const QString &pagePath, bool ignorelanguage, QString &renderFunc, QString &content)
+///Temporary function for https://github.com/jasp-stats/INTERNAL-jasp/issues/1215 
+bool HelpModel::pageExists(QString pagePath)
+{
+	pagePath = convertPagePathToLower(pagePath);
+	
+	 QString renderFunc, content;
+	 
+	 //We will simply have to use loadHelpContent to make sure we follow the same logic.
+	 
+	 return loadHelpContent(pagePath, false, renderFunc, content) || loadHelpContent(pagePath, true, renderFunc, content);
+}
+
+bool HelpModel::loadHelpContent(const QString & pagePath, bool ignorelanguage, QString &renderFunc, QString &content)
 {
 
 	QString _localname = ignorelanguage ? "" : LanguageModel::currentTranslationSuffix();
@@ -160,21 +172,21 @@ bool HelpModel::loadHelpContent(const QString &pagePath, bool ignorelanguage, QS
 	content = "";
 
 	QFile fileMD, fileHTML;
-	QFileInfo pathMd(_pagePath + _localname + ".md");
+	QFileInfo pathMd(pagePath + _localname + ".md");
 
 	bool relative = pathMd.isRelative();
 
 	if(relative) //This is probably a file in resources then
 	{
-		fileMD.setFileName(AppDirs::help() + "/" + _pagePath + _localname + ".md");
-		fileHTML.setFileName(AppDirs::help() + "/" + _pagePath + _localname + ".html");
+		fileMD.setFileName(  AppDirs::help() + "/" + pagePath + _localname + ".md");
+		fileHTML.setFileName(AppDirs::help() + "/" + pagePath + _localname + ".html");
 	}
 	else
 	{
 		//We got an absolute path, this probably means it comes from a (dynamic) module.
 
-		fileMD.setFileName(_pagePath + _localname + ".md");
-		fileHTML.setFileName(_pagePath + _localname + ".html");
+		fileMD.setFileName(	 pagePath + _localname + ".md");
+		fileHTML.setFileName(pagePath + _localname + ".html");
 	}
 
 	if (fileHTML.exists())

--- a/Desktop/utilities/helpmodel.h
+++ b/Desktop/utilities/helpmodel.h
@@ -32,6 +32,7 @@ public slots:
 	void	loadingSucceeded();
 	void	setMarkdown(QString markdown);
 	void	loadMarkdown(QString md);
+	bool	pageExists(QString pagePath);
 
 signals:
 	void renderCode(QString javascript);


### PR DESCRIPTION
- Implements https://github.com/jasp-stats/INTERNAL-jasp/issues/1215
- Also makes sure loadHelpContent actually uses the pagepath argument...

