### PR TITLE
Hide menu options for plots when they can't be used

### DIFF
--- a/Desktop/html/js/image.js
+++ b/Desktop/html/js/image.js
@@ -38,9 +38,10 @@ JASPWidgets.imageView = JASPWidgets.objectView.extend({
 
 
 	hasNotes:					function() {	return this.$el.hasClass('jasp-collection-item')	=== false;	},
-	isEditable:					function() {	return true;													},
+	hasCopy:					function() {	return this.model.get("error") === null;						},
+	isEditable:					function() {	return this.model.get("error") === null;						},
+	isConvertible:				function() {	return this.model.get("error") === null && this.model.get("convertible") ===  true;	},
 	hasCollapse:				function() {	return this.$el.hasClass('jasp-collection-item')	=== false;	},
-	isConvertible:				function() {	return this.model.get("convertible")				==  true;	},
 	saveImageClicked:			function() {	this.model.trigger("SaveImage:clicked",							{ data: this.model.get("data"), width: this.model.get("width"), height: this.model.get("height"), name: this.model.get("name")							});	},
 	editImageClicked:			function() {	this.model.trigger("EditImage:clicked",			this.myView,	{ data: this.model.get("data"), width: this.model.get("width"), height: this.model.get("height"), name: this.model.get("name"), title: this.model.get("title"), type: "interactive"		});	},
 	showDependenciesClicked:	function() {	this.model.trigger("ShowDependencies:clicked",	this.model.get("name")); },


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1547

The menu for plots always shows these options:

![image](https://user-images.githubusercontent.com/21319932/134698321-ff59e2cd-56cb-493a-9311-62ff137133c1.png)

But when a plot shows an error message, like so:

![image](https://user-images.githubusercontent.com/21319932/134698357-949672d8-9faa-4b53-a5e2-d29d493113eb.png)

It makes no sense to
- Copy the image
- Save the image
- Edit the image

This PR disables those options:

![image](https://user-images.githubusercontent.com/21319932/134698459-a5dd9b79-7445-47b4-a1b4-6027bc08a4b7.png)
 