### PR TITLE
Fix meta encoding level

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -469,7 +469,7 @@ void Analysis::setBoundValue(const std::string &name, const Json::Value &value, 
 	{
 		parentBoundValue[name] = value;
 
-		if (!meta.isNull())
+		if ((meta.isObject() || meta.isArray()) && meta.size() > 0)
 			_boundValues[".meta"][name] = meta;
 	}
 }

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -55,7 +55,7 @@ Analysis::Analysis(size_t id, Analysis * duplicateMe)
 	, _boundValues(		duplicateMe->boundValues()	)
 	, _optionsDotJASP(	duplicateMe->_optionsDotJASP)
 	, _results(			duplicateMe->_results		)
-	, _meta(			_results.get(".meta", Json::arrayValue))
+	, _resultsMeta(			_results.get(".meta", Json::arrayValue))
 	, _imgResults(		duplicateMe->_imgResults	)
 	, _userData(		duplicateMe->_userData		)
 	, _imgOptions(		duplicateMe->_imgOptions	)
@@ -139,7 +139,7 @@ void Analysis::setResults(const Json::Value & results, Status status, const Json
 {
 	_results	= results;
 	_progress	= progress;
-	_meta		= _results.get(".meta", Json::arrayValue);
+	_resultsMeta		= _results.get(".meta", Json::arrayValue);
 
 	setStatus(status);
 

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -127,7 +127,8 @@ public:
 			bool				hasVolatileNotes()	const	{ return _hasVolatileNotes;					}
 			bool				utilityRunAllowed() const	{ return  isSaveImg() || isEditImg() || isRewriteImgs();									}
 			bool				shouldRun()					{ return !isWaitingForModule() && ( utilityRunAllowed() || isEmpty() ) && optionsBound();	}
-	const	Json::Value		&	meta()				const	{ return _meta;																				}
+	const	Json::Value		&	resultsMeta()		const	{ return _resultsMeta;						}
+	const	Json::Value			optionsMeta()		const	{ return _boundValues.get(".meta", Json::nullValue);	}
 			QString				helpMD()			const;
 			bool				optionsBound()		const	{ return _optionsBound;	}
 
@@ -240,7 +241,7 @@ protected:
 	///For backward compatibility: _optionsDotJASP = options from (old) JASP file.
 	Json::Value				_optionsDotJASP = Json::nullValue,
 							_results		= Json::nullValue,
-							_meta			= Json::nullValue,
+							_resultsMeta			= Json::nullValue,
 							_imgResults		= Json::nullValue,
 							_userData		= Json::nullValue,
 							_imgOptions		= Json::nullValue,

--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -731,7 +731,7 @@ QString AnalysisForm::metaHelpMD() const
 		return markdown.join("");
 	};
 
-	return "---\n# " + tr("Output") + "\n\n" + metaMDer(_analysis->meta(), 2);
+	return "---\n# " + tr("Output") + "\n\n" + metaMDer(_analysis->resultsMeta(), 2);
 }
 
 std::vector<std::vector<string> > AnalysisForm::getValuesFromRSource(const QString &sourceID, const QStringList &searchPath)

--- a/Desktop/analysis/boundcontrol.h
+++ b/Desktop/analysis/boundcontrol.h
@@ -25,12 +25,13 @@ class BoundControl
 {
 
 public:
-	virtual Json::Value					createJson()									= 0;
-	virtual bool						isJsonValid(const Json::Value& optionValue)		= 0;
-	virtual void						bindTo(const Json::Value& value)				= 0;
-	virtual const Json::Value&			boundValue()									= 0;
-	virtual void						resetBoundValue()								= 0;
-	virtual std::vector<std::string>	usedVariables()									= 0;
+	virtual Json::Value					createJson()													= 0;
+	virtual Json::Value					createMeta()													= 0;
+	virtual bool						isJsonValid(const Json::Value& optionValue)						= 0;
+	virtual void						bindTo(const Json::Value& value)								= 0;
+	virtual const Json::Value&			boundValue()													= 0;
+	virtual void						resetBoundValue()												= 0;
+	virtual std::vector<std::string>	usedVariables()													= 0;
 	virtual void						setBoundValue(const Json::Value& value, bool emitChange = true) = 0;
 };
 

--- a/Desktop/analysis/boundcontrolbase.h
+++ b/Desktop/analysis/boundcontrolbase.h
@@ -33,6 +33,7 @@ public:
 	virtual				~BoundControlBase()	{}
 
 	Json::Value					createJson()														override { return Json::nullValue;		}
