### PR TITLE
Increment and Decrement of the SpinBox Should be Invoked by ↑ and ↓

### DIFF
--- a/Desktop/components/JASP/Widgets/SpinBox.qml
+++ b/Desktop/components/JASP/Widgets/SpinBox.qml
@@ -44,8 +44,8 @@ FocusScope
 					width:					plus.x + plus.width
 					height:					valueField.height
 
-					Keys.onLeftPressed:		{ minus.clicked(); event.accepted = true; }
-					Keys.onRightPressed:	{ plus.clicked();  event.accepted = true; }
+					Keys.onDownPressed:		{ minus.clicked(); event.accepted = true; }
+					Keys.onUpPressed:		{ plus.clicked();  event.accepted = true; }
 					Keys.onEnterPressed:	valueField.focus = !valueField.focus;
 					Keys.onReturnPressed:	valueField.focus = !valueField.focus;
 					Keys.onEscapePressed:	focus = false;
@@ -113,7 +113,7 @@ FocusScope
 		selectByMouse:				true
 		selectedTextColor:			jaspTheme.white
 		selectionColor:				jaspTheme.itemSelectedColor
-		color:						jaspTheme.textEnabled
+		color:						enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
 
 		function processInput()
 		{


### PR DESCRIPTION
I'm trying to investigate the source of [this](https://github.com/jasp-stats/INTERNAL-jasp/issues/1482), and I'm noticing some strange interactions. This one is very odd, and it should not be like this. Different platforms are calling this control differently, but they are often falling under the Stepper category. On .NET, we have [NumericUpDown](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.numericupdown?view=net-5.0), and on iOS and macOS, they are called [Stepper](https://developer.apple.com/design/human-interface-guidelines/macos/selectors/steppers/), and in both systems, the changes are invoked by Up and Down keys. Qt visual implementation of this is the strangest but even they mapped the +/- to ↑/↓. 

So, I changed it to use up/down instead of left/right. In addition, I fixed a bug where the control looked enabled when being disabled.

![Screenshot 2021-09-20 at 17 43 25](https://user-images.githubusercontent.com/1290841/134031818-4600be31-df6b-4267-93d8-87a3c2ee96ff.png)

P.S. I'm trying to bring some logic to the KeyNavigation, so, I have to remove some of these nonstandard navigations here and there. It seems like that there are many competing KeyNavigation in JASP interface.

P.P.S. I see that we went through the pain of implementing this control from scratch. If in the far far future, we want to improve it, we can stack the up/down button and make it looks normal!