### PR TITLE
Add error handling for dependencies with optionContainsValue

### DIFF
--- a/R-Interface/jaspResults/R/zzzWrappers.R
+++ b/R-Interface/jaspResults/R/zzzWrappers.R
@@ -243,6 +243,8 @@ jaspObjR <- R6Class(
 				for (i in seq_along(optionContainsValue)) {
 					name <- names(optionContainsValue)[i]
 					value <- optionContainsValue[[i]]
+					if (!is.character(value))
+						stop(sprintf("Expected a character vector but got object of class %s", paste(class(value), collapse = ", ")))
 					private$jaspObject$setOptionMustContainDependency(name, value)
 				}
 			}

--- a/R-Interface/jaspResults/src/jaspObject.cpp
+++ b/R-Interface/jaspResults/src/jaspObject.cpp
@@ -328,6 +328,9 @@ void jaspObject::setOptionMustBeDependency(std::string optionName, Rcpp::RObject
 
 void jaspObject::setOptionMustContainDependency(std::string optionName, Rcpp::RObject mustContainThis)
 {
+	if (!Rcpp::is<Rcpp::CharacterVector>(mustContainThis))
+		Rf_error("setOptionMustContainDependency expected a character string but got something else!");
+
 	_optionMustContain[optionName] = jaspJson::RObject_to_JsonValue(mustContainThis);
 }
 


### PR DESCRIPTION
So this adds an error message when people put invalid stuff into `plot$dependOn(optionContainsValue = )`. Basically, it checks whether the value is a character string and otherwise throws an error. It might be a bit redundant to do this in two places, but the stack trace is just a bit nicer when we put the error on the R side (which is where it's most likely to go wrong). The error handling on the C++ side guarantees that it's really impossible to use invalid values as dependencies, but it is a bit superfluous if the error check also happens on the R side.

The stack trace when the error is thrown in R: 

![errorinR](https://user-images.githubusercontent.com/21319932/107781507-435a5b00-6d48-11eb-8b94-a0b43e4a088f.png)

The stack trace when the error is thrown in C++:

![errorinCpp](https://user-images.githubusercontent.com/21319932/107781517-45241e80-6d48-11eb-9d50-c7403673a53d.png)
