### PR TITLE
Bump jaspColumnEncoder + small changes to the flatpak script

### DIFF
--- a/Tools/flatpak/setup-rpkgs/R/validators.R
+++ b/Tools/flatpak/setup-rpkgs/R/validators.R
@@ -1,25 +1,25 @@
 assertDirExists <- function(x) {
   if (!dir.exists(x))
-    stop("Directory ", x, " does not exist", domain = NA)
+    stop2("Directory ", x, " does not exist")
 }
 
 validateJaspDir <- function(dir) {
   assertDirExists(dir)
   expectedDirs <- c("Common", "Desktop", "Engine", "Modules", "R-Interface", "Resources", "Tools")
   if (!all(expectedDirs %in% list.dirs(dir, full.names = FALSE, recursive = FALSE)))
-    stop("Invalid jaspDir. Expected these folders: ", paste(expectedDirs, collapse = ", "), domain = NA)
+    stop2("Invalid jaspDir. Expected these folders: ", paste(expectedDirs, collapse = ", "))
 }
 
 validateFlatpakDir <- function(dir) {
   assertDirExists(dir)
   expectedFiles <- c("flathub.json", "org.jaspstats.JASP.json", "RPackages.json")
   if (!all(expectedFiles %in% list.files(dir)))
-    stop("Invalid flatpakDir. Expected these files", domain = NA)
+    stop2("Invalid flatpakDir. Expected these files")
 }
 
 validateGithubPath <- function() {
   if (Sys.getenv("GITHUB_PAT") == "")
-    stop("GITHUB_PAT is not set!", domain = NA)
+    stop2("GITHUB_PAT is not set!")
 }
 
 validateSetup <- function(jaspDir, flatpakDir) {
@@ -54,7 +54,7 @@ validateGithubPkgs <- function(dirs) {
     errorMessages <- c(errorMessages, paste0("These github packages are missing a tarball: ", paste(names(SHAs)[missing], collapse = ", ")))
 
   if (length(errorMessages) > 0L)
-    stop("These error message occurred:\n\n", paste(errorMessages, collapse = "\n"))
+    stop2("These error message occurred:\n\n", paste(errorMessages, collapse = "\n"))
 
   return(invisible(TRUE))
 
@@ -64,11 +64,11 @@ validateV8folder <- function(dirs) {
 
   v8Dir <- file.path(dirs["other-dependencies"], "v8")
   if (!dir.exists(v8Dir))
-    stop("V8 dir does not exist at ", v8Dir, domain = NA)
+    stop2("V8 dir does not exist at ", v8Dir, domain = NA)
 
   subdirs <- file.path(v8Dir, c("include", "lib", "lic"))
   if (!all(dir.exists(subdirs)))
-    stop("V8 dir does not contain the following subdirectories: ", paste(subdirs, collapse = ", "), domain = NA)
+    stop2("V8 dir does not contain the following subdirectories: ", paste(subdirs, collapse = ", "), domain = NA)
 
 
 }

--- a/Tools/flatpak/setup-rpkgs/renv.lock
+++ b/Tools/flatpak/setup-rpkgs/renv.lock
@@ -3,12 +3,19 @@
     "Version": "4.1.0",
     "Repositories": [
       {
-        "Name": "CRAN",
+        "Name": "repos",
         "URL": "https://cran.rstudio.com"
       }
     ]
   },
   "Packages": {
+    "crayon": {
+      "Package": "crayon",
+      "Version": "1.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0a6a65d92bd45b47b94b84244b528d17"
+    },
     "renv": {
       "Package": "renv",
       "Version": "0.14.0",


### PR DESCRIPTION
Bumps jaspColumnEncoder to the new master (required for flatpak).

The install script should be a bit more robust, but if there is an error it now prints a stack trace and (in non-interactive mode, so `Rscript`) it exits (with status 1):

![image](https://user-images.githubusercontent.com/21319932/141131663-0b68eafd-66ec-49a8-9497-69a3ff1d1976.png)

This stack trace could be more pretty but I hope it suffices for now.

The versions of remotes and renv are no longer hardcoded, so that shouldn't cause errors anymore.