### PR TITLE
Improvement to the MessageBoxes

### DIFF
--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -367,8 +367,8 @@ FocusScope
 		SaveDiscardCancelDialog
 		{
 			id:			saveDialog
-			title:		qsTr("Computed Column Changed")
-			text:		qsTr("There are unapplied changes to your computed column; what would you like to do?")
+			title:		qsTr("Do you want to save your changes to the Computed Column?")
+			text:		qsTr("Your changes will be lost if you don't save them.")
 			onDiscard:	computedColumnContainer.close()
 			onSave:
 			{

--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -367,7 +367,7 @@ FocusScope
 		SaveDiscardCancelDialog
 		{
 			id:			saveDialog
-			title:		qsTr("Do you want to save your changes to the Computed Column?")
+			title:		qsTr("Would you like to save your changes to the Computed Column?")
 			text:		qsTr("Your changes will be lost if you don't save them.")
 			onDiscard:	computedColumnContainer.close()
 			onSave:

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -145,7 +145,7 @@ FocusScope
 				{
 					id:		easySaveDialog
 
-					title:	qsTr("Do you want to save your changes to the Filtered Column?")
+					title:	qsTr("Would you like to save your changes to the Filter?")
 					text:	qsTr("Your changes will be lost if you don't save them.")
 
 					property var closeFunc: undefined

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -145,8 +145,8 @@ FocusScope
 				{
 					id:		easySaveDialog
 
-					title:	qsTr("Filter Changed")
-					text:	qsTr("There are unapplied changes to your filter; what would you like to do?")
+					title:	qsTr("Do you want to save your changes to the Filtered Column?")
+					text:	qsTr("Your changes will be lost if you don't save them.")
 
 					property var closeFunc: undefined
 

--- a/Desktop/gui/messageforwarder.cpp
+++ b/Desktop/gui/messageforwarder.cpp
@@ -20,15 +20,25 @@ MessageForwarder * MessageForwarder::_singleton = nullptr;
 
 void MessageForwarder::showWarning(QString title, QString message)
 {
-	QMessageBox::warning(nullptr, title, message);
+    QMessageBox box;
+
+	box.setText(title);
+	box.setInformativeText(message);
+	box.setIcon(QMessageBox::Warning);
 }
 
 bool MessageForwarder::showYesNo(QString title, QString message, QString YesButtonText, QString NoButtonText)
 {
+
+	QMessageBox box;
+
+	box.setText(title);
+	box.setInformativeText(message);
+	box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+	box.setIcon(QMessageBox::Question);
+
 	if(YesButtonText == "")		YesButtonText	= tr("Yes");
 	if(NoButtonText == "")		NoButtonText	= tr("No");
-
-	QMessageBox box(QMessageBox::Question, title, message,  QMessageBox::Yes | QMessageBox::No);
 
 	box.setButtonText(QMessageBox::Yes,		YesButtonText);
 	box.setButtonText(QMessageBox::No,		NoButtonText);
@@ -38,11 +48,17 @@ bool MessageForwarder::showYesNo(QString title, QString message, QString YesButt
 
 MessageForwarder::DialogResponse MessageForwarder::showYesNoCancel(QString title, QString message, QString YesButtonText, QString NoButtonText, QString CancelButtonText)
 {
+
+	QMessageBox box;
+
+	box.setText(title);
+	box.setInformativeText(message);
+	box.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+	box.setIcon(QMessageBox::Question);
+
 	if(YesButtonText == "")		YesButtonText		= tr("Yes");
 	if(NoButtonText == "")		NoButtonText		= tr("No");
 	if(CancelButtonText == "")	CancelButtonText	= tr("Cancel");
-
-	QMessageBox box(QMessageBox::Question, title, message,  QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
 
 	box.setButtonText(QMessageBox::Yes,		YesButtonText);
 	box.setButtonText(QMessageBox::No,		NoButtonText);
@@ -58,7 +74,12 @@ MessageForwarder::DialogResponse MessageForwarder::showYesNoCancel(QString title
 
 MessageForwarder::DialogResponse MessageForwarder::showSaveDiscardCancel(QString title, QString message, QString saveTxt, QString discardText, QString cancelText)
 {
-	QMessageBox box(QMessageBox::Question, title, message,  QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+	QMessageBox box;
+
+	box.setText(title);
+	box.setInformativeText(message);
+	box.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+	box.setIcon(QMessageBox::Question);
 
 	if(saveTxt == "")		saveTxt		= tr("Save");
 	if(discardText == "")	discardText = tr("Don't Save");

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -947,7 +947,7 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 			QString title = windowTitle();
 			title.chop(1);
 
-			switch(MessageForwarder::showSaveDiscardCancel(tr("Save File?"), tr("Save changes to the file %1 before closing?\n\nYour changes will be lost if you don't save them.").arg(title)))
+			switch(MessageForwarder::showSaveDiscardCancel(tr("Do you want to save your changes to %1?").arg(title), tr("Your changes will be lost if you don't save them.")))
 			{
 			default:
 			case MessageForwarder::DialogResponse::Cancel:

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -947,7 +947,7 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 			QString title = windowTitle();
 			title.chop(1);
 
-			switch(MessageForwarder::showSaveDiscardCancel(tr("Do you want to save your changes to %1?").arg(title), tr("Your changes will be lost if you don't save them.")))
+			switch(MessageForwarder::showSaveDiscardCancel(tr("Would you like to save your changes to %1 file?").arg(title), tr("Your changes will be lost if you don't save them.")))
 			{
 			default:
 			case MessageForwarder::DialogResponse::Cancel:

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -993,7 +993,7 @@ bool MainWindow::checkPackageModifiedBeforeClosing()
 	QString title = windowTitle();
 	title.chop(1);
 
-	switch(MessageForwarder::showSaveDiscardCancel(tr("File has changed"), tr("Save changes to the file %1 before closing?\n\nYour changes will be lost if you don't save them.").arg(title)))
+	switch(MessageForwarder::showSaveDiscardCancel(tr("Would you like to save your changes to %1 file?").arg(title), tr("Your changes will be lost if you don't save them.")))
 	{
 	case MessageForwarder::DialogResponse::Save:
 	{


### PR DESCRIPTION
I noticed this not so professional message, "There are unapplied changes to your filter; what would you like to do?", and while looking into that, I ended up improving the message box a bit. Because of macOS Guidelines, Qt cannot set the TitleBar text on macOS, and that makes the dialog looks a bit too bold. I don't expect this to break anything on Windows, but it's good to check it anyway.

@boutinb, I have changed a few labels and text, do I have to do anything for this to get into our translation portal?

![CleanShot 2021-10-11 at 18 15 47](https://user-images.githubusercontent.com/1290841/136822998-5a8c9e73-0a17-4602-9c98-3d14a626c77d.png)

![CleanShot 2021-10-11 at 18 12 05](https://user-images.githubusercontent.com/1290841/136823015-59f09aa7-1b92-4500-b45d-f31d68a8a73b.png)


