### PR TITLE
Add the possibility to set initial values in the FilteredDataEntryModel TableView

### DIFF
--- a/Desktop/components/JASP/Controls/TableView.qml
+++ b/Desktop/components/JASP/Controls/TableView.qml
@@ -33,7 +33,7 @@ TableViewBase
 	implicitWidth:		400
 	implicitHeight:		400
 	shouldStealHover:	false
-	defaultEmptyValue:	modelType === JASP.JAGSDataInputModel	? "..." : (modelType === JASP.CustomContrasts	? "0" : "1")
+	defaultValue:		modelType === JASP.JAGSDataInputModel	? "..." : (modelType === JASP.CustomContrasts	? "0" : "1")
 	initialColumnCount: modelType === JASP.MultinomialChi2Model ? 1 : 0
 
 	property string factorsSource	: ""
@@ -186,7 +186,7 @@ TableViewBase
 						value:					itemText
 						useLastValidValue:		false
 						parseDefaultValue:		tableView.parseDefaultValue
-						defaultEmptyValue:		tableView.defaultEmptyValue
+						defaultEmptyValue:		tableView.defaultValue
 						selectValueOnFocus:		true
 						validator:				tableView.validator
 						onPressed:				tableView.colSelected = columnIndex

--- a/Desktop/widgets/boundcontrolfilteredtableview.cpp
+++ b/Desktop/widgets/boundcontrolfilteredtableview.cpp
@@ -29,10 +29,12 @@ Json::Value BoundControlFilteredTableView::createJson()
 {
 	Json::Value result(Json::arrayValue);
 	Json::Value row(Json::objectValue);
+	Json::Value values(Json::arrayValue);
 
 	row["colName"]	= fq(_tableView->property("colName").toString());
 	row["filter"]	= fq(_tableView->property("filter").toString());
 	row["extraCol"] = fq(_tableView->property("extraCol").toString());
+	row["values"] = values;
 
 	result.append(row);
 	return result;

--- a/Desktop/widgets/boundcontroltableview.cpp
+++ b/Desktop/widgets/boundcontroltableview.cpp
@@ -136,11 +136,11 @@ Json::Value BoundControlTableView::_defaultValue()
 	JASPControl::ItemType itemType = _tableView->itemType();
 
 	if (itemType == JASPControl::ItemType::Double)
-		defaultValue = _tableView->defaultEmptyValue().toDouble();
+		defaultValue = _tableView->defaultValue().toDouble();
 	else if (itemType == JASPControl::ItemType::Integer)
-		defaultValue = _tableView->defaultEmptyValue().toInt();
+		defaultValue = _tableView->defaultValue().toInt();
 	else
-		defaultValue = fq(_tableView->defaultEmptyValue());
+		defaultValue = fq(_tableView->defaultValue().toString());
 
 	return defaultValue;
 }

--- a/Desktop/widgets/listmodelfiltereddataentry.h
+++ b/Desktop/widgets/listmodelfiltereddataentry.h
@@ -50,6 +50,7 @@ public:
 
 public slots:
 	void	sourceTermsReset()															override;
+	void	initialValuesChanged()														override;
 	void	setFilter(QString filter);
 	void	setColName(QString colName);
 	void	setExtraCol(QString extraCol);
@@ -73,6 +74,7 @@ private:
 	std::vector<bool>			_acceptedRows;
 	std::vector<size_t>			_filteredRowToData;
 	std::map<size_t, double>	_enteredValues;
+	std::vector<double>			_initialValues;
 	int							_editableColumn = 0;
 	QStringList					_dataColumns,
 								_extraColsStr;

--- a/Desktop/widgets/listmodeltableviewbase.h
+++ b/Desktop/widgets/listmodeltableviewbase.h
@@ -108,6 +108,9 @@ signals:
 	void variableCountChanged();
 	void itemChangedSignal(int column, int row, double value);
 
+public slots:
+	virtual void initialValuesChanged() {}
+
 protected slots:
 	void formulaCheckSucceededSlot();
 

--- a/Desktop/widgets/tableviewbase.cpp
+++ b/Desktop/widgets/tableviewbase.cpp
@@ -142,16 +142,6 @@ void TableViewBase::rScriptDoneHandler(const QString & result)
 		_tableModel->rScriptDoneHandler(result);
 }
 
