### PR TITLE
General updates to language changing in JASP

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -736,14 +736,24 @@ void Analyses::analysisTitleChangedHandler(string moduleName, string oldTitle, s
 	});
 }
 
+void Analyses::prepareForLanguageChange()
+{
+	applyToAll([&](Analysis * a)
+	{ 
+		a->setRefreshBlocked(true); 
+		a->abort();
+	});
+}
+
+
 void Analyses::languageChangedHandler()
 {
-	refreshAllAnalyses();
 	applyToAll([&](Analysis * a)
 	{
+		a->setRefreshBlocked(false);
 		emit a->form()->languageChanged();
 	});
-
+	refreshAllAnalyses();
 	emit setResultsMeta(tq(_resultsMeta.toStyledString()));
 }
 

--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -125,6 +125,7 @@ public slots:
 	void duplicateAnalysis(size_t id);
 	void showDependenciesInAnalysis(size_t analysis_id, QString optionName);
 	void analysisTitleChangedHandler(std::string moduleName, std::string oldTitle, std::string newTitle);
+	void prepareForLanguageChange();
 	void languageChangedHandler();
 	void resultsMetaChanged(QString json);
 	void allUserDataChanged(QString json);

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -30,7 +30,7 @@ Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::strin
 	  QObject(Analyses::analyses()),
 	  _options(new Options()),
 	  _id(id),
-	  _name(analysisEntry->title()),
+	  _name(analysisEntry->function()),
 	  _qml(analysisEntry->qml().empty() ? _name : analysisEntry->qml()),
 	  _titleDefault(analysisEntry->title()),
 	  _title(title == "" ? _titleDefault : title),
@@ -102,6 +102,13 @@ bool Analysis::checkAnalysisEntry()
 			Modules::ModuleException("???", "No coded reference stored or _dynamicModule == nullptr...");
 
 		_moduleData = _dynamicModule->retrieveCorrespondingAnalysisEntry(_codedReferenceToAnalysisEntry);
+		
+		bool updateTitleToDefault = _title == _titleDefault;
+		
+		_titleDefault = _moduleData->title();
+		
+		if(updateTitleToDefault)
+			setTitle(_titleDefault);
 
 		return true;
 	}
@@ -157,6 +164,8 @@ void Analysis::setResults(const Json::Value & results, Status status, const Json
 		checkForRSources();
 
 	_wasUpgraded = false;
+	
+	
 }
 
 void Analysis::reload()
@@ -353,6 +362,8 @@ Json::Value Analysis::asJSON() const
 	analysisAsJson["progress"]		= _progress;
 	analysisAsJson["version"]		= _version.asString();
 	analysisAsJson["results"]		= _results;
+	
+	
 
 	std::string status;
 
@@ -547,6 +558,8 @@ void Analysis::setHelpFile(QString helpFile)
 
 void Analysis::setTitleQ(QString title)
 {
+	//Log::log() << "void Analysis::setTitleQ('" << title << "')" << std::endl;
+	
 	std::string strippedTitle	= title.simplified().toStdString();
 
 	if(strippedTitle == "")

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -49,7 +49,7 @@ class Analysis : public QObject
 	Q_PROPERTY(bool		hasVolatileNotes	READ hasVolatileNotes	WRITE setHasVolatileNotes	NOTIFY hasVolatileNotesChanged	)
 	Q_PROPERTY(bool		optionsBound		READ optionsBound		WRITE setOptionsBound		NOTIFY optionsBoundChanged		)
 
-
+	friend class Analyses;
 
 	typedef std::map<std::string, std::set<std::string>> optionColumns;
 
@@ -204,6 +204,7 @@ public slots:
 	void					emitDuplicationSignals();
 	void					showDependenciesOnQMLForObject(QString uniqueName); //uniqueName is basically "name" in meta in results.
 	void					setOptionsBound(bool optionsBound);
+
 
 protected:
 	void					abort();

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -192,7 +192,7 @@ Item
 				Connections
 				{
 					target:		resultsJsInterface
-					function onRunJavaScript(js)				{ resultsView.runJavaScript(js); }
+					function onRunJavaScriptSignal(js)			{ resultsView.runJavaScript(js); }
 					function onScrollAtAllChanged(scrollAtAll)	{ resultsView.runJavaScript("window.setScrollAtAll("+(scrollAtAll ? "true" : "false")+")"); }
 
 					function onExportToPDF(pdfPath)

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -281,8 +281,8 @@ QVariant DataSetPackage::data(const QModelIndex &index, int role) const
 		{
 		case int(specialRoles::filter):				return labels[index.row()].filterAllows();
 		case int(specialRoles::value):				return tq(labels.getValueFromRow(index.row()));
-		case Qt::DisplayRole:
-		default:									return tq(labels.getLabelFromRow(index.row()));
+		case Qt::DisplayRole:						return tq(labels.getLabelFromRow(index.row()));
+		default:									return QVariant();
 		}
 	}
 	}

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -50,8 +50,8 @@ void DataSetPackage::setEngineSync(EngineSync * engineSync)
 	_engineSync = engineSync;
 
 	//These signals should *ONLY* be called from a different thread than _engineSync!
