### PR TITLE
FactorLevel control in Repeated ANOVA crash when adding a new factor

### DIFF
--- a/Desktop/components/JASP/Controls/FactorLevelList.qml
+++ b/Desktop/components/JASP/Controls/FactorLevelList.qml
@@ -107,23 +107,19 @@ FactorLevelListBase
 				focus:			true
 				color:			jaspTheme.controlBackgroundColor
 
-				property bool isDeletable:	model.type.includes("deletable")
-				property bool isVirtual:	model.type.includes("virtual")
-				property bool isLevel:		model.type.includes("level")
-
 				TextField
 				{
 					id:								colName
 					isBound:						false
-					value:							itemRectangle.isVirtual ? "" : model.name
-					placeholderText:				itemRectangle.isVirtual ? model.name : ""
+					value:							model.virtual ? "" : model.name
+					placeholderText:				model.virtual ? model.name : ""
 					anchors.centerIn:				parent
 					fieldWidth:						parent.width
 					fieldHeight:					parent.height
 					useExternalBorder:				false
 					showBorder:						false
 					selectValueOnFocus:				true
-					control.horizontalAlignment:	itemRectangle.isLevel ? TextInput.AlignLeft : TextInput.AlignHCenter
+					control.horizontalAlignment:	model.type === "level" ? TextInput.AlignLeft : TextInput.AlignHCenter
 					onEditingFinished:				itemChanged(index, value)
 				}
 
@@ -132,7 +128,7 @@ FactorLevelListBase
 					source:					jaspTheme.iconPath + deleteIcon
 					anchors.right:			parent.right
 					anchors.verticalCenter:	parent.verticalCenter
-					visible:				itemRectangle.isDeletable
+					visible:				model.deletable
 					height:					16 * preferencesModel.uiScale
 					width:					16 * preferencesModel.uiScale
 					z:						2

--- a/Desktop/widgets/listmodel.cpp
+++ b/Desktop/widgets/listmodel.cpp
@@ -57,6 +57,8 @@ QHash<int, QByteArray> ListModel::roleNames() const
 		roles[NameRole]						= "name";
 		roles[RowComponentRole]				= "rowComponent";
 		roles[ValueRole]					= "value";
+		roles[VirtualRole]					= "virtual";
+		roles[DeletableRole]				= "deletable";
 
 		setMe = false;
 	}

--- a/Desktop/widgets/listmodel.h
+++ b/Desktop/widgets/listmodel.h
@@ -48,7 +48,9 @@ public:
 		ColumnTypeIconRole,
 		ColumnTypeDisabledIconRole,
 		RowComponentRole,
-		ValueRole
+		ValueRole,
+		VirtualRole,
+		DeletableRole
     };
 	typedef QMap<QString, QMap<QString, Json::Value> > RowControlsValues;
 

--- a/Desktop/widgets/listmodelfactorlevels.h
+++ b/Desktop/widgets/listmodelfactorlevels.h
@@ -50,52 +50,35 @@ protected:
 		QString				value;
 		bool				isVirtual;
 		bool				isLevel;
-		FactorLevelItem*	headFactor;
-		FactorLevelItem(const QString& _value, bool _isVirtual, bool _isLevel, FactorLevelItem* _factor = nullptr) :
-			value(_value), isVirtual(_isVirtual), isLevel(_isLevel)
-		{
-			if (_factor)
-				headFactor = _factor;
-			else
-				headFactor = this;
-		}
 
-		FactorLevelItem(const FactorLevelItem& item) : value(item.value), isVirtual(item.isVirtual), isLevel(item.isLevel)
-		{
-			if (&item == item.headFactor)
-				headFactor = this;
-			else
-				headFactor = item.headFactor;
-		}
+		FactorLevelItem(const QString& _value, bool _isVirtual, bool _isLevel) :
+			value(_value), isVirtual(_isVirtual), isLevel(_isLevel) {}
 
-		bool operator==(const FactorLevelItem& item)
-		{
-			return item.headFactor == headFactor
-					&& item.isLevel == isLevel
-					&& item.isVirtual == isVirtual
-					&& item.value == value;
-		}
+		FactorLevelItem(const FactorLevelItem& item) : value(item.value), isVirtual(item.isVirtual), isLevel(item.isLevel) {}
 
         bool operator==(const FactorLevelItem& item) const
         {
-            return item.headFactor == headFactor
-                    && item.isLevel == isLevel
-                    && item.isVirtual == isVirtual
-                    && item.value == value;
+			return item.isLevel == isLevel
+				&& item.isVirtual == isVirtual
+				&& item.value == value;
         }
+		bool operator!=(const FactorLevelItem& item) const
+		{
+			return !(item == *this);
+		}
+
+		static FactorLevelItem dummyFactor;
 	};
+
 	QList<FactorLevelItem>	_items;
 	Terms					_allLevelsCombinations;
 
-	QStringList		_getOtherLevelsStringList(const FactorLevelItem& item);
-	QStringList		_getAllFactorsStringList();
-	QString			_giveUniqueName(const QStringList& names, const QString startName);
-	int				_getIndex(const FactorLevelItem& item) const;
-	
-	void			_updateVirtualLevelIndex(FactorLevelItem* headFactor);
-	void			_updateVirtualFactorIndex();
-	void			_setAllLevelsCombinations();
-	QString			_removeItem(int row);
+	QStringList			_getAllFactors()													const;
+	QString				_giveUniqueValue(const FactorLevelItem& item, const QString value)	const;
+	bool				_isDeletable(const FactorLevelItem& item)							const;
+	FactorLevelItem&	_getFactor(const FactorLevelItem& item)								const;
+	void				_setAllLevelsCombinations();
+	bool				_removeItem(int row);
 };
 
 #endif // LISTMODELFACTORLEVELS_H


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1765

The problem was that the _items in ListModelFactorLevels is a list of FactorLevelItem, and the FactorLevelItem structure had a reference to another FactorLevelItem: this reference in a QList is apparently a bad idea, since in Qt 6.2, it sometimes points to a deleted item.
So I have decided to remove this reference and to reshape the ListModelFactorLevels with comments.

This ListModelFactorLevels is only used for the Repeated Measures Factors in (Bayesian) Repeated Measures ANOVA. So it is quite easy to test whether this fix is safe: just add/delete/edit levels and factors in this component. I have tested it quite extensively, and it works.
