### PR TITLE
Replacing limit macros with numeric limits

### DIFF
--- a/Common/column.cpp
+++ b/Common/column.cpp
@@ -65,7 +65,7 @@ void Column::_convertVectorIntToDouble(vector<int> &intValues, vector<double> &d
 	{
 		const int &intValue = *it;
 		double doubleValue = intValue;
-		if (intValue == std::numeric_limits<int>::min())
+		if (intValue == std::numeric_limits<int>::lowest())
 			doubleValue = NAN;
 		doubleValues.push_back(doubleValue);
 	}
@@ -87,7 +87,7 @@ bool Column::_resetEmptyValuesForNominal(std::map<int, string> &emptyValuesMap)
 	for (; ints != end; ints++)
 	{
 		int intValue = *ints;
-		if (intValue == std::numeric_limits<int>::min() && hasEmptyValues)
+		if (intValue == std::numeric_limits<int>::lowest() && hasEmptyValues)
 		{
 			auto search = emptyValuesMap.find(row);
 			if (search != emptyValuesMap.end())
@@ -113,10 +113,10 @@ bool Column::_resetEmptyValuesForNominal(std::map<int, string> &emptyValuesMap)
 				}
 			}
 		}
-		else if (intValue != std::numeric_limits<int>::min() && Utils::isEmptyValue(intValue))
+		else if (intValue != std::numeric_limits<int>::lowest() && Utils::isEmptyValue(intValue))
 		{
 			// This value is now considered as empty
-			*ints = std::numeric_limits<int>::min();
+			*ints = std::numeric_limits<int>::lowest();
 			uniqueValues.erase(intValue);
 			hasChanged = true;
 			std::ostringstream strs;
@@ -242,7 +242,7 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 	{
 		int key = *ints;
 
-		if (key == std::numeric_limits<int>::min() && hasEmptyValues)
+		if (key == std::numeric_limits<int>::lowest() && hasEmptyValues)
 		{
 			auto search = emptyValuesMap.find(row);
 			if (search != emptyValuesMap.end())
@@ -257,7 +257,7 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 				{
 					if (Utils::isEmptyValue(orgValue))
 					{
-						if (canBeConvertedToIntegers)	intValues.push_back(std::numeric_limits<int>::min());
+						if (canBeConvertedToIntegers)	intValues.push_back(std::numeric_limits<int>::lowest());
 						else							doubleValues.push_back(NAN);
 					}
 					else
@@ -310,15 +310,15 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 			{
 				values.push_back(Utils::emptyValue);
 
-				if (canBeConvertedToIntegers)		intValues.push_back(std::numeric_limits<int>::min());
+				if (canBeConvertedToIntegers)		intValues.push_back(std::numeric_limits<int>::lowest());
 				else if (canBeConvertedToDoubles)	doubleValues.push_back(NAN);
 			}
 		}
-		else if (key == std::numeric_limits<int>::min())
+		else if (key == std::numeric_limits<int>::lowest())
 		{
 			values.push_back(Utils::emptyValue);
 
-			if (canBeConvertedToIntegers)		intValues.push_back(std::numeric_limits<int>::min());
+			if (canBeConvertedToIntegers)		intValues.push_back(std::numeric_limits<int>::lowest());
 			else if (canBeConvertedToDoubles)	doubleValues.push_back(NAN);
 		}
 		else
@@ -331,7 +331,7 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 				hasChanged = true;
 				if (canBeConvertedToIntegers)
 				{
-					intValues.push_back(std::numeric_limits<int>::min());
+					intValues.push_back(std::numeric_limits<int>::lowest());
 					emptyValuesMap.insert(make_pair(row, orgValue));
 				}
 				else if (canBeConvertedToDoubles)
@@ -465,9 +465,9 @@ columnTypeChangeResult Column::_changeColumnToNominalOrOrdinal(enum columnType n
 
 		for (int key : AsInts)
 		{
-			int intValue = std::numeric_limits<int>::min();
+			int intValue = std::numeric_limits<int>::lowest();
 
-			if (key != std::numeric_limits<int>::min())
+			if (key != std::numeric_limits<int>::lowest())
 			{
 				std::string value = _labels.getValueFromKey(key);
 				if (!Utils::isEmptyValue(value) && !Utils::getIntValue(value, intValue))
@@ -476,7 +476,7 @@ columnTypeChangeResult Column::_changeColumnToNominalOrOrdinal(enum columnType n
 
 			values.push_back(intValue);
 
-			if (intValue != std::numeric_limits<int>::min())
+			if (intValue != std::numeric_limits<int>::lowest())
 			{
 				if (uniqueIntValues.find(intValue) != uniqueIntValues.end())
 				{
@@ -504,7 +504,7 @@ columnTypeChangeResult Column::_changeColumnToNominalOrOrdinal(enum columnType n
 
 		for (double doubleValue : AsDoubles)
 		{
-			int intValue = std::numeric_limits<int>::min();
+			int intValue = std::numeric_limits<int>::lowest();
 
 			if (!Utils::isEmptyValue(doubleValue) && !Utils::getIntValue(doubleValue, intValue))
 				break;
@@ -548,7 +548,7 @@ columnTypeChangeResult Column::_changeColumnToScale()
 		{
 			double doubleValue = NAN;
 
-			if (intValue != std::numeric_limits<int>::min() && !Utils::isEmptyValue(intValue))
+			if (intValue != std::numeric_limits<int>::lowest() && !Utils::isEmptyValue(intValue))
 				doubleValue = double(intValue);
 
 			values.push_back(doubleValue);
@@ -562,14 +562,14 @@ columnTypeChangeResult Column::_changeColumnToScale()
 			double	doubleValue = NAN;
 			bool	converted	= false;
 
-			if (key != std::numeric_limits<int>::min())
+			if (key != std::numeric_limits<int>::lowest())
 			{
 				string value = _labels.getValueFromKey(key);
 				if (!Utils::isEmptyValue(value))
 					converted = Utils::getDoubleValue(value, doubleValue);
 			}
 			else
-				converted = true; //Because if key == std::numeric_limits<int>::min() then it is missing value
+				converted = true; //Because if key == std::numeric_limits<int>::lowest() then it is missing value
 
 			if (converted)	values.push_back(doubleValue);
 			else			return columnTypeChangeResult::cannotConvertStringValueToDouble;
@@ -614,7 +614,7 @@ bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData, std::map<int
 		ordinalData.resize(rowCount());
 
 	for(size_t setThis = setVals; setThis<ordinalData.size(); setThis++)
-		ordinalData[setThis] = std::numeric_limits<int>::min();
+		ordinalData[setThis] = std::numeric_limits<int>::lowest();
 
 	return setColumnAsNominalOrOrdinal(ordinalData, levels, true);
 }
@@ -627,7 +627,7 @@ bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData)
 		ordinalData.resize(rowCount());
 
 	for(size_t setThis = setVals; setThis<ordinalData.size(); setThis++)
-		ordinalData[setThis] = std::numeric_limits<int>::min();
+		ordinalData[setThis] = std::numeric_limits<int>::lowest();
 
 	return setColumnAsNominalOrOrdinal(ordinalData, true);
 }
@@ -640,7 +640,7 @@ bool Column::overwriteDataWithNominal(std::vector<int> nominalData, std::map<int
 		nominalData.resize(rowCount());
 
 	for(size_t setThis = setVals; setThis<nominalData.size(); setThis++)
-		nominalData[setThis] = std::numeric_limits<int>::min();
+		nominalData[setThis] = std::numeric_limits<int>::lowest();
 
 	return setColumnAsNominalOrOrdinal(nominalData, levels, false);
 }
@@ -653,7 +653,7 @@ bool Column::overwriteDataWithNominal(std::vector<int> nominalData)
 		nominalData.resize(rowCount());
 
 	for(size_t setThis = setVals; setThis<nominalData.size(); setThis++)
-		nominalData[setThis] = std::numeric_limits<int>::min();
+		nominalData[setThis] = std::numeric_limits<int>::lowest();
 
 	return setColumnAsNominalOrOrdinal(nominalData, false);
 }
@@ -677,8 +677,8 @@ void Column::setDefaultValues(enum columnType columnType)
 	switch(columnType)
 	{
 	case columnType::scale:			overwriteDataWithScale(std::vector<double>(rowCount(), static_cast<double>(std::nanf(""))));	break;
-	case columnType::ordinal:		overwriteDataWithOrdinal(std::vector<int>(rowCount(), std::numeric_limits<int>::min()));								break;
-	case columnType::nominal:		overwriteDataWithNominal(std::vector<int>(rowCount(), std::numeric_limits<int>::min()));								break;
+	case columnType::ordinal:		overwriteDataWithOrdinal(std::vector<int>(rowCount(), std::numeric_limits<int>::lowest()));								break;
+	case columnType::nominal:		overwriteDataWithNominal(std::vector<int>(rowCount(), std::numeric_limits<int>::lowest()));								break;
 	case columnType::nominalText:	overwriteDataWithNominal(std::vector<std::string>(rowCount()));									break;
 	case columnType::unknown:		throw std::runtime_error("Trying to set default values of a column with unknown column type...");
 	}
@@ -688,7 +688,7 @@ void Column::setDefaultValues(enum columnType columnType)
 bool Column::setColumnAsNominalOrOrdinal(const std::vector<int> &values, bool is_ordinal)
 {
 	std::set<int> uniqueValues(values.begin(), values.end());
-	uniqueValues.erase(std::numeric_limits<int>::min());
+	uniqueValues.erase(std::numeric_limits<int>::lowest());
 
 	bool labelChanged	= _labels.syncInts(uniqueValues);
 	bool dataChanged	= _setColumnAsNominalOrOrdinal(values, is_ordinal);
@@ -699,7 +699,7 @@ bool Column::setColumnAsNominalOrOrdinal(const std::vector<int> &values, bool is
 bool Column::setColumnAsNominalOrOrdinal(const vector<int> &values, map<int, string> uniqueValues, bool is_ordinal)
 {
 	std::set<int> uniqueValuesData(values.begin(), values.end());
-	uniqueValuesData.erase(std::numeric_limits<int>::min());
+	uniqueValuesData.erase(std::numeric_limits<int>::lowest());
 	
 	std::stringstream labelsMissing;
 	int cnt = 0;
@@ -742,10 +742,10 @@ bool Column::_setColumnAsNominalOrOrdinal(const vector<int> &values, bool is_ord
 
 	while (nb_values < _rowCount)
 	{
-		if(*intInputItr != std::numeric_limits<int>::min())
+		if(*intInputItr != std::numeric_limits<int>::lowest())
 			changedSomething = true;
 
-		*intInputItr = std::numeric_limits<int>::min();
+		*intInputItr = std::numeric_limits<int>::lowest();
 		intInputItr++;
 		nb_values++;
 	}
@@ -821,10 +821,10 @@ std::map<int, std::string> Column::setColumnAsNominalText(const std::vector<std:
 
 		if (Utils::isEmptyValue(value))
 		{
-			if(changedSomething != nullptr && *intInputItr != std::numeric_limits<int>::min())
+			if(changedSomething != nullptr && *intInputItr != std::numeric_limits<int>::lowest())
 				*changedSomething = true;
 
-			*intInputItr = std::numeric_limits<int>::min();
+			*intInputItr = std::numeric_limits<int>::lowest();
 			if (!value.empty())
 				emptyValuesMap.insert(make_pair(nb_values, value));
 		}
@@ -850,10 +850,10 @@ std::map<int, std::string> Column::setColumnAsNominalText(const std::vector<std:
 
 	while (nb_values < _rowCount)
 	{
-		if(changedSomething != nullptr && *intInputItr != std::numeric_limits<int>::min())
+		if(changedSomething != nullptr && *intInputItr != std::numeric_limits<int>::lowest())
 			*changedSomething = true;
 
-		*intInputItr = std::numeric_limits<int>::min();
+		*intInputItr = std::numeric_limits<int>::lowest();
 		intInputItr++;
 		nb_values++;
 	}
@@ -865,7 +865,7 @@ std::map<int, std::string> Column::setColumnAsNominalText(const std::vector<std:
 
 string Column::_getLabelFromKey(int key) const
 {
-	if (key == std::numeric_limits<int>::min())
+	if (key == std::numeric_limits<int>::lowest())
 		return Utils::emptyValue;
 
 	if (_labels.size() > 0)
@@ -969,8 +969,8 @@ bool Column::isValueEqual(int row, int value)
 		return result;
 	}
 
-	if (intValue == std::numeric_limits<int>::min())
-		return value == std::numeric_limits<int>::min();
+	if (intValue == std::numeric_limits<int>::lowest())
+		return value == std::numeric_limits<int>::lowest();
 
 	if (_labels.size() > 0)
 	{
@@ -1003,7 +1003,7 @@ bool Column::isValueEqual(int row, const string &value)
 		default:
 		{
 			int key = AsInts[row];
-			return key == std::numeric_limits<int>::min() ? Utils::isEmptyValue(value) : (value.substr(0, 128) == _labels.getValueFromKey(key));
+			return key == std::numeric_limits<int>::lowest() ? Utils::isEmptyValue(value) : (value.substr(0, 128) == _labels.getValueFromKey(key));
 		}
 	}
 
@@ -1015,7 +1015,7 @@ string Column::_getScaleValue(int row)
 	double v = AsDoubles[row];
 
 	if (v > std::numeric_limits<double>::max())					return string({ (char)0xE2, (char)0x88, (char)0x9E, 0 });
-	else if (v < std::numeric_limits<double>::min())			return string({ (char)0x2D, (char)0xE2, (char)0x88, (char)0x9E, 0 });
+	else if (v < std::numeric_limits<double>::lowest())			return string({ (char)0x2D, (char)0xE2, (char)0x88, (char)0x9E, 0 });
 	else if (Utils::isEmptyValue(v))	return Utils::emptyValue;
 	else								return Utils::doubleToString(v);
 }
@@ -1033,7 +1033,7 @@ string Column::getOriginalValue(int row)
 		else
 		{
 			int key = AsInts[row];
-			if (key == std::numeric_limits<int>::min())
+			if (key == std::numeric_limits<int>::lowest())
 				result = Utils::emptyValue;
 			else
 				result = _labels.getValueFromKey(key);

--- a/Common/column.cpp
+++ b/Common/column.cpp
@@ -677,8 +677,8 @@ void Column::setDefaultValues(enum columnType columnType)
 	switch(columnType)
 	{
 	case columnType::scale:			overwriteDataWithScale(std::vector<double>(rowCount(), static_cast<double>(std::nanf(""))));	break;
-	case columnType::ordinal:		overwriteDataWithOrdinal(std::vector<int>(rowCount(), std::numeric_limits<int>::lowest()));								break;
-	case columnType::nominal:		overwriteDataWithNominal(std::vector<int>(rowCount(), std::numeric_limits<int>::lowest()));								break;
+	case columnType::ordinal:		overwriteDataWithOrdinal(std::vector<int>(rowCount(), std::numeric_limits<int>::lowest()));		break;
+	case columnType::nominal:		overwriteDataWithNominal(std::vector<int>(rowCount(), std::numeric_limits<int>::lowest()));		break;
 	case columnType::nominalText:	overwriteDataWithNominal(std::vector<std::string>(rowCount()));									break;
 	case columnType::unknown:		throw std::runtime_error("Trying to set default values of a column with unknown column type...");
 	}
@@ -1016,8 +1016,8 @@ string Column::_getScaleValue(int row)
 
 	if (v > std::numeric_limits<double>::max())					return string({ (char)0xE2, (char)0x88, (char)0x9E, 0 });
 	else if (v < std::numeric_limits<double>::lowest())			return string({ (char)0x2D, (char)0xE2, (char)0x88, (char)0x9E, 0 });
-	else if (Utils::isEmptyValue(v))	return Utils::emptyValue;
-	else								return Utils::doubleToString(v);
+	else if (Utils::isEmptyValue(v))							return Utils::emptyValue;
+	else														return Utils::doubleToString(v);
 }
 
 string Column::getOriginalValue(int row)

--- a/Common/column.cpp
+++ b/Common/column.cpp
@@ -65,7 +65,7 @@ void Column::_convertVectorIntToDouble(vector<int> &intValues, vector<double> &d
 	{
 		const int &intValue = *it;
 		double doubleValue = intValue;
-		if (intValue == INT_MIN)
+		if (intValue == std::numeric_limits<int>::min())
 			doubleValue = NAN;
 		doubleValues.push_back(doubleValue);
 	}
@@ -87,7 +87,7 @@ bool Column::_resetEmptyValuesForNominal(std::map<int, string> &emptyValuesMap)
 	for (; ints != end; ints++)
 	{
 		int intValue = *ints;
-		if (intValue == INT_MIN && hasEmptyValues)
+		if (intValue == std::numeric_limits<int>::min() && hasEmptyValues)
 		{
 			auto search = emptyValuesMap.find(row);
 			if (search != emptyValuesMap.end())
@@ -113,10 +113,10 @@ bool Column::_resetEmptyValuesForNominal(std::map<int, string> &emptyValuesMap)
 				}
 			}
 		}
-		else if (intValue != INT_MIN && Utils::isEmptyValue(intValue))
+		else if (intValue != std::numeric_limits<int>::min() && Utils::isEmptyValue(intValue))
 		{
 			// This value is now considered as empty
-			*ints = INT_MIN;
+			*ints = std::numeric_limits<int>::min();
 			uniqueValues.erase(intValue);
 			hasChanged = true;
 			std::ostringstream strs;
@@ -242,7 +242,7 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 	{
 		int key = *ints;
 
-		if (key == INT_MIN && hasEmptyValues)
+		if (key == std::numeric_limits<int>::min() && hasEmptyValues)
 		{
 			auto search = emptyValuesMap.find(row);
 			if (search != emptyValuesMap.end())
@@ -257,7 +257,7 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 				{
 					if (Utils::isEmptyValue(orgValue))
 					{
-						if (canBeConvertedToIntegers)	intValues.push_back(INT_MIN);
+						if (canBeConvertedToIntegers)	intValues.push_back(std::numeric_limits<int>::min());
 						else							doubleValues.push_back(NAN);
 					}
 					else
@@ -310,15 +310,15 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 			{
 				values.push_back(Utils::emptyValue);
 
-				if (canBeConvertedToIntegers)		intValues.push_back(INT_MIN);
+				if (canBeConvertedToIntegers)		intValues.push_back(std::numeric_limits<int>::min());
 				else if (canBeConvertedToDoubles)	doubleValues.push_back(NAN);
 			}
 		}
-		else if (key == INT_MIN)
+		else if (key == std::numeric_limits<int>::min())
 		{
 			values.push_back(Utils::emptyValue);
 
-			if (canBeConvertedToIntegers)		intValues.push_back(INT_MIN);
+			if (canBeConvertedToIntegers)		intValues.push_back(std::numeric_limits<int>::min());
 			else if (canBeConvertedToDoubles)	doubleValues.push_back(NAN);
 		}
 		else
@@ -331,7 +331,7 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 				hasChanged = true;
 				if (canBeConvertedToIntegers)
 				{
-					intValues.push_back(INT_MIN);
+					intValues.push_back(std::numeric_limits<int>::min());
 					emptyValuesMap.insert(make_pair(row, orgValue));
 				}
 				else if (canBeConvertedToDoubles)
@@ -465,9 +465,9 @@ columnTypeChangeResult Column::_changeColumnToNominalOrOrdinal(enum columnType n
 
 		for (int key : AsInts)
 		{
-			int intValue = INT_MIN;
+			int intValue = std::numeric_limits<int>::min();
 
-			if (key != INT_MIN)
+			if (key != std::numeric_limits<int>::min())
 			{
 				std::string value = _labels.getValueFromKey(key);
 				if (!Utils::isEmptyValue(value) && !Utils::getIntValue(value, intValue))
@@ -476,7 +476,7 @@ columnTypeChangeResult Column::_changeColumnToNominalOrOrdinal(enum columnType n
 
 			values.push_back(intValue);
 
-			if (intValue != INT_MIN)
+			if (intValue != std::numeric_limits<int>::min())
 			{
 				if (uniqueIntValues.find(intValue) != uniqueIntValues.end())
 				{
@@ -504,7 +504,7 @@ columnTypeChangeResult Column::_changeColumnToNominalOrOrdinal(enum columnType n
 
 		for (double doubleValue : AsDoubles)
 		{
-			int intValue = INT_MIN;
+			int intValue = std::numeric_limits<int>::min();
 
 			if (!Utils::isEmptyValue(doubleValue) && !Utils::getIntValue(doubleValue, intValue))
 				break;
@@ -548,7 +548,7 @@ columnTypeChangeResult Column::_changeColumnToScale()
 		{
 			double doubleValue = NAN;
 
-			if (intValue != INT_MIN && !Utils::isEmptyValue(intValue))
+			if (intValue != std::numeric_limits<int>::min() && !Utils::isEmptyValue(intValue))
 				doubleValue = double(intValue);
 
 			values.push_back(doubleValue);
@@ -562,14 +562,14 @@ columnTypeChangeResult Column::_changeColumnToScale()
 			double	doubleValue = NAN;
 			bool	converted	= false;
 
-			if (key != INT_MIN)
+			if (key != std::numeric_limits<int>::min())
 			{
 				string value = _labels.getValueFromKey(key);
 				if (!Utils::isEmptyValue(value))
 					converted = Utils::getDoubleValue(value, doubleValue);
 			}
 			else
-				converted = true; //Because if key == INT_MIN then it is missing value
+				converted = true; //Because if key == std::numeric_limits<int>::min() then it is missing value
 
 			if (converted)	values.push_back(doubleValue);
 			else			return columnTypeChangeResult::cannotConvertStringValueToDouble;
@@ -614,7 +614,7 @@ bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData, std::map<int
 		ordinalData.resize(rowCount());
 
 	for(size_t setThis = setVals; setThis<ordinalData.size(); setThis++)
-		ordinalData[setThis] = INT_MIN;
+		ordinalData[setThis] = std::numeric_limits<int>::min();
 
 	return setColumnAsNominalOrOrdinal(ordinalData, levels, true);
 }
@@ -627,7 +627,7 @@ bool Column::overwriteDataWithOrdinal(std::vector<int> ordinalData)
 		ordinalData.resize(rowCount());
 
 	for(size_t setThis = setVals; setThis<ordinalData.size(); setThis++)
-		ordinalData[setThis] = INT_MIN;
+		ordinalData[setThis] = std::numeric_limits<int>::min();
 
 	return setColumnAsNominalOrOrdinal(ordinalData, true);
 }
@@ -640,7 +640,7 @@ bool Column::overwriteDataWithNominal(std::vector<int> nominalData, std::map<int
 		nominalData.resize(rowCount());
 
 	for(size_t setThis = setVals; setThis<nominalData.size(); setThis++)
-		nominalData[setThis] = INT_MIN;
+		nominalData[setThis] = std::numeric_limits<int>::min();
 
 	return setColumnAsNominalOrOrdinal(nominalData, levels, false);
 }
@@ -653,7 +653,7 @@ bool Column::overwriteDataWithNominal(std::vector<int> nominalData)
 		nominalData.resize(rowCount());
 
 	for(size_t setThis = setVals; setThis<nominalData.size(); setThis++)
-		nominalData[setThis] = INT_MIN;
+		nominalData[setThis] = std::numeric_limits<int>::min();
 
 	return setColumnAsNominalOrOrdinal(nominalData, false);
 }
@@ -677,8 +677,8 @@ void Column::setDefaultValues(enum columnType columnType)
 	switch(columnType)
 	{
 	case columnType::scale:			overwriteDataWithScale(std::vector<double>(rowCount(), static_cast<double>(std::nanf(""))));	break;
-	case columnType::ordinal:		overwriteDataWithOrdinal(std::vector<int>(rowCount(), INT_MIN));								break;
-	case columnType::nominal:		overwriteDataWithNominal(std::vector<int>(rowCount(), INT_MIN));								break;
+	case columnType::ordinal:		overwriteDataWithOrdinal(std::vector<int>(rowCount(), std::numeric_limits<int>::min()));								break;
+	case columnType::nominal:		overwriteDataWithNominal(std::vector<int>(rowCount(), std::numeric_limits<int>::min()));								break;
 	case columnType::nominalText:	overwriteDataWithNominal(std::vector<std::string>(rowCount()));									break;
 	case columnType::unknown:		throw std::runtime_error("Trying to set default values of a column with unknown column type...");
 	}
@@ -688,7 +688,7 @@ void Column::setDefaultValues(enum columnType columnType)
 bool Column::setColumnAsNominalOrOrdinal(const std::vector<int> &values, bool is_ordinal)
 {
 	std::set<int> uniqueValues(values.begin(), values.end());
-	uniqueValues.erase(INT_MIN);
+	uniqueValues.erase(std::numeric_limits<int>::min());
 
 	bool labelChanged	= _labels.syncInts(uniqueValues);
 	bool dataChanged	= _setColumnAsNominalOrOrdinal(values, is_ordinal);
@@ -699,7 +699,7 @@ bool Column::setColumnAsNominalOrOrdinal(const std::vector<int> &values, bool is
 bool Column::setColumnAsNominalOrOrdinal(const vector<int> &values, map<int, string> uniqueValues, bool is_ordinal)
 {
 	std::set<int> uniqueValuesData(values.begin(), values.end());
-	uniqueValuesData.erase(INT_MIN);
+	uniqueValuesData.erase(std::numeric_limits<int>::min());
 	
 	std::stringstream labelsMissing;
 	int cnt = 0;
@@ -742,10 +742,10 @@ bool Column::_setColumnAsNominalOrOrdinal(const vector<int> &values, bool is_ord
 
 	while (nb_values < _rowCount)
 	{
-		if(*intInputItr != INT_MIN)
+		if(*intInputItr != std::numeric_limits<int>::min())
 			changedSomething = true;
 
-		*intInputItr = INT_MIN;
+		*intInputItr = std::numeric_limits<int>::min();
 		intInputItr++;
 		nb_values++;
 	}
@@ -821,10 +821,10 @@ std::map<int, std::string> Column::setColumnAsNominalText(const std::vector<std:
 
 		if (Utils::isEmptyValue(value))
 		{
-			if(changedSomething != nullptr && *intInputItr != INT_MIN)
+			if(changedSomething != nullptr && *intInputItr != std::numeric_limits<int>::min())
 				*changedSomething = true;
 
-			*intInputItr = INT_MIN;
+			*intInputItr = std::numeric_limits<int>::min();
 			if (!value.empty())
 				emptyValuesMap.insert(make_pair(nb_values, value));
 		}
@@ -850,10 +850,10 @@ std::map<int, std::string> Column::setColumnAsNominalText(const std::vector<std:
 
 	while (nb_values < _rowCount)
 	{
-		if(changedSomething != nullptr && *intInputItr != INT_MIN)
+		if(changedSomething != nullptr && *intInputItr != std::numeric_limits<int>::min())
 			*changedSomething = true;
 
-		*intInputItr = INT_MIN;
+		*intInputItr = std::numeric_limits<int>::min();
 		intInputItr++;
 		nb_values++;
 	}
@@ -865,7 +865,7 @@ std::map<int, std::string> Column::setColumnAsNominalText(const std::vector<std:
 
 string Column::_getLabelFromKey(int key) const
 {
-	if (key == INT_MIN)
+	if (key == std::numeric_limits<int>::min())
 		return Utils::emptyValue;
 
 	if (_labels.size() > 0)
@@ -969,8 +969,8 @@ bool Column::isValueEqual(int row, int value)
 		return result;
 	}
 
-	if (intValue == INT_MIN)
-		return value == INT_MIN;
+	if (intValue == std::numeric_limits<int>::min())
+		return value == std::numeric_limits<int>::min();
 
 	if (_labels.size() > 0)
 	{
@@ -1003,7 +1003,7 @@ bool Column::isValueEqual(int row, const string &value)
 		default:
 		{
 			int key = AsInts[row];
-			return key == INT_MIN ? Utils::isEmptyValue(value) : (value.substr(0, 128) == _labels.getValueFromKey(key));
+			return key == std::numeric_limits<int>::min() ? Utils::isEmptyValue(value) : (value.substr(0, 128) == _labels.getValueFromKey(key));
 		}
 	}
 
@@ -1014,8 +1014,8 @@ string Column::_getScaleValue(int row)
 {
 	double v = AsDoubles[row];
 
-	if (v > DBL_MAX)					return string({ (char)0xE2, (char)0x88, (char)0x9E, 0 });
-	else if (v < -DBL_MAX)				return string({ (char)0x2D, (char)0xE2, (char)0x88, (char)0x9E, 0 });
+	if (v > std::numeric_limits<double>::max())					return string({ (char)0xE2, (char)0x88, (char)0x9E, 0 });
+	else if (v < std::numeric_limits<double>::min())			return string({ (char)0x2D, (char)0xE2, (char)0x88, (char)0x9E, 0 });
 	else if (Utils::isEmptyValue(v))	return Utils::emptyValue;
 	else								return Utils::doubleToString(v);
 }
@@ -1033,7 +1033,7 @@ string Column::getOriginalValue(int row)
 		else
 		{
 			int key = AsInts[row];
-			if (key == INT_MIN)
+			if (key == std::numeric_limits<int>::min())
 				result = Utils::emptyValue;
 			else
 				result = _labels.getValueFromKey(key);

--- a/Common/utils.cpp
+++ b/Common/utils.cpp
@@ -291,7 +291,7 @@ bool Utils::getIntValue(const double &value, int &intValue)
 
 		if (modf(value, &intPart) == 0.0)
 		{
-			if (intPart <=  std::numeric_limits<int>::max() && intPart >= std::numeric_limits<int>::min())
+			if (intPart <=  std::numeric_limits<int>::max() && intPart >= std::numeric_limits<int>::lowest())
 			{
 				intValue = int(intPart);
 				return true;
@@ -379,7 +379,7 @@ bool Utils::convertValueToIntForImport(const std::string &strValue, int &intValu
 			return false;
 	}
 	else
-		intValue = std::numeric_limits<int>::min();
+		intValue = std::numeric_limits<int>::lowest();
 
 	return true;
 }

--- a/Common/utils.cpp
+++ b/Common/utils.cpp
@@ -291,7 +291,7 @@ bool Utils::getIntValue(const double &value, int &intValue)
 
 		if (modf(value, &intPart) == 0.0)
 		{
-			if (intPart <=  INT_MAX && intPart >= INT_MIN)
+			if (intPart <=  std::numeric_limits<int>::max() && intPart >= std::numeric_limits<int>::min())
 			{
 				intValue = int(intPart);
 				return true;
@@ -379,7 +379,7 @@ bool Utils::convertValueToIntForImport(const std::string &strValue, int &intValu
 			return false;
 	}
 	else
-		intValue = INT_MIN;
+		intValue = std::numeric_limits<int>::min();
 
 	return true;
 }
@@ -446,13 +446,13 @@ bool Utils::isEqual(const double a, const double b)
 {
 	if (isnan(a) || isnan(b)) return false;
 
-	return (fabs(a - b) <= ( (fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * DBL_EPSILON));
+	return (fabs(a - b) <= ( (fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * std::numeric_limits<double>::epsilon()));
 }
 bool Utils::isEqual(const float a, const float b)
 {
 	if (isnan(a) || isnan(b)) return false;
 
-	return fabs(a - b) <= ( (fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * FLT_EPSILON);
+	return fabs(a - b) <= ( (fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * std::numeric_limits<float>::epsilon());
 }
 
 #ifdef _WIN32

--- a/Common/utils.h
+++ b/Common/utils.h
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <vector>
+#include <limits>
 #include <boost/filesystem.hpp>
 #include "timers.h"
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1241,7 +1241,7 @@ void DataSetPackage::setColumnDataInts(size_t columnIndex, std::vector<int> ints
 		//Maybe something went wrong somewhere and we do not have labels for all values...
 		try
 		{
-			if (value != std::numeric_limits<int>::min())
+			if (value != std::numeric_limits<int>::lowest())
 				lab.getLabelObjectFromKey(value);
 		}
 		catch (const labelNotFound &)

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1241,7 +1241,7 @@ void DataSetPackage::setColumnDataInts(size_t columnIndex, std::vector<int> ints
 		//Maybe something went wrong somewhere and we do not have labels for all values...
 		try
 		{
-			if (value != INT_MIN)
+			if (value != std::numeric_limits<int>::min())
 				lab.getLabelObjectFromKey(value);
 		}
 		catch (const labelNotFound &)

--- a/Desktop/data/importers/importcolumn.cpp
+++ b/Desktop/data/importers/importcolumn.cpp
@@ -35,7 +35,7 @@ bool ImportColumn::convertVecToInt(const std::vector<std::string> &values, std::
 		if (Utils::convertValueToIntForImport(value, intValue))
 		{
 			if (intValue != std::numeric_limits<int>::lowest())	uniqueValues.insert(intValue);
-			else if (!value.empty())	emptyValuesMap.insert(make_pair(row, value));
+			else if (!value.empty())							emptyValuesMap.insert(make_pair(row, value));
 
 			intValues.push_back(intValue);
 		}

--- a/Desktop/data/importers/importcolumn.cpp
+++ b/Desktop/data/importers/importcolumn.cpp
@@ -30,11 +30,11 @@ bool ImportColumn::convertVecToInt(const std::vector<std::string> &values, std::
 
 	for (const std::string &value : values)
 	{
-		int intValue = std::numeric_limits<int>::min();
+		int intValue = std::numeric_limits<int>::lowest();
 
 		if (Utils::convertValueToIntForImport(value, intValue))
 		{
-			if (intValue != std::numeric_limits<int>::min())	uniqueValues.insert(intValue);
+			if (intValue != std::numeric_limits<int>::lowest())	uniqueValues.insert(intValue);
 			else if (!value.empty())	emptyValuesMap.insert(make_pair(row, value));
 
 			intValues.push_back(intValue);

--- a/Desktop/data/importers/importcolumn.cpp
+++ b/Desktop/data/importers/importcolumn.cpp
@@ -30,11 +30,11 @@ bool ImportColumn::convertVecToInt(const std::vector<std::string> &values, std::
 
 	for (const std::string &value : values)
 	{
-		int intValue = INT_MIN;
+		int intValue = std::numeric_limits<int>::min();
 
 		if (Utils::convertValueToIntForImport(value, intValue))
 		{
-			if (intValue != INT_MIN)	uniqueValues.insert(intValue);
+			if (intValue != std::numeric_limits<int>::min())	uniqueValues.insert(intValue);
 			else if (!value.empty())	emptyValuesMap.insert(make_pair(row, value));
 
 			intValues.push_back(intValue);

--- a/Desktop/data/importers/jaspimporter.cpp
+++ b/Desktop/data/importers/jaspimporter.cpp
@@ -199,7 +199,7 @@ void JASPImporter::loadDataArchive_1_00(const std::string &path, boost::function
 			{
 				int value = *reinterpret_cast<int*>(buff);
 
-				if (columnType == columnType::nominalText && value != INT_MIN)
+				if (columnType == columnType::nominalText && value != std::numeric_limits<int>::min())
 					value = mapValues[value];
 
 				ints[r] = value;

--- a/Desktop/data/importers/jaspimporter.cpp
+++ b/Desktop/data/importers/jaspimporter.cpp
@@ -199,7 +199,7 @@ void JASPImporter::loadDataArchive_1_00(const std::string &path, boost::function
 			{
 				int value = *reinterpret_cast<int*>(buff);
 
-				if (columnType == columnType::nominalText && value != std::numeric_limits<int>::min())
+				if (columnType == columnType::nominalText && value != std::numeric_limits<int>::lowest())
 					value = mapValues[value];
 
 				ints[r] = value;

--- a/Desktop/data/importers/readstat/readstatimportcolumn.h
+++ b/Desktop/data/importers/readstat/readstatimportcolumn.h
@@ -28,10 +28,10 @@ public:
 	void						addLabel(const std::string		& val,	const std::string & label);
 
 	static bool						isMissingValue(double d)		{ return isnan(d);				}
-	static bool						isMissingValue(int i)			{ return i == std::numeric_limits<int>::min();			}
+	static bool						isMissingValue(int i)			{ return i == std::numeric_limits<int>::lowest();			}
 	static bool						isMissingValue(std::string s);
 
-	static int							missingValueInt()			{ return std::numeric_limits<int>::min();		}
+	static int							missingValueInt()			{ return std::numeric_limits<int>::lowest();		}
 	static double						missingValueDouble()		{ return NAN; }
 	static std::string					missingValueString();
 

--- a/Desktop/data/importers/readstat/readstatimportcolumn.h
+++ b/Desktop/data/importers/readstat/readstatimportcolumn.h
@@ -28,10 +28,10 @@ public:
 	void						addLabel(const std::string		& val,	const std::string & label);
 
 	static bool						isMissingValue(double d)		{ return isnan(d);				}
-	static bool						isMissingValue(int i)			{ return i == INT_MIN;			}
+	static bool						isMissingValue(int i)			{ return i == std::numeric_limits<int>::min();			}
 	static bool						isMissingValue(std::string s);
 
-	static int							missingValueInt()			{ return INT_MIN;		}
+	static int							missingValueInt()			{ return std::numeric_limits<int>::min();		}
 	static double						missingValueDouble()		{ return NAN; }
 	static std::string					missingValueString();
 

--- a/Desktop/data/importers/readstat/readstatimportcolumn.h
+++ b/Desktop/data/importers/readstat/readstatimportcolumn.h
@@ -28,7 +28,7 @@ public:
 	void						addLabel(const std::string		& val,	const std::string & label);
 
 	static bool						isMissingValue(double d)		{ return isnan(d);				}
-	static bool						isMissingValue(int i)			{ return i == std::numeric_limits<int>::lowest();			}
+	static bool						isMissingValue(int i)			{ return i == std::numeric_limits<int>::lowest();	}
 	static bool						isMissingValue(std::string s);
 
 	static int							missingValueInt()			{ return std::numeric_limits<int>::lowest();		}

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -774,7 +774,7 @@ bool Engine::setColumnDataAsNominalOrOrdinal(bool isOrdinal, const std::string &
 	if(uniqueInts.size() == levels.size()) //everything was an int!
 	{
 		for(auto & dat : data)
-			if(dat != std::numeric_limits<int>::min())
+			if(dat != std::numeric_limits<int>::lowest())
 				dat = uniqueInts[dat];
 
 		if(isOrdinal)	return	provideDataSet()->columns()[columnName].overwriteDataWithOrdinal(data);

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -774,7 +774,7 @@ bool Engine::setColumnDataAsNominalOrOrdinal(bool isOrdinal, const std::string &
 	if(uniqueInts.size() == levels.size()) //everything was an int!
 	{
 		for(auto & dat : data)
-			if(dat != INT_MIN)
+			if(dat != std::numeric_limits<int>::min())
 				dat = uniqueInts[dat];
 
 		if(isOrdinal)	return	provideDataSet()->columns()[columnName].overwriteDataWithOrdinal(data);

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -449,7 +449,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 					if(rowNo < filteredRowCount && (!obeyFilter || rbridge_dataSet->filterVector()[dataSetRowNo++]))
 					{
 						if (value == std::numeric_limits<int>::lowest())	resultCol.ints[rowNo++] = std::numeric_limits<int>::lowest();
-						else					resultCol.ints[rowNo++] = value;
+						else												resultCol.ints[rowNo++] = value;
 					}
 
 				resultCol.labels = rbridge_getLabels(column.labels(), resultCol.nbLabels);
@@ -476,7 +476,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 					if(rowNo < filteredRowCount && (!obeyFilter || rbridge_dataSet->filterVector()[dataSetRowNo++]))
 					{
 						if (value == std::numeric_limits<int>::lowest())	resultCol.ints[rowNo++] = std::numeric_limits<int>::lowest();
-						else					resultCol.ints[rowNo++] = indices.at(value);
+						else												resultCol.ints[rowNo++] = indices.at(value);
 					}
 
 				resultCol.labels = rbridge_getLabels(labels, resultCol.nbLabels);
@@ -514,7 +514,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 				{
 					valueToIndex[value] = index++;
 
-					if (value == std::numeric_limits<int>::max())		labels.push_back("Inf");
+					if (value == std::numeric_limits<int>::max())			labels.push_back("Inf");
 					else if (value == std::numeric_limits<int>::lowest())	labels.push_back("-Inf");
 					else
 					{
@@ -644,9 +644,9 @@ extern "C" RBridgeColumnDescription* STDCALL rbridge_readDataSetDescription(RBri
 
 				for (int value: uniqueValues)
 				{
-					if (value == std::numeric_limits<int>::max())			labels.push_back("Inf");
+					if (value == std::numeric_limits<int>::max())				labels.push_back("Inf");
 					else if (value == std::numeric_limits<int>::lowest())		labels.push_back("-Inf");
-					else							labels.push_back(std::to_string((double)value / 1000.0f));
+					else														labels.push_back(std::to_string((double)value / 1000.0f));
 				}
 
 				resultCol.labels = rbridge_getLabels(labels, resultCol.nbLabels);

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -448,7 +448,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 				for(int value : column.AsInts)
 					if(rowNo < filteredRowCount && (!obeyFilter || rbridge_dataSet->filterVector()[dataSetRowNo++]))
 					{
-						if (value == std::numeric_limits<int>::min())	resultCol.ints[rowNo++] = std::numeric_limits<int>::min();
+						if (value == std::numeric_limits<int>::lowest())	resultCol.ints[rowNo++] = std::numeric_limits<int>::lowest();
 						else					resultCol.ints[rowNo++] = value;
 					}
 
@@ -475,7 +475,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 				for(int value : column.AsInts)
 					if(rowNo < filteredRowCount && (!obeyFilter || rbridge_dataSet->filterVector()[dataSetRowNo++]))
 					{
-						if (value == std::numeric_limits<int>::min())	resultCol.ints[rowNo++] = std::numeric_limits<int>::min();
+						if (value == std::numeric_limits<int>::lowest())	resultCol.ints[rowNo++] = std::numeric_limits<int>::lowest();
 						else					resultCol.ints[rowNo++] = indices.at(value);
 					}
 
@@ -500,7 +500,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 					int intValue;
 
 					if (std::isfinite(value))	intValue = (int)(value * 1000);
-					else if (value < 0)			intValue = std::numeric_limits<int>::min();
+					else if (value < 0)			intValue = std::numeric_limits<int>::lowest();
 					else						intValue = std::numeric_limits<int>::max();
 
 					uniqueValues.insert(intValue);
@@ -515,7 +515,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 					valueToIndex[value] = index++;
 
 					if (value == std::numeric_limits<int>::max())		labels.push_back("Inf");
-					else if (value == std::numeric_limits<int>::min())	labels.push_back("-Inf");
+					else if (value == std::numeric_limits<int>::lowest())	labels.push_back("-Inf");
 					else
 					{
 						std::stringstream ss;
@@ -528,10 +528,10 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 					if(rowNo < filteredRowCount && (!obeyFilter || rbridge_dataSet->filterVector()[dataSetRowNo++]))
 					{
 
-						if (std::isnan(value))			resultCol.ints[rowNo] = std::numeric_limits<int>::min();
+						if (std::isnan(value))			resultCol.ints[rowNo] = std::numeric_limits<int>::lowest();
 						else if (std::isfinite(value))	resultCol.ints[rowNo] = valueToIndex[(int)(value * 1000)] + 1;
 						else if (value > 0)				resultCol.ints[rowNo] = valueToIndex[std::numeric_limits<int>::max()] + 1;
-						else							resultCol.ints[rowNo] = valueToIndex[std::numeric_limits<int>::min()] + 1;
+						else							resultCol.ints[rowNo] = valueToIndex[std::numeric_limits<int>::lowest()] + 1;
 
 						rowNo++;
 					}
@@ -634,7 +634,7 @@ extern "C" RBridgeColumnDescription* STDCALL rbridge_readDataSetDescription(RBri
 					int intValue;
 
 					if (std::isfinite(value))	intValue = (int)(value * 1000);
-					else if (value < 0)			intValue = std::numeric_limits<int>::min();
+					else if (value < 0)			intValue = std::numeric_limits<int>::lowest();
 					else						intValue = std::numeric_limits<int>::max();
 
 					uniqueValues.insert(intValue);
@@ -645,7 +645,7 @@ extern "C" RBridgeColumnDescription* STDCALL rbridge_readDataSetDescription(RBri
 				for (int value: uniqueValues)
 				{
 					if (value == std::numeric_limits<int>::max())			labels.push_back("Inf");
-					else if (value == std::numeric_limits<int>::min())		labels.push_back("-Inf");
+					else if (value == std::numeric_limits<int>::lowest())		labels.push_back("-Inf");
 					else							labels.push_back(std::to_string((double)value / 1000.0f));
 				}
 

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -448,7 +448,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 				for(int value : column.AsInts)
 					if(rowNo < filteredRowCount && (!obeyFilter || rbridge_dataSet->filterVector()[dataSetRowNo++]))
 					{
-						if (value == INT_MIN)	resultCol.ints[rowNo++] = INT_MIN;
+						if (value == std::numeric_limits<int>::min())	resultCol.ints[rowNo++] = std::numeric_limits<int>::min();
 						else					resultCol.ints[rowNo++] = value;
 					}
 
@@ -475,7 +475,7 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 				for(int value : column.AsInts)
 					if(rowNo < filteredRowCount && (!obeyFilter || rbridge_dataSet->filterVector()[dataSetRowNo++]))
 					{
-						if (value == INT_MIN)	resultCol.ints[rowNo++] = INT_MIN;
+						if (value == std::numeric_limits<int>::min())	resultCol.ints[rowNo++] = std::numeric_limits<int>::min();
 						else					resultCol.ints[rowNo++] = indices.at(value);
 					}
 
@@ -500,8 +500,8 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 					int intValue;
 
 					if (std::isfinite(value))	intValue = (int)(value * 1000);
-					else if (value < 0)			intValue = INT_MIN;
-					else						intValue = INT_MAX;
+					else if (value < 0)			intValue = std::numeric_limits<int>::min();
+					else						intValue = std::numeric_limits<int>::max();
 
 					uniqueValues.insert(intValue);
 				}
@@ -514,8 +514,8 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 				{
 					valueToIndex[value] = index++;
 
-					if (value == INT_MAX)		labels.push_back("Inf");
-					else if (value == INT_MIN)	labels.push_back("-Inf");
+					if (value == std::numeric_limits<int>::max())		labels.push_back("Inf");
+					else if (value == std::numeric_limits<int>::min())	labels.push_back("-Inf");
 					else
 					{
 						std::stringstream ss;
@@ -528,10 +528,10 @@ extern "C" RBridgeColumn* STDCALL rbridge_readDataSet(RBridgeColumnType* colHead
 					if(rowNo < filteredRowCount && (!obeyFilter || rbridge_dataSet->filterVector()[dataSetRowNo++]))
 					{
 
-						if (std::isnan(value))			resultCol.ints[rowNo] = INT_MIN;
+						if (std::isnan(value))			resultCol.ints[rowNo] = std::numeric_limits<int>::min();
 						else if (std::isfinite(value))	resultCol.ints[rowNo] = valueToIndex[(int)(value * 1000)] + 1;
-						else if (value > 0)				resultCol.ints[rowNo] = valueToIndex[INT_MAX] + 1;
-						else							resultCol.ints[rowNo] = valueToIndex[INT_MIN] + 1;
+						else if (value > 0)				resultCol.ints[rowNo] = valueToIndex[std::numeric_limits<int>::max()] + 1;
+						else							resultCol.ints[rowNo] = valueToIndex[std::numeric_limits<int>::min()] + 1;
 
 						rowNo++;
 					}
@@ -634,8 +634,8 @@ extern "C" RBridgeColumnDescription* STDCALL rbridge_readDataSetDescription(RBri
 					int intValue;
 
 					if (std::isfinite(value))	intValue = (int)(value * 1000);
-					else if (value < 0)			intValue = INT_MIN;
-					else						intValue = INT_MAX;
+					else if (value < 0)			intValue = std::numeric_limits<int>::min();
+					else						intValue = std::numeric_limits<int>::max();
 
 					uniqueValues.insert(intValue);
 				}
@@ -644,8 +644,8 @@ extern "C" RBridgeColumnDescription* STDCALL rbridge_readDataSetDescription(RBri
 
 				for (int value: uniqueValues)
 				{
-					if (value == INT_MAX)			labels.push_back("Inf");
-					else if (value == INT_MIN)		labels.push_back("-Inf");
+					if (value == std::numeric_limits<int>::max())			labels.push_back("Inf");
+					else if (value == std::numeric_limits<int>::min())		labels.push_back("-Inf");
 					else							labels.push_back(std::to_string((double)value / 1000.0f));
 				}
 


### PR DESCRIPTION
This is trying to address jasp-stats/jasp-issues#1410 issue. I basically replaced all the limit macros with their equivalent `numeric_limits` from `<limits>` header. It's somewhat a moderner C++ I guess 🤷🏻‍♂️ and it should be portable as long as we are building with C++11. 

P.S. I truly hope that I haven't messed up the submodule syncing. I think I handled it correctly, but I really cannot tell! 