### PR TITLE
Add preprocessing for help markdown

### DIFF
--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -165,7 +165,7 @@ public:
 
 	const QList<std::string>&	computedColumns()								const	{ return _computedColumns; }
 	const Json::Value&		getRSource(const std::string& name)					const	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }
-
+	
 signals:
 	void				nameChanged();
 	void				helpFileChanged();

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -882,6 +882,11 @@ QString AnalysisForm::helpMD() const
 		markdown.push_back(control->helpMD());
 
 	markdown.push_back(metaHelpMD());
-
-	return markdown.join("");
+	
+	QString md = markdown.join("");
+	
+	if(_analysis && _analysis->dynamicModule())
+		_analysis->dynamicModule()->preprocessMarkdownHelp(md);
+	
+	return md;
 }

--- a/Desktop/components/JASP/Controls/HelpButton.qml
+++ b/Desktop/components/JASP/Controls/HelpButton.qml
@@ -32,5 +32,5 @@ MenuButton
 	buttonPadding:		2 * preferencesModel.uiScale
 	_scaledDim:			22 * preferencesModel.uiScale
 	Layout.alignment: 	Qt.AlignRight
-	onClicked: 			helpModel.showOrTogglePage(myAnalysis.fullHelpPath(helpPage))
+	onClicked: 			helpModel.showOrToggleParticularPageForAnalysis(myAnalysis, helpPage)
 }

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -364,7 +364,7 @@ DropArea
 										else
 										{
 											helpModel.markdown = ""; //To break any previous binding we might have made
-											helpModel.showOrTogglePage(loader.myAnalysis.helpFile)
+											helpModel.showOrTogglePageForAnalysis(loader.myAnalysis)
 										}
 					toolTip:			qsTr("Show info for this analysis")
 					radius:				height

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -619,6 +619,13 @@ QString DynamicModule::helpFolderPath() const
 	return tq(moduleInstFolder() + "/help/");
 }
 
+///The helpcontents might contain relative paths, this is sadly enough not easy to solve because the HelpWindow relies on its url to find relevant things in Resources
+///What we can do however is preprocess the markdown and replace certain string(s), in this case "%HELP_FOLDER%"
+void DynamicModule::preprocessMarkdownHelp(QString & md) const
+{
+	md.replace("%HELP_FOLDER%",  helpFolderPath());
+}
+
 AnalysisEntry* DynamicModule::retrieveCorrespondingAnalysisEntry(const Json::Value & jsonFromJaspFile) const
 {
 	std::string moduleName		= jsonFromJaspFile.get("moduleName", "Modulename wasn't actually filled!").asString(),

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -201,6 +201,7 @@ public:
 
 	std::string toString();
 	void loadInfoFromDescriptionItem(Description * description);
+	void preprocessMarkdownHelp(QString & md) const;
 
 public slots:
 	void reloadDescription();
@@ -210,7 +211,7 @@ public slots:
 	void setBundled(			bool		isBundled);
 	void setInstallLog(			std::string installLog);
 	void setLoadLog(			std::string loadLog);
-	void setImportsR(	stringset	importsR);
+	void setImportsR(			stringset	importsR);
 
 signals:
 	void		installLogChanged();

--- a/Desktop/utilities/helpmodel.h
+++ b/Desktop/utilities/helpmodel.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include "languagemodel.h"
+#include "analysis/analysis.h"
 
 class HelpModel : public QObject
 {
@@ -25,6 +26,8 @@ public slots:
 	void	setAnalysispagePath(QString analysisName) { setPagePath("analyses/" + analysisName); }
 	void	generateJavascript();
 	void	showOrTogglePage(QString pagePath);
+	void	showOrTogglePageForAnalysis(Analysis * analysis)	{ showOrToggleParticularPageForAnalysis(analysis, ""); }
+	void	showOrToggleParticularPageForAnalysis(Analysis * analysis, QString helpPage);
 	QString	indexURL();
 	void	reloadPage();
 	void	setThemeCss(QString themeName);
@@ -47,9 +50,10 @@ private:
 	bool loadHelpContent(const QString & pagePath, bool ignorelanguage, QString &renderFunc, QString &content);
 
 private:
-	bool	_visible	= false;
-	QString _pagePath	= "",
-			_markdown	= "";
+	bool		_visible	= false;
+	QString		_pagePath	= "",
+				_markdown	= "";
+	Analysis *	_analysis	= nullptr;
 };
 
 #endif // HELPMODEL_H

--- a/Docs/development/jasp-adding-module.md
+++ b/Docs/development/jasp-adding-module.md
@@ -158,7 +158,10 @@ The qml folder is where you place your [qml](https://en.wikipedia.org/wiki/QML) 
 In the R folder you should place your R file(s). You could add all your analyses into one file, or store separately them into separate files (recommended). You might event want to separate the reusable parts of your code further into their own file(s). The important part is that the name(s) of your main function(s) match the name(s) you specified under `function` in the analysis-entries of the [menu](#description-menu). A detailed guide on creating R analyses can be found [here](r-analyses-guide.md).
 
 #### help
-The help folder is where you place the documentation for your module. You should name the helpfile for each analysis with the exact same functionname as your analysis has. **Only all characters should be lowercase**.
+The help folder is where you place the documentation for your module. You should name the helpfile for each analysis with the exact same functionname as your analysis has. **Only all characters should be lowercase**. 
+To be able to refer to another helpfile or an image in your module's  helpfile or in the `info` field of the = options in QML you can use a special string.
+This string is `%HELP_FOLDER%` and when loaded it will be replaced with the path to the `help`-folder of your module.
+So suppose you have an image in `module/help/img/picture.png`, to link to it you would put `"%HELP_FOLDER%/img/picture.png"` in your markdown.
 
 #### Package Metadata
 Because a JASP Module is also an R package it should contain a [DESCRIPTION](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#The-DESCRIPTION-file) file and a [NAMESPACE](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Package-namespaces) file. 


### PR DESCRIPTION
- You can now get the help-folder location in a sort of define called %HELP_FOLDER%
- Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/318 and https://github.com/jasp-stats/INTERNAL-jasp/issues/1151

