### PR TITLE
Added a link in Pref to our translation doc

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -175,10 +175,13 @@ ScrollView
 			id:		languageGroup
 			title:	qsTr("Preferred language")
 
+			height: 85
+
 			ComboBox
 			{
 				id:						languages
 				fieldWidth:				100
+				height:					25
 
 				label:					qsTr("Choose language  ")
 
@@ -189,6 +192,27 @@ ScrollView
 
 				KeyNavigation.tab:		uiScaleSpinBox
 				KeyNavigation.down:		uiScaleSpinBox
+			}
+
+			Text
+			{
+				id:				translationDocLink
+				anchors.top:	languages.bottom
+				anchors.left:	parent.left
+				height:			25
+
+
+				text:			qsTr("Help us translate or improve JASP in your language.")
+				color:			jaspTheme.blue
+				font.underline:	true
+
+				MouseArea
+				{
+					id:				mouseAreaTranslationDocLink
+					anchors.fill:	parent
+					onClicked:		Qt.openUrlExternally("https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/jasp-guideline-translators.md")
+					cursorShape:	Qt.PointingHandCursor
+				}
 			}
 
 		}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -175,13 +175,10 @@ ScrollView
 			id:		languageGroup
 			title:	qsTr("Preferred language")
 
-			height: 85
-
 			ComboBox
 			{
 				id:						languages
 				fieldWidth:				100
-				height:					25
 
 				label:					qsTr("Choose language  ")
 
@@ -196,11 +193,7 @@ ScrollView
 
 			Text
 			{
-				id:				translationDocLink
-				anchors.top:	languages.bottom
-				anchors.left:	parent.left
-				height:			25
-
+                id:                     translationDocLink
 
 				text:			qsTr("Help us translate or improve JASP in your language.")
 				color:			jaspTheme.blue
@@ -210,7 +203,7 @@ ScrollView
 				{
 					id:				mouseAreaTranslationDocLink
 					anchors.fill:	parent
-					onClicked:		Qt.openUrlExternally("https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/jasp-guideline-translators.md")
+                    onClicked:		Qt.openUrlExternally("https://jasp-stats.org/translation-guidelines")
 					cursorShape:	Qt.PointingHandCursor
 				}
 			}


### PR DESCRIPTION
I added a tiny link to the Pref->Language to let users know that they can help us with the translation. I was expecting the `PrefsGroupRect` to deduct its height from its child but it didn't, so I added them myself, and for this reason, I went for a very concise message that we don't run into layout issue when we have this text translate.

→ This is related to #4625, and as @boutinb said, we need to wait until we have this phrase translated as well before merging this.

![Screenshot 2021-09-15 at 14 44 07](https://user-images.githubusercontent.com/1290841/133435926-58a0d8da-abbc-4d9c-8ebd-287094f5325b.png)
