### PR TITLE
Make sure analyses respond to label reorder/changes

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -298,7 +298,7 @@ void Analysis::initialized(AnalysisForm* form, bool isNewAnalysis)
 		_status = Empty;
 	
 	connect(_analysisForm,			&AnalysisForm::helpMDChanged,		this,			&Analysis::helpMDChanged					);
-	connect(this,					&Analysis::rSourceChanged,	_analysisForm,	&AnalysisForm::rSourceChanged				);
+	connect(this,					&Analysis::rSourceChanged,			_analysisForm,	&AnalysisForm::rSourceChanged				);
 	connect(this,					&Analysis::refreshTableViewModels,	_analysisForm,	&AnalysisForm::refreshTableViewModels		);
 }
 

--- a/Desktop/widgets/jasplistcontrol.h
+++ b/Desktop/widgets/jasplistcontrol.h
@@ -92,7 +92,7 @@ public:
 			bool				encodeValue()				const override	{ return containsVariables() || containsInteractions();	}
 			bool				useSourceLevels()			const			{ return _useSourceLevels;		}
 			void				setUseSourceLevels(bool b)					{ _useSourceLevels = b;			}
-	virtual std::vector<std::string> usedVariables()		const;
+	virtual stringvec			usedVariables()				const;
 
 signals:
 			void				modelChanged();


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/1369
- Done roughly now by calling refresh if a variable is used in an analysis
- If we no longer cache `Analysis::_boundValues` but create it dynamically we can add it to `createMeta` and only invalidate those parts of jaspResults that use that particular column. Would be much cleaner

