### PR TITLE
Dropdown with a ComponentList source must be updated on source change

### DIFF
--- a/Desktop/widgets/listmodel.cpp
+++ b/Desktop/widgets/listmodel.cpp
@@ -87,9 +87,13 @@ void ListModel::_initTerms(const Terms &terms, const RowControlsValues& allValue
 	_setTerms(terms);
 	endResetModel();
 
-	if (setupControlConnections)
-		for (SourceItem* sourceItem : listView()->sourceItems())
-			_connectSourceControls(sourceItem->listModel(), sourceItem->usedControls());
+	if (setupControlConnections) _connectAllSourcesControls();
+}
+
+void ListModel::_connectAllSourcesControls()
+{
+	for (SourceItem* sourceItem : listView()->sourceItems())
+		_connectSourceControls(sourceItem->listModel(), sourceItem->usedControls());
 }
 
 void ListModel::_connectSourceControls(ListModel* sourceModel, const QSet<QString>& controls)

--- a/Desktop/widgets/listmodel.h
+++ b/Desktop/widgets/listmodel.h
@@ -121,6 +121,7 @@ protected:
 			void	_addTerms(const Terms& terms);
 			void	_addTerm(const QString& term, bool isUnique = true);
 			void	_replaceTerm(int index, const Term& term);
+			void	_connectAllSourcesControls();
 
 			QString							_itemType;
 			bool							_needsSource			= true;

--- a/Desktop/widgets/listmodellabelvalueterms.cpp
+++ b/Desktop/widgets/listmodellabelvalueterms.cpp
@@ -54,6 +54,8 @@ void ListModelLabelValueTerms::resetTermsFromSources(bool )
 	setLabelValuesFromSource();
 
 	endResetModel();
+
+	_connectAllSourcesControls();
 }
 
 


### PR DESCRIPTION
If a DropDown has a control in a ComponentList as source (or a control in any widget with extra row components), the values of the dropdown must be updated if this control changes.
Fixes jasp-stats/jasp-test-release#1516

