### PR TITLE
Update translation guideline text

### DIFF
--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -1,10 +1,10 @@
 # Guideline for JASP translators
 
 ## Introduction
-In this document we keep track of some general guidelines that translators of JASP should follow during the tanslation process. This is an ongoing process and this document should help to maintain consistancy. 
+In this document we keep track of some general guidelines that translators of JASP should follow during the translation process. This is an ongoing process and this document should help to maintain consistency. 
 
 ## Weblate
-JASP uses the online localisation tool 'Weblate' for its translations. <br>To contribute to the translations of JASP you need to make an account for Weblate:<br>
+JASP uses the online localization tool 'Weblate' for its translations. <br>To contribute to the translations of JASP you need to make an account for Weblate:<br>
 * Open the page https://weblate.org/en-gb/  
 * Press the persons icon  
 * And register your new account in https://hosted.weblate.org/accounts/register/
@@ -14,31 +14,28 @@ Here you can find an overview of all the different modules JASP consists of and 
 E.g. the Anova module consists of the jaspANOVA-QML component for the interface and the jaspANOVA-R component for the R part. Pressing on the component show the current translation of the component.<br><br>
 <img src="https://static.jasp-stats.org/images/Weblate-component.png" width="800" height="250" /><br>For adding a new translation:<br>
 * Press the Start New Translation button.<br>
-* Choose your language from the available Languages list.<br>
+* Choose your language from the list of available languages.<br>
 * If your language is not in the list, report this to Weblate with the 'Cannot find your language in the list above?' link.
 <br>
-When you select your language from the list you will get an overview of the translated and not yet translated strings.<br><br>
+When you select your language from the list you will get an overview of the translated and the not-yet-translated strings.<br><br>
 <img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" width="800" height="250" /> <br>
 Selecting the part of strings you want to change will bring you to the form where you do the actual translation work. Be aware that all Weblate users have the same rights filling in this form.<br><br>
 <img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" width="800" height="250" /> <br><br>
-There are a lot of options to be chosen here but all are well described in the online documentaion you can find in the right corner of the page. <br><img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" width="80" height="100" /> <br>The working procedure is now as follows:<br>  
+There are a lot of options to be chosen here but all are well described in the online documentation you can find in the right corner of the page. <br><img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" width="80" height="100" /> <br>The working procedure is now as follows:<br>  
 * When you save (Save button) your work, your translated strings are stored in Weblates repository. And everybody will see your work.<br>  
