### PR TITLE
Default Value with Binding issue

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -159,12 +159,6 @@ void Analysis::reload()
 	Analyses::analyses()->reload(this, true);
 }
 
-void Analysis::rebind()
-{
-	if (_analysisForm)
-		_analysisForm->bindTo();
-}
-
 void Analysis::exportResults()
 {
 	emit Analyses::analyses()->analysesExportResults();

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -134,7 +134,6 @@ public:
 			void		run();
 			void		refresh();
 			void		reload();
-			void		rebind();
 			void        exportResults();
 			void		remove();
 

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -399,7 +399,7 @@ void AnalysisForm::bindTo()
 
 	for (ListModelAvailableInterface* availableModel : availableModelsToBeReset)
 		availableModel->resetTermsFromSources(true);
-	
+
 	_addLoadingError(tql(controlsJsonWrong));
 
 	//Ok we can only set the warnings on the components now, because otherwise _addLoadingError() will add a big fat red warning on top of the analysisform without reason...
@@ -599,6 +599,7 @@ void AnalysisForm::setAnalysisUp()
 	blockValueChangeSignal(false, false);
 
 	_analysis->initialized(this, isNewAnalysis);
+	_initialized = true;
 
 	emit analysisChanged();
 }

--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -106,6 +106,7 @@ public:
 	Q_INVOKABLE void		addFormError(const QString& message);
 	Q_INVOKABLE void		refreshAnalysis();
 	Q_INVOKABLE void		runAnalysis();
+	Q_INVOKABLE bool		initialized()	const	{ return _initialized; }
 
 	void		addControlError(JASPControl* control, QString message, bool temporary = false, bool warning = false);
 	void		clearControlError(JASPControl* control);
@@ -180,7 +181,8 @@ private:
 	QQmlComponent*								_controlErrorMessageComponent = nullptr;
 	QList<QQuickItem*>							_controlErrorMessageCache;
 	bool										_runOnChange	= true,
-												_formCompleted = false;
+												_formCompleted = false,
+												_initialized = false;
 	QString										_info;
 	QMap<QString, QSet<ListModel*> >			_rSourceModelMap;
 	int											_signalValueChangedBlocked = 0;

--- a/Desktop/analysis/boundcontrolbase.h
+++ b/Desktop/analysis/boundcontrolbase.h
@@ -33,9 +33,9 @@ public:
 	virtual				~BoundControlBase()	{}
 
 	Json::Value					createJson()														override { return Json::nullValue;		}
-	void						bindTo(const Json::Value& value)									override { setBoundValue(value, false); }
+	void						bindTo(const Json::Value& value)									override { _orgValue = value; setBoundValue(value, false); }
 	const Json::Value&			boundValue()														override;
-	void						resetBoundValue()													override { }
+	void						resetBoundValue()													override { bindTo(_orgValue); }
 	void						setBoundValue(const Json::Value& value, bool emitChange = true)		override;
 	std::vector<std::string>	usedVariables()														override;
 	void						setIsRCode(std::string key = "");
@@ -50,7 +50,8 @@ protected:
 	JASPControl*	_control			= nullptr;
 	bool			_isComputedColumn	= false,
 					_isColumn			= false;
-	Json::Value		_meta;
+	Json::Value		_meta,
+					_orgValue;
 	std::string		_name;
 	columnType		_columnType			= columnType::unknown;
 };

--- a/Desktop/analysis/jaspcontrol.cpp
+++ b/Desktop/analysis/jaspcontrol.cpp
@@ -61,6 +61,7 @@ JASPControl::JASPControl(QQuickItem *parent) : QQuickItem(parent)
 	connect(this, &JASPControl::debugChanged,			[this] () { _setBackgroundColor(); _setVisible(); } );
 	connect(this, &JASPControl::parentDebugChanged,		[this] () { _setBackgroundColor(); _setVisible(); } );
 	connect(this, &JASPControl::toolTipChanged,			[this] () { QQmlProperty(this, "ToolTip.text", qmlContext(this)).write(toolTip()); } );
