### PR TITLE
Make JASP use renv stuff

### DIFF
--- a/Common/appinfo.cpp
+++ b/Common/appinfo.cpp
@@ -44,10 +44,6 @@ std::string AppInfo::getBuildYear()
 
 std::string AppInfo::getRVersion()
 {
-	std::stringstream ss;
-	ss << CURRENT_R_VERSION;
-	std::string str;
-	ss >> str;
-	return str;
+	return CURRENT_R_VERSION;
 }
 

--- a/Common/log.h
+++ b/Common/log.h
@@ -32,6 +32,8 @@ public:
 
 	static std::string	whereStr() { return logTypeToString(_where); }
 
+	static bool			toCout() { return _where == logType::cout; }
+
 private:
 						Log() { }
 	static void			redirectStdOut();

--- a/Desktop/Desktop.pro
+++ b/Desktop/Desktop.pro
@@ -172,72 +172,6 @@ unix {
 	copyres.commands += cp -R $$RESOURCES_PATH/* $$RESOURCES_DESTINATION ;
 }
 
-$$GENERATE_LANGUAGE_FILES { 
-	
-	win32 { ######################## Windows language files ##################################
-		
-		#Update and Cleanup .pot file
-		maketranslations.commands += $$quote($${WINQTBIN}lupdate.exe -locations none -extensions $${EXTENSIONS} -recursive \"$${WINPWD}\" -ts \"$$SOURCES_TRANSLATIONS\jaspDesktop.pot\") &&
-		maketranslations.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location \"$${SOURCES_TRANSLATIONS}\jaspDesktop.pot\" -o \"$${SOURCES_TRANSLATIONS}\jaspDesktop.pot\") &&
-		
-		for(LANGUAGE_CODE, SUPPORTED_LANGUAGES) {
-			maketranslations.commands += $$quote(echo "Generating Language Files: $${LANGUAGE_CODE}") &&
-	
-			#Initialize jaspDesktop-xx.po from previous language files
-			!exists($$SOURCES_TRANSLATIONS/jaspDesktop-$${LANGUAGE_CODE}.po){
-				maketranslations.commands += $$quote(echo "INITIALIZE JASPDESKTOP FILES WITH MSGMERGE: $${LANGUAGE_CODE} ;") &&
-				maketranslations.commands += $$quote($${WINQTBIN}lupdate.exe -locations none -extensions $${EXTENSIONS} -recursive \"$${WINPWD}\" -ts \"$$SOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.po\") &&
-				maketranslations.commands += $$quote(\"$${GETTEXT_LOCATION}\msgmerge.exe\" \"$$SOURCES_TRANSLATIONS\jasp_$${LANGUAGE_CODE}.po\" \"$$SOURCES_TRANSLATIONS\jaspDesktop.pot\" > \"$$SOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.po\" ) &&
-				maketranslations.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location \""$$SOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.po\" -o \""$$SOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.po\") &&
-			}
-			
-			#Update and Cleanup .po file
-			maketranslations.commands += $$quote($${WINQTBIN}lupdate.exe -locations none -extensions $${EXTENSIONS} -recursive \"$${WINPWD}\" -ts \"$$SOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.po\") &&
-			maketranslations.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location \""$$SOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.po\" -o \""$$SOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.po\") &&
-			
-			#Create jaspDesktop-$${LANGUAGE_CODE}.qm
-			maketranslations.commands += $$quote($${WINQTBIN}lrelease.exe \"$$SOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.po\" -qm \"$$RESOURCES_TRANSLATIONS\jaspDesktop-$${LANGUAGE_CODE}.qm\") &&
-			
-		}#Loop over Languages
-		
-		#Create R-jaspGraphs.mo translation file. (Need to add GETTEXT location to PATH environment.)
-		maketranslations.commands += $$quote(\"$$PWD/../Tools/translate.cmd\" \"$$_R_HOME/bin\" \"$${GETTEXT_LOCATION}\" \"$$PWD/../Tools\" \"$$PWD/../Engine/jaspGraphs\" ) &&
-		
-		#Create R-jaspBase.mo translation file. (Need to add GETTEXT location to PATH environment.)
-		maketranslations.commands += $$quote(\"$$PWD/../Tools/translate.cmd\" \"$$_R_HOME/bin\" \"$${GETTEXT_LOCATION}\" \"$$PWD/../Tools\" \"$$PWD/../Engine/jaspBase\" ) &&
-		maketranslations.commands += $$quote(copy \"$${RESOURCES_TRANSLATIONS}\*.qm\" \"$${RESOURCES_DESTINATION_TRANSLATIONS}\" ) &&
-		maketranslations.depends  = copyres
-		maketranslations.commands += $$quote(echo "End translation task")
-	}
-	
-	unix { ######################## Unix language files ##################################
-			
-		#Update and  Cleanup .pot file
-		maketranslations.commands += PATH=$$EXTENDED_PATH lupdate -locations none -extensions cpp,qml -recursive $$PWD -ts $$SOURCES_TRANSLATIONS/jaspDesktop.pot ;   
-		maketranslations.commands += PATH=$$EXTENDED_PATH msgattrib --no-obsolete --no-location $$SOURCES_TRANSLATIONS/jaspDesktop.pot -o $$SOURCES_TRANSLATIONS/jaspDesktop.pot ;
-	
-		for(LANGUAGE_CODE, SUPPORTED_LANGUAGES) {
-			maketranslations.commands += $$quote(echo "Generating language File: $${LANGUAGE_CODE}" ;) 
-
-			#Update and Cleanup QML .po file
-			maketranslations.commands += PATH=$$EXTENDED_PATH lupdate -locations none -extensions cpp,qml -recursive $$PWD -ts $$SOURCES_TRANSLATIONS/jaspDesktop-$${LANGUAGE_CODE}.po ;
-			maketranslations.commands += PATH=$$EXTENDED_PATH msgattrib --no-obsolete --no-location $$SOURCES_TRANSLATIONS/jaspDesktop-$${LANGUAGE_CODE}.po -o $$SOURCES_TRANSLATIONS/jaspDesktop-$${LANGUAGE_CODE}.po ;
-			
-			#Create jaspDesktop-$${LANGUAGE_CODE}.qm
-			maketranslations.commands += PATH=$$EXTENDED_PATH lrelease  $$SOURCES_TRANSLATIONS/jaspDesktop-$${LANGUAGE_CODE}.po -qm $$RESOURCES_TRANSLATIONS/jaspDesktop-$${LANGUAGE_CODE}.qm ;
-			
-		}#Loop over languages
-		
-		#Create jaspBase.mo translation files. (Need to add GETTEXT location to PATH environment.)
-		maketranslations.commands += JASP_R_HOME=$$_R_HOME \"$$R_EXE\" -e \"rootfolder <- \'$$PWD/../Engine/jaspBase\';    source(\'$$PWD/../Tools/translate.R\');\"
-		maketranslations.commands += JASP_R_HOME=$$_R_HOME \"$$R_EXE\" -e \"rootfolder <- \'$$PWD/../Engine/jaspGraphs\';  source(\'$$PWD/../Tools/translate.R\');\"
-	
-		#Copy to Resources
-		maketranslations.commands += cp $$RESOURCES_TRANSLATIONS/*.qm $$RESOURCES_DESTINATION_TRANSLATIONS/ ;
-		maketranslations.depends  = copyres
-	}
-}
-
 copyres.depends = delres
 
 ! equals(PWD, $${OUT_PWD}) {
@@ -335,6 +269,7 @@ HEADERS += \
     utilities/appdirs.h \
     utilities/application.h \
     utilities/jsonutilities.h \
+    utilities/processhelper.h \
     utilities/qutils.h \
     results/resultsjsinterface.h \
     utilities/settings.h \
@@ -526,6 +461,7 @@ SOURCES += \
     utilities/appdirs.cpp \
     utilities/application.cpp \
     utilities/jsonutilities.cpp \
+    utilities/processhelper.cpp \
     utilities/qutils.cpp \
     results/resultsjsinterface.cpp \
     utilities/settings.cpp \

--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -109,7 +109,7 @@ FocusScope
 					anchors.leftMargin: modules.buttonMargin
 					anchors.left:		parent.left
 					onClicked: 			folderSelected ? dynamicModules.installJASPDeveloperModule() : preferencesModel.browseDeveloperFolder()
-					toolTip:			folderSelected ? (dynamicModules.developersModuleInstallButtonEnabled ? qsTr("Install selected developer module") : qsTr("Installing developer module now")) : qsTr("Select a developer module under Left menu->Preference->Advanced")
+					toolTip:			folderSelected ? (dynamicModules.developersModuleInstallButtonEnabled ? qsTr("Install selected developer module") : qsTr("Installing developer module now")) : qsTr("Select a developer module by clicking here")
 					visible:			preferencesModel.developerMode
 					enabled:			dynamicModules.developersModuleInstallButtonEnabled
 
@@ -126,7 +126,6 @@ FocusScope
 
 				Repeater
 				{
-
 					model: ribbonModelUncommon
 
 					Rectangle

--- a/Desktop/gui/preferencesmodel.cpp
+++ b/Desktop/gui/preferencesmodel.cpp
@@ -486,7 +486,8 @@ int PreferencesModel::lcCtypeWin() const
 bool PreferencesModel::setLC_CTYPE_C() const
 {
 #ifndef _WIN32
-	throw std::runtime_error("PreferencesModel::setLC_CTYPE_C() should only be used on Windows.");
+	//throw std::runtime_error("PreferencesModel::setLC_CTYPE_C() should only be used on Windows.");
+	return false; //The result is interpreted as "force LC_CTYPE to C". I guess the "neverC" enum is also a bit misleading then... But all of this can be thrown away once utf-8 is supported on win.
 #endif
 	
 	switch(Settings::getWinLcCtypeSetting())

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -32,7 +32,44 @@
 const std::string	jaspExtension	= ".jasp",
 					unitTestArg		= "--unitTest",
 					saveArg			= "--save",
-					timeOutArg		= "--timeOut=";
+					timeOutArg		= "--timeOut=",
+					junctionArg		= "--junctions";
+
+#ifdef _WIN32
+
+#include "utilities/processhelper.h"
+//This function simply sets the proper environment of jaspengine, and starts it in junction-fixing mode. This is called after the installer runs to fix the junctions in Modules that actually point to renv-cache instead of nowhere
+bool runJaspEngineJunctionFixer(int argc, char *argv[], bool exitAfterwards = true)
+{
+	QApplication		app(argc, argv);
+	QProcessEnvironment env		= ProcessHelper::getProcessEnvironmentForJaspEngine(false, false);
+	QString				workDir = QFileInfo( QCoreApplication::applicationFilePath() ).absoluteDir().absolutePath();
+	
+	QProcess engine;
+	
+	engine.setProcessChannelMode(QProcess::ForwardedChannels);
+	engine.setProcessEnvironment(env);
+	engine.setWorkingDirectory(workDir);
+	engine.setProgram("JASPEngine.exe");
+	engine.setArguments({"--recreateJunctions", workDir});
+	engine.start();
+	
+	if(!engine.waitForStarted())		{	std::cerr << "JASPEngine failed to start for junctions!" << std::endl;						exit(2); }
+	//Something like 10 minutes tops should be more than enough for the junctions to be replaced and otherwise it probably crashed?
+	if(!engine.waitForFinished(600000)) {	std::cerr << "JASPEngine started but timed out before finishing junctions!" << std::endl;	exit(3); }
+
+	bool worked = engine.exitCode() == 0;
+	
+	std::cout << "Replacing junctions with JASPEngine seems to have " << (worked ? "worked." : "failed.")  << std::endl;
+
+	
+	if(exitAfterwards)
+		exit(engine.exitCode());
+	
+	return worked;
+}
+
+#endif
 
 void parseArguments(int argc, char *argv[], std::string & filePath, bool & unitTest, bool & dirTest, int & timeOut, bool & save, bool & logToFile, bool & hideJASP, bool & safeGraphics, bool & LC_CTYPE_C, bool & LC_CTYPE_system)
 {
@@ -60,6 +97,9 @@ void parseArguments(int argc, char *argv[], std::string & filePath, bool & unitT
 		else if(args[arg] == "--safeGraphics")					safeGraphics			= true;
 		else if(args[arg] == "--setLC_CTYPE_C")					LC_CTYPE_C				= true;
 		else if(args[arg] == "--setLC_CTYPE_system")			LC_CTYPE_system			= true;
+#ifdef _WIN32
+		else if(args[arg] == junctionArg)						runJaspEngineJunctionFixer(argc, argv); //Run the junctionfixer, it will exit the application btw!
+#endif
 		else if(args[arg] == "--unitTestRecursive")
 		{
 			if(arg >= args.size() - 1)
@@ -168,6 +208,7 @@ void parseArguments(int argc, char *argv[], std::string & filePath, bool & unitT
 					<< "If --safeGraphics is specified then JASP will be started with software rendering enabled.\n"
 			   #ifdef _WIN32
 					<< "If --setLC_CTYPE_C is specified JASP will make sure LC_CTYPE is set to \"C\" for the engine, --setLC_CTYPE_system is specified the system default is used."
+					<< "If --junctions is specified JASP will recreate the junctions in Modules/ to renv-cache/, this needs to be done at least once after install, but is usually triggered automatically."
 			   #endif
 					<< "This text will be shown when either --help or -h is specified or something else that JASP does not understand is given as argument.\n"
 					<< std::flush;
@@ -273,7 +314,7 @@ int main(int argc, char *argv[])
 	int			timeOut;
 
 	parseArguments(argc, argv, filePath, unitTest, dirTest, timeOut, save, logToFile, hideJASP, safeGraphics, setLC_CTYPE_C, setLC_CTYPE_system);
-
+	
 	QCoreApplication::setOrganizationName("JASP");
 	QCoreApplication::setOrganizationDomain("jasp-stats.org");
 	QCoreApplication::setApplicationName("JASP");
@@ -291,6 +332,19 @@ int main(int argc, char *argv[])
 	std::vector<std::string> args(argv, argv + argc);
 
 	boost::filesystem::path::imbue(std::locale( std::locale(), new std::codecvt_utf8_utf16<wchar_t>() ) );
+	
+#ifdef _WIN32
+	// Since we introduced renv to JASP the win installer needs to recreate the junctions from Modules -> renv-cache on install. Because they do not support relative paths
+	// For this JASP has the --junctions argument, and is run by JASP-*.msi during install to make sure everything is ready.
+	// However, we also want to support ZIP distributions of jasp, and there is no installer. But the good thing is it also means the user has write access to the main folder. Which means we can fix it now.
+	QDir modulesDir("Modules");
+	
+	if(!modulesDir.exists() && !runJaspEngineJunctionFixer(argc, argv, false)) 
+	{
+		std::cerr << "Modules folder missing and couldn't be created!\nContact the JASP team for support, or try the MSI." << std::endl;	
+		exit(1234);
+	}
+#endif
 
 	if(!dirTest)
 		//try

--- a/Desktop/modules/description/description.cpp
+++ b/Desktop/modules/description/description.cpp
@@ -72,7 +72,7 @@ void Description::addChild(DescriptionChildBase * child)
 {
 	assert(child);
 
-	if(dynamic_cast<EntryBase*>(child))			_entries.push_back(dynamic_cast<EntryBase*>			(child));
+	if(qobject_cast<EntryBase*>(child))			_entries.push_back(dynamic_cast<EntryBase*>			(child));
 	
 	connect(child, &DescriptionChildBase::somethingChanged, this, &Description::childChanged, Qt::UniqueConnection);
 }
@@ -82,7 +82,7 @@ void Description::removeChild(DescriptionChildBase * child)
 {
 	assert(child);
 
-	if(dynamic_cast<EntryBase*>(child))			_entries.removeAll(dynamic_cast<EntryBase*>			(child));
+	if(qobject_cast<EntryBase*>(child))			_entries.removeAll(dynamic_cast<EntryBase*>			(child));
 
 	disconnect(child, &DescriptionChildBase::somethingChanged, this, &Description::childChanged);
 }

--- a/Desktop/modules/description/descriptionchildbase.cpp
+++ b/Desktop/modules/description/descriptionchildbase.cpp
@@ -11,7 +11,7 @@ DescriptionChildBase::DescriptionChildBase()
 
 void DescriptionChildBase::registerDescription(QQuickItem * parent)
 {
-	Description * newDesc = dynamic_cast<Description*>(parent);
+	Description * newDesc = qobject_cast<Description*>(parent);
 
 	if(newDesc != _description)
 	{

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -522,7 +522,7 @@ std::string DynamicModule::generateModuleLoadingR(bool shouldReturnSucces)
 	//Add the module name to the "do not remove from global env" list in R. See jaspRCPP_purgeGlobalEnvironment
 	R << "jaspBase:::.addModuleToDoNotRemove('" << _name << _modulePostFix << "');\n";
 
-	R << _name << _modulePostFix << " <- module({\n" << standardRIndent << ".libPaths(" << getLibPathsToUse() <<");\n\n";
+	R << _name << _modulePostFix << " <- modules::module({\n" << standardRIndent << ".libPaths(" << getLibPathsToUse() <<");\n\n";
 
 	for(const std::string & reqMod : requiredModules())
 		R << standardRIndent << "import('" << reqMod << "');\n";

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -74,7 +74,9 @@ void DynamicModules::initializeInstalledModules()
 
 		//Development Module should always be fresh!
 		if(name == defaultDevelopmentModuleName())	boost::filesystem::remove_all(itr->path());
-		else if(name.size() > 0 && name[0] != '.')	initializeModuleFromDir(path);
+		else if(name.size() > 0		&& 
+				name[0] != '.'		&&
+				QFileInfo(tq(path)).isDir()		)	initializeModuleFromDir(path);
 	}
 }
 

--- a/Desktop/modules/ribbonbutton.cpp
+++ b/Desktop/modules/ribbonbutton.cpp
@@ -44,15 +44,15 @@ void RibbonButton::setDynamicModule(DynamicModule * module)
 	{
 		_module = module;
 		connect(_module, &DynamicModule::descriptionReloaded,	this, &RibbonButton::reloadDynamicModule,	Qt::QueuedConnection);
-		connect(_module, &DynamicModule::loadedChanged,			this, &RibbonButton::setReady			);
-		connect(_module, &DynamicModule::errorChanged,			this, &RibbonButton::setError			);
+		connect(_module, &DynamicModule::installedChanged,		this, &RibbonButton::setReady									);
+		connect(_module, &DynamicModule::errorChanged,			this, &RibbonButton::setError									);
 
 		if(!_analysisMenuModel)
 			_analysisMenuModel = new AnalysisMenuModel(this, _module);
 
 		_analysisMenuModel->setDynamicModule(_module);
 
-		setReady(false);
+		setReady(_module->installed());
 	}
 }
 

--- a/Desktop/modules/upgrader/changebase.cpp
+++ b/Desktop/modules/upgrader/changebase.cpp
@@ -52,7 +52,7 @@ QString ChangeBase::_toString() const
 
 void ChangeBase::registerChange(QQuickItem * parent)
 {
-	Upgrade * upgrade = dynamic_cast<Upgrade*>(parent);
+	Upgrade * upgrade = qobject_cast<Upgrade*>(parent);
 	
 	if(!upgrade && parent)
 		throw upgradeLoadError(fq(toString()), "A Change* Item must always be a child of Upgrade");

--- a/Desktop/modules/upgrader/upgrade.cpp
+++ b/Desktop/modules/upgrader/upgrade.cpp
@@ -90,7 +90,7 @@ QString Upgrade::module() const
 
 void Upgrade::registerStep(QQuickItem * parent)
 {
-	Upgrades * upgrades = dynamic_cast<Upgrades*>(parent);
+	Upgrades * upgrades = qobject_cast<Upgrades*>(parent);
 	
 	if(!upgrades && parent)
 		throw upgradeLoadError(fq(toString()), "An Upgrade Item must always be a child of Upgrades");

--- a/Desktop/utilities/appdirs.cpp
+++ b/Desktop/utilities/appdirs.cpp
@@ -105,7 +105,7 @@ QString AppDirs::documents()
 	return processPath(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 }
 
-QString AppDirs::logDir()
+QString AppDirs::logDir()	
 {
 	QString path = appData();
 	path += "/Logs/";
@@ -151,4 +151,35 @@ QString AppDirs::rHome()
 QDir AppDirs::programDir()
 {
 	return QFileInfo( QCoreApplication::applicationFilePath() ).absoluteDir();	
+}
+
+//After getting an error on giving "consent" to renv to do stuff I checked the page https://rstudio.github.io/renv/reference/paths.html
+//I think it would be good to make sure the root-renv folder is also within the appdata of JASP and not in their own, because then we would be partially clobbering users own renv stuff
+QString AppDirs::renvRootLocation()
+{
+	const char * renvRootName = "renv";
+	
+	QDir(appData()).mkpath(renvRootName); //create it if missing
+	
+	return appData() + "/" + renvRootName;
+}
+
+QString AppDirs::renvCacheLocations()
+{
+	const char * renvCacheName = "cache";
+	
+	QDir(renvRootLocation()).mkpath(renvCacheName); //create it if missing
+	
+	QString dynamicCache = renvRootLocation() + "/" + renvCacheName,
+			staticCache  = processPath(programDir().absoluteFilePath("renv-cache"));
+	
+	const QChar separator =
+#ifdef WIN32
+							';';
+#else
+							':';
+#endif
+	
+	return dynamicCache + separator + staticCache;
+	
 }

--- a/Desktop/utilities/appdirs.h
+++ b/Desktop/utilities/appdirs.h
@@ -38,6 +38,8 @@ public:
 	static QString appData();
 	static QString rHome();
 	static QDir    programDir();
+	static QString renvRootLocation();
+	static QString renvCacheLocations(); //Just one for now, but expected to become at least two separated by ;
 	
 private:
 	static QString processPath(const QString & path);

--- a/Desktop/utilities/processhelper.cpp
+++ b/Desktop/utilities/processhelper.cpp
@@ -1,0 +1,99 @@
+#include "processhelper.h"
+#include "appdirs.h"
+#include "tempfiles.h"
+#include "utilities/qutils.h"
+#include "utils.h"
+#include "log.h"
+
+QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool withTmpDir, bool forceLC_CTYPE_C)
+{
+	QDir				programDir	= AppDirs::programDir();
+	QString				engineExe	= programDir.absoluteFilePath("JASPEngine");
+	QProcessEnvironment env			= QProcessEnvironment::systemEnvironment();
+
+	if(withTmpDir)
+		env.insert("TMPDIR",						tq(TempFiles::createTmpFolder()));
+	
+	env.insert("R_REMOTES_NO_ERRORS_FROM_WARNINGS", "true"); //Otherwise installing dependencies for modules can crap out on ridiculous warnings
+	env.insert("RENV_PATHS_ROOT",					AppDirs::renvRootLocation());
+	env.insert("RENV_PATHS_CACHE",					AppDirs::renvCacheLocations());
+	
+	//Seems a bit weird but we need to tell this to jaspBase so it can tell renv to run it again because that will be running in a subprocess. 
+	//Which also means we have the following process -> subprocess structure while installing a dynamic module:
+	// jasp -> JASPEngine with R-embedded -> Separate R -> separate instances of JASPEngine...
+	env.insert("JASPENGINE_LOCATION",				engineExe); 
+	
+	QString rHomePath = AppDirs::rHome();
+	QDir rHome(rHomePath);
+
+	QString custom_R_library = "";
+#ifdef JASP_DEBUG
+	// allow an environment variables to specify the location of packages
+	if (env.contains("JASP_R_Library"))
+		custom_R_library = ":" + env.value("JASP_R_Library");
+#endif
+#ifdef _WIN32
+#if defined(ARCH_32)
+#define ARCH_SUBPATH "i386"
+#else
+#define ARCH_SUBPATH "x64"
+#endif
+	
+	auto longToShort = [](QString in) -> QString { return QString::fromStdWString(Utils::getShortPathWin(in.toStdWString())); };
+	
+	QString PATH		= longToShort(programDir.absoluteFilePath("R/library/RInside/libs/" ARCH_SUBPATH)) + ";" + longToShort(programDir.absoluteFilePath("R/library/Rcpp/libs/" ARCH_SUBPATH)) + ";" + longToShort(programDir.absoluteFilePath("R/bin/" ARCH_SUBPATH)) + ";" + longToShort(env.value("PATH")),
+			R_HOME		= longToShort(rHome.absolutePath()),
+			JAGS_HOME	= longToShort(programDir.absoluteFilePath("JAGS/"));
+	
+	Log::log() << "R_HOME set to " << R_HOME << std::endl;
+
+	env.insert("PATH",				PATH);
+	env.insert("R_HOME",			R_HOME);
+	env.insert("JAGS_HOME",			JAGS_HOME);
+	
+#undef ARCH_SUBPATH
+
+	env.insert("R_LIBS",			 R_HOME + "/library");
+
+	env.insert("R_ENVIRON",			"something-which-doesn't-exist");
+	env.insert("R_PROFILE",			"something-which-doesn't-exist");
+	env.insert("R_PROFILE_USER",	"something-which-doesn't-exist");
+	env.insert("R_ENVIRON_USER",	"something-which-doesn't-exist");
+	
+	if(forceLC_CTYPE_C)
+	{
+		Log::log() << "Setting LC_CTYPE to C!" << std::endl;
+		env.insert("LC_CTYPE",			"C"); //To force utf-8 output from gettext et al.
+	}
+	else
+		Log::log() << "Leaving LC_CTYPE at systemdefault" << std::endl;
+					  
+
+#elif __APPLE__
+
+	env.insert("R_HOME",			rHome.absolutePath());
+	env.insert("JASP_R_HOME",		rHome.absolutePath()); //Used by the modified R script in jasp-required-files/Framework/etc/bin to make sure we use the actual R of JASP! (https://github.com/jasp-stats/INTERNAL-jasp/issues/452)
+	env.insert("R_LIBS",			rHome.absoluteFilePath("library") + ":" + programDir.absoluteFilePath("R/library"));
+	env.insert("JAGS_HOME",			programDir.absoluteFilePath("JAGS/"));
+
+	//env.insert("R_ENVIRON",			"something-which-doesnt-exist");
+	//env.insert("R_PROFILE",			"something-which-doesnt-exist");
+	//env.insert("R_PROFILE_USER",	"something-which-doesnt-exist");
+	//env.insert("R_ENVIRON_USER",	"something-which-doesnt-exist");
+
+	env.insert("LC_CTYPE",			"UTF-8"); //This isn't really a locale but seems necessary to get proper output from gettext on mac
+
+#else  // linux
+	env.insert("LD_LIBRARY_PATH",	rHome.absoluteFilePath("lib") + ":" + rHome.absoluteFilePath("library/RInside/lib") + ":" + rHome.absoluteFilePath("library/Rcpp/lib") + ":" + rHome.absoluteFilePath("site-library/RInside/lib") + ":" + rHome.absoluteFilePath("site-library/Rcpp/lib") + ":/app/lib/:/app/lib64/");
+	env.insert("R_HOME",			rHome.absolutePath());
+	env.insert("R_LIBS",			programDir.absoluteFilePath("R/library") + custom_R_library + ":" + rHome.absoluteFilePath("library") + ":" + rHome.absoluteFilePath("site-library"));
+
+	//Let's just trust linux and *not set* LC_CTYPE at all. It'll be fine.
+#endif
+
+
+	env.insert("R_LIBS_SITE",		"");
+	env.insert("R_LIBS_USER",		AppDirs::userRLibrary().toStdString().c_str());
+
+	return(env);	
+}

--- a/Desktop/utilities/processhelper.h
+++ b/Desktop/utilities/processhelper.h
@@ -1,0 +1,16 @@
+#ifndef PROCESSHELPER_H
+#define PROCESSHELPER_H
+
+#include <QProcessEnvironment>
+
+class ProcessHelper
+{
+public:
+	
+	static QProcessEnvironment getProcessEnvironmentForJaspEngine(bool withTmpDir, bool forceLC_CTYPE_C = false);
+	
+private:
+	ProcessHelper(){}
+};
+
+#endif // PROCESSHELPER_H

--- a/Docs/development/jasp-building-guide.md
+++ b/Docs/development/jasp-building-guide.md
@@ -23,7 +23,7 @@ JASP requires several dependencies which are documented below.
 
 JASP depends on:
 
- - [Qt (5.15 + QtWebEngine)](http://qt-project.org)
+ - [Qt (5.15.2 + QtWebEngine)](http://qt-project.org)
  - [R](http://cran.r-project.org)
  - [boost](http://boost.org)
  - [libarchive](http://libarchive.org/)
@@ -42,9 +42,9 @@ Windows
 
 Building JASP under windows is most temperamental but should pose no large problems. Besides the above described GitHub repositories, you will need to install the following preliminaries to build JASP on Windows, later on described in more detail:
 
-- [Qt 5.15.1](https://www.qt.io/download) Download the Open Source version from (https://www.qt.io/download).
+- [Qt 5.15.2](https://www.qt.io/download) Download the Open Source version from (https://www.qt.io/download).
 - [Visual Studio 2019](https://www.visualstudio.com/downloads/) Download the community version
-- [R Tools 3.5](https://cran.r-project.org/bin/windows/Rtools/Rtools35.exe) Download from (https://cran.r-project.org/bin/windows/Rtools/Rtools35.exe)
+- [R Tools 4.0](https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe) Download from (https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe)
 
 Besides installing and cloning the software above, one needs to make some kits in Qt Creator to be able to build JASP and separately R-Interface.
 
@@ -77,7 +77,8 @@ To build JASP follow the next steps:
 
 3. Switch to the Windows branch in **jasp-required-files**.
 
-	Warning in advance:  
+***Warning in advance:***
+
 Because the **jasp-required-files** folder contains binary files as well as R packages with text files it is necessary that git performs a checkout or commit without changing the line endings. Some packages might generate MD5 checksum errors if line endings are changed. It is possible to change this behavior of git configuration per repository. For more information on this subject see https://help.github.com/articles/dealing-with-line-endings/  
 (To use a repository specific setting for this: in the **jasp-required-files** folder, type: `git config core.autocrlf false`)  
         From the \<JASP\> root folder in a terminal, type:
@@ -86,7 +87,8 @@ Because the **jasp-required-files** folder contains binary files as well as R pa
 	git checkout Windows  
 	git branch  
 ```
-	Should confirm that you are on the Windows branch now.
+	
+Should confirm that you are on the Windows branch now.
 	
 	
 4.	Create a build folder(s). From the \<JASP\> root folder for a 64-bit version e.g.:
@@ -94,37 +96,37 @@ Because the **jasp-required-files** folder contains binary files as well as R pa
 	mkdir build-release-64  
 	mkdir build-debug-64  
 ```
-	Later you may want to build a debug version.
-	In the description it is assumed that you are now only building a release version.  
-	You should now have:  
+Later you may want to build a debug version.
+In the description it is assumed that you are now only building a release version.  
+You should now have:  
 
-	 \<JASP\>\build-release-64  
-	 \<JASP\>\build-debug-64  
+- \<JASP\>\build-release-64  
+- \<JASP\>\build-debug-64  
 
-	The distinction between debug version and release only differs in the option you choose in QtCreator. Only the description for the release version is given here.
+The distinction between debug version and release only differs in the option you choose in QtCreator. Only the description for the release version is given here.
 
 5.	**Copy & Link files** to their expected locations in the build folders:    
-	From \<JASP\>\jasp-required-files\64\\* -> \<JASP\>\build-release-64  
-	
-	You then open a cmd-prompt as admin(!) and make a symbolic link to R as follows:
+From \<JASP\>\jasp-required-files\64\\* -> \<JASP\>\build-release-64  
+
+You then open a cmd-prompt as admin(!) and make a symbolic link to R as follows:
 ```	
 	cd \<JASP\>\build-release-64  
 	mklink /D R ..\jasp-required-files\R  
 ```	
-	If you don't do it like that, aka a command prompt that you started as admin, JASP *will not compile at all*. So make sure to do it in the described manner.	
+If you don't do it like that, aka a command prompt that you started as admin, JASP *will not compile at all*. So make sure to do it in the described manner.	
 
-	You should now have :  
+You should now have :  
 
-	\<JASP\>\build-release-64\R  
-	\<JASP\>\build-release-64\*.lib and *.dll  
-	\<JASP\>\build-release-64\JAGS\*
+- \<JASP\>\build-release-64\R  
+- \<JASP\>\build-release-64\*.lib and *.dll  
+- \<JASP\>\build-release-64\JAGS\*
    
-6.	**Install Qt 5.15.1**  
-	Go to https://www.qt.io/download  
-	Choose Open Source and Download.  
-	Start qt-unified-windows-x86-?.?.?-online.exe from your download folder.  
-	Having a Qt account is now mandatory because [their sales-team wants to know us to harass us](https://www.qt.io/blog/qt-offering-changes-2020).
-	Use the default options but select the following components to install:
+6.	**Install Qt 5.15.2**  
+Go to https://www.qt.io/download  
+Choose Open Source and Download.  
+Start qt-unified-windows-x86-?.?.?-online.exe from your download folder.  
+Having a Qt account is now mandatory because [their sales-team wants to know us to (potentially) harass us](https://www.qt.io/blog/qt-offering-changes-2020).
+Use the default options but select the following components to install:
 
 ![Image of Qt Installer](https://static.jasp-stats.org/images/QtCreator-Components.png)  
 
@@ -134,43 +136,48 @@ For following updates of Qt you can use the MaintenanceTool for Qt in \<QTINSTAL
 
 
 7. **Install Microsoft Visual Studio 2019**  
-	Go to https://www.visualstudio.com/downloads/  
-	Download Community version
-	Start vs_community_.. from your download folder.  
-	Choose all the default options.   
-	For components to install only choose the Desktop development with C++ option:  
+Go to https://www.visualstudio.com/downloads/  
+Download Community version
+Start vs_community_.. from your download folder.  
+Choose all the default options.   
+For components to install only choose the Desktop development with C++ option:  
 
 ![Image of Qt Installer](https://static.jasp-stats.org/images/Visual-Studio-Options.png)  
 
-8. **Install RTools 3.5**  
-	Download from https://cran.r-project.org/bin/windows/Rtools/Rtools35.exe  
-	Start RTools35 from your download folder.  
-	Choose the default options.  
+8. **Install RTools 4.0**  
+Download from https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe
+Run it and install as you like.  
 
-	You will now have RTools 3.5 installed in C:\RTools  
+If used the default options you will now have RTools 4.0 installed in C:\rtools40  
 
-9.	The last step you have to do is **configuring QtCreator with the proper kits** to build JASP.    
-	Start QtCreator and load, through File->Open File or Project, the JASP.pro file from \<JASP\>\jasp-desktop\JASP.pro.  
-	Also load \<JASP\>\jasp-desktop\R-Interface\R-Interface.pro.  
-	Both projects are built with a different kit in Qt because they are built with different compilers.  
-	Select Manage Kits in QtCreator, through Project in the side panel, and go to the Compilers Tab and add manually the MINGW compiler needed to build R-Interface. After adding a new compiler select its location in RTools mingw folder.   
-	The compiler tab should now be similar to:  
+Because we are using this toolkit for building a small part of jasp as well we need to install some extra stuff. For this, open the folder where you installed rtools.
+Run `msys2.exe` and see a terminal appear as your reward. 
+In it, enter `pacman -Syu` to update the package manager it uses (familiar from arch linux perhaps) but don't worry if you do not know what that means.
+After that run `pacman -S mingw-w64-x86_64-toolchain`
 
+To make sure that Qt knows how to find the newly installed `make` et al, you could add the binary folder to your `PATH` environment variable in Windows.
+Make sure to add `C:\rtools40\mingw_64\bin`. When you are doing, take care to place it as "early" as possible, so if possible as first entry. If you have any references to `C:\Rtools\bin` you can remove those entirely.
+
+9.	**configuring QtCreator with the proper kits**
+The last step you have to do is setting up the proper kits to build JASP.    
+Start QtCreator and load, through File->Open File or Project, the JASP.pro file from \<JASP\>\jasp-desktop\JASP.pro.  
+Also load \<JASP\>\jasp-desktop\R-Interface\R-Interface.pro.  
+Both projects are built with a different kit in Qt because they are built with different compilers.  
+Select Manage Kits in QtCreator, through Project in the side panel, and go to the Compilers Tab and manually ad the `g++` and `gcc` MINGW compiler required for building R-Interface. After adding a new compiler select its location in RTools mingw folder.   
+
+The compiler tab should now be similar to:  
 ![Image of Qt Installer](https://static.jasp-stats.org/images/Compilers.png)    
-	The Debuggers tab should now be similar to:  
 
+The Debuggers tab should now be similar to:  
 ![Image of Qt Installer](https://static.jasp-stats.org/images/Debuggers.png)   	
 
 You should now create two kits, one for building JASP desktop and one for building R-Interface. Both are equal except for the Compiler versions. The kits should look similar to:
-
 ![Image of Qt Installer](https://static.jasp-stats.org/images/MSVC-Kit.png)   
 
 And   
-
 ![Image of Qt Installer](https://static.jasp-stats.org/images/MINGW-Kit.png)
 
 Your deployment configuration, in the side panel, should now show something like:  
-
 ![Image of Qt Installer](https://static.jasp-stats.org/images/Configuration.png)   
 ![Image of Qt Installer](https://static.jasp-stats.org/images/R-Interface-Configuration.png)   
 
@@ -209,38 +216,38 @@ To build JASP you need to clone **jasp-desktop** and **jasp-required-files** rep
  - Tell XCode which "Command Line Tools" to use
  - Close
 
- 2. [Qt](https://www.qt.io/): **Install Qt 5.15.1**
+ 2. [Qt](https://www.qt.io/): **Install Qt 5.15.2**
  Select:
   - macOS
   - Qt WebEngine
 
 ![Image of Qt Installer](https://static.jasp-stats.org/images/jasp2.InstallQt.png)
 
- 2.a. **Configure Qt5.15.1**: Once installed:
- - Go to "Qt Creator" - "Preference" - "Kits"
- - Auto-detect should give "Desktop Qt 5.15.1 clang 64bit". Click on this.
- - Choose the compiler **Clang (x86 64bit in /usr/bin)** for both C and C++.
+2.a. **Configure Qt5.15.2**: Once installed:
+- Go to "Qt Creator" - "Preference" - "Kits"
+- Auto-detect should give "Desktop Qt 5.15.2 clang 64bit". Click on this.
+- Choose the compiler **Clang (x86 64bit in /usr/bin)** for both C and C++.
 
 ![Image of Qt Configuration](https://static.jasp-stats.org/images/jasp2a.ConfigureQt.png)
 
- 2.b. **Configure project**: 
- Open "JASP.pro" as the project in qtcreator.
- Click "Projects" in the left ribbon and provide the "debug build" and "release build" folders with the correct compilers.
- These folders should be placed in the same directory as `jasp-desktop` and `jasp-required-files` (so next to them).
- 
- The projects, once configure, should look like:
+2.b. **Configure project**: 
+Open "JASP.pro" as the project in qtcreator.
+Click "Projects" in the left ribbon and provide the "debug build" and "release build" folders with the correct compilers.
+These folders should be placed in the same directory as `jasp-desktop` and `jasp-required-files` (so next to them).
 
- ![Image of Project debug](https://static.jasp-stats.org/images/jasp2b.1.ConfigureProjectDebug.png)
+The projects, once configure, should look like:
 
- and like:
+![Image of Project debug](https://static.jasp-stats.org/images/jasp2b.1.ConfigureProjectDebug.png)
 
- ![Image of Project release](https://static.jasp-stats.org/images/jasp2b.2.ConfigureProjectRelease.png)
+and like:
+
+![Image of Project release](https://static.jasp-stats.org/images/jasp2b.2.ConfigureProjectRelease.png)
 
 In both case, I've added the flag "-j4" to make use of all my four cores on my mac. (This seems to be enabled by default in newer versions of qtcreator)
 
- 3. Clone the repository **jasp-required-files** and select the **MacOS** branch. These files can now be put in the folders as shown here:
+3. Clone the repository **jasp-required-files** and select the **MacOS** branch. These files can now be put in the folders as shown here:
 
- ![Image of folder structure](https://static.jasp-stats.org/images/jasp5.FolderStructure.png)
+![Image of folder structure](https://static.jasp-stats.org/images/jasp5.FolderStructure.png)
 
 where the blue files are the binaries that are added manually. Keep in mind that the screenshot is kind of old and is missing the `jasp-required-files` folder.
 The process will be smoothened out in the near future.
@@ -253,7 +260,7 @@ This means that whenever **jasp-required-files** gets updated the same happens f
 
 To get this same structure  you will need to make a so-called symbolic link by issuing the following command: `"ln -s jasp-required-files/Frameworks Frameworks"`
 
- 5. Install packages in your local R for JASP to build JASPGraph:
+5. Install packages in your local R for JASP to build JASPGraph:
 
 ```
  install.packages(c("ggplot2", "scales", "cowplot", "gridExtra", "stringr","gbm", "kknn"))

--- a/Engine/Engine.pro
+++ b/Engine/Engine.pro
@@ -57,38 +57,38 @@ INCLUDEPATH += $$PWD/../Common/
 
 
 mkpath($$OUT_PWD/../R/library)
+mkpath($$OUT_PWD/../renv-cache)
 
 exists(/app/lib/*) {
     # org.jaspstats.JASP.json and flatpakbuilder do all this
 } else {
 
-	
 	InstallJASPRPackage.commands        = ""
     #InstallJASPRPackage.commands        =  $${INSTALL_R_PKG_DEPS_CMD_PREFIX}$$PWD/jaspBase$${INSTALL_R_PKG_DEPS_CMD_POSTFIX};	 $$escape_expand(\\n\\t) 
 	InstallJASPRPackage.commands       +=       $${INSTALL_R_PKG_CMD_PREFIX}$$PWD/jaspBase$${INSTALL_R_PKG_CMD_POSTFIX}
 	
-	InstalljaspGraphsRPackage.commands  =  ""
+	#InstalljaspGraphsRPackage.commands  =  ""
 	#InstalljaspGraphsRPackage.commands  =  $${INSTALL_R_PKG_DEPS_CMD_PREFIX}$$PWD/jaspGraphs$${INSTALL_R_PKG_DEPS_CMD_POSTFIX};	 $$escape_expand(\\n\\t) 
-	InstalljaspGraphsRPackage.commands +=       $${INSTALL_R_PKG_CMD_PREFIX}$$PWD/jaspGraphs$${INSTALL_R_PKG_CMD_POSTFIX}
+	#InstalljaspGraphsRPackage.commands +=       $${INSTALL_R_PKG_CMD_PREFIX}$$PWD/jaspGraphs$${INSTALL_R_PKG_CMD_POSTFIX}
 
-    InstalljaspGraphsRPackage.depends	= InstallJASPRPackage
+    #InstalljaspGraphsRPackage.depends	= InstallJASPRPackage
 
 	win32 {
 	    RemoveJASPRPkgLock       = $${PKG_LOCK_CMD_PREFIX}00LOCK-jaspBase$${PKG_LOCK_CMD_INFIX}00LOCK-jaspBase$${PKG_LOCK_CMD_POSTFIX}
-		RemovejaspGraphsRPkgLock = $${PKG_LOCK_CMD_PREFIX}00LOCK-jaspGraphs$${PKG_LOCK_CMD_INFIX}00LOCK-jaspGraphs$${PKG_LOCK_CMD_POSTFIX}
+		#RemovejaspGraphsRPkgLock = $${PKG_LOCK_CMD_PREFIX}00LOCK-jaspGraphs$${PKG_LOCK_CMD_INFIX}00LOCK-jaspGraphs$${PKG_LOCK_CMD_POSTFIX}
 
-		InstalljaspGraphsRPackage.depends	= RemovejaspGraphsRPkgLock
+		#InstalljaspGraphsRPackage.depends	= RemovejaspGraphsRPkgLock
 		InstallJASPRPackage.depends 		= RemoveJASPRPkgLock
 
-        QMAKE_EXTRA_TARGETS += RemovejaspGraphsRPkgLock
-		POST_TARGETDEPS     += RemovejaspGraphsRPkgLock
+        #QMAKE_EXTRA_TARGETS += RemovejaspGraphsRPkgLock
+		#POST_TARGETDEPS     += RemovejaspGraphsRPkgLock
 
         QMAKE_EXTRA_TARGETS += RemoveJASPRPkgLock
 		POST_TARGETDEPS     += RemoveJASPRPkgLock
 	}
 
-	QMAKE_EXTRA_TARGETS += InstalljaspGraphsRPackage
-	POST_TARGETDEPS     += InstalljaspGraphsRPackage
+	#QMAKE_EXTRA_TARGETS += InstalljaspGraphsRPackage
+	#POST_TARGETDEPS     += InstalljaspGraphsRPackage
 
 	QMAKE_EXTRA_TARGETS += InstallJASPRPackage
 	POST_TARGETDEPS     += InstallJASPRPackage
@@ -98,10 +98,10 @@ QMAKE_CLEAN += $$OUT_PWD/../R/library/* #Does this not mess up Windows somehow?
 
 SOURCES += 	main.cpp \
  			engine.cpp \
-  otoolstuff.cpp \
+			otoolstuff.cpp \
 			rbridge.cpp
 
 HEADERS += \
   			engine.h \
-  otoolstuff.h \
+			otoolstuff.h \
 			rbridge.h

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -23,6 +23,7 @@
 #include <boost/filesystem.hpp>
 #include <codecvt>
 #include "otoolstuff.h"
+#include "rbridge.h"
 
 #ifdef _WIN32
 void openConsoleOutput(unsigned long slaveNo, unsigned parentPID)
@@ -113,8 +114,22 @@ int main(int argc, char *argv[])
 
 		exit(0);
 	}
+#ifdef _WIN32
+	else if(argc == 3)
+	{
+		std::string arg1(argv[1]), arg2(argv[2]);
+		const std::string junctionCollectArg("--collectJunctions"), junctionRecreateArg("--recreateJunctions");
+		
+		if(arg1 == junctionCollectArg || arg1 == junctionRecreateArg)
+		{
+			std::cout << "Engine started for junctions!" << std::endl;
+			rbridge_junctionHelper(arg1 == junctionCollectArg, arg2);
+			exit(0);
+		}
+	}
+#endif
 
-	std::cout << "Engine started in testing mode because it didn't receive 4 (or 1) arguments." << std::endl;
+	std::cout << "Engine started in testing mode because it didn't receive any count of arguments otherwise, (1, 3 or 4), it got " << argc << " instead." << std::endl;
 
 	const char * testFileName = "testFile.txt";
 	std::ofstream writeTestFile(testFileName);

--- a/Engine/otoolstuff.cpp
+++ b/Engine/otoolstuff.cpp
@@ -36,9 +36,7 @@ std::string _system(std::string cmd)
 	return out.str();
 }
 
-// see https://gcc.gnu.org/onlinedocs/gcc-4.8.5/cpp/Stringification.html
-#define xstr(s) str(s)
-#define str(s)  #s
+#define MAC_RHOME "@executable_path/../Frameworks/R.framework/Versions/"  CURRENT_R_VERSION "/Resources"
 
 void _moduleLibraryFixer(const std::string & moduleLibraryPath, bool printStuff)
 {
@@ -56,84 +54,101 @@ void _moduleLibraryFixer(const std::string & moduleLibraryPath, bool printStuff)
 		remove_all(rcppPath);
 
 #ifdef __APPLE__
-	std::cout << "This is a mac so we are trying to fix the otool mess..." << std::endl;
+	std::cout << "This is a mac so we will fix the otool mess of folder '" << modLibpath << "'...\n";
 
 	typedef filesystem::recursive_directory_iterator	recIt;
-
-	for(recIt dir(modLibpath); dir != recIt(); dir++)
-	{
-		filesystem::path path = dir->path();
 	
-
-		//We only want files that have dylib or so as extension and don't have dSYM anywhere in the path (because those are some kind of debugsymbols)
-		if(	! (	filesystem::is_regular_file(path)							&&
-				(path.extension() == ".dylib" || path.extension() == ".so")	&&
-				path.string().find("dSYM") == std::string::npos				))
-			continue;
-
-		if(printStuff)
-			std::cout << "	Now checking and fixing otool paths for file '" << path.string() << "'." << std::endl;
-
-		std::string libDir		= stringUtils::replaceBy(path.string(), " ", "\\ "),
-					otoolCmd	= "otool -L " + libDir,
-					otoolOut	= _system(otoolCmd);
-		auto		otoolLines	= stringUtils::splitString(otoolOut, '\n');
-
-		if(printStuff)
+	filesystem::path path;
+	
+	try
+	{
+		for(recIt dir(modLibpath, filesystem::symlink_option::recurse); dir != recIt(); dir++) //Follow symlinks so that we may fix pkgs installed by renv (where the actual files are in cacche and only symlinked in library)
 		{
-			std::cout << "jaspRCPP_postProcessLocalPackageInstall used otool -L on " << libDir << " and found this output:" << std::endl;
-
-			for(const auto & line : otoolLines)
-				std::cout << line << std::endl;
-		}
+			path = dir->path();
+	
+			//We only want files that have dylib or so as extension and don't have dSYM anywhere in the path (because those are some kind of debugsymbols)
+			if(	! (	filesystem::is_regular_file(path)							&&
+					(path.extension() == ".dylib" || path.extension() == ".so")	&&
+					path.string().find("dSYM") == std::string::npos				))
+				continue;
+	
+			if(printStuff)
+				std::cout << "- Now checking and fixing otool paths for file '" << path.string() << "'.\n";
+	
+			std::string libDir		= stringUtils::replaceBy(path.string(), " ", "\\ "),
+						otoolCmd	= "otool -L " + libDir,
+						otoolOut	= _system(otoolCmd);
+			auto		otoolLines	= stringUtils::splitString(otoolOut, '\n');
+	
+			/*if(printStuff)
+			{
+				std::cout << "- jaspRCPP_postProcessLocalPackageInstall used otool -L on " << libDir;
+				std::cout << " and found this output:\n";
 		
-		//ok otoolLines[1] represents the "id" of the lib but we do not need to change it because it probably points directly back to itself. The other lines however we should change
-
-		for(size_t i=2; i<otoolLines.size(); i++)
-		{
-			std::string line = otoolLines[i];
-			line = line.substr(0, line.find_first_of('('));
-			stringUtils::trim(line);
-			line = stringUtils::replaceBy(line, " ", "\\ ");
-
-			//For all the libs of R we have the following startsWith we can check:
-			const std::string libStart = "/Library/Frameworks/R.framework/Versions/";
-
-			//For the JAGS stuff we need to replace like so:
-			const std::map<std::string, std::string> replaceThese =
+				for(const auto & line : otoolLines)
+					std::cout << line << std::endl;
+			
+			}*/
+			
+			//ok otoolLines[1] represents the "id" of the lib but we do not need to change it because it probably points directly back to itself. The other lines however we should change
+	
+			for(size_t i=2; i<otoolLines.size(); i++)
 			{
-				{	"/usr/local/lib/libjags.4.dylib",	"@executable_path/JAGS/libjags.4.dylib"														},
-				{	"/usr/lib/libc++abi.dylib",			"@executable_path/../Frameworks/R.framework/Versions/3.6/Resources/lib/libc++abi.1.dylib"	},
-				{	"/usr/lib/libc++.1.dylib",			"@executable_path/../Frameworks/R.framework/Versions/3.6/Resources/lib/libc++.1.dylib"		}
-			};
-			//This ought to be sort of mirrored in jasp-required-files/MacOS/Frameworks/create-framework.py
-
-			auto install_name_tool_cmd = [&](const std::string & replaceThisLine, const std::string & withThisLine)
-			{
-				const std::string cmd = "install_name_tool -change " + replaceThisLine + " " + withThisLine + " " + libDir;
-
-				if(printStuff)
-					std::cout << cmd << std::endl;
-
-				_system(cmd);
-			};
-
-			if(replaceThese.count(line) > 0)
-			{
-				install_name_tool_cmd(line, replaceThese.at(line));
-			}
-			if(stringUtils::startsWith(line, libStart))
-			{
-				install_name_tool_cmd(line, stringUtils::replaceBy("@executable_path/../Frameworks/R.framework/Versions/" + line.substr(libStart.size()), " ", "\\ "));
-			}
-			else if(stringUtils::startsWith(line, "/opt/") || stringUtils::startsWith(line, "/usr/local/"))
-			{
-				std::string baseName	= line.substr(line.find_last_of('/') == std::string::npos ? 0 : line.find_last_of('/') + 1),
-							newLine		= stringUtils::replaceBy("@executable_path/../Frameworks/R.framework/Versions/"  xstr(CURRENT_R_VERSION) "/Resources/lib/" + baseName, " ", "\\ ");
-
-				install_name_tool_cmd(line, newLine);
+				std::string line = otoolLines[i];
+				line = line.substr(0, line.find_first_of('('));
+				stringUtils::trim(line);
+				line = stringUtils::replaceBy(line, " ", "\\ ");
+	
+				//For all the libs of R we have the following startsWith we can check:
+				const std::string libStart = "/Library/Frameworks/R.framework/Versions/";
+	
+				//For the JAGS stuff we need to replace like so:
+				const std::map<std::string, std::string> replaceThese =
+				{
+					{	"/usr/local/lib/libjags.4.dylib",	"@executable_path/JAGS/libjags.4.dylib"														},
+				/*	R 4 doesnt have the following anymore:
+					{	"/usr/lib/libc++abi.dylib",			MAC_RHOME "/lib/libc++abi.1.dylib"	}, 
+					{	"/usr/lib/libc++.1.dylib",			MAC_RHOME "/lib/libc++.1.dylib"		} */
+				};
+				//This ought to be sort of mirrored in jasp-required-files/MacOS/Frameworks/create-framework.py
+	
+				auto install_name_tool_cmd = [&](const std::string & replaceThisLine, const std::string & withThisLine)
+				{
+					const std::string cmd = "install_name_tool -change " + replaceThisLine + " " + withThisLine + " " + libDir;
+	
+					if(printStuff)
+						std::cout << cmd << std::endl;
+	
+					_system(cmd);
+				};
+				
+				if(printStuff && stringUtils::startsWith(line, MAC_RHOME)) //This binary was already fixed
+				{
+					std::cout << "- Already fixed!\n";;
+					break;
+				}
+	
+				if(replaceThese.count(line) > 0)
+				{
+					install_name_tool_cmd(line, replaceThese.at(line));
+				}
+				if(stringUtils::startsWith(line, libStart))
+				{
+					install_name_tool_cmd(line, stringUtils::replaceBy("@executable_path/../Frameworks/R.framework/Versions/" + line.substr(libStart.size()), " ", "\\ "));
+				}
+				else if(stringUtils::startsWith(line, "/opt/") || stringUtils::startsWith(line, "/usr/local/"))
+				{
+					std::string baseName	= line.substr(line.find_last_of('/') == std::string::npos ? 0 : line.find_last_of('/') + 1),
+								newLine		= stringUtils::replaceBy(MAC_RHOME "/lib/" + baseName, " ", "\\ ");
+	
+					install_name_tool_cmd(line, newLine);
+				}
 			}
 		}
