### PR TITLE
plot editing: use onEditingFinished instead of onValueChanged

### DIFF
--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
@@ -30,13 +30,22 @@ Column
 					spacing:	jaspTheme.columnGroupSpacing
 	property var	axisModel:	null
 
+	function updateLastControl(id) {
+		if (plotEditorModel)
+		{
+			console.log("QML sets lastControl to " + id)
+			plotEditorModel.lastControl = id;
+		}
+	}
+
+
 	JASPC.TextField
 	{
 		id:					axisTitle
 		label:				qsTr("Title");
 		fieldWidth:			200
 		value:				axisModel.title
-		onEditingFinished:	if(axisModel) axisModel.title = value
+		onEditingFinished:	{updateLastControl(axisTitle); if(axisModel) axisModel.title = value}
 		enabled:			plotEditorModel.advanced || axisModel.titleType === parseInt(AxisModel.TitleCharacter)
 
 		// TODO: does not work!
@@ -60,7 +69,11 @@ Column
 
 		startValue: axisModel.titleType
 
-		onCurrentValueChanged: axisModel.titleType = parseInt(currentValue)
+		onCurrentValueChanged:
+		{
+			updateLastControl(titleTypeDropDown)
+			axisModel.titleType = parseInt(currentValue)
+		}
 		visible: plotEditorModel.advanced
 	}
 
@@ -78,11 +91,12 @@ Column
 		{
 			switch	(axisBreaksRadioButton.value)
 			{
-				case "range":	axisModel.breaksType = AxisModel.BreaksRange;		break;
-				case "manual":	axisModel.breaksType = AxisModel.BreaksManual;		break;
-				case "NULL":	axisModel.breaksType = AxisModel.BreaksNull;		break;
+				case "range":	updateLastControl(axisBreaksRange);		axisModel.breaksType = AxisModel.BreaksRange;		break;
+				case "manual":	updateLastControl(axisBreaksManual);	axisModel.breaksType = AxisModel.BreaksManual;		break;
+				case "NULL":	updateLastControl(axisBreaksNull);		axisModel.breaksType = AxisModel.BreaksNull;		break;
 			}
 		}
+
 	}
 
 	Column
@@ -107,9 +121,10 @@ Column
 		{
 			visible:	 axisBreaksRange.checked
 
-			JASPC.DoubleField	{	id: axisBreaksRangeFrom;	label: qsTr("from");	value: 	axisModel.from;		onValueChanged: if(axisModel) axisModel.from	= value;	negativeValues: true	}
-			JASPC.DoubleField	{	id: axisBreaksRangeTo;		label: qsTr("to");		value:	axisModel.to;		onValueChanged: if(axisModel) axisModel.to		= value;	negativeValues: true	}
-			JASPC.DoubleField	{	id: axisBreaksRangeSteps;	label: qsTr("steps");	value:	axisModel.steps;	onValueChanged: if(axisModel) axisModel.steps	= value;							}
+			JASPC.DoubleField	{	id: axisBreaksRangeFrom;	label: qsTr("from");	value:	axisModel.from;		onEditingFinished: {updateLastControl(axisBreaksRangeFrom);		if(axisModel) axisModel.from		= value		}		negativeValues: true	}
+			JASPC.DoubleField	{	id: axisBreaksRangeTo;		label: qsTr("to");		value:	axisModel.to;		onEditingFinished: {updateLastControl(axisBreaksRangeTo);		if(axisModel) axisModel.to			= value		}		negativeValues: true	}
+			JASPC.DoubleField	{	id: axisBreaksRangeSteps;	label: qsTr("steps");	value:	axisModel.steps;	onEditingFinished: {updateLastControl(axisBreaksRangeSteps);	if(axisModel) axisModel.steps		= value		}								}
+
 		}
 
 		PlotEditingAxisTable
@@ -134,6 +149,6 @@ Column
 		onValueChanged: axisModel.limitsType = (axisLimitsRadioButton.value === "data" ? AxisModel.LimitsData : axisLimitsRadioButton.value === "breaks" ? AxisModel.LimitsBreaks : AxisModel.LimitsManual)
 	}
 