-QVariant TableViewBase::defaultValue()
-{
-	if (itemType() == JASPControl::ItemType::Double)
-		return defaultEmptyValue().toDouble();
-	else if (itemType() == JASPControl::ItemType::Integer)
-		return defaultEmptyValue().toInt();
-	else
-		return defaultEmptyValue();
-}
-
 void TableViewBase::refreshMe()
 {
 	if(_tableModel)

--- a/Desktop/widgets/tableviewbase.cpp
+++ b/Desktop/widgets/tableviewbase.cpp
@@ -74,6 +74,9 @@ void TableViewBase::setUp()
 
 	JASPListControl::setUp();
 
+	setInitialValuesControl();
+	connect(this,	&TableViewBase::initialValuesSourceChanged, this, &TableViewBase::setInitialValuesControl);
+
 	// form is not always known in the constructor, so all references to form (and dataset) must be done here
 	connect(form(),		&AnalysisForm::refreshTableViewModels,			this, &TableViewBase::refreshMe	);
 	_tableModel->setup();
@@ -115,6 +118,21 @@ void TableViewBase::itemChangedSlot(int col, int row, QString value, QString typ
 	{
 		if (_tableModel->valueOk(value))	_tableModel->itemChanged(col, row, value, type);
 		else								QTimer::singleShot(0, _tableModel, &ListModelTableViewBase::refreshModel);
+	}
+}
+
+void TableViewBase::setInitialValuesControl()
+{
+	if (_initialValuesControl)
+		disconnect(_initialValuesControl->model(), &ListModel::termsChanged, _tableModel, &ListModelTableViewBase::initialValuesChanged);
+
+	QString initialValuesSourceName = initialValuesSource().toString();
+	if (!initialValuesSourceName.isEmpty() && form())
+	{
+		_initialValuesControl = qobject_cast<JASPListControl*>(form()->getControl(initialValuesSourceName));
+		addDependency(_initialValuesControl);
+		connect(_initialValuesControl->model(), &ListModel::termsChanged, _tableModel, &ListModelTableViewBase::initialValuesChanged);
+		_tableModel->initialValuesChanged();
 	}
 }
 

--- a/Desktop/widgets/tableviewbase.h
+++ b/Desktop/widgets/tableviewbase.h
@@ -27,14 +27,15 @@ class TableViewBase : public JASPListControl, public BoundControl
 {
 	Q_OBJECT
 
-	Q_PROPERTY( ModelType		modelType			READ modelType			WRITE setModelType			NOTIFY modelTypeChanged				)
-	Q_PROPERTY( ItemType		itemType			READ itemType			WRITE setItemType			NOTIFY itemTypeChanged				)
-	Q_PROPERTY( QString			defaultEmptyValue	READ defaultEmptyValue	WRITE setDefaultEmptyValue	NOTIFY defaultEmptyValueChanged		)
-	Q_PROPERTY( int				initialColumnCount	READ initialColumnCount	WRITE setInitialColumnCount	NOTIFY initialColumnCountChanged	)
-	Q_PROPERTY( int				initialRowCount		READ initialRowCount	WRITE setInitialRowCount	NOTIFY initialRowCountChanged		)
-	Q_PROPERTY( int				columnCount			READ columnCount									NOTIFY columnCountChanged			)
-	Q_PROPERTY( int				rowCount			READ rowCount										NOTIFY rowCountChanged				)
-	Q_PROPERTY( int				variableCount		READ variableCount									NOTIFY variableCountChanged			)
+	Q_PROPERTY( ModelType		modelType			READ modelType				WRITE setModelType				NOTIFY modelTypeChanged				)
+	Q_PROPERTY( ItemType		itemType			READ itemType				WRITE setItemType				NOTIFY itemTypeChanged				)
+	Q_PROPERTY( QString			defaultEmptyValue	READ defaultEmptyValue		WRITE setDefaultEmptyValue		NOTIFY defaultEmptyValueChanged		)
+	Q_PROPERTY( QVariant		initialValuesSource	READ initialValuesSource	WRITE setInitialValuesSource	NOTIFY initialValuesSourceChanged	)
+	Q_PROPERTY( int				initialColumnCount	READ initialColumnCount		WRITE setInitialColumnCount		NOTIFY initialColumnCountChanged	)
+	Q_PROPERTY( int				initialRowCount		READ initialRowCount		WRITE setInitialRowCount		NOTIFY initialRowCountChanged		)
+	Q_PROPERTY( int				columnCount			READ columnCount											NOTIFY columnCountChanged			)
+	Q_PROPERTY( int				rowCount			READ rowCount												NOTIFY rowCountChanged				)
+	Q_PROPERTY( int				variableCount		READ variableCount											NOTIFY variableCountChanged			)
 
 public:
 	TableViewBase(QQuickItem* parent = nullptr);
@@ -57,6 +58,8 @@ public:
 	JASPControl::ItemType		itemType()								const				{ return _itemType;						}
 	const QString&				defaultEmptyValue()						const				{ return _defaultEmptyValue;			}
 	QVariant					defaultValue();
+	QVariant					initialValuesSource()					const				{ return _initialValuesSource;			}
+	JASPListControl*			initialValuesControl()					const				{ return _initialValuesControl;			}
 	int							initialColumnCount()					const				{ return _initialColumnCount;			}
 	int							initialRowCount()						const				{ return _initialRowCount;				}
 	int							rowCount()								const				{ return _tableModel ? _tableModel->rowCount()		: 0; }
@@ -69,6 +72,7 @@ signals:
 	void						defaultEmptyValueChanged();
 	void						initialRowCountChanged();
 	void						initialColumnCountChanged();
+	void						initialValuesSourceChanged();
 	void						rowCountChanged();
 	void						columnCountChanged();
 	void						variableCountChanged();
@@ -84,6 +88,7 @@ protected slots:
 	GENERIC_SET_FUNCTION(DefaultEmptyValue,		_defaultEmptyValue,		defaultEmptyValueChanged,	QString		)
 	GENERIC_SET_FUNCTION(InitialRowCount,		_initialRowCount,		initialRowCountChanged,		int			)
 	GENERIC_SET_FUNCTION(InitialColumnCount,	_initialColumnCount,	initialColumnCountChanged,	int			)
+	GENERIC_SET_FUNCTION(InitialValuesSource,	_initialValuesSource,	initialValuesSourceChanged,	QVariant	)
 
 protected:
 	BoundControlTableView		* _boundControl	= nullptr;
@@ -96,6 +101,7 @@ private slots:
 	void removeRowSlot(int row);
 	void resetSlot();
 	void itemChangedSlot(int col, int row, QString value, QString type);
+	void setInitialValuesControl();
 
 private:
 	QString					_defaultEmptyValue;
@@ -103,6 +109,8 @@ private:
 	ItemType				_itemType				= ItemType::Double;
 	int						_initialRowCount		= 0,
 							_initialColumnCount		= 0;
+	QVariant				_initialValuesSource;
+	JASPListControl*		_initialValuesControl	= nullptr;
 };
 
 #endif // TABLEVIEWBASE_H

--- a/Desktop/widgets/tableviewbase.h
+++ b/Desktop/widgets/tableviewbase.h
@@ -29,7 +29,7 @@ class TableViewBase : public JASPListControl, public BoundControl
 
 	Q_PROPERTY( ModelType		modelType			READ modelType				WRITE setModelType				NOTIFY modelTypeChanged				)
 	Q_PROPERTY( ItemType		itemType			READ itemType				WRITE setItemType				NOTIFY itemTypeChanged				)
-	Q_PROPERTY( QString			defaultEmptyValue	READ defaultEmptyValue		WRITE setDefaultEmptyValue		NOTIFY defaultEmptyValueChanged		)
+	Q_PROPERTY( QVariant		defaultValue		READ defaultValue			WRITE setDefaultValue			NOTIFY defaultValueChanged			)
 	Q_PROPERTY( QVariant		initialValuesSource	READ initialValuesSource	WRITE setInitialValuesSource	NOTIFY initialValuesSourceChanged	)
 	Q_PROPERTY( int				initialColumnCount	READ initialColumnCount		WRITE setInitialColumnCount		NOTIFY initialColumnCountChanged	)
 	Q_PROPERTY( int				initialRowCount		READ initialRowCount		WRITE setInitialRowCount		NOTIFY initialRowCountChanged		)
@@ -56,8 +56,7 @@ public:
 
 	JASPControl::ModelType		modelType()								const				{ return _modelType;					}
 	JASPControl::ItemType		itemType()								const				{ return _itemType;						}
-	const QString&				defaultEmptyValue()						const				{ return _defaultEmptyValue;			}
-	QVariant					defaultValue();
+	QVariant					defaultValue()							const				{ return _defaultValue;					}
 	QVariant					initialValuesSource()					const				{ return _initialValuesSource;			}
 	JASPListControl*			initialValuesControl()					const				{ return _initialValuesControl;			}
 	int							initialColumnCount()					const				{ return _initialColumnCount;			}
@@ -69,7 +68,7 @@ public:
 signals:
 	void						modelTypeChanged();
 	void						itemTypeChanged();
-	void						defaultEmptyValueChanged();
+	void						defaultValueChanged();
 	void						initialRowCountChanged();
 	void						initialColumnCountChanged();
 	void						initialValuesSourceChanged();
@@ -85,7 +84,7 @@ protected slots:
 
 	GENERIC_SET_FUNCTION(ModelType,				_modelType,				modelTypeChanged,			ModelType	)
 	GENERIC_SET_FUNCTION(ItemType,				_itemType,				itemTypeChanged,			ItemType	)
-	GENERIC_SET_FUNCTION(DefaultEmptyValue,		_defaultEmptyValue,		defaultEmptyValueChanged,	QString		)
+	GENERIC_SET_FUNCTION(DefaultValue,			_defaultValue,			defaultValueChanged,		QVariant	)
 	GENERIC_SET_FUNCTION(InitialRowCount,		_initialRowCount,		initialRowCountChanged,		int			)
 	GENERIC_SET_FUNCTION(InitialColumnCount,	_initialColumnCount,	initialColumnCountChanged,	int			)
 	GENERIC_SET_FUNCTION(InitialValuesSource,	_initialValuesSource,	initialValuesSourceChanged,	QVariant	)
@@ -104,7 +103,7 @@ private slots:
 	void setInitialValuesControl();
 
 private:
-	QString					_defaultEmptyValue;
+	QVariant				_defaultValue;
 	ModelType				_modelType				= ModelType::Simple;
 	ItemType				_itemType				= ItemType::Double;
 	int						_initialRowCount		= 0,


### PR DESCRIPTION
With the property initialValuesSource, you can now set which column(s)
should give the initial values of the table.
To test it, add in AuditClassicalWorkflow or AuditBayesianWorkflow
`initialValuesSource:				"monetaryVariable"`
to the performAudit TableView.