### PR TITLE
Key Navigation for RibbonBar and ModulesMenu

### DIFF
--- a/Desktop/components/JASP/Widgets/CustomMenu.qml
+++ b/Desktop/components/JASP/Widgets/CustomMenu.qml
@@ -43,6 +43,45 @@ FocusScope
 	property var    sourceItem  : null
 	property point	scrollOri	: "0,0" //Just for other qmls to use as a general storage of the origin of their scrolling
 
+	property int	currentIndex: -1
+
+	Keys.onPressed:
+	{
+		if (event.key === Qt.Key_Up)
+		{
+			if (menu.props["navigateFunc"] === undefined || typeof(menu.props["navigateFunc"]) === "undefined")
+				menu.currentIndex = mod(menu.currentIndex - 1, repeater.count)
+			else
+				menu.currentIndex = menu.props["navigateFunc"](currentIndex, -1);
+		}
+		else if (event.key === Qt.Key_Down)
+		{
+			if (menu.props["navigateFunc"] === undefined || typeof(menu.props["navigateFunc"]) === "undefined")
+				menu.currentIndex = mod(menu.currentIndex + 1, repeater.count)
+			else
+				menu.currentIndex = menu.props["navigateFunc"](currentIndex, 1);
+		}
+		else if (event.key === Qt.Key_Return || event.key === Qt.Key_Space)
+		{
+			if (currentIndex > -1)
+			{
+				menu.props['functionCall'](currentIndex)
+				menu.currentIndex = -1;
+			}
+		}
+		else if (event.key === Qt.Key_Escape)
+		{
+			menu.currentIndex = -1;
+			if (menu.sourceItem !== null)
+			{
+				menu.sourceItem.forceActiveFocus();
+				if (menu.sourceItem.myMenuOpen !== undefined && typeof(menu.sourceItem.myMenuOpen) !== 'undefined')
+					menu.sourceItem.myMenuOpen = true;
+			}
+			menu.hide();
+		}
+	}
+
 	onPropsChanged:
 	{
 		hasIcons = (menu.props === undefined || "undefined" === typeof(menu.props["hasIcons"])) ? true : menu.props["hasIcons"]
@@ -188,7 +227,7 @@ FocusScope
 								height: jaspTheme.menuItemHeight
 								color:	!model.isEnabled
 											? "transparent"
-											: mouseArea.pressed
+											: mouseArea.pressed || index == currentIndex
 												? jaspTheme.buttonColorPressed
 												: mouseArea.containsMouse
 													? jaspTheme.buttonColorHovered

--- a/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
@@ -9,10 +9,14 @@ FocusScope
 {
 	id: fileMenu
 
-	Keys.onEscapePressed:	fileMenuModel.visible = false;
+	Keys.onEscapePressed:
+	{
+		ribbon.focus			 = true;
+		ribbon.isFileMenuPressed = true;  // Close FileMenu but show the button as pressed
+		fileMenuModel.visible	= false;
+	}
 	Keys.onDownPressed:		fileMenuModel.actionButtons.selectButtonDown();
 	Keys.onUpPressed:		fileMenuModel.actionButtons.selectButtonUp();
-
 
 	function showToolSeperator(typeRole)
 	{
@@ -33,7 +37,11 @@ FocusScope
 	Connections
 	{
 		target:				fileMenuModel
-		function onVisibleChanged() { if (fileMenuModel.visible) actionMenu.forceActiveFocus(); else fileMenu.focus = false; }
+		function onVisibleChanged()
+		{
+			if (fileMenuModel.visible)
+				actionMenu.forceActiveFocus();
+		}
 	}
 
 	Item
@@ -117,7 +125,12 @@ FocusScope
 								left:		itemActionMenu.left
 							}
 
-							Keys.onLeftPressed:		fileMenuModel.visible = false;
+							Keys.onLeftPressed:
+							{
+								fileMenuModel.visible    = false;
+								ribbon.isFileMenuPressed = true;
+								ribbon.focus             = true;
+							}
 							Keys.onRightPressed:	if(hasSubMenuRole) resourceMenu.forceActiveFocus()
 							Keys.onDownPressed:		fileMenuModel.actionButtons.selectButtonDown()
 							Keys.onUpPressed:		fileMenuModel.actionButtons.selectButtonUp()

--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -58,6 +58,28 @@ Window
 		mainWindowRoot.visibility = mainWindowRoot.visibility === Window.FullScreen ? Window.Windowed : Window.FullScreen;
 	}
 
+	function changeFocusToRibbon()
+	{
+		ribbon.focus = true;
+ 		ribbon.focusOnRibbonMenu();
+	}
+
+	function changeFocusToModulesMenu()
+	{
+		ribbon.showModulesMenuPressed();
+	}
+
+	function changeFocusToFileMenu()
+	{
+		ribbon.focus = true;
+		ribbon.showFileMenuPressed();
+	}
+
+	function mod (a, n)
+	{
+		return ((a % n) + n) % n;
+	}
+
 	Item
 	{
 		anchors.fill:	parent
@@ -73,7 +95,7 @@ Window
 		Shortcut { onActivated: mainWindowRoot.close();							sequences: ["Ctrl+Q", Qt.Key_Close];							}
 		Shortcut { onActivated: fileMenuModel.close();							sequences: ["Ctrl+W"];											}
 		Shortcut { onActivated: mainWindowRoot.toggleFullScreen();				sequences: ["Ctrl+M", Qt.Key_F11];								}
-		Shortcut { onActivated: fileMenuModel.visible = !fileMenuModel.visible; sequences: ["Home",   Qt.Key_Home, Qt.Key_Menu];				}
+		Shortcut { onActivated: mainWindowRoot.changeFocusToFileMenu();			sequences: ["Home",   Qt.Key_Home, Qt.Key_Menu];				}
 		Shortcut { onActivated: mainWindow.setLanguage(0);						sequences: ["Ctrl+1"];											}
 		Shortcut { onActivated: mainWindow.setLanguage(1);						sequences: ["Ctrl+2"];											}
 
@@ -182,6 +204,7 @@ Window
 
 				fileMenuModel.visible	= false
 				modulesMenu.opened		= false
+				ribbon.focusOutRibbonBar();
 			}
 		}
 

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
@@ -25,6 +25,120 @@ FocusScope
 	id		: ribbonBar
 	height	: ribbonMenu.height
 
