### PR TITLE
Make most buttons rounded

### DIFF
--- a/Desktop/components/JASP/Controls/Button.qml
+++ b/Desktop/components/JASP/Controls/Button.qml
@@ -41,10 +41,9 @@ JASPControl
     
 	Component.onCompleted: control.clicked.connect(clicked);
 
-	RectangularButton
+	RoundedButton
 	{
 		id:				control
-		radius:			jaspTheme.borderRadius
 		anchors.fill:	parent
     }
 }

--- a/Desktop/components/JASP/Controls/FileSelector.qml
+++ b/Desktop/components/JASP/Controls/FileSelector.qml
@@ -13,7 +13,7 @@ TextField
 
 	implicitWidth				: button.x + button.width
 
-	RectangularButton
+	RoundedButton
 	{
 		id				: button
 		text			: qsTr("Browse")

--- a/Desktop/components/JASP/Widgets/BasicThreeButtonTableView.qml
+++ b/Desktop/components/JASP/Widgets/BasicThreeButtonTableView.qml
@@ -96,7 +96,7 @@ Item
 		spacing				: jaspTheme.columnGroupSpacing
 		visible				: basicButtonTableView.showButtons
 
-		RectangularButton
+		RoundedButton
 		{
 			id				: addButton
 			text			: qsTr("Add")
@@ -104,7 +104,7 @@ Item
 			onClicked		: { forceActiveFocus(); basicButtonTableView.addClicked() }
 		}
 
-		RectangularButton
+		RoundedButton
 		{
 			id				: deleteButton
 			text			: qsTr("Delete")
@@ -112,7 +112,7 @@ Item
 			onClicked		: { forceActiveFocus(); basicButtonTableView.deleteClicked() }
 		}
 
-		RectangularButton
+		RoundedButton
 		{
 			id				: resetButton
 			text			: qsTr("Reset")

--- a/Desktop/components/JASP/Widgets/CreateComputeColumnDialog.qml
+++ b/Desktop/components/JASP/Widgets/CreateComputeColumnDialog.qml
@@ -180,7 +180,7 @@ Popup
 				anchors.horizontalCenter:	parent.horizontalCenter
 				height:						45 * preferencesModel.uiScale
 
-				RectangularButton
+				RoundedButton
 				{
 					id:						rCodeSelectah
 
@@ -199,7 +199,7 @@ Popup
 					toolTip:				qsTr("Define column through R code")
 				}
 
-				RectangularButton
+				RoundedButton
 				{
 					id:					jsonSelectah
 
@@ -231,7 +231,8 @@ Popup
 				anchors.topMargin:			10
 				anchors.horizontalCenter:	parent.horizontalCenter
 
-				Repeater{
+				Repeater
+				{
 					id:		iconRepeater
 					model:	[columnTypeScale, columnTypeOrdinal, columnTypeNominal, columnTypeNominalText] //these are set in the rootcontext in mainwindow!
 
@@ -243,6 +244,7 @@ Popup
 						color:			iAmSelected ? jaspTheme.buttonColorPressed : popupIconComputeMouseArea.useThisColor
 						border.color:	iAmSelected ? jaspTheme.buttonBorderColorHovered : jaspTheme.buttonBorderColor
 						border.width:	1
+						radius:			jaspTheme.borderRadius
 
 						property bool iAmSelected: rootCreateComputedColumn.selectedColumnType === iconRepeater.model[index]
 
@@ -302,7 +304,7 @@ Popup
 				}
 			}
 
-			RectangularButton
+			RoundedButton
 			{
 				id:				helpButton
 				iconSource:		jaspTheme.iconPath + "info-button.png"
@@ -318,7 +320,7 @@ Popup
 				}
 			}
 
-			RectangularButton
+			RoundedButton
 			{
 				id:			createButton
 				text:		qsTr("Create Column")
@@ -334,7 +336,7 @@ Popup
 				}
 			}
 
-			RectangularButton
+			RoundedButton
 			{
 				id:				closeButtonCross
 				iconSource:		jaspTheme.iconPath + "cross.png"

--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -44,7 +44,7 @@ FocusScope
 				}
 
 			leftTopCornerItem:
-				RectangularButton
+				RoundedButton
 				{
 					id:				filterToggleButton
 					width:			dataTableView.rowNumberWidth
@@ -55,7 +55,7 @@ FocusScope
 				}
 
 			extraColumnItem:
-				RectangularButton
+				RoundedButton
 				{
 					id:				addColumnButton
 					width:			height

--- a/Desktop/components/JASP/Widgets/FileMenu/BreadCrumbs.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/BreadCrumbs.qml
@@ -64,7 +64,7 @@ ListView
 				}
 			}
 
