### PR TITLE
[DO NOT MERGE] Changes for flatpak

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ insert_final_newline = true
 [*]
 charset = utf-8
 
-[*.{cpp,h,qml,json,md}]
+[*.{cpp,h,qml,json,md,pro,pri}]
 indent_style = tab
 indent_size = 4
 

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -103,7 +103,7 @@ void DynamicModule::initialize()
 
 	if(!_moduleFolder.exists())				throw std::runtime_error(_moduleFolder.absolutePath().toStdString() + " does not exist!");
 	else if(!_moduleFolder.isDir())			throw std::runtime_error(_moduleFolder.absolutePath().toStdString() + " is not a directory!");
-	else if(!_moduleFolder.isWritable())	throw std::runtime_error(_moduleFolder.absolutePath().toStdString() + " is not writable!");
+//	else if(!_moduleFolder.isWritable())	throw std::runtime_error(_moduleFolder.absolutePath().toStdString() + " is not writable!");
 
 	setInitialized(true);
 

--- a/JASP.pri
+++ b/JASP.pri
@@ -8,16 +8,17 @@ JASP_R_INTERFACE_MINOR_VERSION =  2   # Code changes
 
 JASP_R_INTERFACE_NAME = $$JASP_R_INTERFACE_TARGET$$JASP_R_INTERFACE_MAJOR_VERSION'.'$$JASP_R_INTERFACE_MINOR_VERSION
 
