### PR TITLE
Fix infinite loop in Cochrane

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -1174,8 +1174,12 @@ void Analysis::checkForRSources()
 
 	for(auto & newOptionJson : newSources)
 	{
-		_rSources[newOptionJson.first] = newOptionJson.second;
-		emit rSourceChanged(tq(newOptionJson.first));
+		//Make sure to only update rSource if it changes
+		if(!_rSources.count(newOptionJson.first) ||  _rSources[newOptionJson.first] != newOptionJson.second)
+		{
+			_rSources[newOptionJson.first] = newOptionJson.second;
+			emit rSourceChanged(tq(newOptionJson.first));
+		}
 	}
 
 	for(const std::string & removeThis : removeAfterwards)


### PR DESCRIPTION
https://github.com/jasp-stats/jasp-test-release/issues/1697

Now existing rSources are only considered updated if their content changes.

