### PR TITLE
Select languages to 0.15 and add incomplete label for Spanish and Chinese

### DIFF
--- a/Desktop/utilities/languagemodel.h
+++ b/Desktop/utilities/languagemodel.h
@@ -15,10 +15,11 @@ class LanguageModel : public QAbstractListModel
 
 	struct LanguageInfo
 	{
-		LanguageInfo(const QLocale& _locale = LanguageModel::_defaultLocale, const QString& _qmFilename = "");
+		LanguageInfo(const QLocale& _locale = LanguageModel::_defaultLocale, const QString& _qmFilename = "", bool _isComplete = true);
 
 		QLocale				locale;
 		QVector<QString>	qmFilenames;
+		bool				isComplete;
 	};
 
 public:
@@ -70,6 +71,7 @@ signals:
 private:
 	static LanguageModel	* _singleton;
 	static QLocale			_defaultLocale;
+	static QMap<QString, bool> _allowedLanguages;
 
 	void					findQmFiles();
 	void					loadQmFilesForLanguage(const QString& language);


### PR DESCRIPTION
For 0.15, only Portuguese, Galician, Japanese, Chinese and Spanish should be added. The Chinese and Spanish language should get the incomplete label.
This code should be removed once we have a module & language online library, where we can more precisely tell how much a language covers JASP and its modules.

Fixes jasp-stats/jasp-test-release#1444