### PR TITLE
JASPWidgets["title"] does not exist anymore

### DIFF
--- a/Desktop/html/js/object.js
+++ b/Desktop/html/js/object.js
@@ -18,7 +18,7 @@ JASPWidgets.objectConstructor = function (results, params, ignoreEvents) {
 	if (metaData.type)
 		type = metaData.type;
 
-	if (type === "qmlSource")
+	if (type === "qmlSource" || type === "title")
 		return null;
 
 	if(_.has(results, "title") && results.title === "" && type === "collection")


### PR DESCRIPTION
Solves jasp-stats/jasp-test-release#1380
Solves jasp-stats/jasp-test-release#1379
Solves jasp-stats/jasp-test-release#1377
Solves jasp-stats/jasp-test-release#1371

I'm not at all sure if this is the right thing to do! 
I just saw that the "title" type is called and that JASPWidgets does not have this type....

