### PR TITLE
Engines on Windows should start with a minimal PATH

### DIFF
--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -483,6 +483,22 @@ void EngineSync::startExtraEngine()
 	}
 }
 
+
+#ifdef _WIN32 
+///Overwrites the PATH with a simple clean one
+void EngineSync::fixPATHForWindows(QProcessEnvironment & env)
+{
+	const QString R_ARCH =
+#ifdef _WIN64
+		"x64";
+#else
+		"i386";
+#endif
+	
+	env.insert("PATH", AppDirs::programDir().absolutePath() + ";" + QDir(AppDirs::rHome()).absoluteFilePath("bin") + ";" + QDir(AppDirs::rHome()).absoluteFilePath("bin/" + R_ARCH)); // + rtoolsInPath); 
+}
+#endif
+
 //Should this function go to EngineRepresentation?
 QProcess * EngineSync::startSlaveProcess(int channel)
 {
@@ -490,6 +506,10 @@ QProcess * EngineSync::startSlaveProcess(int channel)
 	QDir programDir			= AppDirs::programDir();
 	QString engineExe		= programDir.absoluteFilePath("JASPEngine");
 	QProcessEnvironment env = ProcessHelper::getProcessEnvironmentForJaspEngine(true, PreferencesModel::prefs()->setLC_CTYPE_C());
+	
+#ifdef _WIN32 
+	fixPATHForWindows(env);
+#endif
 	
 	env.insert("GITHUB_PAT", PreferencesModel::prefs()->githubPatResolved());
 

--- a/Desktop/engine/enginesync.h
+++ b/Desktop/engine/enginesync.h
@@ -105,6 +105,11 @@ private:
 	bool		allEnginesPaused();
 	bool		allEnginesResumed();
 	QProcess*	startSlaveProcess(int channelNumber);
+
+#ifdef _WIN32 
+	void		fixPATHForWindows(QProcessEnvironment & env);
+#endif
+	
 	void		checkModuleWideCastDone();
 	void		resetModuleWideCastVars();
 	void		setModuleWideCastVars(Json::Value newVars);


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/1233 (Prophet won't load)
- No need to handle Rtools because `pkgbuild` does that for us

