### PR TITLE
Add the possibility to duplicate a tab.

### DIFF
--- a/Desktop/components/JASP/Controls/AssignButton.qml
+++ b/Desktop/components/JASP/Controls/AssignButton.qml
@@ -31,8 +31,6 @@ Button
 				property var	source:			leftToRight ? leftSource : rightSource
 				property var	target:			leftToRight ? rightSource : leftSource
 
-				property var	interactionControl
-
 	readonly	property string iconToLeft:		jaspTheme.iconPath + "arrow-left.png"
 	readonly	property string iconToRight:	jaspTheme.iconPath + "arrow-right.png"
 	
@@ -66,21 +64,6 @@ Button
 						isEnabled = true;
 				}
 			}
-		}
-
-		if (isEnabled && interactionControl)
-		{
-			if (target.addInteractionOptions && source.model)
-			{
-				var nb = source.model.selectedItems().length
-				interactionControl.enabled = isEnabled
-				var enabledOptions = [ true, nb > 1, nb > 2, nb > 3, nb > 4, true ]
-				interactionControl.enabledOptions = enabledOptions
-				if (!enabledOptions[interactionControl.currentIndex])
-					isEnabled = false;
-			}
-			else
-				interactionControl.enabled = false
 		}
 		
 		enabled = isEnabled

--- a/Desktop/components/JASP/Controls/ComponentsList.qml
+++ b/Desktop/components/JASP/Controls/ComponentsList.qml
@@ -30,8 +30,8 @@ ComponentsListBase
 	implicitHeight			: itemTitle.height + itemGrid.height + 2 * jaspTheme.contentMargin + (showAddIcon ? addIconItem.height : 0)
 	shouldStealHover		: false
 	innerControl			: itemGrid
+	addItemManually			: !source && !rSource
 
-	property string title
 	property alias	label				: componentsList.title
 	property alias	columns				: itemGrid.columns
 	property alias	rows				: itemGrid.rows
@@ -41,17 +41,11 @@ ComponentsListBase
 	property alias	itemTitle			: itemTitle
 	property alias	rowSpacing			: itemGrid.rowSpacing
 	property alias	columnSpacing		: itemGrid.columnSpacing
-
-	property bool	addItemManually		: !source && !values && !rSource
 	property bool	showAddIcon			: addItemManually
-	property int	minimumItems		: 0
-	property int	maximumItems		: -1
-	property string newItemName			: "#"
 	property string	removeIcon			: "cross.png"
 	property string	addIcon				: "duplicate.png"
 	property string addTooltip			: qsTr("Add a row")
 	property string removeTooltip		: qsTr("Remove a row")
