### PR TITLE
Show different error messages when plot editing fails vs. when resizing fails

### DIFF
--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -453,9 +453,14 @@ void EngineRepresentation::processAnalysisReply(Json::Value & json)
 
 
 	case analysisResultStatus::imageEdited:
-		if (results.get("error", false).asBool())
-			MessageForwarder::showWarning(tr("Error resizing plot"), tr("Unfortunately the plot could not be edited.\n\nError message:\n%1\n\nIf the problem persists, please report the message above at: https://jasp-stats.org/bug-reports").arg(tq(results.get("errorMessage", "").asString())));
 
+		if (results.get("error", false).asBool())
+		{
+			if (results.get("resized", false).asBool())
+				MessageForwarder::showWarning(tr("Error resizing plot"), tr("Unfortunately the plot could not be resized.\n\nError message:\n%1\n\nIf the problem persists, please report the message above at: https://jasp-stats.org/bug-reports").arg(tq(results.get("errorMessage", "").asString())));
+			else // plot editing
+				MessageForwarder::showWarning(tr("Error editing plot"), tr("Unfortunately the plot could not be edited.\n\nError message:\n%1\n\nIf the problem persists, please report the message above at: https://jasp-stats.org/bug-reports").arg(tq(results.get("errorMessage", "").asString())));
+		}
 		analysis->imageEdited(results); // if an error occurs js needs to resize the plot back to the old size
 		emit plotEditorRefresh();
 


### PR DESCRIPTION
Fixes the third point of https://github.com/jasp-stats/jasp-test-release/issues/1507

When plot editing fails you now see:

![image](https://user-images.githubusercontent.com/21319932/130960606-677464e4-5b67-43f1-9699-c78b1d35fb0f.png)

When resizing fails you now see:

![image](https://user-images.githubusercontent.com/21319932/130960697-7daaef81-ee12-459b-bea6-94c854b8473f.png)
