### PR TITLE
fix encoding in jaspSem

### DIFF
--- a/Desktop/widgets/boundcontrollavaantextarea.cpp
+++ b/Desktop/widgets/boundcontrollavaantextarea.cpp
@@ -101,28 +101,20 @@ void BoundControlLavaanTextArea::checkSyntax()
 
 }
 
-void BoundControlLavaanTextArea::rScriptDoneHandler(const QString &result)
+void BoundControlLavaanTextArea::rScriptDoneHandler(const QString &)
 {
 
-	if (result.length() == 0)
-	{
+	Json::Value boundValue(Json::objectValue);
 
-		Json::Value boundValue(Json::objectValue);
+	boundValue["modelOriginal"] = _textArea->text().toStdString();
+	boundValue["model"]			= _textEncoded.toStdString();
 
-		boundValue["modelOriginal"] = _textArea->text().toStdString();
-		boundValue["model"]			= _textEncoded.toStdString();
+	Json::Value columns(Json::arrayValue);
+	for (const std::string& column : _usedColumnNames)
+		columns.append(ColumnEncoder::columnEncoder()->encode(column));
 
-		Json::Value columns(Json::arrayValue);
-		for (const std::string& column : _usedColumnNames)
-			columns.append(ColumnEncoder::columnEncoder()->encode(column));
+	boundValue["columns"] = columns;
 
-		boundValue["columns"] = columns;
+	setBoundValue(boundValue);
 
-		setBoundValue(boundValue);
-	}
-	else
-	{
-		_textArea->setHasScriptError(true);
-		_textArea->setProperty("infoText", result);
-	}
 }

--- a/Desktop/widgets/boundcontrollavaantextarea.cpp
+++ b/Desktop/widgets/boundcontrollavaantextarea.cpp
@@ -101,8 +101,10 @@ void BoundControlLavaanTextArea::checkSyntax()
 
 }
 
-void BoundControlLavaanTextArea::rScriptDoneHandler(const QString &)
+QString BoundControlLavaanTextArea::rScriptDoneHandler(const QString & result)
 {
+	if (!result.isEmpty())
+		return result;
 
 	Json::Value boundValue(Json::objectValue);
 
@@ -116,5 +118,7 @@ void BoundControlLavaanTextArea::rScriptDoneHandler(const QString &)
 	boundValue["columns"] = columns;
 
 	setBoundValue(boundValue);
+
+	return QString();
 
 }

--- a/Desktop/widgets/boundcontrollavaantextarea.cpp
+++ b/Desktop/widgets/boundcontrollavaantextarea.cpp
@@ -19,6 +19,7 @@
 #include "boundcontrollavaantextarea.h"
 #include "textareabase.h"
 #include "log.h"
+#include "columnencoder.h"
 
 #include <QQuickTextDocument>
 
@@ -38,43 +39,77 @@ BoundControlLavaanTextArea::BoundControlLavaanTextArea(TextAreaBase *textArea)
 		Log::log()  << "No document object found!" << std::endl;
 }
 
+void BoundControlLavaanTextArea::bindTo(const Json::Value &value)
+{
+	if (value.type() != Json::objectValue)	return;
+	BoundControlBase::bindTo(value);
+
+	_textArea->setText(tq(value["modelOriginal"].asString()));
+
+	checkSyntax();
+
+}
+
+Json::Value BoundControlLavaanTextArea::createJson()
+{
+	Json::Value result;
+	std::string text = _textArea->text().toStdString();
+
+	result["modelOriginal"] = text;
+	result["model"]			= text;
+	result["columns"]		= Json::Value(Json::arrayValue);
+
+	return result;
+}
+
+bool BoundControlLavaanTextArea::isJsonValid(const Json::Value &value)
+{
+	if (!value.isObject())					return false;
+	if (!value["modelOriginal"].isString())	return false;
+	if (!value["model"].isString())			return false;
+	if (!value["columns"].isArray())		return false;
+
+	return true;
+}
+
 void BoundControlLavaanTextArea::checkSyntax()
 {
 	QString text = _textArea->text();
 
-	// create an R vector of available column names
-	// TODO: Proper handling of end-of-string characters and funny colnames
-	QString colNames = "c(";
-	bool firstCol = true;
-
-	QList<QString> vars = _textArea->availableModel()->allTerms().asQList();
-	for (QString &var : vars)
-	{
-		if (!firstCol)
-			colNames.append(',');
-		colNames.append('\'')
-				.append(var.replace("\'", "\\u0027")
-						   .replace("\"", "\\u0022")
-						   .replace("\\", "\\\\"))
-				.append('\'');
-		firstCol = false;
-	}
-
-	colNames.append(')');
-
-	// replace ' and " with their unicode counterparts
-	// This protects against arbitrary code being run through string escaping.
-	text.replace("\'", "\\u0027").replace("\"", "\\u0022");
-	// This protects against crashes due to backslashes
-	text.replace("\\", "\\\\");
+	// get the column names of the data set
+	_usedColumnNames.clear();
+	_textEncoded = tq(ColumnEncoder::columnEncoder()->encodeRScript(stringUtils::stripRComments(fq(text)), &_usedColumnNames));
 
 	// Create R code string
-	QString checkCode = "checkLavaanModel('";
+	QString encodedColNames = "c(";
+	for (const std::string& column : _usedColumnNames)
+	{
+		encodedColNames.append("'" + tq(ColumnEncoder::columnEncoder()->encode(column)) + "'");
+		if (column != *_usedColumnNames.rbegin())
+			encodedColNames.append(", ");
+	}
+	encodedColNames.append(")");
+
+	QString checkCode = "jaspSem:::checkLavaanModel('";
 	checkCode
-		.append(text)
+		.append(_textEncoded)
 		.append("', ")
-		.append(colNames)
+		.append(encodedColNames)
 		.append(")");
 
+	Json::Value boundValue(Json::objectValue);
+
+	boundValue["modelOriginal"] = text.toStdString();
+	boundValue["model"] = _textEncoded.toStdString();
+
+	Json::Value columns(Json::arrayValue);
+	for (const std::string& column : _usedColumnNames)
+		columns.append(ColumnEncoder::columnEncoder()->encode(column));
+
+	boundValue["columns"] = columns;
+
+	setBoundValue(boundValue);
+
 	_textArea->runRScript(checkCode, false);
+
 }