+	// This property is required to show filemenu button press in KeyNavigation
+	property bool isFileMenuPressed: false
+
+	function focusOnRibbonMenu()
+	{
+		ribbonMenu.focus = true;
+		ribbonMenu.setCurrentIndex('first');
+	}
+
+	function focusOutRibbonBar()
+	{
+		modulesPlusButton.showPressed = false;
+		isFileMenuPressed             = false;
+		ribbonMenu.focusOut();
+	}
+
+	function focusOutFileMenu()
+	{
+		isFileMenuPressed        = false;
+		fileMenuOpenButton.focus = false;
+	}
+
+	function focusOutModules()
+	{
+		modulesPlusButton.showPressed = false;
+		modulesPlusButton.focus       = false;
+	}
+
+	function focusOutPreviousRibbonButton()
+	{
+		ribbonMenu.focusOut();
+	}
+
+	function goToRibbonIndex(_index)
+	{
+		ribbonMenu.setCurrentIndex('other', _index);
+	}
+
+	Keys.onPressed:
+	{
+		if      (event.key === Qt.Key_Left)
+		{
+			if (modulesPlusButton.focus)
+			{
+				modulesPlusButton.focus        = false;
+				modulesPlusButton.showPressed  = false;
+				ribbonMenu.focus               = true;
+				ribbonMenu.setCurrentIndex('last');
+			}
+			else if (fileMenuOpenButton.focus)
+			{
+				fileMenuOpenButton.focus = false;
+				isFileMenuPressed        = false;
+				showModulesMenuPressed();
+			}
+		}
+		else if (event.key === Qt.Key_Right)
+		{
+			if (modulesPlusButton.focus)
+			{
+				modulesPlusButton.focus       = false;
+				modulesPlusButton.showPressed = false;
+				showFileMenuPressed();
+			}
+			else if (fileMenuOpenButton.focus)
+			{
+				fileMenuOpenButton.focus = false;
+				isFileMenuPressed        = false;
+				ribbonMenu.focus         = true;
+				ribbonMenu.setCurrentIndex('first')
+			}
+		}
+		else if (event.key === Qt.Key_Return || event.key === Qt.Key_Space || event.key === Qt.Key_Down)
+		{
+			if (modulesPlusButton.focus)
+				modulesMenu.opened = true;
+			else if (fileMenuOpenButton.focus)
+			{
+				fileMenuModel.visible = true;
+				isFileMenuPressed     = false;
+			}
+		}
+		else if (event.key === Qt.Key_Escape)
+		{
+			if      (modulesPlusButton.focus)
+			{
+				modulesMenu.opened            = false;
+				modulesPlusButton.focus       = false;
+				modulesPlusButton.showPressed = false;
+			}
+			else if (fileMenuOpenButton.focus)
+			{
+				fileMenuModel.visible    = false;
+				isFileMenuPressed        = false;
+				fileMenuOpenButton.focus = false;
+			}
+			else
+				ribbonMenu.focusOut();
+			ribbonBar.focus = false;
+		}
+	}
+
+	function showModulesMenuPressed()
+	{
+		modulesPlusButton.focus       = true;
+		modulesPlusButton.showPressed = true;
+	}
+
+	function showFileMenuPressed()
+	{
+		isFileMenuPressed        = true;
+		fileMenuOpenButton.focus = true;
+	}
+
 	Rectangle
 	{
 		color			: jaspTheme.uiBackground
@@ -35,16 +149,24 @@ FocusScope
 	MenuArrowButton
 	{
 		id			: fileMenuOpenButton
-		showPressed	: fileMenuModel.visible
+		showPressed	: fileMenuModel.visible || isFileMenuPressed
 		buttonType	: MenuArrowButton.ButtonType.Hamburger
 		z			: 2
 		width		: 0.75 * height
 
 		onClicked:
 		{
-			fileMenuModel.visible	= !fileMenuModel.visible;
-			modulesMenu.opened		= false;
-			
+			fileMenuModel.visible = !fileMenuModel.visible;
+
+			if (fileMenuModel.visible)
+				showFileMenuPressed();
+			else
+				focusOutFileMenu();
+
+			modulesMenu.opened			  = false;
+			modulesPlusButton.showPressed = false;
+			isFileMenuPressed             = false;
+			ribbonMenu.focusOut();
 			customMenu.hide()
 		}
 
@@ -82,10 +204,17 @@ FocusScope
 
 		onClicked	:
 		{
-			modulesMenu.opened		= !modulesMenu.opened;
-			fileMenuModel.visible	= false;
-			
+			modulesMenu.opened = !modulesMenu.opened;
+
+			if (modulesMenu.opened)
+				showModulesMenuPressed();
+			else
+				focusOutModules();
+
+			fileMenuModel.visible = false;
+			isFileMenuPressed     = false;
 			customMenu.hide()
+			ribbonMenu.focusOut();
 		}
 
 		anchors
@@ -126,7 +255,6 @@ FocusScope
 		gradient	: Gradient {
 			GradientStop { position: 0.0; color: jaspTheme.shadow }
 			GradientStop { position: 1.0; color: "transparent" } }
-
 	}
 	
 	Rectangle
@@ -145,6 +273,5 @@ FocusScope
 		gradient	: Gradient {
 			GradientStop { position: 0.0; color: jaspTheme.shadow }
 			GradientStop { position: 1.0; color: "transparent" } }
-
 	}
 }

