### PR TITLE
Aligned the Implementation of PrefsData with the Rest of the Prefs Panels

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -5,29 +5,27 @@ import JASP.Widgets		1.0
 import JASP.Controls	1.0
 
 
-Item
+ScrollView
 {
-	focus:					true
+    id:                     scrollPrefs
+    focus:                  true
 	onActiveFocusChanged:	if(activeFocus) synchronizeDataSave.forceActiveFocus();
+	Keys.onLeftPressed:		resourceMenu.forceActiveFocus();
 
-	MenuHeader
-	{
-		id:			menuHeader
-		headertext:	qsTr("Data Preferences")
-		helpfile:	"preferences/prefsdata"
-	}
+	Column {
 
-	ScrollView
-	{
-		id:					scrollPrefs
-		anchors.top:		menuHeader.bottom
-		anchors.left:		menuHeader.left
-		anchors.right:		menuHeader.right
-		anchors.bottom:		menuHeader.bottom
-		anchors.topMargin:	jaspTheme.generalMenuMargin
-		focus:				true
-		Keys.onLeftPressed: resourceMenu.forceActiveFocus();
-		focusPolicy:		Qt.WheelFocus
+		width: scrollPrefs.width
+		spacing: jaspTheme.rowSpacing
+
+		MenuHeader
+		{
+			id:			menuHeader
+			headertext:	qsTr("Data Preferences")
+			helpfile:	"preferences/prefsdata"
+			anchorMe:	false
+			width:		scrollPrefs.width - (2 * jaspTheme.generalMenuMargin)
+			x:			jaspTheme.generalMenuMargin
+		}
 
 		PrefsGroupRect
 		{


### PR DESCRIPTION
I noticed that the implementation of PrefsData was slightly different from the rest of the panels, and in some situation, it could lead to this:

![2021-09-22 17 31 26](https://user-images.githubusercontent.com/1290841/134465390-c2418350-8c52-42d3-a1d2-b5a8991e5623.gif)

It's fixed now!