### PR TITLE
Fixing the Slider.qml

### DIFF
--- a/Desktop/components/JASP/Controls/Slider.qml
+++ b/Desktop/components/JASP/Controls/Slider.qml
@@ -62,13 +62,13 @@ SliderBase
 				width:			control.vertical ? implicitWidth : control.availableWidth
 				height:			control.vertical ? control.availableHeight : implicitHeight
 				radius:			jaspTheme.sliderWidth / 2
-				color:			jaspTheme.sliderPartOn
+                color:			control.vertical ? jaspTheme.sliderPartOn : jaspTheme.sliderPartOff
 
 				Rectangle
 				{
 					width:		control.vertical ? parent.width : control.visualPosition * parent.width
 					height:		control.vertical ? control.visualPosition * parent.height : parent.height
-					color:		jaspTheme.sliderPartOff
+                    color:		control.vertical ? jaspTheme.sliderPartOff : jaspTheme.sliderPartOn
 					radius:		jaspTheme.sliderWidth / 2
 				}
 			}

--- a/Desktop/components/JASP/Controls/Slider.qml
+++ b/Desktop/components/JASP/Controls/Slider.qml
@@ -30,10 +30,11 @@ SliderBase
 
 	Component.onCompleted: control.moved.connect(moved);
 
-	ColumnLayout
+    GridLayout
 	{
-		id:			columnLayout;
-		spacing:	controlLabel.visible ? jaspTheme.labelSpacing : 0
+        id:             columnLayout;
+        rows:           control.vertical ? 3 : 1
+        columns:        control.vertical ? 1 : 3
 
 		Label
 		{
@@ -46,7 +47,7 @@ SliderBase
 		Slider
 		{
 			id:					control
-			Layout.alignment:	control.orientation === Qt.Vertical ? Qt.AlignCenter : Qt.AlignLeft
+            Layout.alignment:	Qt.AlignCenter
 			Layout.leftMargin:	control.orientation === Qt.Vertical ? leftPadding + jaspTheme.sliderWidth : 0
 			value:				0.5
 			stepSize:			1 / slider.power
@@ -55,8 +56,8 @@ SliderBase
 			background: Rectangle
 			{
 				id:				sliderBackground
-				x:				control.leftPadding
-				y:				control.topPadding
+                x:				control.leftPadding
+                y:				control.topPadding + (control.vertical ? 0 : control.height / 4)
 				implicitWidth:	control.vertical ? jaspTheme.sliderWidth : jaspTheme.sliderLength
 				implicitHeight: control.vertical ? jaspTheme.sliderLength : jaspTheme.sliderWidth
 				width:			control.vertical ? implicitWidth : control.availableWidth
@@ -75,9 +76,9 @@ SliderBase
 
 			handle: Rectangle
 			{
-				id:				sliderHandle
-				x:				control.leftPadding + (control.vertical ? sliderBackground.radius - sliderHandle.radius : control.visualPosition * (control.availableWidth - width))
-				y:				control.topPadding + (control.vertical ? control.visualPosition * (control.availableHeight - height) : sliderBackground.radius - sliderHandle.radius)
+                id:				sliderHandle
+                x:				control.leftPadding + (control.vertical ? sliderBackground.radius - sliderHandle.radius : control.visualPosition * (control.availableWidth - width))
+                y:				control.topPadding + (control.vertical ? control.visualPosition * (control.availableHeight - height) : sliderBackground.radius - sliderHandle.radius) + (control.vertical ? 0 : control.height / 4)
 				implicitWidth:	jaspTheme.sliderHandleDiameter
 				implicitHeight: jaspTheme.sliderHandleDiameter
 				radius:			jaspTheme.sliderHandleDiameter / 2

--- a/Desktop/components/JASP/Controls/Slider.qml
+++ b/Desktop/components/JASP/Controls/Slider.qml
@@ -30,11 +30,11 @@ SliderBase
 
 	Component.onCompleted: control.moved.connect(moved);
 
-    GridLayout
+	GridLayout
 	{
-        id:             columnLayout;
-        rows:           control.vertical ? 3 : 1
-        columns:        control.vertical ? 1 : 3
+		id:				columnLayout;
+		rows:			control.vertical ? 3 : 1
+		columns:		control.vertical ? 1 : 3
 
 		Label
 		{
@@ -47,7 +47,7 @@ SliderBase
 		Slider
 		{
 			id:					control
-            Layout.alignment:	Qt.AlignCenter
+			Layout.alignment:	Qt.AlignCenter
 			Layout.leftMargin:	control.orientation === Qt.Vertical ? leftPadding + jaspTheme.sliderWidth : 0
 			value:				0.5
 			stepSize:			1 / slider.power
@@ -56,29 +56,29 @@ SliderBase
 			background: Rectangle
 			{
 				id:				sliderBackground
-                x:				control.leftPadding
-                y:				control.topPadding + (control.vertical ? 0 : control.height / 4)
+				x:				control.leftPadding
+				y:				control.topPadding + (control.vertical ? 0 : control.height / 4)
 				implicitWidth:	control.vertical ? jaspTheme.sliderWidth : jaspTheme.sliderLength
 				implicitHeight: control.vertical ? jaspTheme.sliderLength : jaspTheme.sliderWidth
 				width:			control.vertical ? implicitWidth : control.availableWidth
 				height:			control.vertical ? control.availableHeight : implicitHeight
 				radius:			jaspTheme.sliderWidth / 2
-                color:			control.vertical ? jaspTheme.sliderPartOn : jaspTheme.sliderPartOff
+				color:			control.vertical ? jaspTheme.sliderPartOn : jaspTheme.sliderPartOff
 
 				Rectangle
 				{
 					width:		control.vertical ? parent.width : control.visualPosition * parent.width
 					height:		control.vertical ? control.visualPosition * parent.height : parent.height
-                    color:		control.vertical ? jaspTheme.sliderPartOff : jaspTheme.sliderPartOn
+					color:		control.vertical ? jaspTheme.sliderPartOff : jaspTheme.sliderPartOn
 					radius:		jaspTheme.sliderWidth / 2
 				}
 			}
 
 			handle: Rectangle
 			{
-                id:				sliderHandle
-                x:				control.leftPadding + (control.vertical ? sliderBackground.radius - sliderHandle.radius : control.visualPosition * (control.availableWidth - width))
-                y:				control.topPadding + (control.vertical ? control.visualPosition * (control.availableHeight - height) : sliderBackground.radius - sliderHandle.radius) + (control.vertical ? 0 : control.height / 4)
+				id:				sliderHandle
+				x:				control.leftPadding + (control.vertical ? sliderBackground.radius - sliderHandle.radius : control.visualPosition * (control.availableWidth - width))
+				y:				control.topPadding + (control.vertical ? control.visualPosition * (control.availableHeight - height) : sliderBackground.radius - sliderHandle.radius) + (control.vertical ? 0 : control.height / 4)
 				implicitWidth:	jaspTheme.sliderHandleDiameter
 				implicitHeight: jaspTheme.sliderHandleDiameter
 				radius:			jaspTheme.sliderHandleDiameter / 2


### PR DESCRIPTION
→ This PR is needed for [this](https://github.com/jasp-stats/jaspFactor/pull/49) one at jaspFactor to work properly.

I basically had to change the orientation, and use GridLayout to make sure that things align correctly. That being said, I had to align the Rectangles manually (just slightly) which is not what I would have liked to do. The Slider control that we have is putting a fight and is really stubborn when it comes to aligning itself with other elements. 

P.S. I'm sure there is a good reason for writing our own `handle` and `background` elements for the Slider. Is it due to custom padding, and theming?