### PR TITLE
Change in a R Source of a ComponentList does not refresh the controls correctly

### DIFF
--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -561,15 +561,6 @@ void AnalysisForm::setAnalysis(QVariant analysis)
 	setAnalysisUp();
 }
 
-void AnalysisForm::rSourceChanged(const QString &name)
-{
-	if (_rSourceModelMap.contains(name))
-	{
-		for (ListModel* model : _rSourceModelMap[name])
-			model->sourceTermsReset();
-	}
-}
-
 void AnalysisForm::boundValueChangedHandler(JASPControl *)
 {
 	if (_signalValueChangedBlocked == 0 && _analysis)

--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -69,7 +69,6 @@ public slots:
 				void			runScriptRequestDone(const QString& result, const QString& requestId);
 				void			setInfo(QString info);
 				void			setAnalysis(QVariant analysis);
-				void			rSourceChanged(const QString& name);
 				void			boundValueChangedHandler(JASPControl* control);
 
 signals:
@@ -87,6 +86,7 @@ signals:
 				void			errorsChanged();
 				void			warningsChanged();
 				void			analysisChanged();
+				void			rSourceChanged(const QString& name);
 
 protected:
 				QVariant		requestInfo(const Term &term, VariableInfo::InfoType info)	const override;
@@ -125,8 +125,6 @@ public:
 	QString		warnings()			const { return msgsListToString(_formWarnings);	}
 	QVariant	analysis()			const { return QVariant::fromValue(_analysis);	}
 	Analysis*	analysisObj()		const { return _analysis;						}
-	void		addRSource(const QString& name, ListModel* model)		{ _rSourceModelMap[name].insert(model); }
-	void		removeRSource(const QString& name, ListModel* model)	{ _rSourceModelMap[name].remove(model);	}
 
 	std::vector<std::vector<std::string> >	getValuesFromRSource(const QString& sourceID, const QStringList& searchPath);
 	void		addColumnControl(JASPControl* control, bool isComputed);
@@ -184,7 +182,6 @@ private:
 												_formCompleted = false,
 												_initialized = false;
 	QString										_info;
-	QMap<QString, QSet<ListModel*> >			_rSourceModelMap;
 	int											_signalValueChangedBlocked = 0;
 	bool										_signalValueChangedWasEmittedButBlocked = false;
 	

--- a/Desktop/widgets/listmodel.cpp
+++ b/Desktop/widgets/listmodel.cpp
@@ -38,7 +38,7 @@ ListModel::ListModel(JASPListControl* listView)
 	connect(this,	&ListModel::rowsInserted,			this,	&ListModel::termsChanged);
 	connect(this,	&ListModel::dataChanged,			this,	&ListModel::dataChangedHandler);
 	connect(this,	&ListModel::namesChanged,			this,	&ListModel::termsChanged);
-	connect(this,	&ListModel::columnTypeChanged,			this,	&ListModel::termsChanged);
+	connect(this,	&ListModel::columnTypeChanged,		this,	&ListModel::termsChanged);
 }
 
 QHash<int, QByteArray> ListModel::roleNames() const

--- a/Desktop/widgets/rowcontrols.h
+++ b/Desktop/widgets/rowcontrols.h
@@ -58,7 +58,7 @@ private:
 	QQuickItem*								_rowObject;
 	QMap<QString, JASPControl*>				_rowJASPControlMap;
 	QQmlContext*							_context;
-	QMap<QString, Json::Value>				_rowValues;
+	QMap<QString, Json::Value>				_initialValues;
 };
 
 #endif // ROWCOMPONENTS_H

--- a/Desktop/widgets/sourceitem.cpp
+++ b/Desktop/widgets/sourceitem.cpp
@@ -94,8 +94,10 @@ void SourceItem::_connectModels()
 	if (!_listControl->initialized()) return;
 
 	ListModel *controlModel = _listControl->model();
+	AnalysisForm* form		= _listControl->form();
 
-	if (_isRSource && _listControl->form()) _listControl->form()->addRSource(_name, controlModel);
+	if (_isRSource && form)
+		connect(form,	&AnalysisForm::rSourceChanged,				this, &SourceItem::_rSourceChanged);
 
 	if (!_nativeModel) return;
 
@@ -140,6 +142,12 @@ void SourceItem::_dataChangedHandler(const QModelIndex &, const QModelIndex &, c
 	if (roles.size() == 1 && roles.contains(ListModel::SelectedRole)) return;
 
 	_resetModel();
+}
+
+void SourceItem::_rSourceChanged(const QString& name)
+{
+	if (_isRSource && name == _name)
+		_listControl->model()->sourceTermsReset();
 }
 
 void SourceItem::_setUp()

--- a/Desktop/widgets/sourceitem.h
+++ b/Desktop/widgets/sourceitem.h
@@ -89,6 +89,7 @@ private slots:
 	void									_connectModels();
 	void									_resetModel();
 	void									_dataChangedHandler(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>());
+	void									_rSourceChanged(const QString& name);
 
 private:
 	JASPListControl		*			_listControl			= nullptr;


### PR DESCRIPTION
In the Cochrane Meta Analysis, a ComponentsList of a ComponentsLists of Checkboxes R Sources. These R sources are changed according to some options.
The ComponentsList were not updated correctly each time the R sources changed.
This was due to bad caching (the _rSourceModelMap in AnalysisForm was not updated correctly and is in fact not needed), and by not signaling that the analysis should be rerun again.

This is already tested by @FBartos in the cochraneFix branch.
