### PR TITLE
Duplicate analyse function do not copy options nor state

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -720,8 +720,7 @@ void Analyses::duplicateAnalysis(size_t id)
 	bindAnalysisHandler(analysis);
 	analysis->emitDuplicationSignals();
 
-	if(analysis->status() != Analysis::Status::Complete)
-		analysis->refresh();
+	analysis->refresh();
 }
 
 void Analyses::showDependenciesInAnalysis(size_t analysis_id, QString optionName)

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -348,7 +348,7 @@ void AnalysisForm::bindTo()
 {
 	unbind();
 
-	const Json::Value & optionsFromJASPFile = _analysis->optionsFromJASPFile();
+	const Json::Value & defaultOptions = _analysis->isDuplicate() ? _analysis->boundValues() : _analysis->optionsFromJASPFile();
 	QVector<ListModelAvailableInterface*> availableModelsToBeReset;
 
 	std::set<std::string> controlsJsonWrong;
@@ -361,7 +361,7 @@ void AnalysisForm::bindTo()
 		if (boundControl)
 		{
 			std::string name = control->name().toStdString();
-			Json::Value optionValue =  optionsFromJASPFile != Json::nullValue ? optionsFromJASPFile[name] : Json::nullValue;
+			Json::Value optionValue =  defaultOptions != Json::nullValue ? defaultOptions[name] : Json::nullValue;
 
 			if (optionValue != Json::nullValue && !boundControl->isJsonValid(optionValue))
 			{
@@ -387,7 +387,7 @@ void AnalysisForm::bindTo()
 			// As their assigned models are not yet bound, resetTermsFromSourceModels (with updateAssigned argument set to true) must be called afterwards.
 			if (availableModel)
 			{
-				if (optionsFromJASPFile != Json::nullValue || _analysis->isDuplicate())
+				if (defaultOptions != Json::nullValue || _analysis->isDuplicate())
 					availableModel->resetTermsFromSources(false);
 				else
 					availableModelsToBeReset.push_back(availableModel);


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp#1235

Always refresh analysis when it is duplicates to be sure whole state is created and all references to plots point to the right ones.
