### PR TITLE
Use of VariablesForm inside a TabView does not work

### DIFF
--- a/Desktop/Desktop.pro
+++ b/Desktop/Desktop.pro
@@ -463,7 +463,8 @@ HEADERS += \
     analysis/boundcontrolbase.h \
     widgets/boundcontroltableview.h \
     widgets/boundcontrolcontraststableview.h \
-    widgets/boundcontrolfilteredtableview.h
+    widgets/boundcontrolfilteredtableview.h \
+    widgets/variablesformbase.h
 
 SOURCES += \
     analysis/analysisform.cpp \
@@ -649,7 +650,8 @@ SOURCES += \
     analysis/boundcontrolbase.cpp \
     widgets/boundcontroltableview.cpp \
     widgets/boundcontrolcontraststableview.cpp \
-    widgets/boundcontrolfilteredtableview.cpp
+    widgets/boundcontrolfilteredtableview.cpp \
+    widgets/variablesformbase.cpp
 
 RESOURCES += \
     html/html.qrc \

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -196,14 +196,8 @@ void AnalysisForm::_setUpModels()
 	}
 }
 
-void AnalysisForm::_setUp()
+void AnalysisForm::sortControls(QList<JASPControl*>& controls)
 {
-	QList<JASPControl*> controls = _controls.values();
-
-	// set the order of the BoundItems according to their dependencies (for binding purpose)
-	for (JASPControl* control : controls)
-		control->setUp();
-
 	for (JASPControl* control : controls)
 	{
 		std::vector<JASPControl*> depends(control->depends().begin(), control->depends().end());
@@ -224,10 +218,21 @@ void AnalysisForm::_setUp()
 		}
 	}
 