-!exists(/app/lib/*){
+GITHUB_PAT_DEF=$$(GITHUB_PAT_DEF)						#First check if we set this special env var (on buildbot)
+isEmpty(GITHUB_PAT_DEF): GITHUB_PAT_DEF=$$(GITHUB_PAT)	#Otherwise use the one we are using
+exists(/app/lib/*){
+	# Note: this crashes is the env variables aren't base64 encoded
+	GITHUB_PAT_DEF	= $$system(echo $${GITHUB_PAT_DEF}	| base64 -d)
+	GITHUB_PAT		= $$system(echo $${GITHUB_PAT}		| base64 -d)
+}
 
-	GITHUB_PAT_DEF=$$(GITHUB_PAT_DEF)						#First check if we set this special env var (on buildbot)
-	isEmpty(GITHUB_PAT_DEF): GITHUB_PAT_DEF=$$(GITHUB_PAT)	#Otherwise use the one we are using
-	isEmpty(GITHUB_PAT_DEF){
-		error("No GITHUB_PAT or GITHUB_PAT_DEF found!  Follow the steps at https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/jasp-building-guide.md$${LITERAL_HASH}github_pat")
-
-		GITHUB_PAT_DEF="NO_GITHUB_PAT_FOUND"	#To indicate a clearer error
-	}
-
+isEmpty(GITHUB_PAT_DEF){
+	error("No GITHUB_PAT or GITHUB_PAT_DEF found!  Follow the steps at https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/jasp-building-guide.md$${LITERAL_HASH}github_pat")
+	GITHUB_PAT_DEF="NO_GITHUB_PAT_FOUND"	#To indicate a clearer error
 }
 #R settings
 CURRENT_R_VERSION = "4.1"

--- a/JASP.pri
+++ b/JASP.pri
@@ -8,12 +8,16 @@ JASP_R_INTERFACE_MINOR_VERSION =  2   # Code changes
 
 JASP_R_INTERFACE_NAME = $$JASP_R_INTERFACE_TARGET$$JASP_R_INTERFACE_MAJOR_VERSION'.'$$JASP_R_INTERFACE_MINOR_VERSION
 
-GITHUB_PAT_DEF=$$(GITHUB_PAT_DEF)						#First check if we set this special env var (on buildbot)
-isEmpty(GITHUB_PAT_DEF): GITHUB_PAT_DEF=$$(GITHUB_PAT)	#Otherwise use the one we are using
-isEmpty(GITHUB_PAT_DEF){
-	error("No GITHUB_PAT or GITHUB_PAT_DEF found!  Follow the steps at https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/jasp-building-guide.md$${LITERAL_HASH}github_pat")
-	
-	GITHUB_PAT_DEF="NO_GITHUB_PAT_FOUND"	#To indicate a clearer error
+!exists(/app/lib/*){
+
+	GITHUB_PAT_DEF=$$(GITHUB_PAT_DEF)						#First check if we set this special env var (on buildbot)
+	isEmpty(GITHUB_PAT_DEF): GITHUB_PAT_DEF=$$(GITHUB_PAT)	#Otherwise use the one we are using
+	isEmpty(GITHUB_PAT_DEF){
+		error("No GITHUB_PAT or GITHUB_PAT_DEF found!  Follow the steps at https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/jasp-building-guide.md$${LITERAL_HASH}github_pat")
+
+		GITHUB_PAT_DEF="NO_GITHUB_PAT_FOUND"	#To indicate a clearer error
+	}
+
 }
 #R settings
 CURRENT_R_VERSION = "4.1"

--- a/Modules/InstallModule.pri
+++ b/Modules/InstallModule.pri
@@ -17,8 +17,15 @@ isEmpty(MODULE_NAME) {
 	#Install the actual module package
 	#Install$${MODULE_NAME}.commands     +=  $${INSTALL_R_PKG_CMD_PREFIX}$${MODULE_DIR}/$${MODULE_NAME}$${INSTALL_R_PKG_CMD_POSTFIX}; $$escape_expand(\\n\\t)
 	SETTING_UP_RENV= "Sys.setenv(RENV_PATHS_ROOT=\'$$MODULES_RENV_ROOT\', RENV_PATHS_CACHE=\'$$MODULES_RENV_CACHE\');"
+
+	linux {
+		exists(/app/lib/*) {
+			SETTING_UP_RENV += "source(\'/app/lib64/Rprofile.R\');"
+		}
+	}
+	message(using SETTING_UP_RENV of $$SETTING_UP_RENV)
 		
-	Install$${MODULE_NAME}.commands     +=  $$runRCommandForInstall("$$SETTING_UP_RENV jaspBase::installJaspModule(modulePkg=\'$${MODULE_DIR}/$${MODULE_NAME}\', libPathsToUse=NULL, moduleLibrary=\'$${JASP_LIBRARY_DIR}\', repos=\'https://cloud.r-project.org/\', onlyModPkg=FALSE)" )
+	Install$${MODULE_NAME}.commands     +=  $$runRCommandForInstall("$$SETTING_UP_RENV jaspBase::installJaspModule(modulePkg=\'$${MODULE_DIR}/$${MODULE_NAME}\', libPathsToUse=NULL, moduleLibrary=\'$${JASP_LIBRARY_DIR}\', repos=\'$${R_REPOSITORY}\', onlyModPkg=FALSE)" )
 	
 	#make sure each module is only installed after the previous one, to avoid renv clobbering itself (or just crashing)
 	!isEmpty(PREVIOUS_MODULE): Install$${MODULE_NAME}.depends += Install$${PREVIOUS_MODULE}

--- a/Modules/Modules.pro
+++ b/Modules/Modules.pro
@@ -1,20 +1,42 @@
 QT -= core gui
 
-JASP_BUILDROOT_DIR = $$OUT_PWD/..
+exists(/app/lib/*){
+	message("On flatpak!")
+	JASP_BUILDROOT_DIR	= /app/bin
+	mkpath($${JASP_BUILDROOT_DIR}/Modules)
+
+	MODULES_RENV_ROOT	= /app/lib64/renv-root
+	MODULES_RENV_CACHE	= /app/lib64/renv-cache
+	R_REPOSITORY		= file:///app/lib64/local-cran
+
+}else{
+
+	JASP_BUILDROOT_DIR  = $$OUT_PWD/.. #We expect this to be run from at least one folder deep into the buildroot! Engine/Desktop/Etc
+
+	MODULES_RENV_ROOT   = $$SYS_RENV_ROOT
+	isEmpty(MODULES_RENV_ROOT):		MODULES_RENV_ROOT	= "$$OUT_PWD/../renv-root"  #I assume we will not need to ship this, but we do need the following folder:
+									MODULES_RENV_CACHE	= "$$OUT_PWD/../renv-cache" #While this one needs to be shipped and the symlinks will need to be relative, but we will find out quick enough if not
+
+	mkpath($$MODULES_RENV_ROOT)
+	mkpath($$MODULES_RENV_CACHE)
+
+	R_REPOSITORY = $$JASP_R_REPOSITORY
+	isEmpty(R_REPOSITORY): R_REPOSITORY = "https://cloud.r-project.org/"
+
+}
+
+message(Modules uses JASP_BUILDROOT_DIR of $${JASP_BUILDROOT_DIR})
+message("Using renv-root: $$MODULES_RENV_ROOT")
+message("Using renv-cache: $$MODULES_RENV_CACHE")
+message("Using repository: $$R_REPOSITORY")
+
+SUPPORTED_LANGUAGES = nl de es #Just setting this once is enough...
 
 include(../JASP.pri)
 include(../R_HOME.pri)
 
 TEMPLATE = aux
 CONFIG -= app_bundle
-
-MODULES_RENV_ROOT   = $$SYS_RENV_ROOT
-isEmpty(MODULES_RENV_ROOT): MODULES_RENV_ROOT	= "$$OUT_PWD/../renv-root"  #I assume we will not need to ship this, but we do need the following folder:
-							MODULES_RENV_CACHE	= "$$OUT_PWD/../renv-cache" #While this one needs to be shipped and the symlinks will need to be relative, but we will find out quick enough if not
-mkpath($$MODULES_RENV_ROOT)
-mkpath($$MODULES_RENV_CACHE)
-
-message("Using renv-root: $$MODULES_RENV_ROOT")
 
 MODULE_DIR			= $$PWD
 

--- a/Tools/flatpak/setup-rpkgs/.gitignore
+++ b/Tools/flatpak/setup-rpkgs/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user/
+flatpak_folder/
+archives/
+app/
+

--- a/Tools/flatpak/setup-rpkgs/.gitignore
+++ b/Tools/flatpak/setup-rpkgs/.gitignore
@@ -2,4 +2,4 @@
 flatpak_folder/
 archives/
 app/
-
+other_deps/

--- a/Tools/flatpak/setup-rpkgs/R/Rprofile.R
+++ b/Tools/flatpak/setup-rpkgs/R/Rprofile.R
@@ -1,0 +1,38 @@
+
+.lib64 <- if (dir.exists("/app")) {
+  file.path("file:", "app", "lib64")
+  cat("/app exists!\n")
+  "/app/lib64"
+} else {
+  file.path("file:", normalizePath("flatpak_folder/flatpak-helper/local-github"))
+  cat("/app does not exist!\n")
+  "app/lib64"
+}
+
+stripUrl <- function(url) {
+  tolower(gsub("/+", "_", strsplit(url, "repos/", fixed = TRUE)[[1L]][2]))
+}
+
+download_override_flatpak <- function(url, destfile, mode = "wb", quiet = FALSE, headers = NULL) {
+
+  options("renv.download.override" = NULL)
+  on.exit(options("renv.download.override" = download_override_flatpak))
+
+  type <- get("type", parent.frame(1))
+  if (identical(type, "github")) {
+    cat("old url:", url, '\n')
+    url <- file.path(.lib64, "local-github", stripUrl(url))
+    cat("new url:", url, '\n')
+  }
+
+  renv:::download(url, destfile, type = type, quiet = quiet, headers = headers)
+
+}
+
+# this will only take effect AFTER flatpakRegenerateRenvStructure.R was run
+if (dir.exists(file.path(.lib64, "local-github"))) {
+  cat("overriding renv download function\n")
+  options("renv.download.override" = download_override_flatpak)
+} else {
+  cat("not overriding renv download function\n")
+}

--- a/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
@@ -4,6 +4,10 @@
 # it would be nice to be able to outsource this to miniCRAN which has a method for adding local pkgs to a repository
 # the only downside is that it looks like miniCRAN is not actively maintained anymore.
 
+# when running this file on a new computer, adjust these paths
+jaspDir    <- "~/github/jasp-desktop"               # local clone of https://github.com/jasp-stats/jasp-desktop
+flatpakDir <- "~/github/flatpak/org.jaspstats.JASP" # local clone of https://github.com/flathub/org.jaspstats.JASP
+
 source("R/functions.R")
 
 # you probably want to set a GITHUB_PAT because otherwise you WILL get rate-limited by GitHub.
@@ -18,7 +22,7 @@ Sys.setenv("RENV_PATHS_CACHE" = dirs["renv-cache"])
 Sys.setenv("RENV_PATHS_ROOT"  = dirs["renv-root"])
 
 # use the default branch of all modules -- always the latest version
-jaspModules <- paste0("jasp-stats/", Filter(function(x) startsWith(x, "jasp"), dir("~/github/jasp-desktop/Modules/")))
+jaspModules <- paste0("jasp-stats/", Filter(function(x) startsWith(x, "jasp"), dir(file.path(jaspDir, "Modules"))))
 
 # this uses the local versions -- but modules that are dependencies are still retrieved from github
 # isJaspModule <- function(path) file.exists(file.path(path, "DESCRIPTION")) && file.exists(file.path(path, "inst", "Description.qml"))
@@ -51,10 +55,10 @@ copyV8Lib(dirs)
 copyRfiles(dirs)
 
 # debugonce(createTarArchive)
-info <- createTarArchive(dirs, verbose = FALSE, compression = "best")
+info <- createTarArchive(dirs, jaspDir, verbose = FALSE, compression = "best")
 
 # update Rpackages.json & install build flatpak
-writeRpkgsJson("~/github/flatpak/org.jaspstats.JASP/RPackages.json", info)
+writeRpkgsJson(file.path(flatpakDir, "RPackages.json"), info)
 
 # IF you have ssh setup this will upload the tar.gz to static-jasp. It's nicer to do this via a terminal because there you see a progress bar
-# uploadTarArchive()
+uploadTarArchive(info["tar-file"])

--- a/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
@@ -30,15 +30,17 @@ installRecommendedPackages(dirs)
 
 cleanupBigPackages(dirs)
 
+downloadFakeV8(dirs)
+
 createLocalPackageRepository(dirs)
 
-updateV8Rpackage(dirs)
+# updateV8Rpackage(dirs)
 
 # TRUE implies all pkgs only appear once -- not sure what will happen when this is not true anymore
 # pkgs <- list.files("toplevelRepository/src/contrib/", pattern = "\\.tar\\.gz$")
 # all(table(sapply(strsplit(pkgs, "_", fixed = TRUE), `[`, 1)) == 1)
 
-downloadV8(dirs)
+# downloadV8(dirs)
 copyRfiles(dirs)
 
 # debugonce(createTarArchive)

--- a/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
@@ -1,0 +1,51 @@
+# This file needs internet!
+
+# TODO: look at https://github.com/andrie/miniCRAN/issues/50#issuecomment-374624319
+# it would be nice to be able to outsource this to miniCRAN which has a method for adding local pkgs to a repository
+# the only downside is that it looks like miniCRAN is not actively maintained anymore.
+
+source("R/functions.R")
+
+# you probably want to set a GITHUB_PAT because otherwise you WILL get rate-limited by GitHub.
+# Sys.setenv("GITHUB_PAT" = ...)
+
+options(repos = list(repos = c(CRAN = "https://cran.rstudio.com")))
+
+dirs <- setupJaspDirs("flatpak_folder")
+# NOTE: if you change the flatpak_dir anywhere you must also change it in the flatpak builder script!
+
+Sys.setenv("RENV_PATHS_CACHE" = dirs["renv-cache"])
+Sys.setenv("RENV_PATHS_ROOT"  = dirs["renv-root"])
+
+# all jaspModules
+jaspModules <- paste0("jasp-stats/", Filter(function(x) startsWith(x, "jasp"), dir("~/github/jasp-desktop/Modules/")))
+names(jaspModules) <- basename(jaspModules)
+
+moduleEnvironments <- getModuleEnvironments(jaspModules)
+saveRDS(moduleEnvironments, file = file.path(dirs["module-environments"], "module-environments.rds"))
+# moduleEnvironments <- readRDS(file.path(dirs["module-environments"], "module-environments.rds"))
+# names(moduleEnvironments[[1]]$records)[1:5]
+
+installRecommendedPackages(dirs)
+
+cleanupBigPackages(dirs)
+
+createLocalPackageRepository(dirs)
+
+updateV8Rpackage(dirs)
+
+# TRUE implies all pkgs only appear once -- not sure what will happen when this is not true anymore
+# pkgs <- list.files("toplevelRepository/src/contrib/", pattern = "\\.tar\\.gz$")
+# all(table(sapply(strsplit(pkgs, "_", fixed = TRUE), `[`, 1)) == 1)
+
+downloadV8(dirs)
+copyRfiles(dirs)
+
+# debugonce(createTarArchive)
+info <- createTarArchive(dirs, verbose = FALSE, compression = "best")
+
+# update Rpackages.json & install build flatpak
+writeRpkgsJson("~/github/flatpak/org.jaspstats.JASP/RPackages.json", info)
+
+# IF you have ssh setup this will upload the tar.gz to static-jasp. It's nicer to do this via a terminal because there you see a progress bar
+# uploadTarArchive()

--- a/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
@@ -17,8 +17,13 @@ dirs <- setupJaspDirs("flatpak_folder")
 Sys.setenv("RENV_PATHS_CACHE" = dirs["renv-cache"])
 Sys.setenv("RENV_PATHS_ROOT"  = dirs["renv-root"])
 
-# all jaspModules
+# use the default branch of all modules -- always the latest version
 jaspModules <- paste0("jasp-stats/", Filter(function(x) startsWith(x, "jasp"), dir("~/github/jasp-desktop/Modules/")))
+
+# this uses the local versions -- but modules that are dependencies are still retrieved from github
+# isJaspModule <- function(path) file.exists(file.path(path, "DESCRIPTION")) && file.exists(file.path(path, "inst", "Description.qml"))
+# jaspModules <- Filter(isJaspModule, list.dirs("~/github/jasp-desktop/Modules", recursive = FALSE))
+
 names(jaspModules) <- basename(jaspModules)
 
 moduleEnvironments <- getModuleEnvironments(jaspModules)

--- a/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
@@ -30,17 +30,19 @@ installRecommendedPackages(dirs)
 
 cleanupBigPackages(dirs)
 
-downloadFakeV8(dirs)
+# downloadFakeV8(dirs)
+updateV8Rpackage(dirs)
 
 createLocalPackageRepository(dirs)
 
-# updateV8Rpackage(dirs)
-
-# TRUE implies all pkgs only appear once -- not sure what will happen when this is not true anymore
-# pkgs <- list.files("toplevelRepository/src/contrib/", pattern = "\\.tar\\.gz$")
-# all(table(sapply(strsplit(pkgs, "_", fixed = TRUE), `[`, 1)) == 1)
+# Test if multiple versions are present
+# pkgs <- list.files(file.path(dirs["local-cran"], "src", "contrib"), pattern = "\\.tar\\.gz$")
+# tb <- table(sapply(strsplit(pkgs, "_", fixed = TRUE), `[`, 1))
+# all(tb == 1)
+# tb[tb != 1] # these packages appear more than once
 
 # downloadV8(dirs)
+copyV8Lib(dirs)
 copyRfiles(dirs)
 
 # debugonce(createTarArchive)

--- a/Tools/flatpak/setup-rpkgs/R/flatpakRegenerateRenvStructure.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakRegenerateRenvStructure.R
@@ -38,15 +38,12 @@ options(renv.cache.linkable = TRUE)
 # remotes is called through loadNamespace somewhere..
 install.packages(c("renv", "remotes"))
 
-moduleEnvironments <- readRDS(file.path(dirs["module-environments"], "module-environments.rds"))
-
-
-dirV8 <- file.path(dirs["other-dependencies"], "v8")
-configureVars <- c(
-  V8 = sprintf("INCLUDE_DIR=%1$s/include LIB_DIR=%1$s/lib", dirV8)
-)
-options(configure.vars = configureVars)
-prettyCat(configureVars)
+# dirV8 <- file.path(dirs["other-dependencies"], "v8")
+# configureVars <- c(
+#   V8 = sprintf("INCLUDE_DIR=%1$s/include LIB_DIR=%1$s/lib", dirV8)
+# )
+# options(configure.vars = configureVars)
+# prettyCat(configureVars)
 
 renv::install("V8")
 

--- a/Tools/flatpak/setup-rpkgs/R/flatpakRegenerateRenvStructure.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakRegenerateRenvStructure.R
@@ -1,0 +1,59 @@
+# To run this locally, first run flatpakGeneratePkgsList.R and then do:
+# next, do:
+# setwd("flatpak_folder")
+
+
+helperfile <- list.files(pattern = "functions\\.R", full.names = TRUE, recursive = TRUE)
+source(helperfile)
+# source("flatpak-helper/r-helpers/functions.R")
+
+prettyCat(getwd())
+prettyCat(dir(getwd()))
+prettyCat(.libPaths())
+
+# these directories point to everything in the zip file
+dirs <- setupJaspDirs(clearAll = FALSE)
+prettyCat(dirs)
+
+# if you're running this locally, we pretend /app is just app so the code can be run
+dirApp <- if (dir.exists("/app")) "/app" else "app"
+dirLib64 <- file.path(dirApp, "lib64")
+flatpakDirs <- setupJaspDirs(dirLib64, jaspSubdir = "", clearAll = FALSE, renvOnly = TRUE)
+
+prettyCat(dirApp)
+prettyCat(dirLib64)
+prettyCat(flatpakDirs)
+
+Sys.setenv("RENV_PATHS_CACHE" = flatpakDirs["renv-cache"])
+Sys.setenv("RENV_PATHS_ROOT"  = flatpakDirs["renv-root"])
+
+options("repos" = c("local" = file.path("file:", dirs["local-cran"])))
+options(install.opts = "--no-html")
+options(renv.cache.linkable = TRUE)
+# options(renv.config.install.verbose = TRUE)
+
+# uncomment to test locally (and not pollute renv/library)
+# .libPaths(c(tempdir(), .libPaths()))
+
+# remotes is called through loadNamespace somewhere..
+install.packages(c("renv", "remotes"))
+
+moduleEnvironments <- readRDS(file.path(dirs["module-environments"], "module-environments.rds"))
+
+
+dirV8 <- file.path(dirs["other-dependencies"], "v8")
+configureVars <- c(
+  V8 = sprintf("INCLUDE_DIR=%1$s/include LIB_DIR=%1$s/lib", dirV8)
+)
+options(configure.vars = configureVars)
+prettyCat(configureVars)
+
+renv::install("V8")
+
+installJaspStats(c("jaspBase", "jaspGraphs"), dirs)
+
+prettyCat(setNames(lapply(.libPaths(), dir), .libPaths()))
+
+file.copy(from = dirs["local-cran"],                         to = dirLib64, recursive = TRUE)
+file.copy(from = dirs["local-github"],                       to = dirLib64, recursive = TRUE)
+file.copy(from = file.path(dirs["r-helpers"], "Rprofile.R"), to = dirLib64)

--- a/Tools/flatpak/setup-rpkgs/R/functions.R
+++ b/Tools/flatpak/setup-rpkgs/R/functions.R
@@ -1,0 +1,735 @@
+assignFunctionInPackage <- function(fun, name, package) {
+  # copied from jaspBase
+  ns <- getNamespace(package)
+  unlockBinding(name, ns)
+  assign(name, fun, ns)
+  lockBinding(name, ns)
+}
+
+packageFromUrl <- function(url) {
+  split <- strsplit(url, "/")[[1]]
+  if (grepl("github", url, fixed = TRUE)) {
+    idx <- which(split == "tarball")[1L]
+    return(split[idx - 1])
+  } else {
+    return(split[length(split) - 1])
+  }
+}
+
+stopEarlyExit <- function(message = "expected error: early exit", call = NULL, ...) {
+  err <- structure(
+    list(
+      message = message,
+      call = call,
+      ...
+    ),
+    class = c("earlyExit", "condition")
+  )
+  stop(err)
+}
+
+download_override <- function(url, destfile, mode = "wb", quiet = FALSE, headers = NULL) {
+
+  # this allows us to just use the standard renv construction for installing stuff
+  tryCatch({
+    options("renv.download.override" = NULL)
+    on.exit(options("renv.download.override" = download_override))
+
+    # a little bit hacky, but without the correct type the GITHUB_PAT is not used (and we really want that to be used)
+    type <- get("type", parent.frame(1))
+
+    file <- renv:::download(url, destfile, type = type, quiet = quiet, headers = headers)
+    if (!identical(type, "github")) {
+      maybecat(sprintf("skipping url: %s\n", url))
+    } else {
+
+      to <- file.path(dirs["local-github"], stripUrl(url))
+      maybecat(sprintf("recording github url: %s to %s\n", url, to))
+      if (file.exists(to))
+        maybecat(sprintf("%s already exists!", to))
+      file.copy(from = destfile, to = to, overwrite = TRUE)
+
+    }
+
+    # renv does need this, but we don't
+    if (endsWith(url, "PACKAGES.rds") || endsWith(destfile, ".json") || startsWith(basename(destfile), "renv-")) {
+      return(file)
+    }
+    # browser()
+    # maybecat(sprintf("recording url: %s, destfile: %s\n", url, destfile))
+    maybecat(sprintf("recording package url: %s\n", url))
+
+    # resultsEnv <- getResultsEnv()
+
+    storeUrl(url, destfile)
+
+    return(file)
+#
+#     # here we optionally download the package to a temporary directory (useful for testing a local CRAN repo)
+#     if (resultsEnv$downloadPkgs) {
+#     # renv expects this function to return where a package was downloaded
+#       path <- renv:::download(url, destfile, type = type, quiet = quiet, headers = headers)
+#
+#       maybe_copy(path)
+#
+#       if (resultsEnv$fromLockFile)
+#         stopEarlyExit()
+#
+#       return(path)
+#     } else {
+#
+#       if (resultsEnv$fromLockFile)
+#         stopEarlyExit()
+#
+#       file.copy(from = resultsEnv$fakepkgtar, to = destfile, overwrite = TRUE)
+#
+#       return(destfile)
+#     }
+
+    }, error = function(e) {
+      browser()
+    }
+  )
+
+}
+
+maybecat <- function(x) {
+  if (getResultsEnv()$debug) cat(x)
+}
+
+maybe_copy <- function(path) {
+  # if (dir.exists(resultsEnv$dirForPkgs) && !startsWith(basename(path), "renv-"))
+  #   file.copy(path, resultsEnv$dirForPkgs)
+}
+
+getResultsEnv <- function() get("resultsEnv", envir = .GlobalEnv)
+
+createResultsEnv <- function(dirForPkgs, downloadPkgs, fromLockFile = FALSE, debug = TRUE) {
+  if (exists("resultsEnv", envir = .GlobalEnv))
+    rm(list = "resultsEnv", envir = .GlobalEnv)
+  assign("resultsEnv", new.env(parent = .GlobalEnv), pos = .GlobalEnv)
+  resultsEnv <- getResultsEnv()
+  resultsEnv$index        <- 1L
+  resultsEnv$dirForPkgs   <- dirForPkgs
+  resultsEnv$downloadPkgs <- downloadPkgs
+  resultsEnv$fromLockFile <- fromLockFile
+  resultsEnv$debug        <- debug
+
+  # if (!downloadPkgs && !fromLockFile) {
+  #   fakepkgpath <- file.path(tempdir(), "fakepkg")
+  #   mkdir(fakepkgpath)
+  #
+  #   if (!file.exists(file.path(fakepkgpath, "fakepkg")))
+  #     utils::package.skeleton(name = "fakepkg", path = fakepkgpath)
+  #
+  #   fakepkgtar <- file.path(tempdir(), "fakepkgtar.tar.gz")
+  #   if (!file.exists(fakepkgtar)) {
+  #     oldwd <- getwd()
+  #     on.exit(setwd(oldwd), add = TRUE)
+  #     setwd(file.path(fakepkgpath))
+  #     tar(fakepkgtar, list.files(), compression = "gzip", tar = "tar")
+  #   }
+  #   resultsEnv$fakepkgtar <- fakepkgtar
+  # }
+
+
+  resultsEnv
+}
+
+storeUrl <- function(url, destfile) {
+  resultsEnv <- getResultsEnv()
+  # destfile <- file.path(resultsEnv$dirForPkgs, basename(destfile))
+
+  i <- resultsEnv$index
+
+  resultsEnv$url[i]       <- url
+  resultsEnv$destfile[i]  <- destfile
+  resultsEnv$index        <- resultsEnv$index + 1
+}
+
+stripUrl <- function(url) {
+  # since repos is hardcoded in renv:::renv_remotes_resolve_github_ref_impl and we modify host,
+  # this ooks like the safest approach
+  tolower(gsub("/+", "_", strsplit(url, "repos/", fixed = TRUE)[[1L]][2]))
+}
+
+mkdir <- function(x) if (!dir.exists(x)) dir.create(x, recursive = TRUE)
+
+hasRenvLockFile <- function(modulePkg) {
+  return(file.exists(file.path(modulePkg, "renv.lock")))
+}
+
+postProcessResults <- function() {
+
+  resultsEnv <- getResultsEnv()
+  resultsEnv$packages <- character(length(resultsEnv$url))
+  resultsEnv$version  <- character(length(resultsEnv$url))
+
+  idx_cran <- grep("src/contrib/",    resultsEnv$url)
+  temp <- strsplit(basename(resultsEnv$url[idx_cran]), "_", fixed = TRUE)
+
+  resultsEnv$packages[idx_cran] <- vapply(temp, `[`, character(1L), 1L)
+  resultsEnv$version [idx_cran] <- sub(".tar.gz$", "", vapply(temp, `[`, character(1L), 2L))
+  resultsEnv$source  [idx_cran] <- "repository"
+
+  idx_github <- grep("api.github.com/", resultsEnv$url)
+
+  resultsEnv$packages[idx_github] <- gsub(".*/(.+)/tarball/.*", "\\1", resultsEnv$url[idx_github])
+  resultsEnv$version [idx_github] <- basename(resultsEnv$url[idx_github]) # actually just the commit
+  resultsEnv$source  [idx_github] <- "github"
+
+  for (i in seq_along(resultsEnv$records))
+    if (isGitHubRecord(resultsEnv$records[[i]]))
+      resultsEnv$records[[i]]$Path <- makePathRelative(resultsEnv$records[[i]]$Path)
+
+  return(resultsEnv)
+}
+
+makePathRelative <- function(path, base = getwd()) {
+  gsub(pattern = paste0(base, .Platform$file.sep), replacement = "", x = path, fixed = TRUE)
+}
+
+getFlatpakJSONFromDESCRIPTION <- function(pathToModule, dirForPkgs = tempdir(), downloadPkgs = FALSE) {
+
+  if (!downloadPkgs)
+    warning("with downloadPkgs = FALSE dependencies of DEPENDENCIES won't show up in the results!", immediate. = TRUE)
+
+  # options("renv.download.override" = download_override)
+  # on.exit(options("renv.download.override" = NULL))
+
+  # oldinstall.opts <- options("install.opts")
+  # on.exit(options(install.opts = oldinstall.opts), add = TRUE)
+  # options(install.opts = "--no-byte-compile --no-test-load --fake --no-R --no-libs --no-data --no-help --no-demo --no-exec --no-inst")
+
+  # oldCache <- Sys.getenv("RENV_PATHS_CACHE")
+  # tempCache <- tempdir()
+  # if (dir.exists(file.path(tempCache, "v5")))
+  #   unlink(file.path(tempCache, "v5"), recursive = TRUE)
+  # Sys.setenv("RENV_PATHS_CACHE" = tempCache)
+  # on.exit(Sys.setenv("RENV_PATHS_CACHE" = oldCache), add = TRUE)
+
+  # old_renv_install <- renv:::renv_install
+  # on.exit(assignFunctionInPackage(old_renv_install, "renv_install", "renv"), add = TRUE)
+  # assignFunctionInPackage(identity, "renv_install", "renv")
+  #
+  # library <- file.path(dirForPkgs, "library")
+  # mkdir(library)
+  #
+  # resultsEnv <- createResultsEnv(dirForPkgs, downloadPkgs)
+  # records <- renv::install(packages = pathToModule, library = library, rebuild = TRUE, sources = "")
+  # resultsEnv$records <- records
+
+  library <- file.path(dirForPkgs, "library")
+  mkdir(library)
+  resultsEnv <- createResultsEnv(dirForPkgs, downloadPkgs)
+  resultsEnv$records <- customRenvInstall(packages = pathToModule, library = library, rebuild = TRUE)
+
+}
+
+customRenvInstall <- function(packages, library = NULL, rebuild = TRUE, customDownload = TRUE) {
+
+  if (customDownload) {
+    options("renv.download.override" = download_override)
+    on.exit(options("renv.download.override" = NULL))
+  }
+
+  old_renv_install <- renv:::renv_install
+  on.exit(assignFunctionInPackage(old_renv_install, "renv_install", "renv"), add = TRUE)
+  assignFunctionInPackage(identity, "renv_install", "renv")
+
+  renv::install(packages = packages, library = library, rebuild = rebuild)
+
+}
+
+installRecommendedPackages <- function(dirs) {
+
+  .libPaths()
+  installed <- installed.packages(.libPaths())
+  rec_pkgs <- unname(installed[installed[, "Priority"] %in% "recommended", "Package"])
+  customRenvInstall(rec_pkgs, customDownload = FALSE)
+
+  downloadRenv(file.path(dirs["local-cran"], "src", "contrib"))
+  downloadRemotes(file.path(dirs["local-cran"], "src", "contrib"))
+}
+
+getFlatpakJSONFromLockfile <- function(pathToModule, dirForPkgs = tempdir(), downloadPkgs = FALSE) {
+
+  options("renv.download.override" = download_override)
+  on.exit(options("renv.download.override" = NULL))
+
+  lockfile <- jsonlite::fromJSON(file.path(pathToModule, "renv.lock"))
+  records <- lockfile$Packages
+  records <- Filter(function(x) !x$Package %in% c("jaspTools", "jaspResults"), records)
+
+  nrecords <- length(records)
+
+  resultsEnv <- createResultsEnv(dirForPkgs, downloadPkgs, fromLockFile = TRUE)
+  resultsEnv$packages <- character(nrecords)
+  resultsEnv$url      <- character(nrecords)
+  resultsEnv$destfile <- character(nrecords)
+  resultsEnv$records  <- vector("list", nrecords)
+
+  pb <- utils::txtProgressBar(max = nrecords, style = 3)
+  on.exit(close(pb), add = TRUE)
+  for (i in seq_along(records)) {
+
+    # TODO: consider the same hack as in getFlatpakJSONFromDESCRIPTION to overwrite renv:::renv_install
+
+    tryCatch(
+      # rebuild ensures we bypass the cache
+      capture.output(renv::install(records[i], rebuild = TRUE, sources = "")),
+      earlyExit = function(e) {},
+      error = function(e) {
+        if (!identical(e[["message"]], "failed to retrieve 'Error: expected error: early exit\n' [expected error: early exit]")) {
+          browser(e)
+          print(paste("got an error:", e[["message"]]))
+        }
+      }
+    )
+
+    utils::setTxtProgressBar(pb, i)
+
+  }
+
+}
+
+getFlatpakJSONFromModule <- function(pathToModule, dirForPkgs = tempdir(), downloadPkgs = FALSE) {
+
+  mkdir(dirForPkgs)
+
+  # for now we assume no modules have a lockfile
+  # if (hasRenvLockFile(pathToModule)) {
+  #   getFlatpakJSONFromLockfile(pathToModule, dirForPkgs, downloadPkgs)
+  # } else {
+  getFlatpakJSONFromDESCRIPTION(pathToModule, dirForPkgs, downloadPkgs)
+  # }
+
+  postProcessResults()
+
+}
+
+# repository infrastructure
+createFolderStructure <- function(toplevel = file.path(getwd(), "toplevelRepository")) {
+
+  contrib  <- file.path(toplevel, "src", "contrib")
+  github   <- file.path(toplevel, "github")
+  mkdir(contrib)
+  mkdir(github)
+  return(c("root" = toplevel, "contrib" = contrib, "github" = github))
+
+}
+
+getPackageFilesBySource <- function(resultsEnv, source, invert = FALSE) {
+
+  idx <- if (invert) resultsEnv$source != source else resultsEnv$source == source
+  return(paste0(resultsEnv$packages[idx], "_", resultsEnv$version[idx], ".tar.gz"))
+
+}
+
+createLocalRepository <- function(contrib, sourcePkgsDir) {
+
+  # nonRepositoryPkgsNames <- Reduce(unique, lapply(
+  #   moduleEnvironments,
+  #   function(resultsEnv) getPackageFilesBySource(resultsEnv, "repository", invert = TRUE)
+  # ))
+
+  # repositoryPkgFiles <- setdiff(list.files(sourcePkgsDir, pattern = "\\.tar\\.gz$", recursive = TRUE), nonRepositoryPkgsNames)
+
+  repositoryPkgFiles <- list.files(sourcePkgsDir, pattern = "\\.tar\\.gz$", recursive = TRUE, full.names = TRUE)
+
+  file.copy(repositoryPkgFiles, to = file.path(contrib, basename(repositoryPkgFiles)))
+  tools::write_PACKAGES(contrib, type = "source")
+
+}
+
+createLocalGithubRepository <- function(resultsEnv, githubDir, sourcePkgsDir) {
+
+  githubPkgsNames <- getPackageFilesBySource(resultsEnv, "github")
+
+  githubRecords <- Filter(function(x) x[["Source"]] == "GitHub", resultsEnv$records)
+  temp <- vapply(githubRecords, function(x) paste0(x$Package, "_", x$RemoteSha, ".tar.gz"), character(1L))
+  githubPkgsNames <- githubPkgsNames[match(temp, githubPkgsNames)]
+
+  fmt <- "%s/repos/%s/%s/tarball/%s"
+  for (i in seq_along(githubRecords)) {
+    record <- githubRecords[[i]]
+    newPath <- file.path(githubDir, sprintf(fmt, record$RemoteUsername, record$RemoteRepo, record$RemoteSha, githubPkgsNames[i]))
+    mkdir(dirname(newPath))
+    file.copy(file.path(sourcePkgsDir, githubPkgsNames[i]), newPath)
+  }
+
+}
+
+createLocalPackageRepository <- function(dirs) {
+
+  sourcePkgsDir <- file.path(dirs["renv-root"], "source", "repository")
+
+  paths <- createFolderStructure(dirs["local-cran"])
+
+  createLocalRepository(paths[["contrib"]], sourcePkgsDir)
+  # createLocalGithubRepository(resultsEnv, paths[["github"]],  sourcePkgsDir)
+  paths
+}
+
+setupJaspDirs <- function(root = getwd(), jaspSubdir = "jasp-build", flatpakSubdir = "flatpak-helper", clearAll = FALSE, renvOnly = FALSE) {
+
+  paths <- c(
+    # folder structure should be identical to JASP
+    "Modules"    = file.path(root, jaspSubdir, "Modules"),
+    "renv-cache" = file.path(root, jaspSubdir, "renv-cache"),
+    "renv-root"  = file.path(root, jaspSubdir, "renv-root"),
+
+    # this directories are only relevant for building flatpak
+    "module-environments" = file.path(root, flatpakSubdir, "module-environments"),
+    "other-dependencies"  = file.path(root, flatpakSubdir, "other-dependencies"),
+    "r-helpers"           = file.path(root, flatpakSubdir, "r-helpers"),
+    "local-cran"          = file.path(root, flatpakSubdir, "local-cran"),
+    "local-github"        = file.path(root, flatpakSubdir, "local-github"),
+    "root"                = root,
+    "jasp-subdir"         = file.path(root, jaspSubdir),
+    "flatpak-dir"         = file.path(root, flatpakSubdir)
+  )
+
+  if (renvOnly)
+    paths <- paths[startsWith(names(paths), "renv-")]
+
+  if (clearAll)
+    lapply(paths, unlink, recursive = TRUE)
+
+  lapply(paths, mkdir)
+
+  return(sapply(paths, normalizePath))
+}
+
+getModuleEnvironments <- function(jaspModules) {
+  moduleEnvironments <- setNames(vector("list", length(jaspModules)), names(jaspModules))
+
+  for (url in jaspModules) {
+    nm <- basename(url)
+    moduleEnvironments[[nm]] <- getFlatpakJSONFromModule(url, downloadPkgs = TRUE)
+  }
+  return(moduleEnvironments)
+}
+
+installGitHubRecords <- function(githubRecords, tempLib) {
+
+  # pretend the github packages are local packages (which they are)
+  # the order of githubRecords follows the order of the obtained URLs so the module of interest is always last
+  for (temprecord in githubRecords) {
+    record <- list(list(
+      Package   = temprecord[["Package"]],
+      Version   = temprecord[["Version"]],
+      Path      = fixLocalPath(temprecord[["Path"]]), # renv requires an absolute path
+      Source    = "Local",
+      Cacheable = TRUE
+    ))
+    names(record) <- temprecord[["Package"]]
+    print("installing record:")
+    print(record)
+    renv::install(record, library = tempLib, project = tempLib[1])
+  }
+
+}
+
+fixLocalPath <- function(path) {
+
+  # TODO: this function is unnessecary if we'd store the correct path immediately!
+  # the problem is that if you modify flatpakGeneratePkgsList, this might modify the path
+  # and this function is a convenient fallback
+
+  # .. I should really delete this
+  path <- sub(pattern = "jasp_build", replacement = "jasp-build", x = path, fixed = TRUE)
+
+  cat("wd:\t", getwd(), "\ndir():\t", dir(getwd()), "\npath:\t", path, '\n')
+  cat(file.path(getwd(), path), "\n")
+  if (file.exists(path))
+    return(normalizePath(path))
+
+
+  print(dir(file.path(getwd(), "jasp-build", "renv-root/source/github/jaspBase/")))
+  print(dir(file.path(getwd(), "jasp-build", "renv-root/source/github/")))
+  print(dir(file.path(getwd(), "jasp-build", "renv-root/source/")))
+
+  orgpath <- path
+  oldpath <- path
+  newpath <- sub("[^/]+/", "", oldpath)
+
+  # drop the highest directory until the thingy exists
+  while (oldpath != newpath) {
+    cat(sprintf("trying path %s\n", file.path(getwd(), newpath)))
+    if (file.exists(file.path(getwd(), newpath)))
+        return(normalizePath(file.path(getwd(), newpath)))
+    oldpath <- newpath
+    newpath <- sub("[^/]+/", "", newpath)
+  }
+  stop(sprintf("Could not make this path work: %s", orgpath))
+
+}
+
+isGitHubRecord <- function(x) {
+  x[["Source"]] == "GitHub"
+}
+
+installModules <- function(dirs, moduleEnvironments) {
+
+  moduleNames <- names(moduleEnvironments)
+  for (i in seq_along(moduleEnvironments)) {
+
+    env <- moduleEnvironments[[i]]
+    githubRecords <- Filter(isGitHubRecord, env$records)
+
+    lib <- file.path(dirs["Modules"], moduleNames[i])
+    unlink(lib, recursive = TRUE)
+    mkdir(lib)
+
+    # we use here the last libPaths. Usually that one only contains the default packages (e.g., when using renv)
+    # when this also contains other packages, the installation behavior might differ from flatpak
+    libpaths <- .libPaths()
+    installGitHubRecords(githubRecords, c(normalizePath(lib), libpaths[length(libpaths)]))
+
+  }
+
+}
+
+downloadFile <- function(url, destdir) {
+  mkdir(destdir)
+  destfile <- file.path(destdir, basename(url))
+  download.file(url = url, destfile = destfile)
+  return(destfile)
+}
+
+downloadRenv <- function(destdir) {
+  # TODO: don't hardcode the renv version? maybe use 1 older than the current release so the url always works?
+  downloadFile("https://cran.r-project.org/src/contrib/renv_0.13.2.tar.gz", destdir)
+}
+
+downloadRemotes <- function(destdir) {
+  downloadFile("https://cran.r-project.org/src/contrib/remotes_2.4.0.tar.gz", destdir)
+}
+
+downloadV8 <- function(dirs) {
+
+  # see https://github.com/jeroen/V8/blob/master/configure#L61
+  # this might need to be updated from time to time!
+  tarfile <- downloadFile("http://jeroen.github.io/V8/v8-8.3.110.13-linux.tar.gz", dirs["other-dependencies"])
+  untar(tarfile, exdir = dirs["other-dependencies"]) # otherwise we need to do this on flatpak
+  unlink(tarfile)
+  # delelte all the ._ files?
+  # unlink(list.files(path = dirs["other-dependencies"], pattern = "\\._(.+)", recursive = TRUE, full.names = TRUE))
+
+}
+
+copyRfiles <- function(dirs) {
+  file.copy(from = list.files("R", pattern = "*\\.R$", full.names = TRUE), to = dirs["r-helpers"], overwrite = TRUE)
+}
+
+createTarArchive <- function(dirs, outputPath = "archives/flatpak_archive.tar.gz", compression = c("fast", "none", "best"),
+                             verbose = TRUE, update = FALSE) {
+
+  # TODO: update does not work
+
+  if (update && !identical(compression[1L], "none")) {
+    warning("can only update when compression is 'none'! Not updating instead.", immediate. = TRUE)
+    update <- FALSE
+  }
+
+  if (!is.numeric(compression)) {
+    compression <- match.arg(compression)
+    compression <- switch(compression,
+      "none" = "",
+      "best" = "-I 'gzip -9'",
+      "fast" = "-I 'gzip -1'"
+    )
+  } else if (!is.numeric(compression) || (is.numeric(compression) && !(compression >= 1 && compression <= 9))) {
+    stop("compression must be character ('best' or 'fast') or numeric (1-9)")
+  }
+
+  dirsForArchive <- dirs["flatpak-dir"]
+  # dirsForArchive <- c(dirs["flatpak-dir"], file.path(dirs["renv-root"], "source", "github"))
+
+  # files <- file.path("..", basename(getwd()), makePathRelative(dirsForArchive))
+  files <- makePathRelative(dirsForArchive, base = dirname(dirs["root"]))
+
+  mkdir(dirname(outputPath))
+
+  creatArchive <- sprintf(
+    "tar %s -%s%sf %s %s",
+    compression,
+    if (verbose) "v" else "",
+    if (update)  "u" else "c",
+    outputPath,
+    paste(files, collapse = " ")
+  )
+  cat('running: ', creatArchive, '\n')
+  system(creatArchive)
+
+  sha256 <- strsplit(system2("sha256sum", outputPath, stdout = TRUE), " ", fixed = TRUE)[[1]][1]
+  cat("\nsha256sum\n")
+  cat(sha256, '\n')
+
+  rfile <- makePathRelative(file.path(dirs["r-helpers"], "flatpakRegenerateRenvStructure.R"), base = dirs["root"])
+  cat(sprintf("command for flatpak\nR --vanilla --file=%s\n", rfile))
+
+  return(c(
+    "tar-file" = outputPath,
+    "sha256"   = sha256,
+    "r-file"   = rfile
+  ))
+}
+
+uploadTarArchive <- function(archivePath = "archives/flatpak_archive.tar.gz") {
+
+  if (!file.exists(archivePath))
+    stop("Archive does not exist")
+
+  archivePath <- normalizePath(archivePath)
+
+  cmd <- sprintf("scp %s jonathonlove@static.jasp-stats.org:static.jasp-stats.org/flatpak_archive.tar.gz", archivePath)
+  system(cmd)
+
+}
+
+writeRpkgsJson <- function(path, info, local = FALSE) {
+
+  template <- '{
+	"name": "RPackages2",
+	"buildsystem": "simple",
+	"build-commands": [],
+	"modules":
+	[
+		{
+			"name": "Rpackages",
+			"buildsystem": "simple",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "%s",
+					"sha256": "%s"
+				}
+			],
+			"build-commands": [ "R --vanilla --file=%s" ]
+		}
+	]
+}
+'
+
+  location <- if (local) {
+    file.path("file:/", normalizePath(info["tar-file"]))
+  } else {
+    "http://static.jasp-stats.org/flatpak_archive.tar.gz"
+  }
+
+  new <- sprintf(template, location, info["sha256"], info["r-file"])
+  writeLines(new, path)
+
+}
+
+prettyCat <- function(x) {
+  name <- deparse(substitute(x))
+  if (is.list(x)) {
+    cat(name, '\n')
+    cat(unlist(lapply(seq_along(x), function(i) paste(c(names(x[i]), x[[i]]), collapse = "\n"))), sep = '\n\n')
+  } else if (!is.null(names(x)))
+    cat(name, '\n', paste(format(names(x)), unname(x), sep = '\t', collapse = '\n'), '\n', sep = "")
+  else if (length(x) == 1L)
+    cat(name, '\t', x, '\n', sep = "")
+  else
+    cat(name, '\n', paste(x, collapse = '\n'), '\n', sep = "")
+}
+
+updateV8Rpackage <- function(dirs) {
+
+  pathV8 <- list.files(file.path(dirs["local-cran"], "src", "contrib"), pattern = "^V8_*", full.names = TRUE)
+  dirTemp <- file.path(tempdir(), "V8_fix")
+  mkdir(dirTemp)
+  untar(tarfile = pathV8, exdir = dirTemp)
+  dirTempV8 <- file.path(dirTemp, "V8")
+  configureLines <- readLines(file.path(dirTempV8, "configure"))
+  configureLines[startsWith(configureLines, "PKG_LIBS=\"-lv8")] <- "PKG_LIBS=\"-lv8_monolith\""
+  configureLines[startsWith(configureLines, "PKG_CFLAGS=\"-I/usr/include/v8")] <- "PKG_CFLAGS=\"\""
+  writeLines(configureLines, file.path(dirTempV8, "configure"))
+
+  newPathV8 <- file.path(dirTemp, basename(pathV8))
+  oldwd <- getwd()
+  on.exit(setwd(oldwd))
+  setwd(dirTemp)
+  tar(tarfile = newPathV8, files = "V8", compression = "gzip")
+
+  file.copy(from = newPathV8, to = pathV8, overwrite = TRUE)
+
+}
+
+installJaspStats <- function(pkgs, dirs) {
+
+  paths <- character(length(pkgs))
+  for (i in seq_along(pkgs)) {
+    pathsFound <- list.files(path = dirs["local-github"], pattern = sprintf("^jasp-stats_%s_tarball_", tolower(pkgs[i])), full.names = TRUE)
+    if (length(pathsFound) != 1L)
+      stop("There are ", if (length(pathsFound) < 1L) "zero" else "multiple", " ", pkgs[i], "_*.tar.gz present!")
+    paths[i] <- pathsFound
+  }
+
+  prettyCat(paths)
+
+  for (path in paths) {
+    pathtemp <- tempfile(fileext = ".tar.gz")
+    file.copy(path, to = pathtemp)
+    renv::install(pathtemp)
+  }
+
+}
+
+makeTar <- function(pathOriginal, dirTemp) {
+
+  newPathV8 <- file.path(dirTemp, basename(pathOriginal))
+  oldwd <- getwd()
+  on.exit(setwd(oldwd))
+  setwd(dir)
+  tar(tarfile = newPathV8, files = "V8", compression = "gzip")
+
+  file.copy(from = newPathV8, to = pathOriginal, overwrite = TRUE)
+
+}
+
+cleanupBigPackages <- function(dirs) {
+
+  oldwd <- getwd()
+  on.exit(setwd(oldwd))
+  paths <- list.files(dirs["local-github"], pattern = "*_tarball_*", full.names = TRUE)
+
+  mkdir2 <- function(x) {
+    if (dir.exists(x)) unlink(x, recursive = TRUE)
+    mkdir(x)
+  }
+
+  dirTemp <- file.path(tempdir(), "resize-github-pkgs")
+  mkdir2(dirTemp)
+
+  rpath <- file.path(Sys.getenv("R_HOME"), "bin", "R")
+
+  for (i in seq_along(paths)) {
+
+    path <- paths[i]
+    dirTempPkg <- file.path(dirTemp, basename(path))
+    mkdir2(dirTempPkg)
+    untar(path, exdir = dirTempPkg)
+
+    newPath <- file.path(dirTempPkg, dir(dirTempPkg))
+
+    unlink(file.path(newPath, c(
+      "vignettes",
+      "tests"
+    )), recursive = TRUE)
+
+    dirTemp2 <- file.path(tempdir(), basename(path))
+    mkdir2(dirTemp2)
+
+    setwd(dirTemp2)
+    cmd <- sprintf("%s CMD build --no-build-vignettes --no-manual --resave-data %s", rpath, newPath)
+    system(cmd)
+
+    file.copy(from = dir(dirTemp2), to = path, overwrite = TRUE)
+
+  }
+
+}