-	connect(this,	&DataSetPackage::pauseEnginesSignal,	_engineSync,	&EngineSync::pause,		Qt::BlockingQueuedConnection);
-	connect(this,	&DataSetPackage::resumeEnginesSignal,	_engineSync,	&EngineSync::resume,	Qt::BlockingQueuedConnection);
+	connect(this,	&DataSetPackage::pauseEnginesSignal,	_engineSync,	&EngineSync::pauseEngines,		Qt::BlockingQueuedConnection);
+	connect(this,	&DataSetPackage::resumeEnginesSignal,	_engineSync,	&EngineSync::resumeEngines,	Qt::BlockingQueuedConnection);
 
 	reset();
 }
@@ -63,13 +63,13 @@ bool DataSetPackage::isThisTheSameThreadAsEngineSync()
 
 void DataSetPackage::pauseEngines()
 {
-	if(isThisTheSameThreadAsEngineSync())	_engineSync->pause();
+	if(isThisTheSameThreadAsEngineSync())	_engineSync->pauseEngines();
 	else									emit pauseEnginesSignal();
 }
 
 void DataSetPackage::resumeEngines()
 {
-	if(isThisTheSameThreadAsEngineSync())	_engineSync->resume();
+	if(isThisTheSameThreadAsEngineSync())	_engineSync->resumeEngines();
 	else									emit resumeEnginesSignal();
 
 	ColumnEncoder::setCurrentColumnNames(getColumnNames()); //Same place as in engine, should be fine right?

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -600,6 +600,7 @@ void EngineRepresentation::restartEngine(QProcess * jaspEngineProcess)
 	sendString("");
 	setSlaveProcess(jaspEngineProcess);
 	cleanUpAfterClose();
+	loadAllActiveModules();
 
 	_engineState	 = engineState::initializing;
 }

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -149,7 +149,7 @@ void EngineRepresentation::setAnalysisInProgress(Analysis* analysis)
 	_engineState		= engineState::analysis;
 }
 