-	property var	defaultValues		: []
 
 	Text
 	{

--- a/Desktop/components/JASP/Controls/TabView.qml
+++ b/Desktop/components/JASP/Controls/TabView.qml
@@ -31,28 +31,23 @@ ComponentsListBase
 	implicitHeight			: itemStack.y + itemStack.height
 	shouldStealHover		: false
 	innerControl			: itemTabBar
+	addItemManually			: !source
+	minimumItems			: 1
+	newItemName				: qsTr("New tab")
 
-	property string title
 	property alias	label				: tabView.title
-	property var	defaultValues		: []
-	property bool	addItemManually		: !source
 	property bool	showAddIcon			: addItemManually
 	property bool	showRemoveIcon		: addItemManually
 	property bool	tabNameEditable		: addItemManually
-	property int	minimumItems		: 1
-	property int	maximumItems		: -1
 	property string	removeIcon			: "cross.png"
 	property string	addIcon				: "duplicate.png"
 	property string addTooltip			: qsTr("Add a tab")
 	property string removeTooltip		: qsTr("Remove this tab")
-	property string newItemName			: qsTr("New tab")
 	property alias	newTabName			: tabView.newItemName
-
 	property alias	itemTabBar			: itemTabBar
 	property alias	itemTitle			: itemTitle
 	property alias  content				: tabView.rowComponent
 	property alias	currentIndex		: itemTabBar.currentIndex
-
 	property var	buttonComponent		: defaultButtonButton
 
 	Text

--- a/Desktop/components/JASP/Controls/VariablesForm.qml
+++ b/Desktop/components/JASP/Controls/VariablesForm.qml
@@ -65,92 +65,24 @@ VariablesFormBase
 		id: assignButtonRepeater
 		model: 0
 		
-		Loader
+		AssignButton
 		{
-			property var myLeftSource:			availableVariablesList
-			property var myRightSource:			allAssignedVariablesList[index];
-			property bool interactionAssign:	allAssignedVariablesList[index].addInteractionOptions
-			z:	10
-			
-			
-			sourceComponent: interactionAssign ? assignInteractionButtonComponent : assignButtonComponent
-			x:		(allAssignedVariablesList[index].x + availableVariablesList.width - 40 * preferencesModel.uiScale) / 2
-			y:      allAssignedVariablesList[index].y  + allAssignedVariablesList[index].rectangleY
-		
-			onLoaded:
+			x:				(allAssignedVariablesList[index].x + availableVariablesList.width - 40 * preferencesModel.uiScale) / 2
+			y:				allAssignedVariablesList[index].y  + allAssignedVariablesList[index].rectangleY
+			z:				10
+			leftSource:		availableVariablesList
+			rightSource:	allAssignedVariablesList[index]
+
+			Component.onCompleted:
 			{
-				allAssignedVariablesList[index]	.activeFocusChanged		.connect(item.setIconToLeft	);
-				availableVariablesList			.activeFocusChanged		.connect(item.setIconToRight);
-				allAssignedVariablesList[index]	.selectedItemsChanged	.connect(item.setState		);
-				availableVariablesList			.selectedItemsChanged	.connect(item.setState		);
-				
-				if (interactionAssign)
-				{
-					allAssignedVariablesList[index].interactionControl = item.interactionControl
-					item.interactionControl.resetWidth(["Main Effects"])
-					item.interactionControl.activated.connect(item.setState)
-				}
+				allAssignedVariablesList[index]	.activeFocusChanged		.connect(setIconToLeft	);
+				availableVariablesList			.activeFocusChanged		.connect(setIconToRight	);
+				allAssignedVariablesList[index]	.selectedItemsChanged	.connect(setState		);
+				availableVariablesList			.selectedItemsChanged	.connect(setState		);
 			}
 		}
-
 	}
 	
-	Component
-	{
-		id: assignButtonComponent
-		AssignButton 
-		{
-			z:				30
-			leftSource:		myLeftSource
-			rightSource:	myRightSource
-		}		
-	}
-	
-	Component
-	{
-		id: assignInteractionButtonComponent
-		Item
-		{
-			z:	10
-
-			property alias assignButton: assignButton
-			property alias interactionControl: interactionControl
-			
-			function setIconToLeft()	{ assignButton.setIconToLeft() }
-			function setIconToRight()	{ assignButton.setIconToRight() }
-			function setState()			{ assignButton.setState() }
-
-			
-			AssignButton
-			{
-				id:					assignButton
-				leftSource:			myLeftSource
-				rightSource:		myRightSource
-				interactionControl: interactionControl
-				z:					3
-			}
-			
-			DropDown
-			{
-				id:					interactionControl
-				anchors.left:		assignButton.left
-				anchors.leftMargin: (assignButton.width - width - 4) / 2
-				anchors.top:		assignButton.bottom
-				anchors.topMargin:	2
-				currentIndex:		0
-				values: ListModel 
-				{
-					ListElement { label: qsTr("Main Effects");	value: "MainEffects" }
-					ListElement { label: qsTr("Only 2 way");		value: "All2Way" }
-					ListElement { label: qsTr("Only 3 way");		value: "All3Way" }
-					ListElement { label: qsTr("Only 4 way");		value: "All4Way" }
-					ListElement { label: qsTr("Only 5 way");		value: "All5Way" }
-					ListElement { label: qsTr("All");				value: "Cross" }
-				}
-			}			
-		}
-	}
-
 	function init()
 	{
 		var first = true
@@ -165,24 +97,28 @@ VariablesFormBase
 		}
 
 		var countAssignedList = 0