--- a/Desktop/modules/analysismenumodel.cpp
+++ b/Desktop/modules/analysismenumodel.cpp
@@ -78,3 +78,8 @@ const std::vector<Modules::AnalysisEntry*> &	AnalysisMenuModel::analysisEntries(
 
 	return _module ? _module->menu() : dummy;
 }
+
+bool AnalysisMenuModel::isAnalysisEnabled(int index)
+{
+	return analysisEntries().at(index)->isEnabled() && (!analysisEntries().at(index)->requiresData() || _ribbonButton->dataLoaded());
+}

--- a/Desktop/modules/analysismenumodel.h
+++ b/Desktop/modules/analysismenumodel.h
@@ -59,6 +59,7 @@ public:
 	Q_INVOKABLE QString						getAnalysisFunction(int index)								const			{	return QString::fromStdString(analysisEntries().at(index)->function());	}
 	Q_INVOKABLE QString						getAnalysisTitle(int index)									const			{	return QString::fromStdString(analysisEntries().at(index)->title());	}
 	Q_INVOKABLE QString						getAnalysisQML(int index)									const			{	return QString::fromStdString(analysisEntries().at(index)->qml());	}
+	Q_INVOKABLE bool						isAnalysisEnabled(int index);
 	void									setDynamicModule(Modules::DynamicModule * module)							{ beginResetModel(); _module = module; endResetModel(); }
 
 	Q_INVOKABLE bool						hasIcons()													const			{	return _hasIcons; }


### PR DESCRIPTION
## Description 

With "Ctrl + A", focus is given to the first element in the RibbonBar. You can switch between modules with Left and Right arrow keys. On pressing "Enter" key, the analysis menu opens (if it exists). "Esc" hides the menu.  The menu can be navigated with Up and Down arrow keys. Pressing "Enter" key starts an analysis. 

Update:
Added navigation in modulesmenu

#### Related Issue: jasp-stats/INTERNAL-jasp#1245

I tested it on Ubuntu 20.10

![jasp_navigation_modules](https://user-images.githubusercontent.com/6959308/113490740-6d203a80-94cc-11eb-9ed1-cc8526b35609.gif)

