### PR TITLE
Use user setting also when starting spreadsheet editor for sav file.

### DIFF
--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1406,12 +1406,6 @@ void MainWindow::startDataEditor(QString path)
 	bool useDefaultSpreadsheetEditor = Settings::value(Settings::USE_DEFAULT_SPREADSHEET_EDITOR).toBool();
 	QString appname = Settings::value(Settings::SPREADSHEET_EDITOR_NAME).toString();
 
-	if (QString::compare(fileInfo.suffix(), "sav", Qt::CaseInsensitive) == 0)
-	{
-		if (!useDefaultSpreadsheetEditor && !appname.contains("SPSS", Qt::CaseInsensitive))
-			useDefaultSpreadsheetEditor = true;
-	}
-
 	if (appname.isEmpty())
 		useDefaultSpreadsheetEditor = true;
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1424,7 +1424,7 @@ void MainWindow::startDataEditor(QString path)
 	else
 #endif
 		if (!QDesktopServices::openUrl(QUrl::fromLocalFile(path)))
-			MessageForwarder::showWarning(tr("Start Spreadsheet Editor"), tr("No default spreadsheet editor for file %1. Use Preferences to set the right editor.").arg(fileInfo.completeBaseName()));
+			MessageForwarder::showWarning(tr("Start Spreadsheet Editor"), tr("No default spreadsheet editor for file %1. Use Preferences to set the right editor.").arg(fileInfo.fileName()));
 
 }
 


### PR DESCRIPTION
Fixes jasp-stats/jasp-issues#1189

When the file is a sav file, JASP used to bypass the user settings, and
start always the default editor associated with this kind of file, with
the presumption that SPSS is this default application for sav file.
But this might be confusing: some users have set JASP as default
application, starting JASP a second time when double-clicking the data
panel