+	}
+	catch(boost::filesystem::filesystem_error & error)
+	{
+		std::cout << "Filesystem iterating had error: '" << error.what() << "' last path was: '" << path.string() << "'" << std::endl;
 	}
 
 #else

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -52,13 +52,16 @@ char** rbridge_getLabels(const std::vector<std::string> &levels, size_t &nbLevel
 
 size_t _logWriteFunction(const void * buf, size_t len)
 {
-	try {
-		if(len > 0)
-			Log::log(false).write(static_cast<const char *>(buf), len);
-	} catch (...) {
-		Log::log() << "there was a problem writing to buffer from R"<< std::flush;
+	try 
+	{
+		if(len > 0 && buf)
+			Log::log(false).write(static_cast<const char *>(buf), len) << std::flush;
+	} 
+	catch (...) 
+	{
+		Log::log() << "there was a problem writing to buffer from R" << std::endl;
 	}
-
+	
 	return len;
 }
 
@@ -112,6 +115,11 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 	);
 	JASPTIMER_STOP(jaspRCPP_init);
 
+}
+
+void rbridge_junctionHelper(bool collectNotRestore, const std::string & folder)
+{
+	jaspRCPP_junctionHelper(collectNotRestore, folder.c_str());	
 }
 
 void rbridge_setDataSetSource(			boost::function<DataSet* ()> source)												{	rbridge_dataSetSource			= source; }