--- a/Desktop/widgets/boundcontrollavaantextarea.h
+++ b/Desktop/widgets/boundcontrollavaantextarea.h
@@ -27,10 +27,18 @@ class BoundControlLavaanTextArea : public BoundControlTextArea
 public:
 	BoundControlLavaanTextArea(TextAreaBase* textArea);
 
+	bool		isJsonValid(const Json::Value& optionValue)		override;
+	Json::Value	createJson()									override;
+	void		bindTo(const Json::Value &value)				override;
+
 	void	checkSyntax()			override;
 
 protected:
 	LavaanSyntaxHighlighter*	_lavaanHighlighter		= nullptr;
+
+	std::set<std::string>		_usedColumnNames;
+	QString						_textEncoded;
+
 };
 
 #endif // BOUNDCONTROLLAVAANTEXTAREA_H

--- a/Desktop/widgets/boundcontrollavaantextarea.h
+++ b/Desktop/widgets/boundcontrollavaantextarea.h
@@ -31,7 +31,8 @@ public:
 	Json::Value	createJson()									override;
 	void		bindTo(const Json::Value &value)				override;
 
-	void	checkSyntax()			override;
+	void		checkSyntax()									override;
+	void		rScriptDoneHandler(const QString &result)		override;
 
 protected:
 	LavaanSyntaxHighlighter*	_lavaanHighlighter		= nullptr;

--- a/Desktop/widgets/boundcontrollavaantextarea.h
+++ b/Desktop/widgets/boundcontrollavaantextarea.h
@@ -32,7 +32,7 @@ public:
 	void		bindTo(const Json::Value &value)				override;
 
 	void		checkSyntax()									override;
-	void		rScriptDoneHandler(const QString &result)		override;
+	QString		rScriptDoneHandler(const QString &result)		override;
 
 protected:
 	LavaanSyntaxHighlighter*	_lavaanHighlighter		= nullptr;

--- a/Desktop/widgets/boundcontroltextarea.h
+++ b/Desktop/widgets/boundcontroltextarea.h
@@ -35,6 +35,7 @@ public:
 	void					bindTo(const Json::Value& value)			override;
 
 	virtual	void			checkSyntax();
+	virtual void			rScriptDoneHandler(const QString &result)	{ throw std::runtime_error("runRScript done but handler not implemented!\nImplement an override for RScriptDoneHandler!\nResult was: " + result.toStdString()); };
 
 protected:
 	TextAreaBase*				_textArea	= nullptr;

--- a/Desktop/widgets/boundcontroltextarea.h
+++ b/Desktop/widgets/boundcontroltextarea.h
@@ -35,7 +35,7 @@ public:
 	void					bindTo(const Json::Value& value)			override;
 
 	virtual	void			checkSyntax();
-	virtual void			rScriptDoneHandler(const QString &result)	{ throw std::runtime_error("runRScript done but handler not implemented!\nImplement an override for RScriptDoneHandler!\nResult was: " + result.toStdString()); };
+	virtual QString			rScriptDoneHandler(const QString &result)	{ throw std::runtime_error("runRScript done but handler not implemented!\nImplement an override for RScriptDoneHandler!\nResult was: " + result.toStdString()); };
 
 protected:
 	TextAreaBase*				_textArea	= nullptr;

--- a/Desktop/widgets/textareabase.cpp
+++ b/Desktop/widgets/textareabase.cpp
@@ -72,14 +72,11 @@ void TextAreaBase::setUp()
 
 void TextAreaBase::rScriptDoneHandler(const QString & result)
 {
-	//This is for the lavaan model, but can be used by other type
-	if (result.length() == 0)
+	QString error = _boundControl->rScriptDoneHandler(result);
+	if (error.isEmpty())
 	{
 		setHasScriptError(false);
 		setProperty("infoText", tr("Model applied"));
-
-		_boundControl->rScriptDoneHandler(result);
-
 	}
 	else
 	{

--- a/Desktop/widgets/textareabase.cpp
+++ b/Desktop/widgets/textareabase.cpp
@@ -78,7 +78,8 @@ void TextAreaBase::rScriptDoneHandler(const QString & result)
 		setHasScriptError(false);
 		setProperty("infoText", tr("Model applied"));
 
-		_boundControl->setBoundValue(Json::Value(text().toStdString()));
+		_boundControl->rScriptDoneHandler(result);
+
 	}
 	else
 	{


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1150

This does 2 things:

1. Encode column names in a lavaan model.
2. Pass found column names to R. That should make the R code a lot simpler. For example, right now jaspSem parses the lavaan model (again) and extracts the column names.

The code is mainly inspired by https://github.com/jasp-stats/jasp-desktop/blob/development/Desktop/widgets/boundcontroljagstextarea.cpp.

Requires https://github.com/jasp-stats/jaspSem/pull/15 to see it in action in JASP.