+		var availableDropKeys = []
 		for (var key in allAssignedVariablesList)
 		{
 			countAssignedList++;
 			var assignedList = allAssignedVariablesList[key]
-			availableVariablesList.dropKeys.push(assignedList.name);
+			var assignedDropKeys = [];
+			availableDropKeys.push(assignedList.name);
 			availableVariablesList.draggingChanged.connect(assignedList.setEnabledState);
-			assignedList.dropKeys.push(availableVariablesList.name);
+			assignedDropKeys.push(availableVariablesList.name);
 
 			for (var key2 in allAssignedVariablesList)
 			{
-				assignedList.dropKeys.push(allAssignedVariablesList[key2].name);
+				assignedDropKeys.push(allAssignedVariablesList[key2].name);
 				if (assignedList !== allAssignedVariablesList[key2])
 					assignedList.draggingChanged.connect(allAssignedVariablesList[key2].setEnabledState);
 			}
+
+			assignedList.dropKeys = assignedDropKeys;
 		}
 
+		availableVariablesList.dropKeys = availableDropKeys
 		setControlsSize()
-
 		assignButtonRepeater.model = countAssignedList;
 	}
 

--- a/Desktop/components/JASP/Controls/VariablesList.qml
+++ b/Desktop/components/JASP/Controls/VariablesList.qml
@@ -58,9 +58,6 @@ VariablesListBase
 	property bool	allowAnalysisOwnComputedColumns	: true
 	property bool	allowDuplicatesInMultipleColumns: false // This property is used in the constructor and is not updatable afterwards.
 
-	property var	interactionControl
-	property bool	addInteractionOptions			: false
-
 	property int	indexInDroppedListViewOfDraggedItem:	-1
 	
 	readonly property int rectangleY				: itemRectangle.y
@@ -74,7 +71,7 @@ VariablesListBase
 	property string	searchKeys						: ""
 	
 	signal itemDoubleClicked(int index);
-	signal itemsDropped(var indexes, var dropList, int dropItemIndex, int assignOption);
+	signal itemsDropped(var indexes, var dropList, int dropItemIndex);
 	signal draggingChanged(var context, bool dragging);
 	signal selectedItemsChanged();
 
@@ -114,8 +111,7 @@ VariablesListBase
 		var selectedItems = variablesList.model.selectedItems()
 		if (selectedItems.length === 0) return;
 
-		var assignOption = (target && target.interactionControl) ? JASP.AssignCross: JASP.AssignDefault
-		itemsDropped(selectedItems, target, -1, assignOption);
+		itemsDropped(selectedItems, target, -1);
 		variablesList.clearSelectedItems();
 	}
 
@@ -656,8 +652,7 @@ VariablesListBase
 									return;
 								
 								var variablesListName = variablesList.name
-								var assignOption = dropTarget.interactionControl ? dropTarget.interactionControl.model.get(dropTarget.interactionControl.currentIndex).value : JASP.AssignDefault
-								itemsDropped(selectedItems, dropTarget, dropTarget.indexInDroppedListViewOfDraggedItem, assignOption);
+								itemsDropped(selectedItems, dropTarget, dropTarget.indexInDroppedListViewOfDraggedItem);
 								variablesList.clearSelectedItems();
 							}
 						}