+	connect(this, &JASPControl::boundValueChanged,		this, &JASPControl::_resetBindingValue);
 }
 
 void JASPControl::setFocusOnTab(bool focus)
@@ -130,6 +131,15 @@ void JASPControl::_setVisible()
 #endif
 	if (!isDebug && (debug() || parentDebug()))
 		setVisible(false);
+}
+
+void JASPControl::_resetBindingValue()
+{
+	// If a control gets a value from a JASP file, this value may differ from its default value sets by a QML binding:
+	// this QML binding may then change the value during the initialization of the form.
+	// In this case, restore the original value.
+	if (isBound() && hasUserInteractiveValue() && initialized() && form() && !form()->initialized())
+		boundControl()->resetBoundValue();
 }
 
 void JASPControl::setHasError(bool hasError)

--- a/Desktop/analysis/jaspcontrol.h
+++ b/Desktop/analysis/jaspcontrol.h
@@ -121,6 +121,8 @@ public:
 	bool			childHasError()			const;
 	bool			childHasWarning()		const;
 	bool			focusOnTab()			const	{ return activeFocusOnTab();	}
+	bool			hasUserInteractiveValue() const	{ return _hasUserInteractiveValue; }
+
 	AnalysisForm*	form()					const	{ return _form;					}
 	QQuickItem*		childControlsArea()		const	{ return _childControlsArea;	}
 	JASPListControl* parentListView()		const	{ return _parentListView;		}
@@ -205,6 +207,7 @@ private slots:
 	void	_setBackgroundColor();
 	void	_setVisible();
 	void	_hoveredChangedSlot() { emit hoveredChanged(); }
+	void	_resetBindingValue();
 
 signals:
 	void setOptionBlockSignal(	bool blockSignal);
@@ -264,7 +267,8 @@ protected:
 							_useControlMouseArea	= true,
 							_shouldShowFocus		= false,
 							_shouldStealHover		= false,
-							_nameMustBeUnique		= true;
+							_nameMustBeUnique		= true,
+							_hasUserInteractiveValue = true;
 	JASPListControl		*	_parentListView			= nullptr;
 	QQuickItem			*	_childControlsArea		= nullptr,
 						*	_innerControl			= nullptr,

--- a/Desktop/widgets/comboboxbase.cpp
+++ b/Desktop/widgets/comboboxbase.cpp
@@ -24,6 +24,7 @@ ComboBoxBase::ComboBoxBase(QQuickItem* parent)
 	: JASPListControl(parent), BoundControlBase(this)
 {
 	_controlType = ControlType::ComboBox;
+	_hasUserInteractiveValue = true;
 }
 
 void ComboBoxBase::bindTo(const Json::Value& value)

--- a/Desktop/widgets/jasplistcontrol.cpp
+++ b/Desktop/widgets/jasplistcontrol.cpp
@@ -32,6 +32,7 @@
 JASPListControl::JASPListControl(QQuickItem *parent)
 	: JASPControl(parent)
 {
+	_hasUserInteractiveValue = false;
 }
 
 void JASPListControl::setUpModel()

--- a/Desktop/widgets/radiobuttonsgroupbase.cpp
+++ b/Desktop/widgets/radiobuttonsgroupbase.cpp
@@ -124,6 +124,11 @@ void RadioButtonsGroupBase::_setCheckedButton(RadioButtonBase* button)
 	QString buttonName = button->name();
 	button->setProperty("checked", true);
 
+	// Ensure that other buttons are unchecked
+	for (RadioButtonBase* otherButton : _buttons)
+		if (otherButton != button)
+			otherButton->setProperty("checked", false);
+
 	if (_value != buttonName)
 	{
 		setValue(buttonName);


### PR DESCRIPTION
This issue was discovered when trying to solve
https://github.com/jasp-stats/jasp-issues/issues/1139

Open the ‘Default values with bindings’ analysis from the Test Module.
Assign some variables, uncheck the ‘check’ checkbox, set the `radio`
Radio Button to ‘three’ and set the Dropdown too ‘none’. Save the JASP
file, and load it again: the same values should be set.

