### PR TITLE
PlotEditing now shows a message for unsupported figures

### DIFF
--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
@@ -29,12 +29,11 @@ Column
 					id:			axis
 					spacing:	jaspTheme.columnGroupSpacing
 	property var	axisModel:	null
-	property string title:		""
 
 	JASPC.TextField
 	{
 		id:					axisTitle
-		label:				qsTr("Title of %1").arg(axis.title);
+		label:				qsTr("Title");
 		fieldWidth:			200
 		value:				axisModel.title
 		onEditingFinished:	if(axisModel) axisModel.title = value

--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
@@ -117,7 +117,6 @@ Popup
 						PlotEditingAxis
 						{
 							id:				xAxis
-							title:			axisDropDown.label
 							axisModel:		plotEditorModel.currentAxis
 
 							anchors

--- a/Desktop/html/js/image.js
+++ b/Desktop/html/js/image.js
@@ -38,7 +38,7 @@ JASPWidgets.imageView = JASPWidgets.objectView.extend({
 
 
 	hasNotes:					function() {	return this.$el.hasClass('jasp-collection-item')	=== false;	},
-	isEditable:					function() {	return this.model.get("editable")					==  true;	},
+	isEditable:					function() {	return true;													},
 	hasCollapse:				function() {	return this.$el.hasClass('jasp-collection-item')	=== false;	},
 	isConvertible:				function() {	return this.model.get("convertible")				==  true;	},
 	saveImageClicked:			function() {	this.model.trigger("SaveImage:clicked",							{ data: this.model.get("data"), width: this.model.get("width"), height: this.model.get("height"), name: this.model.get("name")							});	},

--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -92,7 +92,8 @@ void PlotEditorModel::processImgOptions()
 	setWidth(				_imgOptions.get(	"width",		100).asInt());
 	setHeight(				_imgOptions.get(	"height",		100).asInt());
 
-	_editOptions = _name == "" || !_analysis ? Json::objectValue : _analysis->editOptionsOfPlot(_name.toStdString());
+	//_editOptions		=	_imgOptions.get(	"editOptions",	Json::objectValue);
+	_editOptions		=	_name == "" || !_analysis ? Json::objectValue : _analysis->editOptionsOfPlot(_name.toStdString());
 
 	std::string reasonOptionsAreInvalid = _editOptions.get("reasonNotEditable", "").asString();
 

--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -48,7 +48,8 @@ void PlotEditorModel::showPlotEditor(int id, QString options)
 	
 	processImgOptions();
 
-	setVisible(true);
+	if (_validOptions)
+		setVisible(true);
 	setLoading(false);
 }
 
@@ -91,8 +92,17 @@ void PlotEditorModel::processImgOptions()
 	setWidth(				_imgOptions.get(	"width",		100).asInt());
 	setHeight(				_imgOptions.get(	"height",		100).asInt());
 
-	//_editOptions		=	_imgOptions.get(	"editOptions",	Json::objectValue);
-	_editOptions		=	_name == "" || !_analysis ? Json::objectValue : _analysis->editOptionsOfPlot(_name.toStdString());
+	_editOptions = _name == "" || !_analysis ? Json::objectValue : _analysis->editOptionsOfPlot(_name.toStdString());
+
+	std::string reasonOptionsAreInvalid = _editOptions.get("reasonNotEditable", "").asString();
+
+	_validOptions = reasonOptionsAreInvalid.empty();
+	if (!_validOptions)
+	{
+		MessageForwarder::showWarning(reasonOptionsAreInvalid);
+		return;
+	}
+
 	Json::Value	xAxis	=	_editOptions.get(	"xAxis",		Json::objectValue),
 				yAxis	=	_editOptions.get(	"yAxis",		Json::objectValue);
 

--- a/Desktop/results/ploteditormodel.h
+++ b/Desktop/results/ploteditormodel.h
@@ -111,6 +111,7 @@ public slots:
 
 private:
 	void		processImgOptions();
+	void		validateEditOptions();
 	Json::Value generateImgOptions()	const;
 	Json::Value generateEditOptions()	const;
 
@@ -132,7 +133,8 @@ private:
 	bool					_visible		= false,
 							_goBlank		= false,
 							_loading		= false,
-							_advanced		= false;
+							_advanced		= false,
+							_validOptions	= false;
 	int						_width,
 							_height,
 							_analysisId,

--- a/Desktop/results/ploteditormodel.h
+++ b/Desktop/results/ploteditormodel.h
@@ -111,7 +111,6 @@ public slots:
 
 private:
 	void		processImgOptions();
-	void		validateEditOptions();
 	Json::Value generateImgOptions()	const;
 	Json::Value generateEditOptions()	const;
 

--- a/R-Interface/jaspResults/R/writeImage.R
+++ b/R-Interface/jaspResults/R/writeImage.R
@@ -110,7 +110,7 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
   }
   #If we have jaspGraphs available we can get the plotEditingOptions for this plot
   if(requireNamespace("jaspGraphs", quietly = TRUE))
-    image[["editOptions"]] <- jaspGraphs::plotEditingOptions(graph = plot, asJSON = TRUE)
+    image[["editOptions"]] <- jaspGraphs::plotEditingOptions(plot, asJSON = TRUE)
 
   return(image)
 }

--- a/R-Interface/jaspResults/R/writeImage.R
+++ b/R-Interface/jaspResults/R/writeImage.R
@@ -75,10 +75,6 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
       limitsize = FALSE # only necessary if users make the plot ginormous.
     )
 
