### PR TITLE
After opening R-commander reload results

### DIFF
--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -546,8 +546,18 @@ void MainWindow::showRCommander()
 	else
 	{
 		Log::log() << "Loading RCommander"  << std::endl;
-		_qml->load(QUrl("qrc:///components/JASP/Widgets/RCommanderWindow.qml"));
+		_qml		-> load(QUrl("qrc:///components/JASP/Widgets/RCommanderWindow.qml"));
+
+		_resultsJsInterface->resetResults();//To reload page
+
+		QTimer::singleShot(500, this, &MainWindow::resendResultsToWebEngine);
 	}
+}
+
+void MainWindow::resendResultsToWebEngine()
+{
+	//Make sure the result are reloaded after triggering a qml wipe
+	_analyses	-> applyToAll([&](Analysis * a){ emit a->resultsChangedSignal(a); });
 }
 
 void MainWindow::jaspThemeChanged(JaspTheme * newTheme)

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -212,6 +212,7 @@ private slots:
 	void populateUIfromDataSet();
 	void startDataEditorEventCompleted(FileEvent *event);
 	void analysisAdded(Analysis *analysis);
+	void resendResultsToWebEngine();
 
 	void fatalError();
 


### PR DESCRIPTION
- loading the qml apparently messes up webengine, so we reset it
- after a small delay we resend the results to webengine and voila they appear again.
- fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1280

