### PR TITLE
Some fixes to get SEM to load properly and general improvements

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -460,10 +460,11 @@ Json::Value& Analysis::_getParentBoundValue(const QVector<JASPControl::ParentKey
 	return *result;
 }
 
-void Analysis::setBoundValue(const std::string &name, const Json::Value &value, const Json::Value &meta, const QVector<JASPControl::ParentKey>& parentKeys)
+bool Analysis::setBoundValue(const std::string &name, const Json::Value &value, const Json::Value &meta, const QVector<JASPControl::ParentKey>& parentKeys)
 {
 	bool found = false;
-	Json::Value& parentBoundValue = _getParentBoundValue(parentKeys, found, true);
+	Json::Value &	parentBoundValue	= _getParentBoundValue(parentKeys, found, true),
+					copyPBV				= parentBoundValue; 
 
 	if (found && parentBoundValue.isObject())
 	{
@@ -472,6 +473,16 @@ void Analysis::setBoundValue(const std::string &name, const Json::Value &value, 
 		if ((meta.isObject() || meta.isArray()) && meta.size() > 0)
 			_boundValues[".meta"][name] = meta;
 	}
+	
+	return copyPBV != parentBoundValue;
+}
+
+bool Analysis::setBoundValues(const Json::Value &boundValues)		
+{
+	bool changed = _boundValues != boundValues;
+	_boundValues = boundValues; 
+	
+	return changed;
 }
 
 const Json::Value &Analysis::boundValue(const std::string &name, const QVector<JASPControl::ParentKey> &parentKeys)

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -79,6 +79,7 @@ public:
 	Q_INVOKABLE void	duplicateMe();
 
 	bool needsRefresh()			const;
+	bool wasUpgraded()			const { return _wasUpgraded; }
 	bool isWaitingForModule();
 	bool isDynamicModule()		const { return bool(_dynamicModule); }
 	void setResults(		const Json::Value & results, analysisResultStatus	status, const Json::Value & progress = Json::nullValue) { setResults(results, analysisResultsStatusToAnalysisStatus(status), progress); }
@@ -280,7 +281,8 @@ private:
 
 	Modules::UpgradeMsgs	_msgs;
 
-	std::map<std::string, Json::Value>	_rSources;
+	std::map<std::string,
+		Json::Value>		_rSources;
 };
 
 #endif // ANALYSIS_H

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -70,9 +70,10 @@ public:
 	const Json::Value&	optionsFromJASPFile()		const	{ return _optionsDotJASP;	}
 
 	const Json::Value&	boundValues()				const	{ return _boundValues;		}
-	void				setBoundValue(const std::string& name, const Json::Value& value, const Json::Value& meta, const QVector<JASPControl::ParentKey>& parentKeys = {});
 	const Json::Value&	boundValue(const std::string& name, const QVector<JASPControl::ParentKey>& parentKeys = {});
-	void				setBoundValues(const Json::Value& boundValues)			{ _boundValues = boundValues; }
+	
+	bool				setBoundValue(const std::string& name, const Json::Value& value, const Json::Value& meta, const QVector<JASPControl::ParentKey>& parentKeys = {});
+	bool				setBoundValues(const Json::Value& boundValues);
 
 	Q_INVOKABLE	QString	fullHelpPath(QString helpFileName);
 	Q_INVOKABLE void	duplicateMe();

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -695,13 +695,16 @@ void AnalysisForm::blockValueChangeSignal(bool block, bool notifyOnceUnblocked)
 			if(notifyOnceUnblocked && _analysis)
 				_analysis->boundValueChangedHandler();
 		
-			while(_waitingRScripts.size() > 0)
-			{
-				const auto & front = _waitingRScripts.front();
-				emit _analysis->sendRScript(_analysis, std::get<0>(front), std::get<1>(front), std::get<2>(front));
-				_waitingRScripts.pop();
-			}
-		}	
+			if(_analysis->wasUpgraded()) //Maybe something was upgraded and we want to run the dropped rscripts (for instance for https://github.com/jasp-stats/INTERNAL-jasp/issues/1399)
+				while(_waitingRScripts.size() > 0)
+				{
+					const auto & front = _waitingRScripts.front();
+					emit _analysis->sendRScript(_analysis, std::get<0>(front), std::get<1>(front), std::get<2>(front));
+					_waitingRScripts.pop();
+				}
+			else //Otherwise just clean it up
+				_waitingRScripts = std::queue<std::tuple<QString, QString, bool>>();
+		}
 	}
 }
 

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -695,7 +695,7 @@ void AnalysisForm::blockValueChangeSignal(bool block, bool notifyOnceUnblocked)
 			if(notifyOnceUnblocked && _analysis)
 				_analysis->boundValueChangedHandler();
 		
