### PR TITLE
- Make sure the keys for labels are stored as string

### DIFF
--- a/Desktop/data/importers/readstat/readstatimportcolumn.cpp
+++ b/Desktop/data/importers/readstat/readstatimportcolumn.cpp
@@ -135,6 +135,9 @@ void ReadStatImportColumn::setType(columnType newType)
 		throw std::runtime_error("An attempt was made to change the columntype of '" + _name + "' to "+ columnTypeToString(newType) + " from " + columnTypeToString(_type) + " but the conversion failed.\n" + extraMsg);
 	};
 
+	if(_type != columnType::unknown && newType == columnType::unknown)
+		throw std::runtime_error("Changing the importcolumns type back to unknown from " + columnTypeToString(_type) + " is not allowed!");
+
 	switch(_type)
 	{
 	case columnType::unknown:
@@ -146,8 +149,6 @@ void ReadStatImportColumn::setType(columnType newType)
 	case columnType::scale:
 		switch(newType)
 		{
-		case columnType::unknown:		throw std::runtime_error("Changing the importcolumns type back to unknown from " + columnTypeToString(_type) + " is not allowed!");
-
 		case columnType::ordinal:		[[clang::fallthrough]];
 		case columnType::nominal:
 			for(double d : _doubles)
@@ -170,7 +171,6 @@ void ReadStatImportColumn::setType(columnType newType)
 	case columnType::nominal:
 		switch(newType)
 		{
-		case columnType::unknown:		throw std::runtime_error("Changing the importcolumns type back to unknown from " + columnTypeToString(_type) + " is not allowed!");
 		case columnType::ordinal:		[[clang::fallthrough]];
 		case columnType::nominal:
 			_type = newType; //Ordinal <> Nominal?
@@ -201,7 +201,6 @@ void ReadStatImportColumn::setType(columnType newType)
 	case columnType::nominalText:
 		switch(newType)
 		{
-		case columnType::unknown:		throw std::runtime_error("Changing the importcolumns type back to unknown from " + columnTypeToString(_type) + " is not allowed!");
 		case columnType::scale:
 			if(_strLabels.size() > 0)
 				conversionFailed("Because we would have to drop some labels.");
@@ -357,6 +356,8 @@ void ReadStatImportColumn::addValue(const int & val)
 
 void ReadStatImportColumn::addLabel(const int & val, const std::string & label)
 {
+	//Log::log() << "ReadStatImportColumn::addLabel(int '" << val << "', '" << label << "');" <<std::endl;
+
 	if(_type == columnType::unknown)
 		setType(columnType::nominal);
 
@@ -387,6 +388,8 @@ void ReadStatImportColumn::addLabel(const int & val, const std::string & label)
 
 void ReadStatImportColumn::addLabel(const double & val, const std::string & label)
 {
+	//Log::log() << "ReadStatImportColumn::addLabel(dbl '" << val << "', '" << label << "');" <<std::endl;
+
 	if(_type != columnType::nominalText)
 	{
 		if(double(int(val)) == val)
@@ -404,6 +407,8 @@ void ReadStatImportColumn::addLabel(const double & val, const std::string & labe
 
 void ReadStatImportColumn::addLabel(const std::string & val, const std::string & label)
 {
+	//Log::log() << "ReadStatImportColumn::addLabel(str '" << val << "', '" << label << "');" <<std::endl;
+
 	if(_ints.size() == 0 && _doubles.size() == 0)
 		setType(columnType::nominalText); //If we haven't added anything else and the first value is a string then the rest should also be a string from now on
 

--- a/Desktop/data/importers/readstat/readstatimportcolumn.h
+++ b/Desktop/data/importers/readstat/readstatimportcolumn.h
@@ -5,8 +5,6 @@
 #include "readstat.h"
 #include "../importcolumn.h"
 
-
-
 class ReadStatImportColumn : public ImportColumn
 {
 public:

--- a/Desktop/data/importers/readstat/readstatimportdataset.cpp
+++ b/Desktop/data/importers/readstat/readstatimportdataset.cpp
@@ -17,23 +17,32 @@
 
 #include "readstatimportdataset.h"
 #include "log.h"
+#include "utils.h"
 
 bool operator<(const readstat_value_t & l, const readstat_value_t & r)
 {
-	readstat_type_t ltype = readstat_value_type(l),
-					rtype = readstat_value_type(r);
-
-	if(ltype != rtype) return ltype < rtype;
-
-	switch(ltype)
+	try 
+	{	
+		readstat_type_t ltype = readstat_value_type(l),
+						rtype = readstat_value_type(r);
+	
+		if(ltype != rtype) return ltype < rtype;
+	
+		switch(ltype)
+		{
+		case READSTAT_TYPE_STRING:		return std::string(readstat_string_value(l)) < std::string(readstat_string_value(r));
+		case READSTAT_TYPE_INT8:		return readstat_int8_value(l)	< readstat_int8_value(r);
+		case READSTAT_TYPE_INT16:		return readstat_int16_value(l)	< readstat_int16_value(r);
+		case READSTAT_TYPE_INT32:		return readstat_int32_value(l)	< readstat_int32_value(r);
+		case READSTAT_TYPE_FLOAT:		return readstat_float_value(l)	< readstat_float_value(r);
+		case READSTAT_TYPE_DOUBLE:		return readstat_double_value(l)	< readstat_double_value(r);
+		default:						return &l < &r; //If we cannot do anything else just order them based on their pointer to make sure < is well-ordered
+		}
+	}
+	catch(...)
 	{
-	case READSTAT_TYPE_STRING:		return std::string(readstat_string_value(l)) < std::string(readstat_string_value(r));
-	case READSTAT_TYPE_INT8:		return readstat_int8_value(l)	< readstat_int8_value(r);
-	case READSTAT_TYPE_INT16:		return readstat_int16_value(l)	< readstat_int16_value(r);
-	case READSTAT_TYPE_INT32:		return readstat_int32_value(l)	< readstat_int32_value(r);
-	case READSTAT_TYPE_FLOAT:		return readstat_float_value(l)	< readstat_float_value(r);
-	case READSTAT_TYPE_DOUBLE:		return readstat_double_value(l)	< readstat_double_value(r);
-	default:						return &l < &r; //If we cannot do anything else just order them based on their pointer to make sure < is well-ordered
+		Log::log() << "bool operator<(const readstat_value_t & l, const readstat_value_t & r) had some kind of problem..." << std::endl;
+		return &l < &r; //Try to keep things in order
 	}
 }
 
@@ -44,12 +53,18 @@ ReadStatImportDataSet::~ReadStatImportDataSet()
 
 void ReadStatImportDataSet::addLabelKeyValue(const std::string & labelsID, const readstat_value_t & key, const std::string & label)
 {
-	_labelMap[labelsID][key] = label;
+	//Log::log()		<< "addLabelKeyValue(labelsID='" << labelsID << "', key='" << std::flush;
+	
+	const std::string str = ReadStatImportColumn::readstatValueToString(key);
+	
+	//Log::log(false) << str << "', label='" << label << "')" << std::endl;
+
+	_labelMap[labelsID][str] = std::make_pair(readstat_value_type(key), label);
 }
 
 const std::string &	ReadStatImportDataSet::getLabel(const std::string & labelsID, const readstat_value_t & key)
 {
-	return _labelMap[labelsID][key];
+	return _labelMap[labelsID][ReadStatImportColumn::readstatValueToString(key)].second;
 }
 
 void ReadStatImportDataSet::addColumn(int index, ReadStatImportColumn * col)
@@ -70,30 +85,67 @@ void ReadStatImportDataSet::setLabelsToColumns()
 	{
 		ReadStatImportColumn * col = colKeyVal.second;
 		
-		Log::log() << "Setting labels for column " << col->name() << std::endl;		
+		//Log::log() << "Setting labels for column " << col->name() << std::endl;		
 
 		if(col->hasLabels())
 		{
-			auto valueLabelMap = _labelMap[col->labelsID()];
+			//Log::log() << "It has labels" << std::endl;
+			//Log::log() << "It's labelID is " << col->labelsID() << std::endl;
 
-			for(auto & valueLabel : valueLabelMap)
+			const auto & valueLabelMap = _labelMap[col->labelsID()];
+
+			//Log::log() << "It has about " << valueLabelMap.size() << std::endl;
+
+			for(const auto & valueLabel : valueLabelMap)
 			{
-						readstat_type_t			type	= readstat_value_type(valueLabel.first);
-				const	readstat_value_t 	&	value	= valueLabel.first;
-				const	std::string			&	label	= valueLabel.second;
+				readstat_type_t			type	= valueLabel.second.first;
+
+				/*switch(type)
+				{
+				case READSTAT_TYPE_STRING:		Log::log() << "Type is STRING" << std::endl;	break;
+				case READSTAT_TYPE_INT8:		Log::log() << "Type is INT8" << std::endl;			break;
+				case READSTAT_TYPE_INT16:		Log::log() << "Type is INT16" << std::endl;			break;
+				case READSTAT_TYPE_INT32:		Log::log() << "Type is INT32" << std::endl;			break;
+				case READSTAT_TYPE_FLOAT:		Log::log() << "Type is FLOAT" << std::endl;			break;
+				case READSTAT_TYPE_DOUBLE:		Log::log() << "Type is DOUBLE" << std::endl;		break;
+				case READSTAT_TYPE_STRING_REF:	Log::log() << "Type is STRING_REF" << std::endl;	break;
+				}*/
+
+				const	std::string			&	key		= valueLabel.first;
+				const	std::string			&	label	= valueLabel.second.second;
+
+				//Log::log() << "label: '" << label << "'" << std::endl;
 
 				switch(type)
 				{
-				case READSTAT_TYPE_STRING:		col->addLabel(			readstat_string_value(value),	label);	break;
-				case READSTAT_TYPE_INT8:		col->addLabel(int(		readstat_int8_value(value)),	label);	break;
-				case READSTAT_TYPE_INT16:		col->addLabel(int(		readstat_int16_value(value)),	label);	break;
-				case READSTAT_TYPE_INT32:		col->addLabel(int(		readstat_int32_value(value)),	label);	break;
-				case READSTAT_TYPE_FLOAT:		col->addLabel(double(	readstat_float_value(value)),	label);	break;
-				case READSTAT_TYPE_DOUBLE:		col->addLabel(			readstat_float_value(value),	label);	break;
-				case READSTAT_TYPE_STRING_REF:																	break;
+				default:
+				case READSTAT_TYPE_STRING_REF:	//? I guess this won't occur because we don't accept it elsewhere
+				case READSTAT_TYPE_STRING:		
+					col->addLabel(key,	label);	
+					break;
+					
+				case READSTAT_TYPE_INT8:		
+				case READSTAT_TYPE_INT16:		
+				case READSTAT_TYPE_INT32:		
+				{
+					int keyInt;
+					if(Utils::convertValueToIntForImport(key, keyInt))		col->addLabel(keyInt,		label);
+					else													col->addLabel(key,			label);
+					break;
+				}
+				case READSTAT_TYPE_FLOAT:		
+				case READSTAT_TYPE_DOUBLE:		
+				{
+					double keyDbl;
+					if(Utils::convertValueToDoubleForImport(key, keyDbl))	col->addLabel(keyDbl,		label);
+					else													col->addLabel(key,			label);
+					break;
+				}
 				}
 			}
 		}
+
+		//Log::log() << "Done setting labels for column " << col->name() << std::endl;
 	}
 }
 

--- a/Desktop/data/importers/readstat/readstatimportdataset.h
+++ b/Desktop/data/importers/readstat/readstatimportdataset.h
@@ -29,14 +29,15 @@ bool operator<(const readstat_value_t & l, const readstat_value_t & r);
 
 class ReadStatImportDataSet : public ImportDataSet
 {
-	typedef std::map<std::string, std::map<readstat_value_t, std::string>> labelsMapT;
+	typedef std::pair<readstat_type_t, std::string>							keyTypeAndLabelT;
+	typedef std::map<std::string, std::map<std::string, keyTypeAndLabelT>>	labelsMapT;
 public:
 				ReadStatImportDataSet(ReadStatImporter * importer, boost::function<void(int)>	progressCallback)
 					: ImportDataSet(importer), _progressCallback(progressCallback) {}
 
 				~ReadStatImportDataSet()					override;
 
-	int			var_count()						const	{ return _var_count; }
+	int			var_count()							const	{ return _var_count; }
 	void		setVariableCount(int newCount)				{ _var_count = newCount; }
 
 	void						addLabelKeyValue(	const std::string & labelsID, const readstat_value_t & key, const std::string & label);

--- a/Desktop/data/importers/readstatimporter.cpp
+++ b/Desktop/data/importers/readstatimporter.cpp
@@ -98,13 +98,8 @@ ImportDataSet* ReadStatImporter::loadFile(const std::string &locator, boost::fun
 	else							throw std::runtime_error("JASP does not support extension " + _ext);
 
 	Log::log() << "Done parsing file" << std::endl;
-	readstat_parser_free(parser);
-	
-#ifdef WIN32
-	io_cleanup();
-#endif
 
-	Log::log() << "Setting labels to column" << std::endl;
+	Log::log() << "Setting labels to columns" << std::endl;
 	data->setLabelsToColumns();
 
 	if (error != READSTAT_OK)
@@ -112,6 +107,14 @@ ImportDataSet* ReadStatImporter::loadFile(const std::string &locator, boost::fun
 
 	Log::log() << "Building dictionary" << std::endl;
 	data->buildDictionary(); //Not necessary for opening this file but synching will break otherwise...
+
+
+	Log::log() << "Freeing readstat structs" << std::endl;
+	readstat_parser_free(parser);
+
+#ifdef WIN32
+	io_cleanup();
+#endif
 
 	Log::log() << "Returning data" << std::endl;
 	return data;


### PR DESCRIPTION
instead of dangerous readstat_value_t/s... Apparently those values get wiped somehow somewhere on some systems.

- Fixes https://github.com/jasp-stats/jasp-issues/issues/1337 (Crash on sav load)
- Also added a bunch of commented out logstatements

