### PR TITLE
JAGS: Encode the column names found in the model before sending them to R

### DIFF
--- a/Desktop/widgets/boundcontroljagstextarea.cpp
+++ b/Desktop/widgets/boundcontroljagstextarea.cpp
@@ -101,7 +101,7 @@ void BoundControlJAGSTextArea::checkSyntax()
 	boundValue["model"] = _textEncoded.toStdString();
 	Json::Value columns(Json::arrayValue);
 	for (const std::string& column : _usedColumnNames)
-		columns.append(column);
+		columns.append(ColumnEncoder::columnEncoder()->encode(column));
 	boundValue["columns"] = columns;
 	Json::Value parameters(Json::arrayValue);
 	for (const QString& parameter : _usedParameters)


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1468

So I looked at this and noticed this:

![image](https://user-images.githubusercontent.com/21319932/129922574-c9128e13-2805-4a3b-b40a-e19b2a6e3cba.png)

it's trying to read in `contBinom` but R should have gotten the encoded name, not `contBinom`.

I think that it used to be that after
```c++
_textEncoded = tq(ColumnEncoder::columnEncoder()->encodeRScript(stringUtils::stripRComments(fq(text)), &_usedColumnNames));
```
`_usedColumnNames` contained encoded column names. However, now it contains the decoded names. So this PR just encodes those. It's also possible that this always returned decoded names, in that case, JAGS has been broken for a long, long time. I'm not sure how nobody noticed that during the last testing round though.


