### PR TITLE
Replaced the `KeyNavigation.KeyUp` and `.KeyDown` with `tab` and `backTab`

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/Computer.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/Computer.qml
@@ -60,9 +60,7 @@ Item
 			bottomMargin:	jaspTheme.generalMenuMargin
 		}
 
-		KeyNavigation.down:		browseButton
 		KeyNavigation.tab:		browseButton
-		KeyNavigation.up:		browseButton
 		KeyNavigation.backtab:	browseButton
 	}
 

--- a/Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
@@ -142,7 +142,6 @@ FocusScope
 				onTextChanged		: fileMenuModel.osf.username = text
 				onAccepted			: passwordText.focus = true
 
-				KeyNavigation.down	: passwordText
 				KeyNavigation.tab	: passwordText
 				focus				: true
 			}
@@ -205,9 +204,6 @@ FocusScope
 				onTextChanged:	fileMenuModel.osf.password = text;
 				onAccepted:		fileMenuModel.osf.loginRequested(fileMenuModel.osf.username, fileMenuModel.osf.password)
 
-				KeyNavigation.up		: usernameText
-				KeyNavigation.backtab	: usernameText
-				KeyNavigation.down		: loginButton
 				KeyNavigation.tab		: loginButton
 
 			}
@@ -235,9 +231,6 @@ FocusScope
 
 			onClicked:			fileMenuModel.osf.loginRequested(fileMenuModel.osf.username, fileMenuModel.osf.password)
 
-			KeyNavigation.up		: passwordText
-			KeyNavigation.backtab	: passwordText
-			KeyNavigation.down		: idRememberMe
 			KeyNavigation.tab		: idRememberMe
 		}
 
@@ -245,21 +238,20 @@ FocusScope
 		{
 			id: idRememberMe
 
-			checked: fileMenuModel.osf.rememberme
-			label   : qsTr("Remember me")
+			checked:				fileMenuModel.osf.rememberme
+			label   :				qsTr("Remember me")
 
-			anchors.left  : parent.left
-			anchors.right : parent.right
-			anchors.bottom: parent.bottom
+			anchors.left  :			parent.left
+			anchors.right :			parent.right
+			anchors.bottom:			parent.bottom
 
-			anchors.bottomMargin: 30 * preferencesModel.uiScale
-			anchors.leftMargin  : 20 * preferencesModel.uiScale
-			anchors.topMargin   : 10 * preferencesModel.uiScale
+			anchors.bottomMargin:	30 * preferencesModel.uiScale
+			anchors.leftMargin  :	20 * preferencesModel.uiScale
+			anchors.topMargin   :	10 * preferencesModel.uiScale
 
-			onCheckedChanged:	fileMenuModel.osf.rememberme = checked
+			onCheckedChanged:		fileMenuModel.osf.rememberme = checked
 
-			KeyNavigation.up		: loginButton
-			KeyNavigation.backtab	: loginButton
+			KeyNavigation.tab:		usernameText
 		}
 	}
 

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -38,7 +38,6 @@ ScrollView
 				onCheckedChanged:	preferencesModel.modulesRemember = checked
 				toolTip:			qsTr("Continue where you left of the next time JASP starts.\nEnabling this option makes JASP remember which Modules you've enabled.")
 				
-				KeyNavigation.backtab:	maxEngineCount
 				KeyNavigation.tab:		developerMode
 			}
 
@@ -50,7 +49,6 @@ ScrollView
 				onCheckedChanged:	preferencesModel.developerMode = checked
 				toolTip:			qsTr("To use JASP Modules enable this option.")
 				
-				KeyNavigation.backtab:	rememberModulesSelected
 				KeyNavigation.tab:		browseDeveloperFolderButton
 			}
 
@@ -69,8 +67,7 @@ ScrollView
 					anchors.left:		parent.left
 					anchors.leftMargin: jaspTheme.subOptionOffset
 					toolTip:			qsTr("Browse to your JASP Module folder.")
-					
-					KeyNavigation.backtab:	developerMode
+
 					KeyNavigation.tab:		developerFolderText.textInput
 				}
 				
@@ -126,7 +123,6 @@ ScrollView
 						right:		parent.right
 					}
 
-					KeyNavigation.backtab: 	developerMode
 					KeyNavigation.tab:		githubPatDefault
 				}
 			}
@@ -139,8 +135,7 @@ ScrollView
 				checked:			preferencesModel.githubPatUseDefault
 				onCheckedChanged:	preferencesModel.githubPatUseDefault = checked
 				toolTip:			qsTr("Either use the bundled GITHUB_PAT or, if available, use the one set in environment variables.")
-				
-				KeyNavigation.backtab:	cranRepoUrl
+
 				KeyNavigation.tab:		githubPatCustomToken
 			}
 			
@@ -186,7 +181,6 @@ ScrollView
 
 					textInput.echoMode:	TextInput.PasswordEchoOnEdit
 
-					KeyNavigation.backtab:	githubPatDefault
 					KeyNavigation.tab:		generateMarkdown
 				}
 			}				
@@ -198,8 +192,7 @@ ScrollView
 				toolTip:			qsTr("Enabling this will generate markdown helpfile from the info at qml options.")
 				checked:			preferencesModel.generateMarkdown
 				onCheckedChanged:	preferencesModel.generateMarkdown = checked
-				
-				KeyNavigation.backtab:	githubPatCustomToken
+
 				KeyNavigation.tab:		cleanModulesFolder
 
 			}
@@ -210,8 +203,7 @@ ScrollView
 				text:				qsTr("Clear installed modules and packages")
 				toolTip:			qsTr("This will erase the 'renv' and 'Modules' folders in the appdata.")
 				onClicked:			mainWindow.clearModulesFoldersUser();
-				
-				KeyNavigation.backtab:	generateMarkdown
+
 				KeyNavigation.tab:		checkForLC_CTYPE_C
 			}
 		}
@@ -234,8 +226,7 @@ ScrollView
 					toolTip:			qsTr("Check the install and user directory path for compatibility with LC_CTYPE=\"C\" and set if reasonable.")
 					checked:			preferencesModel.lcCtypeWin == 0
 					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 0
-					
-					KeyNavigation.backtab:	cleanModulesFolder
+
 					KeyNavigation.tab:		alwaysSetLC_CTYPE_C
 				}
 				
@@ -247,8 +238,7 @@ ScrollView
 					info:				qsTr("If this is enabled and you have non-ascii characters in your install path JASP won't work anymore.  If you only have non-ascii characters in your username then installing modules will probably break.")
 					checked:			preferencesModel.lcCtypeWin == 1
 					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 1
-					
-					KeyNavigation.backtab:	checkForLC_CTYPE_C
+
 					KeyNavigation.tab:		neverSetLC_CTYPE_C
 				}
 				