--- a/Desktop/widgets/componentslistbase.h
+++ b/Desktop/widgets/componentslistbase.h
@@ -26,6 +26,14 @@
 class ComponentsListBase : public JASPListControl, public BoundControlBase
 {
 	Q_OBJECT
+
+	Q_PROPERTY( bool			addItemManually		READ addItemManually		WRITE setAddItemManually		NOTIFY addItemManuallyChanged		)
+	Q_PROPERTY( int				minimumItems		READ minimumItems			WRITE setMinimumItems			NOTIFY minimumItemsChanged			)
+	Q_PROPERTY( int				maximumItems		READ maximumItems			WRITE setMaximumItems			NOTIFY maximumItemsChanged			)
+	Q_PROPERTY( QString			newItemName			READ newItemName			WRITE setNewItemName			NOTIFY newItemNameChanged			)
+	Q_PROPERTY( QList<QVariant>	defaultValues		READ defaultValues			WRITE setDefaultValues			NOTIFY defaultValuesChanged			)
+	Q_PROPERTY( bool			duplicateWhenAdding	READ duplicateWhenAdding	WRITE setDuplicateWhenAdding	NOTIFY duplicateWhenAddingChanged	)
+
 public:
 	ComponentsListBase(QQuickItem* item = nullptr);
 
@@ -35,10 +43,31 @@ public:
 	ListModel*		model()								const	override { return _termsModel; }
 	void			setUpModel()								override;
 
+	QString			newItemName()						const			{ return _newItemName;			}
+	bool			addItemManually()					const			{ return _addItemManually;		}
+	int				minimumItems()						const			{ return _minimumItems;			}
+	int				maximumItems()						const			{ return _maximumItems;			}
+	QList<QVariant>	defaultValues()						const			{ return _defaultValues;		}
+	bool			duplicateWhenAdding()				const			{ return _duplicateWhenAdding;	}
+
 signals:
 	void			addItem();
 	void			removeItem(int index);
 	void			nameChanged(int index, QString name);
+	void			newItemNameChanged();
+	void			addItemManuallyChanged();
+	void			minimumItemsChanged();
+	void			maximumItemsChanged();
+	void			defaultValuesChanged();
+	void			duplicateWhenAddingChanged();
+
+public slots:
+	GENERIC_SET_FUNCTION(NewItemName,			_newItemName,			newItemNameChanged,				QString			)
+	GENERIC_SET_FUNCTION(AddItemManually,		_addItemManually,		addItemManuallyChanged,			bool			)
+	GENERIC_SET_FUNCTION(MinimumItems,			_minimumItems,			minimumItemsChanged,			int				)
+	GENERIC_SET_FUNCTION(MaximumItems,			_maximumItems,			maximumItemsChanged,			int				)
+	GENERIC_SET_FUNCTION(DefaultValues,			_defaultValues,			defaultValuesChanged,			QList<QVariant>	)
+	GENERIC_SET_FUNCTION(DuplicateWhenAdding,	_duplicateWhenAdding,	duplicateWhenAddingChanged,		bool			)
 
 protected slots:
 	void			termsChangedHandler()						override;
@@ -46,15 +75,19 @@ protected slots:
 	void			removeItemHandler(int index);
 	void			nameChangedHandler(int index, QString name);
 
-private:
-	ListModelTermsAssigned*		_termsModel		= nullptr;
-
 protected:
 	QString				_makeUnique(const QString& val, int index = -1);
 	QString				_makeUnique(const QString& val, const QList<QString>& values, int index = -1);
 	QString				_changeLastNumber(const QString& val);
 
-
+private:
+	ListModelTermsAssigned*		_termsModel				= nullptr;
+	QString						_newItemName			= "#";
+	bool						_addItemManually		= false,
+								_duplicateWhenAdding	= false;
+	int							_minimumItems			= 0,
+								_maximumItems			= -1;
+	QList<QVariant>				_defaultValues;
 };
 
 #endif // COMPONENTSLIST_H