-	std::sort(controls.begin(), controls.end(), 
+	std::sort(controls.begin(), controls.end(),
 		[](JASPControl* a, JASPControl* b) {
 			return a->depends().size() < b->depends().size();
 		});
+}
+
+void AnalysisForm::_setUp()
+{
+	QList<JASPControl*> controls = _controls.values();
+
+	// set the order of the BoundItems according to their dependencies (for binding purpose)
+	for (JASPControl* control : controls)
+		control->setUp();
+
+	sortControls(controls);
 
 	for (JASPControl* control : controls)
 	{

--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -132,6 +132,8 @@ public:
 	void		setBoundValue(const std::string& name, const Json::Value& value, const Json::Value& meta, const QVector<JASPControl::ParentKey>& parentKeys = {});
 	std::set<std::string> usedVariables();
 
+	void		sortControls(QList<JASPControl*>& controls);
+
 protected:
 	QString		msgsListToString(const QStringList & list) const;
 

--- a/Desktop/analysis/jaspcontrol.h
+++ b/Desktop/analysis/jaspcontrol.h
@@ -34,7 +34,7 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( bool								shouldShowFocus		READ shouldShowFocus		WRITE setShouldShowFocus	NOTIFY shouldShowFocusChanged		)
 	Q_PROPERTY( bool								shouldStealHover	READ shouldStealHover		WRITE setShouldStealHover	NOTIFY shouldStealHoverChanged		)
 	Q_PROPERTY( QQuickItem						*	childControlsArea	READ childControlsArea		WRITE setChildControlsArea										)
-	Q_PROPERTY( JASPControl						*	parentListView		READ parentListView										NOTIFY parentListViewChanged		)
+	Q_PROPERTY( JASPControl						*	parentListView		READ parentListViewEx									NOTIFY parentListViewChanged		)
 	Q_PROPERTY( QQuickItem						*	innerControl		READ innerControl			WRITE setInnerControl		NOTIFY innerControlChanged			)
 	Q_PROPERTY( QQuickItem						*	background			READ background				WRITE setBackground			NOTIFY backgroundChanged			)
 	Q_PROPERTY( QQuickItem						*	focusIndicator		READ focusIndicator			WRITE setFocusIndicator		NOTIFY focusIndicatorChanged		)
@@ -78,6 +78,7 @@ public:
 		, ComponentsList
 		, GroupBox
 		, TabView
+		, VariablesForm
 	};
 
 	// Be careful not to reuse a name in a enum type: in QML, they are mixed up with a 'JASP' prefix: JASP.DropNone or JASP.None
@@ -122,7 +123,8 @@ public:
 	bool			focusOnTab()			const	{ return activeFocusOnTab();	}
 	AnalysisForm*	form()					const	{ return _form;					}
 	QQuickItem*		childControlsArea()		const	{ return _childControlsArea;	}
-	JASPControl*	parentListView()		const	{ return _parentListView;		}
+	JASPListControl* parentListView()		const	{ return _parentListView;		}
+	JASPControl*	parentListViewEx()		const;
 	QString			parentListViewKey()		const	{ return _parentListViewKey;	}
 	QQuickItem*		innerControl()			const	{ return _innerControl;			}
 	QQuickItem*		background()			const	{ return _background;			}
@@ -263,7 +265,7 @@ protected:
 							_shouldShowFocus		= false,
 							_shouldStealHover		= false,
 							_nameMustBeUnique		= true;
-	JASPControl			*	_parentListView			= nullptr;
+	JASPListControl		*	_parentListView			= nullptr;
 	QQuickItem			*	_childControlsArea		= nullptr,
 						*	_innerControl			= nullptr,
 						*	_background				= nullptr,

--- a/Desktop/components/JASP/Controls/ComboBox.qml
+++ b/Desktop/components/JASP/Controls/ComboBox.qml
@@ -24,7 +24,6 @@ ComboBoxBase
 	property var	enabledOptions:			[]
 	property bool	setLabelAbove:			false
 	property int	controlMinWidth:		0
-	property bool	setWidthInForm:			true
 	property bool	useExternalBorder:		true
 	property bool	showBorder:				true
 	property bool	addScrollBar:			false

--- a/Desktop/components/JASP/Controls/RepeatedMeasuresFactorsList.qml
+++ b/Desktop/components/JASP/Controls/RepeatedMeasuresFactorsList.qml
@@ -28,8 +28,6 @@ RepeatedMeasuresFoctorsListBase
 	implicitHeight:				jaspTheme.defaultVariablesFormHeight
 	background:					rectangle
 
-				property bool	setWidthInForm: false
-				property bool	setHeightInForm: false
 	readonly	property string deleteIcon: "cross.png"
 
 	Text

--- a/Desktop/components/JASP/Controls/TabView.qml
+++ b/Desktop/components/JASP/Controls/TabView.qml
@@ -201,7 +201,7 @@ ComponentsListBase
 		height			: 28 * preferencesModel.uiScale //jaspTheme.defaultRectangularButtonHeight
 		width			: height
 		radius			: height
-		visible			: tabView.showAddIcon && (tabView.maximumItems <= 0 || tabView.maximumItems >= tabView.count)
+		visible			: tabView.showAddIcon && (tabView.maximumItems <= 0 || tabView.maximumItems > tabView.count)
 		iconSource		: jaspTheme.iconPath + tabView.addIcon
 		onClicked		: addItem()
 		toolTip			: tabView.addTooltip

--- a/Desktop/components/JASP/Controls/VariablesList.qml
+++ b/Desktop/components/JASP/Controls/VariablesList.qml
@@ -52,8 +52,6 @@ VariablesListBase
 	property bool	dropModeReplace					: dropMode === JASP.DropReplace
 	property bool	showElementBorder				: false
 	property bool	showVariableTypeIcon			: containsVariables
-	property bool	setWidthInForm					: false
-	property bool	setHeightInForm					: false
 	property bool	addInteractionsByDefault		: true
 	property bool	interactionContainLowerTerms	: true
 	property bool	addAvailableVariablesToAssigned	: listViewType === JASP.Interaction

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -54,6 +54,7 @@
 #include "widgets/sliderbase.h"
 #include "widgets/expanderbuttonbase.h"
 #include "widgets/variableslistbase.h"
+#include "widgets/variablesformbase.h"
 #include "widgets/repeatedmeasuresfactorslistbase.h"
 #include "widgets/tableviewbase.h"
 #include "widgets/radiobuttonbase.h"
@@ -164,6 +165,7 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 	qmlRegisterType<InputListBase>								("JASP",		1, 0, "InputListBase"					);
 	qmlRegisterType<RepeatedMeasuresFactorsListBase>			("JASP",		1, 0, "RepeatedMeasuresFoctorsListBase"	);
 	qmlRegisterType<VariablesListBase>							("JASP",		1, 0, "VariablesListBase"				);
+	qmlRegisterType<VariablesFormBase>							("JASP",		1, 0, "VariablesFormBase"				);
 	qmlRegisterType<TableViewBase>								("JASP",		1, 0, "TableViewBase"					);
 	qmlRegisterType<JASPDoubleValidator>						("JASP",		1, 0, "JASPDoubleValidator"				);
 	qmlRegisterType<ResultsJsInterface>							("JASP",		1, 0, "ResultsJsInterface"				);

--- a/Desktop/widgets/jasplistcontrol.cpp
+++ b/Desktop/widgets/jasplistcontrol.cpp
@@ -165,10 +165,6 @@ void JASPListControl::cleanUp()
 					control->cleanUp();
 		}
 
