### PR TITLE
The value of a control initialized by a file should not change via binding

### DIFF
--- a/Desktop/analysis/analysisform.cpp
+++ b/Desktop/analysis/analysisform.cpp
@@ -358,6 +358,7 @@ void AnalysisForm::bindTo()
 	
 	for (JASPControl* control : _dependsOrderedCtrls)
 	{
+		bool hasOption = false;
 		BoundControl* boundControl = control->boundControl();
 		JASPListControl* listControl = dynamic_cast<JASPListControl *>(control);
 
@@ -375,6 +376,8 @@ void AnalysisForm::bindTo()
 
 			if (optionValue == Json::nullValue)
 				optionValue = boundControl->createJson();
+			else
+				hasOption = true;
 
 			boundControl->bindTo(optionValue);
 		}
@@ -397,7 +400,7 @@ void AnalysisForm::bindTo()
 			}
 		}
 
-		control->setInitialized();
+		control->setInitialized(hasOption);
 	}
 
 	for (ListModelAvailableInterface* availableModel : availableModelsToBeReset)

--- a/Desktop/analysis/jaspcontrol.cpp
+++ b/Desktop/analysis/jaspcontrol.cpp
@@ -138,7 +138,7 @@ void JASPControl::_resetBindingValue()
 	// If a control gets a value from a JASP file, this value may differ from its default value sets by a QML binding:
 	// this QML binding may then change the value during the initialization of the form.
 	// In this case, restore the original value.
-	if (isBound() && hasUserInteractiveValue() && initialized() && form() && !form()->initialized())
+	if (isBound() && hasUserInteractiveValue() && initializedByFile() && form() && !form()->initialized())
 		boundControl()->resetBoundValue();
 }
 
@@ -580,6 +580,16 @@ QString JASPControl::humanFriendlyLabel() const
 
 	return label;
 
+		}
+
+void JASPControl::setInitialized(bool byFile)
+{
+	if (!_initialized)
+	{
+		_initialized = true;
+		_initializedByFile = byFile;
+		emit initializedChanged();
+	}
 }
 
 QVector<JASPControl::ParentKey> JASPControl::getParentKeys()

--- a/Desktop/analysis/jaspcontrol.cpp
+++ b/Desktop/analysis/jaspcontrol.cpp
@@ -138,7 +138,7 @@ void JASPControl::_resetBindingValue()
 	// If a control gets a value from a JASP file, this value may differ from its default value sets by a QML binding:
 	// this QML binding may then change the value during the initialization of the form.
 	// In this case, restore the original value.
-	if (isBound() && hasUserInteractiveValue() && initializedByFile() && form() && !form()->initialized())
+	if (isBound() && hasUserInteractiveValue() && initializedFromJaspFile() && form() && !form()->initialized())
 		boundControl()->resetBoundValue();
 }
 
@@ -587,7 +587,7 @@ void JASPControl::setInitialized(bool byFile)
 	if (!_initialized)
 	{
 		_initialized = true;
-		_initializedByFile = byFile;
+		_initializedFromJaspFile = byFile;
 		emit initializedChanged();
 	}
 }

--- a/Desktop/analysis/jaspcontrol.h
+++ b/Desktop/analysis/jaspcontrol.h
@@ -116,6 +116,7 @@ public:
 	bool				indent()					const	{ return _indent;				}
 	bool				isDependency()				const	{ return _isDependency;			}
 	bool				initialized()				const	{ return _initialized;			}
+	bool				initializedByFile()			const	{ return _initializedByFile;	}
 	bool				shouldShowFocus()			const	{ return _shouldShowFocus;		}
 	bool				shouldStealHover()			const	{ return _shouldStealHover;		}
 	bool				debug()						const	{ return _debug;				}
@@ -125,7 +126,7 @@ public:
 	bool				childHasError()				const;
 	bool				childHasWarning()			const;
 	bool				focusOnTab()				const	{ return activeFocusOnTab();	}
-	bool				hasUserInteractiveValue()	const	{ return _hasUserInteractiveValue; }
+	bool				hasUserInteractiveValue()	const	{ return _hasUserInteractiveValue;	}
 
 	AnalysisForm	*	form()						const	{ return _form;					}
 	QQuickItem		*	childControlsArea()			const	{ return _childControlsArea;	}
@@ -143,7 +144,7 @@ public:
 	int					alignment()					const	{ return _alignment;			}
 													
 	QString				humanFriendlyLabel()		const;
-	void				setInitialized()	{ if (!_initialized) { _initialized = true; emit initializedChanged();} }
+	void				setInitialized(bool byFile = false);
 	
 	QVector<JASPControl::ParentKey>	getParentKeys();
 
@@ -265,6 +266,7 @@ protected:
 	bool					_isBound					= true,
 							_indent						= false,
 							_initialized				= false,
+							_initializedByFile			= false,
 							_debug						= false,
 							_parentDebug				= false,
 							_hasError					= false,

--- a/Desktop/analysis/jaspcontrol.h
+++ b/Desktop/analysis/jaspcontrol.h
@@ -116,7 +116,7 @@ public:
 	bool				indent()					const	{ return _indent;				}
 	bool				isDependency()				const	{ return _isDependency;			}
 	bool				initialized()				const	{ return _initialized;			}
-	bool				initializedByFile()			const	{ return _initializedByFile;	}
+	bool				initializedFromJaspFile()	const	{ return _initializedFromJaspFile;	}
 	bool				shouldShowFocus()			const	{ return _shouldShowFocus;		}
 	bool				shouldStealHover()			const	{ return _shouldStealHover;		}
 	bool				debug()						const	{ return _debug;				}
@@ -142,10 +142,10 @@ public:
 	int					cursorShape()				const	{ return _cursorShape;			}
 	bool				hovered()					const;
 	int					alignment()					const	{ return _alignment;			}
-													
+
 	QString				humanFriendlyLabel()		const;
 	void				setInitialized(bool byFile = false);
-	
+
 	QVector<JASPControl::ParentKey>	getParentKeys();
 
 	QQmlComponent				*	rowComponent()						const { return _rowComponent;	}
@@ -244,7 +244,7 @@ signals:
 	void hoveredChanged();
 	void controlTypeChanged();			// Not used, defined only to suppress warning in QML
 	void boundValueChanged(JASPControl* control);
-	
+
 	void				requestColumnCreation(std::string columnName, columnType columnType);
 	ComputedColumn *	requestComputedColumnCreation(std::string columnName);
 	void				requestComputedColumnDestruction(std::string columnName);
@@ -266,7 +266,7 @@ protected:
 	bool					_isBound					= true,
 							_indent						= false,
 							_initialized				= false,
-							_initializedByFile			= false,
+							_initializedFromJaspFile	= false,
 							_debug						= false,
 							_parentDebug				= false,
 							_hasError					= false,


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1760

If a value of a control is set with a binding in QML (for example a DoubleField is set per default by the number of variables selected by the user), this value can be changed by the user self to another value. If this value is saved in a JASP file, when reading the file, JASP must prevent the binding to overwrite the value.
This mechanism exists already via the _resetBindingValue JASPControl function. But in a case of an upgrade, an option that did not exist in a previous version, may have a default value set via a binding. In this particular case, the value should not be reset.