-			RectangularButton
+			RoundedButton
 			{
 				id:				rectButton
 				anchors.left:	index > 0 ? rectArrow.right : rect.left

--- a/Desktop/components/JASP/Widgets/FileMenu/Computer.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/Computer.qml
@@ -17,7 +17,7 @@ Item
 		toolseparator:		false
 	}
 
-	RectangularButton
+	RoundedButton
 	{
 		id:						browseButton
 		text:					qsTr("Browse")

--- a/Desktop/components/JASP/Widgets/FileMenu/ListItem.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/ListItem.qml
@@ -21,6 +21,7 @@ FocusScope
 		color:			rectTitle.color
 		z:				-1
 		anchors.fill:	parent
+		radius:			jaspTheme.borderRadius
 	}
 
 	property var cppModel:			undefined
@@ -55,6 +56,7 @@ FocusScope
 		anchors.right:		parent.right
 		anchors.top:		parent.top
 		anchors.margins:	1
+		radius:				jaspTheme.borderRadius
 
 		color:				rectTitleAndDescripton.allPressed || (rectTitleAndDescripton.activeFocus && !datafileMouseArea.containsMouse) ?
 								jaspTheme.buttonColorPressed :
@@ -113,6 +115,7 @@ FocusScope
 												   jaspTheme.buttonColorHovered : jaspTheme.buttonColor
 			border.color:	jaspTheme.uiBorder
 			border.width:	hasDatafile ? 1 : 0
+			radius:			jaspTheme.borderRadius
 
 			property bool hasDatafile: model.associated_datafile !== ""
 
@@ -235,6 +238,7 @@ FocusScope
 		anchors.right:		parent.right
 		anchors.top:		rectTitle.bottom
 		anchors.margins:	visible ? 1 : 0
+		radius:				jaspTheme.borderRadius
 
 		color:				rectTitleAndDescripton.color//allHovered ? jaspTheme.buttonColorHovered : jaspTheme.buttonColor
 		visible:			model.description !== ""

--- a/Desktop/components/JASP/Widgets/FileMenu/OSF.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/OSF.qml
@@ -46,7 +46,7 @@ Item
 		toolseparator	: !loggedin
 	}
 
-	RectangularButton
+	RoundedButton
 	{
 		id						: logoutButton
 		text					: qsTr("Logout")
@@ -115,7 +115,7 @@ Item
 
 	/////////////////////////// File dialog to save in OSF ////////////////////////////////////
 
-	RectangularButton
+	RoundedButton
 	{
 		id		: newDirectoryButton
 		text	: qsTr("Create Folder")
@@ -201,7 +201,7 @@ Item
 			}
 		}
 
-		RectangularButton
+		RoundedButton
 		{
 			id		: saveFoldernameButton
 			width	: 30 * preferencesModel.uiScale
@@ -222,7 +222,7 @@ Item
 			}
 		}
 
-		RectangularButton
+		RoundedButton
 		{
 			id					: cancelCreateFolderButton
 			width				: 30 * preferencesModel.uiScale
@@ -310,7 +310,7 @@ Item
 			}
 		}
 
-		RectangularButton
+		RoundedButton
 		{
 			id					: saveFilenameButton
 			width				: saveFoldernameButton.width + cancelCreateFolderButton.width + jaspTheme.generalAnchorMargin

--- a/Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
@@ -214,7 +214,7 @@ FocusScope
 			}
 		}
 
-		RectangularButton
+		RoundedButton
 		{
 			id: loginButton
 

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -193,7 +193,7 @@ ScrollView
 
 			}
 	
-			RectangularButton
+			RoundedButton
 			{	
 				id:					cleanModulesFolder
 				text:				qsTr("Clear installed modules and packages")
@@ -301,7 +301,7 @@ ScrollView
 					}
 				}
 
