### PR TITLE
Column width in TableView does not fit the width of the content of the column

### DIFF
--- a/Desktop/widgets/listmodelfiltereddataentry.cpp
+++ b/Desktop/widgets/listmodelfiltereddataentry.cpp
@@ -292,7 +292,7 @@ int ListModelFilteredDataEntry::getMaximumColumnWidthInCharacters(size_t column)
 
 	DataSetTableModel* dataSetModel = DataSetTableModel::singleton();
 
-	if (!(dataSetModel->columnCount() >= 0 || colIndex > _tableTerms.colNames.size() || colIndex < 0))
+	if (dataSetModel->columnCount() >= 0 && colIndex < _tableTerms.colNames.size() && colIndex >= 0)
 	{
 		std::string colName		= _tableTerms.colNames[colIndex].toStdString();
 		int			colIndex	= dataSetModel->getColumnIndex(colName);


### PR DESCRIPTION
In Classical or Bayesian Sampling Workflow, if you use a column with long values (bigger than the column name), then the Table View (in Data Entry) cut the values of this column: the width of the column is too small.