@@ -260,8 +250,7 @@ ScrollView
 					info:				qsTr("Enabling this will make certain characters in the results look weird, but at least you can use JASP if you installed it in a folder with non-ascii characters in the path. Sorry for the inconvenience, we are working on it and hopefully have this fixed next release.")
 					checked:			preferencesModel.lcCtypeWin == 2
 					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 2
-					
-					KeyNavigation.backtab:	alwaysSetLC_CTYPE_C
+
 					KeyNavigation.tab:		logToFile
 				}
 			}
@@ -281,8 +270,7 @@ ScrollView
 				checked:			preferencesModel.logToFile
 				onCheckedChanged:	preferencesModel.logToFile = checked
 				toolTip:			qsTr("To store debug-logs of JASP in a file, check this box.")
-				
-				KeyNavigation.backtab:	neverSetLC_CTYPE_C
+
 				KeyNavigation.tab:		maxLogFilesSpinBox
 			}
 
@@ -304,8 +292,7 @@ ScrollView
 					to:					1000000
 					defaultValue:		10
 					stepSize:			1
-					
-					KeyNavigation.backtab:	logToFile
+
 					KeyNavigation.tab:		showLogs
 					text:				qsTr("Max logfiles to keep: ")
 
@@ -329,9 +316,6 @@ ScrollView
 						left:		maxLogFilesSpinBox.right
 					}
 
-
-					
-					KeyNavigation.backtab:	maxLogFilesSpinBox
 					KeyNavigation.tab:		maxEngineCount
 				}
 			}
@@ -351,8 +335,7 @@ ScrollView
 				to:					preferencesModel.maxEnginesAdmin > 0 ? preferencesModel.maxEnginesAdmin : 16
 				defaultValue:		Math.max(preferencesModel.maxEnginesAdmin, 4)
 				stepSize:			1
-				
-				KeyNavigation.backtab:	showLogs
+
 				KeyNavigation.tab:		rememberModulesSelected
 				text:				qsTr("Maximum # of engines: ")
 			}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -37,8 +37,9 @@ ScrollView
 				checked:			preferencesModel.modulesRemember
 				onCheckedChanged:	preferencesModel.modulesRemember = checked
 				toolTip:			qsTr("Continue where you left of the next time JASP starts.\nEnabling this option makes JASP remember which Modules you've enabled.")
-				KeyNavigation.tab:	developerMode
-				KeyNavigation.down:	developerMode
+				
+				KeyNavigation.backtab:	maxEngineCount
+				KeyNavigation.tab:		developerMode
 			}
 
 			CheckBox
@@ -48,8 +49,9 @@ ScrollView
 				checked:			preferencesModel.developerMode
 				onCheckedChanged:	preferencesModel.developerMode = checked
 				toolTip:			qsTr("To use JASP Modules enable this option.")
-				KeyNavigation.tab:	browseDeveloperFolderButton
-				KeyNavigation.down:	browseDeveloperFolderButton
+				
+				KeyNavigation.backtab:	rememberModulesSelected
+				KeyNavigation.tab:		browseDeveloperFolderButton
 			}
 
 			Item
@@ -67,8 +69,9 @@ ScrollView
 					anchors.left:		parent.left
 					anchors.leftMargin: jaspTheme.subOptionOffset
 					toolTip:			qsTr("Browse to your JASP Module folder.")
-					KeyNavigation.tab:	developerFolderText.textInput
-					KeyNavigation.down:	developerFolderText.textInput
+					
+					KeyNavigation.backtab:	developerMode
+					KeyNavigation.tab:		developerFolderText.textInput
 				}
 				
 				PrefsTextInput
@@ -122,6 +125,9 @@ ScrollView
 						left:		cranRepoUrlLabel.right
 						right:		parent.right
 					}
+
+					KeyNavigation.backtab: 	developerMode
+					KeyNavigation.tab:		githubPatDefault
 				}
 			}
 			
@@ -133,8 +139,9 @@ ScrollView
 				checked:			preferencesModel.githubPatUseDefault
 				onCheckedChanged:	preferencesModel.githubPatUseDefault = checked
 				toolTip:			qsTr("Either use the bundled GITHUB_PAT or, if available, use the one set in environment variables.")
-				KeyNavigation.tab:	githubPatCustomToken
-				KeyNavigation.down:	githubPatCustomToken
+				
+				KeyNavigation.backtab:	cranRepoUrl
+				KeyNavigation.tab:		githubPatCustomToken
 			}
 			
 
@@ -178,6 +185,9 @@ ScrollView
 					}
 
 					textInput.echoMode:	TextInput.PasswordEchoOnEdit
+
+					KeyNavigation.backtab:	githubPatDefault
+					KeyNavigation.tab:		generateMarkdown
 				}
 			}				
 
@@ -188,8 +198,9 @@ ScrollView
 				toolTip:			qsTr("Enabling this will generate markdown helpfile from the info at qml options.")
 				checked:			preferencesModel.generateMarkdown
 				onCheckedChanged:	preferencesModel.generateMarkdown = checked
-				KeyNavigation.tab:	cleanModulesFolder
-				KeyNavigation.down:	cleanModulesFolder
+				
+				KeyNavigation.backtab:	githubPatCustomToken
+				KeyNavigation.tab:		cleanModulesFolder
 
 			}
 	
@@ -199,8 +210,9 @@ ScrollView
 				text:				qsTr("Clear installed modules and packages")
 				toolTip:			qsTr("This will erase the 'renv' and 'Modules' folders in the appdata.")
 				onClicked:			mainWindow.clearModulesFoldersUser();
-				KeyNavigation.tab:	checkForLC_CTYPE_C
-				KeyNavigation.down:	checkForLC_CTYPE_C
+				
+				KeyNavigation.backtab:	generateMarkdown
+				KeyNavigation.tab:		checkForLC_CTYPE_C
 			}
 		}
 		
@@ -222,8 +234,9 @@ ScrollView
 					toolTip:			qsTr("Check the install and user directory path for compatibility with LC_CTYPE=\"C\" and set if reasonable.")
 					checked:			preferencesModel.lcCtypeWin == 0
 					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 0
-					KeyNavigation.tab:	alwaysSetLC_CTYPE_C
-					KeyNavigation.down:	alwaysSetLC_CTYPE_C
+					
+					KeyNavigation.backtab:	cleanModulesFolder
+					KeyNavigation.tab:		alwaysSetLC_CTYPE_C
 				}
 				
 				RadioButton
@@ -234,8 +247,9 @@ ScrollView
 					info:				qsTr("If this is enabled and you have non-ascii characters in your install path JASP won't work anymore.  If you only have non-ascii characters in your username then installing modules will probably break.")
 					checked:			preferencesModel.lcCtypeWin == 1
 					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 1
-					KeyNavigation.tab:	neverSetLC_CTYPE_C
-					KeyNavigation.down:	neverSetLC_CTYPE_C
+					
+					KeyNavigation.backtab:	checkForLC_CTYPE_C
+					KeyNavigation.tab:		neverSetLC_CTYPE_C
 				}
 				
 				RadioButton
