### PR TITLE
Remove TypeError in CheckBox and RadioButton

### DIFF
--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -98,7 +98,7 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 	JASPTIMER_START(MainWindowConstructor);
 
 	//This is the constructor, so _qml is not set yet and there is no need to check that with an if statement
-	QQuickStyle::setStyle("Default");// Because otherwise plasma on kde might mess things up...
+	QQuickStyle::setStyle("Basic");
 
 	TempFiles::init(ProcessInfo::currentPID()); // needed here so that the LRNAM can be passed the session directory
 


### PR DESCRIPTION
With Qt6, the CheckBoxes and RadioButtons generated TypeErrors due to apparently https://forum.qt.io/topic/131823/lots-of-typeerrors-in-console-when-migrating-to-qt6

