### PR TITLE
Handle better the constraints inside the Plot Editor

### DIFF
--- a/Common/utils.cpp
+++ b/Common/utils.cpp
@@ -442,6 +442,19 @@ void Utils::convertEscapedUnicodeToUTF8(std::string& inputStr)
 	}
 }
 
+bool Utils::isEqual(const double a, const double b)
+{
+	if (isnan(a) || isnan(b)) return false;
+
+	return (fabs(a - b) <= ( (fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * DBL_EPSILON));
+}
+bool Utils::isEqual(const float a, const float b)
+{
+	if (isnan(a) || isnan(b)) return false;
+
+	return fabs(a - b) <= ( (fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * FLT_EPSILON);
+}
+
 #ifdef _WIN32
 std::wstring Utils::getShortPathWin(const std::wstring & longPath) 
 {

--- a/Common/utils.h
+++ b/Common/utils.h
@@ -67,7 +67,10 @@ public:
 	static bool			convertValueToDoubleForImport(	const std::string &strValue, double &doubleValue);
 	static std::string	doubleToString(double dbl, int precision = 10);
 	static void			convertEscapedUnicodeToUTF8(	std::string &inputStr);
-	
+
+	static bool isEqual(const float a, const float b);
+	static bool isEqual(const double a, const double b);
+
 #ifdef _WIN32
 	static std::wstring	getShortPathWin(const std::wstring & path);
 #endif

--- a/Desktop/components/JASP/Controls/TextField.qml
+++ b/Desktop/components/JASP/Controls/TextField.qml
@@ -76,6 +76,7 @@ TextInputBase
 		control.textEdited.connect(textEdited);
 		control.pressed.connect(pressed);
 		control.released.connect(released);
+		lastValidValue = control.text;
 	}	
 		
 	Rectangle

--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
@@ -33,29 +33,29 @@ Column
 
 	JASPC.CheckBox
 	{
-		id		: showTitle
-		label	: qsTr("Show title")
-		checked	: axisModel.titleType !== AxisModel.TitleNull
-		onClicked: axisModel.titleType = (checked ? AxisModel.TitleCharacter : AxisModel.TitleNull)
+		id			: showTitle
+		label		: qsTr("Show title")
+		checked		: axisModel.titleType !== AxisModel.TitleNull
+		onClicked	: axisModel.titleType = (checked ? AxisModel.TitleCharacter : AxisModel.TitleNull)
 
 		JASPC.TextField
 		{
-			id:					axisTitle
-			label:				qsTr("Title");
-			fieldWidth:			200
-			value:				axisModel.title
-			onEditingFinished:	if(axisModel) axisModel.title = value
+			id					: axisTitle
+			label				: qsTr("Title");
+			fieldWidth			: 200
+			value				: axisModel.title
+			onEditingFinished	: if(axisModel) axisModel.title = value
 		}
 	}
 
 	JASPC.CheckBox
 	{
-		id		: showAxis
-		label	: qsTr("Show axis")
-		visible	: axisModel.continuous
-		checked	: axisModel.breaksType !== AxisModel.BreaksNull
-		onClicked: axisModel.breaksType = (checked ? lastBreakType : AxisModel.BreaksNull)
-		columns	: 1
+		id			: showAxis
+		label		: qsTr("Show axis")
+		visible		: axisModel.continuous
+		checked		: axisModel.breaksType !== AxisModel.BreaksNull
+		onClicked	: axisModel.breaksType = (checked ? lastBreakType : AxisModel.BreaksNull)
+		columns		: 1
 
 		property int lastBreakType: AxisModel.BreaksRange
 
@@ -89,12 +89,38 @@ Column
 
 		JASPC.Group
 		{
-			visible:	 axisBreaksRange.checked
-			Layout.leftMargin: jaspTheme.indentationLength
+			visible				: axisBreaksRange.checked
+			Layout.leftMargin	: jaspTheme.indentationLength
 
-			JASPC.DoubleField	{	id: axisBreaksRangeFrom;	label: qsTr("from");	value:	axisModel.from;		onEditingFinished: {if(axisModel) axisModel.from		= value		}		negativeValues: true;	fieldWidth: 2 * jaspTheme.numericFieldWidth	}
-			JASPC.DoubleField	{	id: axisBreaksRangeTo;		label: qsTr("to");		value:	axisModel.to;		onEditingFinished: {if(axisModel) axisModel.to			= value		}		negativeValues: true;	fieldWidth: 2 * jaspTheme.numericFieldWidth	}
-			JASPC.DoubleField	{	id: axisBreaksRangeSteps;	label: qsTr("steps");	value:	axisModel.steps;	onEditingFinished: {if(axisModel) axisModel.steps		= value		}								fieldWidth: 2 * jaspTheme.numericFieldWidth	}
+			JASPC.DoubleField
+			{
+				id					: axisBreaksRangeFrom
+				label				: qsTr("from")
+				value				: axisModel.from
+				onEditingFinished	: if(axisModel) axisModel.from = value
+				negativeValues		: true
+				fieldWidth			: 2 * jaspTheme.numericFieldWidth
+				max					: axisBreaksRangeSteps.value > 0 ? axisBreaksRangeTo.value : Infinity
+			}
+			JASPC.DoubleField
+			{
+				id					: axisBreaksRangeTo
+				label				: qsTr("to")
+				value				: axisModel.to
+				onEditingFinished	: if(axisModel) axisModel.to = value
+				negativeValues		: true
+				fieldWidth			: 2 * jaspTheme.numericFieldWidth
+				min					: axisBreaksRangeSteps.value > 0 ? axisBreaksRangeFrom.value : -Infinity
+			}
+			JASPC.DoubleField
+			{
+				id					: axisBreaksRangeSteps
+				label				: qsTr("steps")
+				value				: axisModel.steps
+				negativeValues		: true
+				onEditingFinished	: if(axisModel) axisModel.steps = value
+				fieldWidth			: 2 * jaspTheme.numericFieldWidth
+			}
 
 		}
 
@@ -136,20 +162,37 @@ Column
 
 		JASPC.RadioButtonGroup
 		{
-			id:			axisLimitsRadioButton
-			name:		"axisLimits";
-			title:		qsTr("Limits:")
-			visible	:	axisModel.continuous
+			id			: axisLimitsRadioButton
+			name		: "axisLimits";
+			title		: qsTr("Limits:")
+			visible		: axisModel.continuous
 
-			JASPC.RadioButton	{							value: "data";		label:	qsTr("Based on data");		checked: if(axisModel) axisModel.limitsType === AxisModel.LimitsData	}
-			JASPC.RadioButton	{	id: axisLimitsBreaks;	value: "breaks";	label:	qsTr("Based on ticks");		checked: if(axisModel) axisModel.limitsType === AxisModel.LimitsBreaks;		enabled: showAxis.checked	}
-			JASPC.RadioButton
-			{
-				id: axisLimitsManual;	value: "manual";	label:	qsTr("Set manually");		checked: if(axisModel) axisModel.limitsType === AxisModel.LimitsManual
-				columns: 1
+			JASPC.RadioButton { value: "data";		label: qsTr("Based on data");	checked: if(axisModel) axisModel.limitsType === AxisModel.LimitsData								}
+			JASPC.RadioButton { value: "breaks";	label: qsTr("Based on ticks");	checked: if(axisModel) axisModel.limitsType === AxisModel.LimitsBreaks;	enabled: showAxis.checked	}
+			JASPC.RadioButton { value: "manual";	label: qsTr("Set manually");	checked: if(axisModel) axisModel.limitsType === AxisModel.LimitsManual;	columns: 1
 
-				JASPC.DoubleField	{	id: axisLimitsLower;	label: qsTr("Lower limit");	negativeValues: true;	max: axisModel.limitUpper;		value: axisModel.limitLower;	onEditingFinished: if(axisModel) axisModel.limitLower = value; 	decimals: 20; fieldWidth: 2 * jaspTheme.numericFieldWidth}
-				JASPC.DoubleField	{	id: axisLimitsUpper;	label: qsTr("Upper limit");	negativeValues: true;	min: axisModel.limitLower;		value: axisModel.limitUpper;	onEditingFinished: if(axisModel) axisModel.limitUpper = value; 	decimals: 20; fieldWidth: 2 * jaspTheme.numericFieldWidth}
+				JASPC.DoubleField
+				{
+					id					: axisLimitsLower
+					label				: qsTr("Lower limit")
+					negativeValues		: true
+					max					: axisModel.limitUpper
+					value				: axisModel.limitLower
+					onEditingFinished	: if(axisModel) axisModel.limitLower = value
+					decimals			: 20
+					fieldWidth			: 2 * jaspTheme.numericFieldWidth
+				}
+				JASPC.DoubleField
+				{
+					id					: axisLimitsUpper
+					label				: qsTr("Upper limit")
+					negativeValues		: true
+					min					: axisModel.limitLower
+					value				: axisModel.limitUpper
+					onEditingFinished	: if(axisModel) axisModel.limitUpper = value
+					decimals			: 20
+					fieldWidth			: 2 * jaspTheme.numericFieldWidth
+				}
 			}
 			onValueChanged: axisModel.limitsType = (axisLimitsRadioButton.value === "data" ? AxisModel.LimitsData : axisLimitsRadioButton.value === "breaks" ? AxisModel.LimitsBreaks : AxisModel.LimitsManual)
 		}

--- a/Desktop/results/ploteditoraxismodel.cpp
+++ b/Desktop/results/ploteditoraxismodel.cpp
@@ -120,6 +120,16 @@ void AxisModel::getEntryAndBreaks(size_t & entry, bool & breaks, const QModelInd
 	breaks	= hasBreaks() && (	_vertical ? index.row()		: index.column()) == 0;
 }
 
+void AxisModel::refresh()
+{
+	beginResetModel();
+	endResetModel();
+	emit titleTypeChanged(titleType());
+	emit typeChanged(type());
+	emit rangeChanged();
+	emit limitsChanged();
+}
+
 QVariant AxisModel::data(const QModelIndex &index, int role) const
 {
 	if(role != Qt::DisplayRole || index.row() < 0 || index.row() >= rowCount() || index.column() < 0 || index.column() >= columnCount())

--- a/Desktop/results/ploteditoraxismodel.cpp
+++ b/Desktop/results/ploteditoraxismodel.cpp
@@ -4,6 +4,7 @@
 #include "utilities/jsonutilities.h"
 #include "log.h"
 #include "gui/messageforwarder.h"
+#include "utils.h"
 
 namespace PlotEditor
 {
@@ -119,13 +120,6 @@ void AxisModel::getEntryAndBreaks(size_t & entry, bool & breaks, const QModelInd
 	breaks	= hasBreaks() && (	_vertical ? index.row()		: index.column()) == 0;
 }
 
-void AxisModel::simplifyLimitsType()
-{
-	// floating point comparision is fine here
-	if (_range.size() > 0 && _limits.size() > 0 && _range[0] == _limits[0] && _range[1] == _limits[1])
-		setLimitsType(LimitsType::LimitsBreaks);
-}
-
 QVariant AxisModel::data(const QModelIndex &index, int role) const
 {
 	if(role != Qt::DisplayRole || index.row() < 0 || index.row() >= rowCount() || index.column() < 0 || index.column() >= columnCount())
@@ -190,11 +184,20 @@ bool AxisModel::setData(const QModelIndex &index, const QVariant &value, int)
 	{
 		double newBreak = value.toDouble();
 
-		if(_breaks[entry] != newBreak)
+		if(!Utils::isEqual(_breaks[entry], newBreak))
 		{
+			double oldBreak = _breaks[entry];
+
 			if ((entry > 0 && _breaks[entry-1] >= newBreak)
 				|| (entry < _breaks.size() - 1 && _breaks[entry+1] <= newBreak))
 			{
+				// A break value should not be smaller that its left one, and higher than its reight one.
+				// Force the view to change its value back to the old value.
+				// This model is the source of a TableView, and if the _breaks[entry] is not changed,
+				// the TableView model will not see any difference in its values and will not ask the TableView to be updated.
+				_breaks[entry] = newBreak;
+				emit dataChanged(index, index);
+				_breaks[entry] = oldBreak;
 				emit dataChanged(index, index);
 				return false;
 			}
@@ -204,8 +207,9 @@ bool AxisModel::setData(const QModelIndex &index, const QVariant &value, int)
 			double labelDouble = label.toDouble(&labelIsDouble);
 			QModelIndex index2 = index;
 
-			if (labelIsDouble && (std::abs(labelDouble - _breaks[entry]) < 0.00001))
+			if (labelIsDouble && (Utils::isEqual(labelDouble, oldBreak)))
 			{
+				// If the label is the same as the break value, then change olso the label.
 				_labels[entry] = value.toString();
 				int col = _vertical ? int(entry) : 1;
 				int row = _vertical ? 1 : int(entry);
@@ -214,14 +218,8 @@ bool AxisModel::setData(const QModelIndex &index, const QVariant &value, int)
 
 			_breaks[entry] = newBreak;
 
-			if (_limitsType != LimitsType::LimitsManual)
-			{
-				if (newBreak < _limits[0])
-					setLimits(newBreak, 0);
-				else if (newBreak > _limits[1])
-					setLimits(newBreak, 1);
-			}
-
+			if (entry == _breaks.size() - 1)	setTo(newBreak);
+			if (entry == 0)						setFrom(newBreak);
 
 			emit dataChanged(index, index2);
 			emit somethingChanged();
@@ -297,6 +295,10 @@ void AxisModel::insertBreak(const QModelIndex &index, const size_t column, const
 	_labels.insert(_labels.begin() + column + position, QString::number(insertedValue));//, 'f', 3))
 
 	endInsertColumns();
+
+	if (insertedValue > to())	setTo(insertedValue);
+	if (insertedValue < from())	setFrom(insertedValue);
+
 	emit dataChanged(index, index);
 	emit somethingChanged();
 	emit hasBreaksChanged();
@@ -305,6 +307,8 @@ void AxisModel::insertBreak(const QModelIndex &index, const size_t column, const
 void AxisModel::deleteBreak(const QModelIndex &index, const size_t column)
 {
 	Log::log()	<<	"AxisModel::deleteBreak() column index is: " << column  << std::endl;
+	if (_breaks.size() <= 2) return;
+
 	emit addToUndoStack();
 
 	beginRemoveColumns(QModelIndex(), column, column + 1);
@@ -313,6 +317,10 @@ void AxisModel::deleteBreak(const QModelIndex &index, const size_t column)
 	_labels.erase(_labels.begin() + column);
 
 	endRemoveColumns();
+
+	if (column == _breaks.size())	setTo(_breaks[column - 1]);
+	if (column == 0)				setFrom(_breaks[0]);
+
 	emit dataChanged(index, index);
 	emit somethingChanged();
 	emit hasBreaksChanged();
@@ -338,34 +346,29 @@ void AxisModel::setRange(const double value, const size_t idx)
 		Log::log() << "Impossible index passed to setRange: idx: " << idx << " | value: " << value << std::endl;
 		return;
 	}
-	else if(_range[idx] == value)		return;
+	else if(Utils::isEqual(_range[idx], value))		return;
 
 	emit addToUndoStack();
 	_range[idx] = value;
-
-	if (idx <= 1) // only need to update the limits if from (0) or to (1) is modified
-		setLimits(value, idx);
 
 	emit rangeChanged();
 	emit somethingChanged();
 }
 
-void AxisModel::setFrom(const double from)
+void AxisModel::setFrom(const double newFrom)
 {
+	double oldFrom = from();
+	setRange(newFrom, 0);
 
-	setLimits(from, 0);
-	setLimitsType(LimitsType::LimitsBreaks);
-
-	setRange(from, 0);
+	if (Utils::isEqual(lower(), oldFrom))	setLimits(newFrom, 0);
 }
 
-void AxisModel::setTo(const double to)
+void AxisModel::setTo(const double newTo)
 {
+	double oldTo = to();
+	setRange(newTo, 1);
 
-	setLimits(to, 1);
-	setLimitsType(LimitsType::LimitsBreaks);
-
-	setRange(to, 1);
+	if (Utils::isEqual(upper(), oldTo))		setLimits(newTo, 1);
 }
 
 void AxisModel::setLimitsType(const LimitsType limitsType)
@@ -388,7 +391,7 @@ void AxisModel::setLimits(const double value, const size_t idx)
 		Log::log() << "Impossible index passed to setLimits: idx: " << idx << " | value: " << value << std::endl;
 		return;
 	}
-	else if (_limits[idx] == value)		return;
+	else if (Utils::isEqual(_limits[idx], value))		return;
 
 	emit addToUndoStack();
 

--- a/Desktop/results/ploteditoraxismodel.h
+++ b/Desktop/results/ploteditoraxismodel.h
@@ -73,6 +73,7 @@ public:
 	bool				hasBreaks()		const	{ return _breaks.size() > 0; }
 
 	bool				continuous()	const	{ return _continuous;	}
+	void				refresh();
 
 public slots:
 	void setTitle(		QString title);

--- a/Desktop/results/ploteditoraxismodel.h
+++ b/Desktop/results/ploteditoraxismodel.h
@@ -74,8 +74,6 @@ public:
 
 	bool				continuous()	const	{ return _continuous;	}
 
-	void				simplifyLimitsType();
-
 public slots:
 	void setTitle(		QString title);
 	void setTitleType(	TitleType title);

--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -282,13 +282,16 @@ void PlotEditorModel::refresh()
 	if(!_analysis)
 		return;
 
+	_analysis->setEditOptionsOfPlot(_name.toStdString(), _imgOptions["editOptions"]);
+
 	//Lets make sure the plot gets reloaded by QML
 	_goBlank = true;
 	emit dataChanged();
 	_goBlank = false;
 	emit dataChanged();
 
-	_analysis->setEditOptionsOfPlot(_name.toStdString(), _imgOptions["editOptions"]);
+	_xAxis->refresh();
+	_yAxis->refresh();
 }
 
 QUrl PlotEditorModel::imgFile() const


### PR DESCRIPTION
The constraints of the 'from' and 'to' values in the ticks settings are reinforced so that the 'from' value is always smaller than the 'to' value (with exception when the steps is negative: this is a strange default behaviour of the Raincloud plots).
Also when setting manually the ticks, it is not anymore possible to set the value of position smaller than its left value and bigger than its right value.

When the ticks are changed (either by specifying the sequence or setting them manually), the manual Lower & Upper limits (in Advanced) are changed also automatically as long as these limits are not previously changed manually (in fact as long as the upper & lower limits correspond to the 'from' and 'to' values).
The limit type (based on data, ticks or set manually) is not changed anymore.
This solves https://github.com/jasp-stats/jasp-test-release/issues/1502
and part of https://github.com/jasp-stats/jasp-test-release/issues/1385