@@ -246,8 +260,9 @@ ScrollView
 					info:				qsTr("Enabling this will make certain characters in the results look weird, but at least you can use JASP if you installed it in a folder with non-ascii characters in the path. Sorry for the inconvenience, we are working on it and hopefully have this fixed next release.")
 					checked:			preferencesModel.lcCtypeWin == 2
 					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 2
-					KeyNavigation.tab:	logToFile
-					KeyNavigation.down:	logToFile
+					
+					KeyNavigation.backtab:	alwaysSetLC_CTYPE_C
+					KeyNavigation.tab:		logToFile
 				}
 			}
 			
@@ -266,8 +281,9 @@ ScrollView
 				checked:			preferencesModel.logToFile
 				onCheckedChanged:	preferencesModel.logToFile = checked
 				toolTip:			qsTr("To store debug-logs of JASP in a file, check this box.")
-				KeyNavigation.tab:	maxLogFilesSpinBox
-				KeyNavigation.down:	maxLogFilesSpinBox
+				
+				KeyNavigation.backtab:	neverSetLC_CTYPE_C
+				KeyNavigation.tab:		maxLogFilesSpinBox
 			}
 
 			Item
@@ -288,8 +304,9 @@ ScrollView
 					to:					1000000
 					defaultValue:		10
 					stepSize:			1
-					KeyNavigation.tab:	showLogs
-					KeyNavigation.down:	showLogs
+					
+					KeyNavigation.backtab:	logToFile
+					KeyNavigation.tab:		showLogs
 					text:				qsTr("Max logfiles to keep: ")
 
 					anchors
@@ -313,8 +330,9 @@ ScrollView
 					}
 
 
-					KeyNavigation.tab:	maxEngineCount
-					KeyNavigation.down:	maxEngineCount
+					
+					KeyNavigation.backtab:	maxLogFilesSpinBox
+					KeyNavigation.tab:		maxEngineCount
 				}
 			}
 		}
@@ -333,8 +351,9 @@ ScrollView
 				to:					preferencesModel.maxEnginesAdmin > 0 ? preferencesModel.maxEnginesAdmin : 16
 				defaultValue:		Math.max(preferencesModel.maxEnginesAdmin, 4)
 				stepSize:			1
-				KeyNavigation.tab:	rememberModulesSelected
-				KeyNavigation.down:	rememberModulesSelected
+				
+				KeyNavigation.backtab:	showLogs
+				KeyNavigation.tab:		rememberModulesSelected
 				text:				qsTr("Maximum # of engines: ")
 			}
 			

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -7,8 +7,8 @@ import JASP.Controls	1.0
 
 ScrollView
 {
-    id:                     scrollPrefs
-    focus:                  true
+	id:                     scrollPrefs
+	focus:                  true
 	onActiveFocusChanged:	if(activeFocus) synchronizeDataSave.forceActiveFocus();
 	Keys.onLeftPressed:		resourceMenu.forceActiveFocus();
 
@@ -38,8 +38,9 @@ ScrollView
 				label:				qsTr("Synchronize automatically on data file save")
 				checked:			preferencesModel.dataAutoSynchronization
 				onCheckedChanged:	preferencesModel.dataAutoSynchronization = checked
-				KeyNavigation.down:	useDefaultEditor
-				KeyNavigation.tab:	useDefaultEditor
+
+				KeyNavigation.backtab:	missingValuesList.firstComponent
+				KeyNavigation.tab:      useDefaultEditor
 			}
 
 			Item //Use default spreadsheet editor
@@ -50,13 +51,14 @@ ScrollView
 
 				CheckBox
 				{
-					id:					useDefaultEditor
-					label:				qsTr("Use default spreadsheet editor")
-					checked:			LINUX || preferencesModel.useDefaultEditor
-					onCheckedChanged:	preferencesModel.useDefaultEditor = checked
-					KeyNavigation.down:	browseEditorButton
-					KeyNavigation.tab:	browseEditorButton
-					enabled:			!LINUX
+					id:                     useDefaultEditor
+					label:                  qsTr("Use default spreadsheet editor")
+					checked:                LINUX || preferencesModel.useDefaultEditor
+					onCheckedChanged:       preferencesModel.useDefaultEditor = checked
+					enabled:                !LINUX
+
+					KeyNavigation.backtab:  synchronizeDataSave
+					KeyNavigation.tab:      !checked ? browseEditorButton : customThreshold
 				}
 
 				Label
@@ -77,7 +79,8 @@ ScrollView
 				Item
 				{
 					id:					editCustomEditor
-					visible:			!LINUX && !preferencesModel.useDefaultEditor
+					// visible:			!LINUX && !preferencesModel.useDefaultEditor
+					enabled:			!LINUX && !preferencesModel.useDefaultEditor
 					width:				parent.width
 					height:				browseEditorButton.height
 					anchors.top:		useDefaultEditor.bottom
@@ -89,8 +92,9 @@ ScrollView
 						onClicked:			preferencesModel.browseSpreadsheetEditor()
 						anchors.left:		parent.left
 						anchors.leftMargin: jaspTheme.subOptionOffset
-						KeyNavigation.down:	customEditorText
-						KeyNavigation.tab:	customEditorText
+
+						KeyNavigation.backtab:	useDefaultEditor
+						KeyNavigation.tab:      customEditorText
 					}
 
 					Rectangle
@@ -116,8 +120,9 @@ ScrollView
 							font:				jaspTheme.font
 							onTextChanged:		preferencesModel.customEditor = text
 							color:				jaspTheme.textEnabled
-							KeyNavigation.down:	customThreshold
-							KeyNavigation.tab:	customThreshold
+
+							KeyNavigation.backtab:	browseEditorButton
+							KeyNavigation.tab:      customThreshold
 
 							anchors
 							{
@@ -152,8 +157,9 @@ ScrollView
 					ToolTip.delay:		500
 					ToolTip.timeout:	6000 //Some longer to read carefully
 					toolTip:			qsTr("Threshold number of unique integers before classifying a variable as 'scale'.\nYou need to reload your data to take effect! Check help for more info.")
-					KeyNavigation.down:	thresholdScale
-					KeyNavigation.tab:	thresholdScale
+
+					KeyNavigation.backtab:	!useDefaultEditor.checked ? customEditorText : useDefaultEditor
+					KeyNavigation.tab:      preferencesModel.customThresholdScale ? thresholdScale : missingValuesList.firstComponent
 
 				}
 
@@ -162,10 +168,10 @@ ScrollView
 					id:					thresholdScale
 					value:				preferencesModel.thresholdScale
 					onValueChanged:		preferencesModel.thresholdScale = value
-					visible:			preferencesModel.customThresholdScale
+					enabled:			preferencesModel.customThresholdScale
 
