### PR TITLE
Custom fonts attempt 3

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -25,6 +25,7 @@
 #include "utilities/qutils.h"
 #include "log.h"
 #include "utils.h"
+#include "utilities/settings.h"
 
 Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::string title, std::string moduleVersion, Json::Value *data) :
 	  QObject(Analyses::analyses()),
@@ -592,6 +593,7 @@ Json::Value Analysis::createAnalysisRequestJson()
 	json["revision"]			= revision();
 	json["rfile"]				= _moduleData == nullptr ? rfile() : "";
 	json["dynamicModuleCall"]	= _moduleData == nullptr ? "" : _moduleData->getFullRCall();
+	json["resultsFont"]			= Settings::value(Settings::RESULT_FONT).toString().toStdString();
 
 	if (!isAborted())
 	{

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -352,6 +352,7 @@ void MainWindow::makeConnections()
 	connect(_preferences,			&PreferencesModel::jaspThemeChanged,				this,					&MainWindow::jaspThemeChanged								);
 	connect(_preferences,			&PreferencesModel::currentThemeNameChanged,			_resultsJsInterface,	&ResultsJsInterface::setThemeCss							);
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_resultsJsInterface,	&ResultsJsInterface::setFontFamily							);
+	connect(_preferences,			&PreferencesModel::resultFontChanged,				_engineSync,			&EngineSync::refreshAllPlots								);
 	connect(_preferences,			&PreferencesModel::restartAllEngines,				_engineSync,			&EngineSync::haveYouTriedTurningItOffAndOnAgain				);
 
 	connect(_filterModel,			&FilterModel::refreshAllAnalyses,					_analyses,				&Analyses::refreshAllAnalyses,								Qt::QueuedConnection);

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -702,7 +702,7 @@ void Engine::editImage()
 
 void Engine::rewriteImages()
 {
-	jaspRCPP_rewriteImages(_analysisName.c_str(), _ppi, _imageBackground.c_str(), _analysisId);
+	jaspRCPP_rewriteImages(_analysisName.c_str(), _ppi, _imageBackground.c_str(), _resultsFont.c_str(), _analysisId);
 
 	/* Already sent from R! (Through jaspResultsCPP$send())
 	_analysisStatus				= Status::complete;

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -522,6 +522,7 @@ void Engine::receiveAnalysisMessage(const Json::Value & jsonRequest)
 		_imageOptions			= jsonRequest.get("image",				Json::nullValue);
 		_analysisRFile			= jsonRequest.get("rfile",				"").asString();
 		_dynamicModuleCall		= jsonRequest.get("dynamicModuleCall",	"").asString();
+		_resultsFont			= jsonRequest.get("resultsFont",		"").asString();
 		_engineState			= engineState::analysis;
 
 		Json::Value optionsEnc	= jsonRequest.get("options",			Json::nullValue);
@@ -635,7 +636,7 @@ void Engine::runAnalysis()
 
 	Log::log() << "Analysis will be run now." << std::endl;
 
-	_analysisResultsString = rbridge_runModuleCall(_analysisName, _analysisTitle, _dynamicModuleCall, _analysisDataKey, _analysisOptions, _analysisStateKey, _ppi, _analysisId, _analysisRevision, _imageBackground, _developerMode);
+	_analysisResultsString = rbridge_runModuleCall(_analysisName, _analysisTitle, _dynamicModuleCall, _analysisDataKey, _analysisOptions, _analysisStateKey, _ppi, _analysisId, _analysisRevision, _imageBackground, _developerMode, _resultsFont);
 
 	switch(_analysisStatus)
 	{

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -100,7 +100,7 @@ void Engine::initialize()
 
 	try
 	{
-		rbridge_init(SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _extraEncodings);
+		rbridge_init(SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _extraEncodings, _resultsFont.c_str());
 
 		Log::log() << "rbridge_init completed" << std::endl;
 

--- a/Engine/engine.h
+++ b/Engine/engine.h
@@ -136,6 +136,7 @@ private: // Data:
 						_analysisResultsMeta,
 						_analysisStateKey,
 						_analysisResultsString,
+						_resultsFont,
 						_imageBackground	= "white",
 						_analysisRFile		= "",
 						_dynamicModuleCall	= "",

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -248,13 +248,13 @@ extern "C" bool STDCALL rbridge_runCallback(const char* in, int progress, const 
 	return true;
 }
 
-std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode)
+std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont)
 {
 	rbridge_callback	= NULL; //Only jaspResults here so callback is not needed
 	if (rbridge_dataSet != nullptr)
 		rbridge_dataSet		= rbridge_dataSetSource();
 
-	return jaspRCPP_runModuleCall(name.c_str(), title.c_str(), moduleCall.c_str(), dataKey.c_str(), options.c_str(), stateKey.c_str(), ppi, analysisID, analysisRevision, imageBackground.c_str(), developerMode);
+	return jaspRCPP_runModuleCall(name.c_str(), title.c_str(), moduleCall.c_str(), dataKey.c_str(), options.c_str(), stateKey.c_str(), ppi, analysisID, analysisRevision, imageBackground.c_str(), developerMode, resultsFont.c_str());
 }
 
 extern "C" RBridgeColumn* STDCALL rbridge_readFullDataSet(size_t * colMax)

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -62,7 +62,7 @@ size_t _logWriteFunction(const void * buf, size_t len)
 	return len;
 }
 
-void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * extraEncoder)
+void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * extraEncoder, const char * resultsFont)
 {
 	JASPTIMER_SCOPE(rbridge_init);
 	
@@ -107,7 +107,8 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 					[](){ Log::log(false).flush(); return 0;},
 					_logWriteFunction,
 					rbridge_system,
-					rbridge_moduleLibraryFixer
+					rbridge_moduleLibraryFixer,
+					resultsFont
 	);
 	JASPTIMER_STOP(jaspRCPP_init);
 

--- a/Engine/rbridge.h
+++ b/Engine/rbridge.h
@@ -84,7 +84,7 @@ extern "C" {
 	void rbridge_setDataSetSource(			boost::function<DataSet *()> source);
 	void rbridge_memoryCleaning();
 
-	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &jaspFont);
+	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont);
 
 	void rbridge_setColumnFunctionSources(			boost::function<int (const std::string &)																		> getTypeSource,
 													boost::function<bool(const std::string &, const std::vector<double>&)											> scaleSource,

--- a/Engine/rbridge.h
+++ b/Engine/rbridge.h
@@ -74,7 +74,7 @@ extern "C" {
 
 	typedef boost::function<std::string (const std::string &, int progress)> RCallback;
 
-	void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * encoder);
+	void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * encoder, const char * resultsFont);
 
 
 	void rbridge_setFileNameSource(			boost::function<void(const std::string &, std::string &, std::string &)> source);

--- a/Engine/rbridge.h
+++ b/Engine/rbridge.h
@@ -84,7 +84,7 @@ extern "C" {
 	void rbridge_setDataSetSource(			boost::function<DataSet *()> source);
 	void rbridge_memoryCleaning();
 
-	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode);
+	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &jaspFont);
 
 	void rbridge_setColumnFunctionSources(			boost::function<int (const std::string &)																		> getTypeSource,
 													boost::function<bool(const std::string &, const std::vector<double>&)											> scaleSource,

--- a/R-Interface/jaspResults/R/writeImage.R
+++ b/R-Interface/jaspResults/R/writeImage.R
@@ -82,11 +82,6 @@ writeImageJaspResults <- function(plot, width = 320, height = 320, obj = TRUE, r
   height <- height * (ppi / 96)
 
   plot2draw <- decodeplot(plot)
-  #   if (ggplot2::is.ggplot(plot))
-  #     plot + ggplot2::theme(text = ggplot2::element_text(family = jaspGraphs::getGraphOption("family")))
-  #   else
-  #     plot
-  # )
 
   openGrDevice(file = relativePathpng, width = width, height = height, res = 72 * (ppi / 96), background = backgroundColor)#, dpi = ppi)
   on.exit(dev.off())

--- a/R-Interface/jaspResults/R/writeImage.R
+++ b/R-Interface/jaspResults/R/writeImage.R
@@ -82,6 +82,11 @@ writeImageJaspResults <- function(plot, width = 320, height = 320, obj = TRUE, r
   height <- height * (ppi / 96)
 
   plot2draw <- decodeplot(plot)
+  #   if (ggplot2::is.ggplot(plot))
+  #     plot + ggplot2::theme(text = ggplot2::element_text(family = jaspGraphs::getGraphOption("family")))
+  #   else
+  #     plot
+  # )
 
   openGrDevice(file = relativePathpng, width = width, height = height, res = 72 * (ppi / 96), background = backgroundColor)#, dpi = ppi)
   on.exit(dev.off())

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -225,9 +225,9 @@ void _setJaspResultsInfo(int analysisID, int analysisRevision, bool developerMod
 	jaspResults::setWriteSealLocation(root, relativePath);
 }
 
-const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode)
+const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont)
 {
-	RInside &rInside				= rinside->instance();
+	RInside &rInside			= rinside->instance();
 
 	rInside["name"]				= CSTRING_TO_R(name);
 	rInside["title"]			= CSTRING_TO_R(title);
@@ -239,6 +239,7 @@ const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, 
 	rInside["resultsMeta"]		= "null";
 	rInside["requiresInit"]		= false;
 	rInside[".imageBackground"]	= imageBackground;
+	rInside[".resultsFont"]		= resultsFont;
 
 	_setJaspResultsInfo(analysisID, analysisRevision, developerMode);
 

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -74,7 +74,7 @@ extern "C" {
 void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks* callbacks,
 	sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction,
 	logFlushDef logFlushFunction, logWriteDef logWriteFunction,
-	systemDef systemFunc, libraryFixerDef libraryFixerFunc)
+	systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont)
 {
 	_logFlushFunction		= logFlushFunction;
 	_logWriteFunction		= logWriteFunction;
@@ -153,6 +153,7 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	char baseCitation[200];
 	sprintf(baseCitation, baseCitationFormat, buildYear, version);
 	rInside[".baseCitation"]		= CSTRING_TO_R(baseCitation);
+	rInside[".resultsFont"]			= resultsFont;
 
 	jaspResults::setSendFunc(sendToDesktopFunction);
 	jaspResults::setPollMessagesFunc(pollMessagesFunction);

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -387,7 +387,7 @@ const char* STDCALL jaspRCPP_editImage(const char * name, const char * optionsJs
 }
 
 
-void STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, int analysisID)
+void STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, const char* resultsFont, int analysisID)
 {
 
 	RInside &rInside = rinside->instance();
@@ -395,6 +395,7 @@ void STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char
 	rInside[".ppi"]				= ppi;
 	rInside[".imageBackground"] = imageBackground;
 	rInside[".analysisName"]	= CSTRING_TO_R(name);
+	rInside[".resultsFont"]     = resultsFont;
 
 	_setJaspResultsInfo(analysisID, 0, false);
 

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -121,7 +121,7 @@ typedef size_t			(*logWriteDef)			(const void * buf, size_t len);
 // Calls from rbridge to jaspRCPP
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc);
 
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode);
+RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_check();
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_saveImage(const char *data, const char *type, const int height, const int width, const int ppi, const char* imageBackground);

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -119,7 +119,7 @@ typedef size_t			(*logWriteDef)			(const void * buf, size_t len);
 
 
 // Calls from rbridge to jaspRCPP
-RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont);
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_check();

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -126,7 +126,7 @@ RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_check();
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_saveImage(const char *data, const char *type, const int height, const int width, const int ppi, const char* imageBackground);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_editImage(const char *name, const char *optionsJson, const int ppi, const char* imageBackground, int analysisID);
-RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, int analysisID);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, const char* resultsFont, int analysisID);
 
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_check();


### PR DESCRIPTION
So the third (and hopefully last) PR for custom fonts for plots. This should also partially fix https://github.com/jasp-stats/INTERNAL-jasp/issues/929 and https://github.com/jasp-stats/jasp-issues/issues/363.

For example the beautiful font "Ani":

![image](https://user-images.githubusercontent.com/21319932/109559610-2ad59900-7adb-11eb-8613-17b783e818b6.png)

From the screenshot, you'll notice that `geom_text` in the prior-posterior plot still uses the default font. For some reason, that kind of text doesn't inherit from the theme. I think we can fix this, although it might need to be fixed separately for each individual plot element that draws text (see e.g., https://ggplot2.tidyverse.org/reference/update_defaults.html).

Requires https://github.com/jasp-stats/jaspBase/pull/20 and  R packages `systemfonts` and `ragg`.

Since this PR also implies switching from `grDevices::png` to `ragg::agg_png` it's probably a good idea to test this very thoroughly. To change the font you can just change the font at `Preferences`->`Interface`->`Results & Help`.