-		if (_defaultRowControls)
-			for (JASPControl* control : _defaultRowControls->getJASPControlsMap().values())
-				control->cleanUp();
-
 		_sourceItems.clear();
 
 		JASPControl::cleanUp();

--- a/Desktop/widgets/jasplistcontrol.h
+++ b/Desktop/widgets/jasplistcontrol.h
@@ -125,7 +125,6 @@ protected:
 	QVector<SourceItem*>	_sourceItems;
 	int						_variableTypesAllowed	= 0xff;
 	QString					_optionKey				= "value";
-	RowControls*			_defaultRowControls		= nullptr;
 	QVariant				_source;
 	QString					_rSource;
 	QVariant				_values;

--- a/Desktop/widgets/rowcontrols.h
+++ b/Desktop/widgets/rowcontrols.h
@@ -56,7 +56,6 @@ private:
 	QQuickItem*								_rowObject;
 	QMap<QString, JASPControl*>				_rowJASPControlMap;
 	QQmlContext*							_context;
-	QMap<QString, QVariant>					_rowControlsVarMap;
 	QMap<QString, Json::Value>				_rowValues;
 };
 

--- a/Desktop/widgets/sourceitem.cpp
+++ b/Desktop/widgets/sourceitem.cpp
@@ -44,7 +44,7 @@ SourceItem::SourceItem(
 	_rSource				= map["rSource"].toString();
 
 	_isValuesSource			= map.contains("isValuesSource")			? map["isValuesSource"].toBool()			: false;
-	_isColumnsModel			= map.contains("isDataSetColumns")			? map["isDataSetColumns"].toBool()			: false;
+	_isColumnsModel			= map.contains("isDataSetVariables")		? map["isDataSetVariables"].toBool()		: false;
 	_combineWithOtherModels	= map.contains("combineWithOtherModels")	? map["combineWithOtherModels"].toBool()	: false;
 	_nativeModelRole		= map.contains("nativeModelRole")			? map["nativeModelRole"].toInt()			: Qt::DisplayRole;
 

--- a/Desktop/widgets/variablesformbase.cpp
+++ b/Desktop/widgets/variablesformbase.cpp
@@ -1,0 +1,135 @@
+//
+// Copyright (C) 2013-2021 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#include "variablesformbase.h"
+#include "variableslistbase.h"
+#include "qquick/jasptheme.h"
+
+VariablesFormBase::VariablesFormBase(QQuickItem* parent) : JASPControl(parent)
+{
+	_controlType = ControlType::VariablesForm;
+}
+
+void VariablesFormBase::componentComplete()
+{
+	JASPControl::componentComplete();
+
+	_allJASPControls.clear();
+	_allAssignedVariablesList.clear();
+	_availableVariablesList = nullptr;
+
+	QQuickItem* contentItems = property("contentItems").value<QQuickItem*>();
+	QList<QQuickItem*> items = contentItems->childItems();
+
+	bool debugMode = false;
+#ifdef JASP_DEBUG
+	debugMode = true;
+#endif
+
+	for (QQuickItem* item : items)
+	{
+		JASPControl* control = qobject_cast<JASPControl*>(item);
+		if (!control) continue;
+
+		if (debug())	control->setDebug(true);
+		if (debugMode || !control->debug())
+		{
+			VariablesListBase* variablesList = qobject_cast<VariablesListBase*>(control);
+			if (variablesList)
+			{
+				if (variablesList->listViewType() == JASPControl::ListViewType::AvailableVariables || variablesList->listViewType() == JASPControl::ListViewType::AvailableInteraction)
+				{
+					if (_availableVariablesList)
+						addControlError(tr("Only 1 Available Variables list can be set in a VariablesForm"));
+
+					_availableVariablesList = variablesList;
+				}
+				else
+					_allAssignedVariablesList.push_back(control);
+			}
+			if (control != _availableVariablesList)
+				_allJASPControls.push_back(control);
+
+			control->setParentItem(this);
+		}
+	}
+
+	if (!_availableVariablesList)
+	{
+		addControlError(tr("There is no Available List in the Variables Form"));
+		return;
+	}
+
+	_availableVariablesList->setY(0);
+	_availableVariablesList->setX(0);
+
+	// Set the width of the VariablesList to listWidth only if it is not set explicitely
+	// Implicitely, the width is set to the parent width.
+	if (qFuzzyCompare(_availableVariablesList->width(), width()))
+		_controlsWidthSetByForm.push_back(_availableVariablesList);
+
+	for (JASPControl* control : _allJASPControls)
+	{
+		ControlType type = control->controlType();
+		if ((type == ControlType::VariablesListView) || (type == ControlType::RepeatedMeasuresFactorsList) || (type == ControlType::InputListView))
+		{
+			if (qFuzzyCompare(control->width(), width()))
+				_controlsWidthSetByForm.push_back(control);
+
+			if (qFuzzyCompare(control->height(), double(JaspTheme::currentTheme()->defaultVariablesFormHeight())))
+				_controlsHeightSetByForm.push_back(control);
+		}
+		else if (type == ControlType::ComboBox)
+		{
+			_controlsWidthSetByForm.push_back(control);
+			connect(control, &QQuickItem::heightChanged, this, &VariablesFormBase::setControlsSizeSlot);
+		}
+	}
+
+	QMetaObject::invokeMethod(this, "init");
+
+	setInitialized();
+}
+
+void VariablesFormBase::setMarginBetweenVariablesLists(qreal value)
+{
+	if (qFuzzyCompare(value, _marginBetweenVariablesLists))
+	{
+		_marginBetweenVariablesLists = value;
+		emit marginBetweenVariablesListsChanged();
+	}
+}
+
+void VariablesFormBase::setMinimumHeightVariablesLists(qreal value)
+{
+	if (qFuzzyCompare(value, _minimumHeightVariablesLists))
+	{
+		_minimumHeightVariablesLists = value;
+		emit minimumHeightVariablesListsChanged();
+	}
+}
+
+JASPControl* VariablesFormBase::availableVariablesList() const
+{
+	return _availableVariablesList;
+}
+
+void VariablesFormBase::setControlsSizeSlot()
+{
+	QMetaObject::invokeMethod(this, "setControlsSize");
+}

--- a/Desktop/widgets/variablesformbase.h
+++ b/Desktop/widgets/variablesformbase.h
@@ -1,0 +1,75 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef VARIABLESFROMBASE_H
+#define VARIABLESFROMBASE_H
+
+#include "analysis/jaspcontrol.h"
+
+class VariablesListBase;
+
+class VariablesFormBase : public JASPControl
+{
+	Q_OBJECT
+
+	Q_PROPERTY( JASPControl*			availableVariablesList			READ availableVariablesList													NOTIFY availableVariablesListChanged		)
+	Q_PROPERTY( QList<JASPControl*>		allAssignedVariablesList		READ allAssignedVariablesList												NOTIFY allAssignedVariablesListChanged		)
+	Q_PROPERTY( QList<JASPControl*>		allJASPControls					READ allJASPControls														NOTIFY allJASPControlsChanged				)
+	Q_PROPERTY( qreal					marginBetweenVariablesLists		READ marginBetweenVariablesLists	WRITE setMarginBetweenVariablesLists	NOTIFY marginBetweenVariablesListsChanged	)
+	Q_PROPERTY( qreal					minimumHeightVariablesLists		READ minimumHeightVariablesLists	WRITE setMinimumHeightVariablesLists	NOTIFY minimumHeightVariablesListsChanged	)
+
+public:
+	VariablesFormBase(QQuickItem* parent = nullptr);
+
+	JASPControl*			availableVariablesList()		const;
+	QList<JASPControl*>		allAssignedVariablesList()		const	{ return _allAssignedVariablesList;		}
+	QList<JASPControl*>		allJASPControls()				const	{ return _allJASPControls;				}
+	qreal					marginBetweenVariablesLists()	const	{ return _marginBetweenVariablesLists;	}
+	qreal					minimumHeightVariablesLists()	const	{ return _minimumHeightVariablesLists;	}
+
+	Q_INVOKABLE bool		widthSetByForm(JASPControl* control)	{ return _controlsWidthSetByForm.contains(control); }
+	Q_INVOKABLE bool		heightSetByForm(JASPControl* control)	{ return _controlsHeightSetByForm.contains(control); }
+
+signals:
+	void availableVariablesListChanged();
+	void allAssignedVariablesListChanged();
+	void allJASPControlsChanged();
+	void marginBetweenVariablesListsChanged();
+	void minimumHeightVariablesListsChanged();
+
+protected:
+	void componentComplete() override;
+
+protected slots:
+	void setMarginBetweenVariablesLists(qreal value);
+	void setMinimumHeightVariablesLists(qreal value);
+	void setControlsSizeSlot();
+
+private:
+
+	VariablesListBase*			_availableVariablesList = nullptr;
+	QList<JASPControl*>			_allAssignedVariablesList,
+								_allJASPControls,
+								_controlsWidthSetByForm,
+								_controlsHeightSetByForm;
+	qreal						_marginBetweenVariablesLists = 8;
+	qreal						_minimumHeightVariablesLists = 25;
+
+};
+
+#endif // VARIABLESFROMBASE_H

--- a/Desktop/widgets/variableslistbase.cpp
+++ b/Desktop/widgets/variableslistbase.cpp
@@ -317,9 +317,20 @@ void VariablesListBase::moveItems(QList<int> &indexes, ListModelDraggable* targe
 
 ListModel *VariablesListBase::getRelatedModel()
 {
-	if (dropKeys().count() > 0) return form()->getModel(dropKeys()[0]); // The first key gives the default drop item.
+	ListModel* result = nullptr;
+	if (dropKeys().count() > 0)
+	{
+		QString relatedName = dropKeys()[0]; // The first key gives the default drop item.
+		if (_parentListView)
+		{
+			JASPListControl* relatedControl = qobject_cast<JASPListControl*>(_parentListView->model()->getRowControl(_parentListViewKey, relatedName));
+			if (relatedControl)
+				result = relatedControl->model();
+		}
+		if (!result && form())	result = form()->getModel(relatedName);
+	}
 
-	return nullptr;
+	return result;
 }
 
 void VariablesListBase::termsChangedHandler()


### PR DESCRIPTION
This is due to the initialisation of dynamic controls. They should not
be setup immediately when they are created, but when all dynamic
controls are created: when there are some dependencies between some
controls, they can then refer to each other being sure that they are
already created.
The VariablesForm is set as a JASPControl, so that we can beter control
when its initialisation starts: this initialisation sets the
relationships between the VariablesList inside the form, and those
relationships must be set before the VariablesLists self start their
setup.

To test it, just add this in a QML file:
```
		TabView
		{
			name: "modelsList"
			maximumItems: 6
			content: VariablesForm
			{
				height: jaspTheme.smallDefaultVariablesFormHeight
				AvailableVariablesList { name: "availableCovariates"; source: [{name: "allVariablesList", use: "type=scale"}] }
				AssignedVariablesList  { name: "covariates"; title: qsTr("Covariates"); allowedColumns: "scale" }
			}
		}
```

