### PR TITLE
Added the extra s to the translation guidelines page

### DIFF
--- a/Resources/Help/preferences/prefsui.md
+++ b/Resources/Help/preferences/prefsui.md
@@ -14,7 +14,7 @@ Here you can specify if you would like to have a "light" or a "dark" theme on th
 ### Preferred Language
 Select the language in which you would like to use JASP.
 
-If you would like to improve our translations, or to add a new language, please visit https://jasp-stats.org/translation-guideline/
+If you would like to improve our translations, or to add a new language, please visit https://jasp-stats.org/translation-guidelines/
 
 ### Zoom
 This number specifies how the JASP interface will be scaled.

--- a/Resources/Help/preferences/prefsui_nl.md
+++ b/Resources/Help/preferences/prefsui_nl.md
@@ -8,28 +8,28 @@ Met de gebruikersinterface parameters in JASP kunnen de volgende opties gespecif
 Hier kun je aangeven welk lettertype gebruikt wordt door de interface (bestandsmenu, ribbon balk en de analyseopties), code invoer, of de resultaten. Als je geen keuze maakt, wordt het standaard lettertype gebruikt.
 
 ### Thema's
-Hier kan worden gespecificeerd of de gebruiker liever een 'licht' of 'donker' thema heeft op de interface van JASP. Het donkere thema is fijner om naar te kijken in donkere omgevingen, terwijl het lichte (en standaard) thema duidelijker is in lichte omgevingen. 
+Hier kan worden gespecificeerd of de gebruiker liever een 'licht' of 'donker' thema heeft op de interface van JASP. Het donkere thema is fijner om naar te kijken in donkere omgevingen, terwijl het lichte (en standaard) thema duidelijker is in lichte omgevingen.
 
 ### Voorkeurstaal
-Hier kan de voorkeurstaal voor JASP worden geselecteerd. 
+Hier kan de voorkeurstaal voor JASP worden geselecteerd.
 
-Als je een vertaling wilt verbeteren, of een nieuwe taal toevoegen, kijk eerst hier https://jasp-stats.org/translation-guideline/
+Als je een vertaling wilt verbeteren, of een nieuwe taal toevoegen, kijk eerst hier https://jasp-stats.org/translation-guidelines/
 
 ### Zoom
-Dit nummer specificeert hoe de JASP interface wordt geschaald. 
+Dit nummer specificeert hoe de JASP interface wordt geschaald.
 Alle menus en resultaten zijn geschaald op deze factor.
 Er kan ook gebruik worden gemaakt van toetsenbord shortcuts:
 - OSX:   &#8984; met `+`, `-` of `0`
 - Windows en Linux: Ctrl met `+`, `-` of `0`
 
-`-` verkleint en `+` vergroot de schaal, en `0` reset de schaal naar de standaardinstellingen. 
+`-` verkleint en `+` vergroot de schaal, en `0` reset de schaal naar de standaardinstellingen.
 
 ### Scrollsnelheid
-Deze snelheid, in pixels per seconde, specificeert wat de maximale flick- / scrollsnelheid is in verschillende bewegende elementen in JASP. 
-Wanneer scrollen te snel of te langzaam gaat, kan dat hier aangepast worden. 
+Deze snelheid, in pixels per seconde, specificeert wat de maximale flick- / scrollsnelheid is in verschillende bewegende elementen in JASP.
+Wanneer scrollen te snel of te langzaam gaat, kan dat hier aangepast worden.
 
 ### Veilige Grafische Weergave
-Als dit aanstaat, zal JASP in een software rendering modus werken, wat betekent dat de interface langzamer is, maar dat vreemde glitches en andere problemen mogelijk verdwijnen. Om deze instelling te starten moet JASP opnieuw opgestart worden. 
+Als dit aanstaat, zal JASP in een software rendering modus werken, wat betekent dat de interface langzamer is, maar dat vreemde glitches en andere problemen mogelijk verdwijnen. Om deze instelling te starten moet JASP opnieuw opgestart worden.
 
 ### Gebruik Ingebouwde Bestandsdialogen
 Sommige gebruikers op bepaalde systemen (Windows) kunnen problemen hebben met de ingebouwde systeem bestandsdialogen.


### PR DESCRIPTION
We seemed to have changed the link to have and extra "s" at the end of the https://jasp-stats.org/translation-guidelines/ to align with the link shown in Menu - Preferences - Interface - Preferred language. 

Does the link appear somewhere else Bruno?