### PR TITLE
Fix multiple issues with plotediting

### DIFF
--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
@@ -150,6 +150,6 @@ Column
 		onValueChanged: axisModel.limitsType = (axisLimitsRadioButton.value === "data" ? AxisModel.LimitsData : axisLimitsRadioButton.value === "breaks" ? AxisModel.LimitsBreaks : AxisModel.LimitsManual)
 	}
 
-	JASPC.DoubleField	{	visible: plotEditorModel.advanced && axisLimitsManual.checked;	id: axisLimitsLower;	label: qsTr("Lower limit");	negativeValues: true;	max: axisModel.limitUpper;		value: axisModel.limitLower;	onEditingFinished: if(axisModel) axisModel.limitLower = value; 	}
-	JASPC.DoubleField	{	visible: plotEditorModel.advanced && axisLimitsManual.checked;	id: axisLimitsUpper;	label: qsTr("Upper limit");	negativeValues: true;	min: axisModel.limitLower;		value: axisModel.limitUpper;	onEditingFinished: if(axisModel) axisModel.limitUpper = value; 	}
+	JASPC.DoubleField	{	visible: plotEditorModel.advanced && axisLimitsManual.checked;	id: axisLimitsLower;	label: qsTr("Lower limit");	negativeValues: true;	max: axisModel.limitUpper;		value: axisModel.limitLower;	onEditingFinished: if(axisModel) axisModel.limitLower = value; 	decimals: 20; fieldWidth: 3 * jaspTheme.numericFieldWidth}
+	JASPC.DoubleField	{	visible: plotEditorModel.advanced && axisLimitsManual.checked;	id: axisLimitsUpper;	label: qsTr("Upper limit");	negativeValues: true;	min: axisModel.limitLower;		value: axisModel.limitUpper;	onEditingFinished: if(axisModel) axisModel.limitUpper = value; 	decimals: 20; fieldWidth: 3 * jaspTheme.numericFieldWidth}
 }

--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
@@ -262,7 +262,7 @@ Popup
 				{
 					id:					advanced
 					label:				qsTr("Advanced settings")
-					checked:			false
+					checked:			plotEditorModel.advanced
 					anchors
 					{
 						right:			parent.right

--- a/Desktop/results/ploteditoraxismodel.cpp
+++ b/Desktop/results/ploteditoraxismodel.cpp
@@ -332,13 +332,18 @@ void AxisModel::setBreaksType(const BreaksType breaksType)
 
 void AxisModel::setRange(const double value, const size_t idx)
 {
-	if(_range.size() <= idx)			_range.resize(idx + 1);
+
+	if(_range.size() <= idx)
+	{
+		Log::log() << "Impossible index passed to setRange: idx: " << idx << " | value: " << value << std::endl;
+		return;
+	}
 	else if(_range[idx] == value)		return;
 
 	emit addToUndoStack();
 	_range[idx] = value;
 
-	if (!_plotEditor->advanced())
+	if (!_plotEditor->advanced() && idx <= 1) // only need to update the limits if from (0) or to (1) is modified
 		setLimits(value, idx);
 
 	emit rangeChanged();
@@ -347,18 +352,26 @@ void AxisModel::setRange(const double value, const size_t idx)
 
 void AxisModel::setFrom(const double from)
 {
-	setRange(from, 0);
 
 	if (!_plotEditor->advanced())
+	{
 		setLimits(from, 0);
+		setLimitsType(LimitsType::LimitsBreaks);
+	}
+
+	setRange(from, 0);
 }
 
 void AxisModel::setTo(const double to)
 {
-	setRange(to, 1);
 
 	if (!_plotEditor->advanced())
+	{
 		setLimits(to, 1);
+		setLimitsType(LimitsType::LimitsBreaks);
+	}
+
+	setRange(to, 1);
 }
 
 void AxisModel::setLimitsType(const LimitsType limitsType)
@@ -378,7 +391,11 @@ void AxisModel::setLimitsType(const LimitsType limitsType)
 
 void AxisModel::setLimits(const double value, const size_t idx)
 {
-	if(_limits.size() <= idx)			_limits.resize(idx + 1);
+	if(_limits.size() <= idx)
+	{
+		Log::log() << "Impossible index passed to setLimits: idx: " << idx << " | value: " << value << std::endl;
+		return;
+	}
 	else if (_limits[idx] == value)		return;
 
 	if (_plotEditor->advanced())


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1349
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1350
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1351


#### https://github.com/jasp-stats/jasp-test-release/issues/1351
Fixed by the changes in Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml. Doing `checked: plotEditorModel.advanced` ensures that the checkbox is actually filled (also, I think it makes sense if `Advanced mode` is actually remembered).

#### https://github.com/jasp-stats/jasp-test-release/issues/1350
Fixed by the changes in  Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml. Changing the height (mostly) worked. The red checkbox happens because R provides (many) more decimals than QML expects and inside jaspdoublevalidator.cpp we do
```c++
if (lengthDecimals > decimals())
    return QValidator::Invalid;
```
so too many decimals is an error. Now, you might think that one way around this might be to say "let's round everything to x decimals", but the problem with that is that a plot may be on an extremely small scale, say from 1e-7 to 1e-8. If we'd round the decimals, we would destroy the plot and since that would happen on every edit it would effectively make plot editing impossible. I also adjusted the `fieldWidth` to accommodate this.

#### https://github.com/jasp-stats/jasp-test-release/issues/1349
Fixed by the changes in Desktop/results/ploteditoraxismodel.cpp. There were two issues here.

1. The `limitsType` was not changed. If the `limitsType` is set to "data" then we ignore the values set by a user (or developer) and use the default algorithm ggplot2 uses to compute the limits. This only occurred when limitsType was data, which is not very often and also why it only happened for the particular figure that EJ tried to edit.
2. I think the order mattered. In the old order
```c++
setRange(from, 0);
if (!_plotEditor->advanced())
{
	setLimits(from, 0);
	setLimitsType(LimitsType::LimitsBreaks);
}
```
`somethingChanged()` is emitted once at then end of `setRange`, but `setLimits` and `setLimitsType` are not in effect then. When `!_plotEditor->advanced()` these two also don't emit `somethingChanged()`. The new order simply flips this.

Aside from that, I deleted `if(_range.size() <= idx) _range.resize(idx + 1);` and `if(_limits.size() <= idx) _limits.resize(idx + 1);`. Both `_range` and `_limits` are fixed size vectors that should never ever change size (they could also be `std::array<double, 2 or 3 respectively>`). I did git blame who introduced them, it was me, and I have no idea why I added that in the first place.