-					KeyNavigation.down:	missingValueDataLabelInput
 					KeyNavigation.tab:	missingValueDataLabelInput
+
 					anchors
 					{
 						left:			customThreshold.right
@@ -204,7 +210,7 @@ ScrollView
 
 					text:			preferencesModel.dataLabelNA
 					onTextChanged:	preferencesModel.dataLabelNA = text
-					nextEl:			missingFileList.firstComponent
+					nextEl:			missingValuesList.firstComponent
 
 					anchors
 					{
@@ -214,11 +220,17 @@ ScrollView
 				}
 			}
 
-			PrefsMissingValues { id: missingFileList; navigateAfter: noBomNative }
+			PrefsMissingValues
+			{
+				id: 			missingValuesList
+				navigateFrom:   missingValueDataLabelInput
+				navigateTo:     noBomNative
+			}
 			
 			PrefsGroupRect
 			{
 				visible:	WINDOWS
+				enabled:	WINDOWS
 				title:		qsTr("Windows workaround")
 				
 				CheckBox
@@ -228,8 +240,9 @@ ScrollView
 					checked:			preferencesModel.windowsNoBomNative
 					onCheckedChanged:	preferencesModel.windowsNoBomNative = checked
 					toolTip:			qsTr("See documentation for more information ")
-					KeyNavigation.down:	synchronizeDataSave
-					KeyNavigation.tab:	synchronizeDataSave
+
+					KeyNavigation.backtab:	missingValuesList.firstComponent
+					KeyNavigation.tab:		synchronizeDataSave
 
 				}
 			}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -39,7 +39,6 @@ ScrollView
 				checked:			preferencesModel.dataAutoSynchronization
 				onCheckedChanged:	preferencesModel.dataAutoSynchronization = checked
 
-				KeyNavigation.backtab:	missingValuesList.firstComponent
 				KeyNavigation.tab:      useDefaultEditor
 			}
 
@@ -57,8 +56,7 @@ ScrollView
 					onCheckedChanged:       preferencesModel.useDefaultEditor = checked
 					enabled:                !LINUX
 
-					KeyNavigation.backtab:  synchronizeDataSave
-					KeyNavigation.tab:      !checked ? browseEditorButton : customThreshold
+					KeyNavigation.tab:      browseEditorButton
 				}
 
 				Label
@@ -93,7 +91,6 @@ ScrollView
 						anchors.left:		parent.left
 						anchors.leftMargin: jaspTheme.subOptionOffset
 
-						KeyNavigation.backtab:	useDefaultEditor
 						KeyNavigation.tab:      customEditorText
 					}
 
@@ -121,7 +118,6 @@ ScrollView
 							onTextChanged:		preferencesModel.customEditor = text
 							color:				jaspTheme.textEnabled
 
-							KeyNavigation.backtab:	browseEditorButton
 							KeyNavigation.tab:      customThreshold
 
 							anchors
@@ -158,8 +154,7 @@ ScrollView
 					ToolTip.timeout:	6000 //Some longer to read carefully
 					toolTip:			qsTr("Threshold number of unique integers before classifying a variable as 'scale'.\nYou need to reload your data to take effect! Check help for more info.")
 
-					KeyNavigation.backtab:	!useDefaultEditor.checked ? customEditorText : useDefaultEditor
-					KeyNavigation.tab:      preferencesModel.customThresholdScale ? thresholdScale : missingValuesList.firstComponent
+					KeyNavigation.tab:      thresholdScale
 
 				}
 
@@ -241,7 +236,6 @@ ScrollView
 					onCheckedChanged:	preferencesModel.windowsNoBomNative = checked
 					toolTip:			qsTr("See documentation for more information ")
 
-					KeyNavigation.backtab:	missingValuesList.firstComponent
 					KeyNavigation.tab:		synchronizeDataSave
 
 				}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsMissingValues.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsMissingValues.qml
@@ -120,8 +120,7 @@ Rectangle
 				font:				jaspTheme.font
 				color:				jaspTheme.textEnabled
 				onAccepted:			addButton.clicked();
-				
-				KeyNavigation.backtab:	missingValuesList
+
 				KeyNavigation.tab:		addButton
 
 				anchors
@@ -141,8 +140,7 @@ Rectangle
 			iconSource:			jaspTheme.iconPath + "/addition-sign-small.svg"
 			anchors.top:		parent.top
 			anchors.right:		parent.right
-			
-			KeyNavigation.backtab:	missingValueToAddText
+
 			KeyNavigation.tab:		resetButton
 
 			onClicked:
@@ -158,8 +156,7 @@ Rectangle
 		id:					resetButton
 		text:				qsTr("Reset")
 		onClicked:			preferencesModel.resetMissingValues()
-		
-		KeyNavigation.backtab:	missingValueToAddText
+
 		KeyNavigation.tab:		navigateTo
 
 		anchors

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsMissingValues.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsMissingValues.qml
@@ -14,7 +14,8 @@ Rectangle
 	color:			jaspTheme.uiBackground
 
 	property alias firstComponent:	missingValuesList
-	property var   navigateAfter:	undefined
+	property var   navigateFrom:	undefined
+	property var   navigateTo:		undefined
 
 	Text
 	{
@@ -55,8 +56,8 @@ Rectangle
 			anchors.fill:		parent
 			anchors.margins:	jaspTheme.generalAnchorMargin
 			model:				preferencesModel.missingValues
-			KeyNavigation.tab:	missingValueToAddText
-			KeyNavigation.down:	missingValueToAddText
+			
+
 			delegate:			MenuButton
 				{
 					id:					hoverphonic
@@ -77,6 +78,9 @@ Rectangle
 						sourceSize.height:	height * 2
 						visible:			parent.hovered
 					}
+
+					KeyNavigation.backtab:	navigateFrom
+					KeyNavigation.tab:		missingValueToAddText
 				}
 		}
 	}
@@ -115,9 +119,11 @@ Rectangle
 				clip:				true
 				font:				jaspTheme.font
 				color:				jaspTheme.textEnabled
-				KeyNavigation.tab:	addButton
-				KeyNavigation.down:	addButton
 				onAccepted:			addButton.clicked();