-void EngineRepresentation::process()
+void EngineRepresentation::processReplies()
 {
 	if (_engineState == engineState::idle)
 	{
@@ -555,7 +555,7 @@ void EngineRepresentation::shutEngineDown()
 		
 		//Wait for the engine to get the message.
 		while(_analysisAborted && _analysisInProgress && _abortTime + ENGINE_KILLTIME + 1 < Utils::currentSeconds())
-			process();
+			processReplies();
 		
 		if(!killed() && !stopped())
 			killEngine();
@@ -566,7 +566,7 @@ void EngineRepresentation::shutEngineDown()
 		stopEngine();
 		
 		while(!stopped() && stopTime + ENGINE_KILLTIME < Utils::currentSeconds())
-			process();
+			processReplies();
 		
 		if(!stopped())
 			killEngine();

--- a/Desktop/engine/enginerepresentation.h
+++ b/Desktop/engine/enginerepresentation.h
@@ -109,6 +109,7 @@ public slots:
 	void setRunsRCmd(		bool runsRCmd);
 
 signals:
+	void loadAllActiveModules();
 	void engineTerminated();
 	void filterDone(															int requestID);
 	void processFilterErrorMsg(			const QString & error,					int requestId = -1);

--- a/Desktop/engine/enginerepresentation.h
+++ b/Desktop/engine/enginerepresentation.h
@@ -77,7 +77,7 @@ public:
 
 	bool jaspEngineStillRunning() { return  _slaveProcess != nullptr && !killed(); }
 
-	void process();
+	void processReplies();
 	void restartAbortedAnalysis();
 	void checkIfExpectedReplyType(engineState expected) { unexpectedEngineReply::checkIfExpected(expected, _engineState, channelNumber()); }
 	bool willProcessAnalysis(Analysis * analysis) const;

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -242,7 +242,7 @@ void EngineSync::process()
 	std::vector<EngineRepresentation *> boredEngines;
 	for (auto engine : _engines)
 	{
-		engine->process();
+		engine->processReplies();
 		
 		if(
 			_workers.count(engine) > 0	&& 
@@ -616,7 +616,7 @@ void EngineSync::stopEngines()
 
 	//make sure we process any received messages first.
 	for(auto engine : _engines)
-		engine->process();
+		engine->processReplies();
 
 	_engineStarted		= false;
 
@@ -635,12 +635,13 @@ void EngineSync::stopEngines()
 		}
 		else
 			for (auto * engine : _engines)
-				engine->process();
+				engine->processReplies();
 
 	//timeout = QDateTime::currentSecsSinceEpoch() + 10;
 
 	/*
-
+		This is all commented out because it is very dangerous to just go and processEvents in the middle of other functions...
+	  
 	  Log::log() << "Checking if engines are running by using QApplication::processEvents to get answers." << std::endl;
 
 	bool stillRunning;
@@ -676,7 +677,7 @@ void EngineSync::pause()
 
 	//make sure we process any received messages first.
 	for(auto engine : _engines)
-		engine->process();
+		engine->processReplies();
 
 	for(EngineRepresentation * e : _engines)
 		e->pauseEngine();
@@ -685,7 +686,7 @@ void EngineSync::pause()
 
 	while(!allEnginesPaused() && tryTill >= Utils::currentSeconds())
 		for (auto * engine : _engines)
-			engine->process();
+			engine->processReplies();
 
 	for (auto * engine : _engines)
 		if(!engine->paused())
@@ -712,7 +713,7 @@ void EngineSync::resume()
 
 	while(!allEnginesResumed())
 		for (auto * engine : _engines)
-			engine->process();
+			engine->processReplies();
 
 	if(restartedAnEngine)
 		setModuleWideCastVars(DynamicModules::dynMods()->getJsonForReloadingActiveModules());

--- a/Desktop/engine/enginesync.h
+++ b/Desktop/engine/enginesync.h
@@ -57,13 +57,15 @@ public slots:
 	int			sendFilter(		const QString & generatedFilter,	const QString & filter);
 	void		sendRCode(		const QString & rCode,				int requestId,					bool whiteListedVersion);
 	void		computeColumn(	const QString & columnName,			const QString & computeCode,	columnType columnType);
-	void		pause();
-	void		resume();
-	void		refreshAllPlots();
+	void		pauseEngines();
 	void		stopEngines();
+	void		resumeEngines();
+	void		restartEngines();
+	void		refreshAllPlots();
 	void		logCfgRequest();
 	void		logToFileChanged(bool) { logCfgRequest(); }
 	void		cleanUpAfterClose();
+	void		loadAllActiveModules();
 	void		filterDone(int requestID);
 	std::string	currentStateForDebug() const;
 	void		haveYouTriedTurningItOffAndOnAgain() { stopEngines(); restartEngines(); } // https://www.youtube.com/watch?v=DPqdyoTpyEs
@@ -119,7 +121,6 @@ private slots:
 	void	moduleLoadingSucceededHandler(	const QString & moduleName, int channelID);
 	void	moduleUnloadingFinishedHandler(	const QString & moduleName, int channelID);
 
-	void	restartEngines();
 	void	restartEngineAfterCrash(EngineRepresentation * engine);
 	void	restartKilledEngines();
 

--- a/Desktop/html/js/analysis.js
+++ b/Desktop/html/js/analysis.js
@@ -3,6 +3,7 @@ JASPWidgets.Analysis = Backbone.Model.extend({
 		id: -1,
 		progress: -1,
 		results: {},
+		title: 'Analysis Title',
 		status: 'waiting',
 		optionschanged: [],
 		saveimage: [],
@@ -514,17 +515,10 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 			if (!_.has(results, name))
 				continue
+
 			let data = results[name];
-
-			/*if (meta.type == 'collection' && data.title == "") {  // remove collections without a title from view
-				let collectionMeta = meta.meta;
-				if (Array.isArray(collectionMeta)) { // the meta comes from a jaspResult analysis
-					this.createResultsViewFromMeta(data["collection"], collectionMeta, $result);
-					continue;
-				}
-			}*/
-
 			let itemView = this.createChild(data, this.model.get("status"), meta);
+			
 			if (itemView === null)
 				continue;
 
@@ -580,40 +574,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 	createChild: function (result, status, metaEntry) {
 
-		var itemView = null;
-
-//backwards compatibility//////////////////
-		if (metaEntry.type == "title") {
-			this.titleRequest = { title: result, titleFormat: 'h2' };
-			this.labelRequest = null;
-		}
-		else if (metaEntry.type == "h1")
-			this.labelRequest = { title: result, titleFormat: 'h3' };
-		else if (metaEntry.type == "h2")
-			this.labelRequest = { title: result, titleFormat: 'h4' };
-		else {
-
-			if (_.isArray(result)) {
-
-				result = { collection: result };
-				if (this.labelRequest) {
-					result.title = this.labelRequest.title;
-					result.titleFormat = this.labelRequest.titleFormat;
-				}
-				if (metaEntry.type === 'tables')
-					metaEntry.meta = 'table';
-				else if (metaEntry.type === 'images')
-					metaEntry.meta = 'image';
-
-				metaEntry.type = 'collection'
-			}
-			this.labelRequest = null;
-///////////////////////////////////////////
-
-			itemView = JASPWidgets.objectConstructor.call(this, result, { meta: metaEntry, status: status, childOfCollection: false, embeddedLevel: 1, indent: false }, false);
-		}
-
-		return itemView;
+		return JASPWidgets.objectConstructor.call(this, result, { meta: metaEntry, status: status, childOfCollection: false, embeddedLevel: 1, indent: false }, false);
 	},
 
 	overwriteUserData: function(userdata) {
@@ -632,15 +593,8 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 	render: function () {
 
-		var results = this.model.get("results");
-
-		// once everything becomes jaspResults this is always an object and the following can be removed
-		var progress = this.model.get("progress")
-		if (typeof progress == "number")
-			this.model.set("progress", { value: progress, label: "" })
-		else if (!progress)
-			this.model.set("progress", { value: -1, label: "" })
-		// up to here
+		var results			= this.model.get("results");
+		var titleAnalysis	= this.model.get("title");
 
 		if (results == "" || results == null) {
 			progress = this.model.get("progress");
@@ -677,10 +631,7 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 			this.setErrorOnPreviousResults(errorMessage, status, $tempClone, $innerElement);
 		}
 
-		if (this.titleRequest)
-			this._setTitle(this.titleRequest.title, this.titleRequest.titleFormat);
-		else
-			this._setTitle(results.title, 'h2');
+		this._setTitle(titleAnalysis, 'h2');
 
 		this.progressbar.render();
 		$innerElement.prepend(this.progressbar.$el);

--- a/Desktop/html/js/analysis.js
+++ b/Desktop/html/js/analysis.js
@@ -1,7 +1,7 @@
 JASPWidgets.Analysis = Backbone.Model.extend({
 	defaults: {
 		id: -1,
-		progress: -1,
+		progress: null,
 		results: {},
 		title: 'Analysis Title',
 		status: 'waiting',
@@ -596,9 +596,10 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		var results			= this.model.get("results");
 		var titleAnalysis	= this.model.get("title");
 
-		if (results == "" || results == null) {
+		if (results === "" || results === null) {
 			progress = this.model.get("progress");
-			if (progress.value > -1)
+
+			if (progress !== null && progress.value > -1)
 				this.updateProgressbarInResults();
 			return this;
 		}

--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -70,7 +70,8 @@ $(document).ready(function () {
 	
 	window.setStatus = function(id, status) {
 		var analysis = analyses.getAnalysis(id);
-		if (analysis === undefined) return;
+		if (analysis === undefined) 
+			return;
 
 		analysis.toolbar.setStatus(status);
 		analysis.toolbar.render();
@@ -78,7 +79,8 @@ $(document).ready(function () {
 
 	window.changeTitle = function(id, title) {
 		var analysis = analyses.getAnalysis(id);
-		if (analysis === undefined) return;
+		if (analysis === undefined) 
+			return;
 
 		analysis.toolbar.setTitle(title);
 		analysis.toolbar.render();
@@ -86,7 +88,8 @@ $(document).ready(function () {
 
 	window.overwriteUserdata = function(id, userData) {
 		var analysis = analyses.getAnalysis(id);
-		if (analysis === undefined) return;
+		if (analysis === undefined) 
+			return;
 
 		analysis.overwriteUserData(userData)
 	}

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -382,8 +382,9 @@ void MainWindow::makeConnections()
 	connect(_languageModel,			&LanguageModel::aboutToChangeLanguage,				_analyses,				&Analyses::prepareForLanguageChange							);
 	connect(_languageModel,			&LanguageModel::languageChanged,					_analyses,				&Analyses::languageChangedHandler,							Qt::QueuedConnection);
 	connect(_languageModel,			&LanguageModel::languageChanged,					_helpModel,				&HelpModel::generateJavascript,								Qt::QueuedConnection);
-	connect(_languageModel,			&LanguageModel::pauseEngines,						_engineSync,			&EngineSync::pause											);
-	connect(_languageModel,			&LanguageModel::resumeEngines,						_engineSync,			&EngineSync::resume,										Qt::QueuedConnection);
+	connect(_languageModel,			&LanguageModel::pauseEngines,						_engineSync,			&EngineSync::pauseEngines									);
+	connect(_languageModel,			&LanguageModel::stopEngines,						_engineSync,			&EngineSync::stopEngines									);
+	connect(_languageModel,			&LanguageModel::resumeEngines,						_engineSync,			&EngineSync::resumeEngines,									Qt::QueuedConnection);
 
 	connect(_qml,					&QQmlApplicationEngine::warnings,					this,					&MainWindow::printQmlWarnings								);
 
@@ -507,6 +508,9 @@ void MainWindow::loadQML()
 		{ 	"jaspDescriptives", "jaspTTests", "jaspAnova", "jaspMixedModels", "jaspRegression", "jaspFrequencies", "jaspFactor" },
 		{ 	"jaspAudit", "jaspBain", "jaspDistributions" , "jaspEquivalenceTTests", "jaspJags", "jaspLearnBayes", "jaspMachineLearning",
 			"jaspMetaAnalysis", "jaspNetwork", "jaspProcessControl", "jaspProphet", "jaspReliability", "jaspSem", "jaspSummaryStatistics", "jaspVisualModeling" });
+
+	_engineSync->loadAllActiveModules();
+	_dynamicModules->startUpCompleted();
 }
 
 QObject * MainWindow::loadQmlData(QString data, QUrl url)
@@ -1017,8 +1021,8 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 			if (resultXmlCompare::compareResults::theOne()->testMode())
 			{
 				//Make sure the engine gets enough time to load data
-				_engineSync->pause();
-				_engineSync->resume();
+				_engineSync->pauseEngines();
+				_engineSync->resumeEngines();
 
 				//Also give it like 3secs to have the ribbon load
 				QTimer::singleShot(3000, this, &MainWindow::startComparingResults);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -366,7 +366,6 @@ void MainWindow::makeConnections()
 	connect(_labelFilterGenerator,	&labelFilterGenerator::setGeneratedFilter,			_filterModel,			&FilterModel::setGeneratedFilter							);
 
 	connect(_ribbonModel,			&RibbonModel::analysisClickedSignal,				_analyses,				&Analyses::analysisClickedHandler							);
-	connect(_ribbonModel,			&RibbonModel::analysisTitleChanged,					_analyses,				&Analyses::analysisTitleChangedHandler						);
 	connect(_ribbonModel,			&RibbonModel::showRCommander,						this,					&MainWindow::showRCommander									);
 
 	connect(_dynamicModules,		&DynamicModules::dynamicModuleUnloadBegin,			_analyses,				&Analyses::removeAnalysesOfDynamicModule					);
@@ -380,8 +379,11 @@ void MainWindow::makeConnections()
 	connect(_dynamicModules,		&DynamicModules::loadQmlData,						this,					&MainWindow::loadQmlData,									Qt::UniqueConnection);
 
 	connect(_languageModel,			&LanguageModel::languageChanged,					_fileMenu,				&FileMenu::refresh											);
+	connect(_languageModel,			&LanguageModel::aboutToChangeLanguage,				_analyses,				&Analyses::prepareForLanguageChange							);
 	connect(_languageModel,			&LanguageModel::languageChanged,					_analyses,				&Analyses::languageChangedHandler,							Qt::QueuedConnection);
-	connect(_languageModel,			&LanguageModel::languageChanged,					_helpModel,				&HelpModel::generateJavascript,								Qt::QueuedConnection);	
+	connect(_languageModel,			&LanguageModel::languageChanged,					_helpModel,				&HelpModel::generateJavascript,								Qt::QueuedConnection);
+	connect(_languageModel,			&LanguageModel::pauseEngines,						_engineSync,			&EngineSync::pause											);
+	connect(_languageModel,			&LanguageModel::resumeEngines,						_engineSync,			&EngineSync::resume,										Qt::QueuedConnection);
 
 	connect(_qml,					&QQmlApplicationEngine::warnings,					this,					&MainWindow::printQmlWarnings								);
 

--- a/Desktop/modules/description/entrybase.cpp
+++ b/Desktop/modules/description/entrybase.cpp
@@ -152,6 +152,8 @@ AnalysisEntry * EntryBase::convertToAnalysisEntry(bool requiresDataDefault) cons
 	entry->_isGroupTitle	= _entryType == EntryType::groupTitle;
 
 	entry->_dynamicModule	= _description->dynMod();
+	
+	//Log::log()<<"convertToAnalysisEntry has title '"<<title()<<"'"<<std::endl;
 
 	return entry;
 }

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -322,6 +322,14 @@ void DynamicModule::loadInfoFromDescriptionItem(Description * description)
 	emit descriptionReloaded(this);
 }
 
+
+
+void DynamicModule::setReadyForUse()
+{
+	if(_status != moduleStatus::installNeeded)
+		setStatus(moduleStatus::readyForUse);
+}
+
 void DynamicModule::setLoadingNeeded()
 {
 	if(_status != moduleStatus::installNeeded)

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -140,6 +140,7 @@ public:
 	void				setLoadingSucces(bool succes);
 	void				setInstallingSucces(bool succes);
 	void				setLoadingNeeded();
+	void				setReadyForUse();
 	void				setStatus(moduleStatus newStatus);
 
 	const AnalysisEntries & menu()		const	{ return _menuEntries; }

--- a/Desktop/modules/dynamicmodules.h
+++ b/Desktop/modules/dynamicmodules.h
@@ -40,6 +40,7 @@ public:
 	static DynamicModules * dynMods()	{ return _singleton; }
 
 	void					initializeInstalledModules();
+	void					startUpCompleted()				{ _startingUp = false; }
 
 	bool					unpackAndInstallModule(		const	std::string & moduleZipFilename);
 	void					uninstallModule(			const	std::string & moduleName);
@@ -90,7 +91,7 @@ public:
 
 	void startWatchingDevelopersModule();
 
-	bool developersModuleInstallButtonEnabled() const { return _developersModuleInstallButtonEnabled; }
+	bool developersModuleInstallButtonEnabled() const { return _devModInstallButtonOn; }
 	bool dataLoaded()							const { return _dataLoaded;	}
 
 	void stopAndRestartEngines();
@@ -156,16 +157,17 @@ private:
 															_modulesWaitingForDependency;
 	std::map<std::string, Json::Value>						_modulesToBeUnloaded;
 	boost::filesystem::path									_modulesInstallDirectory;
-	QString													_currentInstallMsg = "",
-															_currentInstallName = "";
-	bool													_currentInstallDone = false;
+	QString													_currentInstallMsg			= "",
+															_currentInstallName			= "";
+	bool													_currentInstallDone			= false,
+															_devModInstallButtonOn		= true,
+															_dataLoaded					= false,
+															_startingUp					= true;
 	QDir													_devModSourceDirectory;
 	QFileSystemWatcher									*	_devModDescriptionWatcher	= nullptr,
 														*	_devModRWatcher				= nullptr,
 														*	_devModHelpWatcher			= nullptr;
 	Modules::DynamicModule								*	_devModule					= nullptr;
-	bool													_developersModuleInstallButtonEnabled = true,
-															_dataLoaded = false;
 };
 
 #endif // DYNAMICMODULES_H

--- a/Desktop/modules/ribbonbutton.h
+++ b/Desktop/modules/ribbonbutton.h
@@ -86,8 +86,8 @@ public slots:
 	void setRequiresData(bool requiresData);
 	void setIsCommon(bool isCommonModule);
 	void setTitle(std::string title);
-	void setIconSource(QString iconSource);
 	void setTitleQ(QString title)									{ setTitle(title.toStdString()); }
+	void setIconSource(QString iconSource);
 	void setEnabled(bool enabled);
 	void setModuleName(std::string moduleName);
 	void setModuleNameQ(QString moduleName)							{ setModuleName(moduleName.toStdString()); }
@@ -113,7 +113,6 @@ signals:
 	void iconSourceChanged();
 	void dataLoadedChanged();
 	void activeChanged();
-	void analysisTitleChanged(std::string moduleName, std::string oldTitle, std::string newTitle);
 	void toolTipChanged(QString toolTip);
 	void analysisMenuChanged();
 	void isSpecialChanged(); //This wont be called it is just here to keep qml from complaining

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -117,7 +117,6 @@ void RibbonModel::addRibbonButtonModel(RibbonButton* model)
 	emit endInsertRows();
 
 	connect(model, &RibbonButton::iChanged,				this, &RibbonModel::ribbonButtonModelChanged);
-	connect(model, &RibbonButton::analysisTitleChanged, this, &RibbonModel::analysisTitleChanged	);
 }
 
 void RibbonModel::dynamicModuleReplaced(Modules::DynamicModule * oldModule, Modules::DynamicModule * module)

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -86,7 +86,6 @@ signals:
 				void currentButtonModelChanged();
 				void analysisClickedSignal(QString analysisFunction, QString analysisQML, QString analysisTitle, QString module);
 				void highlightedModuleIndexChanged(int highlightedModuleIndex);
-				void analysisTitleChanged(std::string moduleName, std::string oldTitle, std::string newTitle);
 				void showRCommander();
 
 public slots:

--- a/Desktop/results/resultsjsinterface.h
+++ b/Desktop/results/resultsjsinterface.h
@@ -24,6 +24,7 @@
 #include <QQmlWebChannel>
 #include <QAuthenticator>
 #include <QNetworkReply>
+#include <queue>
 
 #include "utilities/jsonutilities.h"
 #include "analysis/analysis.h"
@@ -46,7 +47,7 @@ public:
 	void analysisChanged(	Analysis *	analysis);
 	void overwriteUserdata(	Analysis *	analysis);
 	void showAnalysis(		int			id);
-	void setResultsMeta(	QString		str);
+	void setResultsMeta(	const QString &	str);
 	void showInstruction();
 	void exportPreviewHTML();
 	void exportHTML();
@@ -60,6 +61,7 @@ public:
 	Q_INVOKABLE void unselect();
 	Q_INVOKABLE void purgeClipboard();
 	Q_INVOKABLE void analysisEditImage(int id, QString options);
+	Q_INVOKABLE void runJavaScript(const QString & js);
 
 	//Callable from javascript through resultsJsInterfaceInterface...
 signals:
@@ -104,7 +106,8 @@ signals:
 	void resultsMetaChanged(	QString resultsMeta);
 	void allUserDataChanged(	QString userData);
 	void resultsPageUrlChanged(	QUrl	resultsPageUrl);
-	void runJavaScript(			QString js);
+	void runJavaScriptSignal(			QString js); //Do not call this directly here, use runJavaScript()
+	void runJavaScriptSignalQueued(		QString js); //Same same
 	void zoomChanged();
 	void resultsPageLoadedSignal();
 	void resultsLoadedChanged(bool resultsLoaded);
@@ -121,20 +124,22 @@ public slots:
 	void setZoomInWebEngine();
 	void setResultsLoaded(			bool			resultsLoaded);
 	void setScrollAtAll(			bool			scrollAtAll);
-
+	
 private:
 	void	setGlobalJsValues();
 	QString escapeJavascriptString(const QString &str);
-
+	void	dequeueJsQueue();
 
 private slots:
-	void menuHidding();
+	void menuHiding();
 
 private:
-	double			_webEngineZoom	= 1.0;
-	QString			_resultsPageUrl = "qrc:///html/index.html";
-	bool			_resultsLoaded	= false,
-					_scrollAtAll	= true;
+	double				_webEngineZoom	= 1.0;
+	QString				_resultsPageUrl = "qrc:///html/index.html";
+	bool				_resultsLoaded	= false,
+						_scrollAtAll	= true;
+	
+	std::queue<QString>	_delayedJs;
 
 	static ResultsJsInterface * _singleton;
 };

--- a/Desktop/utilities/languagemodel.cpp
+++ b/Desktop/utilities/languagemodel.cpp
@@ -154,8 +154,15 @@ void LanguageModel::changeLanguage(int index)
 	//prepare for language change
 	emit aboutToChangeLanguage();								//asks all analyses to abort and to block refresh
 	ResultsJsInterface::singleton()->setResultsLoaded(false);	//So that javascript starts queueing any Js (such as title changed of an analysis) until the page is reloaded
-	emit pauseEngines();												//Hopefully avoids process being called while we are in the middle of changing the language
-	
+
+	//On linux it somehow ignores the newer settings, so instead of pausing we kill the engines... https://github.com/jasp-stats/jasp-test-release/issues/1046
+	//But I do not know if it necessary, because the modules-translations aren't working.
+#ifdef __gnu_linux__
+	emit stopEngines();
+#else
+	emit pauseEngines();										//Hopefully avoids process being called while we are in the middle of changing the language
+#endif
+
 	//do it
 	_qml->retranslate();
 	Settings::setValue(Settings::PREFERRED_LANGUAGE, cl);

--- a/Desktop/utilities/languagemodel.h
+++ b/Desktop/utilities/languagemodel.h
@@ -73,6 +73,9 @@ public slots:
 signals:
 	void currentIndexChanged();
 	void languageChanged();
+	void aboutToChangeLanguage();
+	void pauseEngines();
+	void resumeEngines();
 
 private:
 	static char		suffixChar() { return _singleton->_suffixChar; }

--- a/Desktop/utilities/languagemodel.h
+++ b/Desktop/utilities/languagemodel.h
@@ -75,6 +75,7 @@ signals:
 	void languageChanged();
 	void aboutToChangeLanguage();
 	void pauseEngines();
+	void stopEngines();
 	void resumeEngines();
 
 private:

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -658,7 +658,6 @@ void Engine::saveImage()
 
 	_analysisStatus								= Status::complete;
 	_analysisResults["results"]["inputOptions"]	= _imageOptions;
-	_progress									= -1;
 
 	sendAnalysisResults();
 
@@ -677,7 +676,6 @@ void Engine::editImage()
 		_analysisResults["results"]["request"] = _imageOptions.get("request", -1);
 
 	_analysisStatus			= Status::complete;
-	_progress				= -1;
 
 	sendAnalysisResults();
 
@@ -692,7 +690,6 @@ void Engine::rewriteImages()
 	_analysisStatus				= Status::complete;
 	_analysisResults			= Json::Value();
 	_analysisResults["status"]	= analysisResultStatusToString(analysisResultStatus::imagesRewritten);
-	_progress					= -1;
 
 	sendAnalysisResults();
 
@@ -714,14 +711,14 @@ analysisResultStatus Engine::getStatusToAnalysisStatus()
 
 void Engine::sendAnalysisResults()
 {
-	Json::Value response = Json::Value(Json::objectValue);
+	Json::Value response			= Json::Value(Json::objectValue);
 
-	response["typeRequest"]	= engineStateToString(engineState::analysis);
-	response["id"]			= _analysisId;
-	response["name"]		= _analysisName;
-	response["revision"]	= _analysisRevision;
-	response["progress"]	= _progress;
-
+	response["typeRequest"]			= engineStateToString(engineState::analysis);
+	response["id"]					= _analysisId;
+	response["name"]				= _analysisName;
+	response["revision"]			= _analysisRevision;
+	response["progress"]			= Json::nullValue;
+	
 	bool					sensibleResultsStatus	= _analysisResults.isObject() && _analysisResults.get("status", Json::nullValue) != Json::nullValue;
 	analysisResultStatus	resultStatus			= !sensibleResultsStatus ? getStatusToAnalysisStatus() : analysisResultStatusFromString(_analysisResults["status"].asString());
 

--- a/JASP.pri
+++ b/JASP.pri
@@ -4,7 +4,7 @@
 JASP_R_INTERFACE_TARGET = R-Interface
 
 JASP_R_INTERFACE_MAJOR_VERSION =  10  # Interface changes or whenever you feel majorlike
-JASP_R_INTERFACE_MINOR_VERSION =  12   # Code changes
+JASP_R_INTERFACE_MINOR_VERSION =  13   # Code changes
 
 JASP_R_INTERFACE_NAME = $$JASP_R_INTERFACE_TARGET$$JASP_R_INTERFACE_MAJOR_VERSION'.'$$JASP_R_INTERFACE_MINOR_VERSION
 
@@ -124,19 +124,21 @@ GENERATE_LANGUAGE_FILES = false
 message("AM_I_BUILDBOT: '$$[AM_I_BUILDBOT]'")
 COPY_BUILDBOTNESS = $$[AM_I_BUILDBOT] # We need to copy it to make sure the equals function below actually works...
 !equals(COPY_BUILDBOTNESS, "") {
-!equals(COPY_BUILDBOTNESS, "\"\"") { #this should be done less stupidly but I do not want to waste my time on that now
-	GENERATE_LANGUAGE_FILES = true
-}
+	!equals(COPY_BUILDBOTNESS, "\"\"") { #this should be done less stupidly but I do not want to waste my time on that now
+		GENERATE_LANGUAGE_FILES = true
+	}
 }
 
 GETTEXT_LOCATION = $$(GETTEXT_PATH) #The GETTEXT_PATH can be used as environment for a specific gettext location
-unix{
-isEmpty(GETTEXT_LOCATION): GETTEXT_LOCATION=/usr/local/bin
-EXTENDED_PATH = $$(PATH):$$GETTEXT_LOCATION:$$_R_HOME:$$dirname(QMAKE_QMAKE)
+
+unix {
+	isEmpty(GETTEXT_LOCATION): GETTEXT_LOCATION=/usr/local/bin
+	EXTENDED_PATH = $$(PATH):$$GETTEXT_LOCATION:$$_R_HOME:$$dirname(QMAKE_QMAKE)
 }
-win32{
-isEmpty(GETTEXT_LOCATION): GETTEXT_LOCATION=$${_GIT_LOCATION}\usr\bin
-WINQTBIN=$$QMAKE_QMAKE
-WINQTBIN ~= s,qmake.exe,,gs
-WINQTBIN ~= s,/,\\,g
+
+win32 {
+	isEmpty(GETTEXT_LOCATION): GETTEXT_LOCATION=$${_GIT_LOCATION}\usr\bin
+	WINQTBIN=$$QMAKE_QMAKE
+	WINQTBIN ~= s,qmake.exe,,gs	
+	WINQTBIN ~= s,/,\\,g
 }

--- a/R-Interface/jaspResults/src/jaspResults.cpp
+++ b/R-Interface/jaspResults/src/jaspResults.cpp
@@ -305,7 +305,7 @@ const char * jaspResults::constructResultJson()
 {
 	_response["typeRequest"]	= "analysis"; // Should correspond to engineState::analysis to string
 	_response["results"]		= dataEntry();
-	_response["name"]			= _response["results"]["title"];
+	//Why was this here anyway and why is the title used as "name" because that is confusing: _response["name"]			= _response["results"]["title"];
 
 	if(errorMessage != "" )
 	{
@@ -352,7 +352,7 @@ Json::Value jaspResults::dataEntry(std::string &) const
 {
 	Json::Value dataJson(jaspObject::dataEntryBase());
 
-	dataJson["title"]	= _title;
+	//dataJson["title"]	= _title; We dont need this anymore. Js doesnt look at this anymore because of the solution to https://github.com/jasp-stats/jasp-issues/issues/1088. Leaving comment here for a feautre moment where someone wonders why title is a property of jaspResults but doesnt do anything.
 	dataJson["name"]	= getUniqueNestedName();
 	dataJson[".meta"]	= metaEntry();
 


### PR DESCRIPTION
- Also fix some whitespace
- Fixes https://github.com/jasp-stats/jasp-issues/issues/1088 (analysis results headers dont change on language change)
- Javascript should use just the proper title from Analysis directly instead of the one From R. So jaspResults does not need to send it either.
- pause and resume engines for languagechange to avoid running stuff while it is still going on
- Also added a queue for javascript commands to the results, this because the commands are otherwise silently ignored during the small window of time where the webeengine is reloading during languagechange.
- And removed some legacy JS code, pretty sure this doesn't affect anything but would appreciate if Tim glances at it suavely.

