### PR TITLE
Improve Radio Buttons

### DIFF
--- a/Desktop/analysis/jaspcontrol.cpp
+++ b/Desktop/analysis/jaspcontrol.cpp
@@ -376,6 +376,11 @@ void JASPControl::_setFocusBorder()
 				_borderAnimation.start();
 			}
 		}
+		else
+		{
+			_borderAnimation.stop();
+			border->setProperty("width", borderWidth); // just to be sure..
+		}
 	}
 }
 

--- a/Desktop/components/JASP/Controls/RadioButton.qml
+++ b/Desktop/components/JASP/Controls/RadioButton.qml
@@ -51,14 +51,9 @@ RadioButtonBase
 
 	function click()
 	{
-		if (!checked)
-		{
-			control.toggle();
-			control.clicked()
-		}
+		if (buttonGroup) buttonGroup.clicked(control)
 	}
 
-	function toggle() { control.toggle() }
 
 	RadioButton
 	{
@@ -66,6 +61,8 @@ RadioButtonBase
 		ButtonGroup.group:	buttonGroup
 		padding:			jaspTheme.jaspControlPadding
 		focus:				true
+
+		onCheckedChanged:	if (buttonGroup && checked) buttonGroup.clicked(control)
 
 		indicator: Rectangle
 		{

--- a/Desktop/components/JASP/Controls/RadioButtonGroup.qml
+++ b/Desktop/components/JASP/Controls/RadioButtonGroup.qml
@@ -33,12 +33,11 @@ RadioButtonsGroupBase
 	default property alias	content:				contentArea.children
 			property alias	buttons:				buttonGroup.buttons
 			property alias	checkedButton:			buttonGroup.checkedButton
-			property var	buttonGroup:			buttonGroup
+			property alias	buttonGroup:			buttonGroup
 			property bool	radioButtonsOnSameRow:	false
 			property alias	columns:				contentArea.columns
 			property alias	text:					control.title
 			property int	leftPadding:			jaspTheme.groupContentPadding
-			property string	value:					""
 
 	implicitWidth:	radioButtonsOnSameRow
 						? contentArea.x + contentArea.implicitWidth
@@ -49,6 +48,11 @@ RadioButtonsGroupBase
 						: contentArea.y + contentArea.implicitHeight	
     
 	L.Layout.leftMargin:	indent ? jaspTheme.indentationLength : 0
+
+	Component.onCompleted:
+	{
+		buttonGroup.clicked.connect(clicked);
+	}
 	
 	Label
 	{
@@ -73,12 +77,7 @@ RadioButtonsGroupBase
 		anchors.topMargin:	control.title && !radioButtonsOnSameRow ? jaspTheme.titleBottomMargin : 0
 		anchors.left:		control.title && radioButtonsOnSameRow ? label.right : control.left
 		anchors.leftMargin: control.title ? jaspTheme.groupContentPadding : 0
-    }
-	
-	Component.onCompleted:
-	{
-        buttonGroup.clicked.connect(clicked);
-    }
+	}
 
 	background: backgroundBox
 

--- a/Desktop/widgets/radiobuttonsgroupbase.h
+++ b/Desktop/widgets/radiobuttonsgroupbase.h
@@ -29,6 +29,8 @@ class RadioButtonsGroupBase : public JASPControl, public BoundControlBase
 {
 	Q_OBJECT
 	
+	Q_PROPERTY( QString		value	READ value	WRITE setValue	NOTIFY valueChanged	)
+
 public:
 	RadioButtonsGroupBase(QQuickItem* parent = nullptr);
 
@@ -37,17 +39,24 @@ public:
 	void		bindTo(const Json::Value& value)			override;
 	void		setUp()										override;
     
+	const QString&	value()										const	{ return _value; }
+
 signals:
+	void valueChanged();
 	void clicked(const QVariant& button);
 
 protected slots:
 	void clickedSlot(const QVariant& button);
 
 protected:
-	QMap<QString, RadioButtonBase *>	_buttons;
-	RadioButtonBase*					_checkedButton	= nullptr;
-	
+	GENERIC_SET_FUNCTION(Value,		_value,		valueChanged,	QString	)
+
+	void _setCheckedButton(RadioButtonBase* button);
 	void _getRadioButtons(QQuickItem* item, QList<RadioButtonBase* >& buttons);
+
+	QMap<QString, RadioButtonBase *>	_buttons;
+	QString								_value;
+	
 };
 
 #endif // RADIOBUTTONSGROUPBASE_H


### PR DESCRIPTION
. Set first button as default checked RadioButton when no other default
button is given.
. Add possibility to set the checked property with a binding.
For example
`RadioButton { value: "histogram";	label: qsTr("Histogram");  checked : mycheck.checked 	}`
histogram should be checked everytime the checkbox mycheck is checked.
. Sometimes the focus indicator was still on, even if the control was
not focused anymore