### PR TITLE
JAGS Observed Values should not list the variable names

### DIFF
--- a/Desktop/components/JASP/Widgets/JagsTableView.qml
+++ b/Desktop/components/JASP/Widgets/JagsTableView.qml
@@ -40,7 +40,7 @@ BasicThreeButtonTableView
 
 	buttonDeleteText	: qsTr("Delete Data")
 	onDeleteClicked		: tableView.removeARow()
-	buttonDeleteEnabled	: tableView.rowCount > 1
+	buttonDeleteEnabled	: tableView.rowCount > 0
 
 	buttonResetText		: qsTr("Reset")
 	onResetClicked		: tableView.reset()

--- a/Desktop/widgets/listmodeljagsdatainput.cpp
+++ b/Desktop/widgets/listmodeljagsdatainput.cpp
@@ -25,6 +25,7 @@
 
 ListModelJAGSDataInput::ListModelJAGSDataInput(TableViewBase *parent) : ListModelTableViewBase(parent)
 {
+	_needsSource = false;
 	_keepRowsOnReset = false;
 	_tableTerms.colNames.push_back(getDefaultColName(0));
 	_tableTerms.values.push_back({});

--- a/Desktop/widgets/listmodeljagsdatainput.h
+++ b/Desktop/widgets/listmodeljagsdatainput.h
@@ -33,7 +33,7 @@ public:
 
 	QString			getDefaultColName(size_t index)				const	override;
 	bool			isEditable(const QModelIndex& index)		const	override;
-	QString			getItemInputType(const QModelIndex& )		const	override	{ return isRCodeColumn(1) ? "formulaArray" : "string"; }
+	QString			getItemInputType(const QModelIndex&index )	const	override	{ return isRCodeColumn(index.column()) ? "formulaArray" : "string"; }
 	bool			isRCodeColumn(int col)				const	override			{ return col == 1; }
 
 public slots:


### PR DESCRIPTION
Fixes jasp-stats/jasp-test-release#1471
Delete button should be disabled only if there no row (now it is disabled with 1 row).