+				
+				KeyNavigation.backtab:	missingValuesList
+				KeyNavigation.tab:		addButton
+
 				anchors
 				{
 					left:			parent.left
@@ -135,8 +141,9 @@ Rectangle
 			iconSource:			jaspTheme.iconPath + "/addition-sign-small.svg"
 			anchors.top:		parent.top
 			anchors.right:		parent.right
-			KeyNavigation.tab:	resetButton
-			KeyNavigation.down:	resetButton
+			
+			KeyNavigation.backtab:	missingValueToAddText
+			KeyNavigation.tab:		resetButton
 
 			onClicked:
 			{
@@ -151,8 +158,10 @@ Rectangle
 		id:					resetButton
 		text:				qsTr("Reset")
 		onClicked:			preferencesModel.resetMissingValues()
-		KeyNavigation.tab:	navigateAfter
-		KeyNavigation.down:	navigateAfter
+		
+		KeyNavigation.backtab:	missingValueToAddText
+		KeyNavigation.tab:		navigateTo
+
 		anchors
 		{
 			top:			addValueItem.bottom

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
@@ -37,8 +37,9 @@ ScrollView
 				label:					qsTr("Display exact p-values")
 				checked:				preferencesModel.exactPValues
 				onCheckedChanged:		preferencesModel.exactPValues = checked
-				KeyNavigation.tab:		useNormalizedNotation
-				KeyNavigation.down:		useNormalizedNotation
+				
+				KeyNavigation.backtab:		transparentBackgroundButton
+				KeyNavigation.tab:			useNormalizedNotation
 			}
 
 			CheckBox
@@ -49,6 +50,7 @@ ScrollView
 				onCheckedChanged:		preferencesModel.normalizedNotation = !checked
 				KeyNavigation.tab:		fixDecs
 				KeyNavigation.down:		fixDecs
+
 			}
 
 			Item
@@ -62,8 +64,9 @@ ScrollView
 					label:					qsTr("Fix the number of decimals")
 					checked:				preferencesModel.fixedDecimals
 					onCheckedChanged:		preferencesModel.fixedDecimals = checked
-					KeyNavigation.tab:		numDecs
-					KeyNavigation.down:		numDecs
+					
+					KeyNavigation.backtab:		useNormalizedNotation
+					KeyNavigation.tab:			numDecs
 				}
 
 				SpinBox
@@ -71,10 +74,11 @@ ScrollView
 					id:						numDecs
 					value:					preferencesModel.numDecimals
 					onValueChanged:			preferencesModel.numDecimals = value
-					visible:				preferencesModel.fixedDecimals
+					enabled:				preferencesModel.fixedDecimals
 
-					KeyNavigation.tab:		useDefaultPPICheckbox
-					KeyNavigation.down:		useDefaultPPICheckbox
+                    KeyNavigation.backtab:		fixDecs
+					KeyNavigation.tab:			useDefaultPPICheckbox
+
 					anchors
 					{
 						left:				fixDecs.right
@@ -98,8 +102,9 @@ ScrollView
 				height:				implicitHeight * preferencesModel.uiScale
 				toolTip:			qsTr("Use the Pixels Per Inch of your screen to render your plots.")
 				focus:				true
-				KeyNavigation.tab:	customPPISpinBox
-				KeyNavigation.down:	customPPISpinBox
+				
+				KeyNavigation.backtab:	numDecs
+				KeyNavigation.tab:		customPPISpinBox
 			}
 
 			SpinBox
@@ -111,12 +116,13 @@ ScrollView
 				to:						2000
 				stepSize:				16
 
-				KeyNavigation.tab:		whiteBackgroundButton
-				KeyNavigation.down:		whiteBackgroundButton
 				text:					qsTr("Custom PPI: ")
 				enabled:				!preferencesModel.useDefaultPPI
 
 				x:						jaspTheme.subOptionOffset
+				
+				KeyNavigation.backtab:		useDefaultPPICheckbox
+				KeyNavigation.tab:			whiteBackgroundButton
 			}
 
 			RadioButtonGroup
@@ -130,8 +136,9 @@ ScrollView
 					checked:			preferencesModel.whiteBackground
 					onCheckedChanged:	preferencesModel.whiteBackground = checked
 					toolTip:			qsTr("This makes the background of all plots white, quite useful if you want to use it in LaTeX or submit it to a journal.")
-					KeyNavigation.tab:	transparentBackgroundButton
-					KeyNavigation.down:	transparentBackgroundButton
+					
+					KeyNavigation.backtab:	customPPISpinBox
+					KeyNavigation.tab:      transparentBackgroundButton
 				}
 
 				RadioButton
@@ -141,8 +148,9 @@ ScrollView
 					checked:			!preferencesModel.whiteBackground
 					onCheckedChanged:	preferencesModel.whiteBackground = !checked
 					toolTip:			qsTr("This makes the background of all plots transparent, quite useful if you want to use it seamlessly on any background that isn't white.")
-					KeyNavigation.tab:	displayExactPVals
-					KeyNavigation.down:	displayExactPVals
+					
+					KeyNavigation.backtab:	whiteBackgroundButton
+					KeyNavigation.tab:		displayExactPVals
 				}
 			}
 		}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
@@ -38,7 +38,6 @@ ScrollView
 				checked:				preferencesModel.exactPValues
 				onCheckedChanged:		preferencesModel.exactPValues = checked
 				
-				KeyNavigation.backtab:		transparentBackgroundButton
 				KeyNavigation.tab:			useNormalizedNotation
 			}
 
@@ -49,7 +48,6 @@ ScrollView
 				checked:				!preferencesModel.normalizedNotation
 				onCheckedChanged:		preferencesModel.normalizedNotation = !checked
 				KeyNavigation.tab:		fixDecs
-				KeyNavigation.down:		fixDecs
 
 			}
 
@@ -65,7 +63,6 @@ ScrollView
 					checked:				preferencesModel.fixedDecimals
 					onCheckedChanged:		preferencesModel.fixedDecimals = checked
 					
-					KeyNavigation.backtab:		useNormalizedNotation
 					KeyNavigation.tab:			numDecs
 				}
 
@@ -76,7 +73,6 @@ ScrollView
 					onValueChanged:			preferencesModel.numDecimals = value
 					enabled:				preferencesModel.fixedDecimals
 
-                    KeyNavigation.backtab:		fixDecs
 					KeyNavigation.tab:			useDefaultPPICheckbox
 
 					anchors
@@ -102,8 +98,7 @@ ScrollView
 				height:				implicitHeight * preferencesModel.uiScale
 				toolTip:			qsTr("Use the Pixels Per Inch of your screen to render your plots.")
 				focus:				true
-				
-				KeyNavigation.backtab:	numDecs
+
 				KeyNavigation.tab:		customPPISpinBox
 			}
 
@@ -120,8 +115,7 @@ ScrollView
 				enabled:				!preferencesModel.useDefaultPPI
 
 				x:						jaspTheme.subOptionOffset
-				
-				KeyNavigation.backtab:		useDefaultPPICheckbox
+
 				KeyNavigation.tab:			whiteBackgroundButton
 			}
 
@@ -136,8 +130,7 @@ ScrollView
 					checked:			preferencesModel.whiteBackground
 					onCheckedChanged:	preferencesModel.whiteBackground = checked
 					toolTip:			qsTr("This makes the background of all plots white, quite useful if you want to use it in LaTeX or submit it to a journal.")