-* Once you have committed your work (the Manage/Commit button in the previous screen) a PR (pull request) is made to the JASP github repository belonging to this component.  For instance see the [JASP Anova repository](https://github.com/jasp-stats/jaspAnova) for the JASP Anova module repository.<br>  
-* This PR is then merged into this JASP module repository by the responsable developer of this repository.<br>  
+* Once you have committed your work (the Manage/Commit button in the previous screen) a PR (pull request) is made to the JASP GitHub repository belonging to this component.  For instance see the [JASP ANOVA repository](https://github.com/jasp-stats/jaspAnova) for the JASP ANOVA module repository.<br>  
+* This PR is then merged into this JASP module repository by the responsible developer of this repository.<br>  
 * During the nightly build new JASP binary translation files (.qm and .mo) are generated. These files are added to the setup of JASP, so the new translations should be available in this [nightly](http://static.jasp-stats.org/Nightlies/) made version.<br>
-* Every week new JASP .po files are generated containing the new translatable strings inside JASP. They will then be merged into Weblate. Some component may then have new strings to translate.<br>
+* Every week, new JASP .po files are generated containing the new translatable strings inside JASP. They will then be merged into Weblate. Some component may then have new strings to translate.<br>
 
 ## Translation of statistical terms
-1. Weblate has the functionality of defining glossaries. Each project can have an assigned glossary for any language as a shorthand for storing terminology. Consistency is more easily maintained this way. If a term is defined in the Weblate glossery in its proper context this definition should be used. Definitions defined in the glossery can be exported and imported.
+1. Weblate has the functionality of defining glossaries. Each project can have an assigned glossary for any language as a shorthand for storing terminology. Consistency is more easily maintained this way. If a term is defined in the Weblate glossary in its proper context, this definition should be used. Definitions defined in the glossary can be exported and imported.
 2. When in doubt, please use the statistical terms as they occur in introductory statistics textbooks and courses in your language. We would like users to recognize the terms that are used. If you deem this useful you can mention alternative terms in the help file.   
-3. Weblate has the possibility of giving a suggestion of the translation in the "Automatic suggestions" tab. Three automatic translate machines are available i.e. Google Translate, Microsoft Translator and DeepL. Above that, Weblate offers you the possibility to generate a complete translation of a component.
+3. Weblate has the possibility of giving a suggestion of the translation in the "Automatic suggestions" tab. Three automatic translate machines are available, i.e. Google Translate, Microsoft Translator and DeepL. Above that, Weblate offers you the possibility to generate a complete translation of a component.
 
 ## Capitalization
-As a general rule we use the following conventions. For names of titles, groups and sections all the words are capitalized. For all the subnames in those groups, e.g. the labels of the controls, those names only start with a capital. For instanca the Visual Modeling module is named 'Visual Modeling' and one of the analysis is called 'Generalized Linear Modeling'. But if we look at the section 'Results Display' the checkbox 'Model plot' only starts wit a capital.
-
+As a general rule we use the following conventions. For names of titles, groups and sections all the words are capitalized. For all the sub-names in those groups, e.g. the labels of the controls, those names only start with a capital. For instance, the Visual Modeling module is named 'Visual Modeling' and one of the analyses is called 'Generalized Linear Modeling'. But if we look at the section 'Results Display', the checkbox 'Model plot' only starts with a capital.
 
 ## Formal or Familiar 
-In JASP we have choosen for a formal way of addressing a user. In some languages there are more levels of speech but in general we use the formal level of speech. So in Dutch we use the persons forms 'U' instead of 'jij' and in French 'vous' instead of 'tu'. 
-
-
+In JASP, we have chosen a formal way of addressing a user. In some languages there are more levels of speech but in general we use the formal level of speech. So in Dutch we use the persons forms 'U' instead of 'jij' and in French 'vous' instead of 'tu'. 
 

--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -36,19 +36,19 @@ Clicking on a component shows an overview of the current translation status, as 
 To add a new translation language to a component, click on the button *Start New Translation* and select from the list of available languages.
 If you cannot find your language, please [report that to the JASP team](https://jasp-stats.org/feature-requests-bug-reports/).
 
-<img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" height="250px" />
-
 ### Contributing to existing languages
 If you select an existing language, *Weblate* shows more details about the current translation status:
 
-<img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" height="250px" />
+<img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" height="250px" />
 
 When you select a set of strings within a component, *Weblate* opens the form to create/change a single translation string.
 Note that all *Weblate* users have the same privileges to use this form: If you click the *Save* button after a change, it will remain until it is revised and saved again.
 If you are unsure about a change, you can also use the *Suggest* button to inform other translators about your opinion.
 
+<img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" height="250px" />
+
 There are a lot of options to get information about a string, and how to interact with it.
-Fortunately, they are well explained in the *Documentation* that you can find in the right corner of the page.
+Fortunately, they are well explained in the *Documentation* that you can find in the right corner of the page:
 
 <img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" />
 
@@ -57,13 +57,13 @@ You are done, and anyone else will be able to see your change.
 Now you can log out of *Weblate*, or translate some more.
 
 #### Glossary
-*Weblate* offers glossaries.
-They are useful to maintain consistency of specific terms, especially across modules.
+*Weblate* offers glossaries, which are useful to maintain consistency of terminology translations, especially across modules.
 Terms that are defined in the glossary are marked yellow in the translation form.
-All translators can define new terms to the glossary.
-Each project can have an assigned glossary for any language as a shorthand for storing terminology.
 If a term is defined in the Weblate glossary in its proper context, you should use it.
 If you disagree with a glossary term, don't just ignore it, but try to or discuss or change it first.
+
+All translators can define new terminology into the glossary.
+Each project can have an assigned glossary for any language as a shorthand for storing terminology.
 
 #### Automatic suggestions
 *Weblate* features machine translations in the *"Automatic suggestions"* tab.
@@ -71,21 +71,22 @@ This can be very useful as a starting point for a translation, but make sure to 
 Be aware that glossary terms are ignored and that these tools lack any understanding of the specific context of a string.
 
 ### The pipeline past Weblate
-If you are interested, here is a summary what happens after saving translations on *Weblate*.
-Knowledge of this is not necessary to contribute translations.
+If you are interested, here is a summary what happens after you save translations on *Weblate*.
+Knowledge of these steps are not necessary to contribute translations.
 
 1. If translations on *Weblate* are added or saved, they are automatically sent to [GitHub](https://github.com/), so they can be integrated with the rest of the module's code.
     - This usually takes a few hours, but may also take days.
     - More technically, *Weblate* opens a [Pull Request](https://en.wikipedia.org/wiki/Distributed_version_control#Pull_requests) to the code repository of the translated module.
     - For example, translations to `jaspAnova-R` or `jaspAnova-QML` components are sent to the [jaspAnova repository on GitHub](https://github.com/jasp-stats/jaspAnova).
 2. On *GitHub*, one of the module developers will manually check and merge the translation into the module's repository.
-3. Every week, *GitHub* automatically updates the translation files; now they are ready to be compiled into an executable program.
-   If new translatable strings were added to the code, they will become available on *Weblate* for translation.
-   (This step involves multiple sub-tasks and file conversions (e.g. from `.po` files to `.qm` and `.mo`); if you are interested, you can read [more technical details here](translate.md).)
-4. Once a new JASP executable is compiled, the new translation become visible in the program.
-   Every night, JASP is automatically compiled as a fresh [nightly build](https://static.jasp-stats.org/Nightlies/) that you can download and test.
-   (Alternatively, you can also compile JASP on your own computer by following the [JASP building guide](jasp-building-guide.md).)
-   Finally, your translations will become available to everybody, once the JASP team releases a [new version of JASP](https://jasp-stats.org/release-notes/).
+3. Every week, *GitHub* automatically updates the translation files.
+   Now they are ready to be compiled into an executable program.
+    - If new translatable strings were added to the code, they will become available on *Weblate* for translation.
+    - More technically, this step involves multiple sub-tasks and file conversions (e.g. from `.po` files to `.qm` and `.mo`); if you are interested, you can read [more technical details here](translate.md).
+4. Once a new JASP executable is compiled, all new translations become part of the program.
+    - Every night, JASP is automatically compiled as a fresh [nightly build](https://static.jasp-stats.org/Nightlies/) that you can download and test.
+    - Alternatively, you can also compile JASP on your own computer by following the [JASP building guide](jasp-building-guide.md).
+    - Finally, your translations will become available to everybody, once the JASP team releases a [new version of JASP](https://jasp-stats.org/release-notes/).
 
 ## Translation conventions
 This section lists general rules for translation.
@@ -102,7 +103,7 @@ For instance, the *Visual Modeling* module is called *'Visual Modeling'* and one
 But if we look at the section *'Results Display'*, the checkbox label *'Model plot'* only starts with a capital in the first word.
 
 ### Address the user formally
-The JASP interface occasionally addresses the user directly, e.g. "what would *you* like to do?".
-Some languages have multiple ways to translate the English "you", ranging from formal to informal ways (see [T-V distinction](https://en.wikipedia.org/wiki/T%E2%80%93V_distinction)).
+The JASP interface occasionally addresses the user directly, e.g. 'what would *you* like to do?'.
+Some languages have multiple ways to translate the English 'you', ranging from formal to informal ways (see [T-V distinction](https://en.wikipedia.org/wiki/T%E2%80%93V_distinction)).
 If you translate JASP into such a language, you should choose a formal way of addressing the user.
-For example, in Dutch use the pronoun *U* instead of *jij*, and in French use *vous* instead of *tu*.
+For example, in Dutch use the pronoun *'U'* instead of *'jij'*, and in French use *'vous'* instead of *'tu'*.

--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -1,31 +1,31 @@
 # Guideline for JASP translators
 
-Thank you for your interest in the translation of JASP.
+Thank you for your interest in translating JASP.
 This document provides some first steps and general guidelines to maintain consistency.
-As part of JASP's development, translation is an ongoing process, and participation is welcome.
+As part of JASP's development, translating is an ongoing process, and participation is welcome.
 
 ## Weblate
-To make translation easy, JASP uses the web-based localization tool [Weblate](https://hosted.weblate.org/projects/jasp/).
-All you need to is a web browser, and you can start as soon as you log in.
+To make translating easy, JASP uses the web-based localization tool [Weblate](https://hosted.weblate.org/projects/jasp/).
+All you need is a web browser, and you can start as soon as you log in.
 
-Once you save translations on *Weblate*, they are on their way into JASP.
-(If you are interested, you can read about [the pipeline past *Weblate*](#the-pipeline-past-weblate).)
+Once you save translations on *Weblate*, they will be incorporated in JASP.
+(Below you can read [how your translations get into JASP after you commit them to *Weblate*](#how-your-translations-get-into-jasp-after-you-commit-them-to-weblate).)
 
 ### Log in to Weblate
-Before you can add or change translations, you have to log in at <https://hosted.weblate.org/>.
-To log in, you can either [register a new account](https://hosted.weblate.org/accounts/register/) or [sign in with a third-party account](https://hosted.weblate.org/accounts/login/), like your GitHub account.
+Before you can add or modify translations, you have to log in at <https://hosted.weblate.org/>.
+To log in, you can either [register a new account](https://hosted.weblate.org/accounts/register/) or [sign in with a third-party account](https://hosted.weblate.org/accounts/login/) such as your GitHub account.
 
-Note that your translations will be publicly attributed to your account's full name and email address, so you may want to adjust these settings beforehand.
+Note that your translations will be publicly attributed to your account's full name and email address, so you might want to adjust these settings beforehand.
 
 ### JASP modules and Weblate components
 Once you logged in, you can contribute translations to the JASP project at <https://hosted.weblate.org/projects/jasp/>.
-JASP consists of many modules that offer different statistical analyses.
-For example, the module `jaspAnova` offers analyses of variance (ANOVA).
+JASP consists of various modules each offering several statistical analyses.
+For example, the module `jaspAnova` offers both frequentist and Bayesian analysis of variance (ANOVA), repeated measures analysis of variance (RM ANOVA), analysis of covariance (ANCOVA), and multivariate analysis of variance (MANOVA). 
 
 On *Weblate*, every JASP module is split into two components.
-The two components have different name suffixes (`-QML` or `-R`) that indicate their programming language:
-- A component to define the user interface, written in the language [QML](https://en.wikipedia.org/wiki/QML).
-- A component to define the statistical analysis, written in the language [R](https://en.wikipedia.org/wiki/R_(programming_language)).
+The two components have the suffixes (`-QML` or `-R`) that indicate their programming language:
+- The [QML](https://en.wikipedia.org/wiki/QML) component refers to strings (i.e., text) found in the user interface, that is, the left-hand panel in JASP
+- The [R](https://en.wikipedia.org/wiki/R_(programming_language)) component refers to strings found in the output pane that appear in the right-hand panel in JASP resulting from statistical analyses computed using R. 
 
 For example, the `jaspAnova` module consists of the components [jaspAnova-QML](https://hosted.weblate.org/projects/jasp/jaspanova-qml/) for the interface and [jaspAnova-R](https://hosted.weblate.org/projects/jasp/jaspanova-r/) for the analysis code.
 Clicking on a component shows an overview of the current translation status:
@@ -33,7 +33,7 @@ Clicking on a component shows an overview of the current translation status:
 <img src="https://static.jasp-stats.org/images/Weblate-component.png" height="250px" />
 
 ### Adding languages
-To add a new translation language to a component, click on the button *Start New Translation* (see screenshot above) and select from the list of available languages.
+To add a new language to translate to a component, click on the button *Start New Translation* (see screenshot above) and select from the list of available languages.
 If you cannot find your language, please [report that to the JASP team](https://jasp-stats.org/feature-requests-bug-reports/).
 
 ### Contributing to existing languages
@@ -42,71 +42,73 @@ If you select an existing language, *Weblate* shows more details about the curre
 <img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" height="250px" />
 
 When you select a set of strings within a component, *Weblate* opens the form to create or change a single translation string.
-Strings are the smallest unit to translate, and they can vary in length from a just one character to entire paragraphs, as decided by the module developers.
+Strings are the smallest unit to translate, and they can vary in length from just one character to entire paragraphs, as decided by the module developers.
 
-Note that all *Weblate* users have the same privileges to use this form: If you click the *Save* button after a change, it will remain until it is revised and saved again.
+Note that all *Weblate* users have the same privileges to use this form: If you click the *Save* button after a change, the change will remain until it is revised and saved again.
 If you are unsure about a change, you can also click the *Suggest* button to inform other translators about your opinion.
 
 <img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" height="250px" />
 
-There are a lot of options to get information about a string, and how to interact with it.
+There are a lot of options to get additional information about a string, and how to interact with it.
 Fortunately, they are well explained in the *Documentation* that you can find in the right corner of the page:
 
 <img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" />
 
 Once you press the *Save* button, your translated string is stored in *Weblate*.
-You are done, and anyone else will be able to see your change.
+Once saved, everyone will be able to see your change.
 Now you can log out of *Weblate*, or translate some more.
 
 #### Glossary
-*Weblate* offers glossaries, which are useful to maintain consistency of terminology translations, especially across modules.
-Terminology defined in the glossary is marked yellow in the translation form, to help the translator.
+To help translators, *Weblate* offers glossaries to maintain consistency of translated terminology, especially across modules.
+Terminology defined in the glossary are marked yellow in the translation form. 
 If a term is defined in the Weblate glossary in its proper context, you should use it.
-If you disagree with a term translation, don't just ignore it.
-Instead, try to or discuss it with other translators, or change it in the glossary first.
+If you disagree with a translate term, don't just ignore it. 
+Instead, try to discuss it with other translators, or change it in the glossary first.
 
 Note that all translators can define new terminology into the glossary.
-Each project can have an assigned glossary for any language as a shorthand for storing terminology.
+Each project can have an assigned glossary for any language as a shorthand to store terminology.
 
 #### Automatic suggestions
 *Weblate* can suggest machine translations in the *Automatic suggestions* tab.
 This can be very useful as a starting point for a translation, but make sure to always scrutinize the output for errors.
 Note that glossary terms are ignored and that these tools lack any understanding of the specific context of a string.
 
-### The pipeline past Weblate
-If you are interested, here is a summary what happens after you save translations on *Weblate*.
+## Translation conventions
+This section lists general rules for translation.
+
+## Statistical terms
+Use statistical terms as they occur in introductory statistics textbooks and courses in the target language.
+Users should be able to recognize established terminology in JASP's interface.
+If you deem it useful to offer alternative terms (e.g., that may be more suitable for beginners), provide them in the help file.
+
+### Capitalization
+For names of titles, groups and sections (tabs such as *Advanced*) in the interface, all words should be capitalized.
+For names within such groupings, e.g., the labels of the controls, only the first word should be capitalized.
+For instance, the *Visual Modeling* module is called *'Visual Modeling'* and one of the analyses is called *'Generalized Linear Modeling'*.
+All words in the section title are also capitalized *'Results Display'*, but only the first words of elements within the section are capitalized, e.g., the checkbox label *'Model plot'*. 
+
+### Address the user formally
+The JASP interface occasionally addresses the user directly, e.g., 'what would *you* like to do?'.
+Some languages have multiple ways to translate the English 'you', which could be formal or informal (see [T-V distinction](https://en.wikipedia.org/wiki/T%E2%80%93V_distinction)).
+If you translate JASP into such language, you should choose the formal form to address the user.
+For example, in Dutch please use the pronoun *'U'* instead of *'jij'*, in French please use *'vous'* instead of *'tu'*, and in German please use *'Sie'* instead of *'du'*.
+
+## How your translations get into JASP after you commit them to Weblate
+This section provides a summary of what happens to your translation once it is saved on *Weblate*.
 Knowledge of these steps are not necessary to contribute translations.
 
 1. If translations on *Weblate* are added or saved, they are automatically sent to [GitHub](https://github.com/), so they can be integrated with the rest of the module's code.
     - This usually takes a few hours, but may also take days.
     - More technically, *Weblate* opens a [Pull Request](https://en.wikipedia.org/wiki/Distributed_version_control#Pull_requests) to the code repository of the translated module.
-    - For example, translations to `jaspAnova-R` or `jaspAnova-QML` components are sent to the [jaspAnova repository on GitHub](https://github.com/jasp-stats/jaspAnova).
+    - For example, translations of the `jaspAnova-R` or `jaspAnova-QML` components are sent to the [jaspAnova repository on GitHub](https://github.com/jasp-stats/jaspAnova).
 2. On *GitHub*, one of the module developers will manually check and merge the translation into the module's repository.
 3. Every week, *GitHub* automatically updates the translation files.
    Now they are ready to be compiled into an executable program.
     - If new translatable strings were added to the code, they will become available on *Weblate* for translation.
-    - More technically, this step involves multiple sub-tasks and file conversions (e.g. from `.po` files to `.qm` and `.mo`); if you are interested, you can read [more technical details here](translate.md).
+    - More technically, this step involves multiple sub-tasks and file conversions (e.g., from `.po` files to `.qm` and `.mo` files); if you are interested, you can read [more technical details here](translate.md).
 4. Once a new JASP executable is compiled, all new translations become part of the program.
-    - Every night, JASP is automatically compiled as a fresh [nightly build](https://static.jasp-stats.org/Nightlies/) that you can download and test.
+    - Every night, JASP is automatically compiled as a fresh [nightly build](https://static.jasp-stats.org/Nightlies/) which you can download and test.
     - Alternatively, you can also compile JASP on your own computer by following the [JASP building guide](jasp-building-guide.md).
     - Finally, your translations will become available to everybody, once the JASP team releases a [new version of JASP](https://jasp-stats.org/release-notes/).
 
-## Translation conventions
-This section lists general rules for translation.
 
-## Statistical terms
-Use statistical terms as they occur in introductory statistics textbooks and courses in your language.
-Users should be able to recognize established terms in JASP's interface.
-If you deem it useful to offer alternative terms (e.g. that may be suitable for beginners), provide them in the help file.
-
-### Capitalization
-For names of titles, groups and sections in the interface, all words should be capitalized.
-For names within such groupings, e.g. the labels of the controls, only the first word should be capitalized.
-For instance, the *Visual Modeling* module is called *'Visual Modeling'* and one of the analyses is called *'Generalized Linear Modeling'*.
-But if we look at the section *'Results Display'*, the checkbox label *'Model plot'* only starts with a capital in the first word.
-
-### Address the user formally
-The JASP interface occasionally addresses the user directly, e.g. 'what would *you* like to do?'.
-Some languages have multiple ways to translate the English 'you', ranging from formal to informal ways (see [T-V distinction](https://en.wikipedia.org/wiki/T%E2%80%93V_distinction)).
-If you translate JASP into such a language, you should choose a formal way of addressing the user.
-For example, in Dutch use the pronoun *'U'* instead of *'jij'*, and in French use *'vous'* instead of *'tu'*.

--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -1,15 +1,13 @@
 # Guideline for JASP translators
 
 Thank you for your interest in translating JASP.
-This document provides some first steps and general guidelines to maintain consistency.
-As part of JASP's development, translating is an ongoing process, and participation is welcome.
+This document provides information to get you started and general guidelines to maintain consistency.
+JASP's constantly being extended and further developed. As such, translations are ongoing, and participation is very much appreciated. 
 
 ## Weblate
-To make translating easy, JASP uses the web-based localization tool [Weblate](https://hosted.weblate.org/projects/jasp/).
+JASP uses the web-based localization tool [Weblate](https://hosted.weblate.org/projects/jasp/) for translations. 
 All you need is a web browser, and you can start as soon as you log in.
-
-Once you save translations on *Weblate*, they will be incorporated in JASP.
-(Below you can read [how your translations get into JASP after you commit them to *Weblate*](#how-your-translations-get-into-jasp-after-you-commit-them-to-weblate).)
+Once you save translations on *Weblate*, they will be incorporated into JASP.
 
 ### Log in to Weblate
 Before you can add or modify translations, you have to log in at <https://hosted.weblate.org/>.

--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -19,7 +19,7 @@ Every single module contains two components: an interface component and an R com
 E.g. the Anova module consists of the jaspANOVA-QML component for the interface and the jaspANOVA-R component for the R part.
 Pressing on the component show the current translation of the component.
 
-<img src="https://static.jasp-stats.org/images/Weblate-component.png" width="800" height="250" />
+<img src="https://static.jasp-stats.org/images/Weblate-component.png" height="250px" />
 
 For adding a new translation:
 
@@ -30,16 +30,16 @@ For adding a new translation:
 
 When you select your language from the list you will get an overview of the translated and the not-yet-translated strings.
 
-<img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" width="800" height="250" />
+<img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" height="250px" />
 
 Selecting the part of strings you want to change will bring you to the form where you do the actual translation work.
 Be aware that all Weblate users have the same rights filling in this form.
 
-<img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" width="800" height="250" />
+<img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" height="250px" />
 
 There are a lot of options to be chosen here but all are well described in the online documentation you can find in the right corner of the page.
 
-<img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" width="80" height="100" />
+<img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" />
 
 The working procedure is now as follows:
 

--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -6,10 +6,10 @@ As part of JASP's development, translation is an ongoing process, and participat
 
 ## Weblate
 To make translation easy, JASP uses the web-based localization tool [Weblate](https://hosted.weblate.org/projects/jasp/).
-All you need to translate is a web browser — you can start as soon as you log in.
+All you need to is a web browser, and you can start as soon as you log in.
 
 Once you save translations on *Weblate*, they are on their way into JASP.
-(And if you are interested, you can read about [the pipeline past *Weblate*](#the-pipeline-past-weblate).)
+(If you are interested, you can read about [the pipeline past *Weblate*](#the-pipeline-past-weblate).)
 
 ### Log in to Weblate
 Before you can add or change translations, you have to log in at <https://hosted.weblate.org/>.
@@ -23,7 +23,7 @@ JASP consists of many modules that offer different statistical analyses.
 For example, the module `jaspAnova` offers analyses of variance (ANOVA).
 
 On *Weblate*, every JASP module is split into two components.
-The two components are distinguishable their name suffix (`-QML` or `-R`) that indicates their programming language:
+The two components have different name suffixes (`-QML` or `-R`) that indicate their programming language:
 - A component to define the user interface, written in the language [QML](https://en.wikipedia.org/wiki/QML).
 - A component to define the statistical analysis, written in the language [R](https://en.wikipedia.org/wiki/R_(programming_language)).
 
@@ -41,9 +41,11 @@ If you select an existing language, *Weblate* shows more details about the curre
 
 <img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" height="250px" />
 
-When you select a set of strings within a component, *Weblate* opens the form to create/change a single translation string.
+When you select a set of strings within a component, *Weblate* opens the form to create or change a single translation string.
+Strings are the smallest unit to translate, and they can vary in length from a just one character to entire paragraphs, as decided by the module developers.
+
 Note that all *Weblate* users have the same privileges to use this form: If you click the *Save* button after a change, it will remain until it is revised and saved again.
-If you are unsure about a change, you can also use the *Suggest* button to inform other translators about your opinion.
+If you are unsure about a change, you can also click the *Suggest* button to inform other translators about your opinion.
 
 <img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" height="250px" />
 
@@ -67,9 +69,9 @@ Note that all translators can define new terminology into the glossary.
 Each project can have an assigned glossary for any language as a shorthand for storing terminology.
 
 #### Automatic suggestions
-*Weblate* features machine translations in the *"Automatic suggestions"* tab.
+*Weblate* can suggest machine translations in the *Automatic suggestions* tab.
 This can be very useful as a starting point for a translation, but make sure to always scrutinize the output for errors.
-Be aware that glossary terms are ignored and that these tools lack any understanding of the specific context of a string.
+Note that glossary terms are ignored and that these tools lack any understanding of the specific context of a string.
 
 ### The pipeline past Weblate
 If you are interested, here is a summary what happens after you save translations on *Weblate*.

--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -1,80 +1,108 @@
 # Guideline for JASP translators
 
-## Introduction
-In this document we keep track of some general guidelines that translators of JASP should follow during the translation process.
-This is an ongoing process and this document should help to maintain consistency.
+Thank you for your interest in the translation of JASP.
+This document provides some first steps and general guidelines to maintain consistency of the translations.
+Like the rest of JASP development, this is an ongoing process, and participation is welcome.
 
 ## Weblate
-JASP uses the online localization tool 'Weblate' for its translations.
+JASP uses the web-based localization tool [Weblate](https://hosted.weblate.org/projects/jasp/).
+All you need to translate is a web browser — you can start as soon as you log in.
 
-To contribute to the translations of JASP you need to make an account for Weblate:
+Once you save translations on *Weblate*, they are on their way into JASP.
+(And if you are interested, you can read about [the pipeline past *Weblate*](#the-pipeline-past-weblate).)
 
-* Open the page https://weblate.org/en-gb/
-* Press the persons icon
-* And register your new account in https://hosted.weblate.org/accounts/register/
+### Log in to Weblate
+Before you can add or change translations, you have to log in at <https://hosted.weblate.org/>.
+To log in, you can either [register a new account](https://hosted.weblate.org/accounts/register/) or [sign in with a third-party account](https://hosted.weblate.org/accounts/login/), like your GitHub account.
 
-Once you've registered your account you can open the JASP project at <https://hosted.weblate.org/projects/jasp/>.
-Here you can find an overview of all the different modules JASP consists of and the translations it contains.
-Every single module contains two components: an interface component and an R component.
-E.g. the Anova module consists of the jaspANOVA-QML component for the interface and the jaspANOVA-R component for the R part.
-Pressing on the component show the current translation of the component.
+Note that your translations will be publicly attributed to your account's full name and email address, so you may want to adjust these settings beforehand.
+
+### JASP modules and Weblate components
+Once you logged in, you can contribute translations to the JASP project at <https://hosted.weblate.org/projects/jasp/>.
+JASP consists of many modules that offer different statistical analyses.
+For example, the module `jaspAnova` offers analyses of variance (ANOVA).
+
+On *Weblate*, every JASP module is split into two components.
+The two components are distinguishable their name suffix (`-QML` or `-R`) that indicates their programming language:
+- A component to define the user interface, written in the language [QML](https://en.wikipedia.org/wiki/QML).
+- A component to define the statistical analysis, written in the language [R](https://en.wikipedia.org/wiki/R_(programming_language)).
+
+For example, the `jaspAnova` module consists of the [jaspAnova-QML](https://hosted.weblate.org/projects/jasp/jaspanova-qml/) component for the interface and [`jaspAnova-R`](https://hosted.weblate.org/projects/jasp/jaspanova-r/) for the analysis code.
+Clicking on a component shows an overview of the current translation status, as shown in this screenshot:
 
 <img src="https://static.jasp-stats.org/images/Weblate-component.png" height="250px" />
 
-For adding a new translation:
-
-* Press the Start New Translation button.
-* Choose your language from the list of available languages.
-* If your language is not in the list, report this to Weblate with the 'Cannot find your language in the list above?' link.
-
-
-When you select your language from the list you will get an overview of the translated and the not-yet-translated strings.
+### Adding languages
+To add a new translation language to a component, click on the button *Start New Translation* and select from the list of available languages.
+If you cannot find your language, please [report that to the JASP team](https://jasp-stats.org/feature-requests-bug-reports/).
 
 <img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" height="250px" />
 
-Selecting the part of strings you want to change will bring you to the form where you do the actual translation work.
-Be aware that all Weblate users have the same rights filling in this form.
+### Contributing to existing languages
+If you select an existing language, *Weblate* shows more details about the current translation status:
 
 <img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" height="250px" />
 
-There are a lot of options to be chosen here but all are well described in the online documentation you can find in the right corner of the page.
+When you select a set of strings within a component, *Weblate* opens the form to create/change a single translation string.
+Note that all *Weblate* users have the same privileges to use this form: If you click the *Save* button after a change, it will remain until it is revised and saved again.
+If you are unsure about a change, you can also use the *Suggest* button to inform other translators about your opinion.
+
+There are a lot of options to get information about a string, and how to interact with it.
+Fortunately, they are well explained in the *Documentation* that you can find in the right corner of the page.
 
 <img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" />
 
-The working procedure is now as follows:
+Once you press the *Save* button, your translated string is stored in *Weblate*.
+You are done, and anyone else will be able to see your change.
+Now you can log out of *Weblate*, or translate some more.
 
-* When you save (Save button) your work, your translated strings are stored in Weblates repository.
-  And everybody will see your work.
-* Once you have committed your work (the Manage/Commit button in the previous screen) a PR (pull request) is made to the JASP GitHub repository belonging to this component.
-  For instance see the [JASP ANOVA repository](https://github.com/jasp-stats/jaspAnova) for the JASP ANOVA module repository.
-* This PR is then merged into this JASP module repository by the responsible developer of this repository.
-* During the nightly build new JASP binary translation files (.qm and .mo) are generated.
-  These files are added to the setup of JASP, so the new translations should be available in this [nightly](http://static.jasp-stats.org/Nightlies/) made version.
-* Every week, new JASP .po files are generated containing the new translatable strings inside JASP.
-  They will then be merged into Weblate.
-  Some component may then have new strings to translate.
+#### Glossary
+*Weblate* offers glossaries.
+They are useful to maintain consistency of specific terms, especially across modules.
+Terms that are defined in the glossary are marked yellow in the translation form.
+All translators can define new terms to the glossary.
+Each project can have an assigned glossary for any language as a shorthand for storing terminology.
+If a term is defined in the Weblate glossary in its proper context, you should use it.
+If you disagree with a glossary term, don't just ignore it, but try to or discuss or change it first.
 
-## Translation of statistical terms
-1. Weblate has the functionality of defining glossaries.
-   Each project can have an assigned glossary for any language as a shorthand for storing terminology.
-   Consistency is more easily maintained this way.
-   If a term is defined in the Weblate glossary in its proper context, this definition should be used.
-   Definitions defined in the glossary can be exported and imported.
-2. When in doubt, please use the statistical terms as they occur in introductory statistics textbooks and courses in your language.
-   We would like users to recognize the terms that are used.
-   If you deem this useful you can mention alternative terms in the help file.
-3. Weblate has the possibility of giving a suggestion of the translation in the "Automatic suggestions" tab.
-   Three automatic translate machines are available, i.e. Google Translate, Microsoft Translator and DeepL.
-   Above that, Weblate offers you the possibility to generate a complete translation of a component.
+#### Automatic suggestions
+*Weblate* features machine translations in the *"Automatic suggestions"* tab.
+This can be very useful as a starting point for a translation, but make sure to always scrutinize the output for errors.
+Be aware that glossary terms are ignored and that these tools lack any understanding of the specific context of a string.
 
-## Capitalization
-As a general rule we use the following conventions.
-For names of titles, groups and sections all the words are capitalized.
-For all the sub-names in those groups, e.g. the labels of the controls, those names only start with a capital.
-For instance, the Visual Modeling module is named 'Visual Modeling' and one of the analyses is called 'Generalized Linear Modeling'.
-But if we look at the section 'Results Display', the checkbox 'Model plot' only starts with a capital.
+### The pipeline past Weblate
+If you are interested, here is a summary what happens after saving translations on *Weblate*.
+Knowledge of this is not necessary to contribute translations.
 
-## Formal or Familiar 
-In JASP, we have chosen a formal way of addressing a user.
-In some languages there are more levels of speech but in general we use the formal level of speech.
-So in Dutch we use the persons forms 'U' instead of 'jij' and in French 'vous' instead of 'tu'.
+1. If translations on *Weblate* are added or saved, they are automatically sent to [GitHub](https://github.com/), so they can be integrated with the rest of the module's code.
+    - This usually takes a few hours, but may also take days.
+    - More technically, *Weblate* opens a [Pull Request](https://en.wikipedia.org/wiki/Distributed_version_control#Pull_requests) to the code repository of the translated module.
+    - For example, translations to `jaspAnova-R` or `jaspAnova-QML` components are sent to the [jaspAnova repository on GitHub](https://github.com/jasp-stats/jaspAnova).
+2. On *GitHub*, one of the module developers will manually check and merge the translation into the module's repository.
+3. Every week, *GitHub* automatically updates the translation files; now they are ready to be compiled into an executable program.
+   If new translatable strings were added to the code, they will become available on *Weblate* for translation.
+   (This step involves multiple sub-tasks and file conversions (e.g. from `.po` files to `.qm` and `.mo`); if you are interested, you can read [more technical details here](translate.md).)
+4. Once a new JASP executable is compiled, the new translation become visible in the program.
+   Every night, JASP is automatically compiled as a fresh [nightly build](https://static.jasp-stats.org/Nightlies/) that you can download and test.
+   (Alternatively, you can also compile JASP on your own computer by following the [JASP building guide](jasp-building-guide.md).)
+   Finally, your translations will become available to everybody, once the JASP team releases a [new version of JASP](https://jasp-stats.org/release-notes/).
+
+## Translation conventions
+This section lists general rules for translation.
+
+## Statistical terms
+Use statistical terms as they occur in introductory statistics textbooks and courses in your language.
+Users should be able to recognize established terms in JASP's interface.
+If you deem it useful to offer alternative terms (e.g. that may be suitable for beginners), provide them in the help file.
+
+### Capitalization
+For names of titles, groups and sections in the interface, all words should be capitalized.
+For names within such groupings, e.g. the labels of the controls, only the first word should be capitalized.
+For instance, the *Visual Modeling* module is called *'Visual Modeling'* and one of the analyses is called *'Generalized Linear Modeling'*.
+But if we look at the section *'Results Display'*, the checkbox label *'Model plot'* only starts with a capital in the first word.
+
+### Address the user formally
+The JASP interface occasionally addresses the user directly, e.g. "what would *you* like to do?".
+Some languages have multiple ways to translate the English "you", ranging from formal to informal ways (see [T-V distinction](https://en.wikipedia.org/wiki/T%E2%80%93V_distinction)).
+If you translate JASP into such a language, you should choose a formal way of addressing the user.
+For example, in Dutch use the pronoun *U* instead of *jij*, and in French use *vous* instead of *tu*.

--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -1,41 +1,80 @@
 # Guideline for JASP translators
 
 ## Introduction
-In this document we keep track of some general guidelines that translators of JASP should follow during the translation process. This is an ongoing process and this document should help to maintain consistency. 
+In this document we keep track of some general guidelines that translators of JASP should follow during the translation process.
+This is an ongoing process and this document should help to maintain consistency.
 
 ## Weblate
-JASP uses the online localization tool 'Weblate' for its translations. <br>To contribute to the translations of JASP you need to make an account for Weblate:<br>
-* Open the page https://weblate.org/en-gb/  
-* Press the persons icon  
+JASP uses the online localization tool 'Weblate' for its translations.
+
+To contribute to the translations of JASP you need to make an account for Weblate:
+
+* Open the page https://weblate.org/en-gb/
+* Press the persons icon
 * And register your new account in https://hosted.weblate.org/accounts/register/
-<br>
-Once you've registered your account you can open the JASP project at https://hosted.weblate.org/projects/jasp/
-Here you can find an overview of all the different modules JASP consists of and the translations it contains. Every single module contains two components: an interface component and an R component. 
-E.g. the Anova module consists of the jaspANOVA-QML component for the interface and the jaspANOVA-R component for the R part. Pressing on the component show the current translation of the component.<br><br>
-<img src="https://static.jasp-stats.org/images/Weblate-component.png" width="800" height="250" /><br>For adding a new translation:<br>
-* Press the Start New Translation button.<br>
-* Choose your language from the list of available languages.<br>
+
+Once you've registered your account you can open the JASP project at <https://hosted.weblate.org/projects/jasp/>.
+Here you can find an overview of all the different modules JASP consists of and the translations it contains.
+Every single module contains two components: an interface component and an R component.
+E.g. the Anova module consists of the jaspANOVA-QML component for the interface and the jaspANOVA-R component for the R part.
+Pressing on the component show the current translation of the component.
+
+<img src="https://static.jasp-stats.org/images/Weblate-component.png" width="800" height="250" />
+
+For adding a new translation:
+
+* Press the Start New Translation button.
+* Choose your language from the list of available languages.
 * If your language is not in the list, report this to Weblate with the 'Cannot find your language in the list above?' link.
-<br>
-When you select your language from the list you will get an overview of the translated and the not-yet-translated strings.<br><br>
-<img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" width="800" height="250" /> <br>
-Selecting the part of strings you want to change will bring you to the form where you do the actual translation work. Be aware that all Weblate users have the same rights filling in this form.<br><br>
-<img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" width="800" height="250" /> <br><br>
-There are a lot of options to be chosen here but all are well described in the online documentation you can find in the right corner of the page. <br><img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" width="80" height="100" /> <br>The working procedure is now as follows:<br>  
-* When you save (Save button) your work, your translated strings are stored in Weblates repository. And everybody will see your work.<br>  
-* Once you have committed your work (the Manage/Commit button in the previous screen) a PR (pull request) is made to the JASP GitHub repository belonging to this component.  For instance see the [JASP ANOVA repository](https://github.com/jasp-stats/jaspAnova) for the JASP ANOVA module repository.<br>  
-* This PR is then merged into this JASP module repository by the responsible developer of this repository.<br>  
-* During the nightly build new JASP binary translation files (.qm and .mo) are generated. These files are added to the setup of JASP, so the new translations should be available in this [nightly](http://static.jasp-stats.org/Nightlies/) made version.<br>
-* Every week, new JASP .po files are generated containing the new translatable strings inside JASP. They will then be merged into Weblate. Some component may then have new strings to translate.<br>
+
+
+When you select your language from the list you will get an overview of the translated and the not-yet-translated strings.
+
+<img src="https://static.jasp-stats.org/images/Weblate-Chosen-Dutch.png" width="800" height="250" />
+
+Selecting the part of strings you want to change will bring you to the form where you do the actual translation work.
+Be aware that all Weblate users have the same rights filling in this form.
+
+<img src="https://static.jasp-stats.org/images/Weblate-Dutch.png" width="800" height="250" />
+
+There are a lot of options to be chosen here but all are well described in the online documentation you can find in the right corner of the page.
+
+<img src="https://static.jasp-stats.org/images/Weblate-Documentation.png" width="80" height="100" />
+
+The working procedure is now as follows:
+
+* When you save (Save button) your work, your translated strings are stored in Weblates repository.
+  And everybody will see your work.
+* Once you have committed your work (the Manage/Commit button in the previous screen) a PR (pull request) is made to the JASP GitHub repository belonging to this component.
+  For instance see the [JASP ANOVA repository](https://github.com/jasp-stats/jaspAnova) for the JASP ANOVA module repository.
+* This PR is then merged into this JASP module repository by the responsible developer of this repository.
+* During the nightly build new JASP binary translation files (.qm and .mo) are generated.
+  These files are added to the setup of JASP, so the new translations should be available in this [nightly](http://static.jasp-stats.org/Nightlies/) made version.
+* Every week, new JASP .po files are generated containing the new translatable strings inside JASP.
+  They will then be merged into Weblate.
+  Some component may then have new strings to translate.
 
 ## Translation of statistical terms
-1. Weblate has the functionality of defining glossaries. Each project can have an assigned glossary for any language as a shorthand for storing terminology. Consistency is more easily maintained this way. If a term is defined in the Weblate glossary in its proper context, this definition should be used. Definitions defined in the glossary can be exported and imported.
-2. When in doubt, please use the statistical terms as they occur in introductory statistics textbooks and courses in your language. We would like users to recognize the terms that are used. If you deem this useful you can mention alternative terms in the help file.   
-3. Weblate has the possibility of giving a suggestion of the translation in the "Automatic suggestions" tab. Three automatic translate machines are available, i.e. Google Translate, Microsoft Translator and DeepL. Above that, Weblate offers you the possibility to generate a complete translation of a component.
+1. Weblate has the functionality of defining glossaries.
+   Each project can have an assigned glossary for any language as a shorthand for storing terminology.
+   Consistency is more easily maintained this way.
+   If a term is defined in the Weblate glossary in its proper context, this definition should be used.
+   Definitions defined in the glossary can be exported and imported.
+2. When in doubt, please use the statistical terms as they occur in introductory statistics textbooks and courses in your language.
+   We would like users to recognize the terms that are used.
+   If you deem this useful you can mention alternative terms in the help file.
+3. Weblate has the possibility of giving a suggestion of the translation in the "Automatic suggestions" tab.
+   Three automatic translate machines are available, i.e. Google Translate, Microsoft Translator and DeepL.
+   Above that, Weblate offers you the possibility to generate a complete translation of a component.
 
 ## Capitalization
-As a general rule we use the following conventions. For names of titles, groups and sections all the words are capitalized. For all the sub-names in those groups, e.g. the labels of the controls, those names only start with a capital. For instance, the Visual Modeling module is named 'Visual Modeling' and one of the analyses is called 'Generalized Linear Modeling'. But if we look at the section 'Results Display', the checkbox 'Model plot' only starts with a capital.
+As a general rule we use the following conventions.
+For names of titles, groups and sections all the words are capitalized.
+For all the sub-names in those groups, e.g. the labels of the controls, those names only start with a capital.
+For instance, the Visual Modeling module is named 'Visual Modeling' and one of the analyses is called 'Generalized Linear Modeling'.
+But if we look at the section 'Results Display', the checkbox 'Model plot' only starts with a capital.
 
 ## Formal or Familiar 
-In JASP, we have chosen a formal way of addressing a user. In some languages there are more levels of speech but in general we use the formal level of speech. So in Dutch we use the persons forms 'U' instead of 'jij' and in French 'vous' instead of 'tu'. 
-
+In JASP, we have chosen a formal way of addressing a user.
+In some languages there are more levels of speech but in general we use the formal level of speech.
+So in Dutch we use the persons forms 'U' instead of 'jij' and in French 'vous' instead of 'tu'.

--- a/Docs/development/jasp-guideline-translators.md
+++ b/Docs/development/jasp-guideline-translators.md
@@ -1,11 +1,11 @@
 # Guideline for JASP translators
 
 Thank you for your interest in the translation of JASP.
-This document provides some first steps and general guidelines to maintain consistency of the translations.
-Like the rest of JASP development, this is an ongoing process, and participation is welcome.
+This document provides some first steps and general guidelines to maintain consistency.
+As part of JASP's development, translation is an ongoing process, and participation is welcome.
 
 ## Weblate
-JASP uses the web-based localization tool [Weblate](https://hosted.weblate.org/projects/jasp/).
+To make translation easy, JASP uses the web-based localization tool [Weblate](https://hosted.weblate.org/projects/jasp/).
 All you need to translate is a web browser — you can start as soon as you log in.
 
 Once you save translations on *Weblate*, they are on their way into JASP.
@@ -27,13 +27,13 @@ The two components are distinguishable their name suffix (`-QML` or `-R`) that i
 - A component to define the user interface, written in the language [QML](https://en.wikipedia.org/wiki/QML).
 - A component to define the statistical analysis, written in the language [R](https://en.wikipedia.org/wiki/R_(programming_language)).
 
-For example, the `jaspAnova` module consists of the [jaspAnova-QML](https://hosted.weblate.org/projects/jasp/jaspanova-qml/) component for the interface and [`jaspAnova-R`](https://hosted.weblate.org/projects/jasp/jaspanova-r/) for the analysis code.
-Clicking on a component shows an overview of the current translation status, as shown in this screenshot:
+For example, the `jaspAnova` module consists of the components [jaspAnova-QML](https://hosted.weblate.org/projects/jasp/jaspanova-qml/) for the interface and [jaspAnova-R](https://hosted.weblate.org/projects/jasp/jaspanova-r/) for the analysis code.
+Clicking on a component shows an overview of the current translation status:
 
 <img src="https://static.jasp-stats.org/images/Weblate-component.png" height="250px" />
 
 ### Adding languages
-To add a new translation language to a component, click on the button *Start New Translation* and select from the list of available languages.
+To add a new translation language to a component, click on the button *Start New Translation* (see screenshot above) and select from the list of available languages.
 If you cannot find your language, please [report that to the JASP team](https://jasp-stats.org/feature-requests-bug-reports/).
 
 ### Contributing to existing languages
@@ -58,11 +58,12 @@ Now you can log out of *Weblate*, or translate some more.
 
 #### Glossary
 *Weblate* offers glossaries, which are useful to maintain consistency of terminology translations, especially across modules.
-Terms that are defined in the glossary are marked yellow in the translation form.
+Terminology defined in the glossary is marked yellow in the translation form, to help the translator.
 If a term is defined in the Weblate glossary in its proper context, you should use it.
-If you disagree with a glossary term, don't just ignore it, but try to or discuss or change it first.
+If you disagree with a term translation, don't just ignore it.
+Instead, try to or discuss it with other translators, or change it in the glossary first.
 
-All translators can define new terminology into the glossary.
+Note that all translators can define new terminology into the glossary.
 Each project can have an assigned glossary for any language as a shorthand for storing terminology.
 
 #### Automatic suggestions


### PR DESCRIPTION
Hi, I'd like to offer some fixes for the translation guideline.
My initial commit only contains "uncontroversial" fixes of spelling and some grammar.

If you want, I can also offer more opinionated edits:
1. Convert the text more to Markdown (currently it contains HTML tags and unnecessary Markdown-interpreted syntax, like double-spaces).
2. Try and simplify/fix the text content itself (e.g. it's not *quite* correct that you need a new Weblate account; Weblate offers alternative sign-in options).