@@ -793,14 +801,6 @@ char** rbridge_getLabels(const std::vector<std::string> &levels, size_t &nbLevel
 	}
 
 	return results;
-}
-
-
-std::string rbridge_check()
-{
-	Json::Value v;
-	Json::Reader().parse(jaspRCPP_check(), v);
-	return v.toStyledString(); //Adds some nice newlines etc
 }
 
 std::string	rbridge_encodeColumnNamesInScript(const std::string & filterCode)

--- a/Engine/rbridge.h
+++ b/Engine/rbridge.h
@@ -75,7 +75,7 @@ extern "C" {
 	typedef boost::function<std::string (const std::string &, int progress)> RCallback;
 
 	void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * encoder, const char * resultsFont);
-
+	void rbridge_junctionHelper(bool collectNotRestore, const std::string & folder);
 
 	void rbridge_setFileNameSource(			boost::function<void(const std::string &, std::string &, std::string &)> source);
 	void rbridge_setSpecificFileNameSource(	boost::function<void(const std::string &, std::string &, std::string &)> source);
@@ -92,8 +92,6 @@ extern "C" {
 													boost::function<bool(const std::string &,		std::vector<int>&,			const std::map<int, std::string>&)	> nominalSource,
 													boost::function<bool(const std::string &, const std::vector<std::string>&)										> nominalTextSource);
 	void rbridge_setGetDataSetRowCountSource(		boost::function<int()> source);
