### PR TITLE
Adding several factors in once with a model having nuisance can crash

### DIFF
--- a/Desktop/widgets/boundcontrolterms.cpp
+++ b/Desktop/widgets/boundcontrolterms.cpp
@@ -140,7 +140,7 @@ bool BoundControlTerms::isJsonValid(const Json::Value &optionValue)
 void BoundControlTerms::resetBoundValue()
 {
 	const Terms& terms = _termsModel->terms();
-	const QMap<QString, RowControls*>& allControls = _termsModel->getRowControls();
+	const QMap<QString, RowControls*>& allControls = _termsModel->getAllRowControls();
 
 	if (_listView->hasRowComponent() || _listView->containsInteractions())
 		_setTableValue(terms, allControls, _optionKey, _listView->containsInteractions());

--- a/Desktop/widgets/componentslistbase.cpp
+++ b/Desktop/widgets/componentslistbase.cpp
@@ -138,7 +138,7 @@ bool ComponentsListBase::isJsonValid(const Json::Value &value)
 void ComponentsListBase::termsChangedHandler()
 {
 	const Terms& terms = _termsModel->terms();
-	const QMap<QString, RowControls*>& allControls = _termsModel->getRowControls();
+	const QMap<QString, RowControls*>& allControls = _termsModel->getAllRowControls();
 
 	_setTableValue(terms, allControls, fq(_optionKey), containsInteractions());
 }

--- a/Desktop/widgets/inputlistbase.cpp
+++ b/Desktop/widgets/inputlistbase.cpp
@@ -112,7 +112,7 @@ bool InputListBase::isJsonValid(const Json::Value &value)
 void InputListBase::termsChangedHandler()
 {
 	const Terms& terms = _inputModel->terms();
-	const QMap<QString, RowControls*>& allControls = _inputModel->getRowControls();
+	const QMap<QString, RowControls*>& allControls = _inputModel->getAllRowControls();
 
 	if (hasRowComponent())
 		_setTableValue(terms, allControls, fq(_optionKey), containsInteractions());

--- a/Desktop/widgets/jasplistcontrol.cpp
+++ b/Desktop/widgets/jasplistcontrol.cpp
@@ -159,7 +159,7 @@ void JASPListControl::cleanUp()
 		if (_model)
 		{
 			_model->disconnect();
-			for (RowControls* rowControls : _model->getRowControls().values())
+			for (RowControls* rowControls : _model->getAllRowControls().values())
 				for (JASPControl* control : rowControls->getJASPControlsMap().values())
 					control->cleanUp();
 		}

--- a/Desktop/widgets/listmodel.h
+++ b/Desktop/widgets/listmodel.h
@@ -76,7 +76,8 @@ public:
 			void					setColumnsUsedForLabels(const QStringList& columns)						{ _columnsUsedForLabels = columns; }
 			void					setRowComponent(QQmlComponent* rowComponents);
 	virtual void					setUpRowControls();
-	const rowControlMap	&			getRowControls() const { return _rowControlsMap; }
+	const rowControlMap	&			getAllRowControls()											const		{ return _rowControlsMap;				}
+	RowControls*					getRowControls(const QString& key)							const		{ return _rowControlsMap.value(key);	}
 	virtual JASPControl	*			getRowControl(const QString& key, const QString& name)		const;
 	virtual bool					addRowControl(const QString& key, JASPControl* control);
 			QStringList				termsTypes();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1644
When several factors are added at the same time, the interaction high order check is run for each new checkbox added, but not all checkboxes are maybe not yet created. So the code must check before if these checkboxes (rowControls) are created.

