### PR TITLE
Prophet analysis: adding seasonality may crash

### DIFF
--- a/Desktop/analysis/boundcontrolbase.cpp
+++ b/Desktop/analysis/boundcontrolbase.cpp
@@ -171,7 +171,7 @@ void BoundControlBase::_setTableValue(const Terms& terms, const QMap<QString, Ro
 			rowValues[key] = keyValue;
 		}
 
-		RowControls* rowControls = allControls[term.asQString()];
+		RowControls* rowControls = allControls.value(term.asQString());
 		if (rowControls)
 		{
 			const QMap<QString, JASPControl*>& controlsMap = rowControls->getJASPControlsMap();

--- a/Desktop/widgets/listmodeltermsassigned.cpp
+++ b/Desktop/widgets/listmodeltermsassigned.cpp
@@ -109,15 +109,14 @@ void ListModelTermsAssigned::removeTerm(int index)
 	const Term& term = terms().at(size_t(index));
 	const QString& termQ = term.asQString();
 
-	if (_rowControlsMap.contains(termQ))
+	RowControls* controls = _rowControlsMap.value(termQ);
+	if (controls)
 	{
-		RowControls* controls = _rowControlsMap[termQ];
-		if (controls)
-			for (JASPControl* control : controls->getJASPControlsMap().values())
-			{
-				control->setHasError(false);
-				listView()->form()->clearControlError(control);
-			}
+		for (JASPControl* control : controls->getJASPControlsMap().values())
+		{
+			control->setHasError(false);
+			listView()->form()->clearControlError(control);
+		}
 
 		_rowControlsMap.remove(termQ);
 	}
@@ -131,8 +130,8 @@ void ListModelTermsAssigned::changeTerm(int index, const QString& name)
 	QString oldName = terms()[size_t(index)].asQString();
 	if (oldName != name)
 	{
-		_rowControlsMap[name] = _rowControlsMap[oldName];
-		_rowControlsValues[name] = _rowControlsValues[oldName];
+		_rowControlsMap[name] = _rowControlsMap.value(oldName);
+		_rowControlsValues[name] = _rowControlsValues.value(oldName);
 		_rowControlsMap.remove(oldName);
 		_rowControlsValues.remove(oldName);
 		_replaceTerm(index, Term(name));


### PR DESCRIPTION
In Prophet, if you change the name of a seasonality, and directly add a new one, it crashes.
This is caused by asking for a value in a QMap by directly calling the [] operator: if no value is found, it adds an empty entry. The QMap value method prevents this problem.