+	Json::Value					createMeta()														override;
 	void						bindTo(const Json::Value& value)									override { _orgValue = value; setBoundValue(value, false); }
 	const Json::Value&			boundValue()														override;
 	void						resetBoundValue()													override { bindTo(_orgValue); }
@@ -40,6 +41,7 @@ public:
 	std::vector<std::string>	usedVariables()														override;
 	void						setIsRCode(std::string key = "");
 	void						setIsColumn(bool isComputed, columnType type = columnType::unknown);
+	
 
 protected:
 	inline const std::string&	getName();
@@ -47,13 +49,13 @@ protected:
 	void						_readTableValue(const Json::Value& value, const std::string& key, bool hasMultipleTerms, Terms& terms, ListModel::RowControlsValues& allControlValues);
 	void						_setTableValue(const Terms& terms, const QMap<QString, RowControls*>& allControls, const std::string& key, bool hasMultipleTerms);
 
-	JASPControl*	_control			= nullptr;
-	bool			_isComputedColumn	= false,
-					_isColumn			= false;
-	Json::Value		_meta,
-					_orgValue;
-	std::string		_name;
-	columnType		_columnType			= columnType::unknown;
+	JASPControl*				_control			= nullptr;
+	bool						_isComputedColumn	= false,
+								_isColumn			= false;
+	std::set<std::string>		_isRCode;
+	Json::Value					_orgValue;
+	std::string					_name;
+	columnType					_columnType			= columnType::unknown;
 };
 
 #endif // BOUNDCONTROLBASE_H

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -872,6 +872,9 @@ void MainWindow::analysisEditImageHandler(int id, QString options)
 		string utf8 = fq(options);
 		Json::Value root;
 		Json::Reader().parse(utf8, root);
+		
+		root[".meta"] = analysis->optionsMeta();
+		
 		analysis->editImage(root);
 	}
 }

--- a/Desktop/widgets/boundcontrolmeasurescells.h
+++ b/Desktop/widgets/boundcontrolmeasurescells.h
@@ -39,7 +39,7 @@ public:
 	Terms		getLevels();
 	
 private:
-	ListModelMeasuresCellsAssigned*				_measuresCellsModel;
+	ListModelMeasuresCellsAssigned*	_measuresCellsModel;
 	QList<ListModelFactorLevels*>	_sourceFactorsModels;
 	
 	void _initLevels();

--- a/Desktop/widgets/factorlevellistbase.cpp
+++ b/Desktop/widgets/factorlevellistbase.cpp
@@ -78,6 +78,27 @@ Json::Value FactorLevelListBase::createJson()
 	return result;
 }
 