-					
-					KeyNavigation.backtab:	customPPISpinBox
+
 					KeyNavigation.tab:      transparentBackgroundButton
 				}
 
@@ -148,8 +141,7 @@ ScrollView
 					checked:			!preferencesModel.whiteBackground
 					onCheckedChanged:	preferencesModel.whiteBackground = !checked
 					toolTip:			qsTr("This makes the background of all plots transparent, quite useful if you want to use it seamlessly on any background that isn't white.")
-					
-					KeyNavigation.backtab:	whiteBackgroundButton
+
 					KeyNavigation.tab:		displayExactPVals
 				}
 			}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -8,7 +8,7 @@ ScrollView
 {
 	id:						scrollPrefs
 	focus:					true
-	onActiveFocusChanged:	if(activeFocus) uiScaleSpinBox.forceActiveFocus();
+	onActiveFocusChanged:	if(activeFocus) interfaceFonts.forceActiveFocus();
 	Keys.onLeftPressed:		resourceMenu.forceActiveFocus();
 
 	function resetMe()
@@ -51,35 +51,35 @@ ScrollView
 
 			GridLayout
 			{
-				columns			: 2
-				rowSpacing		: 3 * preferencesModel.uiScale
-				columnSpacing	: 3 * preferencesModel.uiScale
+				columns:		2
+				rowSpacing: 	3 * preferencesModel.uiScale
+				columnSpacing:	3 * preferencesModel.uiScale
 
 				Text { text: qsTr("Interface:") }
 
 				DropDown
 				{
-					id						: interfaceFonts
-					values					: preferencesModel.allInterfaceFonts
-					addEmptyValue			: true
-					showEmptyValueAsNormal	: true
-					addLineAfterEmptyValue	: true
-					addScrollBar			: true
-					placeholderText			: qsTr("default: %1").arg(defaultInterfaceFont.fontInfo.family)
-					startValue				: preferencesModel.interfaceFont
-					onValueChanged			: preferencesModel.interfaceFont = (currentIndex <= 0 ? "" : value)
+					id:			 			interfaceFonts
+					values:			 		preferencesModel.allInterfaceFonts
+					addEmptyValue:			true
+					showEmptyValueAsNormal:	true
+					addLineAfterEmptyValue:	true
+					addScrollBar:			true
+					placeholderText:		qsTr("default: %1").arg(defaultInterfaceFont.fontInfo.family)
+					startValue:				preferencesModel.interfaceFont
+					onValueChanged: 		preferencesModel.interfaceFont = (currentIndex <= 0 ? "" : value)
 
-					KeyNavigation.tab		: codeFonts
-					KeyNavigation.down		: codeFonts
+					KeyNavigation.backtab: 	useNativeFileDialog
+					KeyNavigation.tab:		codeFonts
 
 					Text
 					{
 						// If the defaultInterfaceFont does not exist on the machine, then the default font of the machine is used.
 						// This (invisible) Text item is just to ask what will be the real font used.
-						id					: defaultInterfaceFont
-						font.family			: preferencesModel.defaultInterfaceFont
-						text				: fontInfo.family
-						visible				: false
+						id:				 defaultInterfaceFont
+						font.family:	 preferencesModel.defaultInterfaceFont
+						text:			 fontInfo.family
+						visible:		 false
 					}
 				}
 
@@ -87,25 +87,25 @@ ScrollView
 
 				DropDown
 				{
-					id						: codeFonts
-					values					: preferencesModel.allCodeFonts
-					addEmptyValue			: true
-					showEmptyValueAsNormal	: true
-					addLineAfterEmptyValue	: true
-					addScrollBar			: true
-					placeholderText			: qsTr("default: %1").arg(defaultRCodeFont.fontInfo.family)
-					startValue				: preferencesModel.codeFont
-					onValueChanged			: preferencesModel.codeFont = (currentIndex <= 0 ? "" : value)
+					id:							codeFonts
+					values:		 				preferencesModel.allCodeFonts
+					addEmptyValue:		 		true
+					showEmptyValueAsNormal:		true
+					addLineAfterEmptyValue:		true
+					addScrollBar:		 		true
+					placeholderText:		 	qsTr("default: %1").arg(defaultRCodeFont.fontInfo.family)
+					startValue:				 	preferencesModel.codeFont
+					onValueChanged:				preferencesModel.codeFont = (currentIndex <= 0 ? "" : value)
 
-					KeyNavigation.tab		: resultFonts
-					KeyNavigation.down		: resultFonts
+					KeyNavigation.backtab:		interfaceFonts
+					KeyNavigation.tab:			resultFonts
 
 					Text
 					{
-						id					: defaultRCodeFont
-						text				: fontInfo.family
-						font.family			: preferencesModel.defaultCodeFont
-						visible				: false
+						id:			 	defaultRCodeFont
+						text:			fontInfo.family
+						font.family:	preferencesModel.defaultCodeFont
+						visible:		false
 					}
 
 				}
@@ -114,25 +114,25 @@ ScrollView
 
 				DropDown
 				{
-					id						: resultFonts
-					values					: preferencesModel.allResultFonts
-					addEmptyValue			: true
-					showEmptyValueAsNormal	: true
-					addLineAfterEmptyValue	: true
-					addScrollBar			: true
-					placeholderText			: qsTr("default: %1").arg(defaultResultFont.fontInfo.family)
-					startValue				: preferencesModel.resultFont
-					onValueChanged			: preferencesModel.resultFont = (currentIndex <= 0 ? "" : value)
+					id:							resultFonts
+					values:						preferencesModel.allResultFonts
+					addEmptyValue:				true
+					showEmptyValueAsNormal:		true
+					addLineAfterEmptyValue:		true
+					addScrollBar:				true
+					placeholderText: 			qsTr("default: %1").arg(defaultResultFont.fontInfo.family)
+					startValue: 				preferencesModel.resultFont
+					onValueChanged: 			preferencesModel.resultFont = (currentIndex <= 0 ? "" : value)
 
-					KeyNavigation.tab		: lightThemeButton
-					KeyNavigation.down		: lightThemeButton
+					KeyNavigation.backtab: 		codeFonts
+					KeyNavigation.tab: 			lightThemeButton
 
 					Text
 					{
-						id					: defaultResultFont
-						text				: fontInfo.family
-						font.family			: preferencesModel.defaultResultFont
-						visible				: false
+						id: 			defaultResultFont
+						text: 			fontInfo.family
+						font.family: 	preferencesModel.defaultResultFont
+						visible: 		false
 					}
 				}
 			}
@@ -153,8 +153,9 @@ ScrollView
 					checked:			preferencesModel.currentThemeName === "lightTheme"
 					onCheckedChanged:	preferencesModel.currentThemeName  =  "lightTheme"
 					toolTip:			qsTr("Switches to a light theme, this is the default and original flavour of JASP.")
-					KeyNavigation.tab:	darkThemeButton
-					KeyNavigation.down:	darkThemeButton
+
+					KeyNavigation.backtab:	resultFonts
+					KeyNavigation.tab:		darkThemeButton
 				}
 
 				RadioButton
