### PR TITLE
Make sentence about Linux translatable

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -64,7 +64,7 @@ Item
 				Label
 				{
 					id:					linuxInfo
-					text:				"<i>On linux the default spreadsheet editor is always used.</i>"
+					text:				qsTr("<i>On Linux the default spreadsheet editor is always used.</i>")
 					visible:			LINUX
 					textFormat:			Text.StyledText
 


### PR DESCRIPTION
Currently, the hint about spreadheets in  Linux can't be translated. Also, Linux is a name, so it should be capitalized :).