-	JASPC.DoubleField	{	visible: plotEditorModel.advanced && axisLimitsManual.checked;	id: axisLimitsLower;	label: qsTr("Lower limit");	negativeValues: true;	max: axisModel.limitUpper;		value: axisModel.limitLower;	onValueChanged: if(axisModel) axisModel.limitLower = value; 	}
-	JASPC.DoubleField	{	visible: plotEditorModel.advanced && axisLimitsManual.checked;	id: axisLimitsUpper;	label: qsTr("Upper limit");	negativeValues: true;	min: axisModel.limitLower;		value: axisModel.limitUpper;	onValueChanged: if(axisModel) axisModel.limitUpper = value; 	}
+	JASPC.DoubleField	{	visible: plotEditorModel.advanced && axisLimitsManual.checked;	id: axisLimitsLower;	label: qsTr("Lower limit");	negativeValues: true;	max: axisModel.limitUpper;		value: axisModel.limitLower;	onEditingFinished: if(axisModel) axisModel.limitLower = value; 	}
+	JASPC.DoubleField	{	visible: plotEditorModel.advanced && axisLimitsManual.checked;	id: axisLimitsUpper;	label: qsTr("Upper limit");	negativeValues: true;	min: axisModel.limitLower;		value: axisModel.limitUpper;	onEditingFinished: if(axisModel) axisModel.limitUpper = value; 	}
 }

--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
@@ -30,22 +30,13 @@ Column
 					spacing:	jaspTheme.columnGroupSpacing
 	property var	axisModel:	null
 
-	function updateLastControl(id) {
-		if (plotEditorModel)
-		{
-			console.log("QML sets lastControl to " + id)
-			plotEditorModel.lastControl = id;
-		}
-	}
-
-
 	JASPC.TextField
 	{
 		id:					axisTitle
 		label:				qsTr("Title");
 		fieldWidth:			200
 		value:				axisModel.title
-		onEditingFinished:	{updateLastControl(axisTitle); if(axisModel) axisModel.title = value}
+		onEditingFinished:	if(axisModel) axisModel.title = value
 		enabled:			plotEditorModel.advanced || axisModel.titleType === parseInt(AxisModel.TitleCharacter)
 
 		// TODO: does not work!
@@ -69,11 +60,7 @@ Column
 
 		startValue: axisModel.titleType
 
-		onCurrentValueChanged:
-		{
-			updateLastControl(titleTypeDropDown)
-			axisModel.titleType = parseInt(currentValue)
-		}
+		onCurrentValueChanged: axisModel.titleType = parseInt(currentValue)
 		visible: plotEditorModel.advanced
 	}
 
@@ -91,12 +78,11 @@ Column
 		{
 			switch	(axisBreaksRadioButton.value)
 			{
-				case "range":	updateLastControl(axisBreaksRange);		axisModel.breaksType = AxisModel.BreaksRange;		break;
-				case "manual":	updateLastControl(axisBreaksManual);	axisModel.breaksType = AxisModel.BreaksManual;		break;
-				case "NULL":	updateLastControl(axisBreaksNull);		axisModel.breaksType = AxisModel.BreaksNull;		break;
+				case "range":	axisModel.breaksType = AxisModel.BreaksRange;		break;
+				case "manual":	axisModel.breaksType = AxisModel.BreaksManual;		break;
+				case "NULL":	axisModel.breaksType = AxisModel.BreaksNull;		break;
 			}
 		}
-
 	}
 
 	Column
@@ -121,9 +107,9 @@ Column
 		{
 			visible:	 axisBreaksRange.checked
 
-			JASPC.DoubleField	{	id: axisBreaksRangeFrom;	label: qsTr("from");	value:	axisModel.from;		onEditingFinished: {updateLastControl(axisBreaksRangeFrom);		if(axisModel) axisModel.from		= value		}		negativeValues: true	}
-			JASPC.DoubleField	{	id: axisBreaksRangeTo;		label: qsTr("to");		value:	axisModel.to;		onEditingFinished: {updateLastControl(axisBreaksRangeTo);		if(axisModel) axisModel.to			= value		}		negativeValues: true	}
-			JASPC.DoubleField	{	id: axisBreaksRangeSteps;	label: qsTr("steps");	value:	axisModel.steps;	onEditingFinished: {updateLastControl(axisBreaksRangeSteps);	if(axisModel) axisModel.steps		= value		}								}
+			JASPC.DoubleField	{	id: axisBreaksRangeFrom;	label: qsTr("from");	value:	axisModel.from;		onEditingFinished: {if(axisModel) axisModel.from		= value		}		negativeValues: true	}
+			JASPC.DoubleField	{	id: axisBreaksRangeTo;		label: qsTr("to");		value:	axisModel.to;		onEditingFinished: {if(axisModel) axisModel.to			= value		}		negativeValues: true	}
+			JASPC.DoubleField	{	id: axisBreaksRangeSteps;	label: qsTr("steps");	value:	axisModel.steps;	onEditingFinished: {if(axisModel) axisModel.steps		= value		}								}
 
 		}
 