--- a/Desktop/widgets/listmodelassignedinterface.cpp
+++ b/Desktop/widgets/listmodelassignedinterface.cpp
@@ -18,6 +18,7 @@
 
 #include "listmodelassignedinterface.h"
 #include "variableslistbase.h"
+#include "analysis/analysisform.h"
 
 ListModelAssignedInterface::ListModelAssignedInterface(JASPListControl* listView)
 	: ListModelDraggable(listView)
@@ -74,4 +75,24 @@ int ListModelAssignedInterface::sourceColumnTypeChanged(QString name)
 	}
 
 	return index;
+}
+
+bool ListModelAssignedInterface::sourceLabelsChanged(QString columnName, QMap<QString, QString> changedLabels)
+{
+	bool change = ListModelDraggable::sourceLabelsChanged(columnName, changedLabels);
+
+	if (change && listView() && listView()->form())
+		listView()->form()->refreshAnalysis();
+
+	return change;
+}
+
+bool ListModelAssignedInterface::sourceLabelsReordered(QString columnName)
+{
+	bool change = ListModelDraggable::sourceLabelsReordered(columnName);
+
+	if (change && listView() && listView()->form())
+		listView()->form()->refreshAnalysis();
+
+	return change;
 }

--- a/Desktop/widgets/listmodelassignedinterface.h
+++ b/Desktop/widgets/listmodelassignedinterface.h
@@ -36,7 +36,8 @@ public:
 public slots:
 	virtual void availableTermsResetHandler(Terms termsAdded, Terms termsRemoved)				{}
 			int  sourceColumnTypeChanged(QString name)												override;
-
+			bool sourceLabelsChanged(QString columnName, QMap<QString, QString> changedLabels)		override;
+			bool sourceLabelsReordered(QString columnName)											override;
 protected:
 	ListModelAvailableInterface*			_availableModel;
 };

--- a/Desktop/widgets/listmodeldraggable.cpp
+++ b/Desktop/widgets/listmodeldraggable.cpp
@@ -89,10 +89,8 @@ void ListModelDraggable::moveTerms(const QList<int> &indexes, int dropItemIndex)
 	endResetModel();
 }
 
-Terms ListModelDraggable::addTerms(const Terms& terms, int dropItemIndex, JASPControl::AssignType)
+Terms ListModelDraggable::addTerms(const Terms& terms, int dropItemIndex, const RowControlsValues&)
 {
-	Q_UNUSED(dropItemIndex);
-
 	if (terms.size() > 0)
 	{
 		beginResetModel();
@@ -100,7 +98,7 @@ Terms ListModelDraggable::addTerms(const Terms& terms, int dropItemIndex, JASPCo
 		endResetModel();
 	}
 
-	return nullptr;
+	return Terms();
 }
 
 Terms ListModelDraggable::canAddTerms(const Terms& terms) const

--- a/Desktop/widgets/listmodeldraggable.h
+++ b/Desktop/widgets/listmodeldraggable.h
@@ -38,9 +38,9 @@ public:
 	void setDropMode(JASPControl::DropMode dropMode)	{ _dropMode = dropMode; }
 	void setCopyTermsWhenDropped(bool copy)					{ _copyTermsWhenDropped = copy; }
 	
-	virtual Terms termsFromIndexes(const QList<int> &indexes) const;
-	virtual Terms canAddTerms(const Terms& terms) const;
-	virtual Terms addTerms(const Terms& terms, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault) ;
+	virtual Terms termsFromIndexes(const QList<int> &indexes)					const;
+	virtual Terms canAddTerms(const Terms& terms)								const;
+	virtual Terms addTerms(const Terms& terms, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues());
 	virtual void removeTerms(const QList<int>& indexes);
 	virtual void moveTerms(const QList<int>& indexes, int dropItemIndex = -1);
 

--- a/Desktop/widgets/listmodelinteractionassigned.cpp
+++ b/Desktop/widgets/listmodelinteractionassigned.cpp
@@ -208,7 +208,7 @@ void ListModelInteractionAssigned::addCombinedTerms(const Terms& terms, JASPCont
 	setTerms();
 }
 
-Terms ListModelInteractionAssigned::addTerms(const Terms& terms, int dropItemIndex, JASPControl::AssignType assignType)
+Terms ListModelInteractionAssigned::addTerms(const Terms& terms, int dropItemIndex, const RowControlsValues&)
 {
 	Q_UNUSED(dropItemIndex);
 
@@ -217,12 +217,9 @@ Terms ListModelInteractionAssigned::addTerms(const Terms& terms, int dropItemInd
 	if (terms.size() == 0)
 		return result;
 	
-	if (assignType == JASPControl::AssignType::AssignDefault)
-		assignType = JASPControl::AssignType::AssignCross;
-		
-	addCombinedTerms(terms, assignType);
+	addCombinedTerms(terms, JASPControl::AssignType::AssignCross);
 	
-	return nullptr;
+	return Terms();
 }
 
 void ListModelInteractionAssigned::moveTerms(const QList<int> &indexes, int dropItemIndex)

--- a/Desktop/widgets/listmodelinteractionassigned.h
+++ b/Desktop/widgets/listmodelinteractionassigned.h
@@ -33,7 +33,7 @@ public:
 	void			initTerms(const Terms &terms, const RowControlsValues& = RowControlsValues())	override;
 	Terms			termsFromIndexes(const QList<int> &indexes)								const	override;
 	Terms			canAddTerms(const Terms& terms) const override;
-	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, JASPControl::AssignType assignType = JASPControl::AssignType::AssignDefault) override;
+	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues())	override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)					override;
 	void			removeTerms(const QList<int> &indices)											override;
 	QString			getItemType(const Term &term)											const	override;