@@ -164,8 +165,9 @@ ScrollView
 					checked:			preferencesModel.currentThemeName === "darkTheme"
 					onCheckedChanged:	preferencesModel.currentThemeName  =  "darkTheme"
 					toolTip:			qsTr("Switches to a dark theme, makes JASP a lot easier on the eyes for those night owls out there.")
-					KeyNavigation.tab:	languages
-					KeyNavigation.down:	languages
+					
+					KeyNavigation.backtab:	lightThemeButton
+					KeyNavigation.tab:		languages
 				}
 			}
 		}
@@ -187,13 +189,13 @@ ScrollView
 
 				source:					languageModel
 
-				KeyNavigation.tab:		uiScaleSpinBox
-				KeyNavigation.down:		uiScaleSpinBox
+				KeyNavigation.backtab:		darkThemeButton
+				KeyNavigation.tab:			uiScaleSpinBox
 			}
 
 			Text
 			{
-                id:                     translationDocLink
+				id:                     translationDocLink
 
 				text:				qsTr("Help us translate or improve JASP in your language")
 				color:				jaspTheme.blue
@@ -205,7 +207,7 @@ ScrollView
 				{
 					id:				mouseAreaTranslationDocLink
 					anchors.fill:	parent
-                    onClicked:		Qt.openUrlExternally("https://jasp-stats.org/translation-guidelines")
+					onClicked:		Qt.openUrlExternally("https://jasp-stats.org/translation-guidelines")
 					cursorShape:	Qt.PointingHandCursor
 				}
 			}
@@ -228,8 +230,8 @@ ScrollView
 				text:					qsTr("Zoom (%): ")
 				toolTip:				qsTr("Increase or decrease the size of the interface elements (text, buttons, etc).")
 
-				KeyNavigation.tab:		uiMaxFlickVelocity
-				KeyNavigation.down:		uiMaxFlickVelocity
+				KeyNavigation.backtab:		languages
+				KeyNavigation.tab:			uiMaxFlickVelocity
 
 				widthLabel:				Math.max(uiScaleSpinBox.implicitWidthLabel, uiMaxFlickVelocity.implicitWidthLabel)
 			}
@@ -247,8 +249,8 @@ ScrollView
 				toolTip:				qsTr("Set the speed with which you can scroll in the options, dataviewer and other places.")
 				widthLabel:				uiScaleSpinBox.widthLabel
 
-				KeyNavigation.tab:		safeGraphicsMode
-				KeyNavigation.down:		safeGraphicsMode
+				KeyNavigation.backtab:		uiScaleSpinBox
+				KeyNavigation.tab:			safeGraphicsMode
 			}
 
 
@@ -260,9 +262,8 @@ ScrollView
 				onCheckedChanged:	preferencesModel.safeGraphics = checked
 				toolTip:			qsTr("Switches to a \"safer\" mode for graphics aka software rendering.\nIt will make your interface slower but if you have some problems (weird glitches, cannot see results or anything even) might fix them.\nAnalyses will still be just as fast though.")
 
-
-				KeyNavigation.tab:		disableAnimations
-				KeyNavigation.down:		disableAnimations
+				KeyNavigation.backtab:		uiMaxFlickVelocity
+				KeyNavigation.tab:			disableAnimations
 
 			}
 
@@ -276,8 +277,8 @@ ScrollView
 
 				enabled:			!preferencesModel.safeGraphics
 
-				KeyNavigation.tab:		useNativeFileDialog
-				KeyNavigation.down:		useNativeFileDialog
+				KeyNavigation.backtab:		safeGraphicsMode
+				KeyNavigation.tab:			useNativeFileDialog
 			}
 
 
@@ -289,8 +290,8 @@ ScrollView
 				onCheckedChanged:	preferencesModel.useNativeFileDialog = checked
 				toolTip:			qsTr("If disabled it will not use your operating system's file dialogs but those made by Qt. This might solve some problems on Windows where JASP crashes on pressing \"Browse\".")
 
-				KeyNavigation.tab:		interfaceFonts
-				KeyNavigation.down:		interfaceFonts
+				KeyNavigation.backtab:		disableAnimations
+				KeyNavigation.tab:			interfaceFonts
 			}
 		}
 	}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -69,7 +69,6 @@ ScrollView
 					startValue:				preferencesModel.interfaceFont
 					onValueChanged: 		preferencesModel.interfaceFont = (currentIndex <= 0 ? "" : value)
 
-					KeyNavigation.backtab: 	useNativeFileDialog
 					KeyNavigation.tab:		codeFonts
 
 					Text
@@ -97,7 +96,6 @@ ScrollView
 					startValue:				 	preferencesModel.codeFont
 					onValueChanged:				preferencesModel.codeFont = (currentIndex <= 0 ? "" : value)
 
-					KeyNavigation.backtab:		interfaceFonts
 					KeyNavigation.tab:			resultFonts
 
 					Text
@@ -124,7 +122,6 @@ ScrollView
 					startValue: 				preferencesModel.resultFont
 					onValueChanged: 			preferencesModel.resultFont = (currentIndex <= 0 ? "" : value)
 
-					KeyNavigation.backtab: 		codeFonts
 					KeyNavigation.tab: 			lightThemeButton
 
 					Text
@@ -154,7 +151,6 @@ ScrollView
 					onCheckedChanged:	preferencesModel.currentThemeName  =  "lightTheme"
 					toolTip:			qsTr("Switches to a light theme, this is the default and original flavour of JASP.")
 
-					KeyNavigation.backtab:	resultFonts
 					KeyNavigation.tab:		darkThemeButton
 				}
 
@@ -166,7 +162,6 @@ ScrollView
 					onCheckedChanged:	preferencesModel.currentThemeName  =  "darkTheme"
 					toolTip:			qsTr("Switches to a dark theme, makes JASP a lot easier on the eyes for those night owls out there.")
 					
-					KeyNavigation.backtab:	lightThemeButton
 					KeyNavigation.tab:		languages
 				}
 			}
@@ -189,7 +184,6 @@ ScrollView
 
 				source:					languageModel
 
-				KeyNavigation.backtab:		darkThemeButton
 				KeyNavigation.tab:			uiScaleSpinBox
 			}
 
@@ -230,8 +224,7 @@ ScrollView
 				text:					qsTr("Zoom (%): ")
 				toolTip:				qsTr("Increase or decrease the size of the interface elements (text, buttons, etc).")
 
-				KeyNavigation.backtab:		languages
-				KeyNavigation.tab:			uiMaxFlickVelocity
+				KeyNavigation.tab:		uiMaxFlickVelocity
 
 				widthLabel:				Math.max(uiScaleSpinBox.implicitWidthLabel, uiMaxFlickVelocity.implicitWidthLabel)
 			}
