### PR TITLE
Take semi-column default separator if only 1 column is in the file.

### DIFF
--- a/Desktop/data/importers/csv.cpp
+++ b/Desktop/data/importers/csv.cpp
@@ -314,7 +314,7 @@ void CSV::determineDelimiters(size_t fromHere)
 		}
 	}
 
-	_delim = ',';
+	_delim = commas == 0 ? ';' : ',';
 	int countDelim = commas; 
 	
 	if (semicolons > countDelim)


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1213