-    #If we have jaspGraphs available we can get the plotEditingOptions for this plot
-    if(requireNamespace("jaspGraphs", quietly = TRUE))
-      plotEditingOptions <- jaspGraphs::plotEditingOptions(graph=plot, asJSON=TRUE)
-
   } else {
     
     isRecordedPlot <- inherits(plot2draw, "recordedplot")
@@ -111,8 +107,10 @@ writeImageJaspResults <- function(width=320, height=320, plot, obj=TRUE, relativ
 
   if (obj) {
     image[["obj"]]         <- plot2draw
-    image[["editOptions"]] <- plotEditingOptions
   }
+  #If we have jaspGraphs available we can get the plotEditingOptions for this plot
+  if(requireNamespace("jaspGraphs", quietly = TRUE))
+    image[["editOptions"]] <- jaspGraphs::plotEditingOptions(graph = plot, asJSON = TRUE)
 
   return(image)
 }

--- a/R-Interface/jaspResults/src/jaspPlot.cpp
+++ b/R-Interface/jaspResults/src/jaspPlot.cpp
@@ -40,7 +40,8 @@ Json::Value jaspPlot::dataEntry(std::string & errorMessage) const
 	data["revision"]	= _revision;
 	data["name"]		= getUniqueNestedName();
 	data["editOptions"]	= _editOptions;
-	data["editable"]	= !_editOptions.isNull();
+	data["reasonNotEditable"] = _editOptions.get("reasonNotEditable", "unknown reason");
+	data["editable"]	= !_editOptions.isNull() && data["reasonNotEditable"] == "";
 
 	return data;
 }

--- a/R-Interface/jaspResults/src/jaspPlot.cpp
+++ b/R-Interface/jaspResults/src/jaspPlot.cpp
@@ -41,7 +41,8 @@ Json::Value jaspPlot::dataEntry(std::string & errorMessage) const
 	data["name"]		= getUniqueNestedName();
 	data["editOptions"]	= _editOptions;
 	data["reasonNotEditable"] = _editOptions.get("reasonNotEditable", "unknown reason");
-	data["editable"]	= !_editOptions.isNull() && data["reasonNotEditable"] == "";
+	data["errorType"]	= _editOptions.get("errorType", "fatalError");
+	data["editable"]	= !_editOptions.isNull() && data["errorType"] == "success";
 
 	return data;
 }


### PR DESCRIPTION
Requires https://github.com/jasp-stats/jaspGraphs/pull/11

The changes to PlotEditingAxis.qml & PlotEditor.qml fix the issue where `title: axisDropDown.label` should have been `title: axisDropDown.currentLabel`. Before we had:
![image](https://user-images.githubusercontent.com/21319932/107034021-67e98c80-67b6-11eb-8513-281015c892c1.png)

The original idea was to show "Title of x-axis". Nevertheless, since we use a drop-down to select which axis is shown, I think this information is just duplicative (and error-prone) so I changed the text to just `"Title"`.

The other changes are the start of an error messaging system. The field error can have 3 values on the R side: "success", "validationError", and "fatalError". The C++ side doesn't do much with that yet, but it could.
