### PR TITLE
Prevent infinite loop when creating or change name of a computed column

### DIFF
--- a/Common/column.cpp
+++ b/Common/column.cpp
@@ -608,8 +608,6 @@ bool Column::overwriteDataWithScale(std::vector<double> scalarData)
 
 bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData, std::map<int, std::string> levels)
 {
-	labels().clear();
-
 	size_t setVals = ordinalData.size();
 
 	if(ordinalData.size() != rowCount())
@@ -623,8 +621,6 @@ bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData, std::map<int
 
 bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData)
 {
-	labels().clear();
-
 	size_t setVals = ordinalData.size();
 
 	if(ordinalData.size() != rowCount())
@@ -638,8 +634,6 @@ bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData)
 
 bool Column::overwriteDataWithNominal(std::vector<int> nominalData, std::map<int, std::string> levels)
 {
-	labels().clear();
-
 	size_t setVals = nominalData.size();
 
 	if(nominalData.size() != rowCount())
@@ -653,8 +647,6 @@ bool Column::overwriteDataWithNominal(std::vector<int> nominalData, std::map<int
 
 bool Column::overwriteDataWithNominal(std::vector<int> nominalData)
 {
-	labels().clear();
-
 	size_t setVals = nominalData.size();
 
 	if(nominalData.size() != rowCount())
@@ -668,8 +660,6 @@ bool Column::overwriteDataWithNominal(std::vector<int> nominalData)
 
 bool Column::overwriteDataWithNominal(std::vector<std::string> nominalData)
 {
-	labels().clear();
-
 	if(nominalData.size() != rowCount())
 		nominalData.resize(rowCount());
 

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -873,10 +873,10 @@ std::set<string> AnalysisForm::usedVariables()
 
 	for (JASPControl* control : _controls)
 	{
-		BoundControl* boundControl = control->boundControl();
-		if (boundControl)
+		JASPListControl* listControl = qobject_cast<JASPListControl*>(control);
+		if (listControl)
 		{
-			std::vector<std::string> usedVariables = boundControl->usedVariables();
+			std::vector<std::string> usedVariables = listControl->usedVariables();
 			result.insert(usedVariables.begin(), usedVariables.end());
 		}
 	}

--- a/Desktop/analysis/boundcontrol.h
+++ b/Desktop/analysis/boundcontrol.h
@@ -31,7 +31,6 @@ public:
 	virtual void						bindTo(const Json::Value& value)								= 0;
 	virtual const Json::Value&			boundValue()													= 0;
 	virtual void						resetBoundValue()												= 0;
-	virtual std::vector<std::string>	usedVariables()													= 0;
 	virtual void						setBoundValue(const Json::Value& value, bool emitChange = true) = 0;
 };
 

--- a/Desktop/analysis/boundcontrolbase.cpp
+++ b/Desktop/analysis/boundcontrolbase.cpp
@@ -79,24 +79,6 @@ void BoundControlBase::setBoundValue(const Json::Value &value, bool emitChange)
 		emit _control->boundValueChanged(_control);
 }
 
-std::vector<std::string> BoundControlBase::usedVariables()
-{
-	if (_isColumn || _control->encodeValue())
-	{
-		JASPListControl* listControl = qobject_cast<JASPListControl*>(_control);
-		if (listControl)
-			return listControl->model()->terms().asVector();
-		else
-		{
-			const Json::Value value = boundValue();
-			if (value.isString())
-				return { value.asString() };
-		}
-	}
-
-	return {};
-}
-
 void BoundControlBase::setIsRCode(std::string key)
 {
 	_isRCode.insert(key);

--- a/Desktop/analysis/boundcontrolbase.h
+++ b/Desktop/analysis/boundcontrolbase.h
@@ -38,7 +38,6 @@ public:
 	const Json::Value&			boundValue()														override;
 	void						resetBoundValue()													override { bindTo(_orgValue); }
 	void						setBoundValue(const Json::Value& value, bool emitChange = true)		override;
-	std::vector<std::string>	usedVariables()														override;
 	void						setIsRCode(std::string key = "");
 	void						setIsColumn(bool isComputed, columnType type = columnType::unknown);
 	

--- a/Desktop/widgets/comboboxbase.cpp
+++ b/Desktop/widgets/comboboxbase.cpp
@@ -106,6 +106,12 @@ void ComboBoxBase::setUpModel()
 	JASPListControl::setUpModel();
 }
 
+std::vector<std::string> ComboBoxBase::usedVariables() const
+{
+	if (containsVariables())	return { fq(_currentValue) };
+	else						return {};
+}
+
 void ComboBoxBase::termsChangedHandler()
 {
 	std::vector<std::string> values = _model->getValues();

--- a/Desktop/widgets/comboboxbase.h
+++ b/Desktop/widgets/comboboxbase.h
@@ -52,7 +52,7 @@ public:
 	const QString&		currentColumnTypeIcon()				const				{ return _currentColumnTypeIcon;}
 	int					currentIndex()						const				{ return _currentIndex;			}
 
-
+	std::vector<std::string> usedVariables()				const	override;
 signals:
 	void currentTextChanged();
 	void currentValueChanged();

--- a/Desktop/widgets/jasplistcontrol.cpp
+++ b/Desktop/widgets/jasplistcontrol.cpp
@@ -232,6 +232,12 @@ int JASPListControl::count()
 	return model() ? model()->rowCount() : 0;
 }
 
+std::vector<std::string> JASPListControl::usedVariables() const
+{
+	if (containsVariables() && isBound() && model())	return model()->terms().asVector();
+	else												return {};
+}
+
 void JASPListControl::sourceChangedHandler()
 {
 	if (!model())	return;

--- a/Desktop/widgets/jasplistcontrol.h
+++ b/Desktop/widgets/jasplistcontrol.h
@@ -92,6 +92,7 @@ public:
 			bool				encodeValue()				const override	{ return containsVariables() || containsInteractions();	}
 			bool				useSourceLevels()			const			{ return _useSourceLevels;		}
 			void				setUseSourceLevels(bool b)					{ _useSourceLevels = b;			}
+	virtual std::vector<std::string> usedVariables()		const;
 
 signals:
 			void				modelChanged();

--- a/Desktop/widgets/listmodelfiltereddataentry.h
+++ b/Desktop/widgets/listmodelfiltereddataentry.h
@@ -47,6 +47,7 @@ public:
 
 	void			refreshModel()															override;
 
+	bool			areColumnNamesVariables()										const	override	{ return true; }
 
 public slots:
 	void	sourceTermsReset()															override;

--- a/Desktop/widgets/listmodeltableviewbase.h
+++ b/Desktop/widgets/listmodeltableviewbase.h
@@ -97,6 +97,7 @@ public:
 
 				bool				valueOk(QVariant value, int col = -1, int row = -1);
 	virtual		bool				isRCodeColumn(int)													const				{ return false; }
+	virtual		bool				areColumnNamesVariables()											const				{ return false; }
 
 
 				JASPControl*		getRowControl(const QString& key, const QString& name)				const	override;

--- a/Desktop/widgets/tableviewbase.cpp
+++ b/Desktop/widgets/tableviewbase.cpp
@@ -216,6 +216,19 @@ QVariant TableViewBase::defaultValue() const
 	return _defaultValue;
 }
 
+std::vector<std::string> TableViewBase::usedVariables() const
+{
+	std::vector<std::string> result;
+
+	if (_tableModel && _tableModel->areColumnNamesVariables())
+	{
+		for (int i = 0; i < _tableModel->columnCount(); i++)
+			result.push_back(fq(_tableModel->headerData(i, Qt::Horizontal).toString()));
+	}
+
+	return result;
+}
+
 void TableViewBase::setItemTypePerRow(QVariantList list)
 {
 	QList<JASPControl::ItemType> typeList;

--- a/Desktop/widgets/tableviewbase.h
+++ b/Desktop/widgets/tableviewbase.h
@@ -57,7 +57,6 @@ public:
 	Json::Value					createMeta()								override	{ return _boundControl->createMeta();				}
 	void						setBoundValue(const Json::Value& value, 
 											  bool emitChange = true)		override	{ return _boundControl->setBoundValue(value, emitChange);	}
-	std::vector<std::string>	usedVariables()								override	{ return _boundControl->usedVariables();			}
 
 	ListModel*					model()									const	override { return _tableModel; }
 	ListModelTableViewBase*		tableModel()							const			 { return _tableModel; }
@@ -86,7 +85,7 @@ public:
 	QStringList					columnNames()							const				{ return _columnNames;					}
 	QStringList					rowNames()								const				{ return _rowNames;						}
 	bool						updateSource()							const				{ return _updateSource;					}
-
+	std::vector<std::string>	usedVariables()							const override;
 
 	Q_INVOKABLE void addColumn(int col = -1, bool left = true);
 	Q_INVOKABLE void removeColumn(int col);

--- a/Desktop/widgets/textareabase.h
+++ b/Desktop/widgets/textareabase.h
@@ -50,7 +50,6 @@ public:
 	Json::Value					createMeta()								override	{ return _boundControl->createMeta();				}
 	void						setBoundValue(const Json::Value& value, 
 											  bool emitChange = true)		override	{ return _boundControl->setBoundValue(value, emitChange);	}
-	std::vector<std::string>	usedVariables()								override	{ return _boundControl->usedVariables();			}
 
 	ListModel*					model()								const	override	{ return _model; }
 	ListModelTermsAvailable*	availableModel()					const				{ return _model; }

--- a/Desktop/widgets/variableslistbase.h
+++ b/Desktop/widgets/variableslistbase.h
@@ -54,7 +54,6 @@ public:
 	Json::Value					createMeta()								override	{ return _boundControl->createMeta();				}
 	void						setBoundValue(const Json::Value& value, 
 											  bool emitChange = true)		override	{ return _boundControl->setBoundValue(value, emitChange);	}
-	std::vector<std::string>	usedVariables()								override	{ return _boundControl->usedVariables();			}
 
 	ListViewType				listViewType()						const				{ return _listViewType;								}
 	BoundControl*				boundControl()								override	{ return _boundControl;								}


### PR DESCRIPTION
When overwriting the column, the labels were first removed, and then it was checked whether column is changed: which was always true. Removing the labels is not necessary, since it synchronizes anyway the old labels with the new ones.

Fixes jasp-stats/INTERNAL-jasp#1406