--- a/Tools/flatpak/setup-rpkgs/README.md
+++ b/Tools/flatpak/setup-rpkgs/README.md
@@ -1,0 +1,1 @@
+Helper functions to JASP work on flatpak

--- a/Tools/flatpak/setup-rpkgs/TODO.md
+++ b/Tools/flatpak/setup-rpkgs/TODO.md
@@ -10,7 +10,7 @@
   - [x] a. how to update jasp? can look at specific commit I guess
 
 - [x] 7. can we do without the custom download script? No we can't
-- [ ] 8. make this a github repo and push it (too much work went into it already!)
+- [x] 8. make this a github repo and push it (too much work went into it already!)
 - [x] 9. add renv to the local CRAN repo and install it from there!
 
 - [x] 10. Somehow put stuff in /app/lib64/

--- a/Tools/flatpak/setup-rpkgs/TODO.md
+++ b/Tools/flatpak/setup-rpkgs/TODO.md
@@ -23,12 +23,4 @@
 
 - [ ] 14. The moduleEnvironments object is no longer necessary. It's probably useful for debugging to create it but it shouldn't be in the archive.
 
-# BONUS
-
-- [x] 1. Clean out the massive pile of shit that some people put in uncommon directories.
-         At least flexplot/vignettes/* & flexplot/flexplot.jmo should be deleted.
-- [ ] 2. delete ._v8?
-- [x] 3. Don't install helpfiles and stuff
-- [x] 4. Don't compress the archive locally so it can be updated. No bad idea.
-- [ ] 5. the url for github should be case insensitive (since web urls are, but remotes specification is not)
-  - a. [ ] Test the above.
+- [ ] 15. Reduce the size of the flatpak object (1.2 GB is a bit much). Check if unnecessary stuff is actually deleted (like local-github)

--- a/Tools/flatpak/setup-rpkgs/TODO.md
+++ b/Tools/flatpak/setup-rpkgs/TODO.md
@@ -1,0 +1,34 @@
+# TODO:
+
+- [x] 1. make sure the installed packages are actually symlinks
+- [x] 2. make a neat interface to loop over all modules (folder structure identical to JASP!)
+- [x] 3. test it for 4-5 modules
+- [ ] 4. look at how multiple versions are handled within a custom CRAN repo! test if renv::install(@version) works!
+- [x] 5. bundle an renv tar.gz into this and make sure we can install it separately!
+
+- [x] 6. look into running flatpak locally
+  - [x] a. how to update jasp? can look at specific commit I guess
+
+- [x] 7. can we do without the custom download script? No we can't
+- [ ] 8. make this a github repo and push it (too much work went into it already!)
+- [x] 9. add renv to the local CRAN repo and install it from there!
+
+- [x] 10. Somehow put stuff in /app/lib64/
+- [x] 11. Don't install all the r packages, only V8, renv, and jaspBase. + jaspGraphs
+
+- [x] 12. Upload the big tar.gz to static.
+
+- [ ] 13. There are messages about "package is not available" (devtools, roxygen2, etc.)
+  - a. [ ] figure out if we can get these by also downloading Suggests!
+
+- [ ] 14. The moduleEnvironments object is no longer necessary. It's probably useful for debugging to create it but it shouldn't be in the archive.
+
+# BONUS
+
+- [x] 1. Clean out the massive pile of shit that some people put in uncommon directories.
+         At least flexplot/vignettes/* & flexplot/flexplot.jmo should be deleted.
+- [ ] 2. delete ._v8?
+- [x] 3. Don't install helpfiles and stuff
+- [x] 4. Don't compress the archive locally so it can be updated. No bad idea.
+- [ ] 5. the url for github should be case insensitive (since web urls are, but remotes specification is not)
+  - a. [ ] Test the above.

--- a/Tools/flatpak/setup-rpkgs/renv.lock
+++ b/Tools/flatpak/setup-rpkgs/renv.lock
@@ -1,0 +1,20 @@
+{
+  "R": {
+    "Version": "4.1.0",
+    "Repositories": [
+      {
+        "Name": "CRAN",
+        "URL": "https://cran.rstudio.com"
+      }
+    ]
+  },
+  "Packages": {
+    "renv": {
+      "Package": "renv",
+      "Version": "0.13.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "079cb1f03ff972b30401ed05623cbe92"
+    }
+  }
+}

--- a/Tools/flatpak/setup-rpkgs/renv/.gitignore
+++ b/Tools/flatpak/setup-rpkgs/renv/.gitignore
@@ -1,0 +1,5 @@
+library/
+local/
+lock/
+python/
+staging/

--- a/Tools/flatpak/setup-rpkgs/renv/activate.R
+++ b/Tools/flatpak/setup-rpkgs/renv/activate.R
@@ -1,0 +1,654 @@
+
+local({
+
+  # the requested version of renv
+  version <- "0.13.2"
+
+  # the project directory
+  project <- getwd()
+
+  # avoid recursion
+  if (!is.na(Sys.getenv("RENV_R_INITIALIZING", unset = NA)))
+    return(invisible(TRUE))
+
+  # signal that we're loading renv during R startup
+  Sys.setenv("RENV_R_INITIALIZING" = "true")
+  on.exit(Sys.unsetenv("RENV_R_INITIALIZING"), add = TRUE)
+
+  # signal that we've consented to use renv
+  options(renv.consent = TRUE)
+
+  # load the 'utils' package eagerly -- this ensures that renv shims, which
+  # mask 'utils' packages, will come first on the search path
+  library(utils, lib.loc = .Library)
+
+  # check to see if renv has already been loaded
+  if ("renv" %in% loadedNamespaces()) {
+
+    # if renv has already been loaded, and it's the requested version of renv,
+    # nothing to do
+    spec <- .getNamespaceInfo(.getNamespace("renv"), "spec")
+    if (identical(spec[["version"]], version))
+      return(invisible(TRUE))
+
+    # otherwise, unload and attempt to load the correct version of renv
+    unloadNamespace("renv")
+
+  }
+
+  # load bootstrap tools   
+  bootstrap <- function(version, library) {
+  
+    # attempt to download renv
+    tarball <- tryCatch(renv_bootstrap_download(version), error = identity)
+    if (inherits(tarball, "error"))
+      stop("failed to download renv ", version)
+  
+    # now attempt to install
+    status <- tryCatch(renv_bootstrap_install(version, tarball, library), error = identity)
+    if (inherits(status, "error"))
+      stop("failed to install renv ", version)
+  
+  }
+  
+  renv_bootstrap_tests_running <- function() {
+    getOption("renv.tests.running", default = FALSE)
+  }
+  
+  renv_bootstrap_repos <- function() {
+  
+    # check for repos override
+    repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
+    if (!is.na(repos))
+      return(repos)
+  
+    # if we're testing, re-use the test repositories
+    if (renv_bootstrap_tests_running())
+      return(getOption("renv.tests.repos"))
+  
+    # retrieve current repos
+    repos <- getOption("repos")
+  
+    # ensure @CRAN@ entries are resolved
+    repos[repos == "@CRAN@"] <- getOption(
+      "renv.repos.cran",
+      "https://cloud.r-project.org"
+    )
+  
+    # add in renv.bootstrap.repos if set
+    default <- c(FALLBACK = "https://cloud.r-project.org")
+    extra <- getOption("renv.bootstrap.repos", default = default)
+    repos <- c(repos, extra)
+  
+    # remove duplicates that might've snuck in
+    dupes <- duplicated(repos) | duplicated(names(repos))
+    repos[!dupes]
+  
+  }
+  
+  renv_bootstrap_download <- function(version) {
+  
+    # if the renv version number has 4 components, assume it must
+    # be retrieved via github
+    nv <- numeric_version(version)
+    components <- unclass(nv)[[1]]
+  
+    methods <- if (length(components) == 4L) {
+      list(
+        renv_bootstrap_download_github
+      )
+    } else {
+      list(
+        renv_bootstrap_download_cran_latest,
+        renv_bootstrap_download_cran_archive
+      )
+    }
+  
+    for (method in methods) {
+      path <- tryCatch(method(version), error = identity)
+      if (is.character(path) && file.exists(path))
+        return(path)
+    }
+  
+    stop("failed to download renv ", version)
+  
+  }
+  
+  renv_bootstrap_download_impl <- function(url, destfile) {
+  
+    mode <- "wb"
+  
+    # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17715
+    fixup <-
+      Sys.info()[["sysname"]] == "Windows" &&
+      substring(url, 1L, 5L) == "file:"
+  
+    if (fixup)
+      mode <- "w+b"
+  
+    utils::download.file(
+      url      = url,
+      destfile = destfile,
+      mode     = mode,
+      quiet    = TRUE
+    )
+  
+  }
+  
+  renv_bootstrap_download_cran_latest <- function(version) {
+  
+    spec <- renv_bootstrap_download_cran_latest_find(version)
+  
+    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+  
+    type  <- spec$type
+    repos <- spec$repos
+  
+    info <- tryCatch(
+      utils::download.packages(
+        pkgs    = "renv",
+        destdir = tempdir(),
+        repos   = repos,
+        type    = type,
+        quiet   = TRUE
+      ),
+      condition = identity
+    )
+  
+    if (inherits(info, "condition")) {
+      message("FAILED")
+      return(FALSE)
+    }
+  
+    # report success and return
+    message("OK (downloaded ", type, ")")
+    info[1, 2]
+  
+  }
+  
+  renv_bootstrap_download_cran_latest_find <- function(version) {
+  
+    # check whether binaries are supported on this system
+    binary <-
+      getOption("renv.bootstrap.binary", default = TRUE) &&
+      !identical(.Platform$pkgType, "source") &&
+      !identical(getOption("pkgType"), "source") &&
+      Sys.info()[["sysname"]] %in% c("Darwin", "Windows")
+  
+    types <- c(if (binary) "binary", "source")
+  
+    # iterate over types + repositories
+    for (type in types) {
+      for (repos in renv_bootstrap_repos()) {
+  
+        # retrieve package database
+        db <- tryCatch(
+          as.data.frame(
+            utils::available.packages(type = type, repos = repos),
+            stringsAsFactors = FALSE
+          ),
+          error = identity
+        )
+  
+        if (inherits(db, "error"))
+          next
+  
+        # check for compatible entry
+        entry <- db[db$Package %in% "renv" & db$Version %in% version, ]
+        if (nrow(entry) == 0)
+          next
+  
+        # found it; return spec to caller
+        spec <- list(entry = entry, type = type, repos = repos)
+        return(spec)
+  
+      }
+    }
+  
+    # if we got here, we failed to find renv
+    fmt <- "renv %s is not available from your declared package repositories"
+    stop(sprintf(fmt, version))
+  
+  }
+  
+  renv_bootstrap_download_cran_archive <- function(version) {
+  
+    name <- sprintf("renv_%s.tar.gz", version)
+    repos <- renv_bootstrap_repos()
+    urls <- file.path(repos, "src/contrib/Archive/renv", name)
+    destfile <- file.path(tempdir(), name)
+  
+    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+  
+    for (url in urls) {
+  
+      status <- tryCatch(
+        renv_bootstrap_download_impl(url, destfile),
+        condition = identity
+      )
+  
+      if (identical(status, 0L)) {
+        message("OK")
+        return(destfile)
+      }
+  
+    }
+  
+    message("FAILED")
+    return(FALSE)
+  
+  }
+  
+  renv_bootstrap_download_github <- function(version) {
+  
+    enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
+    if (!identical(enabled, "TRUE"))
+      return(FALSE)
+  
+    # prepare download options
+    pat <- Sys.getenv("GITHUB_PAT")
+    if (nzchar(Sys.which("curl")) && nzchar(pat)) {
+      fmt <- "--location --fail --header \"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "curl", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    } else if (nzchar(Sys.which("wget")) && nzchar(pat)) {
+      fmt <- "--header=\"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "wget", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    }
+  
+    message("* Downloading renv ", version, " from GitHub ... ", appendLF = FALSE)
+  
+    url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
+    name <- sprintf("renv_%s.tar.gz", version)
+    destfile <- file.path(tempdir(), name)
+  
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
+      condition = identity
+    )
+  
+    if (!identical(status, 0L)) {
+      message("FAILED")
+      return(FALSE)
+    }
+  
+    message("OK")
+    return(destfile)
+  
+  }
+  
+  renv_bootstrap_install <- function(version, tarball, library) {
+  
+    # attempt to install it into project library
+    message("* Installing renv ", version, " ... ", appendLF = FALSE)
+    dir.create(library, showWarnings = FALSE, recursive = TRUE)
+  
+    # invoke using system2 so we can capture and report output
+    bin <- R.home("bin")
+    exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
+    r <- file.path(bin, exe)
+    args <- c("--vanilla", "CMD", "INSTALL", "-l", shQuote(library), shQuote(tarball))
+    output <- system2(r, args, stdout = TRUE, stderr = TRUE)
+    message("Done!")
+  
+    # check for successful install
+    status <- attr(output, "status")
+    if (is.numeric(status) && !identical(status, 0L)) {
+      header <- "Error installing renv:"
+      lines <- paste(rep.int("=", nchar(header)), collapse = "")
+      text <- c(header, lines, output)
+      writeLines(text, con = stderr())
+    }
+  
+    status
+  
+  }
+  
+  renv_bootstrap_platform_prefix <- function() {
+  
+    # construct version prefix
+    version <- paste(R.version$major, R.version$minor, sep = ".")
+    prefix <- paste("R", numeric_version(version)[1, 1:2], sep = "-")
+  
+    # include SVN revision for development versions of R
+    # (to avoid sharing platform-specific artefacts with released versions of R)
+    devel <-
+      identical(R.version[["status"]],   "Under development (unstable)") ||
+      identical(R.version[["nickname"]], "Unsuffered Consequences")
+  
+    if (devel)
+      prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
+  
+    # build list of path components
+    components <- c(prefix, R.version$platform)
+  
+    # include prefix if provided by user
+    prefix <- renv_bootstrap_platform_prefix_impl()
+    if (!is.na(prefix) && nzchar(prefix))
+      components <- c(prefix, components)
+  
+    # build prefix
+    paste(components, collapse = "/")
+  
+  }
+  
+  renv_bootstrap_platform_prefix_impl <- function() {
+  
+    # if an explicit prefix has been supplied, use it
+    prefix <- Sys.getenv("RENV_PATHS_PREFIX", unset = NA)
+    if (!is.na(prefix))
+      return(prefix)
+  
+    # if the user has requested an automatic prefix, generate it
+    auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
+    if (auto %in% c("TRUE", "True", "true", "1"))
+      return(renv_bootstrap_platform_prefix_auto())
+  
+    # empty string on failure
+    ""
+  
+  }
+  
+  renv_bootstrap_platform_prefix_auto <- function() {
+  
+    prefix <- tryCatch(renv_bootstrap_platform_os(), error = identity)
+    if (inherits(prefix, "error") || prefix %in% "unknown") {
+  
+      msg <- paste(
+        "failed to infer current operating system",
+        "please file a bug report at https://github.com/rstudio/renv/issues",
+        sep = "; "
+      )
+  
+      warning(msg)
+  
+    }
+  
+    prefix
+  
+  }
+  
+  renv_bootstrap_platform_os <- function() {
+  
+    sysinfo <- Sys.info()
+    sysname <- sysinfo[["sysname"]]
+  
+    # handle Windows + macOS up front
+    if (sysname == "Windows")
+      return("windows")
+    else if (sysname == "Darwin")
+      return("macos")
+  
+    # check for os-release files
+    for (file in c("/etc/os-release", "/usr/lib/os-release"))
+      if (file.exists(file))
+        return(renv_bootstrap_platform_os_via_os_release(file, sysinfo))
+  
+    # check for redhat-release files
+    if (file.exists("/etc/redhat-release"))
+      return(renv_bootstrap_platform_os_via_redhat_release())
+  
+    "unknown"
+  
+  }
+  
+  renv_bootstrap_platform_os_via_os_release <- function(file, sysinfo) {
+  
+    # read /etc/os-release
+    release <- utils::read.table(
+      file             = file,
+      sep              = "=",
+      quote            = c("\"", "'"),
+      col.names        = c("Key", "Value"),
+      comment.char     = "#",
+      stringsAsFactors = FALSE
+    )
+  
+    vars <- as.list(release$Value)
+    names(vars) <- release$Key
+  
+    # get os name
+    os <- tolower(sysinfo[["sysname"]])
+  
+    # read id
+    id <- "unknown"
+    for (field in c("ID", "ID_LIKE")) {
+      if (field %in% names(vars) && nzchar(vars[[field]])) {
+        id <- vars[[field]]
+        break
+      }
+    }
+  
+    # read version
+    version <- "unknown"
+    for (field in c("UBUNTU_CODENAME", "VERSION_CODENAME", "VERSION_ID", "BUILD_ID")) {
+      if (field %in% names(vars) && nzchar(vars[[field]])) {
+        version <- vars[[field]]
+        break
+      }
+    }
+  
+    # join together
+    paste(c(os, id, version), collapse = "-")
+  
+  }
+  
+  renv_bootstrap_platform_os_via_redhat_release <- function() {
+  
+    # read /etc/redhat-release
+    contents <- readLines("/etc/redhat-release", warn = FALSE)
+  
+    # infer id
+    id <- if (grepl("centos", contents, ignore.case = TRUE))
+      "centos"
+    else if (grepl("redhat", contents, ignore.case = TRUE))
+      "redhat"
+    else
+      "unknown"
+  
+    # try to find a version component (very hacky)
+    version <- "unknown"
+  
+    parts <- strsplit(contents, "[[:space:]]")[[1L]]
+    for (part in parts) {
+  
+      nv <- tryCatch(numeric_version(part), error = identity)
+      if (inherits(nv, "error"))
+        next
+  
+      version <- nv[1, 1]
+      break
+  
+    }
+  
+    paste(c("linux", id, version), collapse = "-")
+  
+  }
+  
+  renv_bootstrap_library_root_name <- function(project) {
+  
+    # use project name as-is if requested
+    asis <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT_ASIS", unset = "FALSE")
+    if (asis)
+      return(basename(project))
+  
+    # otherwise, disambiguate based on project's path
+    id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
+    paste(basename(project), id, sep = "-")
+  
+  }
+  
+  renv_bootstrap_library_root <- function(project) {
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
+    if (!is.na(path))
+      return(path)
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
+    if (!is.na(path)) {
+      name <- renv_bootstrap_library_root_name(project)
+      return(file.path(path, name))
+    }
+  
+    prefix <- renv_bootstrap_profile_prefix()
+    paste(c(project, prefix, "renv/library"), collapse = "/")
+  
+  }
+  
+  renv_bootstrap_validate_version <- function(version) {
+  
+    loadedversion <- utils::packageDescription("renv", fields = "Version")
+    if (version == loadedversion)
+      return(TRUE)
+  
+    # assume four-component versions are from GitHub; three-component
+    # versions are from CRAN
+    components <- strsplit(loadedversion, "[.-]")[[1]]
+    remote <- if (length(components) == 4L)
+      paste("rstudio/renv", loadedversion, sep = "@")
+    else
+      paste("renv", loadedversion, sep = "@")
+  
+    fmt <- paste(
+      "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
+      "Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
+      "Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
+      sep = "\n"
+    )
+  
+    msg <- sprintf(fmt, loadedversion, version, remote)
+    warning(msg, call. = FALSE)
+  
+    FALSE
+  
+  }
+  
+  renv_bootstrap_hash_text <- function(text) {
+  
+    hashfile <- tempfile("renv-hash-")
+    on.exit(unlink(hashfile), add = TRUE)
+  
+    writeLines(text, con = hashfile)
+    tools::md5sum(hashfile)
+  
+  }
+  
+  renv_bootstrap_load <- function(project, libpath, version) {
+  
+    # try to load renv from the project library
+    if (!requireNamespace("renv", lib.loc = libpath, quietly = TRUE))
+      return(FALSE)
+  
+    # warn if the version of renv loaded does not match
+    renv_bootstrap_validate_version(version)
+  
+    # load the project
+    renv::load(project)
+  
+    TRUE
+  
+  }
+  
+  renv_bootstrap_profile_load <- function(project) {
+  
+    # if RENV_PROFILE is already set, just use that
+    profile <- Sys.getenv("RENV_PROFILE", unset = NA)
+    if (!is.na(profile) && nzchar(profile))
+      return(profile)
+  
+    # check for a profile file (nothing to do if it doesn't exist)
+    path <- file.path(project, "renv/local/profile")
+    if (!file.exists(path))
+      return(NULL)
+  
+    # read the profile, and set it if it exists
+    contents <- readLines(path, warn = FALSE)
+    if (length(contents) == 0L)
+      return(NULL)
+  
+    # set RENV_PROFILE
+    profile <- contents[[1L]]
+    if (nzchar(profile))
+      Sys.setenv(RENV_PROFILE = profile)
+  
+    profile
+  
+  }
+  
+  renv_bootstrap_profile_prefix <- function() {
+    profile <- renv_bootstrap_profile_get()
+    if (!is.null(profile))
+      return(file.path("renv/profiles", profile))
+  }
+  
+  renv_bootstrap_profile_get <- function() {
+    profile <- Sys.getenv("RENV_PROFILE", unset = "")
+    renv_bootstrap_profile_normalize(profile)
+  }
+  
+  renv_bootstrap_profile_set <- function(profile) {
+    profile <- renv_bootstrap_profile_normalize(profile)
+    if (is.null(profile))
+      Sys.unsetenv("RENV_PROFILE")
+    else
+      Sys.setenv(RENV_PROFILE = profile)
+  }
+  
+  renv_bootstrap_profile_normalize <- function(profile) {
+  
+    if (is.null(profile) || profile %in% c("", "default"))
+      return(NULL)
+  
+    profile
+  
+  }
+
+  # load the renv profile, if any
+  renv_bootstrap_profile_load(project)
+
+  # construct path to library root
+  root <- renv_bootstrap_library_root(project)
+
+  # construct library prefix for platform
+  prefix <- renv_bootstrap_platform_prefix()
+
+  # construct full libpath
+  libpath <- file.path(root, prefix)
+
+  # attempt to load
+  if (renv_bootstrap_load(project, libpath, version))
+    return(TRUE)
+
+  # load failed; inform user we're about to bootstrap
+  prefix <- paste("# Bootstrapping renv", version)
+  postfix <- paste(rep.int("-", 77L - nchar(prefix)), collapse = "")
+  header <- paste(prefix, postfix)
+  message(header)
+
+  # perform bootstrap
+  bootstrap(version, libpath)
+
+  # exit early if we're just testing bootstrap
+  if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
+    return(TRUE)
+
+  # try again to load
+  if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
+    message("* Successfully installed and loaded renv ", version, ".")
+    return(renv::load())
+  }
+
+  # failed to download or load renv; warn the user
+  msg <- c(
+    "Failed to find an renv installation: the project will not be loaded.",
+    "Use `renv::activate()` to re-initialize the project."
+  )
+
+  warning(paste(msg, collapse = "\n"), call. = FALSE)
+
+})


### PR DESCRIPTION
Some changes required for flatpak

I hardcoded most of the paths for flatpak. We could use environment variables instead of hardcoded paths (such as `MODULES_RENV_ROOT = /app/lib64/renv-root`) but flatpak didn't seem to always pick up the environment variables and modifying an environment variable deletes all cached modules (although I suppose you can avoid that by making those environment variables specific to particular modules).

In addition, people can now also set a cran repository (if they are building) by specifying an environment variable (`JASP_R_REPOSITORY`). This is also the only environment variable I use on flatpak atm.