### PR TITLE
Moving the Run and Clear Buttons to the Right

### DIFF
--- a/Desktop/components/JASP/Widgets/RCommanderWindow.qml
+++ b/Desktop/components/JASP/Widgets/RCommanderWindow.qml
@@ -248,8 +248,8 @@ Window
 				anchors
 				{
 					top:		parent.top
-					left:		runButton.right
-					right:		parent.right
+					right:		runButton.left
+					left:		parent.left
 					bottom:		parent.bottom
 					margins:	jaspTheme.generalAnchorMargin
 				}
@@ -270,7 +270,7 @@ Window
 				anchors
 				{
 					top:			parent.top
-					left:			parent.left
+					right:			parent.right
 					bottom:			parent.verticalCenter
 					margins:		jaspTheme.generalAnchorMargin
 					bottomMargin:	jaspTheme.generalAnchorMargin * 0.5
@@ -305,8 +305,8 @@ Window
 				anchors
 				{
 					top:		parent.verticalCenter
-					left:		parent.left
-					bottom:	parent.bottom
+					right:		parent.right
+					bottom:		parent.bottom
 					margins:	jaspTheme.generalAnchorMargin
 					topMargin:	jaspTheme.generalAnchorMargin * 0.5
 				}


### PR DESCRIPTION
I think in a left-to-right interface, buttons should be on the right side of the text input. So, we go from this:

![Screenshot 2021-09-14 at 13 42 31](https://user-images.githubusercontent.com/1290841/133251652-911b40e5-116a-45e3-9149-41732129c596.png)

to this:

![Screenshot 2021-09-14 at 13 42 44](https://user-images.githubusercontent.com/1290841/133251660-c6c54d66-7725-4013-8d7e-66825db91a12.png)

P.S. I think I fixed the submodule issue! 🎉
