### PR TITLE
Flatpak 0.16 - more edits to setup-rpkgs

### DIFF
--- a/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
@@ -37,7 +37,9 @@ source(file.path("R", "validators.R"))
 
 validateSetup(jaspDir, flatpakDir)
 
-options(repos = list(repos = c(CRAN = "https://cran.rstudio.com")))
+# options(repos = list(repos = c(CRAN = "https://cran.rstudio.com")))
+options(repos = list(repos = c(RSPM = "https://packagemanager.rstudio.com/all/__linux__/focal/latest")))
+options("binaryPkgs" = TRUE)
 
 # NOTE: if you change the flatpak_dir anywhere you must also change it in the flatpak builder script!
 dirs <- setupJaspDirs("flatpak_folder")

--- a/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
@@ -37,9 +37,10 @@ source(file.path("R", "validators.R"))
 
 validateSetup(jaspDir, flatpakDir)
 
-# options(repos = list(repos = c(CRAN = "https://cran.rstudio.com")))
-options(repos = list(repos = c(RSPM = "https://packagemanager.rstudio.com/all/__linux__/focal/latest")))
-options("binaryPkgs" = TRUE)
+options(repos = list(repos = c(CRAN = "https://cran.rstudio.com")))
+# for binary packages, but this does not yet work well
+# options(repos = list(repos = c(RSPM = "https://packagemanager.rstudio.com/all/__linux__/focal/latest")))
+# options("binaryPkgs" = TRUE)
 
 # NOTE: if you change the flatpak_dir anywhere you must also change it in the flatpak builder script!
 dirs <- setupJaspDirs("flatpak_folder")
@@ -90,4 +91,4 @@ info <- createTarArchive(dirs, jaspDir, verbose = FALSE, compression = "best")
 writeRpkgsJson(file.path(flatpakDir, "RPackages.json"), info, local = TRUE)
 
 # IF you have ssh setup this will upload the tar.gz to static-jasp. It's nicer to do this via a terminal because there you see a progress bar
-# uploadTarArchive(info["tar-file"])
+uploadTarArchive(info["tar-file"], printOnly = TRUE)


### PR DESCRIPTION
This PR contains some fixes that are applied to the tar.gz that is currently used for the flatpak build:

- in the .Rbuildignore for flatpak, do not remove any files that contain "JASP" and end with .R.
- for the v8 R package, always apply the fix to the configure file to both the source package in `renv-root/.../v8_<version>.tar.gz` and to `local-cran/src/contrib/v8_<version>.tar.gz`. That should be a bit more robust when commands are run out of order (or run multiple times).
- delete some unused stuff (e.g., `downloadFakeV8`, we're not doing that anymore).
- started on binary packages. To try it out, uncomment
```r
# options(repos = list(repos = c(RSPM = "https://packagemanager.rstudio.com/all/__linux__/focal/latest")))
# options("binaryPkgs" = TRUE)
```
and then everything else should be automatic. This may speed up local builds in the future.