### PR TITLE
A bit of a Softer/Brighter Divider

### DIFF
--- a/Desktop/components/JASP/Widgets/Divider.qml
+++ b/Desktop/components/JASP/Widgets/Divider.qml
@@ -36,7 +36,7 @@ Item
 		border.width: 1
 		height: 2
 		width: parent.implicitWidth
-		border.color: jaspTheme.black
+		border.color: jaspTheme.gray
 	}
 
 	Rectangle


### PR DESCRIPTION
I found it very black in the middle of our mostly gray interface. The better solution would be to rely on the GroupBox border, but I don't see our GroupBox having a border.

![CleanShot 2021-10-15 at 10 47 42](https://user-images.githubusercontent.com/1290841/137460040-275181ec-b96d-42e0-95ec-2ddde1ee3dff.png)

![CleanShot 2021-10-15 at 10 47 46](https://user-images.githubusercontent.com/1290841/137460079-8b4e2ef1-9a2c-4984-8a16-52d03c2697c2.png)

