### PR TITLE
R-Interface: put column encoder behind an ifdef so R can still install jaspResults

### DIFF
--- a/R-Interface/jaspResults/src/jaspContainer.cpp
+++ b/R-Interface/jaspResults/src/jaspContainer.cpp
@@ -1,6 +1,7 @@
 #include "jaspContainer.h"
+#ifdef JASP_R_INTERFACE_LIBRARY
 #include "columnencoder.h"
-
+#endif
 
 void jaspContainer::insert(std::string field, Rcpp::RObject value)
 {
@@ -497,6 +498,10 @@ void jaspContainer::renderPlotsOfChildren()
 
 Rcpp::RObject jaspContainer_Interface::findObjectWithUniqueNestedName(std::string uniqueNestedName)
 {
+#ifdef JASP_R_INTERFACE_LIBRARY
 	std::string encodedUniqueNestedName = ColumnEncoder::columnEncoder()->encodeAll(uniqueNestedName);
+#else
+	std::string encodedUniqueNestedName = uniqueNestedName;
+#endif
 	return jaspContainer::wrapJaspObject(((jaspContainer*)myJaspObject)->findObjectWithUniqueNestedName(encodedUniqueNestedName));
 }


### PR DESCRIPTION
basically, Github Actions doesn't work anymore because of

```c++
#include "columnencoder.h"

...

std::string encodedUniqueNestedName = ColumnEncoder::columnEncoder()->encodeAll(uniqueNestedName);
```