--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -79,8 +79,8 @@ void PlotEditorModel::reset()
 	setHeight(			100);
 
 	setAxisType(AxisType::Xaxis);
-	_undo = std::stack<Json::Value>();
-	_redo = std::stack<Json::Value>();
+	_undo = std::stack<undoRedoData>();
+	_redo = std::stack<undoRedoData>();
 	emit unOrRedoEnabledChanged();
 }
 
@@ -162,10 +162,13 @@ void PlotEditorModel::addToUndoStack()
 
 	Json::Value options = generateImgOptions();
 
-	if (_undo.empty() || _undo.top() != options)
-		_undo.push(options);
+	if (_undo.empty() || _undo.top().options != options)
+	{
+		Log::log() << "undo.top now contains _axisType: " + QString(_axisType == AxisType::Xaxis ? "Xaxis" : "Yaxis") + " and _advanced: " + _advanced << std::endl;
+		_undo.push(undoRedoData{_axisType, _advanced, options});
+	}
 
-	_redo = std::stack<Json::Value>();
+	_redo = std::stack<undoRedoData>();
 	
 	emit unOrRedoEnabledChanged();
 }
@@ -174,13 +177,15 @@ void PlotEditorModel::undoSomething()
 {
 	if (!_undo.empty())
 	{
-		Json::Value options		= generateImgOptions();
-					_imgOptions	= _undo.top();
-					
-		_redo.push(options);
+
+		Log::log() << "undoing something and redo now contains _axisType: " + QString(_axisType == AxisType::Xaxis ? "Xaxis" : "Yaxis") + " and _advanced: " + _advanced << std::endl;
+		_redo.push(undoRedoData{_axisType, _advanced, generateImgOptions()});
+
+		undoRedoData newData = _undo.top();
 		_undo.pop();
-		
-		applyChangesFromUndoOrRedo();
+		applyChangesFromUndoOrRedo(newData);
+
+
 	}
 }
 
@@ -188,19 +193,26 @@ void PlotEditorModel::redoSomething()
 {
 	if (!_redo.empty())
 	{
-		Json::Value options		= generateImgOptions();
-					_imgOptions = _redo.top();
-		
-		_undo.push(options);
-		_redo.pop();
 
-		applyChangesFromUndoOrRedo();
+		Log::log() << "redoing something and undo now contains _axisType: " + QString(_axisType == AxisType::Xaxis ? "Xaxis" : "Yaxis") + " and _advanced: " + _advanced << std::endl;
+		_undo.push(undoRedoData{_axisType, _advanced, generateImgOptions()});
+
+		undoRedoData newData = _redo.top();
+		_redo.pop();
+		applyChangesFromUndoOrRedo(newData);
+
+
 	}
 }
 
-void PlotEditorModel::applyChangesFromUndoOrRedo()
+void PlotEditorModel::applyChangesFromUndoOrRedo(const undoRedoData& newData)
 {
+	_imgOptions = newData.options;
+	setAxisType(newData.currentAxis);
+	setAdvanced(newData.advanced);
+
 	setLoading(true);
+
 	_editOptions = _imgOptions["editOptions"];
 
 	_xAxis->setAxisData(_editOptions["xAxis"]);
@@ -208,9 +220,11 @@ void PlotEditorModel::applyChangesFromUndoOrRedo()
 
 	_prevImgOptions = _imgOptions;
 	_analysis->editImage(_prevImgOptions);
+
 	setLoading(false);
-	
+
 	emit unOrRedoEnabledChanged();
+
 }
 
 void PlotEditorModel::setAxisType(const AxisType axisType)
@@ -222,8 +236,8 @@ void PlotEditorModel::setAxisType(const AxisType axisType)
 	_axisType = axisType;
 	switch (_axisType)
 	{
-		case AxisType::Xaxis:	_currentAxis = _xAxis;		break;
-		case AxisType::Yaxis:	_currentAxis = _yAxis;		break;
+	case AxisType::Xaxis:	_currentAxis = _xAxis;		break;
+	case AxisType::Yaxis:	_currentAxis = _yAxis;		break;
 	}
 
 	emit currentAxisChanged(_currentAxis);
@@ -324,7 +338,7 @@ void PlotEditorModel::setLoading(bool loading)
 {
 	if (_loading == loading)
 		return;
-	
+
 	_loading = loading;
 	emit loadingChanged(_loading);
 }

--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -163,10 +163,7 @@ void PlotEditorModel::addToUndoStack()
 	Json::Value options = generateImgOptions();
 
 	if (_undo.empty() || _undo.top().options != options)