-			if(_analysis->wasUpgraded()) //Maybe something was upgraded and we want to run the dropped rscripts (for instance for https://github.com/jasp-stats/INTERNAL-jasp/issues/1399)
+			if(_analysis && (notifyOnceUnblocked || _analysis->wasUpgraded())) //Maybe something was upgraded and we want to run the dropped rscripts (for instance for https://github.com/jasp-stats/INTERNAL-jasp/issues/1399)
 				while(_waitingRScripts.size() > 0)
 				{
 					const auto & front = _waitingRScripts.front();

--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -30,7 +30,7 @@
 #include "gui/messageforwarder.h"
 #include "utilities/qutils.h"
 
-
+#include <queue>
 
 class ListModelTermsAssigned;
 class JASPControl;
@@ -131,7 +131,7 @@ public:
 	std::vector<std::vector<std::string> >	getValuesFromRSource(const QString& sourceID, const QStringList& searchPath);
 	void		addColumnControl(JASPControl* control, bool isComputed);
 
-	void		setBoundValue(const std::string& name, const Json::Value& value, const Json::Value& meta, const QVector<JASPControl::ParentKey>& parentKeys = {});
+	bool		setBoundValue(const std::string& name, const Json::Value& value, const Json::Value& meta, const QVector<JASPControl::ParentKey>& parentKeys = {});
 	std::set<std::string> usedVariables();
 
 	void		sortControls(QList<JASPControl*>& controls);
@@ -186,6 +186,8 @@ private:
 	QString										_info;
 	QMap<QString, QSet<ListModel*> >			_rSourceModelMap;
 	int											_signalValueChangedBlocked = 0;
+	
+	std::queue<std::tuple<QString, QString, bool>>	_waitingRScripts; //Sometimes signals are blocked, and thus rscripts. But they shouldnt just disappear right?
 };
 
 #endif // ANALYSISFORM_H

--- a/Desktop/analysis/boundcontrolbase.cpp
+++ b/Desktop/analysis/boundcontrolbase.cpp
@@ -72,7 +72,11 @@ void BoundControlBase::setBoundValue(const Json::Value &value, bool emitChange)
 
 		form->setBoundValue(getName(), value, createMeta(), _control->getParentKeys());
 	}
-	if (emitChange)	emit _control->boundValueChanged(_control);
+	else
+		emitChange = false;
+	
+	if (emitChange)	
+		emit _control->boundValueChanged(_control);
 }
 
 std::vector<std::string> BoundControlBase::usedVariables()

--- a/Desktop/widgets/boundcontrollavaantextarea.cpp
+++ b/Desktop/widgets/boundcontrollavaantextarea.cpp
@@ -20,7 +20,7 @@
 #include "textareabase.h"
 #include "log.h"
 #include "columnencoder.h"
-
+#include "analysis/analysisform.h"
 #include <QQuickTextDocument>
 
 BoundControlLavaanTextArea::BoundControlLavaanTextArea(TextAreaBase *textArea)
@@ -118,7 +118,7 @@ QString BoundControlLavaanTextArea::rScriptDoneHandler(const QString & result)
 
 	boundValue["columns"] = columns;
 
-	setBoundValue(boundValue);
+	setBoundValue(boundValue, !_control->form()->analysisObj()->wasUpgraded());
 
 	return QString();
 

--- a/Desktop/widgets/boundcontrollavaantextarea.cpp
+++ b/Desktop/widgets/boundcontrollavaantextarea.cpp
@@ -66,8 +66,9 @@ bool BoundControlLavaanTextArea::isJsonValid(const Json::Value &value)
 {
 	if (!value.isObject())					return false;
 	if (!value["modelOriginal"].isString())	return false;
-	if (!value["model"].isString())			return false;
-	if (!value["columns"].isArray())		return false;
+	//If we have modelOriginal the rest follows automatically because of checkSyntax and the result
+	//if (!value["model"].isString())			return false;
+	//if (!value["columns"].isArray())		return false;
 
 	return true;
 }


### PR DESCRIPTION
- the lavaan textarea does not necessarily need syntax$model and syntax$columns as long as it has modelOriginal. Because the others are derived from it.
- to make that work however rscripts should not be silently dropped when signals from the form are blocked. Instead they are now put in a queue and only sent after signals arent blocked anymore.
- this can however make stuff load repeatedly because we do not, until now, check if a boundvalue actually changed if a value is set. So now before and after is compared and a refresh signal is only sent when the options actually changed. This should save some unnecessary engine
activity
- fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1399 (SEM backward compat)

