### PR TITLE
Dynamic options taken from source are not always updated

### DIFF
--- a/Desktop/widgets/sourceitem.cpp
+++ b/Desktop/widgets/sourceitem.cpp
@@ -159,7 +159,8 @@ void SourceItem::_setUp()
 
 		// Do not connect before this control (and the controls of the source) are completely initialized
 		// The source could sent some data to this control before it is completely ready for it.
-		connect(_listControl, &JASPControl::initializedChanged,			this,	&SourceItem::_connectModels);
+		if (_listControl->initialized()) _connectModels();
+		else connect(_listControl, &JASPControl::initializedChanged, this, &SourceItem::_connectModels);
 	}
 	else if (_rSources.length() == 0)
 	{


### PR DESCRIPTION
When the definition of the source self changes, the connection between signal/slot are not set properly
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1582
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1587
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1625