-	{
-		Log::log() << "undo.top now contains _axisType: " + QString(_axisType == AxisType::Xaxis ? "Xaxis" : "Yaxis") + " and _advanced: " + _advanced << std::endl;
 		_undo.push(undoRedoData{_axisType, _advanced, options});
-	}
 
 	_redo = std::stack<undoRedoData>();
 	
@@ -178,8 +175,7 @@ void PlotEditorModel::undoSomething()
 	if (!_undo.empty())
 	{
 
-		Log::log() << "undoing something and redo now contains _axisType: " + QString(_axisType == AxisType::Xaxis ? "Xaxis" : "Yaxis") + " and _advanced: " + _advanced << std::endl;
-		_redo.push(undoRedoData{_axisType, _advanced, generateImgOptions()});
+		_redo.push(undoRedoData{_undo.top().currentAxis, _undo.top().advanced, generateImgOptions()});
 
 		undoRedoData newData = _undo.top();
 		_undo.pop();
@@ -194,7 +190,6 @@ void PlotEditorModel::redoSomething()
 	if (!_redo.empty())
 	{
 
-		Log::log() << "redoing something and undo now contains _axisType: " + QString(_axisType == AxisType::Xaxis ? "Xaxis" : "Yaxis") + " and _advanced: " + _advanced << std::endl;
 		_undo.push(undoRedoData{_axisType, _advanced, generateImgOptions()});
 
 		undoRedoData newData = _redo.top();
@@ -212,7 +207,6 @@ void PlotEditorModel::applyChangesFromUndoOrRedo(const undoRedoData& newData)
 	setAdvanced(newData.advanced);
 
 	setLoading(true);
-
 	_editOptions = _imgOptions["editOptions"];
 
 	_xAxis->setAxisData(_editOptions["xAxis"]);
@@ -220,11 +214,9 @@ void PlotEditorModel::applyChangesFromUndoOrRedo(const undoRedoData& newData)
 
 	_prevImgOptions = _imgOptions;
 	_analysis->editImage(_prevImgOptions);
-
 	setLoading(false);
 
 	emit unOrRedoEnabledChanged();
-
 }
 
 void PlotEditorModel::setAxisType(const AxisType axisType)
@@ -236,8 +228,8 @@ void PlotEditorModel::setAxisType(const AxisType axisType)
 	_axisType = axisType;
 	switch (_axisType)
 	{
-	case AxisType::Xaxis:	_currentAxis = _xAxis;		break;
-	case AxisType::Yaxis:	_currentAxis = _yAxis;		break;
+		case AxisType::Xaxis:	_currentAxis = _xAxis;		break;
+		case AxisType::Yaxis:	_currentAxis = _yAxis;		break;
 	}
 
 	emit currentAxisChanged(_currentAxis);
@@ -338,7 +330,7 @@ void PlotEditorModel::setLoading(bool loading)
 {
 	if (_loading == loading)
 		return;
-
+	
 	_loading = loading;
 	emit loadingChanged(_loading);
 }

--- a/Desktop/results/ploteditormodel.h
+++ b/Desktop/results/ploteditormodel.h
@@ -8,7 +8,6 @@
 #include "ploteditorcoordinates.h"
 #include <stack>
 
-class JASPControl;
 class Analyses;
 class Analysis;
 
@@ -20,22 +19,22 @@ class PlotEditorModel : public QObject
 	Q_OBJECT
 	Q_ENUMS(AxisType)
 
-	Q_PROPERTY(bool						visible				READ visible			WRITE setVisible			NOTIFY visibleChanged			)
-	Q_PROPERTY(QString					name				READ name				WRITE setName				NOTIFY nameChanged				)
-	Q_PROPERTY(QString					data				READ data				WRITE setData				NOTIFY dataChanged				)
-	Q_PROPERTY(QUrl						imgFile				READ imgFile										NOTIFY dataChanged				)
-	Q_PROPERTY(QString					title				READ title				WRITE setTitle				NOTIFY titleChanged				)
-	Q_PROPERTY(int						width				READ width				WRITE setWidth				NOTIFY widthChanged				)
-	Q_PROPERTY(int						height				READ height				WRITE setHeight				NOTIFY heightChanged			)
-	Q_PROPERTY(AxisModel *				xAxis				READ xAxis											NOTIFY dummyAxisChanged			)
-	Q_PROPERTY(AxisModel *				yAxis				READ yAxis											NOTIFY dummyAxisChanged			)
-	Q_PROPERTY(double					ppi					READ ppi											NOTIFY ppiChanged				)
-	Q_PROPERTY(bool						loading				READ loading			WRITE setLoading			NOTIFY loadingChanged			)
-	Q_PROPERTY(bool						advanced			READ advanced			WRITE setAdvanced			NOTIFY advancedChanged			)
-	Q_PROPERTY(bool						undoEnabled			READ undoEnabled									NOTIFY unOrRedoEnabledChanged	)
-	Q_PROPERTY(bool						redoEnabled			READ redoEnabled									NOTIFY unOrRedoEnabledChanged	)
-	Q_PROPERTY(AxisModel *				currentAxis			READ currentAxis									NOTIFY currentAxisChanged		)
-	Q_PROPERTY(AxisType					axisType			READ axisType			WRITE setAxisType			NOTIFY axisTypeChanged			)
+	Q_PROPERTY(bool						visible			READ visible		WRITE setVisible		NOTIFY visibleChanged			)
+	Q_PROPERTY(QString					name			READ name			WRITE setName			NOTIFY nameChanged				)
+	Q_PROPERTY(QString					data			READ data			WRITE setData			NOTIFY dataChanged				)
+	Q_PROPERTY(QUrl						imgFile			READ imgFile								NOTIFY dataChanged				)
+	Q_PROPERTY(QString					title			READ title			WRITE setTitle			NOTIFY titleChanged				)
+	Q_PROPERTY(int						width			READ width			WRITE setWidth			NOTIFY widthChanged				)
+	Q_PROPERTY(int						height			READ height			WRITE setHeight			NOTIFY heightChanged			)
+	Q_PROPERTY(AxisModel *				xAxis			READ xAxis									NOTIFY dummyAxisChanged			)
+	Q_PROPERTY(AxisModel *				yAxis			READ yAxis									NOTIFY dummyAxisChanged			)
+	Q_PROPERTY(double					ppi				READ ppi									NOTIFY ppiChanged				)
+	Q_PROPERTY(bool						loading			READ loading		WRITE setLoading		NOTIFY loadingChanged			)
+	Q_PROPERTY(bool						advanced		READ advanced		WRITE setAdvanced		NOTIFY advancedChanged			)
+	Q_PROPERTY(bool						undoEnabled		READ undoEnabled							NOTIFY unOrRedoEnabledChanged	)
+	Q_PROPERTY(bool						redoEnabled		READ redoEnabled							NOTIFY unOrRedoEnabledChanged	)
+	Q_PROPERTY(AxisModel *				currentAxis		READ currentAxis							NOTIFY currentAxisChanged		)
+	Q_PROPERTY(AxisType					axisType		READ axisType		WRITE setAxisType		NOTIFY axisTypeChanged			)
 
 public:
 	explicit PlotEditorModel();
@@ -69,8 +68,6 @@ public:
 	AxisModel			*	currentAxis()	const {	return _currentAxis;	}
 	AxisType				axisType()		const { return _axisType;		}
 
-	JASPControl			*	lastControl()	const {	return _lastControl;	}
-
 signals:
 	void visibleChanged(		bool		visible			);
 	void nameChanged(			QString		name			);
@@ -90,7 +87,6 @@ signals:
 
 	void currentAxisChanged(	AxisModel * currentAxis);
 	void axisTypeChanged(		AxisType	axisType);
-
 
 public slots:
 	void showPlotEditor(int id, QString options);
@@ -124,7 +120,6 @@ private:
 	void		processImgOptions();
 	Json::Value generateImgOptions()	const;
 	Json::Value generateEditOptions()	const;
-//	void		highlightLastControl(JASPControl *highlightControl) const;
 
 private:
 	Analysis			*	_analysis		= nullptr;
@@ -159,7 +154,6 @@ private:
 								_redo;
 
 	AxisType				_axisType		= AxisType::Xaxis;
-	JASPControl			*	_lastControl = nullptr;
 };
 
 }

--- a/R-Interface/jaspResults/src/jaspPlot.cpp
+++ b/R-Interface/jaspResults/src/jaspPlot.cpp
@@ -127,6 +127,11 @@ void jaspPlot::renderPlot()
 			_error			= true;
 			_errorMessage	= Rcpp::as<std::string>(writeResult["error"]);
 		}
+		else
+		{
+			_error = false;
+			_errorMessage.clear();
+		}
 
 		complete();
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1342

Also fixes:

- after undoing/ redoing we now reset to the last edited axis type/ advanced mode. For example, if you change the x-axis, then navigate to the y-axis, clicking undo would change the x-axis but you would not see that. Now if you click undo the selected axis is changed to the x-axis.

- `renderPlot` may be called multiple times when resizing. For example, when a resize fails we re-render a plot with the original width and height but the error status and message should not persist on the jaspObject. This should actually be in its own PR but the change is very small.
