### PR TITLE
Fixes the eye in the filter

### DIFF
--- a/Desktop/data/datasettablemodel.cpp
+++ b/Desktop/data/datasettablemodel.cpp
@@ -50,9 +50,3 @@ bool DataSetTableModel::filterAcceptsRow(int source_row, const QModelIndex &)	co
 {
 	return _showInactive || DataSetPackage::pkg()->getRowFilter(source_row);
 }
-
-QVariant DataSetTableModel::data(const QModelIndex &index, int role)	const
-{
-	DataSetPackage * package = DataSetPackage::pkg();
-	return package->data(package->index(index.row(), index.column(), package->parentModelForType(parIdxType::data)), role);
-}

--- a/Desktop/data/datasettablemodel.h
+++ b/Desktop/data/datasettablemodel.h
@@ -34,8 +34,6 @@ public:
 	explicit				DataSetTableModel();
 	~DataSetTableModel()	override { if(_singleton == this) _singleton = nullptr; }
 
-	QVariant				data(const QModelIndex &index, int role = Qt::DisplayRole)	const	override;
-
 	bool					filterAcceptsRow(int source_row, const QModelIndex & source_parent)	const override;
 
 				int			columnsFilteredCount()					const				{ return DataSetPackage::pkg()->columnsFilteredCount();								}


### PR DESCRIPTION
- fixes https://github.com/jasp-stats/jasp-test-release/issues/1388

Also, @boutinb why did you add that function in the first place? 
Because `DataSetTableModel` is a `DataSetTableProxy` all the filtering (and sorting) is handled by the class itself, `data` is already defined and works fine. Checkout https://doc.qt.io/qt-5/qsortfilterproxymodel.html