-
-	std::string rbridge_check();
 
 	void	rbridge_setupRCodeEnvReadData(const std::string & dataname, const std::string & readFunction);
 	void	rbridge_setupRCodeEnv(int rowCount, const std::string & dataname = "data");

--- a/JASP.pri
+++ b/JASP.pri
@@ -3,14 +3,14 @@
 #Jasp-R-Interface
 JASP_R_INTERFACE_TARGET = R-Interface
 
-JASP_R_INTERFACE_MAJOR_VERSION =  10  # Interface changes or whenever you feel majorlike
-JASP_R_INTERFACE_MINOR_VERSION =  17  # Code changes
+JASP_R_INTERFACE_MAJOR_VERSION =  11  # Interface changes or whenever you feel majorlike
+JASP_R_INTERFACE_MINOR_VERSION =  0   # Code changes
 
 JASP_R_INTERFACE_NAME = $$JASP_R_INTERFACE_TARGET$$JASP_R_INTERFACE_MAJOR_VERSION'.'$$JASP_R_INTERFACE_MINOR_VERSION
 
 #R settings
-CURRENT_R_VERSION = 3.6
-DEFINES += "CURRENT_R_VERSION=\"$$CURRENT_R_VERSION\""
+CURRENT_R_VERSION = "4.0"
+DEFINES += "CURRENT_R_VERSION=\\\"$$CURRENT_R_VERSION\\\""
 
 #JASP Version
 JASP_VERSION_MAJOR      = 0