--- a/Desktop/widgets/listmodellayersassigned.cpp
+++ b/Desktop/widgets/listmodellayersassigned.cpp
@@ -123,7 +123,7 @@ Terms ListModelLayersAssigned::termsFromIndexes(const QList<int> &indexes) const
 	return terms;
 }
 
-Terms ListModelLayersAssigned::addTerms(const Terms& terms, int dropItemIndex, JASPControl::AssignType)
+Terms ListModelLayersAssigned::addTerms(const Terms& terms, int dropItemIndex, const RowControlsValues&)
 {
 	Terms result;
 	beginResetModel();

--- a/Desktop/widgets/listmodellayersassigned.h
+++ b/Desktop/widgets/listmodellayersassigned.h
@@ -29,7 +29,7 @@ public:
 
 	QVariant	data(const QModelIndex &index, int role = Qt::DisplayRole)					const	override;
 	Terms		termsFromIndexes(const QList<int> &indexes)									const	override;
-	Terms		addTerms(const Terms& terms, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault)	override;
+	Terms		addTerms(const Terms& terms, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues())	override;
 	void		moveTerms(const QList<int>& indexes, int dropItemIndex = -1)						override;
 	void		removeTerms(const QList<int>& indexes)												override;
 	

--- a/Desktop/widgets/listmodelmeasurescellsassigned.cpp
+++ b/Desktop/widgets/listmodelmeasurescellsassigned.cpp
@@ -101,7 +101,7 @@ void ListModelMeasuresCellsAssigned::initTerms(const Terms &terms, const ListMod
 	_fitTermsWithLevels();
 }
 
-Terms ListModelMeasuresCellsAssigned::addTerms(const Terms& termsToAdd, int dropItemIndex, JASPControl::AssignType)
+Terms ListModelMeasuresCellsAssigned::addTerms(const Terms& termsToAdd, int dropItemIndex, const RowControlsValues&)
 {
 	beginResetModel();
 	if (dropItemIndex >= 0)

--- a/Desktop/widgets/listmodelmeasurescellsassigned.h
+++ b/Desktop/widgets/listmodelmeasurescellsassigned.h
@@ -32,8 +32,8 @@ public:
 	int				rowCount(const QModelIndex &parent = QModelIndex())												const	override { return _levels.size() * 2; }
 	QVariant		data(const QModelIndex &index, int role = Qt::DisplayRole)										const	override;
 	Terms			termsFromIndexes(const QList<int> &indexes)														const	override;
-	void			initTerms(const Terms &terms, const RowControlsValues& allValuesMap = RowControlsValues())			override;
-	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault)	override;
+	void			initTerms(const Terms &terms, const RowControlsValues& allValuesMap = RowControlsValues())				override;
+	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues())		override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)											override;
 	void			removeTerms(const QList<int>& indexes) override;
 

