### PR TITLE
Set precision per default to 10 when converting a double to string

### DIFF
--- a/Common/column.cpp
+++ b/Common/column.cpp
@@ -21,7 +21,6 @@
 
 #include <sstream>
 #include <string>
-
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <cmath>
@@ -179,9 +178,7 @@ bool Column::_resetEmptyValuesForScale(std::map<int, string> &emptyValuesMap)
 			// This value is now considered as empty
 			*doubles = NAN;
 			hasChanged = true;
-			std::ostringstream strs;
-			strs << doubleValue;
-			emptyValuesMap.insert(make_pair(row, strs.str()));
+			emptyValuesMap.insert(make_pair(row, Utils::doubleToString(doubleValue)));
 		}
 		row++;
 	}
@@ -1021,26 +1018,10 @@ string Column::_getScaleValue(int row)
 {
 	double v = AsDoubles[row];
 
-	if (v > DBL_MAX)
-	{
-		char inf[] = { (char)0xE2, (char)0x88, (char)0x9E, 0 };
-		return string(inf);
-	}
-	else if (v < -DBL_MAX)
-	{
-		char ninf[] = { (char)0x2D, (char)0xE2, (char)0x88, (char)0x9E, 0 };
-		return string(ninf);
-	}
-	else if (Utils::isEmptyValue(v))
-	{
-		return Utils::emptyValue;
-	}
-	else
-	{
-		stringstream s;
-		s << v;
-		return s.str();
-	}
+	if (v > DBL_MAX)					return string({ (char)0xE2, (char)0x88, (char)0x9E, 0 });
+	else if (v < -DBL_MAX)				return string({ (char)0x2D, (char)0xE2, (char)0x88, (char)0x9E, 0 });
+	else if (Utils::isEmptyValue(v))	return Utils::emptyValue;
+	else								return Utils::doubleToString(v);
 }
 
 string Column::getOriginalValue(int row)

--- a/Common/utils.cpp
+++ b/Common/utils.cpp
@@ -37,6 +37,7 @@
 #include "utilenums.h"
 #include <codecvt>
 #include <regex>
+#include <iomanip>
 
 using namespace std;
 using namespace boost::posix_time;
@@ -398,9 +399,10 @@ bool Utils::convertValueToDoubleForImport(const std::string &strValue, double &d
 	return true;
 }
 
-std::string Utils::doubleToString(double dbl)
+std::string Utils::doubleToString(double dbl, int precision)
 {
 	std::stringstream conv; //Use this instead of std::to_string to make sure there are no trailing zeroes (and to get full precision)
+	conv << std::setprecision(precision);
 	conv << dbl;
 	return conv.str();
 }

--- a/Common/utils.h
+++ b/Common/utils.h
@@ -65,7 +65,7 @@ public:
 
 	static bool			convertValueToIntForImport(		const std::string &strValue, int &intValue);
 	static bool			convertValueToDoubleForImport(	const std::string &strValue, double &doubleValue);
-	static std::string	doubleToString(double dbl);
+	static std::string	doubleToString(double dbl, int precision = 10);
 	static void			convertEscapedUnicodeToUTF8(	std::string &inputStr);
 	
 #ifdef _WIN32


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp#1288
The default 10 should be set in Settings, but these files are in Common, and Setting sin Desktop.

