### PR TITLE
R sources must be duplicated when an analysis is copied

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -72,6 +72,7 @@ Analysis::Analysis(size_t id, Analysis * duplicateMe)
 	, _dynamicModule(	duplicateMe->_dynamicModule	)
 	, _codedReferenceToAnalysisEntry(	duplicateMe->_codedReferenceToAnalysisEntry)
 	, _helpFile(						duplicateMe->_helpFile)
+	, _rSources(		duplicateMe->_rSources		)
 {
 }
 
@@ -169,7 +170,6 @@ void Analysis::run()
 
 void Analysis::refresh()
 {
-	clearRSources();
 	TempFiles::deleteAll(int(_id));
 	run();
 

--- a/Desktop/components/JASP/Controls/TextField.qml
+++ b/Desktop/components/JASP/Controls/TextField.qml
@@ -60,7 +60,7 @@ TextInputBase
 
 	function doEditingFinished()
 	{
-		if (control.text === "" && String(defaultValue) !== "")
+		if (control.text === "" && defaultValue !== undefined && String(defaultValue) !== "")
 			control.text = defaultValue;
 		lastValidValue = control.text
 		editingFinished();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1705
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1708

The R sources should be also duplicated when an analysis is copied.
Also when refreshing, the R sources do not have to be cleared: clearing them removes assigned values, and they will be anyway rebuild by the analysis.

For https://github.com/jasp-stats/jasp-test-release/issues/1708, the problem is that the defaultValue must be first tested whether it's defined before testing whether its string value is empty.