-				RectangularButton
+				RoundedButton
 				{
 					id:			showLogs
 					text:		qsTr("Show logs")

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -84,7 +84,7 @@ Item
 					height:				browseEditorButton.height
 					anchors.top:		useDefaultEditor.bottom
 
-					RectangularButton
+					RoundedButton
 					{
 						id:					browseEditorButton
 						text:				qsTr("Select custom editor")

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsMissingValues.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsMissingValues.qml
@@ -129,7 +129,7 @@ Rectangle
 		}
 
 
-		RectangularButton
+		RoundedButton
 		{
 			id:					addButton
 			iconSource:			jaspTheme.iconPath + "/addition-sign-small.svg"
@@ -146,7 +146,7 @@ Rectangle
 		}
 	}
 
-	RectangularButton
+	RoundedButton
 	{
 		id:					resetButton
 		text:				qsTr("Reset")

--- a/Desktop/components/JASP/Widgets/MenuButton.qml
+++ b/Desktop/components/JASP/Widgets/MenuButton.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts 1.3
 
 import JASP.Widgets 1.0
 
-RectangularButton
+RoundedButton
 {
 	property bool hasSubMenu:			false
 	property bool showHovered:			hasSubMenu ? delayOnhoverTimer.running : hovered

--- a/Desktop/components/JASP/Widgets/MessageBox.qml
+++ b/Desktop/components/JASP/Widgets/MessageBox.qml
@@ -133,7 +133,7 @@ Popup
 			id:				yesNoButtons
 			anchors.fill:	parent
 
-			RectangularButton
+			RoundedButton
 			{
 				id:				yes
 				text:			"Yes"
@@ -149,7 +149,7 @@ Popup
 				onClicked: messageRoot.close()
 			}
 
-			RectangularButton
+			RoundedButton
 			{
 				id:				no
 				text:			"No"

--- a/Desktop/components/JASP/Widgets/ModuleInstaller.qml
+++ b/Desktop/components/JASP/Widgets/ModuleInstaller.qml
@@ -52,7 +52,7 @@ QTCONTROLS.Popup
 		{
 			id:			moduleInstallerRect
 
-			RectangularButton
+			RoundedButton
 			{
 				id:					browseButton
 				iconSource:			jaspTheme.iconPath + "folder.svg"
@@ -74,7 +74,7 @@ QTCONTROLS.Popup
 				onClicked:		descriptionViewer.currentlySelectedFilePath = browse();
 			}
 
-			RectangularButton
+			RoundedButton
 			{
 				id:				closeButtonCross
 				iconSource:		jaspTheme.iconPath + "cross.png"
@@ -172,7 +172,7 @@ QTCONTROLS.Popup
 				}
 			}
 
-			RectangularButton
+			RoundedButton
 			{
 				id:					installButton
 				anchors

--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
@@ -443,7 +443,7 @@ Popup
 				}
 			}
 
-			JASPW.RectangularButton
+			JASPW.RoundedButton
 			{
 				id:					exitButton
 				anchors
@@ -458,7 +458,7 @@ Popup
 				on_PressedChanged:	plotEditorPopup.close()
 			}
 
-			JASPW.RectangularButton
+			JASPW.RoundedButton
 			{
 				id:					cancelButton
 				anchors
@@ -472,7 +472,7 @@ Popup
 				on_PressedChanged:	cancel()
 			}
 
-			JASPW.RectangularButton
+			JASPW.RoundedButton
 			{
 				id:					resetDefaultButton
 				anchors
@@ -485,7 +485,7 @@ Popup
 				onClicked:			plotEditorModel.resetDefaults()
 			}
 
-			JASPW.RectangularButton
+			JASPW.RoundedButton
 			{
 				id:					saveButton
 				anchors

--- a/Desktop/components/JASP/Widgets/RCommanderWindow.qml
+++ b/Desktop/components/JASP/Widgets/RCommanderWindow.qml
@@ -255,7 +255,7 @@ Window
 				}
 			}
 
-			JW.RectangularButton
+			JW.RoundedButton
 			{
 				id:				runButton
 				text:			qsTr("Run Code")
@@ -295,7 +295,7 @@ Window
 				}
 			}
 
