### PR TITLE
Use the right results font

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -587,7 +587,7 @@ Json::Value Analysis::createAnalysisRequestJson()
 	json["revision"]			= revision();
 	json["rfile"]				= _moduleData == nullptr ? rfile() : "";
 	json["dynamicModuleCall"]	= _moduleData == nullptr ? "" : _moduleData->getFullRCall();
-	json["resultsFont"]			= Settings::value(Settings::RESULT_FONT).toString().toStdString();
+	json["resultsFont"]			= PreferencesModel::prefs()->resultFont().toStdString();
 
 	if (!isAborted())
 	{


### PR DESCRIPTION
Do not use directly the Settings object to get a setting value, but use always the PreferencesModel.
Should fix many issues:
Fixes jasp-stats/jasp-test-release#1215
Fixes jasp-stats/jasp-test-release#1206
Fixes jasp-stats/jasp-test-release#1203
Fixes jasp-stats/jasp-test-release#1202
Fixes jasp-stats/jasp-test-release#1188
Fixes jasp-stats/jasp-test-release#1186
Fixes jasp-stats/jasp-test-release#1180
Fixes jasp-stats/jasp-test-release#1179

