### PR TITLE
rSource provokes running engine endlessly

### DIFF
--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -574,6 +574,8 @@ void AnalysisForm::boundValueChangedHandler(JASPControl *)
 {
 	if (_signalValueChangedBlocked == 0 && _analysis)
 		_analysis->boundValueChangedHandler();
+	else
+		_signalValueChangedWasEmittedButBlocked = true;
 }
 
 
@@ -692,8 +694,10 @@ void AnalysisForm::blockValueChangeSignal(bool block, bool notifyOnceUnblocked)
 
 		if (_signalValueChangedBlocked == 0)
 		{
-			if(notifyOnceUnblocked && _analysis)
+			if(notifyOnceUnblocked && _analysis && _signalValueChangedWasEmittedButBlocked)
 				_analysis->boundValueChangedHandler();
+
+			_signalValueChangedWasEmittedButBlocked = false;
 		
 			if(_analysis && (notifyOnceUnblocked || _analysis->wasUpgraded())) //Maybe something was upgraded and we want to run the dropped rscripts (for instance for https://github.com/jasp-stats/INTERNAL-jasp/issues/1399)
 				while(_waitingRScripts.size() > 0)

--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -186,6 +186,7 @@ private:
 	QString										_info;
 	QMap<QString, QSet<ListModel*> >			_rSourceModelMap;
 	int											_signalValueChangedBlocked = 0;
+	bool										_signalValueChangedWasEmittedButBlocked = false;
 	
 	std::queue<std::tuple<QString, QString, bool>>	_waitingRScripts; //Sometimes signals are blocked, and thus rscripts. But they shouldnt just disappear right?
 };


### PR DESCRIPTION
This bug is accidentally revealed when using a rSource in QML as found by @FBartos.
But it is a more general bug: when a value of a control is changed, it emits a signal so that the analysis must be rerun. This signal is sometimes blocked when some block code may change many values (initializing of analysis for example), and it is unblocked at the end of the block. When unblocked the signal was always emitted even if the signal was not called during the block code. But this signal must be emitted only if the signal was called during the block code.