--- a/Desktop/widgets/listmodelmultitermsassigned.cpp
+++ b/Desktop/widgets/listmodelmultitermsassigned.cpp
@@ -163,7 +163,7 @@ void ListModelMultiTermsAssigned::_setTerms()
 }
 
 
-Terms ListModelMultiTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemIndex, JASPControl::AssignType)
+Terms ListModelMultiTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemIndex, const RowControlsValues&)
 {
 	beginResetModel();
 	Terms termsToReturn;

--- a/Desktop/widgets/listmodelmultitermsassigned.h
+++ b/Desktop/widgets/listmodelmultitermsassigned.h
@@ -28,9 +28,9 @@ public:
 	ListModelMultiTermsAssigned(JASPListControl* listView, int columns = 2);
 	
 	void			initTerms(const Terms &terms, const RowControlsValues& allValuesMap = RowControlsValues())		override;
-	Terms			addTerms(const Terms &terms, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault)	override;
-	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)										override;
-	void			removeTerms(const QList<int> &indexes)																override;
+	Terms			addTerms(const Terms &terms, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues())	override;
+	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)									override;
+	void			removeTerms(const QList<int> &indexes)															override;
 
 	const QList<Terms>&	tuples() const { return _tuples; }
 

--- a/Desktop/widgets/listmodeltermsassigned.cpp
+++ b/Desktop/widgets/listmodeltermsassigned.cpp
@@ -71,12 +71,9 @@ Terms ListModelTermsAssigned::canAddTerms(const Terms& terms) const
 	return ListModelDraggable::canAddTerms(terms);
 }
 
-Terms ListModelTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemIndex, JASPControl::AssignType)
+Terms ListModelTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemIndex, const RowControlsValues& rowValues)
 {
-	_tempTermsToSendBack.clear();
-
-	beginResetModel();
-
+	Terms termsToSendBack;
 	Terms newTerms = terms();
 	if (dropItemIndex < 0 && _maxRows == 1)
 		dropItemIndex = 0; // for single row, per default replace old item by new one.
@@ -89,15 +86,20 @@ Terms ListModelTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemInde
 	if (newTerms.size() > maxRows)
 	{
 		for (size_t i = maxRows; i < newTerms.size(); i++)
-			_tempTermsToSendBack.add(newTerms.at(i));
+			termsToSendBack.add(newTerms.at(i));
 		newTerms.remove(maxRows, newTerms.size() - maxRows);
 	}
+
+	beginResetModel();
+
+	for (const auto& it : rowValues.toStdMap())
+		_rowControlsValues[it.first] = it.second;
 
 	_setTerms(newTerms);
 
 	endResetModel();
 
-	return _tempTermsToSendBack;
+	return termsToSendBack;
 }
 
 void ListModelTermsAssigned::removeTerm(int index)

--- a/Desktop/widgets/listmodeltermsassigned.h
+++ b/Desktop/widgets/listmodeltermsassigned.h
@@ -30,8 +30,8 @@ public:
 	ListModelTermsAssigned(JASPListControl* listView, int maxRows = -1);
 	
 	void			initTerms(const Terms &terms, const RowControlsValues& allValuesMap = RowControlsValues())			override;
