### PR TITLE
Escape key should not close JASP

### DIFF
--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
@@ -22,7 +22,7 @@ Popup
 	onVisibleChanged:	plotEditorModel.visible = visible
 	focus:				true
 
-	Shortcut { onActivated: cancel();	sequence: "Escape" }
+	Shortcut { onActivated: cancel(); sequence: StandardKey.Cancel; autoRepeat: false; enabled: visible }
 
 	function cancel()
 	{


### PR DESCRIPTION
In the Plot Editor, the Escape key is a shortkey to close the editor. Re-clicking the escape key should not close JASP afterwards.

Solves jasp-stats/jasp-test-release#1536