-			JW.RectangularButton
+			JW.RoundedButton
 			{
 				id:		clearOutput
 				text:		qsTr("Clear Output")

--- a/Desktop/components/JASP/Widgets/RectangularButton.qml
+++ b/Desktop/components/JASP/Widgets/RectangularButton.qml
@@ -71,7 +71,6 @@ Item
 		border.width:	1
 		width:			parent.width
 		height:			parent.height
-		radius:			jaspTheme.borderRadius
 
 		MouseArea
 		{

--- a/Desktop/components/JASP/Widgets/RoundedButton.qml
+++ b/Desktop/components/JASP/Widgets/RoundedButton.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+
+RectangularButton 
+{
+	radius:			jaspTheme.borderRadius
+}

--- a/Desktop/components/JASP/Widgets/VariablesWindow.qml
+++ b/Desktop/components/JASP/Widgets/VariablesWindow.qml
@@ -343,7 +343,7 @@ FocusScope
 				property real	minimumHeight:		(buttonHeight + spacing) * shownButtons + (3 * spacing)
 				property real	buttonHeight:		32 * preferencesModel.uiScale
 
-				RectangularButton
+				RoundedButton
 				{
 					//text: "UP"
 					iconSource:		jaspTheme.iconPath + "arrow-up.png"
@@ -356,7 +356,7 @@ FocusScope
 					width:			height
 				}
 
-				RectangularButton
+				RoundedButton
 				{
 					//text: "DOWN"
 					iconSource:		jaspTheme.iconPath + "arrow-down.png"
@@ -369,7 +369,7 @@ FocusScope
 					width:			height
 				}
 
-				RectangularButton
+				RoundedButton
 				{
 					//text: "REVERSE"
 					iconSource:		jaspTheme.iconPath + "arrow-reverse.png"
@@ -382,7 +382,7 @@ FocusScope
 					width:			height
 				}
 
-				RectangularButton
+				RoundedButton
 				{
 					id:				eraseFiltersOnThisColumn
 					iconSource:		jaspTheme.iconPath + "eraser.png"
@@ -396,7 +396,7 @@ FocusScope
 					width:			height
 				}
 
-				RectangularButton
+				RoundedButton
 				{
 					id:				eraseFiltersOnAllColumns
 					iconSource:		jaspTheme.iconPath + "eraser_all.png"
@@ -414,7 +414,7 @@ FocusScope
 					Layout.fillHeight: true
 				}
 
-				RectangularButton
+				RoundedButton
 				{
 					id:				variablesWindowCloseButton
 					iconSource:		jaspTheme.iconPath + "cross.png"

--- a/Desktop/components/JASP/Widgets/qmldir
+++ b/Desktop/components/JASP/Widgets/qmldir
@@ -13,6 +13,7 @@ DataPanel                   1.0 DataPanel.qml
 DataTableView               1.0 DataTableView.qml
 MenuButton                  1.0 MenuButton.qml
 RectangularButton           1.0 RectangularButton.qml
+RoundedButton	            1.0 RoundedButton.qml
 FilterWindow                1.0 FilterWindow.qml
 JASPDataView                1.0 JASPDataView.qml
 JASPMouseAreaToolTipped     1.0 JASPMouseAreaToolTipped.qml

--- a/Desktop/qml.qrc
+++ b/Desktop/qml.qrc
@@ -144,5 +144,6 @@
         <file>components/JASP/Widgets/FactorsList.qml</file>
         <file>components/JASP/Controls/FactorLevelList.qml</file>
         <file>components/JASP/Widgets/FileMenu/PrefsTextInput.qml</file>
+        <file>components/JASP/Widgets/RoundedButton.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
- only those in bars and spinbox not
- also make file list rounded

Basically what I mentioned in Slack

Looks like:
<img width="1259" alt="afbeelding" src="https://user-images.githubusercontent.com/29062713/130091701-76f71135-8708-499b-a212-9ffd25e2bc5b.png">

<img width="1035" alt="afbeelding" src="https://user-images.githubusercontent.com/29062713/130091778-facd346c-67b8-42b9-a7a6-a1e7c1b8d1b6.png">

<img width="1263" alt="afbeelding" src="https://user-images.githubusercontent.com/29062713/130091845-47e4745f-5881-4a18-a356-f22ee124c713.png">

<img width="601" alt="afbeelding" src="https://user-images.githubusercontent.com/29062713/130091921-32ae5a5e-6ee3-4632-b018-b2ef33f46f39.png">

<img width="403" alt="afbeelding" src="https://user-images.githubusercontent.com/29062713/130091987-4c32540b-25ca-43f6-b5bf-a6745c1ee00d.png">