-	Terms			canAddTerms(const Terms& terms)																	const	override;
-	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault)	override;
+	Terms			canAddTerms(const Terms& terms)																const	override;
+	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues())	override;
 	void			removeTerm(int index);
 
 	virtual void	changeTerm(int index, const QString& name);
@@ -42,7 +42,6 @@ public slots:
 	
 private:
 	int		_maxRows = -1;
-	Terms	_tempTermsToSendBack;
 
 };
 

--- a/Desktop/widgets/variableslistbase.h
+++ b/Desktop/widgets/variableslistbase.h
@@ -65,7 +65,7 @@ public:
 	const QStringList&			dropKeys()							const				{ return _dropKeys;									}
 	const QString&				interactionHighOrderCheckBox()		const				{ return _interactionHighOrderCheckBox;				}
 	bool						addRowControl(const QString& key, JASPControl* control) override;
-	void						moveItems(QList<int> &indexes, ListModelDraggable* dropModel, int dropItemIndex = -1, JASPControl::AssignType assignOption = JASPControl::AssignType::AssignDefault);
+	void						moveItems(QList<int> &indexes, ListModelDraggable* dropModel, int dropItemIndex = -1);
 
 signals:
 	void listViewTypeChanged();
@@ -84,8 +84,9 @@ protected:
 	GENERIC_SET_FUNCTION(SuggestedColumns,				_suggestedColumns,				suggestedColumnsChanged,				QStringList		)
 	GENERIC_SET_FUNCTION(SuggestedColumnsIcons,			_suggestedColumnsIcons,			suggestedColumnsIconsChanged,			QStringList		)
 	GENERIC_SET_FUNCTION(ColumnsTypes,					_columnsTypes,					columnsTypesChanged,					QStringList		)
-	GENERIC_SET_FUNCTION(DropKeys,						_dropKeys,						dropKeysChanged,						QStringList		)
 	GENERIC_SET_FUNCTION(InteractionHighOrderCheckBox,	_interactionHighOrderCheckBox,	interactionHighOrderCheckBoxChanged,	QString			)
+
+	void						setDropKeys(const QStringList& dropKeys);
 
 	ListModel*					getRelatedModel();
 
@@ -97,19 +98,19 @@ protected slots:
 	void termsChangedHandler()		override;
 	void moveItemsDelayedHandler();
 	void itemDoubleClickedHandler(int index);
-	void itemsDroppedHandler(QVariant indexes, QVariant vdropList, int dropItemIndex, int assignOption);
+	void itemsDroppedHandler(QVariant indexes, QVariant vdropList, int dropItemIndex);
 	void interactionHighOrderHandler(JASPControl* checkBoxControl);
 
 private:
 	int							_getAllowedColumnsTypes();
 	void						_setAllowedVariables();
+	void						_setRelations();
 
 	int							_columns				= 1;
 
 	ListModelDraggable	*		_tempDropModel = nullptr;
 	QList<int>					_tempIndexes;
 	int							_tempDropItemIndex;
-	JASPControl::AssignType		_tempAssignOption = JASPControl::AssignType::AssignDefault;
 
 	QStringList					_allowedColumns,
 								_suggestedColumns,


### PR DESCRIPTION
Add duplicateWhenAdding property to allow to duplicate the content of the current tab when adding a new one.
VariablesForm could not be set in a TabView because the dropKeys property (this sets the relationship between the available & assigned VariablesLists) was handled statically: it is now handled dynamically so that a VariablesForm can also be created dynamically and not only during the initialization of the Analysis form.
Also clean up the TabView & ComponentsList QML components: they use both the ComponentListBase object so common properties should be set in ComponentListBase.
Also the AssignType is not used anymore (there was long ago the possibility to use an option in the arrow to move variables, so that you could tell which kind of interaction between multiple variables you would like): this is also cleaned up.