### PR TITLE
Store R Sources in JASP files

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -118,7 +118,7 @@ Analysis* Analyses::create(const Json::Value & analysisData, Modules::AnalysisEn
 	storeAnalysis(analysis, id, notifyAll);
 	bindAnalysisHandler(analysis);
 	
-	if(!analysisData.isNull())	analysis->loadResultsUserdataFromJASPFile(analysisData);
+	if(!analysisData.isNull())	analysis->loadResultsUserdataAndRSourcesFromJASPFile(analysisData);
 	else						analysis->setResults(analysisEntry->getDefaultResults(), status);
 	
 
@@ -250,7 +250,7 @@ Json::Value Analyses::asJson() const
 				analysesDataList	= Json::arrayValue;;
 
 	applyToAll([&analysesDataList](const Analysis * analysis)
-		{ analysesDataList.append(analysis->asJSON()); });
+		{ analysesDataList.append(analysis->asJSON(true)); });
 
 	analysesJson["analyses"]	= analysesDataList;
 	analysesJson["meta"]		= resultsMeta();

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -98,6 +98,7 @@ public:
 	void rewriteImages();
 
 	void setRFile(const std::string &file)				{ _rfile = file;								}
+	void setRSources(const Json::Value& rSources);
 	void setUserData(Json::Value userData);
 	void setVersion(Version version, bool resetWasUpgraded = false);
 	void setRefreshBlocked(bool block)					{ _refreshBlocked = block;						}
@@ -146,9 +147,9 @@ public:
 			void        exportResults();
 			void		remove();
 
-			Json::Value asJSON()		const;
+			Json::Value asJSON(bool withRSources = false)	const;
 			void		checkDefaultTitleFromJASPFile(	const Json::Value & analysisData);
-			void		loadResultsUserdataFromJASPFile(const Json::Value & analysisData);
+			void		loadResultsUserdataAndRSourcesFromJASPFile(const Json::Value & analysisData);
 			Json::Value createAnalysisRequestJson();
 
 	static	Status		parseStatus(std::string name);
@@ -175,6 +176,7 @@ public:
 
 	const QList<std::string>	& computedColumns()								const	{ return _computedColumns; }
 	const Json::Value			& getRSource(const std::string& name)			const	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }
+	Json::Value				rSources()											const;
 	
 signals:
 	void				nameChanged();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1762

An R Source is set during the running of the analysis. When reading a JASP files containing such an analysis, the analysis cannot be run since it could change the results. So the best way is to store these R sources in the JASP file.