+Json::Value FactorLevelListBase::createMeta()
+{
+	Json::Value meta(BoundControlBase::createMeta()); //Work from parent to get everything it defines
+	
+	auto factors = _factorLevelsModel->getFactors();
+	
+	if(factors.size() == 0)
+		return meta;
+	
+	meta["encodeThis"] = Json::arrayValue;
+	for (const auto & factor : factors)
+	{
+		meta["encodeThis"].append(factor.first);
+		
+		for(const auto & level : factor.second)
+			meta["encodeThis"].append(level);
+	}
+	
+	return meta;
+}
+
 bool FactorLevelListBase::isJsonValid(const Json::Value &value)
 {
 	bool valid = value.isArray();

--- a/Desktop/widgets/factorlevellistbase.h
+++ b/Desktop/widgets/factorlevellistbase.h
@@ -39,6 +39,7 @@ public:
 
 	bool			isJsonValid(const Json::Value& optionValue)	override;
 	Json::Value		createJson()								override;
+	Json::Value		createMeta()								override;
 	void			bindTo(const Json::Value& value)			override;
 	bool			encodeValue()						const	override	{ return true; }
 	ListModel*		model()								const	override	{ return _factorLevelsModel; }

--- a/Desktop/widgets/jasplistcontrol.h
+++ b/Desktop/widgets/jasplistcontrol.h
@@ -89,7 +89,7 @@ public:
 			const QString&		valueRole()					const			{ return _valueRole;			}
 			bool				containsVariables()			const			{ return _containsVariables;	}
 			bool				containsInteractions()		const			{ return _containsInteractions;	}
-			bool				encodeValue()				const override	{ return containsVariables();	}
+			bool				encodeValue()				const override	{ return containsVariables() || containsInteractions();	}
 			bool				useSourceLevels()			const			{ return _useSourceLevels;		}
 			void				setUseSourceLevels(bool b)					{ _useSourceLevels = b;			}
 

--- a/Desktop/widgets/tableviewbase.h
+++ b/Desktop/widgets/tableviewbase.h
@@ -54,7 +54,9 @@ public:
 	void						resetBoundValue()							override	{ return _boundControl->resetBoundValue();			}
 	const Json::Value&			boundValue()								override	{ return _boundControl->boundValue();				}
 	Json::Value					createJson()								override	{ return _boundControl->createJson();				}
-	void						setBoundValue(const Json::Value& value, bool emitChange = true) override	{ return _boundControl->setBoundValue(value, emitChange);	}
+	Json::Value					createMeta()								override	{ return _boundControl->createMeta();				}
+	void						setBoundValue(const Json::Value& value, 
+											  bool emitChange = true)		override	{ return _boundControl->setBoundValue(value, emitChange);	}
 	std::vector<std::string>	usedVariables()								override	{ return _boundControl->usedVariables();			}
 
 	ListModel*					model()									const	override { return _tableModel; }

--- a/Desktop/widgets/textareabase.h
+++ b/Desktop/widgets/textareabase.h
@@ -47,7 +47,9 @@ public:
 	void						resetBoundValue()							override	{ return _boundControl->resetBoundValue();				}
 	const Json::Value&			boundValue()								override	{ return _boundControl->boundValue();				}
 	Json::Value					createJson()								override	{ return _boundControl->createJson();				}
-	void						setBoundValue(const Json::Value& value, bool emitChange = true) override	{ return _boundControl->setBoundValue(value, emitChange);	}
+	Json::Value					createMeta()								override	{ return _boundControl->createMeta();				}
+	void						setBoundValue(const Json::Value& value, 
+											  bool emitChange = true)		override	{ return _boundControl->setBoundValue(value, emitChange);	}
 	std::vector<std::string>	usedVariables()								override	{ return _boundControl->usedVariables();			}
 
 	ListModel*					model()								const	override	{ return _model; }

--- a/Desktop/widgets/variableslistbase.h
+++ b/Desktop/widgets/variableslistbase.h
@@ -49,9 +49,11 @@ public:
 	void						bindTo(const Json::Value &value)			override	{ _boundControl->bindTo(value);						}
 	const Json::Value&			boundValue()								override	{ return _boundControl->boundValue();				}
 	bool						isJsonValid(const Json::Value& optionValue) override	{ return _boundControl->isJsonValid(optionValue);	}
-	void						resetBoundValue()							override	{ return _boundControl->resetBoundValue();				}
+	void						resetBoundValue()							override	{ return _boundControl->resetBoundValue();			}
 	Json::Value					createJson()								override	{ return _boundControl->createJson();				}
-	void						setBoundValue(const Json::Value& value, bool emitChange = true) override	{ return _boundControl->setBoundValue(value, emitChange);	}
+	Json::Value					createMeta()								override	{ return _boundControl->createMeta();				}
+	void						setBoundValue(const Json::Value& value, 
+											  bool emitChange = true)		override	{ return _boundControl->setBoundValue(value, emitChange);	}
 	std::vector<std::string>	usedVariables()								override	{ return _boundControl->usedVariables();			}
 
 	ListViewType				listViewType()						const				{ return _listViewType;								}

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -530,7 +530,7 @@ void Engine::receiveAnalysisMessage(const Json::Value & jsonRequest)
 		ColumnEncoder::encodeColumnNamesinOptions(optionsEnc);
 		_analysisOptions		= optionsEnc.toStyledString();
 	}
-	// No need to check else for aborted because PollMessagesFunctionForJaspResults will pasws that msg on by itself.
+	// No need to check else for aborted because PollMessagesFunctionForJaspResults will pass that msg on by itself.
 }
 
 


### PR DESCRIPTION
This changes the way the `meta` is generated for options and makes sure it includes the levels and factors from RM ANOVA.

It also sends this meta to the engine for editImage and saveImage and makes sure that the levels shown there are decoded as well. There is a weird glitch though but Im not sure if that is my fault. 
The plot resizes, but always with a delay. Unless Don can see what is going there I suggest we make an issue after this is merged because with this PR at least the analysis works