@@ -249,7 +242,6 @@ ScrollView
 				toolTip:				qsTr("Set the speed with which you can scroll in the options, dataviewer and other places.")
 				widthLabel:				uiScaleSpinBox.widthLabel
 
-				KeyNavigation.backtab:		uiScaleSpinBox
 				KeyNavigation.tab:			safeGraphicsMode
 			}
 
@@ -262,7 +254,6 @@ ScrollView
 				onCheckedChanged:	preferencesModel.safeGraphics = checked
 				toolTip:			qsTr("Switches to a \"safer\" mode for graphics aka software rendering.\nIt will make your interface slower but if you have some problems (weird glitches, cannot see results or anything even) might fix them.\nAnalyses will still be just as fast though.")
 
-				KeyNavigation.backtab:		uiMaxFlickVelocity
 				KeyNavigation.tab:			disableAnimations
 
 			}
@@ -277,7 +268,6 @@ ScrollView
 
 				enabled:			!preferencesModel.safeGraphics
 
-				KeyNavigation.backtab:		safeGraphicsMode
 				KeyNavigation.tab:			useNativeFileDialog
 			}
 
@@ -290,7 +280,6 @@ ScrollView
 				onCheckedChanged:	preferencesModel.useNativeFileDialog = checked
 				toolTip:			qsTr("If disabled it will not use your operating system's file dialogs but those made by Qt. This might solve some problems on Windows where JASP crashes on pressing \"Browse\".")
 
-				KeyNavigation.backtab:		disableAnimations
 				KeyNavigation.tab:			interfaceFonts
 			}
 		}

--- a/Desktop/components/JASP/Widgets/SpinBox.qml
+++ b/Desktop/components/JASP/Widgets/SpinBox.qml
@@ -44,10 +44,10 @@ Item
 					width:					plus.x + plus.width
 					height:					valueField.height
 
-					Keys.onDownPressed:		{ minus.clicked(); event.accepted = true; }
-					Keys.onUpPressed:		{ plus.clicked();  event.accepted = true; }
-					Keys.onEnterPressed:	(event)=>   valueField.focus = !valueField.focus;
-					Keys.onReturnPressed: 	(event)=>	valueField.focus = !valueField.focus;
+					Keys.onDownPressed:		(event)=> { minus.clicked(); event.accepted = true; }
+					Keys.onUpPressed:		(event)=> { plus.clicked();  event.accepted = true; }
+					Keys.onEnterPressed:	(event)=> { valueField.focus = !valueField.focus;	}
+					Keys.onReturnPressed: 	(event)=> {	valueField.focus = !valueField.focus;	}
 
 
 	signal editingFinished()

--- a/Desktop/components/JASP/Widgets/SpinBox.qml
+++ b/Desktop/components/JASP/Widgets/SpinBox.qml
@@ -21,7 +21,7 @@ import QtQuick.Controls 2.5
 import JASP.Widgets		1.0
 import JASP				1.0
 
-FocusScope
+Item
 {
 					id:						root
 	property alias	value:					valueField.text
@@ -46,13 +46,13 @@ FocusScope
 
 					Keys.onDownPressed:		{ minus.clicked(); event.accepted = true; }
 					Keys.onUpPressed:		{ plus.clicked();  event.accepted = true; }
-					Keys.onEnterPressed:	valueField.focus = !valueField.focus;
-					Keys.onReturnPressed: (event)=>	valueField.focus = !valueField.focus;
-					Keys.onEscapePressed:	focus = false;
+					Keys.onEnterPressed:	(event)=>   valueField.focus = !valueField.focus;
+					Keys.onReturnPressed: 	(event)=>	valueField.focus = !valueField.focus;
+
 
 	signal editingFinished()
 	
-	Component.onCompleted: valueField.onEditingFinished.connect(editingFinished);        
+	Component.onCompleted: valueField.onEditingFinished.connect(editingFinished);
 	
 	function setValue(val)
 	{
@@ -61,7 +61,6 @@ FocusScope
 		val					= Math.min(root.max, Math.max(root.min, val));
 		valueField.text		= String(val);
 		editingFinished()
-		//valueField.focus	= false;
 	}
 
 	Text
@@ -90,6 +89,8 @@ FocusScope
 			left:				label.right
 			leftMargin:			label.visible ? jaspTheme.labelSpacing : 0
 		}
+
+		activeFocusOnTab: false
 	}
 
 	TextField
@@ -108,20 +109,21 @@ FocusScope
 		padding:					jaspTheme.jaspControlPadding
 		Keys.onReturnPressed: (event)=>		valueField.processInput()
 		Keys.onEnterPressed:		valueField.processInput()
-		Keys.onEscapePressed:		{ text = root.lastValidValue; focus = false; }
+		Keys.onEscapePressed: 		text = root.lastValidValue
+
 		onTextChanged:				if(acceptableInput) root.lastValidValue = text
 		selectByMouse:				true
 		selectedTextColor:			jaspTheme.white
 		selectionColor:				jaspTheme.itemSelectedColor
 		color:						enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
 
+        activeFocusOnTab: false
+
 		function processInput()
 		{
 			if (!acceptableInput)	text				= root.lastValidValue;
 			else					root.lastValidValue = Number(text)
-			focus = false;
 		}
-		onActiveFocusChanged:		if(!activeFocus) focus = false;
 
 		ToolTip.text:				root.toolTip
 		ToolTip.timeout:			jaspTheme.toolTipTimeout
@@ -145,6 +147,8 @@ FocusScope
 		width:				height
 
 		anchors.left:		valueField.right
+
+		activeFocusOnTab: false
 	}
 
 	Rectangle
@@ -164,12 +168,12 @@ FocusScope
 		visible:			root.activeFocus
 	}
 
-	MouseArea
-	{
-		id:					hoverMe
-		anchors.fill:		valueField
-		hoverEnabled:		true
-		acceptedButtons:	Qt.NoButton
-		onWheel:			if(wheel.angleDelta > 0) plus.clicked(); else minus.clicked();
-	}
+     MouseArea
+     {
+        id:					hoverMe
+        anchors.fill:		valueField
+        hoverEnabled:		true
+        acceptedButtons:	Qt.NoButton
+        onWheel:			if(wheel.angleDelta > 0) plus.clicked(); else minus.clicked();
+     }
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/728 and fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1653

I tweaked the SpinBox just enough that it doesn't mess up with the navigation. It works much more predictable now. There are more to fix there, but I think we can just get rid of it at some point, and switch to the one that comes with Qt out of the box.

Also, in this, I have changed a few things to make the overall experience of the preferences consistent. I notice that we sometimes hide, or disable controls. I think disabling them is better than hiding them, and we do disable them for the most part, so I changed them all to be visible but enabled/disabled based on their values. You can see the changes in the `PrefsData`.