@@ -117,14 +117,3 @@ macx {
 DEFINES += JASP_COLUMN_ENCODE_ALL
 
 linux: QMAKE_LFLAGS += -fuse-ld=gold
-
-#All language translation related defines are below
-GENERATE_LANGUAGE_FILES = false
-#AM_I_BUILDBOT is set as a "qmake internal var" in the command line
-message("AM_I_BUILDBOT: '$$[AM_I_BUILDBOT]'")
-COPY_BUILDBOTNESS = $$[AM_I_BUILDBOT] # We need to copy it to make sure the equals function below actually works...
-!equals(COPY_BUILDBOTNESS, "") {
-	!equals(COPY_BUILDBOTNESS, "\"\"") { #this should be done less stupidly but I do not want to waste my time on that now
-		GENERATE_LANGUAGE_FILES = true
-	}
-}

--- a/Modules/InstallModule.pri
+++ b/Modules/InstallModule.pri
@@ -1,200 +1,49 @@
-# This is part of https://github.com/jasp-stats/INTERNAL-jasp/issues/996 and works, but requires me to install V8 because of stupid dependency resolution based on CRAN
-# So ive turned it off for now, but if you'd like to use it you can!
-
-UNSET_INSTALL_LATER = false
-isEmpty(R_MODULES_INSTALL_DEPENDENCIES) { 
-	R_MODULES_INSTALL_DEPENDENCIES = false
-	UNSET_INSTALL_LATER=true
-}
-
-
 isEmpty(MODULE_NAME) {
-    message(You must specify MODULE_NAME to use InstallModule.pri!)
+	message(You must specify MODULE_NAME to use InstallModule.pri!)
 } else {
-    isEmpty(MODULE_DIR) MODULE_DIR=$$PWD
-
-    JASP_LIBRARY_DIR    = $${JASP_BUILDROOT_DIR}/Modules/$${MODULE_NAME}
-	JASP_LIBARY_DIR_FIX = $$JASP_LIBRARY_DIR
-
-	win32: JASP_LIBARY_DIR_FIX ~= s,/,\\,g
-
-    LOAD_WORKAROUND = true
+	isEmpty(MODULE_DIR) MODULE_DIR=$$PWD
+	
+	JASP_LIBRARY_DIR    = $${JASP_BUILDROOT_DIR}/Modules/$${MODULE_NAME}
+	
+	#LOAD_WORKAROUND = true
 	include(../R_INSTALL_CMDS.pri)
 	#First we remove the installed module to make sure it gets properly update. We leave the library dir to avoid having to install the dependencies all the time.
 	#This will just have to get cleaned up by "clean"
-
-    unix:	Install$${MODULE_NAME}.commands        = rm -rf   $$JASP_LIBRARY_DIR/$${MODULE_NAME} && ( [ -d $$JASP_LIBRARY_DIR ] ||  mkdir $$JASP_LIBRARY_DIR ) ;	$$escape_expand(\\n\\t)
-	win32:	Install$${MODULE_NAME}.commands        = IF EXIST $$JASP_LIBARY_DIR_FIX\\$${MODULE_NAME}	( rd /s /q $$JASP_LIBARY_DIR_FIX\\$${MODULE_NAME} );		$$escape_expand(\\n\\t)
-	win32:  Install$${MODULE_NAME}.commands       += IF NOT EXIST \"$$JASP_LIBARY_DIR_FIX\"				( mkdir \"$$JASP_LIBARY_DIR_FIX\") ;						$$escape_expand(\\n\\t)
-
-    #Then, if we so desire, we install all dependencies (that are missing anyhow)
-	$$R_MODULES_INSTALL_DEPENDENCIES:		Install$${MODULE_NAME}.commands		+= $${INSTALL_R_PKG_DEPS_CMD_PREFIX}$${MODULE_DIR}/$${MODULE_NAME}$${INSTALL_R_PKG_DEPS_CMD_POSTFIX} $$escape_expand(\\n\\t) 
 	
-    #Install the actual module package
-	Install$${MODULE_NAME}.commands     +=  $${INSTALL_R_PKG_CMD_PREFIX}$${MODULE_DIR}/$${MODULE_NAME}$${INSTALL_R_PKG_CMD_POSTFIX}; $$escape_expand(\\n\\t)
-
-    #And lastly we do some postprocessing (on mac this includes fixing any and all necessary paths in dylib's and so's)
-	win32 {	
-		JASP_BUILDROOT_DIR_FIX				  = $$JASP_BUILDROOT_DIR
-		JASP_BUILDROOT_DIR_FIX				 ~= s,/,\\,g
-		#PostInstallFix$${MODULE_NAME}.commands		 +=  PUSHD \"$${R_BIN}\" ; $$escape_expand(\\n)
-		PostInstallFix$${MODULE_NAME}.commands		 +=  PATH=\"$${R_BIN};%PATH%\" 
-		PostInstallFix$${MODULE_NAME}.commands      +=  $${JASP_BUILDROOT_DIR_FIX}\\JASPEngine.exe \"$$JASP_LIBRARY_DIR\" ;	$$escape_expand(\\n\\t)
-		#PostInstallFix$${MODULE_NAME}.commands      +=   && echo \"I managed to actually run jaspengine probably?\";			$$escape_expand(\\n\\t)
-		#PostInstallFix$${MODULE_NAME}.commands		 +=  POPD ; $$escape_expand(\\n)
-	}
-	unix:  PostInstallFix$${MODULE_NAME}.commands       +=  LD_LIBRARY_PATH=$${_R_HOME}/lib $${JASP_BUILDROOT_DIR}/JASPEngine $$JASP_LIBRARY_DIR ;				$$escape_expand(\\n\\t)
-
-	PostInstallFix$${MODULE_NAME}.depends = Install$${MODULE_NAME}
+#	unix:	Install$${MODULE_NAME}.commands        = rm -rf   $$JASP_LIBRARY_DIR/$${MODULE_NAME} && ( [ -d $$JASP_LIBRARY_DIR ] ||  mkdir $$JASP_LIBRARY_DIR ) ;	$$escape_expand(\\n\\t)
+#	win32:	Install$${MODULE_NAME}.commands        = IF EXIST $$JASP_LIBRARY_DIR\\$${MODULE_NAME}	( rd /s /q $$JASP_LIBRARY_DIR\\$${MODULE_NAME} );				$$escape_expand(\\n\\t)
+#	win32:  Install$${MODULE_NAME}.commands       += IF NOT EXIST \"$$JASP_LIBRARY_DIR\"				( mkdir \"$$JASP_LIBRARY_DIR\") ;							$$escape_expand(\\n\\t)
 	
-	############# All Translations related commands ###############
+	#Install the actual module package
+	#Install$${MODULE_NAME}.commands     +=  $${INSTALL_R_PKG_CMD_PREFIX}$${MODULE_DIR}/$${MODULE_NAME}$${INSTALL_R_PKG_CMD_POSTFIX}; $$escape_expand(\\n\\t)
+	SETTING_UP_RENV= "Sys.setenv(RENV_PATHS_ROOT=\'$$MODULES_RENV_ROOT\', RENV_PATHS_CACHE=\'$$MODULES_RENV_CACHE\');"
+		
+	Install$${MODULE_NAME}.commands     +=  $$runRCommandForInstall("$$SETTING_UP_RENV jaspBase::installJaspModule(modulePkg=\'$${MODULE_DIR}/$${MODULE_NAME}\', libPathsToUse=NULL, moduleLibrary=\'$${JASP_LIBRARY_DIR}\', repos=\'https://cloud.r-project.org/\', onlyModPkg=FALSE)" )
 	
-	$$GENERATE_LANGUAGE_FILES {
+	#make sure each module is only installed after the previous one, to avoid renv clobbering itself (or just crashing)
+	!isEmpty(PREVIOUS_MODULE): Install$${MODULE_NAME}.depends += Install$${PREVIOUS_MODULE}
 	
-	QM_TRANSLATION_FOLDER = /inst/qml/translations
-	QM_FILE_LOCATION = $$PWD/$${MODULE_NAME}$${QM_TRANSLATION_FOLDER}
-	
-	win32{ ################## Windows ##################
+	QMAKE_EXTRA_TARGETS += Install$${MODULE_NAME}
+	POST_TARGETDEPS     += Install$${MODULE_NAME}
 
-		WIN_MODULE_LOCATION = $$PWD/$${MODULE_NAME}
-		WIN_MODULE_LOCATION ~= s,/,\\,g
-		WIN_QM_FILE_LOCATION = $${QM_FILE_LOCATION}
-		WIN_QM_FILE_LOCATION ~= s,/,\\,g
-		WINPWD=$$PWD
-		WINPWD ~= s,/,\\,g
-		FILE_EXTENSIONS=cpp,qml
-
-		#Create inst/qml/translations folder if not exists
-		!exists($${WIN_QM_FILE_LOCATION}){
-		GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo '\"$${WIN_QM_FILE_LOCATION}\" does not exits. Creating it.') &&
-		GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(md \"$${WIN_QM_FILE_LOCATION}\") &&
-		}
-
-		#Create po folder if not exists
-		!exists($${WIN_MODULE_LOCATION}\po){
-		GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo '\"$${WIN_MODULE_LOCATION}\po\" does not exits. Creating it.') &&
-		GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(md \"$${WIN_MODULE_LOCATION}\po\") &&
-		}
-
-		#Update and Cleanup QML-$${MODULE_NAME}.pot file
-		GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${WINQTBIN}lupdate.exe\" -locations none -extensions $${FILE_EXTENSIONS} -recursive \"$${WIN_MODULE_LOCATION}\" -ts \"$${WIN_MODULE_LOCATION}\po\QML-$${MODULE_NAME}.pot\") &&
-		GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location \"$${WIN_MODULE_LOCATION}\po\QML-$${MODULE_NAME}.pot\" -o \"$${WIN_MODULE_LOCATION}\po\QML-$${MODULE_NAME}.pot\") &&
-
-		for(LANGUAGE_CODE, SUPPORTED_LANGUAGES) {
-			#Busy Message
-			GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo "Generating language File: $${LANGUAGE_CODE}") &&
-
-			#Initialize R-xx.po from previous language files
-			#!exists($${WIN_MODULE_LOCATION}\po\R-$${LANGUAGE_CODE}.po){
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo "INITIALIZE R-TRANSLATION-FILES FOR $${MODULE_NAME} WITH MSGMERGE: $${LANGUAGE_CODE}") &&
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${WINPWD}\..\Tools\translate.cmd\" \"$$_R_HOME\bin\" \"$${GETTEXT_LOCATION}\" \"$${WINPWD}\..\Tools\" \"$${WIN_MODULE_LOCATION}\" ) &&
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${GETTEXT_LOCATION}\msgmerge.exe\" \"$${WINPWD}\..\Engine\jaspBase\po\R-$${LANGUAGE_CODE}.po\" \"$${WIN_MODULE_LOCATION}\po\R-$${MODULE_NAME}.pot\" > \"$${WIN_MODULE_LOCATION}\po\R-$${LANGUAGE_CODE}.po\" ) &&
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location \"$${WIN_MODULE_LOCATION}\po\R-$${LANGUAGE_CODE}.po\" -o \"$${WIN_MODULE_LOCATION}\po\R-$${LANGUAGE_CODE}.po\") &&
-			#}
-
-			#Initialize QML-xx.po from previous language files
-			#!exists($${WIN_MODULE_LOCATION}\po\R-$${LANGUAGE_CODE}.po){
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo "INITIALIZE QML-TRANSLATION-FILES FOR $${MODULE_NAME} WITH MSGMERGE: $${LANGUAGE_CODE}") &&
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${GETTEXT_LOCATION}\msgmerge.exe\" \"$${WINPWD}\..\Desktop\po\jasp_$${LANGUAGE_CODE}.po\" \"$${WIN_MODULE_LOCATION}\po\QML-$${MODULE_NAME}.pot\" > \"$${WIN_MODULE_LOCATION}\po\QML-$${LANGUAGE_CODE}.po\" ) &&
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location \"$${WIN_MODULE_LOCATION}\po\QML-$${LANGUAGE_CODE}.po\" -o \"$${WIN_MODULE_LOCATION}\po\QML-$${LANGUAGE_CODE}.po\") &&
-			#}
-
-			GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${WINQTBIN}lupdate.exe\" -locations none -extensions $${FILE_EXTENSIONS} -recursive \"$${WIN_MODULE_LOCATION}\" -ts  \"$${WIN_MODULE_LOCATION}\po\QML-$${LANGUAGE_CODE}.po\") &&
-			#Cleanup QML-xx.po file
-			GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${GETTEXT_LOCATION}\msgattrib.exe\" --no-obsolete --no-location \"$${WIN_MODULE_LOCATION}\po\QML-$${LANGUAGE_CODE}.po\" -o \"$${WIN_MODULE_LOCATION}\po\QML-$${LANGUAGE_CODE}.po\") &&
-			#Create $${MODULE_NAME}-$${LANGUAGE_CODE}.qm
-			GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${WINQTBIN}lrelease.exe\" \"$${WIN_MODULE_LOCATION}\po\QML-$${LANGUAGE_CODE}.po\" -qm \"$${WIN_QM_FILE_LOCATION}\\$${MODULE_NAME}-$${LANGUAGE_CODE}.qm\") &&
-
-		}#End for
-
-		#Create R-$${MODULE_NAME}.mo translation file for all different languages. (Need to add GETTEXT location to PATH environment.)
-		GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(\"$${WINPWD}\..\Tools\translate.cmd\" \"$$_R_HOME\bin\" \"$${GETTEXT_LOCATION}\" \"$${WINPWD}\..\Tools\" \"$${WIN_MODULE_LOCATION}\" ) &&
-
-		#Ready
-		GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo 'Ready with language files.')
-	}#Win32
-
-	unix{ ################## Unix ##################
-
-		#Create inst/qml/translations folder if not exists
-		!exists($${QM_FILE_LOCATION}){
-			GenerateLanguageFiles$${MODULE_NAME}.commands += echo '\"$${MODULE_NAME}$${QM_TRANSLATION_FOLDER}\" does not exits. Creating it.';
-			GenerateLanguageFiles$${MODULE_NAME}.commands += mkdir -p $${QM_FILE_LOCATION} ;
-		}
-
-		#Create po folder if not exists
-		!exists($$PWD/$${MODULE_NAME}/po){
-			GenerateLanguageFiles$${MODULE_NAME}.commands += echo '\"$$PWD/$${MODULE_NAME}/po\" does not exits. Creating it.';
-			GenerateLanguageFiles$${MODULE_NAME}.commands += mkdir -p \"$$PWD/$${MODULE_NAME}/po\" ;
-		}
-
-		#Update and Cleanup QML-$${MODULE_NAME}.pot file
-		GenerateLanguageFiles$${MODULE_NAME}.commands += export ;  export ; $$escape_expand(\\n\\t)
-		GenerateLanguageFiles$${MODULE_NAME}.commands += PATH=$$EXTENDED_PATH lupdate -locations none -extensions cpp,qml -recursive $$PWD/$${MODULE_NAME} -ts $$PWD/$${MODULE_NAME}/po/QML-$${MODULE_NAME}.pot ; $$escape_expand(\\n\\t)
-		GenerateLanguageFiles$${MODULE_NAME}.commands += PATH=$$EXTENDED_PATH msgattrib --no-obsolete --no-location $$PWD/$${MODULE_NAME}/po/QML-$${MODULE_NAME}.pot -o $$PWD/$${MODULE_NAME}/po/QML-$${MODULE_NAME}.pot ; $$escape_expand(\\n\\t)
-
-		for(LANGUAGE_CODE, SUPPORTED_LANGUAGES) {
-			#Busy Message
-			GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo "Generating language File: $${LANGUAGE_CODE}");
-
-			#Initialize R-xx.po from previous language files
-			#!exists($$PWD/$${MODULE_NAME}/po/R-$${LANGUAGE_CODE}.po){
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo "INITIALIZE R-TRANSLATION-FILES FOR $${MODULE_NAME} WITH MSGMERGE: $${LANGUAGE_CODE}");
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands +=  Rscript $$PWD/../Tools/translate.R $$PWD/$${MODULE_NAME} ;
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands +=  msgmerge $$PWD/../Engine/jaspBase/po/R-$${LANGUAGE_CODE}.po.0.14.1 $$PWD/$${MODULE_NAME}/po/R-$${MODULE_NAME}.pot > $$PWD/$${MODULE_NAME}/po/R-$${LANGUAGE_CODE}.po ;
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += msgattrib --no-obsolete --no-location $$PWD/$${MODULE_NAME}/po/R-$${LANGUAGE_CODE}.po -o $$PWD/$${MODULE_NAME}/po/R-$${LANGUAGE_CODE}.po ;
-			#}
-
-			#Initialize QML-xx.po from previous language files
-			#!exists($$PWD/$${MODULE_NAME}/po/QML-$${LANGUAGE_CODE}.po){
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += $$quote(echo "INITIALIZE QML-TRANSLATION-FILES FOR $${MODULE_NAME} WITH MSGMERGE: $${LANGUAGE_CODE}");
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands +=  msgmerge $$PWD/../Desktop/po/jasp_$${LANGUAGE_CODE}.po $$PWD/$${MODULE_NAME}/po/QML-$${MODULE_NAME}.pot > $$PWD/$${MODULE_NAME}/po/QML-$${LANGUAGE_CODE}.po ;
-			#	GenerateLanguageFiles$${MODULE_NAME}.commands += msgattrib --no-obsolete --no-location $$PWD/$${MODULE_NAME}/po/QML-$${LANGUAGE_CODE}.po -o $$PWD/$${MODULE_NAME}/po/QML-$${LANGUAGE_CODE}.po ;
-			#}
-
-			#Update and Cleanup QML-xx.po file
-			GenerateLanguageFiles$${MODULE_NAME}.commands += PATH=$$EXTENDED_PATH lupdate -locations none -extensions cpp,qml -recursive $$PWD/$${MODULE_NAME} -ts $$PWD/$${MODULE_NAME}/po/QML-$${LANGUAGE_CODE}.po ;				$$escape_expand(\\n\\t)
-			GenerateLanguageFiles$${MODULE_NAME}.commands += PATH=$$EXTENDED_PATH msgattrib --no-obsolete --no-location $$PWD/$${MODULE_NAME}/po/QML-$${LANGUAGE_CODE}.po -o $$PWD/$${MODULE_NAME}/po/QML-$${LANGUAGE_CODE}.po ;		$$escape_expand(\\n\\t)
-
-			#Create $${MODULE_NAME}.qm
-			GenerateLanguageFiles$${MODULE_NAME}.commands += PATH=$$EXTENDED_PATH lrelease $$PWD/$${MODULE_NAME}/po/QML-$${LANGUAGE_CODE}.po -qm $${QM_FILE_LOCATION}/$${MODULE_NAME}-$${LANGUAGE_CODE}.qm ;							$$escape_expand(\\n\\t)
-			}
-
-		#Create $${MODULE_NAME}.mo translation file. (Need to add GETTEXT location to PATH environment.)
-		GenerateLanguageFiles$${MODULE_NAME}.commands += JASP_R_HOME=$$_R_HOME \"$$R_EXE\" -e \"rootfolder <- \'$$PWD/$${MODULE_NAME}\';  source(\'$$PWD/../Tools/translate.R\');\"
-	}#Unix
-	}#########################################################
-
-		QMAKE_EXTRA_TARGETS += Install$${MODULE_NAME}
-		POST_TARGETDEPS     += Install$${MODULE_NAME}
-
-		QMAKE_EXTRA_TARGETS += PostInstallFix$${MODULE_NAME}
-		POST_TARGETDEPS     += PostInstallFix$${MODULE_NAME}
-
-		QMAKE_EXTRA_TARGETS += GenerateLanguageFiles$${MODULE_NAME}
-		POST_TARGETDEPS     += GenerateLanguageFiles$${MODULE_NAME}
+	QMAKE_EXTRA_TARGETS += GenerateLanguageFiles$${MODULE_NAME}
+	POST_TARGETDEPS     += GenerateLanguageFiles$${MODULE_NAME}
 
 
-    #See this: https://www.qtcentre.org/threads/9287-How-do-I-get-QMAKE_CLEAN-to-delete-a-directory
-	unix:  QMAKE_DEL_FILE = rm -rf
-    unix:	QMAKE_CLEAN			  += $$JASP_LIBRARY_DIR/$${MODULE_NAME}/* $$JASP_LIBRARY_DIR/*
-	
+	#See this: https://www.qtcentre.org/threads/9287-How-do-I-get-QMAKE_CLEAN-to-delete-a-directory
+	unix:   QMAKE_DEL_FILE = rm -rf
+	unix:	QMAKE_CLEAN	  += $$JASP_LIBRARY_DIR/* $$JASP_LIBRARY_DIR/.*
+
 	#we do not use QMAKE_DEL_FILE + QMAKE_CLEAN because otherwise /S and /Q get turned into \\S and \\Q :(
 	#see end of Modules.pro for the rest of it
-	win32:	libraryClean.commands += rd $$quote($$JASP_LIBARY_DIR_FIX) /S /Q || exit 0; $$escape_expand(\\n\\t)
+	win32:	libraryClean.commands += rd $$quote($$winPathFix($$JASP_LIBRARY_DIR/*)) /S /Q || exit 0; $$escape_expand(\\n\\t)
+	win32:	libraryClean.commands += rd $$quote($$winPathFix($$JASP_LIBRARY_DIR/.*)) /S /Q || exit 0; $$escape_expand(\\n\\t)
 	
 	#QMAKE_DISTCLEAN	+= $$JASP_LIBRARY_DIR/*/*/* $$JASP_LIBRARY_DIR/*/* $$JASP_LIBRARY_DIR/* $$JASP_LIBRARY_DIR
-
-	#Make sure we install the r pkgs in the right order.
-	for(DEP, MODULE_DEPS) {
-		Install$${MODULE_NAME}.depends	+= PostInstallFix$${DEP}
-	}
 }
 
-#R_MODULES_INSTALL_DEPENDENCIES = false
+# save current module as previous so we can let the next one depend on this one
+PREVIOUS_MODULE = $$MODULE_NAME
 
 #reset the special vars:
 MODULE_NAME =
-MODULE_DEPS = 
-
-$$UNSET_INSTALL_LATER: R_MODULES_INSTALL_DEPENDENCIES =

--- a/Modules/Modules.pro
+++ b/Modules/Modules.pro
@@ -9,14 +9,22 @@ include(../R_HOME.pri)
 TEMPLATE = aux
 CONFIG -= app_bundle
 
-MODULE_DIR  = $$PWD
+MODULES_RENV_ROOT   = $$SYS_RENV_ROOT
+isEmpty(MODULES_RENV_ROOT): MODULES_RENV_ROOT	= "$$OUT_PWD/../renv-root"  #I assume we will not need to ship this, but we do need the following folder:
+							MODULES_RENV_CACHE	= "$$OUT_PWD/../renv-cache" #While this one needs to be shipped and the symlinks will need to be relative, but we will find out quick enough if not
+mkpath($$MODULES_RENV_ROOT)
+mkpath($$MODULES_RENV_CACHE)
+
+message("Using renv-root: $$MODULES_RENV_ROOT")
+
+MODULE_DIR			= $$PWD
 
 ################################## Common ##################################
+PREVIOUS_MODULE = 
 MODULE_NAME = jaspDescriptives
 include(InstallModule.pri)
 
 MODULE_NAME = jaspAnova
-MODULE_DEPS = jaspDescriptives jaspTTests
 include(InstallModule.pri)
 
 MODULE_NAME = jaspFactor
@@ -26,13 +34,11 @@ MODULE_NAME = jaspFrequencies
 include(InstallModule.pri)
 
 MODULE_NAME = jaspRegression
-MODULE_DEPS = jaspDescriptives jaspAnova jaspTTests
 include(InstallModule.pri)
 
 MODULE_NAME = jaspTTests
 include(InstallModule.pri)
 
-#R_MODULES_INSTALL_DEPENDENCIES = true
 MODULE_NAME = jaspMixedModels
 include(InstallModule.pri)
 
@@ -49,12 +55,10 @@ include(InstallModule.pri)
 MODULE_NAME = jaspSem
 include(InstallModule.pri)
 
-#R_MODULES_INSTALL_DEPENDENCIES = true
 MODULE_NAME = jaspMachineLearning
 include(InstallModule.pri)
 
 MODULE_NAME = jaspSummaryStatistics
-MODULE_DEPS = jaspFrequencies jaspRegression jaspTTests jaspAnova jaspDescriptives
 include(InstallModule.pri)
 
 MODULE_NAME = jaspMetaAnalysis
@@ -82,10 +86,11 @@ include(InstallModule.pri)
 MODULE_NAME = jaspProphet
 include(InstallModule.pri)
 
-R_MODULES_INSTALL_DEPENDENCIES = true
 MODULE_NAME = jaspProcessControl
-MODULE_DEPS = jaspDescriptives
 include(InstallModule.pri)
+
+macx:	QMAKE_CLEAN				+=  $$MODULES_RENV_CACHE/* #Dont do this on linux because we are building from source...
+win32:	libraryClean.commands	+= rd $$quote($$winPathFix($$MODULES_RENV_CACHE/*)) /S /Q || exit 0;	$$escape_expand(\\n\\t)
 
 #see https://stackoverflow.com/questions/29853832/adding-custom-commands-to-existing-targets-in-qmake
 win32 {

--- a/R-Interface/R-Interface.pro
+++ b/R-Interface/R-Interface.pro
@@ -85,10 +85,11 @@ windows{
 }
 
 ### making sure that writeImage.R and zzzWrappers.R are available to jaspEngine:
-SRC_WRITE_IMAGE = $${PWD}/jaspResults/R/writeImage.R
-SRC_WRAPPERS    = $${PWD}/jaspResults/R/zzzWrappers.R
-SRC_WORKAROUNDS = $${PWD}/R/workarounds.R
-DEST_DIR_AUX_R  = $$OUT_PWD/$$DESTDIR
+SRC_WRITE_IMAGE = $$winPathFix($${PWD}/jaspResults/R/writeImage.R)
+SRC_WRAPPERS    = $$winPathFix($${PWD}/jaspResults/R/zzzWrappers.R)
+SRC_WORKAROUNDS = $$winPathFix($${PWD}/R/workarounds.R)
+SRC_SYMLINKTOOL = $$winPathFix($${PWD}/R/symlinkTools.R)
+DEST_DIR_AUX_R  = $$winPathFix($$OUT_PWD/$$DESTDIR)
 
 auxillaryRFiles.path   = $$INSTALLPATH
 auxillaryRFiles.files  = $${PWD}/jaspResults/R/writeImage.R
@@ -97,14 +98,10 @@ auxillaryRFiles.files += $${PWD}/R/workarounds.R
 INSTALLS += auxillaryRFiles
 
 win32 {
-    SRC_WRITE_IMAGE ~= s,/,\\,g
-	SRC_WRAPPERS    ~= s,/,\\,g
-	SRC_WORKAROUNDS ~= s,/,\\,g
-	DEST_DIR_AUX_R  ~= s,/,\\,g
-
     copyRFiles.commands  += $$quote(cmd /c xcopy /I /Y $${SRC_WRITE_IMAGE} $${DEST_DIR_AUX_R}) $$escape_expand(\n\t)
 	copyRFiles.commands  += $$quote(cmd /c xcopy /I /Y $${SRC_WRAPPERS}    $${DEST_DIR_AUX_R}) $$escape_expand(\n\t)
-	copyRFiles.commands  += $$quote(cmd /c xcopy /I /Y $${SRC_WORKAROUNDS} $${DEST_DIR_AUX_R})
+	copyRFiles.commands  += $$quote(cmd /c xcopy /I /Y $${SRC_WORKAROUNDS} $${DEST_DIR_AUX_R}) $$escape_expand(\n\t)
+	copyRFiles.commands  += $$quote(cmd /c xcopy /I /Y $${SRC_SYMLINKTOOL} $${DEST_DIR_AUX_R}) $$escape_expand(\n\t)
 }
 
 unix {
@@ -112,8 +109,8 @@ unix {
     copyRFiles.commands += cp $$SRC_WRITE_IMAGE $$DEST_DIR_AUX_R ;
 	copyRFiles.commands += cp $$SRC_WRAPPERS    $$DEST_DIR_AUX_R ;
 	copyRFiles.commands += cp $$SRC_WORKAROUNDS $$DEST_DIR_AUX_R ;
+	copyRFiles.commands += cp $$SRC_SYMLINKTOOL $$DEST_DIR_AUX_R ;
 }
-
 
 ! equals(PWD, $${OUT_PWD}) {
     QMAKE_EXTRA_TARGETS += copyRFiles

--- a/R-Interface/R/symlinkTools.R
+++ b/R-Interface/R/symlinkTools.R
@@ -1,0 +1,294 @@
+
+# Goal of this script:
+# Go through all the module folders
+# Collect all the symlinks
+# Know renv-cache path
+# Subtract renv-cache path from the symlinks to go to relative paths
+# Unix:
+#   Recreate the symlinks directly on unix but relative this time
+# Win:
+#   Save them to a file that can be used to restore them on Windows
+#   Have a function here or in that file that restores them and add it as a custom action to Wix
+
+pastePath <- function(path) { return(paste0(  path, collapse=.Platform$file.sep)     ) }
+splitPath <- function(path) 
+{ 
+  path  <- gsub("\\", "/", path, fixed=TRUE)
+  paths <- strsplit(path, "/")[[1]]; 
+  return(paths[paths != ""]) # Remove "empty" dir between // like: "blablac//weird/path"
+}
+
+#This returns atwo functions that can be used to convert paths in two direcitons
+determineOverlap <- function(targetRoot, sourceRoot)
+{
+  targetSplit <- splitPath(targetRoot)
+  sourceSplit <- splitPath(sourceRoot)
+  len         <- min(length(targetSplit), length(sourceSplit))
+  overlap     <- 0
+
+  for(idx in seq_len(len))
+    if(sourceSplit[[idx]] == targetSplit[[idx]]) overlap <- idx
+    else                                         break
+
+  overlapVec <- targetSplit[seq(overlap)]
+  overlap    <- list(
+    vec = overlapVec, 
+    str = pastePath(overlapVec),
+    len = overlap
+  )
+
+  # This function returns the path from the target location to the source as seen from target (aka "(../)*" with either from the root to the source added or not depending on logical addRootToSource
+  targetToSource <- function(target, addRootToSource)
+  {
+    targetSplit  <- splitPath(target)
+    rootToSrc    <- pastePath(sourceSplit[seq(overlap$len + 1, length(sourceSplit))])
+    stepsDown    <- length(targetSplit) - (overlap$len + as.integer(addRootToSource))
+    tgtToSrc     <- pastePath(rep("..", stepsDown)  )
+
+    #for debug:
+    #tgtToSrc     <- paste0(tgtToSrc, .Platform$file.sep, ".")
+
+    if(addRootToSource)
+      return(paste0(tgtToSrc, rootToSrc)) #We do not need to add the separator because it is there in tgtToSrc
+    return(tgtToSrc)
+  }
+
+  #This one returns the path from the root (overlap) to where target is.
+  sourceToTarget <- function(target)
+  {
+    targetSplit  <- splitPath(target)
+    srcToTgt     <- pastePath(targetSplit[seq(overlap$len + 1, length(targetSplit))])
+
+    return(srcToTgt)
+  }
+
+  return(list(targetToSource=targetToSource, sourceToTarget=sourceToTarget))
+}
+
+#Use overlapfunctions as returned by determineOverlap to generate a function to turn target-path from absolute to relative
+getRelativityFunction <- function(modulesRoot, renvCache)
+{
+  #I wanted this code to be more general but then it is too complicated to debug. And has a bug. And renv-cache can be assumed to be right next to Modules anyway...
+  # So instead of doing:
+  #   modToRenvF <- determineOverlap(modulesRoot, renvCache)
+  #   modToRenvS <-  modToRenvF$targetToSource(renvCache, TRUE)
+  # We can assume:
+  modToRenvS <- pastePath(c("..","..","renv-cache"))
+  #print(paste0("modToRenvS: ", modToRenvS))
+  
+  return(
+    function(linkLocation, targetPath)
+    {
+      linkLocation <-              (path.expand(linkLocation)) #Do not normalize it because Windows then follows this path...
+      targetPath   <- normalizePath(path.expand(targetPath))
+      #linkToMod    <- determineOverlap(linkLocation, modulesRoot)$targetToSource
+      pathToRenv   <- determineOverlap(targetPath,   renvCache)  $sourceToTarget
+
+      #linkToModS   <- linkToMod(linkLocation, FALSE)
+      linkToRenvS  <- modToRenvS #pastePath(c(linkToModS, modToRenvS))
+      pathToRenvS  <- pathToRenv(targetPath)
+
+      newTarget    <- paste0(linkToRenvS, .Platform$file.sep, pathToRenvS)
+
+      #print(paste0("for link '", linkLocation, "' and target '",targetPath, "'"))
+      #print(paste0("- linkToModS '",linkToModS, " modToRenvS: '", modToRenvS, "' pathToRenvS: '", pathToRenvS, "'\n results in newTarget: '", newTarget, "'"))
+      
+      return(newTarget)
+    }
+  )
+}
+
+ # copy paste from https://stat.ethz.ch/R-manual/R-patched/library/base/html/Sys.readlink.html
+is.symlink  <- function(paths) isTRUE(nzchar(Sys.readlink(paths), keepNA=TRUE))
+
+# See https://stackoverflow.com/questions/2311105/test-in-powershell-code-if-a-folder-is-a-junction-point because there is no R equivalent...
+# these functions are also really quite slow... But ok, it is only necessary to run it during building.
+is.junction <- function(paths)
+{
+  #Also this function isn't very safe, make sure that you only ask it about existing paths or you get garbage
+  as.logical(
+    sapply(
+      paths, 
+      function(path) 
+        as.logical(as.integer(
+          system2(command="powershell", args=paste0('-command "if ((Get-Item -Path ', path,' -Force).LinkType -eq \\"Junction\\") { 1 } else { 0 }'), stdout=TRUE)
+        )) 
+    )
+  )
+}
+
+get.junction.pwrshll <- function(paths) 
+{
+  sapply(
+    paths, 
+    function(path) system2(command="powershell", args=paste0('-command "(Get-Item -Path ', path,' -Force).Target'), stdout=TRUE)
+)
+}
+ 
+
+
+# Returns a list of symlinks with target location relative to modulesRoot
+collectLinks <- function(modulesRoot, renvCache, isLink, getLink)
+{
+  #Honestly this whole recursive setup for determining the shared overlap of the renv-cache and Modules is totally overkill as they are always next to each other.
+  #But I wanted to allow for the possibility of moving the renv-cache somewhere else and the code works fine now, so... I'll leave it like this.
+  #The next time someone needs to work on this and this complexity is causing trouble we should know whether or not it is useful to have this flexibility or not. And remove it if not.
+  modulesRoot <- normalizePath(path.expand(modulesRoot))
+  renvCache   <- normalizePath(path.expand(renvCache))
+
+  print(paste0("modulesRoot: '", modulesRoot, "' and renvCache: '", renvCache, "'"))
+
+  #setwd(modulesRoot)
+
+  #Sometimes a dutch word just works so much better than english, so here `relativeer > relativize`
+  relativeer <- getRelativityFunction(modulesRoot, renvCache)
+  symlinks   <- data.frame(linkLocation=character(0), linkTarget=character(0), originalTarget=character(0))
+
+  collectSymlinks <- function(paths)
+    for(path in paths)
+    {
+      #path <- normalizePath(path) This follows the junction immediately...
+      #print(paste0("Checking if path is link: ", path))
+      if(isLink(path))
+      {
+        #print('is symlink')
+        symPath  <- getLink(path)
+        if(!startsWith(symPath, ".")) #if starts with dot it is already relative
+          symlinks[nrow(symlinks)+1, ] <<- list(linkLocation=path, linkTarget=relativeer(path, symPath), originalTarget=symPath)
+      }
+      else
+      {
+        everything  <- list.files(path, recursive=FALSE, include.dirs=TRUE, all.files=FALSE, full.names=TRUE)
+
+        if(length(everything) > 0)
+        {
+          allDirs     <- everything[file.info(everything)$isdir]
+          collectSymlinks(allDirs)
+        }
+      }
+    }
+
+  collectSymlinks(modulesRoot)
+
+  #print("Found symlinks:")
+  #print(symlinks)
+
+  return(symlinks)
+}
+
+
+generatePadFunction <- function()
+{
+  #little helper to make the log output easier to read
+    printSizes <- integer(3)
+    padToMax <- function(str, idx)
+    {
+      printSizes[[idx]] <<- max(nchar(str), printSizes[[idx]])
+      needThisMany      <-  printSizes[[idx]] - nchar(str)
+
+      return(paste0(str, strrep(" ", needThisMany)))
+    }
+}
+
+#call like: convertAbsoluteSymlinksToRelative("~/Broncode/build-JASP-Desktop_Qt_5_15_2_clang_64bit-Debug/Modules", "~/Broncode/build-JASP-Desktop_Qt_5_15_2_clang_64bit-Debug/renv-cache")
+convertAbsoluteSymlinksToRelative <- function(modulesRoot, renvCache)
+{
+  symlinks <- collectLinks(modulesRoot, renvCache, is.symlink, Sys.readlink)
+
+  if(nrow(symlinks) == 0)
+    print("No absolute symlinks found, maybe you ran this script already?")
+  else
+  {
+    #remove absolute links
+    unlink(symlinks$linkLocation)
+    
+    wd       <- getwd()
+    on.exit(setwd(wd))
+    #padToMax <- generatePadFunction()
+
+    #create the new ones
+    for(row in seq(nrow(symlinks)))
+    {
+      linkLoc <- symlinks[row, "linkLocation"]
+      setwd(dirname(linkLoc))
+      #print(paste0("For link '", padToMax(symlinks[row, "linkLocation"], 1), "' will convert '", padToMax(symlinks[row, "originalTarget"], 2), "' to '", padToMax(symlinks[row, "linkTarget"], 3), "'"))
+      file.symlink(from=symlinks[row, "linkTarget"], to=basename(linkLoc))
+      
+    }
+  }
+}
+
+junctionFilename <- function(modulesRoot)
+{
+  return(pastePath(c(modulesRoot, "..", "junctions.rds")))   
+}
+
+collectAndStoreJunctions <- function(buildfolder)
+{
+  modulesRoot <- pastePath(c(buildfolder, "Modules")) 
+  renvCache   <- pastePath(c(buildfolder, "renv-cache"))
+  symlinks    <- collectLinks(modulesRoot, renvCache, is.junction, normalizePath)
+  overlap     <- determineOverlap(modulesRoot, modulesRoot)
+  relLink     <- lapply(symlinks$linkLocation, overlap$sourceToTarget)
+  modules     <- lapply(relLink, function(p) splitPath(p)[[1]])
+  links       <- lapply(relLink, function(p) splitPath(p)[[2]])
+
+  if(nrow(symlinks) == 0)
+    print("No absolute symlinks found, maybe you ran this script already?")
+  else
+  {
+    juncDF <- data.frame(renv=as.character(symlinks$linkTarget), module=as.character(modules), link=as.character(links))
+    saveRDS(juncDF, junctionFilename(modulesRoot))
+  }
+}
+
+restoreJunctions <- function(modulesRoot)
+{
+  #Should contain a data.frame with columns: renv, module and link. As created in collectAndStoreJunctions  
+  junctions <- readRDS(junctionFilename(modulesRoot))
+
+  if(nrow(junctions) == 0)
+    print("No absolute symlinks found in file, maybe something went wrong building?")
+  else
+  {
+    wd       <- getwd()
+    on.exit(setwd(wd))
+    padToMax <- generatePadFunction()
+
+    #create the new ones
+    for(row in seq(nrow(junctions)))
+    {
+      renv    <- junctions[row, "renv"  ]
+      module  <- junctions[row, "module"]
+      link    <- junctions[row, "link"  ]
+      modDir  <- pastePath(c(modulesRoot, module))
+
+      if(!file.exists(modDir))
+        dir.create(modDir)
+
+      setwd(modDir)
+     # print(paste0("Creating junction '", padToMax(link, 1), "' to '", padToMax(renv, 2), "' in '", padToMax(pastePath(c(modulesRoot, module)), 3), "'"))
+
+      if(!dir.exists(link) && link != "BH") #It keeps turning up and this is the easiest way of getting rid of it
+      {
+        print(paste0("Creating junction '", padToMax(link, 1), "' with one to '", padToMax(renv, 2), "' in '", padToMax(pastePath(c(modulesRoot, module)), 3), "'"))
+        Sys.junction(from=renv, to=link)
+      }
+    }
+  }
+}
+
+restoreModulesIfNeeded <- function(jaspFolder)
+{
+  wd       <- getwd()
+  on.exit(setwd(wd))
+  setwd(jaspFolder)
+
+  modulesRoot <- pastePath(c(jaspFolder, "Modules"))
+  if(!file.exists(modulesRoot))
+    dir.create(modulesRoot)
+  
+  restoreJunctions(pastePath(c(jaspFolder, "Modules")))
+}
+
+

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -122,14 +122,10 @@ typedef size_t			(*logWriteDef)			(const void * buf, size_t len);
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont);
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont);
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_check();
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_saveImage(const char *data, const char *type, const int height, const int width, const int ppi, const char* imageBackground);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_editImage(const char *name, const char *optionsJson, const int ppi, const char* imageBackground, int analysisID);
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, const char* resultsFont, int analysisID);
-
-
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_check();
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_evalRCode(const char *rCode);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_evalRCodeCommander(const char *rCode);
@@ -143,6 +139,10 @@ RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_getLastErrorMsg();
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_resetErrorMsg();
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_setErrorMsg(const char* msg);
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_purgeGlobalEnvironment();
+
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_junctionHelper(bool collectNotRestore, const char * folder);
+
+
 
 } // extern "C"
 

--- a/R_HOME.pri
+++ b/R_HOME.pri
@@ -43,18 +43,32 @@ isEmpty(_RLibrary) {
 
 message(using R_HOME of $$_R_HOME)
 
+win32 {
+	defineReplace(winPathFix) {
+		THE_PATH  = $$1
+		THE_PATH ~= s,/,\\,g
+		return($$THE_PATH)
+	}	
+}
+
+unix {
+	defineReplace(winPathFix) {
+		return($$1)
+	}	
+}
+
+
 GETTEXT_LOCATION = $$(GETTEXT_PATH) #The GETTEXT_PATH can be used as environment for a specific gettext location
 
 unix {
 	isEmpty(GETTEXT_LOCATION): GETTEXT_LOCATION=/usr/local/bin
-	EXTENDED_PATH = $$(PATH):$$GETTEXT_LOCATION:$$_R_HOME:$$_R_HOME/bin:$$dirname(QMAKE_QMAKE)
+	EXTENDED_PATH = $$(PATH):$$GETTEXT_LOCATION:$$_R_HOME:$$dirname(QMAKE_QMAKE)
 }
 
 win32 {
 	isEmpty(GETTEXT_LOCATION): GETTEXT_LOCATION=$${_GIT_LOCATION}\usr\bin
-	WINQTBIN=$$QMAKE_QMAKE
+	WINQTBIN  = $$winPathFix($$QMAKE_QMAKE)
 	WINQTBIN ~= s,qmake.exe,,gs	
-	WINQTBIN ~= s,/,\\,g
 }
 
 

--- a/R_INSTALL_CMDS.pri
+++ b/R_INSTALL_CMDS.pri
@@ -7,8 +7,7 @@ macx {
 
 windows {
         isEmpty(_R_HOME):_R_HOME = $${JASP_BUILDROOT_DIR}/R
-        R_BIN  = $$_R_HOME/bin/$$ARCH
-		R_BIN ~= s,/,\\,g        
+        R_BIN  = $$winPathFix($$_R_HOME/bin/$$ARCH)
 		R_EXE  = $$R_BIN\\R
 }
 
@@ -20,36 +19,23 @@ exists(/app/lib/*) {  #for flatpak we can should use R's own library as it is co
 
 isEmpty(JASP_LIBRARY_DIR):   JASP_LIBRARY_DIR   = $$ROOT_LIBRARY_DIR
 
-
-defineReplace(generateExtraLibPaths) {
-	DEPS_VAR	= $$1
-	DEPS		= $$eval($$DEPS_VAR)
-	EXTRA_LIBS	= 
-
-	#The comma even when EXTRA_LIBS is empty is intentional, to make sure it fits right into LIBPATHS if there is at least 1 dep
-	for(DEP, DEPS) {
-		EXTRA_LIBS = $${EXTRA_LIBS}, \'$${JASP_BUILDROOT_DIR}/Modules/$${DEP}\'
-	}
-
-	return($$EXTRA_LIBS)
-}	
-
-#MODULE_DEPS can be used to define which other modules this one is dependent on.
-
-win32:  LIBPATHS = ".libPaths(c(\'$$ROOT_LIBRARY_DIR\', \'$${JASP_BUILDROOT_DIR}/R/library\'$$generateExtraLibPaths(MODULE_DEPS)))"
-unix:	LIBPATHS = ".libPaths(c(\'$$ROOT_LIBRARY_DIR\', \'$$_R_HOME/library\'$$generateExtraLibPaths(MODULE_DEPS)))"
+win32:  LIBPATHS = ".libPaths(c(\'$$ROOT_LIBRARY_DIR\', \'$${JASP_BUILDROOT_DIR}/R/library\'))"
+unix:	LIBPATHS = ".libPaths(c(\'$$ROOT_LIBRARY_DIR\', \'$$_R_HOME/library\'))"
 
 isEmpty(LOAD_WORKAROUND): LOAD_WORKAROUND = false
 WORKAROUND_LOADER =
 $$LOAD_WORKAROUND: WORKAROUND_LOADER = source(\'../workarounds.R\');
 
-INSTALL_R_PKG_CMD_PREFIX		= \"$$R_EXE\" -e \"$$LIBPATHS; $$WORKAROUND_LOADER pkgbuild::with_build_tools( \{ install.packages(\'
-INSTALL_R_PKG_DEPS_CMD_PREFIX	= \"$$R_EXE\" -e \"$$LIBPATHS; $$WORKAROUND_LOADER pkgbuild::with_build_tools( \{ Sys.setenv(\'R_REMOTES_NO_ERRORS_FROM_WARNINGS\'=TRUE); remotes::install_deps(pkg=\'
+INSTALL_R_PKG_PREFIX_PREFIX		= \"$$R_EXE\" -e \"$$LIBPATHS; $$WORKAROUND_LOADER Sys.setenv(\'R_REMOTES_NO_ERRORS_FROM_WARNINGS\'=TRUE); pkgbuild::with_build_tools( \{ 
 
 mac {
-	INSTALL_R_PKG_CMD_PREFIX		= JASP_R_HOME=\"$$_R_HOME\" $$INSTALL_R_PKG_CMD_PREFIX
-	INSTALL_R_PKG_DEPS_CMD_PREFIX	= JASP_R_HOME=\"$$_R_HOME\" $$INSTALL_R_PKG_DEPS_CMD_PREFIX
+	INSTALL_R_PKG_PREFIX_PREFIX		= JASP_R_HOME=\"$$_R_HOME\" $$INSTALL_R_PKG_PREFIX_PREFIX
 }
+
+#everything below here probably wont be necessary, as in fact the whole extraLibPaths thing at the top...
+
+INSTALL_R_PKG_CMD_PREFIX		= $$INSTALL_R_PKG_PREFIX_PREFIX install.packages(\'
+INSTALL_R_PKG_DEPS_CMD_PREFIX	= $$INSTALL_R_PKG_PREFIX_PREFIX remotes::install_deps(pkg=\'
 
 isEmpty(DEPS_LIBRARY_DIR)
 {
@@ -57,9 +43,16 @@ isEmpty(DEPS_LIBRARY_DIR)
 	} else {								DEPS_LIBRARY_DIR=$${ROOT_LIBRARY_DIR} }
 }
 
-INSTALL_R_PKG_CMD_POSTFIX      = \', lib=\'$${JASP_LIBRARY_DIR}\', INSTALL_opts=\'--no-multiarch --no-docs --no-test-load\', repos=NULL, type=\'source\') \}, required=FALSE )\"
-INSTALL_R_PKG_DEPS_CMD_POSTFIX = \', lib=\'$${DEPS_LIBRARY_DIR}\', INSTALL_opts=\'--no-multiarch --no-docs --no-test-load\', repos=\'https://cloud.r-project.org/\', upgrade=\'never\', THREADS=1) \}, required=FALSE )\"
+INSTALL_R_PKG_POSTFIX_POSTFIX  =  \}, required=FALSE )\"
+
+INSTALL_R_PKG_CMD_POSTFIX      = \', lib=\'$${JASP_LIBRARY_DIR}\', INSTALL_opts=\'--no-multiarch --no-docs --no-test-load\', repos=NULL, type=\'source\') $$INSTALL_R_PKG_POSTFIX_POSTFIX
+INSTALL_R_PKG_DEPS_CMD_POSTFIX = \', lib=\'$${DEPS_LIBRARY_DIR}\', INSTALL_opts=\'--no-multiarch --no-docs --no-test-load\', repos=\'https://cloud.r-project.org/\', upgrade=\'never\', THREADS=1) $$INSTALL_R_PKG_POSTFIX_POSTFIX
 
 PKG_LOCK_CMD_PREFIX  = IF exist \"$${JASP_BUILDROOT_DIR}/R/library/
 PKG_LOCK_CMD_INFIX   = /\" (rd /s /q \"$${JASP_BUILDROOT_DIR}/R/library/
 PKG_LOCK_CMD_POSTFIX = /\" && echo Lock removed!) ELSE (echo No lock found!);
+
+defineReplace(runRCommandForInstall) {
+	CMD = $$1
+	return($${INSTALL_R_PKG_PREFIX_PREFIX} $$CMD $${INSTALL_R_PKG_POSTFIX_POSTFIX})
+}

--- a/Tools/autobuild.cmd
+++ b/Tools/autobuild.cmd
@@ -1,17 +1,17 @@
-@echo off
+rem @echo off
 rem autorun
-SETLOCAL EnableDelayedExpansion
+setlocal EnableDelayedExpansion
 
 rem ---------------------- Check arguments -------------------------------
 rem Arguments are: <# CPU's to use> <64/32>bit <full/wix>
-SET CPUS=%1
+set CPUS=%1
 
 if "%1"=="" (
-SET CPUS=%NUMBER_OF_PROCESSORS%
+set CPUS=%NUMBER_OF_PROCESSORS%
 )
 echo Running autobuild in %CPUS% separate processes!
 
-SET ARCH=%2
+set ARCH=%2
 
 
 if NOT "%2"=="32" (
@@ -19,14 +19,14 @@ if NOT "%2"=="64" (
 echo "First argument should be architecture i.e 32 or 64 bits"
 echo "So e.g. run: 'autobuild 32' if you want to build an x86 version."
 echo "But for now the default of 64-bit will be set."
-SET ARCH=64
+set ARCH=64
 ))
 
-SET BUILDSTYLE=%3
+set BUILDSTYLE=%3
 
 rem set the third argument to full for a full build, to wix afterwards if that is all you are interested.
 if "%3"=="" (
-SET BUILDSTYLE=full
+set BUILDSTYLE=full
 )
 
 
@@ -34,75 +34,79 @@ echo "Building %ARCH% bits JASP"
 
 rem I am assuming we are starting from (SOMEDIR)\jasp-desktop\Tools  and that (SOMEDIR) contains folders like jasp-required-files and stuff like that
 rem At least by default
-SET STARTDIR=%CD%
-
+set STARTDIR=%CD%
 rem --- default values ---
-SET JASP_BASE_DIR_DEFAULT=%STARTDIR%\..\..
-SET QTDIR_DEFAULT=C:\Qt
-SET QTVER_DEFAULT=5.15.2
-SET RTOOLSDIR_DEFAULT=C:\Rtools
-SET WIX_DEFAULT=C:\Program Files (x86)\WiX Toolset v3.11
-SET MSVCDIR_DEFAULT=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community
+
+rem set base dir through working directory to avoid inclusion of ..\.. in the path so that wix + StanHeaders doesn't get paths longer than 260 chars
+pushd ..\..
+set JASP_BASE_DIR_DEFAULT=%CD%
+popd
+
+set QTDIR_DEFAULT=C:\Qt
+set QTVER_DEFAULT=5.15.2
+set RTOOLS40DIR_DEFAULT=C:\rtools40
+set WIX_DEFAULT=C:\Program Files (x86)\WiX Toolset v3.11
+set MSVCDIR_DEFAULT=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community
 
 rem ---------------------- Setting up environmet -------------------------------
 
 
 rem for the rest we will check if the user has overridden any particular values manually
 if "%JASP_BASE_DIR%"=="" (
-    SET "JASP_BASE_DIR=%JASP_BASE_DIR_DEFAULT%"
+    set "JASP_BASE_DIR=%JASP_BASE_DIR_DEFAULT%"
     echo Using default JASP_BASE_DIR the folder containing required files and where the wix folder will be built, of:
     echo "%JASP_BASE_DIR_DEFAULT%", to change set the JASP_BASE_DIR environment variable to your install location
 ) else (
     echo JASP_BASE_DIR: "%JASP_BASE_DIR%"
 )
 
-SET JASP_DESKTOP_DEFAULT=%JASP_BASE_DIR%\jasp-desktop
-SET JASP_REQUIRED_FILES_DIR_DEFAULT=%JASP_BASE_DIR%\jasp-required-files
+set JASP_DESKTOP_DEFAULT=%JASP_BASE_DIR%\jasp-desktop
+set JASP_REQUIRED_FILES_DIR_DEFAULT=%JASP_BASE_DIR%\jasp-required-files
 
 if "%QTDIR%"=="" (
-    SET "QTDIR=%QTDIR_DEFAULT%"
+    set "QTDIR=%QTDIR_DEFAULT%"
     echo Using default QTDIR "%QTDIR_DEFAULT%", to change set the QTDIR environment variable to your install location
 ) else (
     echo QTDIR: "%QTDIR%"
 )
 
 if "%QTVER%"=="" (
-    SET "QTVER=%QTVER_DEFAULT%"
+    set "QTVER=%QTVER_DEFAULT%"
     echo Using default QTVER "%QTVER_DEFAULT%", to change set the QTVER environment variable to your preferred version
 ) else (
     echo QTVER: "%QTVER%"
 )
 
-if "%RTOOLSDIR%"=="" (
-    SET "RTOOLSDIR=%RTOOLSDIR_DEFAULT%"
-    echo Using default RTOOLSDIR "%RTOOLSDIR_DEFAULT%", to change set the RTOOLSDIR environment variable to your install location
+if "%RTOOLS40DIR%"=="" (
+    set "RTOOLS40DIR=%RTOOLS40DIR_DEFAULT%"
+    echo Using default RTOOLS40DIR "%RTOOLS40DIR_DEFAULT%", to change set the RTOOLS40DIR environment variable to your install location
 ) else (
-    echo RTOOLSDIR: "%RTOOLSDIR%"
+    echo RTOOLS40DIR: "%RTOOLS40DIR%"
 )
 
 if "%WIX%"=="" (
-    SET "WIX=%WIX_DEFAULT%"
+    set "WIX=%WIX_DEFAULT%"
     echo Using default WIX "%WIX_DEFAULT%", to change set the WIX environment variable to your install location
 ) else (
     echo WIX: "%WIX%"
 )
 
 if "%MSVCDIR%"=="" (
-    SET "MSVCDIR=%MSVCDIR_DEFAULT%"
+    set "MSVCDIR=%MSVCDIR_DEFAULT%"
     echo Using default MSVCDIR "%MSVCDIR_DEFAULT%", to change set the MSVCDIR environment variable to your install location
 ) else (
     echo MSVCDIR: "%MSVCDIR%"
 )
 
 if "%JASP_DESKTOP%"=="" (
-    SET "JASP_DESKTOP=%JASP_DESKTOP_DEFAULT%"
+    set "JASP_DESKTOP=%JASP_DESKTOP_DEFAULT%"
     echo Using default JASP_DESKTOP "%JASP_DESKTOP_DEFAULT%", to change set the JASP_DESKTOP environment variable to your folder
 ) else (
     echo JASP_DESKTOP: "%JASP_DESKTOP%"
 )
 
 if "%JASP_REQUIRED_FILES_DIR%"=="" (
-    SET "JASP_REQUIRED_FILES_DIR=%JASP_REQUIRED_FILES_DIR_DEFAULT%"
+    set "JASP_REQUIRED_FILES_DIR=%JASP_REQUIRED_FILES_DIR_DEFAULT%"
     echo Using default JASP_REQUIRED_FILES_DIR "%JASP_REQUIRED_FILES_DIR_DEFAULT%", to change set the JASP_REQUIRED_FILES_DIR environment variable to your folder
 ) else (
     echo JASP_REQUIRED_FILES_DIR: "%JASP_REQUIRED_FILES_DIR%"
@@ -116,24 +120,24 @@ if not exist Tools (
 )
 cd %STARTDIR%
 
-SET JASP_WIX_DIR=jasp-wix-installer-%ARCH%
-SET JASP_INSTALL_DIR=jasp-installer-files-%ARCH%
-SET JASP_BUILD_DIR=jasp-build-%ARCH%
-SET JASP_R_INTERFACE=R-Interface
-SET JOM=%QTDIR%\Tools\QtCreator\bin\jom.exe
+set JASP_WIX_DIR=jasp-wix-installer-%ARCH%
+set JASP_INSTALL_DIR=jasp-installer-files-%ARCH%
+set JASP_BUILD_DIR=jasp-build-%ARCH%
+set JASP_R_INTERFACE=R-Interface
+set JOM=%QTDIR%\Tools\QtCreator\bin\jom.exe
 
-SET VCVARS_DIR="%MSVCDIR%\VC\Auxiliary\Build"
+set VCVARS_DIR="%MSVCDIR%\VC\Auxiliary\Build"
 
 if "%ARCH%" == "64" (
-SET MINGWDIR=%RTOOLSDIR%\mingw_64\bin
-SET QTVCDIR=%QTDIR%\%QTVER%\msvc2019_64\bin
-SET WIXARCH="x64"
-SET COPY_R_ARCH="x64"
+set MINGWDIR=%RTOOLS40DIR%\mingw64\bin
+set QTVCDIR=%QTDIR%\%QTVER%\msvc2019_64\bin
+set WIXARCH=x64
+set COPY_R_ARCH=x64
 ) else (
-SET MINGWDIR=%RTOOLSDIR%\mingw_32\bin
-SET QTVCDIR=%QTDIR%\%QTVER%\msvc2019\bin
-SET WIXARCH="x86"
-SET COPY_R_ARCH="i386"
+set MINGWDIR=%RTOOLS40DIR%\mingw32\bin
+set QTVCDIR=%QTDIR%\%QTVER%\msvc2019\bin
+set WIXARCH=x86
+set COPY_R_ARCH=i386
 )
 
 echo JASP will be built for %ARCH% bits
@@ -175,10 +179,11 @@ if not exist %VCVARS_DIR% (
     exit /b 11
 )
 
-rem Setting up Visual Studio Environment
+rem Setting up Visual Studio Environment and R/JASPEngine related stuff
 call %VCVARS_DIR%\vcvars%ARCH%.bat
-
-SET PATH=%MINGWDIR%;%QTVCDIR%;%PATH%
+set PATH=%JASP_REQUIRED_FILES_DIR%\R\library\RInside\libs\%COPY_R_ARCH%;%JASP_REQUIRED_FILES_DIR%\R\library\Rcpp\libs\%COPY_R_ARCH%;%JASP_REQUIRED_FILES_DIR%\R\bin\%COPY_R_ARCH%;%MINGWDIR%;%QTVCDIR%;%PATH%
+set R_HOME=%JASP_REQUIRED_FILES_DIR%/R
+set JASPENGINE_LOCATION=%JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\JASPEngine.exe
 
 rem you uncomment the following goto to skip building JASP, but it assumes that you did in fact build it previously in the normal location (see BUILDSTYLE argument though)
 rem goto skipbuilding
@@ -250,7 +255,11 @@ echo Building R-Interface in %JASP_R_INTERFACE%
 if "%BUILDSTYLE%"=="full" (
     %QTVCDIR%\qmake.exe %JASP_DESKTOP%\%JASP_R_INTERFACE%\%JASP_R_INTERFACE%.pro -spec win32-g++
 )
+
 %MINGWDIR%\mingw32-make.exe  -j%CPUS% || exit /B 5
+
+echo PRINT ENVIRONMENT
+set
 
 cd ..
 echo "Building JASP"
@@ -274,37 +283,46 @@ mkdir  %JASP_INSTALL_DIR%
 cd %JASP_INSTALL_DIR%
 
 echo copy icon
-COPY %JASP_DESKTOP%\Desktop\icon.ico /Y
+copy %JASP_DESKTOP%\Desktop\icon.ico /Y
 
 echo copy AGPL txt
-COPY %JASP_DESKTOP%\COPYING.txt  AGPL.txt /Y
+copy %JASP_DESKTOP%\COPYING.txt  AGPL.txt /Y
 
 echo copying JASP.exe, JASPEngine.exe, *.R and *.dll from build dir
-COPY %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\JASP.exe /Y
-COPY %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\JASPEngine.exe /Y
-COPY %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\*.R /Y
-COPY %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\*.dll /Y
+copy %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\JASP.exe /Y
+copy %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\JASPEngine.exe /Y
+copy %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\*.R /Y
+copy %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\*.dll /Y
 
 echo Running windeployqt on JASP.exe
 %QTVCDIR%\windeployqt.exe --no-compiler-runtime -core -gui -webenginewidgets -webchannel -svg -network -printsupport -xml -qml -quick -quickwidgets --qmldir %JASP_DESKTOP%\Desktop JASP.exe
 
 echo copy resources
-XCOPY  %JASP_DESKTOP%\Resources /E /I Resources
-
-echo copy Modules
-XCOPY  %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\Modules /E /I Modules
+xcopy  %JASP_DESKTOP%\Resources /E /I Resources
 
 echo copy help
-XCOPY  %JASP_DESKTOP%\Resources\Help /E /I Help
+xcopy  %JASP_DESKTOP%\Resources\Help /E /I Help
 
 :copyR
+set "RENV_DEST=%JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_INSTALL_DIR%"
 set "RLOCATION=%JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_INSTALL_DIR%\R"
-echo running copyR.cmd script as "%JASP_DESKTOP%\Tools\copyR.cmd %JASP_REQUIRED_FILES_DIR%\R %RLOCATION% %COPY_R_ARCH%"
-
-call %JASP_DESKTOP%\Tools\copyR.cmd %JASP_REQUIRED_FILES_DIR%\R %RLOCATION% %COPY_R_ARCH%
+echo running copyR.cmd script as "%JASP_DESKTOP%\Tools\copyR.cmd %JASP_REQUIRED_FILES_DIR%\R %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR% %RLOCATION% %COPY_R_ARCH% %RENV_ROOT%"
+call %JASP_DESKTOP%\Tools\copyR.cmd %JASP_REQUIRED_FILES_DIR%\R %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR% %RLOCATION% %COPY_R_ARCH% %RENV_DEST% %JASP_DESKTOP%
 
 echo copy JAGS to installer preparation folder
-XCOPY %JASP_REQUIRED_FILES_DIR%\%ARCH%\JAGS /E /I %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_INSTALL_DIR%\JAGS
+xcopy %JASP_REQUIRED_FILES_DIR%\%ARCH%\JAGS /Y /Q /E /I %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_INSTALL_DIR%\JAGS
+
+echo we run symlinkTools.R and then particularly collectAndStoreJunctions to generate junctions.rds which will be used later on the users pc to restore them
+echo Running JASPEngine junction collector
+pushd %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\
+START "junction collector" /B /WAIT JASPEngine.exe --collectJunctions %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\
+popd
+copy %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\junctions.rds 
+
+rem We do not copy Modules, instead we just generate them later. echo now we copy the modules because they will have been turned into dummies by symlinkTools.R
+rem pushd %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_INSTALL_DIR%
+rem xcopy %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\Modules /Y /Q /E /I Modules
+rem popd
 
 :skipbuilding
 
@@ -315,18 +333,18 @@ echo Melting and Coalescing MSI
 
 cd %JASP_BASE_DIR%\%JASP_WIX_DIR%
 
-SET MERGEMODULENAME=Microsoft_VC142_CRT_%WIXARCH%.msm
+set MERGEMODULENAME=Microsoft_VC142_CRT_%WIXARCH%.msm
 
 echo VCToolsRedistDir: "%VCToolsRedistDir%"
 
-COPY "%VCToolsRedistDir%\MergeModules\%MERGEMODULENAME%" /Y
+copy "%VCToolsRedistDir%\MergeModules\%MERGEMODULENAME%" /Y
 "%WIX%\bin\heat.exe" dir .\%JASP_INSTALL_DIR% -cg JASPFiles -gg -scom -sreg -sfrag -srd -dr APPLICATIONFOLDER -var var.JASP_INSTALL_DIR -out JASPFilesFragment.wxs || exit /B 7
 
-COPY %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\jasp.wxi /Y
+copy %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\jasp.wxi /Y
 "%WIX%\bin\candle" -arch %WIXARCH% -dJASP_INSTALL_DIR=%JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_INSTALL_DIR%  JASPFilesFragment.wxs  || exit /B 8
 
-COPY %JASP_DESKTOP%\Tools\wix\jasp.wxs /Y
-COPY %JASP_DESKTOP%\Tools\wix\jaspLicense.rtf /Y
+copy %JASP_DESKTOP%\Tools\wix\jasp.wxs /Y
+copy %JASP_DESKTOP%\Tools\wix\jaspLicense.rtf /Y
 "%WIX%\bin\candle" -dRedistMergeModule=%MERGEMODULENAME% -arch %WIXARCH% -dJASP_DESKTOP_DIR=%JASP_DESKTOP% -ext WixUIExtension -ext WixUtilExtension jasp.wxs || exit /B 9
 
 "%WIX%\bin\light" -sval -dRedistMergeModule=%MERGEMODULENAME% -ext WixUIExtension -ext WixUtilExtension -out JASP.msi JASPFilesFragment.wixobj jasp.wixobj || exit /B 10
@@ -335,8 +353,9 @@ if "%BUILDSTYLE%"=="wix" GOTO end
 
 cd %STARTDIR%
 
-echo Remove readonly from r library again to avoid errors later on
-attrib -r %RLOCATION%\library /d /s
+echo Remove readonly from r-library renv-cache again to avoid errors later on
+attrib -r %JASP_BASE_DIR%\%JASP_WIX_DIR%\%JASP_BUILD_DIR%\renv-cache /d /s
+attrib -r %RLOCATION%\library                                        /d /s
 
 :end
 endlocal

--- a/Tools/copyR.cmd
+++ b/Tools/copyR.cmd
@@ -1,5 +1,5 @@
 @echo off
-SETLOCAL EnableDelayedExpansion
+setlocal EnableDelayedExpansion
 
 set startdir=%CD%
 
@@ -8,85 +8,120 @@ if "%1" == "" (
     echo Must give the path to R source as first argument to copyR.cmd!
     exit /b
 )
-set SOURCEDIR=%1
+set R_ROOT=%1
 
 if "%2" == "" (
-    echo Must give the path to R destination as second argument to copyR.cmd!
+    echo Must give the path to the builddir as second argument to copyR.cmd!
     exit /b
 )
-set DESTDIR=%2
+set BUILDDIR=%2
+
+if "%3" == "" (
+    echo Must give the path to R destination as third argument to copyR.cmd!
+    exit /b
+)
+set R_DEST=%3
 
 
-SET ARCH=%3
-if "%3"=="" (
-    SET ARCH=x64
+set ARCH=%4
+if "%4"=="" (
+    set ARCH=x64
     echo ARCH was not specified so defaulting to x64
 )
 
-echo Copying R %ARCH% from %SOURCEDIR% to %DESTDIR%
+set RENV_DEST=%5
+if "%5"=="" (
+    echo Must give the path to the folder with renv-cache in it as fifth argument
+    exit /b
+)
 
-rmdir /Q /S %DESTDIR%
-mkdir  %DESTDIR%
+set JASP_DESKTOP=%6
+if "%6"=="" (
+    echo Must give the path to jasp-desktop in it as sixth argument
+    exit /b
+)
 
-cd %DESTDIR%
+echo Copying R %ARCH% from %R_ROOT% to %R_DEST%
+
+rmdir /Q /S %R_DEST%
+mkdir  %R_DEST%
+
+cd %R_DEST%
 mkdir bin
 cd bin
-COPY %SOURCEDIR%\bin\*.exe /Y
-COPY %SOURCEDIR%\bin\*.sh /Y
-XCOPY %SOURCEDIR%\bin\%ARCH% /E /I %ARCH%
+copy %R_ROOT%\bin\*.exe /Y
+copy %R_ROOT%\bin\*.sh /Y
+xcopy %R_ROOT%\bin\%ARCH% /E /I %ARCH%
 cd ..
 
 mkdir modules
-XCOPY %SOURCEDIR%\modules\%ARCH% /E /I modules\%ARCH%
+xcopy %R_ROOT%\modules\%ARCH% /E /I modules\%ARCH%
 
-XCOPY %SOURCEDIR%\etc /E /I etc
-XCOPY %SOURCEDIR%\share /E /I share
+xcopy %R_ROOT%\etc /E /I etc
+xcopy %R_ROOT%\etc /E /I Tcl
+xcopy %R_ROOT%\share /E /I share
+xcopy %R_ROOT%\include /E /I include
 
+Echo Copying necessary parts of R-library
 mkdir library
-cd library
 
-Echo Copying necessary parts of R-libraries
-cd %SOURCEDIR%\library
-FOR /D %%G in ("*") DO (
-    echo %%G
-    cd %SOURCEDIR%\library
+pushd %R_ROOT%\library
+for /D %%G in ("*") DO (
+    mkdir %R_DEST%\library\%%G
+    pushd %R_DEST%\library\%%G
+    call %JASP_DESKTOP%\Tools\copyRSub.cmd library\%%G %R_ROOT% %R_DEST% %%G
+    popd
+)
+popd
 
-    mkdir %DESTDIR%\library\%%G
-    cd %DESTDIR%\library\%%G
-    
-    COPY %SOURCEDIR%\library\%%G\INDEX INDEX /Y >nul
-    COPY %SOURCEDIR%\library\%%G\NAMESPACE NAMESPACE /Y >nul
-    COPY %SOURCEDIR%\library\%%G\DESCRIPTION DESCRIPTION /Y >nul
-    COPY %SOURCEDIR%\library\%%G\*.R . /Y >nul
-    
-    if exist %SOURCEDIR%\library\%%G\R            ( XCOPY %SOURCEDIR%\library\%%G\R            /Q /E /I R           >nul )
-    if exist %SOURCEDIR%\library\%%G\Meta         ( XCOPY %SOURCEDIR%\library\%%G\Meta         /Q /E /I Meta        >nul )
-    if exist %SOURCEDIR%\library\%%G\po           ( XCOPY %SOURCEDIR%\library\%%G\po           /Q /E /I po          >nul )
-    if exist %SOURCEDIR%\library\%%G\afm          ( XCOPY %SOURCEDIR%\library\%%G\afm          /Q /E /I afm         >nul )
-    if exist %SOURCEDIR%\library\%%G\enc          ( XCOPY %SOURCEDIR%\library\%%G\enc          /Q /E /I enc         >nul )
-    if exist %SOURCEDIR%\library\%%G\icc          ( XCOPY %SOURCEDIR%\library\%%G\icc          /Q /E /I icc         >nul )
-    if exist %SOURCEDIR%\library\%%G\include      ( XCOPY %SOURCEDIR%\library\%%G\include      /Q /E /I include     >nul )
-	if exist %SOURCEDIR%\library\%%G\shinythemes  ( XCOPY %SOURCEDIR%\library\%%G\shinythemes  /Q /E /I shinythemes >nul )
-	
-	rem for issue https://github.com/jasp-stats/jasp-test-release/issues/823
-	if exist %SOURCEDIR%\library\%%G\template  	  ( XCOPY %SOURCEDIR%\library\%%G\template     /Q /E /I template    >nul ) 
-	
+echo copying renv-cache from %BUILDDIR% to %RENV_DEST%
+cd %RENV_DEST%
+mkdir renv-cache
+cd renv-cache
 
-    rem for issue https://github.com/jasp-stats/jasp-test-release/issues/416#issuecomment-591899068
-    if "%%G"=="viridisLite"                       ( XCOPY %SOURCEDIR%\library\%%G\data         /Q /E /I data        >nul )
+rem structure of renv-cache: renv-cache/RENV_VERSION?/PKGNAME/VERSION/CHECKSUM_OR_SOMETHING/PKGNAME_AGAIN/THE_PKG
+rem sadly enough windows doesn't allow for actually descriptive filenames in this loop... So dictionary:
+rem G=RENV_VERSION H=PKGNAME I=VERSION J=CHECKSUM
+Echo Copying necessary parts of R-libraries in renv-cache
+cd %BUILDDIR%\renv-cache
+for /D %%G in ("*") DO (
+    rem setlocal EnableDelayedExpansion
+    rem set RENV_VERSION=%%G
+    pushd %%G
 
-    if exist %SOURCEDIR%\library\%%G\libs (
-        mkdir %DESTDIR%\library\%%G\libs
-        cd %DESTDIR%\library\%%G\libs
-        
-        COPY %SOURCEDIR%\library\%%G\libs\* /Y >nul
-        XCOPY %SOURCEDIR%\library\%%G\libs\%ARCH% /Q /E /I %ARCH% >nul
-        cd %DESTDIR%\library\%%G
+    for /D %%H in ("*") DO (
+        rem setlocal EnableDelayedExpansion
+        rem set PKGNAME=%%H
+        pushd %%H
+
+        for /D %%I in ("*") DO (
+            rem setlocal EnableDelayedExpansion
+            rem set PKGVERSION=%%i
+            pushd %%I
+
+            for /D %%J in ("*") DO (
+                rem setlocal EnableDelayedExpansion
+                rem set PKGCHECKSUM=%%J
+                pushd %%J\%%H
+
+                call %JASP_DESKTOP%\Tools\copyRSub.cmd renv-cache\%%G\%%H\%%I\%%J\%%H %BUILDDIR% %RENV_DEST% %%H
+                
+                rem ENDLOCAL
+                popd
+            )
+            rem ENDLOCAL
+            popd
+        )
+        rem ENDLOCAL
+        popd
     )
+    rem ENDLOCAL
+    popd
 )
 
-echo Making R readonly
-attrib +r %DESTDIR%\library /d /s
+echo Making R and renv-cache readonly
+attrib +r %RENV_DEST%\renv-cache /d /s
+attrib +r %R_DEST%\library       /d /s
 
 echo Done!
 cd %STARTDIR%

--- a/Tools/copyRSub.cmd
+++ b/Tools/copyRSub.cmd
@@ -1,0 +1,55 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+set REL_PATH=%1
+set SRCE_DIR=%2
+set DEST_DIR=%3
+set PKG_NAME=%4
+
+rem So many boostheaders... https://github.com/jasp-stats/INTERNAL-jasp/issues/1285
+if "%PKG_NAME%" == "BH" ( exit /B 0 )
+
+echo REL_PATH=%REL_PATH%
+
+mkdir %DEST_DIR%\%REL_PATH%
+pushd %DEST_DIR%\%REL_PATH%
+
+IF "%PKG_NAME:~0,4%"=="jasp" (
+
+    rem Because this is some kind of jasp pkg, well probably anyway, we might need anything in there. So no shortcuts, just copy *everything*
+    pushd ..
+    xcopy %SRCE_DIR%\%REL_PATH% /Y /Q /E /I %PKG_NAME% >nul
+    popd
+
+) ELSE (
+    copy %SRCE_DIR%\%REL_PATH%\INDEX INDEX                /Y >nul
+    copy %SRCE_DIR%\%REL_PATH%\NAMESPACE NAMESPACE        /Y >nul
+    copy %SRCE_DIR%\%REL_PATH%\DESCRIPTION DESCRIPTION    /Y >nul
+    copy %SRCE_DIR%\%REL_PATH%\*.R .                      /Y >nul
+
+    if exist %SRCE_DIR%\%REL_PATH%\R            ( xcopy %SRCE_DIR%\%REL_PATH%\R            /Y /Q /E /I R           >nul )
+    if exist %SRCE_DIR%\%REL_PATH%\Meta         ( xcopy %SRCE_DIR%\%REL_PATH%\Meta         /Y /Q /E /I Meta        >nul )
+    if exist %SRCE_DIR%\%REL_PATH%\po           ( xcopy %SRCE_DIR%\%REL_PATH%\po           /Y /Q /E /I po          >nul )
+    if exist %SRCE_DIR%\%REL_PATH%\afm          ( xcopy %SRCE_DIR%\%REL_PATH%\afm          /Y /Q /E /I afm         >nul )
+    if exist %SRCE_DIR%\%REL_PATH%\enc          ( xcopy %SRCE_DIR%\%REL_PATH%\enc          /Y /Q /E /I enc         >nul )
+    if exist %SRCE_DIR%\%REL_PATH%\icc          ( xcopy %SRCE_DIR%\%REL_PATH%\icc          /Y /Q /E /I icc         >nul )
+    if exist %SRCE_DIR%\%REL_PATH%\include      ( xcopy %SRCE_DIR%\%REL_PATH%\include      /Y /Q /E /I include     >nul )
+    if exist %SRCE_DIR%\%REL_PATH%\shinythemes  ( xcopy %SRCE_DIR%\%REL_PATH%\shinythemes  /Y /Q /E /I shinythemes >nul )
+
+    rem for issue https://github.com/jasp-stats/jasp-test-release/issues/823
+    if exist %SRCE_DIR%\%REL_PATH%\template  	  ( xcopy %SRCE_DIR%\%REL_PATH%\template     /Y /Q /E /I template    >nul ) 
+
+    rem for issue https://github.com/jasp-stats/jasp-test-release/issues/416#issuecomment-591899068
+    if "%PKG_NAME%"=="viridisLite"                ( xcopy %SRCE_DIR%\%REL_PATH%\data         /Y /Q /E /I data        >nul )
+
+    if exist %SRCE_DIR%\%REL_PATH%\libs (
+        mkdir %DEST_DIR%\%REL_PATH%\libs
+        pushd %DEST_DIR%\%REL_PATH%\libs
+        
+        copy %SRCE_DIR%\%REL_PATH%\libs\* /Y >nul
+        xcopy %SRCE_DIR%\%REL_PATH%\libs\%ARCH% /Y /Q /E /I %ARCH% >nul
+        popd
+    )
+)
+popd
+endlocal

--- a/Tools/upload-msi.cmd
+++ b/Tools/upload-msi.cmd
@@ -1,10 +1,10 @@
 rem @echo off
-REM autorun
-SETLOCAL EnableDelayedExpansion
+rem autorun
+setlocal EnableDelayedExpansion
 
 SET ARCH=%1
 
-REM - Check arguments -
+rem - Check arguments -
 if NOT "%1"=="32" (
 if NOT "%1"=="64" (
 echo "First argument could be architecture, i.e 32 or 64 bits, to upload"
@@ -12,8 +12,8 @@ echo "But for now the default of 64 will be assumed."
 SET ARCH=64
 ))
 
-FOR /F "tokens=*" %%g IN ('git rev-parse --abbrev-ref HEAD') do (SET GIT_BRANCH=%%g)
-FOR /F "tokens=*" %%h IN ('git rev-parse --verify HEAD')     do (SET GIT_COMMIT=%%h)
+for /F "tokens=*" %%g IN ('git rev-parse --abbrev-ref HEAD') do (SET GIT_BRANCH=%%g)
+for /F "tokens=*" %%h IN ('git rev-parse --verify HEAD')     do (SET GIT_COMMIT=%%h)
 
 SET DEST_FILE=JASP-nightly-%GIT_BRANCH%-%GIT_COMMIT%
 echo "Copying MSI & ZIP to jasp-static with filename : %DEST_FILE%"

--- a/Tools/wix/jasp.wxs
+++ b/Tools/wix/jasp.wxs
@@ -50,6 +50,11 @@
 		<Directory Id="ProgramFilesFolder">
             <Directory Id="APPLICATIONFOLDER" Name="JASP">
                 <!-- files added in JASPFilesFragment.wxs -->
+
+				<Component Id="CleanupMainApplicationFolderOnInstall" Guid="bf3d406f-4778-4c17-a311-c18ba9cede79">
+					<RegistryValue Root="HKMU" Key="SOFTWARE\JASP" Name="Path" Type="string" Value="[APPLICATIONFOLDER]" KeyPath="yes" />
+					<util:RemoveFolderEx On="both" Property="APPLICATIONFOLDER" />
+				</Component>
             </Directory>
         </Directory>
 
@@ -61,8 +66,8 @@
                     
                     <Shortcut Id="ApplicationStartMenuShortcut" Name="JASP $(var.VersionNumber)" Description="$(var.Description)" Target="[APPLICATIONFOLDER]JASP.exe" WorkingDirectory="APPLICATIONFOLDER"/>
                     
-                    <RemoveFolder Id="CleanUpShortCut"      Directory="APPLICATIONFOLDER" On="uninstall"/> 
-                    <RemoveFolder Id="ProgramMenuSubfolder"                             On="uninstall"/> 
+                    <RemoveFolder Id="CleanUpShortCut"      Directory="APPLICATIONFOLDER" 	On="uninstall"/> 
+                    <RemoveFolder Id="ProgramMenuSubfolder"                             	On="uninstall"/> 
                 </Component>
 
                 <Component Id="FileTypeRegistration" Guid="c3591efa-fe71-416e-b5b8-6df0098f03c4">
@@ -71,20 +76,19 @@
                     <!-- Capabilities keys for Vista/7 "Set Program Access and Defaults" -->
 					<!-- HKMU is supposed to resolve to either the user or machine registry root on install-->
                     <RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities"                     Name="ApplicationDescription"   Value="$(var.Description)"                                      Type="string" />
-                    <RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities"                     Name="ApplicationIcon"          Value="[APPLICATIONFOLDER]JASP.exe,0"                             Type="string" />
+                    <RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities"                     Name="ApplicationIcon"          Value="[APPLICATIONFOLDER]JASP.exe,0"                           Type="string" />
                     <RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities"                     Name="ApplicationName"          Value="$(var.ApplicationName)"                                  Type="string" />
-                    <RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities\DefaultIcon"                                         Value="[APPLICATIONFOLDER]JASP.exe,1"                             Type="string" />
+                    <RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities\DefaultIcon"                                         Value="[APPLICATIONFOLDER]JASP.exe,1"                           Type="string" />
                     <RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities\FileAssociations"    Name=".jasp"                    Value="JASP.Document"                                           Type="string" />
                     <RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities\MIMEAssociations"    Name="application/jasp"         Value="JASP.Document"                                           Type="string" />
                     <!--<RegistryValue Root="HKMU" Key="SOFTWARE\JASP\Capabilities\shell\Open\command"                                  Value="&quot;[APPLICATIONFOLDER]JASP.exe&quot; &quot;%1&quot;"    Type="string" />-->
                     <RegistryValue Root="HKMU" Key="SOFTWARE\RegisteredApplications"                Name="JASP"                     Value="SOFTWARE\JASP\Capabilities"                              Type="string" KeyPath="yes"/>
 
-
-
                     <!-- MyApp.Document ProgID -->
                     <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\JASP.Document" Name="FriendlyTypeName" Value="A JASP file, containing analyses and/or data" Type="string"/>
                     <ProgId Id="JASP.Document" Description="A JASP file, containing analyses and/or data">
                         <Extension Id="jasp">
+							<!-- WIX complains about [APPLICATIONFOLDER]JASP.exe but it seems to work so you know, whatever. -->
                             <Verb Id="open" Target="&quot;[APPLICATIONFOLDER]\JASP.exe&quot;" Argument="&quot;%1&quot;" />
                             <!--<MIME Advertise="yes" ContentType="application/jasp" Default="yes" />-->
                         </Extension>
@@ -139,15 +143,28 @@
 	<!-- JASP "license" -->
 	<WixVariable Id="WixUILicenseRtf" Value="jaspLicense.rtf" />
 
-    <!-- WIX complains about [APPLICATIONFOLDER]JASP.exe but it seems to work so you know, whatever. -->
+    
     <Property Id="WixShellExecTarget" Value="[ExeLocation]" />
     <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
+	<CustomAction Id="FixModulesJunctions" Impersonate="no" Execute="deferred" Return="check" Directory="APPLICATIONFOLDER" ExeCommand="[APPLICATIONFOLDER]JASP.exe --junctions" />
+
+	<InstallExecuteSequence>
+		<Custom Action='FixModulesJunctions' Before='InstallFinalize'>NOT REMOVE</Custom>
+	</InstallExecuteSequence>
+
+	<!-- Remember applicationfolderpath to later remove it entirely (mostly to get rid of Modules)-->
+	<Property Id="APPLICATIONFOLDER">
+		<RegistrySearch Key="SOFTWARE\JASP" Root="HKCU" Type="raw" Id="APPLICATIONFOLDER_REGSEARCH_USER" Name="Path" />
+		<RegistrySearch Key="SOFTWARE\JASP" Root="HKLM" Type="raw" Id="APPLICATIONFOLDER_REGSEARCH_MACH" Name="Path" />
+	</Property>
+
     <!-- Set the components defined in our fragment files that will be used for our feature  -->
     <Feature Id="JASPFeature" Title="JASP" Level="1">
-		<ComponentGroupRef Id="JASPFiles" />
-		<ComponentRef Id="ApplicationShortcut" />
-		<ComponentRef Id="FileTypeRegistration" />
+		<ComponentGroupRef Id="JASPFiles" 							/>
+		<ComponentRef Id="ApplicationShortcut"				 		/>
+		<ComponentRef Id="FileTypeRegistration"					 	/>
+		<ComponentRef Id="CleanupMainApplicationFolderOnInstall"	/>
     </Feature>
 
     <Feature Id="VCRedist" Title="Visual C++ 14.0 Runtime" AllowAdvertise="no" Display="collapse" Level="10">


### PR DESCRIPTION
This needs to be combined with https://github.com/jasp-stats/jaspBase/pull/27
And to build you will need to use either https://github.com/jasp-stats/jasp-required-files/tree/MacOS-renv or https://github.com/jasp-stats/jasp-required-files/tree/Windows-renv

And in fact, on Windows you would also need to install `rtools40` and make a new kit for it in qtcreator and also install `make` in there... Hmm, maybe I should update the building guide for all this... Yes, yes I should.

This all doesn't touch flatpak at all btw but I think this is workable now.
Also the latest `renv` nightlies for download are based on the same code as this but just not squashed, so you can use those to test. Which might be good! 

I had to make the installation process on Windows more complicated...

The commit basically says:
- Part of https://github.com/jasp-stats/INTERNAL-jasp/issues/1237
- Break https://github.com/jasp-stats/INTERNAL-jasp/issues/1227 again
- Fix module request tryCatch thing
- Use checksums magic for avoiding reinstalling jasp* pkgs
- Really dont clean cache on linux
- Current R version should be a string not a double

Some MacOS stuff:
makedmg.sh changes for renv
- it should copy renv-cache
- It should replace all absolute symlinks in the build-folder/Modules by relative links to renv-cache
- it should remove BH https://github.com/jasp-stats/INTERNAL-jasp/issues/1285
- handling the symlinks is done in the new symlinkTools.R
-- it can collect all absolute symlinks in a data.frame (tested only on mac for now)
-- it can also use this data.frame to replace them all by their relative variants. (will probably break if the symlinks do not point to renv-cache btw)
-- call it from make-dmg.sh before copying

Some Windows stuff:
- windows symlinkTools.R script can now store junctions relatively in junctions.rds and another function can restore the entire Modules folder from that
- JASP and JASPEngine should be capable of running symlinkTools.R to collect junctions
- Paths should be under 260 chars otherwise WIX/light chokes, so follow path with ../.. to shave some chars off
- Copying *all* contents of jasp* pkgs is important
- Takeaway is that the installer now restores the modules-junctions. Zip should do this as well, but then on startup

- JAGS is now broken on Mac, see https://github.com/jasp-stats/INTERNAL-jasp/issues/1345
- Language files stuff has been removed because we dont need it anymore

Co-authored-by: vandenman <donvdbergh@hotmail.com>

