### PR TITLE
This makes dynamic modules and engines behave themselves much much better

### DIFF
--- a/Common/enginedefinitions.h
+++ b/Common/enginedefinitions.h
@@ -8,12 +8,13 @@
 /// Using enumutilities templates to make sure we can easily and quickly go from enum -> string -> enum for json communication
 ///
 
-DECLARE_ENUM(engineState,			initializing, idle, analysis, filter, rCode, computeColumn, moduleInstallRequest, moduleLoadRequest, pauseRequested, paused, resuming, stopRequested, stopped, logCfg, settings, killed);
+DECLARE_ENUM(engineState,			initializing, idle, analysis, filter, rCode, computeColumn, moduleInstallRequest, moduleLoadRequest, pauseRequested, paused, resuming, stopRequested, stopped, logCfg, settings, killed, reloadData);
 DECLARE_ENUM(performType,			run, abort, saveImg, editImg, rewriteImgs);
 DECLARE_ENUM(analysisResultStatus,	validationError, fatalError, imageSaved, imageEdited, imagesRewritten, complete, running, changed, waiting);
-DECLARE_ENUM(moduleStatus,			initializing, installNeeded, installModPkgNeeded, loadingNeeded, unloadingNeeded, readyForUse, error);
+DECLARE_ENUM(moduleStatus,			initializing, installNeeded, loading, installModPkgNeeded, readyForUse, error);
 DECLARE_ENUM(engineAnalysisStatus,	empty, toRun, running, changed, complete, error, exception, aborted, stopped, saveImg, editImg, rewriteImgs, synchingData);
 DECLARE_ENUM(winLcCtypeSetting,		check, alwaysC, neverC);
+DECLARE_ENUM(enginesListRoles,		channel =  257, module, engineState, analysisStatus, runsWhat, running, idle, idleSoon); //hardcoded Qt::UserRole + 1, sue me.
 
 struct unexpectedEngineReply  : public std::runtime_error
 {
@@ -26,14 +27,12 @@ struct unexpectedEngineReply  : public std::runtime_error
 };
 
 ///How many seconds do we wait for an engine to be killed if it gets stuck in some analysis?
-#define ENGINE_KILLTIME 2
-
-///How many seconds should there be at minimum between two attempts to start an extra idle engine?
-#define ENGINE_EXTRA_INTERVAL 10
+#define ENGINE_KILLTIME 3
 
 ///After how many seconds is an engine allowed to shutdown due to boredom?
-/// SHOULD TOTALLY BE BIGGER THAN 6 in actual development! more like 600
-#define ENGINE_BORED_SHUTDOWN 600
+#define ENGINE_BORED_SHUTDOWN (5 * 60)
 
+///Engines need some time between closing and starting to avoid problems with shared memory
+#define ENGINE_COOLDOWN 50
 
 #endif // ENGINEDEFINITIONS_H

--- a/Common/ipcchannel.cpp
+++ b/Common/ipcchannel.cpp
@@ -21,6 +21,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/nowide/convert.hpp>
 #include "log.h"
+#include "utils.h"
 
 using namespace std;
 using namespace boost;
@@ -35,34 +36,98 @@ IPCChannel::IPCChannel(std::string name, size_t channelNumber, bool isSlave)
 	  _channelNumber(	channelNumber								),
 	  _isSlave(			isSlave										)
 {
-	_memoryControl			= new interprocess::managed_shared_memory(interprocess::open_or_create, _baseName.c_str(), 4096);
+	Log::log() << "IPCChannel(" << name << ", " << channelNumber << ", " << (isSlave ? "slave" : "master") << ");" << std::endl;
 
-	_sizeMtoS				= _memoryControl->find_or_construct<size_t>("sizeMasterToSlave")(1024 * 1024 * 8);
-	_sizeStoM				= _memoryControl->find_or_construct<size_t>("sizeSlaveToMaster")(1024 * 1024 * 8);
+	Log::log() << (!_isSlave ? "Creating control memory" : "Opening control memory") << std::endl;
 
-	_memoryMasterToSlave	= new interprocess::managed_shared_memory(interprocess::open_or_create, _nameMtS.c_str(), *_sizeMtoS);
-	_memorySlaveToMaster	= new interprocess::managed_shared_memory(interprocess::open_or_create, _nameStM.c_str(), *_sizeStoM);
+	_memoryControl			= !isSlave ? new interprocess::managed_shared_memory(interprocess::open_or_create,	_baseName.c_str(), 4096)
+									   : new interprocess::managed_shared_memory(interprocess::open_only,		_baseName.c_str());
 
-	TempFiles::addShmemFileName(_baseName);
-	TempFiles::addShmemFileName(_nameMtS);
-	TempFiles::addShmemFileName(_nameStM);
+	if(!_isSlave)
+	{
+		_sizeMtoS				= _memoryControl->find_or_construct<size_t>("sizeMasterToSlave")(1024 * 1024 * 8);
+		_sizeStoM				= _memoryControl->find_or_construct<size_t>("sizeSlaveToMaster")(1024 * 1024 * 8);
+	}
+	else
+		catchAndRepeat("Finding sizes if communication channels", [&]()
+		{
+			auto foundSizeMtoS  = _memoryControl->find<size_t>("sizeMasterToSlave");
+			auto foundSizeStoM  = _memoryControl->find<size_t>("sizeSlaveToMaster");
+
+			if(foundSizeMtoS.first == nullptr)	throw std::runtime_error("Couldn't find sizeMasterToSlave for IPCChannel...");
+			if(foundSizeStoM.first == nullptr)	throw std::runtime_error("Couldn't find sizeSlaveToMaster for IPCChannel...");
+
+			_sizeMtoS = foundSizeMtoS.first;  //It could actually be an array, but of course, this would just take the first one and we ignore the rest.
+			_sizeStoM = foundSizeStoM.first;
+
+			if(foundSizeMtoS.second > 1 || foundSizeStoM.second > 1)
+				Log::log() << "More than 1 (_sizeMtoS: " << foundSizeMtoS.second << " _sizeStoM: " << foundSizeStoM.second << ") data String found in IPCChannel startup on engine." << std::endl;
+		});
+
+	if(!_isSlave)
+	{
+		Log::log() << "Creating communication memory" << std::endl;
+		_memoryMasterToSlave	= new interprocess::managed_shared_memory(interprocess::open_or_create, _nameMtS.c_str(), *_sizeMtoS);
+		_memorySlaveToMaster	= new interprocess::managed_shared_memory(interprocess::open_or_create, _nameStM.c_str(), *_sizeStoM);
+	}
+	else
+		catchAndRepeat("Opening communications memory", [&]()
+		{
+
+			Log::log() << "Opening M->S" << std::endl;
+			_memoryMasterToSlave	= new interprocess::managed_shared_memory(interprocess::open_only, _nameMtS.c_str());
+			Log::log() << "Opening S->M" << std::endl;
+			_memorySlaveToMaster	= new interprocess::managed_shared_memory(interprocess::open_only, _nameStM.c_str());
+		});
+
 
 	generateNames();
 
-	_mutexIn  = _memoryControl->find_or_construct<interprocess::interprocess_mutex>(_mutexInName.c_str())();
-	_mutexOut = _memoryControl->find_or_construct<interprocess::interprocess_mutex>(_mutexOutName.c_str())();
+	Log::log() << "Finding/constructing mutexes" << std::endl;
 
-	_memoryIn  = _isSlave ? _memoryMasterToSlave : _memorySlaveToMaster;
-	_memoryOut = _isSlave ? _memorySlaveToMaster : _memoryMasterToSlave;
+	if(!_isSlave)	findConstructMutexes();
+	else
+		catchAndRepeat("Finding mutexes", [&]()
+		{
+			auto mutexesIn  = _memoryControl->find<interprocess::interprocess_mutex>(_mutexInName.c_str());
+			auto mutexesOut = _memoryControl->find<interprocess::interprocess_mutex>(_mutexOutName.c_str());
 
-	_sizeIn  = _isSlave ? _sizeMtoS : _sizeStoM;
-	_sizeOut = _isSlave ? _sizeStoM : _sizeMtoS;
+			if(mutexesIn.first  == nullptr)	throw std::runtime_error("Couldn't find mutex in for IPCChannel...");
+			if(mutexesOut.first == nullptr)	throw std::runtime_error("Couldn't find mutex out for IPCChannel...");
 
-	_previousSizeIn = *_sizeIn;
+			_mutexIn	= mutexesIn.first;
+			_mutexOut	= mutexesOut.first;
+		});
+
+	_memoryIn	= _isSlave ? _memoryMasterToSlave : _memorySlaveToMaster;
+	_memoryOut	= _isSlave ? _memorySlaveToMaster : _memoryMasterToSlave;
+
+	_sizeIn		= _isSlave ? _sizeMtoS : _sizeStoM;
+	_sizeOut	= _isSlave ? _sizeStoM : _sizeMtoS;
+
+	_previousSizeIn  = *_sizeIn;
 	_previousSizeOut = *_sizeOut;
 
-	_dataIn		= _memoryIn->find_or_construct<String>(_dataInName.c_str())		(_memoryIn->get_segment_manager());
-	_dataOut	= _memoryOut->find_or_construct<String>(_dataOutName.c_str())	(_memoryOut->get_segment_manager());
+	if(!_isSlave)
+		findConstructDataStrings();
+	else
+		catchAndRepeat("Finding communication strings", [&]()
+		{
+			Log::log() << "Opening " << _dataInName << std::endl;
+			auto foundDataIn  = _memoryIn ->find<String>(_dataInName.c_str());
+
+			Log::log() << "Opening " << _dataOutName << std::endl;
+			auto foundDataOut = _memoryOut->find<String>(_dataOutName.c_str());
+
+			if(foundDataIn.first == nullptr)	throw std::runtime_error("Couldn't find data in for IPCChannel...");
+			if(foundDataOut.first == nullptr)	throw std::runtime_error("Couldn't find data out for IPCChannel...");
+
+			_dataIn	 = foundDataIn.first;  //It could actually be an array, but of course, this would just take the first one and we ignore the rest.
+			_dataOut = foundDataOut.first;
+
+			if(foundDataIn.second > 1 || foundDataOut.second > 1)
+				Log::log() << "More than 1 (in: " << foundDataIn.second << " out: " << foundDataOut.second << ") data String found in IPCChannel startup on engine." << std::endl;
+		});
 
 #ifdef __APPLE__
 	_semaphoreIn  = sem_open(_mutexInName.c_str(),  O_CREAT, S_IWUSR | S_IRGRP | S_IROTH, 0);
@@ -113,15 +178,83 @@ IPCChannel::IPCChannel(std::string name, size_t channelNumber, bool isSlave)
 
 
 #endif
+
+	//Log::log() << "IPCChannel init done" << std::endl;
+}
+
+void IPCChannel::findConstructSizes()
+{
+	_sizeMtoS	= _memoryControl->find_or_construct<size_t>("sizeMasterToSlave")(1024 * 1024 * 8);
+	_sizeStoM	= _memoryControl->find_or_construct<size_t>("sizeSlaveToMaster")(1024 * 1024 * 8);
+}
+
+
+void IPCChannel::findConstructMutexes()
+{
+	_mutexIn  = _memoryControl->find_or_construct<interprocess::interprocess_mutex>(_mutexInName.c_str())();
+	_mutexOut = _memoryControl->find_or_construct<interprocess::interprocess_mutex>(_mutexOutName.c_str())();
+}
+
+
+void IPCChannel::findConstructDataStrings()
+{
+	Log::log() << "Finding/constructing communication strings" << std::endl;
+
+	Log::log() << "Creating " << _dataInName << std::endl;
+	_dataIn		= _memoryIn ->find_or_construct<String>(_dataInName.c_str())	(_memoryIn ->get_segment_manager());
+
+	Log::log() << "Creating " << _dataOutName << std::endl;
+	_dataOut	= _memoryOut->find_or_construct<String>(_dataOutName.c_str())	(_memoryOut->get_segment_manager());
+}
+
+void IPCChannel::findConstructAllAgain()
+{
+	Log::log() << "Finding/constructing all relevant shared memory objects again." << std::endl;
+	findConstructSizes();
+	findConstructMutexes();
+	findConstructDataStrings();
+}
+
+void IPCChannel::catchAndRepeat(const std::string & taskDescription, std::function<void()> doThis)
+{
+	const long	now		= Utils::currentMillis(),
+				wait	= 2000,
+				sleep	= 200;
+
+	bool worked = false;
+
+	Log::log() << taskDescription << " for at least " << wait << "ms" << std::endl;
+
+
+	while(!worked && Utils::currentMillis() < now + wait)
+		try
+		{
+			doThis();
+
+			worked = true;
+		}
+		catch(std::exception e)
+		{
+			Log::log() << "Had exception: " << e.what() << std::endl;
+			Log::log() << "Will sleep for " << sleep << "ms and try again." << std::endl;
+
+			Utils::sleep(sleep);
+		}
+
+	if(!worked)
+	{
+		static std::string failure = taskDescription + " failed...";
+		Log::log() << failure << std::endl;
+		throw std::runtime_error(failure);
+	}
 }
 
 IPCChannel::~IPCChannel()
 {
+
 #ifdef JASP_DEBUG
-	Log::log() << "~IPCChannel() of " << (_isSlave ? "Slave" : "Master") << std::endl;
+	Log::log() << "~IPCChannel(#" << _channelNumber << ") of " << (_isSlave ? "Slave" : "Master") << std::endl;
 #endif
-	if(_isSlave)
-		return;
 
 	delete _memoryControl;
 	delete _memoryMasterToSlave;
@@ -130,6 +263,9 @@ IPCChannel::~IPCChannel()
 	_memoryControl			= nullptr;
 	_memoryMasterToSlave	= nullptr;
 	_memorySlaveToMaster	= nullptr;
+
+	if(_isSlave)
+		return;
 
 	interprocess::shared_memory_object::remove(_baseName.c_str());
 	interprocess::shared_memory_object::remove(_nameMtS.c_str());
@@ -242,7 +378,6 @@ retryAfterDoublingMemory:
 
 bool IPCChannel::receive(string &data, int timeout)
 {
-
 	if (tryWait(timeout))
 	{
 		_mutexIn->lock();

--- a/Common/ipcchannel.h
+++ b/Common/ipcchannel.h
@@ -61,12 +61,19 @@ public:
 
 	size_t channelNumber() { return _channelNumber; }
 
+	void findConstructAllAgain();
+
 private:
 	bool tryWait(int timeout = 0);
+	void catchAndRepeat(const std::string & taskDescription, std::function<void()> doThis);
 
 	void doubleMemoryOut();
 	void rebindMemoryInIfSizeChanged();
 	void generateNames();
+
+	void findConstructSizes();
+	void findConstructDataStrings();
+	void findConstructMutexes();
 
 	std::string										_baseName,
 													_nameControl,

--- a/Common/sharedmemory.cpp
+++ b/Common/sharedmemory.cpp
@@ -41,8 +41,6 @@ DataSet *SharedMemory::createDataSet()
 		ss << ProcessInfo::currentPID();
 		_memoryName = ss.str();
 
-		TempFiles::addShmemFileName(_memoryName);
-
 		interprocess::shared_memory_object::remove(_memoryName.c_str());
 		_memory = new interprocess::managed_shared_memory(interprocess::create_only, _memoryName.c_str(), 6 * 1024 * 1024);
 		Log::log() << "Created shared mem with name " << _memoryName << std::endl;
@@ -109,9 +107,7 @@ void SharedMemory::deleteDataSet(DataSet *dataSet)
 
 void SharedMemory::unloadDataSet()
 {
-	Log::log() << "SharedMemory::unloadDataSet " << _memoryName << std::endl;
-	if(_memory != NULL)
-		delete _memory;
-
-	_memory = NULL;
+	Log::log() << "SharedMemory::unloadDataSet " << _memoryName << ( _memory ? "" : " but it wasn't loaded.") << std::endl;
+	delete _memory;
+	_memory = nullptr;
 }

--- a/Common/tempfiles.cpp
+++ b/Common/tempfiles.cpp
@@ -37,7 +37,6 @@ std::string				TempFiles::_statusFileName	= "";
 std::string				TempFiles::_clipboard		= "";
 int						TempFiles::_nextFileId		= 0;
 int						TempFiles::_nextTmpFolderId	= 0;
-TempFiles::stringvec	TempFiles::_shmemNames		= TempFiles::stringvec();
 
 void TempFiles::init(long sessionId)
 {
@@ -147,10 +146,6 @@ void TempFiles::deleteOrphans()
 			if (p.compare(sessionPath) == 0)
 				continue;
 
-			for (std::string & shmemName : _shmemNames)
-				if (p.compare(shmemName) == 0)
-					continue;
-
 			string fileName		= Utils::osPath(p.filename());
 			bool is_directory	= boost::filesystem::is_directory(p, error);
 
@@ -217,8 +212,6 @@ void TempFiles::deleteOrphans()
 void TempFiles::heartbeat()
 {
 	Utils::touch(_statusFileName);
-	for (string & shmemName : _shmemNames)
-		Utils::touch(shmemName);
 }
 
 void TempFiles::purgeClipboard()
@@ -353,15 +346,3 @@ void TempFiles::deleteList(const vector<string> &files)
 	}
 }
 
-
-///Fairly sure this function is pointless, the "_shmemNames" it collects do not seem to reflect the actual paths to the sharedmem files...
-void TempFiles::addShmemFileName(std::string &name)
-{
-	_shmemNames.push_back(Dirs::tempDir()+ "/" + name);
-
-	Log::log() << "TempFiles::addShmemFileName(" << name << ") called, whole list is now: " ;
-	int c=0;
-	for(const auto & n : _shmemNames)
-		Log::log(false) << ( c++ > 0 ? ", " : "") << "'" << n << "'";
-	Log::log(false) << std::endl;
-}

--- a/Common/tempfiles.h
+++ b/Common/tempfiles.h
@@ -60,8 +60,6 @@ public:
 	static void			deleteAll(int id = -1);
 	static void			deleteOrphans();
 
-	static void			addShmemFileName(std::string &name);
-
 private:
 						TempFiles() {}
 	static long			_sessionId;
@@ -70,7 +68,6 @@ private:
 						_clipboard;
 	static int			_nextFileId,
 						_nextTmpFolderId;
-	static stringvec	_shmemNames;
 };
 
 

--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -27,7 +27,6 @@
 #include <QString>
 #include <QMap>
 #include <QAbstractListModel>
-#include <QFileSystemWatcher>
 #include <sstream>
 
 class RibbonModel;
@@ -60,19 +59,20 @@ public:
 					idRole};
 
 						Analyses();
-						~Analyses() { _singleton = nullptr; }
-	static Analyses *	analyses() { return _singleton; }
+						~Analyses()	{ _singleton = nullptr; }
+	static Analyses *	analyses()	{ return _singleton; }
 
 	Analysis	*	createFromJaspFileEntry(Json::Value analysisData, RibbonModel* ribbonModel);
 
-	Analysis	*	create(const Json::Value & analysisData, Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Initializing, bool notifyAll = true, std::string title = "", std::string moduleVersion = "", Json::Value *options = nullptr);
+	Analysis	*	create(const Json::Value & analysisData, Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Empty, bool notifyAll = true, std::string title = "", std::string moduleVersion = "", Json::Value *options = nullptr);
 	Analysis	*	create(Modules::AnalysisEntry * analysisEntry)													{ return create(Json::nullValue, analysisEntry, _nextId++);						}
 
 	Analysis	*	operator[](size_t index)	{ return _analysisMap[_orderedIds[index]]; }
 	Analysis	*	get(size_t id) const		{ return _analysisMap.count(id) > 0 ? _analysisMap.at(id) : nullptr;	}
 
 	void			clear();
-	void			reload(Analysis* analysis, bool logProblem);
+	void			reload(Analysis* analysis, bool qmlFileChanged, bool logProblem);
+	void			destroyAllForms();
 
 	bool			allFresh() const;
 	void			setAnalysesUserData(Json::Value userData);
@@ -150,6 +150,7 @@ signals:
 	void sendRScript(					QString		script, int requestID, bool whiteListedVersion);
 	void analysisSelectedIndexResults(	int			row);
 	void showAnalysisInResults(			int			id);
+	void reloadQmlForm(					int			row);
 	void currentAnalysisIndexChanged(	int			currentAnalysisIndex);
 	void currentFormHeightChanged(		double		currentFormHeight);
 	void visibleChanged(				bool		visible);
@@ -175,7 +176,6 @@ private:
 	void bindAnalysisHandler(Analysis* analysis);
 	void storeAnalysis(Analysis* analysis, size_t id, bool notifyAll);	
 	void _makeBackwardCompatible(RibbonModel* ribbonModel, Version& version, Json::Value& analysisData);
-	void _analysisQMLFileChanged(Analysis* analysis);
 
 
 private:
@@ -187,7 +187,6 @@ private:
 	std::map<size_t, Analysis*>		_analysisMap;
 	std::vector<size_t>				_orderedIds;
 	std::vector<size_t>				_orderedIdsBeforeMoving;
-	QFileSystemWatcher				_QMLFileWatcher;
 
 	size_t							_nextId					= 0;
 	int								_currentAnalysisIndex	= -1;

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -26,18 +26,20 @@
 #include "log.h"
 #include "utils.h"
 #include "utilities/settings.h"
+#include "utilities/qutils.h"
+
 
 Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::string title, std::string moduleVersion, Json::Value *data) :
-	  QObject(Analyses::analyses()),
-	  _id(id),
-	  _name(analysisEntry->function()),
-	  _qml(analysisEntry->qml().empty() ? _name : analysisEntry->qml()),
-	  _titleDefault(analysisEntry->title()),
-	  _title(title == "" ? _titleDefault : title),
-	  _moduleVersion(moduleVersion),
-	  _version(AppInfo::version),
-	  _moduleData(analysisEntry),
-	  _dynamicModule(_moduleData->dynamicModule())
+	  QObject(			Analyses::analyses()),
+	  _id(				id),
+	  _name(			analysisEntry->function()),
+	  _qml(				analysisEntry->qml().empty() ? _name : analysisEntry->qml()),
+	  _titleDefault(	analysisEntry->title()),
+	  _title(			title == "" ? _titleDefault : title),
+	  _moduleVersion(	moduleVersion),
+	  _version(			AppInfo::version),
+	  _moduleData(		analysisEntry),
+	  _dynamicModule(	_moduleData->dynamicModule())
 {
 	if(_moduleVersion == "" && _dynamicModule)
 		_moduleVersion = _dynamicModule->version();
@@ -45,39 +47,59 @@ Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::strin
 	if (data)
 		_optionsDotJASP = *data; //Same story as other constructor
 
-	_codedReferenceToAnalysisEntry = analysisEntry->codedReference(); //We need to store this to be able to find the right analysisEntry after reloading the entries of a dynamic module (destroys analysisEntries). Or replacing the entry if a different version of the module gets loaded of course.
+	_codedAnalysisEntry = analysisEntry->codedReference(); //We need to store this to be able to find the right analysisEntry after reloading the entries of a dynamic module (destroys analysisEntries). Or replacing the entry if a different version of the module gets loaded of course.
 	setHelpFile(dynamicModule()->helpFolderPath() + tq(analysisEntry->function()));
+
+	initAnalysis();
 }
 
 Analysis::Analysis(size_t id, Analysis * duplicateMe)
-	: QObject(			Analyses::analyses()		)
-	, _status(			duplicateMe->_status		)
-	, _boundValues(		duplicateMe->boundValues()	)
-	, _optionsDotJASP(	duplicateMe->_optionsDotJASP)
-	, _results(			duplicateMe->_results		)
-	, _resultsMeta(			_results.get(".meta", Json::arrayValue))
-	, _imgResults(		duplicateMe->_imgResults	)
-	, _userData(		duplicateMe->_userData		)
-	, _imgOptions(		duplicateMe->_imgOptions	)
-	, _progress(		duplicateMe->_progress		)
-	, _id(				id							)
-	, _name(			duplicateMe->_name			)
-	, _qml(				duplicateMe->_qml			)
-	, _titleDefault(	duplicateMe->_titleDefault	)
-	, _title("Copy of "+duplicateMe->_title			)
-	, _rfile(			duplicateMe->_rfile			)
-	, _isDuplicate(		true						)
-	, _version(			duplicateMe->_version		)
-	, _moduleData(		duplicateMe->_moduleData	)
-	, _dynamicModule(	duplicateMe->_dynamicModule	)
-	, _codedReferenceToAnalysisEntry(	duplicateMe->_codedReferenceToAnalysisEntry)
-	, _helpFile(						duplicateMe->_helpFile)
-	, _rSources(		duplicateMe->_rSources		)
+	: QObject(				Analyses::analyses()					)
+	, _status(				duplicateMe->_status					)
+	, _boundValues(			duplicateMe->boundValues()				)
+	, _optionsDotJASP(		duplicateMe->_optionsDotJASP			)
+	, _results(				duplicateMe->_results					)
+	, _resultsMeta(			_results.get(".meta", Json::arrayValue)	)
+	, _imgResults(			duplicateMe->_imgResults				)
+	, _userData(			duplicateMe->_userData					)
+	, _imgOptions(			duplicateMe->_imgOptions				)
+	, _progress(			duplicateMe->_progress					)
+	, _id(					id										)
+	, _name(				duplicateMe->_name						)
+	, _qml(					duplicateMe->_qml						)
+	, _titleDefault(		duplicateMe->_titleDefault				)
+	, _title("Copy of "+	duplicateMe->_title						)
+	, _rfile(				duplicateMe->_rfile						)
+	, _isDuplicate(			true									)
+	, _version(				duplicateMe->_version					)
+	, _moduleData(			duplicateMe->_moduleData				)
+	, _dynamicModule(		duplicateMe->_dynamicModule				)
+	, _codedAnalysisEntry(	duplicateMe->_codedAnalysisEntry		)
+	, _helpFile(			duplicateMe->_helpFile					)
+	, _rSources(			duplicateMe->_rSources					)
 {
+	initAnalysis();
+}
+
+void Analysis::initAnalysis()
+{
+	watchQmlForm();
+	connect(&_QMLFileWatcher,	&QFileSystemWatcher::fileChanged,			this,	&Analysis::analysisQMLFileChanged,	Qt::UniqueConnection);
+	connect(this,				&Analysis::createFormWhenYouHaveAMoment,	this,	&Analysis::createForm,				Qt::QueuedConnection);
+
+
+	bool isNewAnalysis = optionsFromJASPFile().size() == 0;
+
+	if(!_isDuplicate && isNewAnalysis)
+		_status = Empty;
+
 }
 
 Analysis::~Analysis()
 {
+	if(form())
+		destroyForm();
+
 	const auto & cols = computedColumns();
 
 	if(cols.size() > 0)
@@ -92,12 +114,26 @@ void Analysis::clearOptions()
 
 bool Analysis::checkAnalysisEntry()
 {
+	/*
+		This function is necessary because we have multiple datastructures representing the same data...
+
+		The `RibbonModel` has its own copy and `Analysis` points there.
+		We also have DynamicModule(s) which contains the original data as loaded from Description.qml and the Ribbon* objects are created based on that.
+		
+		This might mean that when a development module is installed the Analysis still has a pointer to the old RibbonButton/Model info and must be updated.
+		Same for when Description.qml was changed and thus reloaded.
+
+		To be able to find the right pointer we store a textual representation of which module+analysis is meant in Analysis::_codedAnalysisEntry.
+
+		This function then corrects the pointers when necessary
+	*/
+
 	try
 	{
-		if(_codedReferenceToAnalysisEntry == "" || !_dynamicModule)
+		if(_codedAnalysisEntry == "" || !_dynamicModule)
 			Modules::ModuleException("???", "No coded reference stored or _dynamicModule == nullptr...");
 
-		_moduleData = _dynamicModule->retrieveCorrespondingAnalysisEntry(_codedReferenceToAnalysisEntry);
+		_moduleData = _dynamicModule->retrieveCorrespondingAnalysisEntry(_codedAnalysisEntry);
 		
 		bool updateTitleToDefault = _title == _titleDefault;
 		
@@ -106,6 +142,18 @@ bool Analysis::checkAnalysisEntry()
 		if(updateTitleToDefault)
 			setTitle(_titleDefault);
 
+		bool qmlFileChanged = _lastQmlFormPath != qmlFormPath(false, true);
+
+		_lastQmlFormPath = qmlFormPath(false, true);
+
+		if(qmlFileChanged)
+		{
+			Log::log() << "Analysis::checkAnalysisEntry() has a changed qml file path, calling watchQmlForm()" << std::endl;
+			watchQmlForm();
+
+			reloadForm();
+		}
+
 		return true;
 	}
 	catch (Modules::ModuleException & e)
@@ -113,6 +161,8 @@ bool Analysis::checkAnalysisEntry()
 		Log::log() << "Analysis::checkAnalysisEntry() had a problem: " << e.what() << std::endl;
 
 		_moduleData = nullptr;
+		if(_QMLFileWatcher.files().size())
+			_QMLFileWatcher.removePaths(_QMLFileWatcher.files());
 		return false;
 	}
 }
@@ -153,11 +203,6 @@ void Analysis::setResults(const Json::Value & results, Status status, const Json
 	_wasUpgraded = false;
 }
 
-void Analysis::reload()
-{
-	Analyses::analyses()->reload(this, true);
-}
-
 void Analysis::exportResults()
 {
 	emit Analyses::analyses()->analysesExportResults();
@@ -165,6 +210,7 @@ void Analysis::exportResults()
 
 void Analysis::run()
 {
+	Log::log() << "Analysis::run() for " << title() << "(" << id() << ")" << std::endl;
 	setStatus(Empty);
 }
 
@@ -245,15 +291,6 @@ bool Analysis::updatePlotSize(const std::string & plotName, int width, int heigh
 	return false;
 }
 
-Modules::AnalysisEntry * Analysis::moduleData()
-{
-	if(!_moduleData)
-		checkAnalysisEntry();
-
-	return _moduleData;
-}
-
-
 void Analysis::rewriteImages()
 {
 	setStatus(Analysis::RewriteImgs);
@@ -270,11 +307,11 @@ void Analysis::imagesRewritten(const Json::Value & results)
 Analysis::Status Analysis::parseStatus(std::string name)
 {
 	if		(name == "empty")			return Analysis::Empty;
-	else if (name == "waiting")			return Analysis::Running; //For backwards compatibility
+	else if (name == "initializing")	return Analysis::Empty;		//For backwards compatibility ?
+	else if (name == "waiting")			return Analysis::Running;	//For backwards compatibility
 	else if (name == "running")			return Analysis::Running;
 	else if (name == "runningImg")		return Analysis::RunningImg;
 	else if (name == "complete")		return Analysis::Complete;
-	else if (name == "initializing")	return Analysis::Initializing;
 	else if (name == "RewriteImgs")		return Analysis::RewriteImgs;
 	else if (name == "validationError")	return Analysis::ValidationError;
 	else if (name == "aborted")			return Analysis::Aborted;
@@ -283,13 +320,8 @@ Analysis::Status Analysis::parseStatus(std::string name)
 	else								return Analysis::FatalError;
 }
 
-void Analysis::initialized(AnalysisForm* form, bool isNewAnalysis)
+void Analysis::formConnect()
 {
-	_analysisForm	= form;
-
-	if(!_isDuplicate && isNewAnalysis)
-		_status = Empty;
-	
 	connect(_analysisForm,			&AnalysisForm::helpMDChanged,		this,			&Analysis::helpMDChanged					);
 	connect(this,					&Analysis::rSourceChanged,			_analysisForm,	&AnalysisForm::rSourceChanged				);
 	connect(this,					&Analysis::refreshTableViewModels,	_analysisForm,	&AnalysisForm::refreshTableViewModels		);
@@ -326,7 +358,6 @@ std::string Analysis::statusToString(Status status)
 	case Analysis::EditImg:			return "EditImg";
 	case Analysis::RewriteImgs:		return "RewriteImgs";
 	case Analysis::ValidationError:	return "validationError";
-	case Analysis::Initializing:	return "initializing";
 	case Analysis::FatalError:		return "fatalError";
 	default:						return "?????";
 	}
@@ -348,6 +379,7 @@ Json::Value Analysis::asJSON(bool withRSource) const
 	analysisAsJson["options"]		= boundValues();
 	analysisAsJson["userdata"]		= userData();
 	analysisAsJson["dynamicModule"] = _moduleData->asJsonForJaspFile();
+
 	if (withRSource)
 		analysisAsJson["rSources"]	= rSources();
 
@@ -520,8 +552,7 @@ void Analysis::setStatus(Analysis::Status status)
 		TempFiles::deleteList(TempFiles::retrieveList(_id));
 		setVersion(AppInfo::version, true);
 
-		if(_dynamicModule)
-			_moduleVersion = _dynamicModule->version();
+		_moduleVersion = _dynamicModule->version();
 
 		if(neededRefresh != needsRefresh())
 			emit needsRefreshChanged();
@@ -580,9 +611,12 @@ performType Analysis::desiredPerformTypeFromAnalysisStatus() const
 	}
 }
 
-std::string Analysis::qmlFormPath() const
+std::string Analysis::qmlFormPath(bool addFileProtocol, bool ignoreReadyForUse) const
 {
-	return "file:" + (_moduleData != nullptr	?
+	if(!ignoreReadyForUse && !dynamicModule()->readyForUse())
+		return "";
+
+	return (addFileProtocol ? "file:" : "") + (_moduleData != nullptr	?
 				_moduleData->qmlFilePath()	:
 				Dirs::resourcesDir() + "/" + module() + "/qml/"  + qml());
 }
@@ -682,8 +716,7 @@ void Analysis::emitDuplicationSignals()
 
 QString	Analysis::fullHelpPath(QString helpFileName)
 {
-	if(isDynamicModule())	return dynamicModule()->helpFolderPath() + helpFileName;
-	else					return "analyses/" + helpFileName;
+	return dynamicModule()->helpFolderPath() + helpFileName;
 }
 
 void Analysis::duplicateMe()
@@ -833,6 +866,118 @@ void Analysis::setErrorInResults(const std::string & msg)
 	errorResults["title"]			= title();
 
 	setResults(errorResults, Status::FatalError);
+}
+
+void Analysis::setFormParent(QQuickItem *formParent)
+{
+	if(_formParent == formParent)
+		return;
+
+	//Log::log() << "Analysis::setFormParent(" << formParent << ") " << name() << std::endl;
+
+	_formParent = formParent;
+
+	emit formParentChanged();
+
+	if(_formParent)
+	{
+		if(_analysisForm)				_analysisForm->setParentItem(_formParent);
+		else if(readyToCreateForm())	createForm();
+	}
+}
+
+bool Analysis::readyToCreateForm() const
+{
+	return _formParent && dynamicModule() && dynamicModule()->readyForUse();
+}
+
+void Analysis::createForm()
+{
+	Log::log() << "Analysis(" << this << ")::createForm() called ";
+
+	setQmlError("");
+
+	if(!_formParent)
+	{
+		Log::log() << "There is no formParent..." << std::endl;
+		return;
+	}
+
+	if(_analysisForm)
+	{
+		Log::log() << "It already has a form, so we destroy it.";
+		destroyForm();
+	}
+
+	try
+	{
+		Log::log()  << std::endl << "Loading QML form from: " << qmlFormPath(false, false) << std::endl;
+
+		QObject * newForm = instantiateQml(QUrl::fromLocalFile(tq(qmlFormPath(false, false))), module(), qmlContext(_formParent));
+
+		Log::log() << "Created a form, got pointer " << newForm << std::endl;
+
+		AnalysisForm * formItem = qobject_cast<AnalysisForm *>(newForm);
+
+		if(!formItem)
+			throw Modules::ModuleException(module(), "QML file '" + qmlFormPath(false, false) + "' didn't spawn into AnalysisForm, but into: " + (newForm ? fq(newForm->objectName()) : "null"));
+
+		setAnalysisForm(formItem);
+
+		formConnect();
+	}
+	catch(Modules::ModuleException me)
+	{
+		Log::log() << "Had an error loading qml: " << me.what() << std::endl;
+		setQmlError(me.what());
+		_analysisForm = nullptr;
+	}
+	catch(std::exception e)
+	{
+		setQmlError(e.what());
+		_analysisForm = nullptr;
+	}
+}
+
+void Analysis::destroyForm()
+{
+	Log::log() << "Analysis(" << this << ")::destroyForm() called";
+
+	if(_analysisForm)
+	{
+		Log::log(false) << " it has a AnalysisForm " << _analysisForm << " so let's destroy it" << std::endl;
+
+		_optionsDotJASP = _boundValues;  //So that we can later reload the controls to what we currently have
+
+		_analysisForm->setParent(		nullptr);
+		_analysisForm->setParentItem(	nullptr);
+
+		delete _analysisForm;
+		_analysisForm = nullptr;
+
+		emit formItemChanged();
+	}
+	else
+		Log::log(false) << " it has no AnalysisForm." << std::endl;
+}
+
+
+
+void Analysis::setAnalysisForm(AnalysisForm * analysisForm)
+{
+	if(_analysisForm == analysisForm)
+		return;
+
+	_analysisForm = analysisForm;
+	_analysisForm->setAnalysis(this);
+	_analysisForm->setParent(this);
+
+	if(formParent())
+		_analysisForm->setParentItem(formParent());
+
+	Log::log() << "AnalysisForm (" << _analysisForm << ") assigned to  " << name() << " (" << id() << ") " << std::endl;
+
+	emit formItemChanged();
 }
 
 std::string Analysis::upgradeMsgsForOption(const std::string & name) const
@@ -1077,7 +1222,7 @@ bool Analysis::needsRefresh() const
 bool Analysis::isWaitingForModule()
 {
 	//if moduleData == nullptr we might still be waiting for the module to be reloaded after replacement. Because it doesnt know which Analyses it contains yet.
-	return isDynamicModule() && (!moduleData() || !moduleData()->dynamicModule()->readyForUse());
+	return !dynamicModule()->readyForUse();
 }
 
 
@@ -1122,9 +1267,53 @@ void Analysis::setRSources(const Json::Value &rSources)
 void Analysis::setDynamicModule(Modules::DynamicModule * module)
 {
 	Log::log() << "Replacing module connected to analysis " << title() << " (" << id() << ") for module " << module->name() << std::endl;
-	_dynamicModule = module;
+	if(_dynamicModule != module)
+	{
+		if(_analysisForm)
+			destroyForm();
+
+		_dynamicModule = module;
+		emit dynamicModuleChanged();
+	}
 
 	checkAnalysisEntry();
+}
+
+void Analysis::watchQmlForm()
+{
+	if(PreferencesModel::prefs()->developerMode())
+	{
+		QString		filePath		= tq(qmlFormPath(false, true));
+
+		if(_QMLFileWatcher.files().size())
+			_QMLFileWatcher.removePaths(_QMLFileWatcher.files());
+
+		if(!_QMLFileWatcher.addPath(filePath))
+			Log::log()  << "Analysis::watchQmlForm, could not watch: " << filePath << std::endl;
+	}
+}
+
+
+void Analysis::reloadForm()
+{
+	if(form())
+		destroyForm();
+
+	if(readyToCreateForm())
+	{
+		emit emptyQMLCache();
+		emit createFormWhenYouHaveAMoment();		//Give Qml a moment to clean up
+	}
+}
+
+void Analysis::analysisQMLFileChanged()
+{
+	Log::log() << "Analysis::analysisQMLFileChanged() for " << name() << " (" << id() << ")" << std::endl;
+	
+	if(form() && form()->formCompleted())	reloadForm();
+	else if(qmlError() != "")				createForm(); //Last time it failed apparently
+	else
+		Log::log() << "Form (" << form() << ") wasn't complete " << ( form() ? std::to_string(form()->formCompleted()) : " because there was no form...") << " yet, and also did not have a QML error set yet, so ignoring it." << std::endl;
 }
 
 void Analysis::checkForRSources()
@@ -1146,11 +1335,11 @@ void Analysis::checkForRSources()
 		else if(meta.isObject())
 		{
 			//Here we collect the meta's names for collections and qmlSources
-			if(meta.isMember("type") && meta["type"].asString() == "qmlSource")
-				sourceIDs.insert(meta["name"].asString());
-
-			if(meta.isMember("type") && meta["type"].asString() == "collection")
-				isCollection.insert(meta["name"].asString());
+			if(meta.isMember("type"))
+			{
+					if(		meta["type"].asString() == "qmlSource")		sourceIDs.insert(	meta["name"].asString());
+					else if(meta["type"].asString() == "collection")	isCollection.insert(meta["name"].asString());
+			}
 
 			if(meta.isMember("meta")) //means there is an array of more meta below there
 				findNewSource(meta["meta"]);
@@ -1220,4 +1409,27 @@ void Analysis::clearRSources()
 	}
 
 	_rSources.clear();
+}
+
+QQuickItem *Analysis::formParent() const
+{
+	return _formParent;
+}
+
+QQuickItem *Analysis::formItem() const
+{
+	return _analysisForm;
+}
+
+const QString &Analysis::qmlError() const
+{
+	return _qmlError;
+}
+
+void Analysis::setQmlError(const QString &newQmlError)
+{
+	if (_qmlError == newQmlError)
+		return;
+	_qmlError = newQmlError;
+	emit qmlErrorChanged();
 }

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -32,6 +32,8 @@
 #include "data/datasetpackage.h"
 #include "utilities/qutils.h"
 #include "modules/upgrader/upgradechange.h"
+#include <QFileSystemWatcher>
+#include <QQuickItem>
 
 class ComputedColumn;
 class DataSet;
@@ -46,14 +48,18 @@ class AnalysisForm;
 class Analysis : public QObject
 {
 	Q_OBJECT
-	Q_PROPERTY(QString	name				READ nameQ											NOTIFY nameChanged				)
-	Q_PROPERTY(QString	title				READ titleQ				WRITE setTitleQ				NOTIFY titleChanged				)
-	Q_PROPERTY(QString	helpFile			READ helpFile										NOTIFY helpFileChanged			)
-	Q_PROPERTY(QString	helpMD				READ helpMD											NOTIFY helpMDChanged			)
-	Q_PROPERTY(bool		needsRefresh		READ needsRefresh									NOTIFY needsRefreshChanged		)
+	Q_PROPERTY(QString						name					READ nameQ											NOTIFY nameChanged				)
+	Q_PROPERTY(QString						title					READ titleQ				WRITE setTitleQ				NOTIFY titleChanged				)
+	Q_PROPERTY(QString						helpFile				READ helpFile										NOTIFY helpFileChanged			)
+	Q_PROPERTY(QString						helpMD					READ helpMD											NOTIFY helpMDChanged			)
+	Q_PROPERTY(bool							needsRefresh			READ needsRefresh									NOTIFY needsRefreshChanged		)
 	///Volatile notes are coupled with results elements and might disappear when the name changes. Some attempt is made to salvage them on a refresh when needsRefresh is true!
-	Q_PROPERTY(bool		hasVolatileNotes	READ hasVolatileNotes	WRITE setHasVolatileNotes	NOTIFY hasVolatileNotesChanged	)
-	Q_PROPERTY(bool		optionsBound		READ optionsBound		WRITE setOptionsBound		NOTIFY optionsBoundChanged		)
+	Q_PROPERTY(bool							hasVolatileNotes		READ hasVolatileNotes	WRITE setHasVolatileNotes	NOTIFY hasVolatileNotesChanged	)
+	Q_PROPERTY(bool							optionsBound			READ optionsBound		WRITE setOptionsBound		NOTIFY optionsBoundChanged		)
+	Q_PROPERTY(Modules::DynamicModule	*	module					READ dynamicModule									NOTIFY dynamicModuleChanged		)
+	Q_PROPERTY(QQuickItem				*	formParent				READ formParent			WRITE setFormParent			NOTIFY formParentChanged		)
+	Q_PROPERTY(QQuickItem				*	formItem				READ formItem										NOTIFY formItemChanged			)
+	Q_PROPERTY(QString						qmlError				READ qmlError			WRITE setQmlError			NOTIFY qmlErrorChanged			)
 
 	friend class Analyses;
 
@@ -61,16 +67,18 @@ class Analysis : public QObject
 
 public:
 
-	enum Status { Empty, Running, RunningImg, Complete, Aborting, Aborted, ValidationError, SaveImg, EditImg, RewriteImgs, FatalError, Initializing, KeepStatus };
-	void setStatus(Status status);
-	static std::string statusToString(Status status);
+	enum Status { Empty, Running, RunningImg, Complete, Aborting, Aborted, ValidationError, SaveImg, EditImg, RewriteImgs, FatalError, KeepStatus };
+
+	void				setStatus(Status status);
+	static std::string	statusToString(Status status);
+
 	///This function transforms an analysisResultStatus to Analysis::Status so that the Analysis gets the correct status after returning from Engine
 	static Analysis::Status analysisResultsStatusToAnalysisStatus(analysisResultStatus result);
 
-	Analysis(size_t id, Analysis * duplicateMe);
-	Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::string title = "", std::string moduleVersion = "", Json::Value *data = nullptr);
+						Analysis(size_t id, Analysis * duplicateMe);
+						Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::string title = "", std::string moduleVersion = "", Json::Value *data = nullptr);
 
-	virtual ~Analysis();
+	virtual				~Analysis();
 
 	void				clearOptions();
 	const Json::Value&	optionsFromJASPFile()		const	{ return _optionsDotJASP;	}
@@ -84,34 +92,33 @@ public:
 	Q_INVOKABLE	QString	fullHelpPath(QString helpFileName);
 	Q_INVOKABLE void	duplicateMe();
 
-	bool needsRefresh()			const;
-	bool wasUpgraded()			const { return _wasUpgraded; }
-	bool isWaitingForModule();
-	bool isDynamicModule()		const { return bool(_dynamicModule); }
-	void setResults(		const Json::Value & results, analysisResultStatus	status, const Json::Value & progress = Json::nullValue) { setResults(results, analysisResultsStatusToAnalysisStatus(status), progress); }
-	void setResults(		const Json::Value & results, Status					status, const Json::Value & progress = Json::nullValue);
-	void imageSaved(		const Json::Value & results);
-	void saveImage(			const Json::Value & options);
-	void editImage(			const Json::Value & options);
-	void imageEdited(		const Json::Value & results);
-	void imagesRewritten(	const Json::Value & results);
-	void rewriteImages();
 
-	void setRFile(const std::string &file)				{ _rfile = file;								}
-	void setRSources(const Json::Value& rSources);
-	void setUserData(Json::Value userData);
-	void setVersion(Version version, bool resetWasUpgraded = false);
-	void setRefreshBlocked(bool block)					{ _refreshBlocked = block;						}
-	void incrementRevision()							{ _revision++;									}
+	bool				needsRefresh()			const;
+	bool				wasUpgraded()			const { return _wasUpgraded; }
+	bool				isWaitingForModule();
+	void				setResults(			const Json::Value & results, analysisResultStatus	status, const Json::Value & progress = Json::nullValue) { setResults(results, analysisResultsStatusToAnalysisStatus(status), progress); }
+	void				setResults(			const Json::Value & results, Status					status, const Json::Value & progress = Json::nullValue);
+	void				imageSaved(			const Json::Value & results);
+	void				saveImage(			const Json::Value & options);
+	void				editImage(			const Json::Value & options);
+	void				imageEdited(		const Json::Value & results);
+	void				imagesRewritten(	const Json::Value & results);
+	void				rewriteImages();
 
-	void setErrorInResults(const std::string & msg);
+	void				setRFile(const std::string &file)							{ _rfile = file;								}
+	void				setRSources(const Json::Value& rSources);
+	void				setUserData(Json::Value userData);
+	void				setVersion(Version version, bool resetWasUpgraded = false);
+	void				setRefreshBlocked(bool block)								{ _refreshBlocked = block;						}
+	void				incrementRevision()											{ _revision++;									}
 
+	void				setErrorInResults(const std::string	& msg);
+	void				setFormParent(			QQuickItem		*	formParent);
 
-	Json::Value editOptionsOfPlot(const std::string & uniqueName, bool emitError = true);
-	void		setEditOptionsOfPlot(const std::string & uniqueName, const Json::Value & editOptions);
-	bool		checkAnalysisEntry();
+	Json::Value			editOptionsOfPlot(		const std::string & uniqueName, bool emitError = true);
+	void				setEditOptionsOfPlot(	const std::string & uniqueName, const Json::Value & editOptions);
+	bool				checkAnalysisEntry();
 
-	//getters
 	const	Json::Value		&	results()			const	{ return _results;							}
 	const	Json::Value		&	userData()			const	{ return _userData;							}
 	const	std::string		&	name()				const	{ return _name;								}
@@ -132,6 +139,7 @@ public:
 	const	Json::Value		&	imgResults()		const	{ return _imgResults;						}
 	Modules::DynamicModule	*	dynamicModule()		const	{ return _dynamicModule;					}
 			AnalysisForm	*	form()				const	{ return _analysisForm;						}
+			bool				hasForm()			const	{ return _analysisForm;						}
 			bool				isDuplicate()		const	{ return _isDuplicate;						}
 			bool				hasVolatileNotes()	const	{ return _hasVolatileNotes;					}
 			bool				utilityRunAllowed() const	{ return  isSaveImg() || isEditImg() || isRewriteImgs();									}
@@ -143,7 +151,7 @@ public:
 
 			void		run();
 			void		refresh();
-			void		reload();
+			void		reloadForm();
 			void        exportResults();
 			void		remove();
 
@@ -156,6 +164,7 @@ public:
 
 	bool isEmpty()			const { return status() == Empty;		}
 	bool isAborted()		const { return status() == Aborted;		}
+	bool isAborting()		const { return status() == Aborting;	}
 	bool isSaveImg()		const { return status() == SaveImg;		}
 	bool isRewriteImgs()	const { return status() == RewriteImgs;	}
 	bool isEditImg()		const { return status() == EditImg;		}
@@ -163,134 +172,150 @@ public:
 	bool isFinished()		const { return status() == Complete || status() == ValidationError || status() == FatalError; }
 
 
-	void initialized(AnalysisForm* form, bool isNewAnalysis);
+	void formConnect();
 
-	performType				desiredPerformTypeFromAnalysisStatus() const;
-	std::string				qmlFormPath() const;
+	performType				desiredPerformTypeFromAnalysisStatus()										const;
+	std::string				qmlFormPath(bool addFileProtocol = true, bool ignoreReadyForUse = false)	const;
 
-	std::set<std::string>	usedVariables();
-	void					runScriptRequestDone(const QString& result, const QString& controlName);
+	stringset				usedVariables();
+	void					runScriptRequestDone(const QString & result, const QString & controlName);
 
 	void					setUpgradeMsgs(const Modules::UpgradeMsgs & msgs);
-	std::string				upgradeMsgsForOption(const std::string & name)		const;
+	std::string				upgradeMsgsForOption(const std::string & name)	const;
 
-	const QList<std::string>	& computedColumns()								const	{ return _computedColumns; }
-	const Json::Value			& getRSource(const std::string& name)			const	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }
-	Json::Value				rSources()											const;
-	
+	const QList<std::string>	&	computedColumns()						const	{ return _computedColumns; }
+	const Json::Value			&	getRSource(const std::string & name)	const	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }
+	Json::Value						rSources()								const;
+	QQuickItem					*	formParent()							const;
+	QQuickItem					*	formItem()								const;
+
+	const QString &qmlError() const;
+	void setQmlError(const QString &newQmlError);
+
 signals:
-	void				nameChanged();
-	void				helpFileChanged();
-	void				helpMDChanged();
-	void				titleChanged();
-	void				needsRefreshChanged();
-	void				hasVolatileNotesChanged(bool hasVolatileNotes);
+	void					nameChanged();
+	void					helpFileChanged();
+	void					helpMDChanged();
+	void					titleChanged();
+	void					needsRefreshChanged();
+	void					hasVolatileNotesChanged(bool hasVolatileNotes);
+	void					dynamicModuleChanged();
 
-	void				sendRScript(			Analysis * analysis, QString script, QString controlName, bool whiteListedVersion);
-	void				statusChanged(			Analysis * analysis);
-	void				imageSavedSignal(		Analysis * analysis);
-	void				imageEditedSignal(		Analysis * analysis);
-	void				resultsChangedSignal(	Analysis * analysis);
-	void				userDataChangedSignal(	Analysis * analysis);
-	void				imageChanged();
-	void				rSourceChanged(QString optionName);
+	void					sendRScript(			Analysis * analysis, QString script, QString controlName, bool whiteListedVersion);
+	void					statusChanged(			Analysis * analysis);
+	void					imageSavedSignal(		Analysis * analysis);
+	void					imageEditedSignal(		Analysis * analysis);
+	void					resultsChangedSignal(	Analysis * analysis);
+	void					userDataChangedSignal(	Analysis * analysis);
+	void					imageChanged();
+	void					rSourceChanged(QString optionName);
 
-	ComputedColumn *	requestComputedColumnCreation(		const std::string& columnName, Analysis * analysis);
-	void				requestColumnCreation(				const std::string& columnName, Analysis *source, columnType type);
-	void				requestComputedColumnDestruction(	const std::string& columnName);
+	ComputedColumn		*	requestComputedColumnCreation(		const std::string& columnName, Analysis * analysis);
+	void					requestColumnCreation(				const std::string& columnName, Analysis *source, columnType type);
+	void					requestComputedColumnDestruction(	const std::string& columnName);
 
-	void				refreshTableViewModels();
-	Q_INVOKABLE void	expandAnalysis();
+	void					refreshTableViewModels();
+	Q_INVOKABLE void		expandAnalysis();
+	void					emptyQMLCache();
+	void					optionsBoundChanged(bool optionsBound);
 
+	void					formParentChanged();
+	void					formItemChanged();
 
-
-
-	void optionsBoundChanged(bool optionsBound);
+	void					qmlErrorChanged();
+	void					createFormWhenYouHaveAMoment();
 
 public slots:
-	void					setName(std::string name);
-	void					setNameQ(QString name) { setName(name.toStdString()); }
-	void					setHelpFile(QString helpFile);
-	void					setTitleQ(QString title);
-	void					setTitle(std::string title) { setTitleQ(tq(title)); }
-	void					setHasVolatileNotes(bool hasVolatileNotes);
-	void					setDynamicModule(Modules::DynamicModule * module);
+	void					setName(			std::string name);
+	void					setNameQ(			QString		name) { setName(name.toStdString()); }
+	void					setHelpFile(		QString		helpFile);
+	void					setTitleQ(			QString		title);
+	void					setTitle(			std::string title) { setTitleQ(tq(title)); }
+	void					setHasVolatileNotes(bool		hasVolatileNotes);
+	void					setDynamicModule(	Modules::DynamicModule * module);
 	void					emitDuplicationSignals();
 	void					showDependenciesOnQMLForObject(QString uniqueName); //uniqueName is basically "name" in meta in results.
 	void					setOptionsBound(bool optionsBound);
 	void					boundValueChangedHandler();
-	ComputedColumn *		requestComputedColumnCreationHandler(const std::string& columnName);
-	void					requestColumnCreationHandler(const std::string&columnName, columnType colType)	{ requestColumnCreation(columnName, this, colType); }
-	void					requestComputedColumnDestructionHandler(const std::string& columnName);
-
+	ComputedColumn *		requestComputedColumnCreationHandler(	const std::string & columnName);
+	void					requestColumnCreationHandler(			const std::string & columnName, columnType colType)	{ emit requestColumnCreation(columnName, this, colType); }
+	void					requestComputedColumnDestructionHandler(const std::string & columnName);
+	void					analysisQMLFileChanged();
 
 protected:
 	void					abort();
-	void					addOwnComputedColumn(const std::string& col)				{ _computedColumns.push_back(col); }
-	void					removeOwnComputedColumn(const std::string& col)				{ _computedColumns.removeAll(col); }
+	void					addOwnComputedColumn(	const std::string & col)	{ _computedColumns.push_back(col); }
+	void					removeOwnComputedColumn(const std::string & col)	{ _computedColumns.removeAll(col); }
+	void					watchQmlForm();
+
+private slots:
+	void					destroyForm();
+	void					createForm();
 
 private:
 	void					processResultsForDependenciesToBeShown();
 	bool					processResultsForDependenciesToBeShownMetaTraverser(const Json::Value & array);
-	bool					_editOptionsOfPlot(const Json::Value & results, const std::string & uniqueName, Json::Value & editOptions);
-	bool					_setEditOptionsOfPlot(Json::Value & results, const std::string & uniqueName, const Json::Value & editOptions);
+	bool					_editOptionsOfPlot(const	Json::Value & results, const std::string & uniqueName,			Json::Value & editOptions);
+	bool					_setEditOptionsOfPlot(		Json::Value & results, const std::string & uniqueName, const	Json::Value & editOptions);
 	void					storeUserDataEtc();
 	void					fitOldUserDataEtc();
 	bool					updatePlotSize(const std::string & plotName, int width, int height, Json::Value & root);
-	Modules::AnalysisEntry	*moduleData();
 	void					checkForRSources();
 	void					clearRSources();
-	Json::Value&			_getParentBoundValue(const QVector<JASPControl::ParentKey>& parentKeys, bool& found, bool createAnyway = false);
+	Json::Value&			_getParentBoundValue(const QVector<JASPControl::ParentKey> & parentKeys, bool & found, bool createAnyway = false);
+	void					initAnalysis();
+	void					setAnalysisForm(AnalysisForm	* analysisForm);
+	bool					readyToCreateForm() const;
 
 protected:
-	Status					_status			= Initializing;
-	bool					_refreshBlocked	= false;
-
-	Json::Value				_boundValues 	= Json::objectValue;
-
-
-	///For backward compatibility: _optionsDotJASP = options from (old) JASP file.
-	Json::Value				_optionsDotJASP = Json::nullValue,
-							_results		= Json::nullValue,
-							_resultsMeta	= Json::nullValue,
-							_imgResults		= Json::nullValue,
-							_userData		= Json::nullValue,
-							_imgOptions		= Json::nullValue,
-							_progress		= Json::nullValue,
-							_oldUserData	= Json::nullValue,
-							_oldMetaData	= Json::nullValue;
-	std::string				_oldVersion		= "0";
+	Status						_status				= Empty;
+	bool						_refreshBlocked		= false;
+	Json::Value					_boundValues		= Json::objectValue,
+								_optionsDotJASP		= Json::nullValue, ///< For backward compatibility: _optionsDotJASP = options from (old) JASP file.
+								_results			= Json::nullValue,
+								_resultsMeta		= Json::nullValue,
+								_imgResults			= Json::nullValue,
+								_userData			= Json::nullValue,
+								_imgOptions			= Json::nullValue,
+								_progress			= Json::nullValue,
+								_oldUserData		= Json::nullValue,
+								_oldMetaData		= Json::nullValue;
+	std::string					_oldVersion			= "0";
 
 private:
-	size_t					_id,
-							_counter		= 0;
-	std::string				_name,
-							_qml,
-							_titleDefault,
-							_title,
-							_rfile,
-							_showDepsName		= "",
-							_moduleVersion		= "";
-	bool					_isDuplicate		= false,
-							_wasUpgraded		= false,
-							_hasVolatileNotes	= false,
-							_tryToFixNotes		= false,
-							_optionsBound		= false;
-	Version					_version;
-	int						_revision		= 0;
+	size_t						_id,
+								_counter			= 0;
+	std::string					_name,
+								_qml,
+								_titleDefault,
+								_title,
+								_rfile,
+								_showDepsName		= "",
+								_moduleVersion		= "",
+								_lastQmlFormPath	= "",
+								_codedAnalysisEntry = "";
+	bool						_isDuplicate		= false,
+								_wasUpgraded		= false,
+								_hasVolatileNotes	= false,
+								_tryToFixNotes		= false,
+								_optionsBound		= false;
+	Version						_version;
+	int							_revision			= 0;
 
-	Modules::AnalysisEntry*	_moduleData		= nullptr;
-	Modules::DynamicModule* _dynamicModule	= nullptr;
-	AnalysisForm*			_analysisForm	= nullptr;
-	QList<std::string>		_computedColumns;
+	Modules::AnalysisEntry	*	_moduleData			= nullptr;
+	Modules::DynamicModule	*	_dynamicModule		= nullptr;
+	AnalysisForm			*	_analysisForm		= nullptr;
+	QQuickItem				*	_formParent			= nullptr;
+	QList<std::string>			_computedColumns;
+	QFileSystemWatcher			_QMLFileWatcher;
 
-	std::string				_codedReferenceToAnalysisEntry = "";
-	QString					_helpFile;
+	QString						_helpFile,
+								_qmlError;
 
-	Modules::UpgradeMsgs	_msgs;
+	Modules::UpgradeMsgs		_msgs;
 
 	std::map<std::string,
-		Json::Value>		_rSources;
+	Json::Value>				_rSources;
 };
 
 #endif // ANALYSIS_H

--- a/Desktop/analysis/knownissues.cpp
+++ b/Desktop/analysis/knownissues.cpp
@@ -32,7 +32,10 @@ void KnownIssues::loadLocalJson(const std::string & filePath, bool saveIt)
 void KnownIssues::loadJson(const std::string & jsonTxt,	bool saveIt)
 {
 	if(jsonTxt == "") 
+	{
 		MessageForwarder::showWarning(tr("Problem loading known issues"), tr("JASP ran into a problem downloading the known issues for this version, it probably could not connect to the server. Don't worry, JASP will work fine it just might not tell you about a few small known issues."));
+		return;
+	}
 	
 	Json::Value known;
 	if(Json::Reader().parse(jsonTxt, known))	loadJson(known, saveIt);

--- a/Desktop/components/JASP/Controls/Form.qml
+++ b/Desktop/components/JASP/Controls/Form.qml
@@ -36,8 +36,7 @@ AnalysisForm
 	property int	majorVersion		: 1
 	property int	minorVersion		: 0
 	property int	availableWidth		: form.width - 2 * jaspTheme.formMargin
-					analysis			: myAnalysis
-	property var	backgroundForms		: backgroundFlickable
+	property var	backgroundForms		: undefined
 	property alias	columns				: contentArea.columns
 	property bool	runAnalysisWhenOptionChange : true
 
@@ -69,7 +68,7 @@ AnalysisForm
 		Rectangle
 		{
 			id:				oldFileMessagesBox
-			visible:		myAnalysis !== null && myAnalysis.needsRefresh && myAnalysis.hasVolatileNotes //Ill leave the text as is for now to avoid having to go back to the po again
+			visible:		form.analysis !== null && form.analysis.needsRefresh && form.analysis.hasVolatileNotes //Ill leave the text as is for now to avoid having to go back to the po again
 			color:			jaspTheme.controlWarningBackgroundColor
 			width:			form.implicitWidth
 			height:			visible ? oldAnalysisText.height : 0
@@ -86,7 +85,7 @@ AnalysisForm
 				width:				parent.width - 10 * jaspTheme.uiScale
 				verticalAlignment:	Text.AlignVCenter
 				text:				qsTr("This analysis was created with an older version of JASP (or a dynamic module)") + //I do not want to bother with formatting strings here to be honest
-									( myAnalysis !== null && !myAnalysis.hasVolatileNotes ?
+									( form.analysis !== null && !form.analysis.hasVolatileNotes ?
 										qsTr(", refreshing could give a slightly different result.") :
 										qsTr(", to keep your notes where they are it is highly recommended to first refresh your analyses!"))
 
@@ -178,14 +177,5 @@ AnalysisForm
 		}
 	}
 	
-	Timer
-	{
-		id:				bindingTimer
-		running:		false
-		repeat:			false
-		interval:		0
-		onTriggered:	formCompleted();
-	}
-	
-	Component.onCompleted:	bindingTimer.start()
+	Component.onCompleted:	formCompletedSignal();
 }

--- a/Desktop/components/JASP/Widgets/AnalysisForms.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisForms.qml
@@ -190,7 +190,6 @@ FocusScope
 						{
 							myIndex:				index
 							myAnalysis:				model.analysis
-							formQmlUrl:				model.formPath
 							backgroundFlickable:	analysesFlickable
 						}
 					}

--- a/Desktop/components/JASP/Widgets/EnginesWindow.qml
+++ b/Desktop/components/JASP/Widgets/EnginesWindow.qml
@@ -1,0 +1,106 @@
+import QtQuick			2.12
+import QtQuick.Window	2.12
+import QtWebEngine		1.8
+import JASP.Widgets		1.0
+import JASP.Controls	1.0
+
+Window
+{
+	id:					enginesWindow
+	width:				400 * jaspTheme.uiScale
+	height:				Screen.height
+	minimumWidth:		200 * preferencesModel.uiScale
+	minimumHeight:		minimumWidth
+	title:				qsTr("Engines Overview")
+	color:				jaspTheme.uiBackground
+	visible:			true
+	x:					0
+	y:					0
+
+	Shortcut { onActivated: enginesWindow.close();				sequences: ["Ctrl+W", Qt.Key_Close];							}
+
+
+	Connections
+	{
+		target:			mainWindow
+		function onCloseWindows() { enginesWindow.close(); }
+	}
+
+
+	ListView
+	{
+		anchors.fill:	parent
+		model:			engineSync
+
+
+		delegate:	Item
+		{
+
+			height:			150 * jaspTheme.uiScale
+			width:			ListView.view.width
+
+			Rectangle
+			{
+				color:					jaspTheme.uiBackground
+				border.color:			jaspTheme.uiBorder
+				border.width:			1
+				radius:					jaspTheme.borderRadius * 2
+
+				anchors.fill:			parent
+				anchors.margins:		jaspTheme.generalAnchorMargin
+
+				Text
+				{
+					text:				model.display + "\nState: " + model.engineState + "\nModule: " + model.module + (model.analysisStatus === "NA" ? "" : "\nAnalysis Status: " + model.analysisStatus)
+					font.pixelSize:		20 * jaspTheme.uiScale
+					font.bold:			true
+					anchors
+					{
+						left:			parent.left
+						leftMargin:		jaspTheme.generalAnchorMargin
+						verticalCenter: parent.verticalCenter
+					}
+				}
+
+				Rectangle
+				{
+					height: parent.height * 0.5
+					width:	height
+					radius: height
+
+					border.color:		jaspTheme.black
+					border.width:		6 * jaspTheme.uiScale
+					color:				model.idle ? "green" : model.analysisStatus !== "NA" ? jaspTheme.jaspBlue : model.idleSoon ? "yellow" : "orange"
+
+					anchors
+					{
+						right:			parent.right
+						rightMargin:	jaspTheme.generalAnchorMargin
+						verticalCenter:	parent.verticalCenter
+					}
+			}
+		}
+
+		JASPMouseAreaToolTipped
+		{
+			acceptedButtons:	Qt.MiddleButton
+
+			toolTipText:		qsTr("Middle mouse button to kill an engine.")
+
+
+
+			onClicked: (mouse) =>
+			{
+				messages.log("engine pressed " + model.engineState + " #" + model.channel);
+				if(mouse.button == Qt.MiddleButton)
+				{
+					//messages.log("killing!");
+					engineSync.killEngine(model.channel);
+				}
+			}
+		}
+
+
+	}
+}
+}

--- a/Desktop/components/JASP/Widgets/EnginesWindow.qml
+++ b/Desktop/components/JASP/Widgets/EnginesWindow.qml
@@ -64,7 +64,7 @@ Window
 
 				Rectangle
 				{
-					height: parent.height * 0.5
+					height: parent.height * 0.4
 					width:	height
 					radius: height
 
@@ -79,20 +79,21 @@ Window
 						verticalCenter:	parent.verticalCenter
 					}
 			}
+				
 		}
 
 		JASPMouseAreaToolTipped
 		{
-			acceptedButtons:	Qt.MiddleButton
+			acceptedButtons:	Qt.MiddleButton | Qt.RightButton
 
-			toolTipText:		qsTr("Middle mouse button to kill an engine.")
+			toolTipText:		qsTr("Right and middle mouse button to kill an engine.")
 
 
 
 			onClicked: (mouse) =>
 			{
 				messages.log("engine pressed " + model.engineState + " #" + model.channel);
-				if(mouse.button == Qt.MiddleButton)
+				if(mouse.button == Qt.MiddleButton || mouse.button == Qt.RightButton)
 				{
 					//messages.log("killing!");
 					engineSync.killEngine(model.channel);

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -335,7 +335,7 @@ ScrollView
 				stepSize:			1
 				KeyNavigation.tab:	showEnginesWindow
 				KeyNavigation.down:	showEnginesWindow
-				text:				qsTr("Maximum # of engines: ")
+				text:				qsTr("Maximum number of engines: ")
 			}
 
 			RoundedButton

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -333,9 +333,18 @@ ScrollView
 				to:					16
 				defaultValue:		4
 				stepSize:			1
+				KeyNavigation.tab:	showEnginesWindow
+				KeyNavigation.down:	showEnginesWindow
+				text:				qsTr("Maximum # of engines: ")
+			}
+
+			RoundedButton
+			{
+				id:					showEnginesWindow
+				text:				qsTr("Show engines")
+				onClicked:			mainWindow.showEnginesWindow()
 				KeyNavigation.tab:	rememberModulesSelected
 				KeyNavigation.down:	rememberModulesSelected
-				text:				qsTr("Maximum # of engines: ")
 			}
 			
 		}

--- a/Desktop/components/JASP/Widgets/LoadingIndicator.qml
+++ b/Desktop/components/JASP/Widgets/LoadingIndicator.qml
@@ -6,10 +6,38 @@ Item
 	implicitWidth:	200
 	implicitHeight: 200
 
+	property bool autoStartOnVisibility:	true
+	property bool runningManually:			false;
+
+	function startManually()
+	{
+		if(container.autoStartOnVisibility)
+		{
+			//console.log("LoadingIndicator ignores manual start/stop if autoStartOnVisibility is true");
+			return;
+		}
+
+		runningManually = true;
+		img.run = 0;
+		anim.start();
+	}
+
+	function stopManually()
+	{
+		if(container.autoStartOnVisibility)
+		{
+			//console.log("LoadingIndicator ignores manual start/stop if autoStartOnVisibility is true");
+			return;
+		}
+
+		runningManually = false;
+		anim.stop();
+	}
+
 	Image
 	{
 		id						: img
-		source					: visible ? jaspTheme.iconPath + "/loading.svg" : ""
+		source					: visible || runningManually ? jaspTheme.iconPath + "/loading.svg" : ""
 		sourceSize.width		: width
 		sourceSize.height		: width
 		height					: width
@@ -23,10 +51,13 @@ Item
 
 		onVisibleChanged: 	startStopIfVisible();
 		ListView.onReused:	startStopIfVisible();
-		ListView.onPooled:	anim.stop()
+		ListView.onPooled:	if(container.autoStartOnVisibility) anim.stop()
 
 		function startStopIfVisible()
 		{
+			if(!container.autoStartOnVisibility)
+				return;
+
 			if ( visible && !anim.running)
 			{
 				run = 0;
@@ -44,7 +75,7 @@ Item
 			loops		: 1
 
 			onFinished :
-				if(visible)
+				if(visible || ( !container.autoStartOnVisibility && container.runningManually))
 				{
 					img.run ++;
 					img.run %= img.segments

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -189,7 +189,9 @@ Item
 				width:					giveResultsSomeSpace.width - panelSplit.hackySplitHandlerHideWidth
 
 				url:					resultsJsInterface.resultsPageUrl
-				onContextMenuRequested: (request)=>{ request.accepted = true; }
+
+				onContextMenuRequested: (request) => request.accepted = true
+
 				backgroundColor:		jaspTheme.uiBackground
 
 				Keys.onPressed: (event) =>

--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -85,19 +85,20 @@ Window
 		anchors.fill:	parent
 		focus:			true
 
-		Shortcut { onActivated: mainWindow.saveKeyPressed();					sequences: ["Ctrl+S", Qt.Key_Save];								}
-		Shortcut { onActivated: mainWindow.openKeyPressed();					sequences: ["Ctrl+O"];											}
-		Shortcut { onActivated: mainWindow.syncKeyPressed();					sequences: ["Ctrl+Y", Qt.Key_Reload];							}
+		Shortcut { onActivated: mainWindow.showEnginesWindow();					sequences: ["Ctrl+Alt+Shift+E"];								context: Qt.ApplicationShortcut; }
+		Shortcut { onActivated: mainWindow.saveKeyPressed();					sequences: ["Ctrl+S", Qt.Key_Save];								context: Qt.ApplicationShortcut; }
+		Shortcut { onActivated: mainWindow.openKeyPressed();					sequences: ["Ctrl+O"];											context: Qt.ApplicationShortcut; }
+		Shortcut { onActivated: mainWindow.syncKeyPressed();					sequences: ["Ctrl+Y", Qt.Key_Reload];							context: Qt.ApplicationShortcut; }
 		Shortcut { onActivated: mainWindow.zoomInKeyPressed();					sequences: [Qt.Key_ZoomIn, "Ctrl+Plus", "Ctrl+\+", "Ctrl+\="];	context: Qt.ApplicationShortcut; }
 		Shortcut { onActivated: mainWindow.zoomOutKeyPressed();					sequences: [Qt.Key_ZoomOut, "Ctrl+Minus", "Ctrl+\-"];			context: Qt.ApplicationShortcut; }
-		Shortcut { onActivated: mainWindow.refreshKeyPressed();					sequences: ["Ctrl+R", Qt.Key_Refresh];							}
 		Shortcut { onActivated: mainWindow.zoomResetKeyPressed();				sequences: ["Ctrl+0", Qt.Key_Zoom];								context: Qt.ApplicationShortcut; }
-		Shortcut { onActivated: mainWindowRoot.close();							sequences: ["Ctrl+Q", Qt.Key_Close];							}
+		Shortcut { onActivated: mainWindow.refreshKeyPressed();					sequences: ["Ctrl+R", Qt.Key_Refresh];							context: Qt.ApplicationShortcut; }
+		Shortcut { onActivated: mainWindowRoot.close();							sequences: ["Ctrl+Q", Qt.Key_Close];							context: Qt.ApplicationShortcut; }
 		Shortcut { onActivated: fileMenuModel.close();							sequences: ["Ctrl+W"];											}
 		Shortcut { onActivated: mainWindowRoot.toggleFullScreen();				sequences: ["Ctrl+M", Qt.Key_F11];								context: Qt.ApplicationShortcut; }
 		Shortcut { onActivated: mainWindowRoot.changeFocusToFileMenu();			sequences: ["Home",   Qt.Key_Home, Qt.Key_Menu];				}
-		Shortcut { onActivated: mainWindow.setLanguage(0);						sequences: ["Ctrl+1"];											}
-		Shortcut { onActivated: mainWindow.setLanguage(1);						sequences: ["Ctrl+2"];											}
+		Shortcut { onActivated: mainWindow.setLanguage(0);						sequences: ["Ctrl+1"];											context: Qt.ApplicationShortcut; }
+		Shortcut { onActivated: mainWindow.setLanguage(1);						sequences: ["Ctrl+2"];											context: Qt.ApplicationShortcut; }
 
 		RibbonBar
 		{

--- a/Desktop/components/JASP/Widgets/MessageBox.qml
+++ b/Desktop/components/JASP/Widgets/MessageBox.qml
@@ -170,7 +170,7 @@ Popup
 
 	function showWarning(warningTitle, warningText)
 	{
-		console.log("Showing warning with title '" + warningTitle + "' and msg '" + warningText + "'")
+		messages.log("Showing warning with title '" + warningTitle + "' and msg '" + warningText + "'")
 
 		messageText.text	= warningText
 		title.text			= warningTitle
@@ -184,7 +184,7 @@ Popup
 
 	function showMessage(messageTitle, message)
 	{
-		console.log("Showing message with title '" + messageTitle + "' and msg '" + message + "'")
+		messages.log("Showing message with title '" + messageTitle + "' and msg '" + message + "'")
 
 		messageText.text	= message
 		title.text			= messageTitle
@@ -199,7 +199,7 @@ Popup
 
 	function showYesNo(messageTitle, message)
 	{
-		console.log("Showing messageBox with Yes/No with title '" + messageTitle + "' and msg '" + message + "'")
+		messages.log("Showing messageBox with Yes/No with title '" + messageTitle + "' and msg '" + message + "'")
 
 		messageText.text	= message
 		title.text			= messageTitle
@@ -213,7 +213,7 @@ Popup
 
 	function showSaveDiscardCancel(messageTitle, message)
 	{
-		console.log("Showing messageBox with SaveDiscardCancel with title '" + messageTitle + "' and msg '" + message + "'")
+		messages.log("Showing messageBox with SaveDiscardCancel with title '" + messageTitle + "' and msg '" + message + "'")
 
 		messageText.text	= message
 		title.text			= messageTitle

--- a/Desktop/components/JASP/Widgets/RCommanderWindow.qml
+++ b/Desktop/components/JASP/Widgets/RCommanderWindow.qml
@@ -305,7 +305,7 @@ Window
 				anchors
 				{
 					top:		parent.verticalCenter
-					right:		parent.right
+					left:		parent.left
 					bottom:		parent.bottom
 					margins:	jaspTheme.generalAnchorMargin
 					topMargin:	jaspTheme.generalAnchorMargin * 0.5

--- a/Desktop/components/JASP/Widgets/RCommanderWindow.qml
+++ b/Desktop/components/JASP/Widgets/RCommanderWindow.qml
@@ -297,7 +297,7 @@ Window
 
 			JW.RoundedButton
 			{
-				id:		clearOutput
+				id:			clearOutput
 				text:		qsTr("Clear Output")
 				onClicked:	rCmd.output = qsTr("Cleared...");
 				width:		Math.max(clearOutput.implicitWidth, runButton.implicitWidth)
@@ -305,7 +305,7 @@ Window
 				anchors
 				{
 					top:		parent.verticalCenter
-					left:		parent.left
+					right:		parent.right
 					bottom:		parent.bottom
 					margins:	jaspTheme.generalAnchorMargin
 					topMargin:	jaspTheme.generalAnchorMargin * 0.5

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -60,7 +60,7 @@ Rectangle
 		}
 		else if (event.key === Qt.Key_Return || event.key === Qt.Key_Space)
 		{
-			if (ribbonButton.enabled)
+			if (ribbonButton.enabled && ribbonButton.ready)
 			{
 				if (ribbonButton.menu.rowCount() > 1) {
 					ribbonButton.showMyMenu();
@@ -70,7 +70,7 @@ Rectangle
 		}
 		else if (event.key === Qt.Key_Down)
 		{
-			if (ribbonButton.enabled && ribbonButton.menu.rowCount() > 1)
+			if (ribbonButton.ready && ribbonButton.enabled && ribbonButton.menu.rowCount() > 1)
 				ribbonButton.showMyMenu();
 			event.accepted = true;
 		}
@@ -89,6 +89,7 @@ Rectangle
 
 	function showMyMenu()
 	{
+
 		if (ribbonButton.menu.rowCount() === 0) //Probably special?
 		{
 			customMenu.hide()
@@ -248,6 +249,8 @@ Rectangle
 
 			onClicked: (mouse)=>
 			{
+				if(!ribbonButton.ready) return; //Be patient!
+
 				fileMenuModel.visible	= false;
 				modulesMenu.opened		= false;
 				ribbon.focusOutFileMenu();

--- a/Desktop/components/JASP/Widgets/qmldir
+++ b/Desktop/components/JASP/Widgets/qmldir
@@ -50,4 +50,4 @@ ImageInverter				1.0 ImageInverter.qml
 PlotEditor                  1.0 PlotEditor/PlotEditor.qml
 FactorsList					1.0 FactorsList.qml
 FactorsForm					1.0 FactorsForm.qml
-
+EnginesWindow				1.0 EnginesWindow.qml

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -54,8 +54,8 @@ void DataSetPackage::setEngineSync(EngineSync * engineSync)
 	_engineSync = engineSync;
 
 	//These signals should *ONLY* be called from a different thread than _engineSync!
-	connect(this,	&DataSetPackage::pauseEnginesSignal,	_engineSync,	&EngineSync::pauseEngines,	Qt::BlockingQueuedConnection);
-	connect(this,	&DataSetPackage::resumeEnginesSignal,	_engineSync,	&EngineSync::resumeEngines,	Qt::BlockingQueuedConnection);
+	connect(this,	&DataSetPackage::enginesPrepareForDataSignal,	_engineSync,	&EngineSync::enginesPrepareForData,	Qt::BlockingQueuedConnection);
+	connect(this,	&DataSetPackage::enginesReceiveNewDataSignal,	_engineSync,	&EngineSync::enginesReceiveNewData,	Qt::BlockingQueuedConnection);
 
 	reset();
 }
@@ -65,16 +65,16 @@ bool DataSetPackage::isThisTheSameThreadAsEngineSync()
 	return	QThread::currentThread() == _engineSync->thread();
 }
 
-void DataSetPackage::pauseEngines()
+void DataSetPackage::enginesPrepareForData()
 {
-	if(isThisTheSameThreadAsEngineSync())	_engineSync->pauseEngines(true);
-	else									emit pauseEnginesSignal(true);
+	if(isThisTheSameThreadAsEngineSync())	_engineSync->enginesPrepareForData();
+	else									emit enginesPrepareForDataSignal();
 }
 
-void DataSetPackage::resumeEngines()
+void DataSetPackage::enginesReceiveNewData()
 {
-	if(isThisTheSameThreadAsEngineSync())	_engineSync->resumeEngines();
-	else									emit resumeEnginesSignal();
+	if(isThisTheSameThreadAsEngineSync())	_engineSync->enginesReceiveNewData();
+	else									emit enginesReceiveNewDataSignal();
 
 	ColumnEncoder::setCurrentColumnNames(getColumnNames()); //Same place as in engine, should be fine right?
 }
@@ -934,11 +934,7 @@ void DataSetPackage::beginLoadingData()
 {
 	JASPTIMER_SCOPE(DataSetPackage::beginLoadingData);
 
-	_enginesLoadedAtBeginSync = !enginesInitializing();
-
-	if(_enginesLoadedAtBeginSync)
-		pauseEngines();
-
+	enginesPrepareForData();
 	beginResetModel();
 }
 
@@ -948,9 +944,7 @@ void DataSetPackage::endLoadingData()
 
 	regenerateInternalPointers();
 	endResetModel();
-
-	if(_enginesLoadedAtBeginSync)
-		resumeEngines();
+	enginesReceiveNewData();
 
 	emit modelInit();
 	emit dataSetChanged();
@@ -1506,15 +1500,14 @@ bool DataSetPackage::createColumn(std::string name, columnType columnType)
 
 	size_t newColumnIndex	= columnCount();
 
+	enginesPrepareForData();
 	beginResetModel();
 	setDataSetColumnCount(newColumnIndex + 1);
 
 	_dataSet->columns().initializeColumnAs(newColumnIndex, name)->setDefaultValues(columnType);
 	regenerateInternalPointers();
 	endResetModel();
-
-	pauseEngines();
-	resumeEngines();
+	enginesReceiveNewData();
 
 	return true;
 }

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -90,6 +90,8 @@ public:
 
 		void				pauseEngines();
 		void				resumeEngines();
+		void				enginesPrepareForData();
+		void				enginesReceiveNewData();
 		bool				enginesInitializing()	{ return emit enginesInitializingSignal();	}
 
 		SubNodeModel	*	dataSubModel	() { return _dataSubModel;	 }
@@ -276,8 +278,8 @@ signals:
 				void				columnDataTypeChanged(	QString columnName);
 				void				labelsReordered(		QString columnName);
 				void				isModifiedChanged();
-				void				pauseEnginesSignal(bool unloadData);
-				void				resumeEnginesSignal();
+				void				enginesPrepareForDataSignal();
+				void				enginesReceiveNewDataSignal();
 				bool				enginesInitializingSignal();
 				void				freeDatasetSignal(DataSet * dataset);
 				void				filteredOutChanged(int column);
@@ -330,8 +332,7 @@ private:
 								_isLoaded					= false,
 								_hasAnalysesWithoutData		= false,
 								_analysesHTMLReady			= false,
-								_filterShouldRunInit		= false,
-								_enginesLoadedAtBeginSync;
+								_filterShouldRunInit		= false;
 
 	Json::Value					_analysesData;
 	Version						_archiveVersion,

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -5,8 +5,8 @@
 #include "utils.h"
 #include "log.h"
 
-EngineRepresentation::EngineRepresentation(IPCChannel * channel, QProcess * slaveProcess, QObject * parent)
-	: QObject(parent), _channel(channel)
+EngineRepresentation::EngineRepresentation(size_t channelNumber, QProcess * slaveProcess, QObject * parent)
+	: QObject(parent), _channelNumber(channelNumber)
 {
 	setSlaveProcess(slaveProcess);
 }
@@ -14,6 +14,8 @@ EngineRepresentation::EngineRepresentation(IPCChannel * channel, QProcess * slav
 
 void EngineRepresentation::setSlaveProcess(QProcess * slaveProcess)
 {
+	Log::log() << "Setting new engine process to engineRepresentation Engine #" << _channelNumber << std::endl;
+
 	_slaveCrashed = false;
 	_slaveProcess = slaveProcess;
 	_slaveProcess->setParent(this);
@@ -23,20 +25,24 @@ void EngineRepresentation::setSlaveProcess(QProcess * slaveProcess)
 
 EngineRepresentation::~EngineRepresentation()
 {
-	Log::log() << "~EngineRepresentation()" << std::endl;
+	Log::log() << "~EngineRepresentation() Engine #" << _channelNumber << std::endl;
+
 
 	if(_slaveProcess != nullptr)
 	{
 		_slaveProcess->terminate();
 		_slaveProcess->kill();
 	}
-
-	delete _channel;
-	_channel = nullptr;
 }
 
 void EngineRepresentation::cleanUpAfterClose()
 {
+	disconnect(_analysisInProgressStatusConnection); //Just in case
+
+	Analysis * runMeLater = nullptr;
+	if(_analysisAborted && (_analysisAborted->isAborted() || _analysisAborted->isAborting()))
+		runMeLater = _analysisAborted;
+
 	_analysisInProgress = nullptr;
 	_analysisAborted	= nullptr;
 	_idRemovedAnalysis	= -1;
@@ -48,6 +54,16 @@ void EngineRepresentation::cleanUpAfterClose()
 	_settingsChanged	= true;
 	_abortAndRestart	= false;
 	_lastCompColName	= "???";
+
+
+	if(_dynModName != "")
+		emit unregisterForModule(this, _dynModName);
+
+	_dynModName			= "";
+	_moduleLoaded		= "";
+
+	if(runMeLater)
+		runMeLater->run();
 }
 
 void EngineRepresentation::sendString(std::string str)
@@ -55,14 +71,17 @@ void EngineRepresentation::sendString(std::string str)
 #ifdef PRINT_ENGINE_MESSAGES
 	Log::log() << "sending to jaspEngine: " << str << "\n" << std::endl;
 #endif
-	_channel->send(str);
+	channel()->send(str);
 }
+
+
 
 void EngineRepresentation::processFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
 	Log::log() << "Engine # " << channelNumber() << " finished while in state '" << _engineState << "' " << (exitStatus == QProcess::ExitStatus::NormalExit || stopped() ? "normally" : "crashing") << " and with exitCode " << exitCode << "!" << std::endl;
 
-	_slaveProcess->deleteLater();
+	if(_slaveProcess)
+		_slaveProcess->deleteLater();
 	_slaveProcess = nullptr;
 	_slaveCrashed = exitStatus == QProcess::ExitStatus::CrashExit && !(stopped() || killed());
 
@@ -114,15 +133,14 @@ void EngineRepresentation::handleEngineCrash()
 		return;
 
 	case engineState::killed:
-		_engineState = engineState::initializing;
-		return; //It will be resumed somewhere in EngineSync::process() or thereabouts
+		return; //It will be resumed by EngineSync::restartKilledEngines()
 
 	default: //If not one of the above then let the engine crash and burn (https://www.youtube.com/watch?v=UtUpXPiSJEg)
 		emit  engineTerminated();
 		return;
 	}
 
-	_engineState = engineState::initializing;
+	setState(engineState::initializing);
 
 	emit requestEngineRestart(this); //Only for actual crashes
 }
@@ -131,41 +149,84 @@ void EngineRepresentation::clearAnalysisInProgress()
 {
 	Log::log() << "Engine " << channelNumber() << " clears current analysis in progress (" << (_analysisInProgress ? _analysisInProgress->name() : "???" ) << ")" << std::endl;
 
+	disconnect(_analysisInProgressStatusConnection);
 	_analysisInProgress = nullptr;
-	_engineState		= engineState::idle;
+	setState(engineState::idle);
 }
 
 void EngineRepresentation::setAnalysisInProgress(Analysis* analysis)
 {
 	if(_engineState == engineState::analysis)
 	{
-		if(_analysisInProgress == analysis)	return; //we are already busy with this analysis so everything is fine
-		else								throw std::runtime_error("Engine " + std::to_string(_channel->channelNumber()) + " is running another analysis. Yet you are trying to set an analysis in progress on it..");
+		if(_analysisInProgress == analysis)
+			return; //we are already busy with this analysis so everything is fine
+		else
+			throw std::runtime_error("Engine " + std::to_string(channel()->channelNumber()) + " is running another analysis. Yet you are trying to set an analysis in progress on it..");
 	}
 
-	if(_engineState != engineState::idle)	throw std::runtime_error("Engine " + std::to_string(_channel->channelNumber()) + " is not idle! Yet you are trying to set an analysis in progress on it..");
+	if(_engineState != engineState::idle)
+		throw std::runtime_error("Engine " + std::to_string(channel()->channelNumber()) + " is not idle! Yet you are trying to set an analysis in progress on it..");
+
+	if(_dynModName	!= analysis->dynamicModule()->name())
+		throw std::runtime_error("Engine " + std::to_string(channel()->channelNumber()) + " is assigned to module '" + _dynModName + "'! Yet you are trying to set an analysis from '" + analysis->dynamicModule()->name() + "' in progress on it..");
 
 	_analysisInProgress = analysis;
-	_engineState		= engineState::analysis;
+
+	setState(engineState::analysis);
+
+	_analysisInProgressStatusConnection = connect(_analysisInProgress, &Analysis::statusChanged, this, &EngineRepresentation::analysisStatusChanged);
+
+}
+
+void EngineRepresentation::setDynamicModule(const std::string & name)
+{
+	if(!_runsAnalysis)
+		throw std::runtime_error("Cannot register engine " + std::to_string(channelNumber()) + " for dynamic module '" + name + "' to engine not meant for analyses!");
+
+	_dynModName		= name;
+	_moduleLoaded	= false;
+}
+
+void EngineRepresentation::moduleLoad()
+{
+	if(_dynModName == "" || moduleLoaded() || moduleLoading())
+		return;
+
+
+	if(!idle())
+		return;
+
+	runModuleLoadRequestOnProcess(Modules::DynamicModules::dynMods()->dynamicModule(_dynModName)->requestJsonForPackageLoadingRequest());
 }
 
 void EngineRepresentation::processReplies()
 {
-	if (_engineState == engineState::idle)
+	if(!channel())
 	{
+		Log::log() << "EngineRepresentation::processReplies() for engine #" << channelNumber() << " called but no channel available." << std::endl;
+		return;
+	}
+
+	if(!_slaveProcess)
+		return; //No point in receiving replies from an engine that isn't running is there?
+
+	if(_engineState == engineState::idle)
+	{
+
 		if		(_stopRequested)	sendStopEngine();
 		else if	(_pauseRequested)	sendPauseEngine();
-		
-		if(_idleStartSecs == -1)	_idleStartSecs = Utils::currentSeconds();
- 
+
+		if(_idleStartSecs == -1)
+			_idleStartSecs = Utils::currentSeconds();
+
 		return;
-	} 
-	
+	}
+
 	_idleStartSecs = -1;
 
 	std::string data;
 
-	if (_channel->receive(data))
+	if (channel()->receive(data))
 	{
 #ifdef PRINT_ENGINE_MESSAGES
 		{
@@ -192,26 +253,40 @@ void EngineRepresentation::processReplies()
 
 		engineState typeRequest = engineStateFromString(json.get("typeRequest", "analysis").asString());
 
-		switch(typeRequest)
+		if(_engineState == engineState::initializing)
 		{
-		case engineState::filter:				processFilterReply(json);			break;
-		case engineState::rCode:				processRCodeReply(json);			break;
-		case engineState::analysis:				processAnalysisReply(json);			break;
-		case engineState::computeColumn:		processComputeColumnReply(json);	break;
-		case engineState::paused:				processEnginePausedReply();			break;
-		case engineState::resuming:				processEngineResumedReply();		break;
-		case engineState::stopped:				processEngineStoppedReply();		break;
-		case engineState::moduleInstallRequest:
-		case engineState::moduleLoadRequest:	processModuleRequestReply(json);	break;
-		case engineState::logCfg:				processLogCfgReply();				break;
-		case engineState::settings:				processSettingsReply();				break;
-		default:								throw std::logic_error("If you define new engineStates you should add them to the switch in EngineRepresentation::process()!");
-		}
-	}
+			Log::log() << "Engine #" << channelNumber() << " still initializing and got " + engineStateToString(typeRequest) << std::endl;
 
-	if(_analysisAborted && _analysisInProgress && _abortTime + ENGINE_KILLTIME < Utils::currentSeconds()) //We wait a second or two before we kill the engine if it does not want to abort.
+			if(typeRequest == engineState::resuming)
+				_engineState = engineState::idle;
+		}
+		else
+			switch(typeRequest)
+			{
+			case engineState::filter:				processFilterReply(json);			break;
+			case engineState::rCode:				processRCodeReply(json);			break;
+			case engineState::analysis:				processAnalysisReply(json);			break;
+			case engineState::computeColumn:		processComputeColumnReply(json);	break;
+			case engineState::paused:				processEnginePausedReply();			break;
+			case engineState::resuming:				processEngineResumedReply();		break;
+			case engineState::stopped:				processEngineStoppedReply();		break;
+			case engineState::moduleInstallRequest:
+			case engineState::moduleLoadRequest:	processModuleRequestReply(json);	break;
+			case engineState::logCfg:				processLogCfgReply();				break;
+			case engineState::settings:				processSettingsReply();				break;
+			case engineState::reloadData:			processReloadDataReply();			break;
+			default:								throw std::logic_error("If you define new engineStates you should add them to the switch in EngineRepresentation::process()!");
+			}
+	}
+	else if(_engineState == engineState::initializing && !_stopRequested)
+		resumeEngine();
+
+
+	if(!_stopRequested && _analysisAborted && _analysisInProgress && _abortTime + ENGINE_KILLTIME < Utils::currentSeconds()) //We wait a second or two before we kill the engine if it does not want to abort.
 	{
-		killEngine();
+		if(jaspEngineStillRunning())
+			killEngine();
+
 		restartAbortedAnalysis();
 	}
 }
@@ -220,7 +295,7 @@ void EngineRepresentation::runScriptOnProcess(RFilterStore * filterStore)
 {
 	Json::Value json = Json::Value(Json::objectValue);
 
-	_engineState			= engineState::filter;
+	setState(engineState::filter);
 
 	json["typeRequest"]		= engineStateToString(_engineState);
 	json["generatedFilter"] = filterStore->generatedfilter.toStdString();
@@ -240,7 +315,7 @@ void EngineRepresentation::processFilterReply(Json::Value & json)
 {
 	checkIfExpectedReplyType(engineState::filter);
 
-	_engineState = engineState::idle;
+	setState(engineState::idle);
 
 #ifdef PRINT_ENGINE_MESSAGES
 			Log::log() << "msg is filter reply" << std::endl;
@@ -278,7 +353,8 @@ void EngineRepresentation::runScriptOnProcess(RScriptStore * scriptStore)
 {
 	Json::Value json = Json::Value(Json::objectValue);
 
-	_engineState			= engineState::rCode;
+	setState(engineState::rCode);
+
 	json["typeRequest"]		= engineStateToString(_engineState);
 	json["rCode"]			= scriptStore->script.toStdString();
 	json["requestId"]		= scriptStore->requestId;
@@ -295,7 +371,7 @@ void EngineRepresentation::processRCodeReply(Json::Value & json)
 {
 	checkIfExpectedReplyType(engineState::rCode);
 
-	_engineState = engineState::idle;
+	setState(engineState::idle);
 
 	std::string rCodeResult = json.get("rCodeResult", "").asString();
 	int requestId			= json.get("requestId", -1).asInt();
@@ -311,7 +387,7 @@ void EngineRepresentation::runScriptOnProcess(RComputeColumnStore * computeColum
 {
 	Json::Value json = Json::Value(Json::objectValue);
 
-	_engineState			= engineState::computeColumn;
+	setState(engineState::computeColumn);
 
 	json["typeRequest"]		= engineStateToString(_engineState);
 	json["columnName"]		= computeColumnStore->_columnName.toStdString();
@@ -328,7 +404,7 @@ void EngineRepresentation::processComputeColumnReply(Json::Value & json)
 {
 	checkIfExpectedReplyType(engineState::computeColumn);
 
-	_engineState = engineState::idle;
+	setState(engineState::idle);
 
 
 	std::string result		= json.get("result", "some string that is not 'TRUE' or 'FALSE'").asString();
@@ -354,7 +430,7 @@ void EngineRepresentation::runAnalysisOnProcess(Analysis *analysis)
 	Log::log() << "sending: " << json.toStyledString() << std::endl;
 #endif
 
-	_channel->send(json.toStyledString());
+	channel()->send(json.toStyledString());
 
 }
 
@@ -366,6 +442,7 @@ void EngineRepresentation::analysisRemoved(Analysis * analysis)
 	_idRemovedAnalysis = analysis->id();
 	abortAnalysisInProgress(false);
 	_analysisInProgress = nullptr; //Because it will be deleted!
+	disconnect(_analysisInProgressStatusConnection);
 	//But we keep the engineState at analysis to make sure another analysis won't try to run until the aborted one gets the message!
 }
 
@@ -393,7 +470,7 @@ void EngineRepresentation::processAnalysisReply(Json::Value & json)
 	Json::Value progress		= json.get("progress",	Json::nullValue);
 	Json::Value results			= json.get("results",	Json::nullValue);
 
-	analysisResultStatus status	= analysisResultStatusFromString(json.get("status", "error").asString());
+	analysisResultStatus status	= analysisResultStatusFromString(json.get("status", "???").asString());
 
 	if(_analysisInProgress == nullptr && id == _idRemovedAnalysis)
 	{
@@ -404,7 +481,7 @@ void EngineRepresentation::processAnalysisReply(Json::Value & json)
 		case analysisResultStatus::complete:
 		case analysisResultStatus::fatalError:
 		case analysisResultStatus::validationError:
-			_engineState		= engineState::idle;
+			setState(engineState::idle);
 			_idRemovedAnalysis	= -1;
 
 			Log::log() << "Analysis got the message and we now reset the engineStatus to idle!" << std::endl;
@@ -520,7 +597,7 @@ void EngineRepresentation::checkForComputedColumns(const Json::Value & results)
 				emit columnDataTypeChanged(tq(columnName));
 		}
 		else
-			for(std::string member : members)
+			for(const std::string & member : members)
 				checkForComputedColumns(results[member]);
 	}
 }
@@ -539,31 +616,47 @@ void EngineRepresentation::killEngine()
 {
 	Log::log() << "Killing Engine #" << channelNumber() << std::endl; //" and " << (disconnectFinished ? "disconnecting" : "leaving attached") << " it's finished signal." << std::endl;
 
-	_engineState  = engineState::killed;
+	if(_analysisInProgress)
+		abortAnalysisInProgress(true);
 
-	//Always disconnect finished because if the engine is to be killed by JASP jasp should not show a "crashed" msgbox
-	//if(disconnectFinished)
-		//We must make sure we do not get a popup, and while processFinished checks for "killed" or not it doesnt help that that needs the eventloop to be processed
-		//I want pause and resume all engines to be done in a single function call without returning to the eventloop, so we just disconnect "finished" if we want to kill the engine.
-	disconnect(_slaveProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),	this, &EngineRepresentation::processFinished);
+	setState(engineState::killed);
 
-	_slaveProcess->kill();
-	//The rest will be handled in EngineRepresentation::processFinished
+	if(_slaveProcess)
+	{
+		//Always disconnect finished because if the engine is to be killed by JASP jasp should not show a "crashed" msgbox
+		//if(disconnectFinished)
+			//We must make sure we do not get a popup, and while processFinished checks for "killed" or not it doesnt help that that needs the eventloop to be processed
+			//I want pause and resume all engines to be done in a single function call without returning to the eventloop, so we just disconnect "finished" if we want to kill the engine.
+		disconnect(_slaveProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),	this, &EngineRepresentation::processFinished);
+
+		_slaveProcess->kill();
+		_slaveProcess->deleteLater();
+		_slaveProcess = nullptr;
+	}
+
+	EngineRepresentation::processFinished();
 }
 
 void EngineRepresentation::stopEngine()
 {
+	Log::log() << "Engine #" << _channelNumber << " stopEngine(), _stopRequested will be set" << std::endl;
 	_stopRequested = true;
 }
 
 void EngineRepresentation::shutEngineDown()
 {
+
+	Log::log() << "Engine #" << _channelNumber << " shutEngineDown()" << std::endl;
+
 	if(_analysisInProgress)
 	{
+		Log::log() << "An analysis is running, so we abort it and wait for the response." << std::endl;
 		abortAnalysisInProgress(true);	
+
+		stopEngine();
 		
 		//Wait for the engine to get the message.
-		while(_analysisAborted && _analysisInProgress && _abortTime + ENGINE_KILLTIME + 1 < Utils::currentSeconds())
+		while(_analysisAborted && _analysisInProgress && _abortTime + ENGINE_KILLTIME > Utils::currentSeconds())
 			processReplies();
 		
 		if(!killed() && !stopped())
@@ -574,7 +667,7 @@ void EngineRepresentation::shutEngineDown()
 		size_t stopTime = Utils::currentSeconds();
 		stopEngine();
 		
-		while(!stopped() && stopTime + ENGINE_KILLTIME < Utils::currentSeconds())
+		while(!stopped() && stopTime + ENGINE_KILLTIME > Utils::currentSeconds())
 			processReplies();
 		
 		if(!stopped())
@@ -585,7 +678,7 @@ void EngineRepresentation::shutEngineDown()
 void EngineRepresentation::sendStopEngine()
 {
 	Json::Value json		= Json::Value(Json::objectValue);
-	_engineState			= engineState::stopRequested;
+	setState(engineState::stopRequested);
 	json["typeRequest"]		= engineStateToString(_engineState);
 
 	Log::log() << "informing engine #" << channelNumber() << " that it ought to stop" << std::endl;
@@ -599,6 +692,11 @@ void EngineRepresentation::restartEngine(QProcess * jaspEngineProcess)
 
 	if(_slaveProcess != nullptr && _slaveProcess != jaspEngineProcess)
 	{
+		Log::log() << "Killing and deleting old engine process and replacing it with fresh one" << std::endl;
+
+		if(jaspEngineStillRunning())
+			shutEngineDown();
+
 		_slaveProcess->kill();
 		_slaveProcess->deleteLater();
 
@@ -607,17 +705,36 @@ void EngineRepresentation::restartEngine(QProcess * jaspEngineProcess)
 	}
 
 	sendString("");
-	setSlaveProcess(jaspEngineProcess);
 	cleanUpAfterClose();
-	loadAllActiveModules();
+	setSlaveProcess(jaspEngineProcess);
 
-	_engineState	 = engineState::initializing;
+	setState(engineState::initializing);
+}
+
+int EngineRepresentation::idleFor() const
+{
+	return _idleStartSecs >= 0 ? Utils::currentSeconds() - _idleStartSecs : 0;
 }
 
 bool EngineRepresentation::isBored() const 
 { 
 	
-	return _idleStartSecs != -1 && _idleStartSecs + ENGINE_BORED_SHUTDOWN < Utils::currentSeconds();		
+	return _idleStartSecs != -1 && (_idleStartSecs + ENGINE_BORED_SHUTDOWN < Utils::currentSeconds());
+}
+
+bool EngineRepresentation::busyWithData() const
+{
+	switch(_engineState)
+	{
+	case engineState::analysis:
+	case engineState::computeColumn:
+	case engineState::filter:
+	case engineState::rCode:
+		return true;
+
+	default:
+		return false;
+	}
 }
 
 void EngineRepresentation::pauseEngine(bool unloadData)
@@ -633,7 +750,7 @@ void EngineRepresentation::pauseEngine(bool unloadData)
 void EngineRepresentation::sendPauseEngine()
 {
 	Json::Value json		= Json::Value(Json::objectValue);
-	_engineState			= engineState::pauseRequested;
+	setState(engineState::pauseRequested);
 	json["typeRequest"]		= engineStateToString(_engineState);
 	json["unloadData"]		= _pauseUnloadData;
 
@@ -642,18 +759,17 @@ void EngineRepresentation::sendPauseEngine()
 	sendString(json.toStyledString());
 }
 
-void EngineRepresentation::resumeEngine()
+void EngineRepresentation::resumeEngine(bool setResuming)
 {
 	if(_engineState != engineState::paused && _engineState != engineState::stopped && _engineState != engineState::initializing)
 		throw unexpectedEngineReply("Attempt to resume engine #" + std::to_string(channelNumber()) + " made but it isn't paused, initializing or stopped");
 
-	if(initializing())
-		return;
+	if(setResuming)
+		setState(engineState::resuming);
 
 	_pauseRequested			= false;
-	_engineState			= engineState::resuming;
 	Json::Value json		= Json::Value(Json::objectValue);
-	json["typeRequest"]		= engineStateToString(_engineState);
+	json["typeRequest"]		= engineStateToString(engineState::resuming);
 
 	addSettingsToJson(json);
 
@@ -667,7 +783,7 @@ void EngineRepresentation::processEnginePausedReply()
 	Log::log() << "EngineRepresentation::processEnginePausedReply() for engine #" << channelNumber() << std::endl;
 	checkIfExpectedReplyType(engineState::pauseRequested);
 
-	_engineState = engineState::paused;
+	setState(engineState::paused);
 }
 
 void EngineRepresentation::processEngineResumedReply()
@@ -679,7 +795,7 @@ void EngineRepresentation::processEngineResumedReply()
 
 	//_settingsChanged = true; //Make sure we send the settings at least once. We now do this be also sending the settings in the resume request
 
-	_engineState = engineState::idle;
+	setState(engineState::idle);
 }
 
 void EngineRepresentation::processEngineStoppedReply()
@@ -687,23 +803,28 @@ void EngineRepresentation::processEngineStoppedReply()
 	Log::log() << "EngineRepresentation::processEngineStoppedReply() for engine #" << channelNumber() << std::endl;
 	checkIfExpectedReplyType(engineState::stopRequested);
 
-	_engineState = engineState::stopped;
+	setState(engineState::stopped);
 
 	disconnect(_slaveFinishedConnection);
 }
 
 void EngineRepresentation::runModuleInstallRequestOnProcess(Json::Value request)
 {
-	_engineState			= engineState::moduleInstallRequest;
+	setState(engineState::moduleInstallRequest);
 	request["typeRequest"]	= engineStateToString(_engineState);
+
+	_requestModName	= request["moduleName"].asString();
 
 	sendString(request.toStyledString());
 }
 
 void EngineRepresentation::runModuleLoadRequestOnProcess(Json::Value request)
 {
-	_engineState			= engineState::moduleLoadRequest;
+	_moduleLoaded = false;
+	setState(engineState::moduleLoadRequest);
 	request["typeRequest"]	= engineStateToString(_engineState);
+
+	_requestModName	= request["moduleName"].asString();
 
 	sendString(request.toStyledString());
 }
@@ -712,12 +833,16 @@ void EngineRepresentation::processModuleRequestReply(Json::Value & json)
 {
 	checkIfExpectedReplyType(_engineState);
 
-	_engineState = engineState::idle;
+	setState(engineState::idle);
 
 	moduleStatus moduleRequest	= moduleStatusFromString(json["moduleRequest"].asString());
 	bool succes					= json["succes"].asBool();
 	QString moduleName			= QString::fromStdString(json["moduleName"].asString());
 	auto getError				= [&](){ return QString::fromStdString(json.get("error", "Unknown error").asString()); };
+
+	if(_requestModName != fq(moduleName))
+		throw std::runtime_error("Received answer for a module request, as expected, but from the wrong module... '" + _requestModName + "' was expected, but got '" + fq(moduleName) + "' instead.");
+	_requestModName = "";
 
 	switch(moduleRequest)
 	{
@@ -726,18 +851,22 @@ void EngineRepresentation::processModuleRequestReply(Json::Value & json)
 		else		emit moduleInstallationFailed(moduleName, getError());
 		break;
 
-	case moduleStatus::loadingNeeded:
-		if(succes)	emit moduleLoadingSucceeded(moduleName, channelNumber());
-		else		emit moduleLoadingFailed(moduleName, getError(), channelNumber());
-		break;
-
-	case moduleStatus::unloadingNeeded:
-		emit moduleUnloadingFinished(moduleName, channelNumber());
+	case moduleStatus::loading:
+		if(succes)	{ emit moduleLoadingSucceeded(moduleName, channelNumber());				_dynModName = fq(moduleName);		_moduleLoaded = true;	}
+		else		{ emit moduleLoadingFailed(moduleName, getError(), channelNumber());	_dynModName = "";											}
 		break;
 
 	default:
 		throw std::runtime_error("Unsupported module request reply to EngineRepresentation::processModuleRequestReply!");
 	}
+
+	// If the engine isn't loading then probably an error occured like "cannot open connection" and this is often solved by restarting the engine,
+	// so unless someone figures out why the connections sometimes isnt there this is a reasonable workaround
+	if(!succes && moduleRequest == moduleStatus::loading)
+		emit stopAndDestroyEngine(this);
+
+	if(moduleRequest == moduleStatus::installNeeded)
+		emit stopModuleEngine(moduleName);
 }
 
 void EngineRepresentation::sendLogCfg()
@@ -747,7 +876,7 @@ void EngineRepresentation::sendLogCfg()
 	if(_engineState != engineState::idle)
 		throw std::runtime_error("EngineRepresentation::sendLogCfg() expects to be run from an idle engine.");
 
-	_engineState		= engineState::logCfg;
+	setState(engineState::logCfg);
 	Json::Value msg		= Log::createLogCfgMsg();
 	msg["typeRequest"]	= engineStateToString(_engineState);
 
@@ -756,7 +885,7 @@ void EngineRepresentation::sendLogCfg()
 
 void EngineRepresentation::processLogCfgReply()
 {
-	_engineState = engineState::idle;
+	setState(engineState::idle);
 
 	emit logCfgReplyReceived(this);
 }
@@ -848,13 +977,27 @@ void EngineRepresentation::sendSettings()
 	if(_engineState != engineState::idle)
 		throw std::runtime_error("EngineRepresentation::sendSettings() expects to be run from an idle engine.");
 
-	_engineState			= engineState::settings;
+	setState(engineState::settings);
 	Json::Value msg			= Json::objectValue;
 	msg["typeRequest"]		= engineStateToString(_engineState);
 	addSettingsToJson(msg);
 	sendString(msg.toStyledString());
 
 	_settingsChanged = false;
+}
+
+void EngineRepresentation::sendReloadData()
+{
+	Log::log() << "EngineRepresentation::sendReloadData()" << std::endl;
+
+	if(_engineState != engineState::idle)
+		throw std::runtime_error("EngineRepresentation::sendReloadData() expects to be run from an idle engine.");
+
+	setState(engineState::reloadData);
+	Json::Value msg			= Json::objectValue;
+	msg["typeRequest"]		= engineStateToString(_engineState);
+
+	sendString(msg.toStyledString());
 }
 
 void EngineRepresentation::addSettingsToJson(Json::Value & msg)
@@ -868,7 +1011,7 @@ void EngineRepresentation::addSettingsToJson(Json::Value & msg)
 
 void EngineRepresentation::processSettingsReply()
 {
-	_engineState = engineState::idle;
+	setState(engineState::idle);
 	restartAbortedAnalysis();
 }
 
@@ -880,13 +1023,18 @@ void EngineRepresentation::restartAbortedAnalysis()
 	_analysisAborted = nullptr;
 }
 
-bool EngineRepresentation::willProcessAnalysis(Analysis * analysis) const
+bool EngineRepresentation::willProcessAnalysis(Analysis * analysis)
 {
-	if(!analysis || !idle() || !analysis->shouldRun())
+	if(_stopRequested || !channel() || !analysis || !idle() || !analysis->shouldRun())
 		return false;
 
-	return runsAnalysis() || (analysis->utilityRunAllowed() && runsUtility());
+	const std::string modName = analysis->dynamicModule()->name();
+
+	return	(	runsAnalysis()					&& _dynModName == modName && _moduleLoaded)
+			|| (analysis->utilityRunAllowed()	&& runsUtility()		 );
 }
+
+void canIRegisterModule(const std::string & name);
 
 bool EngineRepresentation::idleSoon() const
 {
@@ -898,9 +1046,27 @@ bool EngineRepresentation::idleSoon() const
 	case engineState::settings:
 	case engineState::logCfg:
 	case engineState::moduleLoadRequest:
+	case engineState::reloadData:
+	case engineState::idle:
 		return true;
 	
 	default:
 		return false;
 	}
 }
+
+void EngineRepresentation::setState(engineState newState)
+{
+	if (_engineState == newState)
+		return;
+
+	_engineState = newState;
+
+	emit stateChanged();
+}
+
+const QString EngineRepresentation::analysisStatus() const
+{
+	return _analysisInProgress ? _analysisInProgress->statusQ() : "NA";
+}
+

--- a/Desktop/engine/enginerepresentation.h
+++ b/Desktop/engine/enginerepresentation.h
@@ -22,160 +22,206 @@
 class EngineRepresentation : public QObject
 {
 	Q_OBJECT
-	Q_PROPERTY(bool		runsAnalysis		READ runsAnalysis		WRITE setRunsAnalysis		NOTIFY runsAnalysisChanged		)
-	Q_PROPERTY(bool		runsUtility			READ runsUtility		WRITE setRunsUtility		NOTIFY runsUtilityChanged		)
-	Q_PROPERTY(bool		runsRCmd			READ runsRCmd			WRITE setRunsRCmd			NOTIFY runsRCmdChanged			)
+	Q_PROPERTY(bool			runsAnalysis		READ runsAnalysis		WRITE setRunsAnalysis		NOTIFY runsAnalysisChanged		)
+	Q_PROPERTY(bool			runsUtility			READ runsUtility		WRITE setRunsUtility		NOTIFY runsUtilityChanged		)
+	Q_PROPERTY(bool			runsRCmd			READ runsRCmd			WRITE setRunsRCmd			NOTIFY runsRCmdChanged			)
+	Q_PROPERTY(engineState	state				READ state				WRITE setState				NOTIFY stateChanged				)
+	Q_PROPERTY(QString		analysisStatus		READ analysisStatus									NOTIFY analysisStatusChanged	)	//For updates to EngineSync' list capabilities
 
 public:
-	EngineRepresentation(IPCChannel * channel, QProcess * slaveProcess, QObject * parent = nullptr);
-	~EngineRepresentation();
+					EngineRepresentation(size_t channelNumber, QProcess * slaveProcess, QObject * parent = nullptr);
+					~EngineRepresentation();
 
-	void		cleanUpAfterClose();
+	void			cleanUpAfterClose();
 
-	void		clearAnalysisInProgress();
-	void		setAnalysisInProgress(Analysis* analysis);
-	Analysis *	analysisInProgress() const { return _analysisInProgress; }
+	void			clearAnalysisInProgress();
+	void			setAnalysisInProgress(Analysis* analysis);
+	Analysis *		analysisInProgress() const { return _analysisInProgress; }
 
-	void handleRunningAnalysisStatusChanges();
+	void			handleRunningAnalysisStatusChanges();
 
-	void runScriptOnProcess(RFilterStore * filterStore);
-	void runScriptOnProcess(RScriptStore * scriptStore);
-	void runScriptOnProcess(const QString & rCmdCode);
-	void runScriptOnProcess(RComputeColumnStore * computeColumnStore);
-	void runAnalysisOnProcess(Analysis *analysis);
-	void runModuleInstallRequestOnProcess(Json::Value request);
-	void runModuleLoadRequestOnProcess(Json::Value request);
-	void sendLogCfg();
-	void sendSettings();
+	void			runScriptOnProcess(RFilterStore * filterStore);
+	void			runScriptOnProcess(RScriptStore * scriptStore);
+	void			runScriptOnProcess(const QString & rCmdCode);
+	void			runScriptOnProcess(RComputeColumnStore * computeColumnStore);
+	void			runAnalysisOnProcess(Analysis *analysis);
+	void			runModuleInstallRequestOnProcess(Json::Value request);
+	void			runModuleLoadRequestOnProcess(Json::Value request);
+	void			sendLogCfg();
+	void			sendSettings();
+	void			sendReloadData();
 
 	///Kills engine outright by killing process
-	void killEngine();
+	void 			killEngine();
 	
 	///Try to gracefully shut down this engine so it can be removed
-	void shutEngineDown();
+	void 			shutEngineDown();
 	
 	///Stop the engine but keep it so it can be restarted easily
-	void stopEngine();
+	void 			stopEngine();
 	
 	///Tell the engine it shouldn't be doing anything else, aka pause.
-	void pauseEngine(bool unloadData = false);
+	void 			pauseEngine(bool unloadData = false);
 	
 	///Tell engine to resume running
-	void resumeEngine();
+	void 			resumeEngine(bool setResuming = true);
 	
 	///Start engine again in jaspEngineProcess
-	void restartEngine(QProcess * jaspEngineProcess);
-	bool resumed()				const { return _engineState != engineState::resuming && !paused() && !initializing();	}
-	bool paused()				const { return _engineState == engineState::paused || initializing();					}
-	bool initializing()			const { return _engineState == engineState::initializing;								}
-	bool stopped()				const { return _engineState == engineState::stopped;									}
-	bool killed()				const { return _engineState == engineState::killed;										}
-	bool idle()					const { return _engineState == engineState::idle;										}
-	bool idleSoon()				const;
-	bool shouldSendSettings()	const { return idle() && _settingsChanged;												}
-	bool runsAnalysis()			const { return _runsAnalysis;															}
-	bool runsUtility()			const { return _runsUtility;															}
-	bool runsRCmd()				const { return _runsRCmd;																}
-	bool isBored()			const;
+	void 			restartEngine(QProcess * jaspEngineProcess);
 
-	bool jaspEngineStillRunning() { return  _slaveProcess != nullptr && !killed(); }
+	bool			handlingModuleRequest(const std::string & moduleName) const { return _requestModName == moduleName && (installingModule() || moduleLoading()); }
 
-	void processReplies();
-	void restartAbortedAnalysis();
-	void checkIfExpectedReplyType(engineState expected) { unexpectedEngineReply::checkIfExpected(expected, _engineState, channelNumber()); }
-	bool willProcessAnalysis(Analysis * analysis) const;
+	engineState		state()		const { return _engineState; }
 
-	size_t	channelNumber()		const { return _channel->channelNumber(); }
+	bool			resumed()				const { return _engineState != engineState::resuming && !paused() && !initializing();	}
+	bool			paused()				const { return _engineState == engineState::paused || initializing();					}
+	bool			initializing()			const { return _engineState == engineState::initializing;								}
+	bool			stopped()				const { return _engineState == engineState::stopped;									}
+	bool			killed()				const { return _engineState == engineState::killed;										}
+	bool			idle()					const { return _engineState == engineState::idle;										}
+	bool			installingModule()		const { return _engineState == engineState::moduleInstallRequest;						}
+	bool			moduleLoading()			const { return _engineState == engineState::moduleLoadRequest;							}
+	bool			idleSoon()				const;
+	bool			shouldSendSettings()	const { return idle() && _settingsChanged;												}
+	bool			runsAnalysis()			const { return _runsAnalysis;															}
+	bool			runsUtility()			const { return _runsUtility;															}
+	bool			runsRCmd()				const { return _runsRCmd;																}
+	bool			isBored()				const;
+	bool			busyWithData()			const;
+	bool			needsReloadData()		const { return idle() && _reloadData; }
+	bool			moduleLoaded()			const { return _moduleLoaded; }
 
-	std::string currentStateForDebug() const;	
-	
+	///How many seconds has this engine been idle?
+	int				idleFor() const;
+
+	bool			jaspEngineStillRunning() { return  _slaveProcess != nullptr && !killed() && !stopped(); }
+
+	void			processReplies();
+	void			restartAbortedAnalysis();
+	void			checkIfExpectedReplyType(engineState expected) { unexpectedEngineReply::checkIfExpected(expected, _engineState, channelNumber()); }
+	bool			willProcessAnalysis(Analysis * analysis);
+
+	size_t			channelNumber()		const { return _channelNumber; }
+
+	std::string		currentStateForDebug()	const;
+	std::string		module()				const { return _dynModName;		}
+	std::string		moduleRequested()		const { return _requestModName; }
+	void			moduleLoad();
+
+	void			setState(engineState newState);
+
+	const QString	analysisStatus() const;
+
+
 protected:
-	void processRCodeReply(			Json::Value & json);
-	void processFilterReply(		Json::Value & json);
-	void processAnalysisReply(		Json::Value & json);
-	void processComputeColumnReply(	Json::Value & json);
-	void processModuleRequestReply(	Json::Value & json);
-	void processEnginePausedReply();
-	void processEngineStoppedReply();
-	void processEngineResumedReply();
-	void processLogCfgReply();
-	void processSettingsReply();
-	
-	void sendString(std::string str);
+	void			processRCodeReply(			Json::Value & json);
+	void			processFilterReply(		Json::Value & json);
+	void			processAnalysisReply(		Json::Value & json);
+	void			processComputeColumnReply(	Json::Value & json);
+	void			processModuleRequestReply(	Json::Value & json);
+	void			processReloadDataReply()							{ _reloadData = false; setState(engineState::idle); }
+	void			processEnginePausedReply();
+	void			processEngineStoppedReply();
+	void			processEngineResumedReply();
+	void			processLogCfgReply();
+	void			processSettingsReply();
+
+	void			sendString(std::string str);
 
 public slots:
-	void analysisRemoved(Analysis * analysis);
-	void processFinished(int exitCode, QProcess::ExitStatus exitStatus);
-	void settingsChanged();
-	void setRunsAnalysis(	bool runsAnalysis);
-	void setRunsUtility(	bool runsUtility);
-	void setRunsRCmd(		bool runsRCmd);
+	void			analysisRemoved(Analysis * analysis);
+	void			processFinished(int exitCode = 0, QProcess::ExitStatus exitStatus = QProcess::ExitStatus::NormalExit);
+	void			settingsChanged();
+	void			setRunsAnalysis(	bool runsAnalysis);
+	void			setRunsUtility(	bool runsUtility);
+	void			setRunsRCmd(		bool runsRCmd);
+
+	void			setDynamicModule(const std::string & dynamicModule);
+	void			reloadData() { _reloadData = true; }
 
 signals:
-	void loadAllActiveModules();
-	void engineTerminated();
-	void filterDone(															int requestID);
-	void processFilterErrorMsg(			const QString & error,					int requestId = -1);
-	void processNewFilterResult(		const std::vector<bool> & filterResult, int requestId);
-	void computeColumnErrorTextChanged(	const QString & error);
+	void			engineTerminated();
+	void			filterDone(															int requestID);
+	void			processFilterErrorMsg(			const QString & error,					int requestId = -1);
+	void			processNewFilterResult(			const std::vector<bool> & filterResult, int requestId);
+	void			computeColumnErrorTextChanged(	const QString & error);
 
-	void rCodeReturned(					const QString & result, int requestId	);
-	void rCodeReturnedLog(				const QString & log						);
+	void			rCodeReturned(					const QString & result, int requestId	);
+	void			rCodeReturnedLog(				const QString & log						);
 
-	void computeColumnSucceeded(		const QString & columnName, const QString & warning, bool dataChanged);
-	void computeColumnFailed(			const QString & columnName, const QString & error);
-	void columnDataTypeChanged(			const QString & columnName);
+	void			computeColumnSucceeded(			const QString & columnName, const QString & warning, bool dataChanged);
+	void			computeColumnFailed(			const QString & columnName, const QString & error);
+	void			columnDataTypeChanged(			const QString & columnName);
 
-	void moduleInstallationSucceeded(	const QString & moduleName);
-	void moduleInstallationFailed(		const QString & moduleName, const QString & errorMessage);
-	void moduleLoadingSucceeded(		const QString & moduleName, int channelID);
-	void moduleLoadingFailed(			const QString & moduleName, const QString & errorMessage, int channelID);
-	void moduleUnloadingFinished(		const QString & moduleName, int channelID);
-	void moduleUninstallingFinished(	const QString & moduleName);
+	void			moduleInstallationSucceeded(	const QString & moduleName);
+	void			moduleInstallationFailed(		const QString & moduleName, const QString & errorMessage);
+	void			moduleLoadingSucceeded(			const QString & moduleName, int channelID);
+	void			moduleLoadingFailed(			const QString & moduleName, const QString & errorMessage, int channelID);
+	void			moduleUnloadingFinished(		const QString & moduleName, int channelID);
+	void			moduleUninstallingFinished(		const QString & moduleName);
 
-	void logCfgReplyReceived(	EngineRepresentation * engine);
-	void requestEngineRestart(	EngineRepresentation * engine);
-	void plotEditorRefresh();
-	void runsAnalysisChanged(	bool runsAnalysis);
-	void runsUtilityChanged(	bool runsUtility);
-	void runsRCmdChanged(		bool runsRCmd);
+	void			logCfgReplyReceived(	EngineRepresentation * engine);
+	void			requestEngineRestart(	EngineRepresentation * engine);
+	void			registerForModule(		EngineRepresentation * engine, std::string modName);
+	void			unregisterForModule(	EngineRepresentation * engine, std::string modName);
+	void			stopModuleEngine(		QString moduleName);
+	void			stopAndDestroyEngine(	EngineRepresentation * e);
+	void			plotEditorRefresh();
+	void			runsAnalysisChanged(	bool runsAnalysis);
+	void			runsUtilityChanged(	bool runsUtility);
+	void			runsRCmdChanged(		bool runsRCmd);
+
+	bool			moduleHasEngine(const std::string & name);
+
+
+	void			stateChanged();
+
+	void			analysisStatusChanged();
+
+	IPCChannel	*	channelSignal(size_t channelNumber);
 
 private:
-	void sendPauseEngine();
-	void sendStopEngine();
-	void setChannel(IPCChannel * channel)			{ _channel = channel; }
-	void setSlaveProcess(QProcess * slaveProcess);
-	void checkForComputedColumns(const Json::Value & results);
-	void handleEngineCrash();
-	void abortAnalysisInProgress(bool restartAfterwards);
-	void addSettingsToJson(Json::Value & msg);
+	void			sendPauseEngine();
+	void			sendStopEngine();
+	void			setSlaveProcess(QProcess * slaveProcess);
+	void			checkForComputedColumns(const Json::Value & results);
+	void			handleEngineCrash();
+	void			abortAnalysisInProgress(bool restartAfterwards);
+	void			addSettingsToJson(Json::Value & msg);
+
+	IPCChannel	*	channel() { return emit channelSignal(_channelNumber); }
+
 
 private:
 	static Analysis::Status analysisResultStatusToAnalysStatus(analysisResultStatus result);
 
+	size_t			_channelNumber		= 0;
 	engineState		_engineState		= engineState::initializing; // The representation of whatever state the actual engine is supposed to be in.
 	QProcess	*	_slaveProcess		= nullptr;
-	IPCChannel	*	_channel			= nullptr;
 	Analysis	*	_analysisInProgress = nullptr,
-				*	_analysisAborted	= nullptr;	//To make sure we know that the response we got was from this aborted analysis or not
-	int				_idRemovedAnalysis	= -1,		//If the analysis was deleted we should ignore its results
-					_lastRequestId		= -1,		//for R code requests from qml components, so that we can send it back to the right element
-					_abortTime			= -1,		//When did we tell the analysis to abort? So that we can kill it if it takes too long
+				*	_analysisAborted	= nullptr;	///<To make sure we know that the response we got was from this aborted analysis or not
+	int				_idRemovedAnalysis	= -1,		///<If the analysis was deleted we should ignore its results
+					_lastRequestId		= -1,		///<for R code requests from qml components, so that we can send it back to the right element
+					_abortTime			= -1,		///<When did we tell the analysis to abort? So that we can kill it if it takes too long
 					_idleStartSecs		= -1;
-	bool			_pauseRequested		= false,	//should tell the engine to pause as soon as possible
-					_stopRequested		= false,	//should tell the engine to stop as soon as possible
-					_slaveCrashed		= false,	//My slave crashed
-					_settingsChanged	= true,		//Some setting changed and we should send these new settings asap
-					_abortAndRestart	= false,	//abort and restart an analysis
-					_runsAnalysis		= true,		//is this engine meant for running analyses?
-					_runsUtility		= true,		//is this engine meant for running filters, installing modules or running R Code (not the r prompt though)
-					_runsRCmd			= false,	//is this engine meant for the R prompt?
+	bool			_pauseRequested		= false,	///<should tell the engine to pause as soon as possible
+					_stopRequested		= false,	///<should tell the engine to stop as soon as possible
+					_slaveCrashed		= false,	///<My slave crashed
+					_settingsChanged	= true,		///<Some setting changed and we should send these new settings asap
+					_abortAndRestart	= false,	///<abort and restart an analysis
+					_runsAnalysis		= true,		///<is this engine meant for running analyses?
+					_runsUtility		= true,		///<is this engine meant for running filters, installing modules or running R Code (not the r prompt though)
+					_runsRCmd			= false,	///<is this engine meant for the R prompt?
 					_removeEngine		= false,
-					_pauseUnloadData	= false;
-	std::string		_lastCompColName	= "???";
+					_pauseUnloadData	= false,
+					_reloadData			= false,	///<when the idle is engine and this true, it should reload the data
+					_moduleLoaded		= false;	///<If _dynModName is set but this is false the engine should still load the module.
+	std::string		_lastCompColName	= "???",
+					_dynModName			= "",		///<If filled: refers to the particular dynamic module this engine was meant for.
+					_requestModName		= "";		///<To keep track of which engine is handling a request for a module
 
-	QMetaObject::Connection	_slaveFinishedConnection;
-
+	QMetaObject::Connection	_slaveFinishedConnection,
+							_analysisInProgressStatusConnection;
 
 };
 

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -41,10 +41,6 @@
 #include "utilities/qutils.h"
 #include "utilities/processhelper.h"
 
-
-
-
-
 using namespace boost::interprocess;
 
 EngineSync * EngineSync::_singleton = nullptr;
@@ -361,6 +357,9 @@ void EngineSync::shutdownBoredEngines()
 void EngineSync::process()
 {
 	if(_stopProcessing)	return;
+
+	if(_rCmder)
+		_rCmder->processReplies();
 	
 	restartKilledAndStoppedEngines();
 	shutdownBoredEngines();
@@ -664,6 +663,9 @@ bool EngineSync::anEngineIdleSoon() const
 
 IPCChannel *EngineSync::channel(size_t channelNumber)
 {
+	if(_rCmderChannel && channelNumber == _rCmderChannel->channelNumber())
+		return _rCmderChannel;
+
 	if(channelNumber > _channels.size())
 	{
 		Log::log() << "IPCChannel requested for channel #" + std::to_string(channelNumber) + " but only " + std::to_string(_channels.size()) + " exist...";

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -42,12 +42,15 @@
 #include "utilities/processhelper.h"
 
 
+
+
+
 using namespace boost::interprocess;
 
 EngineSync * EngineSync::_singleton = nullptr;
 
 EngineSync::EngineSync(QObject *parent)
-	: QObject(parent)
+	: QAbstractListModel(parent)
 {
 	assert(!_singleton);
 	_singleton = this;
@@ -55,12 +58,10 @@ EngineSync::EngineSync(QObject *parent)
 	using namespace Modules;
 
 	connect(Analyses::analyses(),		&Analyses::sendRScript,								this,						&EngineSync::sendRCode							);
-	connect(this,						&EngineSync::moduleLoadingFailed,					DynamicModules::dynMods(),	&DynamicModules::loadingFailed					);
-	connect(this,						&EngineSync::moduleLoadingSucceeded,				DynamicModules::dynMods(),	&DynamicModules::loadingSucceeded				);
-	connect(this,						&EngineSync::moduleInstallationFailed,				DynamicModules::dynMods(),	&DynamicModules::installationPackagesFailed		);
-	connect(this,						&EngineSync::moduleInstallationSucceeded,			DynamicModules::dynMods(),	&DynamicModules::installationPackagesSucceeded	);
-	connect(DynamicModules::dynMods(),	&DynamicModules::stopEngines,						this,						&EngineSync::stopEngines						);
-	connect(DynamicModules::dynMods(),	&DynamicModules::restartEngines,					this,						&EngineSync::restartEngines						);
+	connect(this,						&EngineSync::moduleInstallationFailed,				this,						&EngineSync::moduleInstallationFailedHandler	);
+	connect(this,						&EngineSync::moduleInstallationFailed,				DynamicModules::dynMods(),	&DynamicModules::installationPackagesFailed,	Qt::DirectConnection);
+	connect(this,						&EngineSync::moduleInstallationSucceeded,			DynamicModules::dynMods(),	&DynamicModules::installationPackagesSucceeded,	Qt::DirectConnection);
+
 
 	connect(PreferencesModel::prefs(),	&PreferencesModel::plotPPIChanged,					this,						&EngineSync::settingsChanged					);
 	connect(PreferencesModel::prefs(),	&PreferencesModel::plotBackgroundChanged,			this,						&EngineSync::settingsChanged					);
@@ -81,22 +82,88 @@ EngineSync::EngineSync(QObject *parent)
 
 EngineSync::~EngineSync()
 {
-	if (_engineStarted)
-	{		
-		try			{ stopEngines(); }
-		catch(...)	{ /* Whatever! */ }
+	try			{ stopEngines(); }
+	catch(...)	{ /* Whatever! */ }
 
-		for(EngineRepresentation * engine : _engines)
-			if(!engine->stopped())
-				engine->killEngine();
+	for(EngineRepresentation * engine : _engines)
+		if(!engine->stopped())
+			engine->killEngine();
 
-		_workers.clear();
-		_rCmders.clear();
-		_engines.clear();
-		
-		TempFiles::deleteAll();
-	}
+	_moduleEngines.clear();
+	_engines.clear();
+
+
+	delete _rCmderChannel;
+	_rCmderChannel	= nullptr;
+	_rCmder			= nullptr;
+
+	TempFiles::deleteAll();
+
 	_singleton = nullptr;
+}
+
+
+int EngineSync::rowCount(const QModelIndex &) const
+{
+	return _engines.size();
+}
+
+std::vector<EngineRepresentation*>  EngineSync::orderedEngines() const
+{
+	std::vector<EngineRepresentation*> ordered(_engines.begin(), _engines.end());
+
+	std::sort(ordered.begin(), ordered.end(), [](EngineRepresentation * l, EngineRepresentation * r) { return l->channelNumber() < r->channelNumber(); });
+
+	return ordered;
+}
+
+QVariant EngineSync::data(const QModelIndex &index, int role) const
+{
+	if(!enginesListRolesValid(role))
+		role=Qt::DisplayRole;
+
+	if(index.row() >= rowCount() || index.row() < 0)
+		return QVariant();
+
+	auto ordered = orderedEngines();
+
+	EngineRepresentation * engine = ordered[index.row()];
+
+	if(role < Qt::UserRole)
+	{
+		if(role == Qt::DisplayRole)	return "Engine " + tq(std::to_string(engine->channelNumber()));
+		return QVariant();
+	}
+
+	switch(static_cast<enginesListRoles>(role))
+	{
+	case enginesListRoles::channel:			return int(engine->channelNumber());
+	case enginesListRoles::module:			return tq(engine->installingModule() ?  engine->moduleRequested() : engine->module());
+	case enginesListRoles::engineState:		return engineStateToQString(engine->state());
+	case enginesListRoles::running:			return !engine->killed() && !engine->stopped();
+	case enginesListRoles::idle:			return engine->idle();
+	case enginesListRoles::idleSoon:		return engine->idleSoon();
+	case enginesListRoles::analysisStatus:	return engine->analysisStatus();
+	case enginesListRoles::runsWhat:		return QString("Runs ") +(engine->runsAnalysis() ? "Analyses " : "") + (engine->runsRCmd() ? "RCmder " : "") + (engine->runsUtility() ? "Utilities " : "") ;
+	}
+
+	return QVariant();
+}
+
+QHash<int, QByteArray> EngineSync::roleNames() const
+{
+	static bool						set = false;
+	static QHash<int, QByteArray> roles = QAbstractListModel::roleNames ();
+
+	if(!set)
+	{
+		for(const auto & listRole : enginesListRolesToStringMap())
+			roles[listRole.first] = tq(listRole.second).toUtf8();
+
+		set = true;
+	}
+
+	return roles;
 }
 
 size_t EngineSync::maxEngineCount() const
@@ -107,38 +174,65 @@ size_t EngineSync::maxEngineCount() const
 
 void EngineSync::maxEngineCountChanged()
 {
-	Log::log() << "EngineSync::maxEngineCountChanged called and currently there are #" << _workers.size() << " while the max we want is: " << maxEngineCount() << std::endl;
+	Log::log() << "EngineSync::maxEngineCountChanged called and currently there are #" << _moduleEngines.size() << " while the max we want is: " << maxEngineCount() << std::endl;
 	
-	//We ignore the R-commander engine for the max count
-	while(_workers.size() > maxEngineCount())
+	//Kill those engines with too high channelnumbers so that we can also destroy the corresponding channels that are no longer needed
+	for(size_t e=maxEngineCount(); e<_engines.size(); e++)
 	{
 		//Pick first one by default
-		EngineRepresentation * engineToKill = *_workers.begin();
+		std::set<EngineRepresentation*> destroyUs;
 		
-		for(EngineRepresentation * engine : _workers)
-			if(engine->idle())
+		for(auto * engine : _engines)
+			if(engine->channelNumber() == e)
 			{
-				//But an idle one if possible
-				engineToKill = engine;
+				destroyUs.insert(engine);
 				break;
 			}
 		
-		engineToKill->shutEngineDown();
-		destroyEngine(engineToKill);
+		for(auto * engine : destroyUs)
+			destroyEngine(engine);
 	}
-		
+
+	if(_channels.size() < maxEngineCount())
+	{
+		size_t startHere = _channels.size();
+		_channels.resize(maxEngineCount());
+
+		for(size_t c=startHere; c<_channels.size(); c++)
+			_channels[c] = new IPCChannel(_memoryName, c);
+	}
+
+	if(_engineStopTimes.size() != maxEngineCount())
+	{
+		size_t prev = _engineStopTimes.size();
+		_engineStopTimes.resize(maxEngineCount());
+
+		for(;prev < _engineStopTimes.size(); prev++)
+			_engineStopTimes[prev] = -1;
+	}	
 }
 
-EngineRepresentation * EngineSync::createNewEngine()
+EngineRepresentation * EngineSync::createNewEngine(bool addToEngines, int overrideChannel)
 {
 	try
 	{
-		static size_t			  freeChannel	= 0;
-		IPCChannel				* newChannel	= new IPCChannel(_memoryName, freeChannel);
-		EngineRepresentation	* engine		= new EngineRepresentation(newChannel, startSlaveProcess(freeChannel), this);
-		freeChannel++;
+		size_t freeChannel = overrideChannel != -1 ? overrideChannel : 0;
+
+		if(overrideChannel == -1)
+		{
+			while(!channelFree(freeChannel) && freeChannel < maxEngineCount())
+				freeChannel++;
+
+			if(freeChannel > maxEngineCount())
+				throw std::runtime_error("createNewEngine but no engines can be started because no channel is free or cooled down...");
+
+			_engineStopTimes[freeChannel] = -1;
+		}
+
+		EngineRepresentation	* engine		= new EngineRepresentation(freeChannel, startSlaveProcess(freeChannel), this);
 		
-		_engines.insert(engine);
+		if(addToEngines)
+			_engines.insert(engine);
 
 		connect(engine,						&EngineRepresentation::rCodeReturned,					Analyses::analyses(),	&Analyses::rCodeReturned												);
 		connect(engine,						&EngineRepresentation::engineTerminated,				this,					&EngineSync::engineTerminated											);
@@ -148,22 +242,29 @@ EngineRepresentation * EngineSync::createNewEngine()
 		connect(engine,						&EngineRepresentation::columnDataTypeChanged,			this,					&EngineSync::columnDataTypeChanged,				Qt::QueuedConnection	);
 		connect(engine,						&EngineRepresentation::computeColumnSucceeded,			this,					&EngineSync::computeColumnSucceeded,			Qt::QueuedConnection	);
 		connect(engine,						&EngineRepresentation::computeColumnFailed,				this,					&EngineSync::computeColumnFailed,				Qt::QueuedConnection	);
-		connect(engine,						&EngineRepresentation::moduleLoadingFailed,				this,					&EngineSync::moduleLoadingFailedHandler									);
-		connect(engine,						&EngineRepresentation::moduleLoadingSucceeded,			this,					&EngineSync::moduleLoadingSucceededHandler								);
 		connect(engine,						&EngineRepresentation::moduleInstallationFailed,		this,					&EngineSync::moduleInstallationFailed									);
 		connect(engine,						&EngineRepresentation::moduleInstallationSucceeded,		this,					&EngineSync::moduleInstallationSucceeded								);
-		connect(engine,						&EngineRepresentation::moduleUnloadingFinished,			this,					&EngineSync::moduleUnloadingFinishedHandler								);
 		connect(engine,						&EngineRepresentation::moduleUninstallingFinished,		this,					&EngineSync::moduleUninstallingFinished									);
+		connect(engine,						&EngineRepresentation::moduleLoadingSucceeded,			this,					&EngineSync::moduleLoadingSucceeded										);
+		connect(engine,						&EngineRepresentation::moduleLoadingFailed,				this,					&EngineSync::moduleLoadingFailed										);
 		connect(engine,						&EngineRepresentation::logCfgReplyReceived,				this,					&EngineSync::logCfgReplyReceived										);
 		connect(engine,						&EngineRepresentation::plotEditorRefresh,				this,					&EngineSync::plotEditorRefresh											);
 		connect(engine,						&EngineRepresentation::requestEngineRestart,			this,					&EngineSync::restartEngineAfterCrash									);
-		connect(engine,						&EngineRepresentation::loadAllActiveModules,			this,					&EngineSync::loadAllActiveModules										);
+		connect(engine,						&EngineRepresentation::registerForModule,				this,					&EngineSync::registerEngineForModule									);
+		connect(engine,						&EngineRepresentation::unregisterForModule,				this,					&EngineSync::unregisterEngineForModule									);
+		connect(engine,						&EngineRepresentation::moduleHasEngine,					this,					&EngineSync::moduleHasEngine											);
+		connect(engine,						&EngineRepresentation::channelSignal,					this,					&EngineSync::channel,							Qt::DirectConnection	);
+		connect(engine,						&EngineRepresentation::stopAndDestroyEngine,			this,					&EngineSync::stopAndDestroyEngine,				Qt::QueuedConnection	);
+		connect(engine,						&EngineRepresentation::stopModuleEngine,				this,					&EngineSync::stopModuleEngine											);
+		connect(this,						&EngineSync::reloadData,								engine,					&EngineRepresentation::reloadData										);
 		connect(this,						&EngineSync::settingsChanged,							engine,					&EngineRepresentation::settingsChanged									);
 		connect(Analyses::analyses(),		&Analyses::analysisRemoved,								engine,					&EngineRepresentation::analysisRemoved									);
-		connect(PreferencesModel::prefs(),	&PreferencesModel::maxEnginesChanged,					this,					&EngineSync::maxEngineCountChanged,				Qt::QueuedConnection	);
+		connect(PreferencesModel::prefs(),	&PreferencesModel::maxEnginesChanged,					this,					&EngineSync::maxEngineCountChanged,				Qt::DirectConnection	);
 
-		//On (re)starts this makes sure all modules are loaded. But on first startup (when JASP is loading) this will do nothing.
-		loadAllActiveModules();
+		connect(engine,						&EngineRepresentation::stateChanged,					this,					&EngineSync::resetListModel,					Qt::QueuedConnection	);
+		connect(engine,						&EngineRepresentation::analysisStatusChanged,			this,					&EngineSync::resetListModel,					Qt::QueuedConnection	);
+
+		resetListModel();
 
 		return engine;
 
@@ -175,22 +276,26 @@ EngineRepresentation * EngineSync::createNewEngine()
 	}
 }
 
-void EngineSync::loadAllActiveModules()
-{
-	setModuleWideCastVars(Modules::DynamicModules::dynMods()->getJsonForReloadingActiveModules());
-}
-
 void EngineSync::start(int )
 {
 	JASPTIMER_SCOPE(EngineSync::start);
 
-	if (_engineStarted)
-		return;
+	//We create the channels for all engines (and update this whenever maxEngineCountChange() gets called)
+	//This avoids any timing problems and boost-shared-memory file allocation mishaps.
+	//Also we do not need to recreate and destroy them all the time this way.
+	_channels.resize(maxEngineCount());
+	for(size_t c=0; c<maxEngineCount(); c++)
+		_channels[c] = new IPCChannel(_memoryName, c);
 
-	_engineStarted = true;
+	//Initialize stop times to -1, because we just started
+	_engineStopTimes.resize(maxEngineCount());
 
-	//We start with a single engine. Later we can start more if necessary and allowed by the user
-	_workers.insert(createNewEngine()); 
+	for(size_t s=0;s < _engineStopTimes.size(); s++)
+		_engineStopTimes[s] = -1;
+
+	//We start with a single engine. Later we can start more if necessary and allowed by the user. This one engine can run filters etc and it can be assigned to a particular module.
+	//Once it is assigned to a module it won't be possible to use it for another module until it is restarted.
+	createNewEngine();
 
 	QTimer	*timerProcess	= new QTimer(this),
 			*timerBeat		= new QTimer(this);
@@ -204,20 +309,14 @@ void EngineSync::start(int )
 
 void EngineSync::restartEngines()
 {
-	if(_engineStarted)
-		return;
-
-	Log::log() << "restarting engines!" << std::endl;
-
 	for(auto * engine : _engines)
-	{
-		engine->restartEngine(startSlaveProcess(engine->channelNumber()));
-		Log::log() << "restarted engine " << engine->channelNumber() << " but should still reload any active (dynamic) modules!"<< std::endl;
-	}
+		if(engine->killed())
+		{
+			engine->restartEngine(startSlaveProcess(engine->channelNumber()));
+			Log::log() << "restarted engine " << engine->channelNumber() << std::endl;
+		}
 
 	logCfgRequest();
-
-	_engineStarted = true;
 }
 
 void EngineSync::restartEngineAfterCrash(EngineRepresentation * engine)
@@ -226,61 +325,109 @@ void EngineSync::restartEngineAfterCrash(EngineRepresentation * engine)
 	logCfgRequest();
 }
 
-void EngineSync::restartKilledEngines()
+void EngineSync::restartKilledAndStoppedEngines()
 {
-	//Maybe we killed an engine because we wanted to pause or some option changed but the analysis wasn't listening. https://github.com/jasp-stats/INTERNAL-jasp/issues/875
-	bool restartedAnEngine = false;
-
 	for(EngineRepresentation * engine : _engines)
-		if(engine->killed())
-		{
+		if(engine->killed() || !engine->jaspEngineStillRunning())
 			engine->restartEngine(startSlaveProcess(engine->channelNumber()));
-			restartedAnEngine = true;
-		}
+	else if(engine->stopped())
+			engine->resumeEngine();
 }
 
-void EngineSync::process()
+void EngineSync::shutdownBoredEngines()
 {
-	restartKilledEngines();
-
 	std::vector<EngineRepresentation *> boredEngines;
 	for (auto engine : _engines)
 	{
 		engine->processReplies();
-		
+
 		if(
-			_workers.count(engine) > 0	&& 
-			engine->isBored()			&& 
-			_workers.size() - boredEngines.size()  > 1
-		)	
+			_engines.count(engine) > 0	&&
+			engine->isBored()			&&
+
+			( _engines.size() - boredEngines.size()  > 1 || engine->module() != "") //because it might be better to have an empty engine later in case the user adds something from a different module
+		)
 		{
 		   Log::log() << "Engine #" << engine->channelNumber()  << " had nothing to do for so long it has decided to shutdown." << std::endl;
 		   engine->shutEngineDown();
 		   boredEngines.push_back(engine);
-		}			
+		}
 	}
-	
-	for(EngineRepresentation * engine : boredEngines)
-		destroyEngine(engine);	
 
+	for(EngineRepresentation * engine : boredEngines)
+		stopAndDestroyEngine(engine);
+}
+
+void EngineSync::process()
+{
+	if(_stopProcessing)	return;
+	
+	restartKilledAndStoppedEngines();
+	shutdownBoredEngines();
+
+	for(auto * engine : _engines)
+		engine->processReplies();
+
+	if(moduleInstallRunning()) return; //First finish any module install running.
+
+	processReloadData();
 	processSettingsChanged();
 	processFilterScript();
 
 	if(_filterRunning) return; //Do not do anything else while waiting for a filter to return
 	
 	processLogCfgRequests();
+
+	if(_engines.size() == 0)
+		startExtraEngines();
 	
-	bool	notEnoughIdlesForScript		=	processScriptQueue(),
-			notEnoughIdlesForModule		=	processDynamicModules(),
-			notEnoughIdlesForAnalysis	=	processAnalysisRequests(),
-			notEnoughIdles				=	notEnoughIdlesForScript || notEnoughIdlesForModule || notEnoughIdlesForAnalysis;
+	bool		notEnoughIdlesForScript		=	processScriptQueue();
+	stringset	notEnoughIdlesForModule		=	processDynamicModules();
+	auto		notEnoughIdlesForAnalysis	=	processAnalysisRequests();
+	bool		notEnoughIdles				=	notEnoughIdlesForScript || notEnoughIdlesForModule.size() || notEnoughIdlesForAnalysis.size();
+	int			wantThisManyEngines			=	notEnoughIdlesForModule.size();
+
+	if(notEnoughIdles)
+		Log::log() << "Not enough idle engines! Need " << (notEnoughIdlesForScript ? " one for script" : "") << (notEnoughIdlesForModule.size() ? std::to_string(notEnoughIdlesForModule.size()) + " for installing modules" : "") <<  (notEnoughIdlesForAnalysis.size() ? std::to_string(notEnoughIdlesForAnalysis.size()) + " for analysis" : "") << ", one will " << ( !anEngineIdleSoon() ? "NOT " : "")  << "be idle soon..." << std::endl;
 	
-	if(notEnoughIdles && !anEngineIdleSoon())	
-		startExtraEngine();
-	else
-		for (auto engine : _workers)
-			if(engine->idle())
-				engine->restartAbortedAnalysis();
+	//First try to find or start some engines specifically for waiting analyses, and we assign them to the module immediately
+	if(notEnoughIdlesForAnalysis.size())
+	{
+		size_t	canStart(enginesStartableCount()),
+				startMe (0);
+
+		for(const std::string & modName : notEnoughIdlesForAnalysis)
+			if(!notEnoughIdlesForModule.count(modName))
+			{
+				bool foundAnEngineAnyway = false;
+				//Can we use an existing engine?
+				for(auto * engine : _engines)
+					if(engine->module() == "" && engine->idleSoon())
+					{
+						registerEngineForModule(engine, modName);
+						foundAnEngineAnyway = true;
+						break;
+					}
+
+				//If that didn't work maybe we can start a new engine?
+				if(!foundAnEngineAnyway && aChannelFree() && startMe++ < canStart)
+				{
+					auto * engine = createNewEngine();
+					registerEngineForModule(engine, modName);
+				}
+				else
+					wantThisManyEngines++; //Otherwise just try later with idle killings
+			}
+	}
+
+	//Maybe some engine is waiting to continue an aborted analysis, let's do it now so that it won't get killed in startExtraEngines
+	for(auto * engine : _engines)
+		if(engine->idle())
+			engine->restartAbortedAnalysis();
+
+	//We might still want some engines and if we can kill some idle ones to make space it ain't bad
+	if(wantThisManyEngines)
+		startExtraEngines(wantThisManyEngines);
 }
 
 int EngineSync::sendFilter(const QString & generatedFilter, const QString & filter)
@@ -290,7 +437,6 @@ int EngineSync::sendFilter(const QString & generatedFilter, const QString & filt
 
 	return _filterCurrentRequestID;
 }
-
 
 void EngineSync::sendRCode(const QString & rCode, int requestId, bool whiteListedVersion)
 {
@@ -320,11 +466,11 @@ void EngineSync::processFilterScript()
 	if (!_waitingFilter)
 		return;
 
-	Log::log() << "Pausing and resuming engines to make sure nothing else is running when we start the filter." << std::endl;
-
 	//First we make sure nothing else is running before we ask the engine to run the filter
 	if(!_filterRunning)
 	{
+		Log::log() << "Pausing and resuming engines to make sure nothing else is running when we start the filter." << std::endl;
+
 		pauseEngines(); //Make sure engines pause/stop
 		_filterRunning = true;
 		resumeEngines();
@@ -333,8 +479,8 @@ void EngineSync::processFilterScript()
 	{
 		try
 		{
-			for (auto *engine : _workers)
-				if (engine->idle())
+			for (auto *engine : _engines)
+				if (engine->idle()  && engine->runsUtility())
 				{
 					engine->runScriptOnProcess(_waitingFilter);
 					_waitingFilter = nullptr;
@@ -353,20 +499,29 @@ void EngineSync::filterDone(int requestID)
 	_filterRunning = false; //Allow other stuff to happen
 }
 
+
 void EngineSync::processSettingsChanged()
 {
-	for(auto * engine : _workers)
+	for(auto * engine : _engines)
 		if(engine->shouldSendSettings())
 			engine->sendSettings();
 }
+
+void EngineSync::processReloadData()
+{
+	for(auto * engine : _engines)
+		if(engine->needsReloadData())
+			engine->sendReloadData();
+}
+
 
 bool EngineSync::processScriptQueue()
 {
 	try
 	{
-		for(auto * engine : _workers)
+		for(auto * engine : _engines)
 		{
-			if(engine->idle() && _waitingScripts.size() > 0)
+			if(engine->idle()  && engine->runsUtility() && _waitingScripts.size() > 0)
 			{
 				RScriptStore * waiting = _waitingScripts.front();
 
@@ -392,49 +547,53 @@ bool EngineSync::processScriptQueue()
 }
 
 
-bool EngineSync::processDynamicModules()
+stringset EngineSync::processDynamicModules()
 {
-	using namespace Modules;
-	
-	if(!amICastingAModuleRequestWide() && (DynamicModules::dynMods()->aModuleNeedsToBeLoadedInR() || DynamicModules::dynMods()->aModuleNeedsToBeUnloadedFromR()))
-	{
-		if(DynamicModules::dynMods()->aModuleNeedsToBeLoadedInR())			setModuleWideCastVars(DynamicModules::dynMods()->getJsonForPackageLoadingRequest());
-		else if(DynamicModules::dynMods()->aModuleNeedsToBeUnloadedFromR())	setModuleWideCastVars(DynamicModules::dynMods()->getJsonForPackageUnloadingRequest());
-	}
-
-	if	(!DynamicModules::dynMods()->aModuleNeedsPackagesInstalled() && _requestWideCastModuleJson.isNull())
-		return false;
-
+	using DynMods = Modules::DynamicModules;
 
 	try
 	{
-		bool wantToRunInstall = DynamicModules::dynMods()->aModuleNeedsPackagesInstalled(), foundIdle = false;
+		stringset	wantToRunInstall	= DynMods::dynMods()->modulesNeedingPackagesInstalled(),
+					stillWantTo			= {};
 		
-		for(auto engine : _engines)
+		for(const std::string & mod : wantToRunInstall)
 		{
-			if(engine->idle())
+			if(moduleHasEngine(mod))
 			{
-				foundIdle = true;
-				if		(DynamicModules::dynMods()->aModuleNeedsPackagesInstalled())												engine->runModuleInstallRequestOnProcess(DynamicModules::dynMods()->getJsonForPackageInstallationRequest());
-				else if	(!_requestWideCastModuleJson.isNull() && _requestWideCastModuleResults.count(engine->channelNumber()) == 0)	engine->runModuleLoadRequestOnProcess(_requestWideCastModuleJson);
+				auto * engine = _moduleEngines[mod];
+
+				if(engine->analysisInProgress())
+					engine->killEngine();
+
+				if(engine->idle())
+					engine->runModuleInstallRequestOnProcess(DynMods::dynMods()->getJsonForPackageInstallationRequest(mod));
 			}
+			else
+				for(auto & engine : _engines)
+					if(engine->idle() && engine->runsUtility()) //We don't care if the engine is meant for some module or other. We restart afterwards anyway
+					{
+						registerEngineForModule(engine, mod);
+						engine->runModuleInstallRequestOnProcess(DynMods::dynMods()->getJsonForPackageInstallationRequest(mod));
+					}
+					else
+						stillWantTo.insert(mod);
 		}
 		
-		if(wantToRunInstall && !foundIdle)
-			return true;
+		return stillWantTo;
 	}
 	catch(Modules::ModuleException & e)	{ Log::log() << "Exception thrown in processDynamicModules: " <<  e.what() << std::endl;	}
 	catch(std::exception & e)			{ Log::log() << "Exception thrown in processDynamicModules: " << e.what() << std::endl;		}
 	catch(...)							{ Log::log() << "Unknown Exception thrown in processDynamicModules..." << std::endl;		}
 	
-	return false;
+	return {};
 }
 
-bool EngineSync::processAnalysisRequests()
+std::set<std::string> EngineSync::processAnalysisRequests()
 {	
-	bool couldntFindIdleEngine = false;
+
+	std::set<std::string> modulesNeedingEngines;
 	
-	for(auto engine : _workers)
+	for(auto * engine : _engines)
 		engine->handleRunningAnalysisStatusChanges();
 
 	Analyses::analyses()->applyToAll([&](Analysis * analysis)
@@ -443,44 +602,156 @@ bool EngineSync::processAnalysisRequests()
 		{
 			try
 			{
-				bool anEngineIsRunningMe = false;
-				
-				for(auto engine : _workers)
+				const std::string modName = analysis->dynamicModule()->name();
+
+				//First check if we already have an engine for this module
+				if(moduleHasEngine(modName))
+				{
+					auto * engine = _moduleEngines[modName];
+
 					if(engine->willProcessAnalysis(analysis))
-					{
 						engine->runAnalysisOnProcess(analysis);
-						return;
+
+					else if(engine->stopped())
+						startStoppedEngine(engine);
+
+					else if(engine->idle())
+					{
+						if(!engine->moduleLoaded())
+						{
+							if(!engine->moduleLoading())
+								engine->moduleLoad();
+						}
+						//else
+						// If the engine is being stopped it might be here	throw std::runtime_error("An engine is meant for module " + modName + " but won't process analysis " + analysis->name() + " and is also loaded, which does not make any sense.");
 					}
-					else if (engine->analysisInProgress() == analysis)
-						anEngineIsRunningMe = true;
-					
-				
-				couldntFindIdleEngine = couldntFindIdleEngine || !anEngineIsRunningMe;
+				}
+				else
+				{
+					bool foundOne = false;
+
+					//See if there is an idle engine we can use
+					for(auto * engine : _engines)
+						if(engine->module() == "" && !foundOne)
+							if(engine->idle() && engine->runsAnalysis())
+							{
+								registerEngineForModule(engine, modName);
+								foundOne = true;
+							}
+
+
+					if(!foundOne)
+						modulesNeedingEngines.insert(modName);
+						
+				}
+
 			}
-			catch(...)	{ Log::log() << "Exception thrown in ProcessAnalysisRequests" << std::endl;	}
+			catch(std::exception & e)	{ Log::log() << "Exception " << e.what() << " thrown in ProcessAnalysisRequests" << std::endl;	}
 		}
 	});
 	
-	return couldntFindIdleEngine;
+	return modulesNeedingEngines;
 }
 
 ///Maybe no engines are idle, but if one is initializing or setting up some stuff it'll be so soon. So tell JASP to be patient then.
-bool EngineSync::anEngineIdleSoon()
+bool EngineSync::anEngineIdleSoon() const
 {
-	for(auto engine : _workers)
+	for(auto * engine : _engines)
 		if(engine->idleSoon())
 			return true;
 	return false;
 }
 
-void EngineSync::startExtraEngine()
+IPCChannel *EngineSync::channel(size_t channelNumber)
 {
-	static int newEngineStartTime		= 0;
-	if(maxEngineCount() > _workers.size() && newEngineStartTime + ENGINE_EXTRA_INTERVAL < Utils::currentSeconds())
+	if(channelNumber > _channels.size())
 	{
-		newEngineStartTime = Utils::currentSeconds();
-		Log::log() << "New engine requested, so starting it!" << std::endl;
-		_workers.insert(createNewEngine());
+		Log::log() << "IPCChannel requested for channel #" + std::to_string(channelNumber) + " but only " + std::to_string(_channels.size()) + " exist...";
+		return nullptr;
+	}
+
+	return _channels[channelNumber];
+}
+
+size_t EngineSync::enginesIdleSoon() const
+{
+	size_t num = 0;
+	for(auto * engine : _engines)
+		if(engine->idleSoon())
+			num++;
+	
+	return num;
+}
+
+size_t EngineSync::enginesStartableCount() const
+{
+	size_t enginesPossible = maxEngineCount() - _engines.size();
+
+	//But perhaps they have to cool down for a bit.
+
+	for(long engineStopTime : _engineStopTimes)
+		if(engineStopTime != -1 && ( engineStopTime + ENGINE_COOLDOWN > Utils::currentMillis() ) && enginesPossible > 0)
+			enginesPossible--;
+
+	return enginesPossible;
+}
+
+bool EngineSync::channelCooledDown(size_t channel) const
+{
+	return _engineStopTimes[channel] == -1 || _engineStopTimes[channel] + ENGINE_COOLDOWN < Utils::currentMillis();
+}
+
+bool EngineSync::channelFree(size_t channel) const
+{
+	for(auto * engine : _engines)
+		if(engine->channelNumber() == channel)
+			return false;
+
+	if(!channelCooledDown(channel))
+		return false;
+
+	return true;
+}
+
+bool EngineSync::aChannelFree() const
+{
+	for(size_t c=0; c<_channels.size() && c<maxEngineCount(); c++)
+		if(channelFree(c))
+			return true;
+	return false;
+}
+
+void EngineSync::startExtraEngines(size_t num)
+{
+	for(; enginesStartableCount() && num > 0; num--)
+		if(aChannelFree())
+			createNewEngine();
+
+	if(num)
+	{
+		Log::log() << "Too many engines running already, perhaps it is time to kill up to " << num << " idle one" << (num == 1 ? "" : "s") << "." << std::endl;
+		
+
+		std::vector<std::pair<int, EngineRepresentation *>> idleEngines;
+
+		for(auto * e : _engines)
+			if(e->idle() && e->idleFor() > 0)
+				idleEngines.push_back(std::make_pair(e->idleFor(), e));
+
+		std::sort(idleEngines.begin(), idleEngines.end(), [](auto & l, auto & r) { return l.first > r.first; }); //longest idle first please
+
+		for(size_t i=0; i<idleEngines.size() && num > 0; i++)
+		{
+			auto * engine = idleEngines[i].second;
+			Log::log() << "Found an idle one, destroying it (" << engine->channelNumber() << "), it was idle for " << idleEngines[i].first << "s." << std::endl;
+
+			stopAndDestroyEngine(engine);
+			//createNewEngine(); //Dont do it here, but wait for the next loop, and we will makes ure there is a small builtin delay to avoid boost failing hard on windows
+			num--;
+		}
+
+		if(num > 0)
+			Log::log() << "Still need " << num << ", let's try again later." << std::endl;
 	}
 }
 
@@ -551,6 +822,14 @@ QProcess * EngineSync::startSlaveProcess(int channel)
 	return slave;
 }
 
+bool EngineSync::moduleInstallRunning() const
+{
+	for(auto * e : _engines)
+		if(e->installingModule())
+			return true;
+	return false;
+}
+
 void EngineSync::deleteOrphanedTempFiles()
 {
 	TempFiles::deleteOrphans();
@@ -563,15 +842,9 @@ void EngineSync::heartbeatTempFiles()
 
 void EngineSync::stopEngines()
 {
-	if(!_engineStarted) return;
-
+	_stopProcessing = true; 
+	
 	auto timeout = QDateTime::currentSecsSinceEpoch() + 10;
-
-	//make sure we process any received messages first.
-	for(auto engine : _engines)
-		engine->processReplies();
-
-	_engineStarted		= false;
 
 	for(EngineRepresentation * e : _engines)
 		e->stopEngine();
@@ -590,35 +863,6 @@ void EngineSync::stopEngines()
 			for (auto * engine : _engines)
 				engine->processReplies();
 
-	//timeout = QDateTime::currentSecsSinceEpoch() + 10;
-
-	/*
-		This is all commented out because it is very dangerous to just go and processEvents in the middle of other functions...
-	  
-	  Log::log() << "Checking if engines are running by using QApplication::processEvents to get answers." << std::endl;
-
-	bool stillRunning;
-	do
-	{
-		QApplication::processEvents(); //Otherwise we will not get feedback from QProcess (aka finished)
-
-		stillRunning = false;
-
-		for (auto * engine : _engines)
-			if(engine->jaspEngineStillRunning())
-				stillRunning = true;
-	}
-	while(stillRunning && timeout > QDateTime::currentSecsSinceEpoch()); //Let's give good old jaspEngines some time to shutdown gracefully
-
-	if(stillRunning)
-	{
-		Log::log() << "Waiting for engine to stop took longer than timeout, so we'll just kill them/it." << std::endl;
-
-		for (auto * engine : _engines)
-			if(engine->jaspEngineStillRunning())
-				engine->killEngine();
-	}*/
-
 	Log::log() << "Engines stopped(/killed)" << std::endl;
 }
 
@@ -626,10 +870,8 @@ void EngineSync::pauseEngines(bool unloadData)
 {
 	JASPTIMER_SCOPE(EngineSync::pauseEngines);
 
-	if(!_engineStarted) return;
-
 	//make sure we process any received messages first.
-	for(auto engine : _engines)
+	for(auto * engine : _engines)
 		engine->processReplies();
 
 	for(EngineRepresentation * e : _engines)
@@ -646,145 +888,119 @@ void EngineSync::pauseEngines(bool unloadData)
 			engine->killEngine();
 }
 
+void EngineSync::startStoppedEngine(EngineRepresentation * engine)
+{
+	if(!engine->jaspEngineStillRunning())
+		engine->restartEngine(startSlaveProcess(engine->channelNumber()));
+	else
+		engine->resumeEngine();
+}
+
 void EngineSync::resumeEngines()
 {
 	JASPTIMER_SCOPE(EngineSync::resumeEngines);
-
-	if(!_engineStarted)
-		return;
-
-	bool restartedAnEngine = false;
-
+	
 	for(EngineRepresentation * engine : _engines)
-		if(!engine->jaspEngineStillRunning())
-		{
-			engine->restartEngine(startSlaveProcess(engine->channelNumber()));
-			restartedAnEngine = true;
-		}
-		else
-			engine->resumeEngine();
+		startStoppedEngine(engine);
+	
+	_stopProcessing = false;
 
 	while(!allEnginesResumed())
 		for (auto * engine : _engines)
 			engine->processReplies();
 }
 
-bool EngineSync::allEnginesStopped()
+bool EngineSync::allEnginesStopped(std::set<EngineRepresentation *> these)
 {
-	for(auto * engine : _engines)
+	for(auto * engine : these.size() > 0 ? these : _engines)
 		if(!engine->stopped())
 			return false;
 	return true;
 }
 
-bool EngineSync::allEnginesPaused()
+bool EngineSync::allEnginesPaused(std::set<EngineRepresentation *> these)
 {
-	for(auto * engine : _engines)
+	for(auto * engine : these.size() > 0 ? these : _engines)
 		if(!engine->paused()) //Initializing() is part paused()
 			return false;
 	return true;
 }
 
-bool EngineSync::allEnginesResumed()
+bool EngineSync::allEnginesResumed(std::set<EngineRepresentation *> these)
 {
-	for(auto * engine : _engines)
+	for(auto * engine : these.size() > 0 ? these : _engines)
 		if(!engine->resumed())
 			return false;
 	return true;
 }
 
-bool EngineSync::allEnginesInitializing()
+bool EngineSync::allEnginesInitializing(std::set<EngineRepresentation *> these)
 {
-	for(auto * engine : _engines)
+	for(auto * engine : these.size() > 0 ? these : _engines)
 		if(!engine->initializing())
 			return false;
 	return true;
 }
 
-void EngineSync::moduleLoadingFailedHandler(const QString & moduleName, const QString & errorMessage, int channelID)
+void EngineSync::enginesPrepareForData()
 {
-	Log::log() << "Received EngineSync::moduleLoadingFailedHandler(" << moduleName.toStdString() << ", " << errorMessage.toStdString() << ", " << channelID << ")" << std::endl;
+	JASPTIMER_SCOPE(EngineSync::enginesPrepareForData);
 
-	if(_requestWideCastModuleName != moduleName.toStdString())
-		throw std::runtime_error("Unexpected module received in EngineSync::moduleLoadingFailed, expected: " + _requestWideCastModuleName + ", but got: " + moduleName.toStdString());
+	//make sure we process any received messages first.
+	for(auto * engine : _engines)
+		engine->processReplies();
 
-	_requestWideCastModuleResults[channelID] = errorMessage.size() == 0 ? "error" : errorMessage.toStdString();
+	std::set<EngineRepresentation *> pauseOrKillThese;
 
-	checkModuleWideCastDone();
+	for(EngineRepresentation * e : _engines)
+		if(e->busyWithData())
+			pauseOrKillThese.insert(e);
+
+	long tryTill = Utils::currentSeconds() + ENGINE_KILLTIME; //Ill give the engine 1 sec to respond
+
+	while(!allEnginesPaused(pauseOrKillThese) && tryTill >= Utils::currentSeconds())
+		for (auto * engine : pauseOrKillThese)
+			engine->processReplies();
+
+	for (auto * engine : pauseOrKillThese)
+		if(!engine->paused())
+			engine->killEngine();
 }
 
-void EngineSync::moduleLoadingSucceededHandler(const QString & moduleName, int channelID)
+void EngineSync::enginesReceiveNewData()
 {
-	Log::log() << "Received EngineSync::moduleLoadingSucceededHandler(" << moduleName.toStdString() << ", " << channelID << ")" << std::endl;
+	if(_stopProcessing)
+		return;
+	
+	JASPTIMER_SCOPE(EngineSync::enginesReceiveNewData);
 
-	if(_requestWideCastModuleName != moduleName.toStdString())
-		throw std::runtime_error("Unexpected module received in EngineSync::moduleLoadingSucceeded, expected: " + _requestWideCastModuleName + ", but got: " + moduleName.toStdString());
+	//make sure we process any received messages first.
+	for(auto * engine : _engines)
+		engine->processReplies();
 
-	_requestWideCastModuleResults[channelID] = "succes";
+	for(auto * engine : _engines)
+		if(engine->paused())
+			engine->resumeEngine();
 
-	checkModuleWideCastDone();
+	for(auto * engine : _engines)
+		if(!engine->jaspEngineStillRunning())
+			engine->restartEngine(startSlaveProcess(engine->channelNumber()));
+
+	emit reloadData();
 }
 
-void EngineSync::moduleUnloadingFinishedHandler(const QString & moduleName, int channelID)
+bool EngineSync::isModuleInstallRequestActive(const QString &moduleName)
 {
-	Log::log() << "Received EngineSync::moduleUnloadingFinishedHandler(" << moduleName.toStdString() << ", " << channelID << ")" << std::endl;
-
-	if(_requestWideCastModuleName != moduleName.toStdString())
-		throw std::runtime_error("Unexpected module received in EngineSync::moduleUnloadingFinishedHandler, expected: " + _requestWideCastModuleName + ", but got: " + moduleName.toStdString());
-
-	_requestWideCastModuleResults[channelID] = "I am an inconsequential message";
-
-	checkModuleWideCastDone();
-}
-
-
-void EngineSync::checkModuleWideCastDone()
-{
-	if(!_requestWideCastModuleJson.isNull() && _requestWideCastModuleResults.size() == _engines.size())
-	{
-		if(moduleStatusFromString(_requestWideCastModuleJson["moduleRequest"].asString()) == moduleStatus::loadingNeeded)
-		{
-			std::string compoundedError = "";
-			int failed = 0;
-
-			for(auto * engine : _engines)
-			{
-				auto res = _requestWideCastModuleResults[engine->channelNumber()];
-				if(res != "succes")
-				{
-					failed ++;
-					compoundedError += std::string(compoundedError != "" ? "\n" : "") + "engine " + std::to_string(engine->channelNumber()) + " reported error: " + res;
-				}
-			}
-
-
-			if(failed == 0)	emit moduleLoadingSucceeded(QString::fromStdString(_requestWideCastModuleName));
-			else			emit moduleLoadingFailed(QString::fromStdString(_requestWideCastModuleName), QString::fromStdString(compoundedError));
-		}
-
-		resetModuleWideCastVars();
-	}
-}
-
-void EngineSync::resetModuleWideCastVars()
-{
-	_requestWideCastModuleName			= "";
-	_requestWideCastModuleJson			= Json::nullValue;
-	_requestWideCastModuleResults.clear();
-}
-
-void EngineSync::setModuleWideCastVars(Json::Value newVars)
-{
-	resetModuleWideCastVars();
-
-	_requestWideCastModuleName			= newVars["moduleName"].asString();
-	_requestWideCastModuleJson			= newVars;
+	for(auto * e : _engines)
+		if(e->installingModule() && e->handlingModuleRequest(fq(moduleName)))
+			return true;
+	return false;
 }
 
 void EngineSync::refreshAllPlots()
 {
 	std::set<Analysis*> inProgress;
-	for(EngineRepresentation * engine : _workers)
+	for(EngineRepresentation * engine : _engines)
 		if(engine->analysisInProgress() != nullptr)
 			inProgress.insert(engine->analysisInProgress());
 
@@ -801,13 +1017,71 @@ void EngineSync::refreshAllPlots()
 
 void EngineSync::logCfgRequest()
 {
-	for(EngineRepresentation * e : _workers)
+	for(EngineRepresentation * e : _engines)
 		_logCfgRequested.insert(e);
 }
 
 void EngineSync::logCfgReplyReceived(EngineRepresentation * engine)
 {
 	_logCfgRequested.erase(engine);
+}
+
+void EngineSync::registerEngineForModule(EngineRepresentation * engine, std::string modName)
+{
+	if(_moduleEngines.count(modName) > 0 && _moduleEngines[modName] != engine)
+		throw std::runtime_error("Trying to register module '" + modName + "' to engine #" +
+								 std::to_string(engine->channelNumber()) + " but it is already registered to " +
+								 std::to_string(_moduleEngines[modName]->channelNumber()));
+
+	Log::log() << "Registering engine #" << engine->channelNumber() << " for module '" << modName << "'" << std::endl;
+
+	_moduleEngines[modName] = engine;
+
+	engine->setDynamicModule(modName);
+}
+
+void EngineSync::unregisterEngineForModule(EngineRepresentation * engine, std::string modName)
+{
+	if(_moduleEngines.count(modName) > 0 && _moduleEngines[modName] != engine)
+		return;
+
+	Log::log() << "Unregistering engine #" << engine->channelNumber() << " for module '" << modName << "'" << std::endl;
+	_moduleEngines.erase(modName); //We only erase it when it is the exact same engine + modName combo
+	engine->setDynamicModule("");
+	//engine->shutEngineDown(); this function is triggered by closing the engine anyway
+}
+
+void EngineSync::stopModuleEngine(QString moduleName)
+{
+	const std::string modName = fq(moduleName);
+	if(_moduleEngines.count(modName))
+		_moduleEngines[modName]->shutEngineDown();
+}
+
+void EngineSync::moduleInstallationFailedHandler(const QString &moduleName, const QString &)
+{
+	const std::string modName = fq(moduleName);
+	if(_moduleEngines.count(modName))
+		unregisterEngineForModule(_moduleEngines[modName], modName);
+}
+
+void EngineSync::killModuleEngine(Modules::DynamicModule * mod)
+{
+	if(!_moduleEngines.count(mod->name()))
+		return;
+
+	_moduleEngines[mod->name()]->shutEngineDown();
+}
+
+void EngineSync::killEngine(int channelNumber)
+{
+	for(auto * engine : _engines)
+		if(engine->channelNumber() == channelNumber)
+		{
+			if(!engine->killed())
+				engine->killEngine();
+			return;
+		}
 }
 
 void EngineSync::processLogCfgRequests()
@@ -852,7 +1126,7 @@ void EngineSync::cleanUpAfterClose()
 	//try { restartEngines(); }
 	catch(unexpectedEngineReply e) {}
 
-
+	resetListModel();
 }
 
 std::string	EngineSync::currentStateForDebug() const
@@ -876,24 +1150,69 @@ std::string	EngineSync::currentStateForDebug() const
 
 EngineRepresentation *	EngineSync::createRCmdEngine()
 {
-	EngineRepresentation * rCmdEngine = createNewEngine();
-	
-	_rCmders.insert(rCmdEngine);
+	if(!_rCmder)
+	{
+		const size_t rCmdChannelNumber = 12345; //Shouldnt ever crash with _channels
 
-	rCmdEngine->setRunsAnalysis(false);
-	rCmdEngine->setRunsUtility(	false);
-	rCmdEngine->setRunsRCmd(	true);
+		_rCmderChannel	= new IPCChannel(_memoryName, rCmdChannelNumber);
+		_rCmder			= createNewEngine(false, rCmdChannelNumber);
 
-	return rCmdEngine;
+		_rCmder->setRunsAnalysis(	false);
+		_rCmder->setRunsUtility(	false);
+		_rCmder->setRunsRCmd(		true);
+
+		resetListModel();
+	}
+
+	return _rCmder;
 }
 
 void EngineSync::destroyEngine(EngineRepresentation * engine)
 {
 	if(!engine) return;
-	
-	_rCmders.erase(engine);
-	_workers.erase(engine);
+
+	const size_t channel = engine->channelNumber();
+
+	if(channel < _engineStopTimes.size())
+	{
+		_engineStopTimes[channel] = Utils::currentMillis();
+
+		QTimer::singleShot(ENGINE_COOLDOWN / 2, [channel, this]()
+		{
+			if(_channels.size() > channel) //still there?
+				_channels[channel]->findConstructAllAgain();
+		});
+	}
+
+	if(engine->module() != "")	_moduleEngines.erase(engine->module());
+	else
+	{
+		std::string modName = "";
+
+		for(const auto & nameEngine : _moduleEngines)
+			if(nameEngine.second == engine)
+				modName = nameEngine.first;
+
+		_moduleEngines.erase(modName);
+	}
+
 	_engines.erase(engine);
 
 	delete engine;
+
+	if(_rCmder  == engine)
+	{
+		_rCmder  = nullptr;
+
+		delete _rCmderChannel;
+		_rCmderChannel = nullptr;
+	}
+
+	resetListModel();
+}
+
+void EngineSync::stopAndDestroyEngine(EngineRepresentation * engine)
+{
+	engine->shutEngineDown();
+	destroyEngine(engine);
 }

--- a/Desktop/engine/enginesync.h
+++ b/Desktop/engine/enginesync.h
@@ -19,6 +19,8 @@
 #ifndef ENGINESYNC_H
 #define ENGINESYNC_H
 
+#include <QAbstractListModel>
+
 #ifdef __APPLE__
 #include <semaphore.h>
 #else
@@ -35,25 +37,33 @@
 /// It keeps track of which analyses, etc are executing on
 /// which background process through the use of EngineRepresentation
 /// 
-class EngineSync : public QObject
+class EngineSync : public QAbstractListModel
 {
 	Q_OBJECT
 	
 public:
+
 	EngineSync(QObject *parent);
 	~EngineSync();
 
 	void start(int ppi);
-	bool engineStarted()			{ return _engineStarted; }
-	bool allEnginesInitializing();
+	bool allEnginesInitializing(std::set<EngineRepresentation *> these = {}); ///< If `these` isn't filled all engines are checked
 
 	static EngineSync * singleton() { return _singleton; }
 
-	EngineRepresentation *	createNewEngine();
+	EngineRepresentation *	createNewEngine(bool addToEngines = true, int overrideChannel = -1);
 	EngineRepresentation *	createRCmdEngine();
+
+	std::string	currentStateForDebug() const;
+
+	int						rowCount(const QModelIndex & = QModelIndex())				const override;
+	QVariant				data(const QModelIndex &index, int role = Qt::DisplayRole)	const override;
+	QHash<int, QByteArray>	roleNames()													const override;
+
 
 public slots:
 	void		destroyEngine(EngineRepresentation * engine);
+	void		stopAndDestroyEngine(EngineRepresentation * engine);
 	int			sendFilter(		const QString & generatedFilter,	const QString & filter);
 	void		sendRCode(		const QString & rCode,				int requestId,					bool whiteListedVersion);
 	void		computeColumn(	const QString & columnName,			const QString & computeCode,	columnType columnType);
@@ -61,15 +71,19 @@ public slots:
 	void		stopEngines();
 	void		resumeEngines();
 	void		restartEngines();
+	void		startStoppedEngine(EngineRepresentation * engine);
 	void		refreshAllPlots();
 	void		logCfgRequest();
 	void		logToFileChanged(bool) { logCfgRequest(); }
 	void		cleanUpAfterClose();
-	void		loadAllActiveModules();
 	void		filterDone(int requestID);
-	std::string	currentStateForDebug() const;
-	void		haveYouTriedTurningItOffAndOnAgain() { stopEngines(); restartEngines(); } // https://www.youtube.com/watch?v=DPqdyoTpyEs
-	
+	void		haveYouTriedTurningItOffAndOnAgain() { stopEngines(); resumeEngines(); } // https://www.youtube.com/watch?v=DPqdyoTpyEs
+	void		killModuleEngine(Modules::DynamicModule * mod);
+	void		killEngine(int channelNumber);
+	void		enginesPrepareForData();
+	void		enginesReceiveNewData();
+	bool		isModuleInstallRequestActive(const QString & moduleName);
+
 signals:
 	void		processNewFilterResult(const std::vector<bool> & filterResult, int requestID);
 	void		processFilterErrorMsg(const QString & error, int requestID);
@@ -90,31 +104,37 @@ signals:
 	void		refreshAllPlotsExcept(const std::set<Analysis*> & inProgress);
 	void		plotEditorRefresh();
 	void		settingsChanged();
+	void		reloadData();
 
 private:
 	//These process functions can request a new engine to be started:
 	bool		processScriptQueue();
-	bool		processDynamicModules();
-	bool		processAnalysisRequests();
+	stringset	processDynamicModules();
+	stringset	processAnalysisRequests();	///< Returns modules that still need an engine
 	
 	void		processLogCfgRequests();
 	void		processFilterScript();
 	void		processSettingsChanged();
+	void		processReloadData();
 	
-	bool		allEnginesStopped();
-	bool		allEnginesPaused();
-	bool		allEnginesResumed();
+	void		shutdownBoredEngines();
+	bool		allEnginesStopped(	std::set<EngineRepresentation *> these = {}); ///< If `these` isn't filled all engines are checked
+	bool		allEnginesPaused(	std::set<EngineRepresentation *> these = {}); ///< If `these` isn't filled all engines are checked
+	bool		allEnginesResumed(	std::set<EngineRepresentation *> these = {}); ///< If `these` isn't filled all engines are checked
 	QProcess*	startSlaveProcess(int channelNumber);
+
+	bool		moduleInstallRunning()				const;
+	size_t		enginesStartableCount()				const;
+	bool		channelFree(size_t channel)			const;
+	bool		aChannelFree()						const;
+	bool		channelCooledDown(size_t channel)	const;
 
 #ifdef _WIN32 
 	void		fixPATHForWindows(QProcessEnvironment & env);
 #endif
 	
-	void		checkModuleWideCastDone();
-	void		resetModuleWideCastVars();
-	void		setModuleWideCastVars(Json::Value newVars);
-	bool		amICastingAModuleRequestWide()	{ return !_requestWideCastModuleJson.isNull(); }
 	size_t		maxEngineCount() const;
+	size_t		enginesIdleSoon() const;
 
 private slots:
 	void	deleteOrphanedTempFiles();
@@ -122,37 +142,46 @@ private slots:
 
 	void	process();
 
-	void	moduleLoadingFailedHandler(		const QString & moduleName, const QString & errorMessage, int channelID);
-	void	moduleLoadingSucceededHandler(	const QString & moduleName, int channelID);
-	void	moduleUnloadingFinishedHandler(	const QString & moduleName, int channelID);
-
 	void	restartEngineAfterCrash(EngineRepresentation * engine);
-	void	restartKilledEngines();
+	void	restartKilledAndStoppedEngines();
 
-	void	logCfgReplyReceived(EngineRepresentation * engine);
+
+	void	logCfgReplyReceived(		EngineRepresentation * engine);
+	void	registerEngineForModule(	EngineRepresentation * engine, std::string modName);
+	void	unregisterEngineForModule(	EngineRepresentation * engine, std::string modName);
+	void	stopModuleEngine(			QString moduleName);
+	void	moduleInstallationFailedHandler(	const QString & moduleName, const QString & );
 	
 	void	maxEngineCountChanged();
-	void	startExtraEngine();
-	bool	anEngineIdleSoon();
+	void	startExtraEngines(size_t num=1);
+	bool	anEngineIdleSoon() const;
+	bool	moduleHasEngine(const std::string & name) { return _moduleEngines.count(name); }
+	void	resetListModel()	{ beginResetModel(); endResetModel(); } // lets keep things easy here, it doesnt have to be highperf
+
+	IPCChannel * channel(size_t channelNumber);
+
+private:
+	std::vector<EngineRepresentation *> orderedEngines() const;
 
 private:
 	static EngineSync				*	_singleton;
 	RFilterStore					*	_waitingFilter					= nullptr;
-
-	bool								_engineStarted					= false,
-										_filterRunning					= false;
+	bool								_filterRunning					= false,
+										_stopProcessing					= false;
 	int									_filterCurrentRequestID			= 0;
 	std::string							_memoryName,
-										_engineInfo,
-										_requestWideCastModuleName		= "";
-	Json::Value							_requestWideCastModuleJson		= Json::nullValue;
-	std::map<int, std::string>			_requestWideCastModuleResults;
+										_engineInfo;
 
 	std::queue<RScriptStore*>			_waitingScripts;
-	std::set<EngineRepresentation*>		_workers,		//Your typical run of the mill engine, can do analyses and Rscript/filter stuff
-										_rCmders,		//For those special occassions where you just want to shout at R in a more personal manner
-										_engines,		//Keeping track of all those engines isn't easy...
+	std::map<std::string,
+		EngineRepresentation * >		_moduleEngines;					///<An engine per module active. Engines will be started and closed as needed.
+	std::set<EngineRepresentation*>		_engines,						///<All analysis/utility/module engines, excepting _rCmder
 										_logCfgRequested;
+	std::vector<IPCChannel*>			_channels;						///<Channels are instantiated separately from the engines to avoid boost messing up
+	EngineRepresentation			*	_rCmder				= nullptr;	///<For those special occassions where you just want to shout at R in a more personal manner
+	IPCChannel						*	_rCmderChannel		= nullptr;	///<The channel for shouting at R in a more personal manner
+	std::vector<long>					_engineStopTimes;				///<Here we keep track of how long ago it is an engine shut down, this way we can give it a slight time between closing and starting an engine. To avoid shared memory problems on windows.
+
 };
 
 #endif // ENGINESYNC_H

--- a/Desktop/engine/enginesync.h
+++ b/Desktop/engine/enginesync.h
@@ -174,13 +174,13 @@ private:
 
 	std::queue<RScriptStore*>			_waitingScripts;
 	std::map<std::string,
-		EngineRepresentation * >		_moduleEngines;					///<An engine per module active. Engines will be started and closed as needed.
-	std::set<EngineRepresentation*>		_engines,						///<All analysis/utility/module engines, excepting _rCmder
+		EngineRepresentation * >		_moduleEngines;					///< An engine per module active. Engines will be started and closed as needed.
+	std::set<EngineRepresentation*>		_engines,						///< All analysis/utility/module engines, excepting _rCmder
 										_logCfgRequested;
-	std::vector<IPCChannel*>			_channels;						///<Channels are instantiated separately from the engines to avoid boost messing up
-	EngineRepresentation			*	_rCmder				= nullptr;	///<For those special occassions where you just want to shout at R in a more personal manner
-	IPCChannel						*	_rCmderChannel		= nullptr;	///<The channel for shouting at R in a more personal manner
-	std::vector<long>					_engineStopTimes;				///<Here we keep track of how long ago it is an engine shut down, this way we can give it a slight time between closing and starting an engine. To avoid shared memory problems on windows.
+	std::vector<IPCChannel*>			_channels;						///< Channels are instantiated separately from the engines to avoid boost messing up
+	EngineRepresentation			*	_rCmder				= nullptr;	///< For those special occassions where you just want to shout at R in a more personal manner
+	IPCChannel						*	_rCmderChannel		= nullptr;	///< The channel for shouting at R in a more personal manner
+	std::vector<long>					_engineStopTimes;				///< Here we keep track of how long ago it is an engine shut down, this way we can give it a slight time between closing and starting an engine. To avoid shared memory problems on windows.
 
 };
 

--- a/Desktop/gui/messageforwarder.cpp
+++ b/Desktop/gui/messageforwarder.cpp
@@ -16,6 +16,11 @@ MessageForwarder::MessageForwarder(MainWindow *main) : QQuickItem(nullptr), _mai
 	setParent(main);
 }
 
+void MessageForwarder::log(QString msg)
+{
+	Log::log() << msg << std::endl;
+}
+
 MessageForwarder * MessageForwarder::_singleton = nullptr;
 
 void MessageForwarder::showWarning(QString title, QString message)

--- a/Desktop/gui/messageforwarder.h
+++ b/Desktop/gui/messageforwarder.h
@@ -23,7 +23,6 @@ public:
 
 	static MessageForwarder * msgForwarder() { return _singleton; }
 
-
 	static void showWarning(QString title, QString message);
 	static void showWarning(std::string title, std::string message)		{ showWarning(QString::fromStdString(title),	QString::fromStdString(message));	}
 	static void showWarning(const char * title, const char * message)	{ showWarning(QString(title),					QString(message));					}
@@ -55,6 +54,8 @@ public slots:
 
 	QString			browseSaveFileQML(QString caption, QString browsePath, QString filter)																	{ return browseSaveFile(caption, browsePath, filter); }
 	QString			browseSaveFileDocumentsQML(QString caption, QString filter)																				{ return browseSaveFileDocuments(caption, filter); }
+
+	void			log(QString msg);
 
 private:
 	static		MessageForwarder	*_singleton;

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -416,7 +416,7 @@ int main(int argc, char *argv[])
 				if(!runJaspEngineJunctionFixer(argc, argv, false, false))
 				{					
 					std::cerr << "Modules folder missing and couldn't be created!\nContact the JASP team for support, or try the MSI." << std::endl;	
-					exit(1234);
+					exit(254);
 				}
 			}
 #endif

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -173,6 +173,7 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 	qmlRegisterType<ResultsJsInterface>							("JASP",		1, 0, "ResultsJsInterface"				);
 	qmlRegisterType<LabelModel>									("JASP",		1, 0, "LabelModel"						);
 
+
 	qmlRegisterUncreatableType<PlotEditor::AxisModel>			("JASP.PlotEditor",	1, 0, "AxisModel",					"Can't make it");
 	qmlRegisterUncreatableType<PlotEditor::PlotEditorModel>		("JASP.PlotEditor",	1, 0, "PlotEditorModel",			"Can't make it");
 
@@ -199,6 +200,8 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 MainWindow::~MainWindow()
 {
 	Log::log() << "MainWindow::~MainWindow()" << std::endl;
+
+	_analyses->destroyAllForms();
 
 	_singleton = nullptr;
 
@@ -283,7 +286,6 @@ void MainWindow::makeConnections()
 	connect(_engineSync,			&EngineSync::processNewFilterResult,				_filterModel,			&FilterModel::processFilterResult							);
 	connect(_engineSync,			&EngineSync::processFilterErrorMsg,					_filterModel,			&FilterModel::processFilterErrorMsg							);
 	connect(_engineSync,			&EngineSync::computeColumnSucceeded,				_filterModel,			&FilterModel::computeColumnSucceeded						);
-	connect(_engineSync,			&EngineSync::moduleLoadingSucceeded,				_ribbonModel,			&RibbonModel::moduleLoadingSucceeded						);
 	connect(_engineSync,			&EngineSync::plotEditorRefresh,						_plotEditorModel,		&PlotEditorModel::refresh									);
 
 	qRegisterMetaType<columnType>();
@@ -356,6 +358,7 @@ void MainWindow::makeConnections()
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_resultsJsInterface,	&ResultsJsInterface::setFontFamily							);
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_engineSync,			&EngineSync::refreshAllPlots								);
 	connect(_preferences,			&PreferencesModel::restartAllEngines,				_engineSync,			&EngineSync::haveYouTriedTurningItOffAndOnAgain				);
+	connect(_preferences,			&PreferencesModel::developerFolderChanged,			_dynamicModules,		&DynamicModules::uninstallJASPDeveloperModule				);
 
 	connect(_filterModel,			&FilterModel::refreshAllAnalyses,					_analyses,				&Analyses::refreshAllAnalyses,								Qt::QueuedConnection);
 	connect(_filterModel,			&FilterModel::updateColumnsUsedInConstructedFilter, _package,				&DataSetPackage::setColumnsUsedInEasyFilter					);
@@ -369,15 +372,15 @@ void MainWindow::makeConnections()
 	connect(_ribbonModel,			&RibbonModel::showRCommander,						this,					&MainWindow::showRCommander									);
 
 	connect(_dynamicModules,		&DynamicModules::dynamicModuleUnloadBegin,			_analyses,				&Analyses::removeAnalysesOfDynamicModule					);
-	connect(_dynamicModules,		&DynamicModules::dynamicModuleChanged,				_analyses,				&Analyses::refreshAnalysesOfDynamicModule					);
-	connect(_dynamicModules,		&DynamicModules::dynamicModuleReplaced,				_analyses,				&Analyses::replaceAnalysesOfDynamicModule					);
-	connect(_dynamicModules,		&DynamicModules::descriptionReloaded,				_analyses,				&Analyses::rescanAnalysisEntriesOfDynamicModule				);
+	connect(_dynamicModules,		&DynamicModules::dynamicModuleChanged,				_analyses,				&Analyses::refreshAnalysesOfDynamicModule						);
+	connect(_dynamicModules,		&DynamicModules::dynamicModuleReplaced,				_analyses,				&Analyses::replaceAnalysesOfDynamicModule,					Qt::DirectConnection);
+	connect(_dynamicModules,		&DynamicModules::descriptionReloaded,				_analyses,				&Analyses::rescanAnalysisEntriesOfDynamicModule,			Qt::QueuedConnection);
 	connect(_dynamicModules,		&DynamicModules::reloadHelpPage,					_helpModel,				&HelpModel::reloadPage										);
 	connect(_dynamicModules,		&DynamicModules::moduleEnabledChanged,				_preferences,			&PreferencesModel::moduleEnabledChanged						);
 	connect(_dynamicModules,		&DynamicModules::loadModuleTranslationFile,			_languageModel,			&LanguageModel::loadModuleTranslationFiles					);
-	connect(_dynamicModules,		&DynamicModules::requestRootContext,				this,					&MainWindow::giveRootQmlContext,							Qt::UniqueConnection);
-	connect(_dynamicModules,		&DynamicModules::loadQmlData,						this,					&MainWindow::loadQmlData,									Qt::UniqueConnection);
 	connect(_dynamicModules,		&DynamicModules::reloadQmlImportPaths,				this,					&MainWindow::setQmlImportPaths,								Qt::QueuedConnection); //If this is queued this should make the loadingprocess of qml a bit less weird I think.
+	connect(_dynamicModules,		&DynamicModules::dynamicModuleUnloadBegin,			_engineSync,			&EngineSync::killModuleEngine								);
+	connect(_dynamicModules,		&DynamicModules::isModuleInstallRequestActive,		_engineSync,			&EngineSync::isModuleInstallRequestActive					);
 
 	connect(_languageModel,			&LanguageModel::currentLanguageChanged,				_fileMenu,				&FileMenu::refresh											);
 	connect(_languageModel,			&LanguageModel::aboutToChangeLanguage,				_analyses,				&Analyses::prepareForLanguageChange							);
@@ -511,8 +514,10 @@ void MainWindow::loadQML()
 		ActiveModules::getActiveCommonModules(),
 		ActiveModules::getActiveExtraModules());
 
-	_engineSync->loadAllActiveModules();
-	_dynamicModules->startUpCompleted();
+void MainWindow::showEnginesWindow()
+{
+	Log::log() << "Showing EnginesWindow"  << std::endl;
+	_qml->load(QUrl("qrc:///components/JASP/Widgets/EnginesWindow.qml"));
 }
 
 void MainWindow::setQmlImportPaths()
@@ -540,6 +545,7 @@ QObject * MainWindow::loadQmlData(QString data, QUrl url)
 
 	QMetaObject::Connection returnTheObjectConn = connect(_qml, &QQmlApplicationEngine::objectCreated, [&](QObject * obj, QUrl url)
 	{
+			//ignore the warnings about the out of scope thing, the lambda is disconnected in this function itself and crashes it on purpose if it didn't et a response by then.
 			createdObject = obj;
 			lambdaCalled = true;
 	});
@@ -570,8 +576,8 @@ void MainWindow::showRCommander()
 		Log::log() << "Loading RCommander"  << std::endl;
 		_qml		-> load(QUrl("qrc:///components/JASP/Widgets/RCommanderWindow.qml"));
 
-		_resultsJsInterface->resetResults();//To reload page
-
+		//To reload page because of https://github.com/jasp-stats/INTERNAL-jasp/issues/1280
+		_resultsJsInterface->resetResults();
 		QTimer::singleShot(500, this, &MainWindow::resendResultsToWebEngine);
 	}
 }
@@ -1113,11 +1119,12 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 			_package->reset();
 
 			setWelcomePageVisible(true);
-			_engineSync->cleanUpAfterClose();
 
-			if (_applicationExiting)	QApplication::exit();
+			if (_applicationExiting)	
+				QApplication::exit();
 			else
 			{
+				_engineSync->cleanUpAfterClose();
 				setDataPanelVisible(false);
 				setDataAvailable(false);
 			}

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -513,6 +513,8 @@ void MainWindow::loadQML()
 	_ribbonModel->loadModules(	
 		ActiveModules::getActiveCommonModules(),
 		ActiveModules::getActiveExtraModules());
+	
+}
 
 void MainWindow::showEnginesWindow()
 {

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -143,7 +143,7 @@ public slots:
 
 	void	setDownloadNewJASPUrl(QString downloadNewJASPUrl);
 
-
+	void	showEnginesWindow(); //For debugging
 	void	setCheckAutomaticSync(bool check)									{  _checkAutomaticSync = check;	}
 	void	openGitHubBugReport() const;
 
@@ -155,6 +155,7 @@ private:
 	void startDataEditor(QString path);
 	void loadRibbonQML();
 	void loadQML();
+
 
 	void checkUsedModules();
 

--- a/Desktop/modules/analysisentry.cpp
+++ b/Desktop/modules/analysisentry.cpp
@@ -49,7 +49,7 @@ DynamicModule*	AnalysisEntry::dynamicModule() const
 
 std::string AnalysisEntry::qmlFilePath() const
 {
-	return dynamicModule()->qmlFilePath(_qml);
+	return dynamicModule() ? dynamicModule()->qmlFilePath(_qml) : "";
 }
 
 std::string AnalysisEntry::icon() const

--- a/Desktop/modules/description/description.cpp
+++ b/Desktop/modules/description/description.cpp
@@ -36,7 +36,8 @@ void Description::setUpDelayedUpdate()
 	_timer.callOnTimeout([=]()
 	{
 		Log::log() << "Description delay timer done, update!" << std::endl;
-		desc->iShouldBeUpdated(desc);
+		try { desc->iShouldBeUpdated(desc); }
+		catch (std::exception e) { Log::log() << "iShouldBeUpdated had exception " << e.what() << std::endl; }
 	});
 }
 

--- a/Desktop/modules/description/description.h
+++ b/Desktop/modules/description/description.h
@@ -35,7 +35,7 @@ class Description : public QQuickItem
 	Q_PROPERTY(QString					maintainer		READ maintainer			WRITE setMaintainer			NOTIFY maintainerChanged		)
 	Q_PROPERTY(QUrl						website			READ website			WRITE setWebsite			NOTIFY websiteChanged			)
 	Q_PROPERTY(QString					license			READ license			WRITE setLicense			NOTIFY licenseChanged			)
-	//requiresData should really be called defaultRequiresData or something. Because that is what it does. But it would be a lot of work to change all the qmls...
+	///requiresData should really be called defaultRequiresData or something. Because that is what it does. But it would be a lot of work to change all the qmls...
 	Q_PROPERTY(bool						requiresData	READ requiresDataDef	WRITE setRequiresDataDef	NOTIFY requiresDataDefChanged	)
 	Q_PROPERTY(Modules::DynamicModule *	dynMod			READ dynMod				WRITE setDynMod				NOTIFY dynModChanged			)
 
@@ -62,32 +62,32 @@ public:
 	std::set<std::string>			requiredModules()	const;
 
 public slots:
-	void setName(				QString			name		);
-	void setTitle(				QString			title		);
-	void setIcon(				QString			icon		);
-	void setDescription(		QString			description	);
-	void setVersion(			QString			version		);
-	void setAuthor(				QString			author		);
-	void setMaintainer(			QString			maintainer	);
-	void setWebsite(			QUrl			website		);
-	void setLicense(			QString			license		);
-	void setRequiresDataDef(	bool			defRequiresData);
-	void setDynMod(				DynamicModule * dynMod		);
+	void setName(				QString							name			);
+	void setTitle(				QString							title			);
+	void setIcon(				QString							icon			);
+	void setDescription(		QString							description		);
+	void setVersion(			QString							version			);
+	void setAuthor(				QString							author			);
+	void setMaintainer(			QString							maintainer		);
+	void setWebsite(			QUrl							website			);
+	void setLicense(			QString							license			);
+	void setRequiresDataDef(	bool							defRequiresData	);
+	void setDynMod(				Modules::DynamicModule		*	dynMod			);
 	void delayedUpdate();
 
 signals:
-	void titleChanged(				QString			title		);
-	void iconChanged(				QString			icon		);
-	void descriptionChanged(		QString			description	);
+	void titleChanged(				QString						title			);
+	void iconChanged(				QString						icon			);
+	void descriptionChanged(		QString						description		);
 	void versionChanged();
-	void authorChanged(				QString			author		);
-	void maintainerChanged(			QString			maintainer	);
-	void websiteChanged(			QUrl			website		);
-	void licenseChanged(			QString			license		);
-	void nameChanged(				QString			name		);
-	void requiresDataDefChanged(	bool			defRequiresData);
-	void dynModChanged(				DynamicModule * dynMod		);
-	void iShouldBeUpdated(			Description	  *	desc		);
+	void authorChanged(				QString						author			);
+	void maintainerChanged(			QString						maintainer		);
+	void websiteChanged(			QUrl						website			);
+	void licenseChanged(			QString						license			);
+	void nameChanged(				QString						name			);
+	void requiresDataDefChanged(	bool						defRequiresData	);
+	void dynModChanged(				Modules::DynamicModule	*	dynMod			);
+	void iShouldBeUpdated(			Modules::Description	*	desc			);
 	void childChanged();
 
 private:

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -450,8 +450,8 @@ std::string DynamicModule::generateModuleInstallingR(bool onlyModPkg)
 	}
 	setInstallLog("Installing module " + _name + ".\n");
 	
-	//installJaspModule <- function(modulePkg, libPathsToUse, moduleLibrary, repos, onlyModPkg)
-	return "jaspBase::installJaspModule(modulePkg='" + _modulePackage + "', libPathsToUse=" + getLibPathsToUse() + ", moduleLibrary='" + moduleRLibrary().toStdString() + "', repos='" + Settings::value(Settings::CRAN_REPO_URL).toString().toStdString() + "', onlyModPkg=" + (onlyModPkg ? "TRUE" : "FALSE") + ", force=TRUE);";
+	//installJaspModule <- function(modulePkg, libPathsToUse, moduleLibrary, repos, onlyModPkg, force = FALSE, cacheAble=TRUE) {
+	return "jaspBase::installJaspModule(modulePkg='" + _modulePackage + "', libPathsToUse=" + getLibPathsToUse() + ", moduleLibrary='" + moduleRLibrary().toStdString() + "', repos='" + Settings::value(Settings::CRAN_REPO_URL).toString().toStdString() + "', onlyModPkg=" + (onlyModPkg ? "TRUE" : "FALSE") + ", force=TRUE, cacheAble=FALSE);";
 }
 
 std::string DynamicModule::generateModuleLoadingR(bool shouldReturnSucces)

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -618,7 +618,7 @@ void DynamicModule::setStatus(moduleStatus newStatus)
 	if(_status == moduleStatus::installNeeded && newStatus == moduleStatus::installModPkgNeeded)
 		return;
 
-	bool readyForUseInvolved = newStatus == moduleStatus::readyForUse || _status == moduleStatus::readyForUse;
+	bool readyForUseInvolved = ( newStatus == moduleStatus::readyForUse ) || ( _status == moduleStatus::readyForUse );
 
 	_status = newStatus;
 

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -66,9 +66,8 @@ DynamicModule::DynamicModule(std::string modulePackageFile, QObject *parent, boo
 {
 	_name			= extractPackageNameFromArchive(modulePackageFile);
 	_moduleFolder	= QFileInfo(AppDirs::userModulesDir() + QString::fromStdString(_name) + "/");
-	unpackage();
 
-	loadDescriptionFromFolder(_modulePackage);
+	loadDescriptionFromArchive(_modulePackage);
 }
 
 QFileInfo DynamicModule::developmentModuleFolder()
@@ -384,28 +383,6 @@ Json::Value	DynamicModule::requestJsonForPackageLoadingRequest()
 	requestJson["moduleCode"]		= generateModuleLoadingR();
 
 	return requestJson;
-}
-
-void DynamicModule::unpackage()
-{
-	if(_modulePackage == "")
-	{
-		Log::log() << "DynamicModule::unpackage has some trouble because _modulePackage is empty..." << std::endl;
-
-		setInstallLog("Installing module " + _name + " failed because package filepath was not specified");
-		setStatus(moduleStatus::error);
-		return;
-	}
-
-	std::string tmpDir = TempFiles::createTmpFolder(),
-				modDir = tmpDir + "/" + _name;
-
-	ExtractArchive::extractArchiveToFolder(_modulePackage, modDir);
-
-	Log::log() << "Unpacked module to folder " << modDir << std::endl;
-
-	_modulePackage = modDir;
-
 }
 
 std::string DynamicModule::getLibPathsToUse()

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -188,7 +188,6 @@ public:
 	static std::string	extractPackageNameFromDescriptionQmlTxt(	const std::string & descriptionQmlTxt);
 	static std::string	extractPackageNameFromDescriptionJsonTxt(	const std::string & descriptionJsonTxt);
 
-	void unpackage();
 	///Make sure url ends with the actual filename of the qml you are loading, otherwise translations will not work! Also make it with QUrl::fromLocalFile otherwise Windows messes things up
 	static Description	* instantiateDescriptionQml(const QString & descriptionTxt, const QUrl & url, const std::string & moduleName);
 	static Upgrades		* instantiateUpgradesQml(	const QString & upgradesTxt,	const QUrl & url, const std::string & moduleName);

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -269,10 +269,6 @@ void DynamicModules::replaceModule(DynamicModule * module)
 
 	_modules[moduleName] = module;
 
-	//Tmp folder with pkg data was removed so lets unpackage (again)
-	if(!module->isDevMod())
-		module->unpackage();
-
 	emit unloadModule(moduleName);
 	emit dynamicModuleReplaced(oldModule, module);
 	emit dynamicModuleChanged(module);
@@ -515,10 +511,7 @@ void DynamicModules::installJASPModule(const QString & moduleZipFilename)
 	if(_modules.count(moduleName) > 0 && _modules[moduleName]->isBundled())
 		replaceModule(dynMod);
 	else
-	{
-		dynMod->unpackage();
 		_modules[moduleName] = dynMod;
-	}
 
 	registerForInstalling(moduleName);
 

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -48,8 +48,6 @@ DynamicModules::DynamicModules(QObject *parent) : QObject(parent)
 	if(_singleton) throw std::runtime_error("Can only instantiate DynamicModules once!");
 	_singleton = this;
 
-	connect(this, &DynamicModules::stopEngines, this, &DynamicModules::enginesStopped, Qt::QueuedConnection);
-
 	_modulesInstallDirectory = AppDirs::userModulesDir().toStdWString();
 
 	if(!boost::filesystem::exists(_modulesInstallDirectory))
@@ -110,12 +108,6 @@ bool DynamicModules::initializeModuleFromDir(std::string moduleDir, bool bundled
 	if(!initializeModule(newMod))
 		return false;
 
-	if(isCommon)
-	{
-		if(_startingUp)	newMod->setReadyForUse();  //To make sure "engineSync->loadAllActiveModules()" loads it.
-		else			newMod->setLoadingNeeded();
-	}
-
 	return true;
 }
 
@@ -135,21 +127,27 @@ bool DynamicModules::initializeModule(DynamicModule * module)
 			wasAddedAlready = false;
 		}
 
-		if(oldModule) //I guess we could also check wasAddedAlready because I assume the only way oldModule can exist is if _moduleNames already contains moduleName.
+		/* Fairly sure this isnt necessary anymore: if(oldModule) //I guess we could also check wasAddedAlready because I assume the only way oldModule can exist is if _moduleNames already contains moduleName.
 		{
 			emit stopEngines();					// Stop engines so that process will not try to work with Analyses while we are changing stuff...
-			_modulesToBeUnloaded.clear(); //if we are going to restart the engines we can also forget anything that's loaded and needs to be unloaded
-		}
+		}*/
 
 		_modules[moduleName] = module;
 		
 		
 		if(!module->initialized())
 		{	
-			connect(module, &DynamicModule::registerForLoading,				this, &DynamicModules::registerForLoading			);
-			connect(module, &DynamicModule::registerForInstalling,			this, &DynamicModules::registerForInstalling		);
-			connect(module, &DynamicModule::registerForInstallingModPkg,	this, &DynamicModules::registerForInstallingModPkg	);
-			connect(module, &DynamicModule::descriptionReloaded,			this, &DynamicModules::descriptionReloaded			);
+			connect(module, &DynamicModule::registerForInstalling,			this,	&DynamicModules::registerForInstalling		);
+			connect(module, &DynamicModule::registerForInstallingModPkg,	this,	&DynamicModules::registerForInstallingModPkg	);
+			connect(module, &DynamicModule::descriptionReloaded,			this,	&DynamicModules::descriptionReloaded			);
+			connect(module, &DynamicModule::statusChanged,					module,	[=]()
+			{
+				if(module->status() == moduleStatus::error)
+				{
+						_modulesInstallPackagesNeeded.erase(moduleName);
+						QTimer::singleShot(0, module, [=](){ uninstallModule(moduleName); });
+				}
+			});
 			
 			module->initialize();
 		}
@@ -161,12 +159,11 @@ bool DynamicModules::initializeModule(DynamicModule * module)
 		}
 		else if(oldModule)
 		{
+			emit unloadModule(moduleName);
 			emit dynamicModuleReplaced(oldModule, module);
 			delete oldModule;
 			emit dynamicModuleChanged(module);
 			emit loadModuleTranslationFile(module);
-			emit restartEngines();
-
 		}		
 
 		emit reloadQmlImportPaths();
@@ -186,8 +183,6 @@ bool DynamicModules::initializeModule(DynamicModule * module)
 				_moduleNames.erase(_moduleNames.begin() + i - 1);
 	}
 
-	emit restartEngines();
-
 	return false;
 }
 
@@ -199,10 +194,7 @@ std::string DynamicModules::loadModule(const std::string & moduleName)
 			throw std::runtime_error("Couldn't load (and initialize) module " + moduleName);
 
 
-		DynamicModule	*loadMe	= _modules[moduleName];
-
-		if(_startingUp)	loadMe->setReadyForUse(); //So that engineSync->loadAllActiveModules will load this module
-		else			loadMe->setLoadingNeeded();
+		//DynamicModule	*loadMe	= _modules[moduleName];
 
 		return moduleName;
 	}
@@ -213,6 +205,22 @@ std::string DynamicModules::loadModule(const std::string & moduleName)
 	}
 }
 
+void DynamicModules::unloadModule(const std::string & moduleName)
+{
+	Log::log() << "Module '" << moduleName << "' being registered for unloading!" << std::endl;
+
+	_modulesInstallPackagesNeeded   .erase(moduleName);
+
+	if(_modules.count(moduleName) > 0)
+	{
+		DynamicModule * dynMod = _modules[moduleName];
+
+		emit dynamicModuleUnloadBegin(dynMod);
+		emit reloadQmlImportPaths();
+	}
+}
+
+
 void DynamicModules::registerForInstalling(const std::string & moduleName)
 {
 	registerForInstallingSubFunc(moduleName, false);
@@ -221,13 +229,6 @@ void DynamicModules::registerForInstalling(const std::string & moduleName)
 void DynamicModules::registerForInstallingModPkg(const std::string & moduleName)
 {
 	registerForInstallingSubFunc(moduleName, true);
-}
-
-void DynamicModules::stopAndRestartEngines()
-{
-	emit stopEngines();
-	_modulesToBeUnloaded.clear(); //if we are going to restart the engines we can also forget anything that's loaded and needs to be unloaded
-	emit restartEngines();
 }
 
 QStringList DynamicModules::importPaths() const
@@ -247,60 +248,14 @@ QStringList DynamicModules::importPaths() const
 
 void DynamicModules::registerForInstallingSubFunc(const std::string & moduleName, bool onlyModPkg)
 {
-	Log::log() << "Module '" << moduleName << "' being registered for installing (onlyModPkg? " << (onlyModPkg ? "true" : "false") << ")!" << std::endl;
+	if(!_modulesInstallPackagesNeeded.count(moduleName) || _modulesInstallPackagesNeeded[moduleName] != onlyModPkg)
+	{ 
+		Log::log() << "Module '" << moduleName << "' being registered for installing (onlyModPkg? " << (onlyModPkg ? "true" : "false") << ")!" << std::endl;
 
-	_modulesToBeUnloaded.erase(moduleName);
-	_modulesToBeLoaded.erase(moduleName);
-	_modulesInstallPackagesNeeded[moduleName] = onlyModPkg;
-
-	if(_modules[moduleName]->loaded())	//If the package is already loaded it might be hard to convince R to reinstall it properly, so let's restart the engines
-	{
-		stopAndRestartEngines();
-		_modules[moduleName]->setUnloaded();
+		_modulesInstallPackagesNeeded[moduleName] = onlyModPkg;
 	}
-}
 
-void DynamicModules::registerForLoading(const std::string & moduleName)
-{
-	Log::log() << "Module '" << moduleName << "' being registered for loading!" << std::endl;
-
-	if(_modulesInstallPackagesNeeded.count(moduleName) > 0)
-		return; //When the install is done it will trigger the need for loading anyway.
-
-	_modulesToBeUnloaded.erase(moduleName);
-	_modulesToBeLoaded.insert(moduleName);
-}
-
-bool DynamicModules::requiredModulesForModuleReady(const std::string & moduleName) const
-{
-	DynamicModule	*	dynMod	= _modules.at(moduleName);
-	std::set<std::string>		reqMods	= dynMod->importsR();
-
-	for(const std::string & reqMod : reqMods)
-		if(_modules.count(reqMod) > 0 && !_modules.at(reqMod)->readyForUse())
-			return false;
-
-	return true;
-}
-
-void DynamicModules::unloadModule(const std::string & moduleName)
-{
-	Log::log() << "Module '" << moduleName << "' being registered for unloading!" << std::endl;
-
-	_modulesInstallPackagesNeeded	.erase(moduleName);
-	_modulesToBeLoaded				.erase(moduleName);
-	_modulesWaitingForDependency	.erase(moduleName);
-
-	if(_modules.count(moduleName) > 0)
-	{
-		DynamicModule * dynMod		= _modules[moduleName];
-		_modulesToBeUnloaded[moduleName]	= dynMod->requestJsonForPackageUnloadingRequest();
-
-		dynMod->setUnloaded();
-
-		emit dynamicModuleUnloadBegin(dynMod);
-		emit reloadQmlImportPaths();
-	}
+	//Installing modules always restarts all the (relevant) engines anyway
 }
 
 void DynamicModules::replaceModule(DynamicModule * module)
@@ -312,25 +267,17 @@ void DynamicModules::replaceModule(DynamicModule * module)
 
 	DynamicModule * oldModule = _modules[moduleName];
 
-	emit stopEngines();					// Stop engines so that process will not try to work with Analyses while we are changing stuff...
-	_modulesToBeUnloaded.clear(); //if we are going to restart the engines we can also forget anything that's loaded and needs to be unloaded
-
 	_modules[moduleName] = module;
 
 	//Tmp folder with pkg data was removed so lets unpackage (again)
 	if(!module->isDevMod())
 		module->unpackage();
 
-	//registerForInstalling(moduleName);
-
-
-
+	emit unloadModule(moduleName);
 	emit dynamicModuleReplaced(oldModule, module);
 	emit dynamicModuleChanged(module);
 	emit reloadQmlImportPaths();
 	delete oldModule;
-
-	emit restartEngines();
 }
 
 void DynamicModules::uninstallModule(const std::string & moduleName)
@@ -372,9 +319,9 @@ void DynamicModules::uninstallModule(const std::string & moduleName)
 
 }
 
-void DynamicModules::removeUninstalledModuleFolder(const std::string & moduleName, bool enginesStopped)
+void DynamicModules::removeUninstalledModuleFolder(const std::string & moduleName)
 {
-	Log::log() << "DynamicModules::removeUninstalledModuleFolder("<< moduleName << ", engines " << (enginesStopped ? "stopped" : "started") << ")" << std::endl;
+	Log::log() << "DynamicModules::removeUninstalledModuleFolder("<< moduleName << ")" << std::endl;
 
 	std::wstring modulePath	= moduleDirectoryW(moduleName);
 
@@ -386,18 +333,7 @@ void DynamicModules::removeUninstalledModuleFolder(const std::string & moduleNam
 	}
 	catch (boost::filesystem::filesystem_error & e)
 	{
-		if(enginesStopped)
-			MessageForwarder::showWarning(tr("Something went wrong removing files for module %1 at path '%2' and the error was: %3").arg(tq(moduleName)).arg(tq(moduleDirectory(moduleName))).arg(e.what()));
-		else
-		{
-			Log::log() << "Probably some library was still loaded in R... Let's stop the engines!" << std::endl;
-
-			emit stopEngines();
-			_modulesToBeUnloaded.clear(); //if we are going to restart the engines we can also forget anything that's loaded and needs to be unloaded
-			removeUninstalledModuleFolder(moduleName, true);
-			emit restartEngines();
-		}
-
+		MessageForwarder::showWarning(tr("Something went wrong removing files for module %1 at path '%2' and the error was: %3").arg(tq(moduleName)).arg(tq(moduleDirectory(moduleName))).arg(e.what()));
 		return;
 	}
 }
@@ -413,56 +349,88 @@ DynamicModule* DynamicModules::requestModuleForSomethingAndRemoveIt(std::set<std
 	return _modules[installMe];
 }
 
-Json::Value	DynamicModules::getJsonForPackageInstallationRequest()
+bool DynamicModules::aModuleNeedsPackagesInstalled() const
+{
+	return numModulesNeedingPackagesInstalled() > 0;
+}
+
+
+size_t DynamicModules::numModulesNeedingPackagesInstalled() const
+{
+	size_t thisMany = 0;
+
+
+	for(auto & nameModPkg : _modulesInstallPackagesNeeded)
+		if(!isModuleInstallRequestActive(tq(nameModPkg.first)))
+			thisMany++;
+
+	return thisMany;
+}
+
+stringset DynamicModules::modulesNeedingPackagesInstalled() const
+{
+	stringset keys;
+
+	for(auto & nameMod : _modulesInstallPackagesNeeded)
+		keys.insert(nameMod.first);
+
+	return keys;
+}
+
+Json::Value	DynamicModules::getJsonForPackageInstallationRequest(const std::string & module)
 {
 	if(_modulesInstallPackagesNeeded.size() == 0)
-		return Json::nullValue;
+		throw std::runtime_error("Tried to get json for open module install request but there are none, getJsonForPackageInstallationRequest should never have been called. Is aModuleNeedsPackagesInstalled perhaps broken?");
 
-	std::string installMe	= _modulesInstallPackagesNeeded.begin()->first;
-	bool		onlyModPkg = _modulesInstallPackagesNeeded.begin()->second;
 
-	_modulesInstallPackagesNeeded.erase(installMe);
+	std::string installMe	= module;
+	bool		onlyModPkg	= installMe == "???" || _modulesInstallPackagesNeeded[module];
+
+	if(installMe == "???")
+		for(auto & nameModPkg : _modulesInstallPackagesNeeded)
+			if(!isModuleInstallRequestActive(tq(nameModPkg.first)))
+			{
+				installMe	= nameModPkg.first;
+				onlyModPkg	= nameModPkg.second;
+			}
+
+	if(installMe == "???")
+		throw std::runtime_error("Tried to get json for module install request but there were none.");
 
 	return _modules[installMe]->requestJsonForPackageInstallationRequest(onlyModPkg);
 }
 
-Json::Value DynamicModules::getJsonForPackageUnloadingRequest()
-{
-	std::string firstModule		= _modulesToBeUnloaded.begin()->first;
-	Json::Value	unloadRequest	= _modulesToBeUnloaded[firstModule];
-
-	_modulesToBeUnloaded.erase(firstModule);
-
-	return unloadRequest;
-}
 
 void DynamicModules::installationPackagesFailed(const QString & moduleName, const QString & errorMessage)
 {
 	if(_modules.count(moduleName.toStdString()) > 0)
 		_modules[moduleName.toStdString()]->setInstallingSucces(false);
 
-	MessageForwarder::showWarning(
-				tq("Installation of Module %1 failed").arg(moduleName),
-				tr("The installation of Module %1 failed with the following errormessage:\n%2").arg(moduleName).arg(errorMessage));
-
 	uninstallModule(moduleName.toStdString());
+
+	_modulesInstallPackagesNeeded.erase(moduleName.toStdString());
 
 	if(moduleName.toStdString() == developmentModuleName())
 		setDevelopersModuleInstallButtonEnabled(true);
+	
+	
+	MessageForwarder::showWarning(
+				tq("Installation of Module %1 failed").arg(moduleName),
+				tr("The installation of Module %1 failed with the following errormessage:\n%2").arg(moduleName).arg(errorMessage));	
 }
 
 void DynamicModules::installationPackagesSucceeded(const QString & moduleName)
 {
 	Log::log() << "Installing packages for module (" << moduleName.toStdString() << ") succeeded!" << std::endl;
 	_modules[moduleName.toStdString()]->setInstallingSucces(true);
+	_modulesInstallPackagesNeeded.erase(moduleName.toStdString());
 
 	auto *dynMod = _modules[moduleName.toStdString()];
 
 	bool wasInitialized = dynMod->initialized();
 
-	if(!wasInitialized)			initializeModule(dynMod);
-	if(dynMod->initialized())	registerForLoading(moduleName.toStdString());
-
+	if(!wasInitialized)
+		initializeModule(dynMod);
 
 	if(dynMod->isDevMod())
 	{
@@ -478,50 +446,6 @@ void DynamicModules::installationPackagesSucceeded(const QString & moduleName)
 	emit reloadQmlImportPaths();
 }
 
-
-void DynamicModules::loadingFailed(const QString & moduleName, const QString & errorMessage)
-{
-	Log::log() << "Loading packages for module (" << moduleName.toStdString() << ") failed because of: " << errorMessage.toStdString() << std::endl;
-	if(moduleName != "*")
-	{
-		_modules[moduleName.toStdString()]->setLoadingSucces(false);
-
-		MessageForwarder::showWarning(
-					tr("Loading packages for Module %1 failed").arg(moduleName),
-					tr("Loading the packages of Module %1 failed with the following errormessage:\n%2").arg(moduleName).arg(errorMessage));
-	}
-	else
-		for(const auto & nameModule : _modules)
-			if(nameModule.second->readyForUse())
-				nameModule.second->setLoaded(false);
-}
-
-void DynamicModules::loadingSucceeded(const QString & moduleName)
-{
-	Log::log() << "Loading packages for module (" << moduleName.toStdString() << ") succeeded!" << std::endl;
-
-	if(moduleName != "*")
-	{
-		_modules[moduleName.toStdString()]->setLoadingSucces(true);
-
-		std::set<std::string> removeThese;
-
-		for(const std::string & modWait : _modulesWaitingForDependency)
-			if(requiredModulesForModuleReady(modWait))
-			{
-				Log::log() << "Required modules for module '" << modWait << "' ready, so now registering it for loading!" << std::endl;
-				removeThese.insert(modWait);
-				_modulesToBeLoaded.insert(modWait);
-			}
-
-		for(const std::string & modWait : removeThese)
-			_modulesWaitingForDependency.erase(modWait);
-	}
-	else
-		for(const auto & nameModule : _modules)
-			if(nameModule.second->readyForUse())
-				nameModule.second->setLoaded(true);
-}
 
 Modules::AnalysisEntry* DynamicModules::retrieveCorrespondingAnalysisEntry(const Json::Value & jsonFromJaspFile)
 {
@@ -600,11 +524,22 @@ void DynamicModules::installJASPModule(const QString & moduleZipFilename)
 
 }
 
+void DynamicModules::uninstallJASPDeveloperModule()
+{
+	if(_modules.count(developmentModuleName()))
+		uninstallModule(developmentModuleName());
+}
+
 void DynamicModules::installJASPDeveloperModule()
 {
 	if(Settings::value(Settings::DEVELOPER_FOLDER).toString() == "")
 	{
 		MessageForwarder::showWarning(tr("Select a folder"), tr("To install a development module you need to select the folder you want to watch and load, you can do this under the filemenu, Preferences->Advanced."));
+		return;
+	}
+	else if(!QDir(Settings::value(Settings::DEVELOPER_FOLDER).toString()).exists())
+	{
+		MessageForwarder::showWarning(tr("Select an exisiting folder"), tr("To install a development module you need to select and existing folder, you selected '$1' but it doesn't exist.").arg(Settings::value(Settings::DEVELOPER_FOLDER).toString()));
 		return;
 	}
 	
@@ -619,6 +554,8 @@ void DynamicModules::installJASPDeveloperModule()
 
 		DynamicModule * devMod = new DynamicModule(this);
 
+		devMod->loadDescriptionFromFolder(fq(_devModSourceDirectory.absolutePath()));
+
 		std::string origin	= devMod->modulePackage(),
 					name	= devMod->name(),
 					dest	= devMod->moduleRLibrary().toStdString();
@@ -626,9 +563,6 @@ void DynamicModules::installJASPDeveloperModule()
 		if(moduleIsInstalledByUser(name))
 		{
 			uninstallModule(name);
-			emit stopEngines();
-			_modulesToBeUnloaded.clear(); //if we are going to restart the engines we can also forget anything that's loaded and needs to be unloaded
-			emit restartEngines();
 		}
 		else if(_modules.count(name) > 0 && _modules[name] != devMod)
 			replaceModule(devMod);
@@ -689,8 +623,10 @@ void DynamicModules::startWatchingDevelopersModule()
 	devModCopyDescription(descFound);
 	devModWatchFolder("R",		_devModRWatcher);
 	devModWatchFolder("help",	_devModHelpWatcher);
+	//QML is watched by Analysis itself
 }
 
+///This function says it's copying something, and maybe it did that before, but it doesn't seem to be doing so now.
 void DynamicModules::devModCopyDescription(QString filename)
 {
 	const QString descJson = "inst/" + filename;
@@ -825,36 +761,6 @@ void DynamicModules::regenerateDeveloperModuleRPackage()
 
 	auto * devMod = _modules[developmentModuleName()];
 	devMod->setStatus(moduleStatus::installModPkgNeeded);
-}
-
-Json::Value	DynamicModules::getJsonForReloadingActiveModules()
-{
-	Json::Value requestJson(Json::objectValue);
-
-	std::stringstream loadingCode;
-	for(size_t i=0; i<_moduleNames.size(); i++)
-	{
-		const std::string & modName = _moduleNames[i];
-
-		if(_modules[modName]->readyForUse()) //should be loaded again
-			loadingCode << _modules[modName]->generateModuleLoadingR(i == _moduleNames.size() - 1) << "\n";
-	}
-
-	if(loadingCode.str() != "")
-		loadingCode << "return('" << DynamicModule::succesResultString() << "')"; //We could also avoid calling getJsonForReloadingActiveModules altogether but whatever
-
-	requestJson["moduleCode"]		= loadingCode.str();
-	requestJson["moduleRequest"]	= moduleStatusToString(moduleStatus::loadingNeeded);
-	requestJson["moduleName"]		= "*";
-
-	return requestJson;
-}
-
-void DynamicModules::enginesStopped()
-{
-	//for(auto & nameMod : _modules)
-	//	nameMod.second->setLoaded(false); //Cause we restarted the engines
-	// It is slightly misleading all this, but by not setting them to unloaded the GUI becomes cleaner and we do not have to set them back to loaded later in a hacky fashion
 }
 
 QString DynamicModules::moduleDirectoryQ(const QString & moduleName)	const

--- a/Desktop/modules/ribbonbutton.cpp
+++ b/Desktop/modules/ribbonbutton.cpp
@@ -45,15 +45,13 @@ void RibbonButton::setDynamicModule(DynamicModule * module)
 	{
 		_module = module;
 		connect(_module, &DynamicModule::descriptionReloaded,	this, &RibbonButton::reloadDynamicModule,	Qt::QueuedConnection);
-		connect(_module, &DynamicModule::installedChanged,		this, &RibbonButton::setReady									);
+		connect(_module, &DynamicModule::readyChanged,			this, &RibbonButton::setReady,				Qt::QueuedConnection);
 		connect(_module, &DynamicModule::errorChanged,			this, &RibbonButton::setError									);
 
 		if(!_analysisMenuModel)
 			_analysisMenuModel = new AnalysisMenuModel(this, _module);
 
 		_analysisMenuModel->setDynamicModule(_module);
-
-		setReady(_module->installed());
 	}
 }
 
@@ -70,7 +68,6 @@ void RibbonButton::reloadDynamicModule(DynamicModule * dynMod)
 	setIconSource(tq(	_module->iconFilePath()));
 	setModuleName(		_module->name()			);
 
-	//if(dynamicModuleChanged)
 	emit iChanged(this);
 }
 
@@ -92,6 +89,9 @@ void RibbonButton::setReady(bool ready)
 
 	_ready = ready;
 	emit readyChanged(_ready);
+	
+	if(_ready && dynamicModule() && dynamicModule()->isDevMod())
+		setEnabled(true); 
 }
 
 RibbonButton::RibbonButton(QObject *parent,	std::string name, std::string title, std::string icon, bool requiresData, std::function<void ()> justThisFunction, std::string toolTip)
@@ -145,7 +145,7 @@ void RibbonButton::setTitle(std::string title)
 
 void RibbonButton::setIconSource(QString iconSource)
 {
-	Log::log() << "Iconsource ribbonbutton changed to: " << iconSource.toStdString() << std::endl;
+	//Log::log() << "Iconsource ribbonbutton changed to: " << iconSource.toStdString() << std::endl;
 
 	_iconSource = iconSource;
 	emit iconSourceChanged();
@@ -194,7 +194,7 @@ void RibbonButton::setModuleName(std::string moduleName)
 
 DynamicModule * RibbonButton::dynamicModule()
 {
-	return DynamicModules::dynMods()->dynamicModule(_moduleName);
+	return _module; //DynamicModules::dynMods()->dynamicModule(_moduleName); //Why would we get this from DynamicModules??
 }
 
 AnalysisEntry *RibbonButton::getAnalysis(const std::string &name)

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -122,12 +122,12 @@ void RibbonModel::addRibbonButtonModel(RibbonButton* model)
 	if(isModuleName(model->moduleName()))
 		removeRibbonButtonModel(model->moduleName());
 
-	emit beginInsertRows(QModelIndex(), rowCount(), rowCount());
+	beginInsertRows(QModelIndex(), rowCount(), rowCount());
 
 	_moduleNames.push_back(model->moduleName());
 	_buttonModelsByName[model->moduleName()] = model;
 
-	emit endInsertRows();
+	endInsertRows();
 
 	connect(model, &RibbonButton::iChanged,				this, &RibbonModel::ribbonButtonModelChanged);
 }
@@ -322,11 +322,11 @@ void RibbonModel::ribbonButtonModelChanged(RibbonButton* model)
 	emit dataChanged(index(row), index(row));
 }
 
-void RibbonModel::moduleLoadingSucceeded(const QString & moduleName)
+/*void RibbonModel::moduleLoadingSucceeded(const QString & moduleName)
 {
 	if(moduleName == "*")
 		return;
 
 	RibbonButton * ribMod = ribbonButtonModel(moduleName.toStdString());
 	ribMod->setEnabled(true);
-}
+}*/

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -94,7 +94,7 @@ public slots:
 	void addDynamicRibbonButtonModel(Modules::DynamicModule * module)	{ addRibbonButtonModelFromDynamicModule(module);		}
 	void removeDynamicRibbonButtonModel(QString moduleName)				{ removeRibbonButtonModel(moduleName.toStdString());				}
 	void setHighlightedModuleIndex(int highlightedModuleIndex);
-	void moduleLoadingSucceeded(const QString & moduleName);
+	//void moduleLoadingSucceeded(const QString & moduleName);
 	void analysisClicked(QString analysisFunction, QString analysisQML, QString analysisTitle, QString module);
 
 private slots:

--- a/Desktop/utilities/appdirs.cpp
+++ b/Desktop/utilities/appdirs.cpp
@@ -206,6 +206,6 @@ QString AppDirs::renvCacheLocations()
 							':';
 #endif
 	
-	return dynamicCache + separator + staticCache;
+    return dynamicCache + separator + staticCache;
 	
 }

--- a/Desktop/utilities/application.cpp
+++ b/Desktop/utilities/application.cpp
@@ -54,7 +54,16 @@ bool Application::notify(QObject *receiver, QEvent *event)
 {
 	try
 	{
-		//Log::log()  << "Application::notify: " << receiver->objectName() << " with event: " << event  << std::endl;
+		//Print events for main thread only
+		/*if(receiver->thread() == QApplication::thread())
+		{
+			static int	eventEnumIndex	= QEvent::staticMetaObject.indexOfEnumerator("Type");
+			QString		name			= QEvent::staticMetaObject.enumerator(eventEnumIndex).valueToKey(event->type()),
+						logThis			= "Application::notify event type: " + (name != "" ? name : QString(event->type())) + " for receiver: '" + receiver->objectName() + "'";
+
+			Log::log()  << logThis << std::endl;
+		}*/
+
 		return QApplication::notify(receiver, event);
 	}
 	catch (std::exception &e)

--- a/Desktop/utilities/languagemodel.cpp
+++ b/Desktop/utilities/languagemodel.cpp
@@ -173,7 +173,7 @@ bool LanguageModel::isValidLocaleName(const QString& filename, QLocale& locale, 
 
 void LanguageModel::loadModuleTranslationFiles(Modules::DynamicModule *dyn)
 {
-	Log::log() << "LanguageModel::loadModuleTranslationFile called for module: " << (dyn ? dyn->name() : "NULL") << std::endl;
+	//Log::log() << "LanguageModel::loadModuleTranslationFile called for module: " << (dyn ? dyn->name() : "NULL") << std::endl;
 
 	bool result;
 	QLocale loc;

--- a/Desktop/utilities/qutils.cpp
+++ b/Desktop/utilities/qutils.cpp
@@ -19,11 +19,14 @@
 #include "utilities/qutils.h"
 #include <QQmlEngine>
 #include <QQmlContext>
+#include <QQmlIncubator>
 #include <QStringList>
 #include <QDateTime>
 #include "appinfo.h"
 #include "simplecrypt.h"
 #include "utils.h"
+#include "mainwindow.h"
+#include "log.h"
 
 using namespace std;
 
@@ -240,4 +243,84 @@ QString shortenWinPaths(QString in)
 #else
 	return in;
 #endif
+}
+
+
+//Turning QMLENGINE_DOES_ALL_THE_WORK on also works fine, but has slightly less transparent errormsgs so isn't recommended
+//#define QMLENGINE_DOES_ALL_THE_WORK
+
+QObject * instantiateQml(const QString & qmlTxt, const QUrl & url, const std::string & moduleName, const std::string & whatAmILoading, const std::string & filename, QQmlContext * ctxt)
+{
+	QObject * obj = nullptr;
+
+#ifdef QMLENGINE_DOES_ALL_THE_WORK
+	obj = MainWindow::singleton()->loadQmlData(qmlTxt, url);
+#else
+	if(!ctxt)
+		ctxt = MainWindow::singleton()->giveRootQmlContext();
+
+	QQmlComponent qmlComp(ctxt->engine());
+
+	//Log::log() << "Setting url to '" << url.toString() << "' for Description.qml.\n" << std::endl;// data: '" << descriptionTxt << "'\n"<< std::endl;
+
+	qmlComp.setData(qmlTxt.toUtf8(), url);
+
+	if(qmlComp.isLoading())
+		Log::log() << whatAmILoading << " for module " << moduleName << " is still loading, make sure you load a local file and that Windows doesn't mess this up for you..." << std::endl;
+
+
+	auto errorLogger =[&](bool isError, QList<QQmlError> errors)
+	{
+		if(!isError) return;
+
+		std::stringstream out;
+
+		out << "Loading " << filename << " for module " << moduleName << " had errors:\n";
+
+		for(const QQmlError & error : errors)
+			out << error.toString() << "\n";
+
+		Log::log() << out.str() << std::flush;
+
+		throw Modules::ModuleException(moduleName, "There were errors loading " + filename + ":\n" + out.str());
+	};
+
+	errorLogger(qmlComp.isError(), qmlComp.errors());
+
+	if(!qmlComp.isReady())
+		throw Modules::ModuleException(moduleName, whatAmILoading + " Component is not ready!");
+
+	QQmlIncubator localIncubator(QQmlIncubator::Synchronous);
+
+
+	qmlComp.create(localIncubator);
+
+	errorLogger(localIncubator.isError(), localIncubator.errors());
+
+	obj = localIncubator.object();
+
+#endif
+
+	return obj;
+}
+
+QObject * instantiateQml(const QUrl & filePath, const std::string & moduleName, QQmlContext * ctxt)
+{
+	if(!filePath.isLocalFile())
+		throw Modules::ModuleException(moduleName, fq(filePath.toLocalFile()) + " is not a local file...");
+
+	QFileInfo	qmlFileInfo(filePath.toLocalFile());
+
+	if(!qmlFileInfo.exists())
+		throw Modules::ModuleException(moduleName, fq(qmlFileInfo.absoluteFilePath()) + " does not exist...");
+
+	QString 	qmlTxt;
+	QFile		qmlFile(qmlFileInfo.absoluteFilePath());
+	
+				qmlFile.open(QIODevice::ReadOnly);
+	qmlTxt =	qmlFile.readAll();
+				qmlFile.close();
+
+	return instantiateQml(qmlTxt, filePath, moduleName, fq(qmlFileInfo.absoluteFilePath()), fq(qmlFileInfo.fileName()),  ctxt);
+
 }

--- a/Desktop/utilities/qutils.h
+++ b/Desktop/utilities/qutils.h
@@ -67,6 +67,9 @@ QString decrypt(const QString &input);
 QString getSortableTimestamp();
 QString QJSErrorToString(QJSValue::ErrorType errorType);
 
+QObject * instantiateQml(const QUrl & filePath, const std::string & moduleName, QQmlContext * ctxt = nullptr);
+QObject * instantiateQml(const QString & qmlTxt, const QUrl & url, const std::string & moduleName, const std::string & whatAmILoading, const std::string & filename, QQmlContext * ctxt = nullptr);
+
 QString shortenWinPaths(QString);
 
 bool pathIsSafeForR(const QString & checkThis);

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2013-2018 University of Amsterdam
 //
 // This program is free software: you can redistribute it and/or modify
@@ -100,15 +100,26 @@ void Engine::initialize()
 
 	try
 	{
+		std::string memoryName = "JASP-IPC-" + std::to_string(_parentPID);
+		_channel = new IPCChannel(memoryName, _slaveNo, true);
+
 		rbridge_init(SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _extraEncodings, _resultsFont.c_str());
 
 		Log::log() << "rbridge_init completed" << std::endl;
 	
 		//Is there maybe already some data? Like, if we just killed and restarted the engine
+		std::vector<std::string> columns;
+		if(provideDataSet())
+		{
+			columns = provideDataSet()->getColumnNames();
+			Log::log() << "There is a dataset and got " << columns.size() << " columns in it, loading them into encoder now." << std::endl;
+		}
+		else
+			Log::log() << "No dataset available so resetting columnnames in encoder." << std::endl;
+
 		ColumnEncoder::columnEncoder()->setCurrentColumnNames(provideDataSet() == nullptr ? std::vector<std::string>({}) : provideDataSet()->getColumnNames());
 
-		_engineState = engineState::idle;
-		sendEngineResumed(); //Then the desktop knows we've finished init.
+
 
 		Log::log() << "Engine::initialize() done" << std::endl;
 	}
@@ -125,30 +136,29 @@ Engine::~Engine()
 
 	delete _channel; //shared memory files will be removed in jaspDesktop
 	_channel = nullptr;
+
+
 }
 
 void Engine::run()
 {
-	JASPTIMER_START(Engine::run startup);
-
-	std::string memoryName = "JASP-IPC-" + std::to_string(_parentPID);
-	_channel = new IPCChannel(memoryName, _slaveNo, true);
-
-	JASPTIMER_STOP(Engine::run startup);
-
-	sendString(""); //Clear the buffer, because it might have been filled by a previous incarnation of the engine
-
 	while(_engineState != engineState::stopped && ProcessInfo::isParentRunning())
 	{
-		if(_engineState == engineState::initializing) //Do this first, otherwise receiveMessages possibly triggers some other functions
+		static bool initDone = false;
+		if(!initDone && _engineState == engineState::initializing) //Do this first, otherwise receiveMessages possibly triggers some other functions
+		{
 			initialize();
+			initDone = true;
+		}
 
 		receiveMessages(100);
 
 		switch(_engineState)
 		{
+
 		case engineState::idle:				beIdle(_lastRequest == engineState::analysis);	break;
 		case engineState::analysis:			runAnalysis();									break;
+		case engineState::initializing:
 		case engineState::paused:			/* Do nothing */
 		case engineState::stopped:															break;
 		case engineState::resuming:			throw std::runtime_error("Enginestate " + engineStateToString(_engineState) + " should NOT be set as currentState!");
@@ -159,6 +169,9 @@ void Engine::run()
 
 	if(_engineState == engineState::stopped)
 		Log::log() << "Engine leaving mainloop after having been asked to stop." << std::endl;
+
+	delete _channel;
+	_channel = nullptr;
 }
 
 void Engine::beIdle(bool newlyIdle)
@@ -177,16 +190,17 @@ void Engine::beIdle(bool newlyIdle)
 	_lastRequest = engineState::idle;
 }
 
-
-
 bool Engine::receiveMessages(int timeout)
 {
 	std::string data;
 
 	if (_channel->receive(data, timeout))
 	{
-		if(data =="")
+		if(data == "")
+		{
+			Log::log() << "Received nothing..." << std::endl;
 			return false;
+		}
 
 		// JSONCPP_STRING          err;
 		// Json::Value		        jsonRequest;
@@ -194,6 +208,7 @@ bool Engine::receiveMessages(int timeout)
 		// std::unique_ptr<Json::CharReader> const jsonReader(jsonReaderBuilder.newCharReader());
 
 		// if(!jsonReader->parse(data.c_str(), data.c_str() + data.length(), &jsonRequest, &err))
+		
 
 		Json::Value		jsonRequest;
 		Json::Reader	jsonReader;
@@ -215,6 +230,8 @@ bool Engine::receiveMessages(int timeout)
 		}
 
 		//Clear send buffer
+		Log::log() << "Received: '" << data << "' so now clearing my send buffer" << std::endl;
+
 		sendString("");
 
 		//Check if we got anyting useful
@@ -230,21 +247,30 @@ bool Engine::receiveMessages(int timeout)
 #ifdef PRINT_ENGINE_MESSAGES
 		Log::log() << "Engine received " << engineStateToString(_lastRequest) <<" message" << std::endl;
 #endif
-		switch(_lastRequest)
+
+		if(_engineState == engineState::initializing)
 		{
-		case engineState::analysis:				receiveAnalysisMessage(jsonRequest);		return true;
-		case engineState::filter:				receiveFilterMessage(jsonRequest);			break;
-		case engineState::rCode:				receiveRCodeMessage(jsonRequest);			break;
-		case engineState::computeColumn:		receiveComputeColumnMessage(jsonRequest);	break;
-		case engineState::pauseRequested:		pauseEngine(jsonRequest);					break;
-		case engineState::resuming:				resumeEngine(jsonRequest);					break;
-		case engineState::moduleInstallRequest:	
-		case engineState::moduleLoadRequest:	receiveModuleRequestMessage(jsonRequest);	break;
-		case engineState::stopRequested:		stopEngine();								break;
-		case engineState::logCfg:				receiveLogCfg(jsonRequest);					break;
-		case engineState::settings:				receiveSettings(jsonRequest);				break;
-		default:								throw std::runtime_error("Engine::receiveMessages begs you to add your new engineState " + engineStateToString(_lastRequest) + " to it!");
+			if(_lastRequest == engineState::resuming)
+				resumeEngine(jsonRequest);
+			//We ignore everything else
 		}
+		else
+			switch(_lastRequest)
+			{
+			case engineState::analysis:				receiveAnalysisMessage(jsonRequest);		return true;
+			case engineState::filter:				receiveFilterMessage(jsonRequest);			break;
+			case engineState::rCode:				receiveRCodeMessage(jsonRequest);			break;
+			case engineState::computeColumn:		receiveComputeColumnMessage(jsonRequest);	break;
+			case engineState::pauseRequested:		pauseEngine(jsonRequest);					break;
+			case engineState::resuming:				resumeEngine(jsonRequest);					break;
+			case engineState::moduleInstallRequest:
+			case engineState::moduleLoadRequest:	receiveModuleRequestMessage(jsonRequest);	break;
+			case engineState::stopRequested:		stopEngine();								break;
+			case engineState::logCfg:				receiveLogCfg(jsonRequest);					break;
+			case engineState::settings:				receiveSettings(jsonRequest);				break;
+			case engineState::reloadData:			receiveReloadData();						break;
+			default:								throw std::runtime_error("Engine::receiveMessages begs you to add your new engineState " + engineStateToString(_lastRequest) + " to it!");
+			}
 	}
 
 	return false;
@@ -456,7 +482,10 @@ void Engine::receiveModuleRequestMessage(const Json::Value & jsonRequest)
 	jsonAnswer["succes"]			= succes;
 	jsonAnswer["error"]				= jaspRCPP_getLastErrorMsg();
 	jsonAnswer["typeRequest"]		= engineStateToString(_engineState);
-	
+
+	if(!succes)
+		Log::log() << "Error was:\n" << jsonAnswer["error"].asString() << std::endl;
+
 	Log::log() << "Sending it." << std::endl;
 
 	sendString(jsonAnswer.toStyledString());
@@ -867,6 +896,29 @@ void Engine::pauseEngine(const Json::Value & json)
 	sendEnginePaused();
 }
 
+void Engine::receiveReloadData()
+{
+	//Im doing the following switch as a copy from Engine::pauseEngine, but probably the engine is always going to be idle anyway.
+	switch(_engineState)
+	{
+	default:							/* everything not mentioned is fine */	break;
+	case engineState::analysis:			_analysisStatus = Status::aborted;		break;
+	case engineState::filter:
+	case engineState::computeColumn:	throw std::runtime_error("Unexpected data synch during " + engineStateToString(_engineState) + " somehow, you should not expect to see this exception ever.");
+	};
+
+	_engineState = engineState::idle;
+
+	Log::log() << "Engine reloadData, unloading dataset now" << std::endl;
+	SharedMemory::unloadDataSet();
+	provideDataSet();
+	reloadColumnNames();
+
+	Json::Value rCodeResponse		= Json::objectValue;
+	rCodeResponse["typeRequest"]	= engineStateToString(engineState::reloadData);
+	sendString(rCodeResponse.toStyledString());
+}
+
 void Engine::sendEnginePaused()
 {
 	Json::Value rCodeResponse		= Json::objectValue;
@@ -875,11 +927,16 @@ void Engine::sendEnginePaused()
 	sendString(rCodeResponse.toStyledString());
 }
 
+void Engine::reloadColumnNames()
+{
+	Log::log() << "Engine rescanning columnNames for en/decoding" << std::endl;
+	ColumnEncoder::columnEncoder()->setCurrentColumnNames(provideDataSet() == nullptr ? std::vector<std::string>({}) : provideDataSet()->getColumnNames());
+}
+
 void Engine::resumeEngine(const Json::Value & jsonRequest)
 {
-	Log::log() << "Engine resuming, absorbing settings and rescanning columnNames for en/decoding" << std::endl;
-	//Any changes to the data that engine needs to know about are accompanied by pause + resume I think.
-	ColumnEncoder::columnEncoder()->setCurrentColumnNames(provideDataSet() == nullptr ? std::vector<std::string>({}) : provideDataSet()->getColumnNames());
+	Log::log() << "Engine resuming and absorbing settings from request." << std::endl;
+	reloadColumnNames();
 
 	absorbSettings(jsonRequest);
 

--- a/Engine/engine.h
+++ b/Engine/engine.h
@@ -73,6 +73,7 @@ private: // Methods:
 	void receiveAnalysisMessage(		const Json::Value & jsonRequest);
 	void receiveComputeColumnMessage(	const Json::Value & jsonRequest);
 	void receiveModuleRequestMessage(	const Json::Value & jsonRequest);
+	void receiveReloadData();
 	void receiveLogCfg(					const Json::Value & jsonRequest);
 	void receiveSettings(				const Json::Value & jsonRequest);
 	void absorbSettings(				const Json::Value & json);
@@ -108,6 +109,7 @@ private: // Methods:
 	void provideStateFileName(											std::string & root,	std::string & relativePath);
 	void provideJaspResultsFileName(									std::string & root,	std::string & relativePath);
 	void provideSpecificFileName(	const std::string & specificName,	std::string & root,	std::string & relativePath);
+	void reloadColumnNames();
 
 private: // Data:
 	static Engine	*	_EngineInstance;

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, char *argv[])
 
 		Log::log() << "Log and possible redirects initialized!" << std::endl;
 		Log::log() << "jaspEngine started and has slaveNo " << slaveNo << " and it's parent PID is " << parentPID << std::endl;
+		Log::log() << "Current directory is: '" << boost::filesystem::current_path().string() << "'" << std::endl;
 
 #ifdef _WIN32
 		//Should help with converting korean/japanese/etc to utf-8.

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -149,7 +149,11 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	rInside[".requestSpecificFileNameNative"]	= Rcpp::InternalFunction(&jaspRCPP_requestSpecificFileNameSEXP);
 	
 	jaspRCPP_logString("Creating Output sink.\n");
-	rInside.parseEvalQNT(".outputSink <- .createCaptureConnection(); sink(.outputSink); print('.outputSink initialized!'); sink();");
+	rInside[".outputSink"]						= jaspRCPP_CreateCaptureConnection();
+
+	rInside.parseEvalQNT("sink(.outputSink); print('.outputSink initialized!'); sink();");
+	Rcpp::RObject sinkObj = rInside[".outputSink"];
+	//jaspRCPP_logString(sinkObj.isNULL() ? "sink is null\n" : !sinkObj.isObject() ? " sink is not object\n" : sinkObj.isS4() ? "sink is s4\n" : "sink is obj but not s4\n");
 
 	static const char *baseCitationFormat	= "JASP Team (%s). JASP (Version %s) [Computer software].";
 	char baseCitation[200];
@@ -262,12 +266,20 @@ const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, 
 
 	_setJaspResultsInfo(analysisID, analysisRevision, developerMode);
 
-	SEXP results = jaspRCPP_parseEval("runJaspResults(name=name, title=title, dataKey=dataKey, options=options, stateKey=stateKey, functionCall=moduleCall)", true);
-
 	static std::string str;
-	if(results != NULL && Rcpp::is<std::string>(results))	str = jaspNativeToUtf8(Rcpp::as<Rcpp::String>(results));
-	else													str = "error!";
+	try
+	{
+		SEXP results = jaspRCPP_parseEval("runJaspResults(name=name, title=title, dataKey=dataKey, options=options, stateKey=stateKey, functionCall=moduleCall)", true);
 
+		if(results != NULL && Rcpp::is<std::string>(results))	str = jaspNativeToUtf8(Rcpp::as<Rcpp::String>(results));
+		else													str = "error!";
+	}
+	catch(std::runtime_error & e)
+	{
+		jaspResults errorResult(title, NULL);
+		errorResult.setErrorMessage(e.what(), "fatalError");
+		errorResult.send();
+	}
 
 #ifdef PRINT_ENGINE_MESSAGES
 	jaspRCPP_logString("result of runJaspResults:\n" + str + "\n");
@@ -423,7 +435,7 @@ const char*	STDCALL jaspRCPP_evalRCode(const char *rCode, bool setWd) {
 		"returnVal = 'null';	"
 		"tryCatch("
 		"    suppressWarnings({	returnVal <- eval(parse(text=.rCode))     }),	"
-		"    error	= function(e) { .setRError(  paste0(toString(e$message), '\n', paste0(sys.calls(), collapse='\n'))) } 	"
+		"    error	= function(e) { .setRError(  paste0(toString(e), '\n', paste0(sys.calls(), collapse='\n'))) } 	"
 		")"
 		"; returnVal	");
 
@@ -1137,11 +1149,11 @@ RInside::Proxy jaspRCPP_parseEval(const std::string & code, bool setWd, bool pre
 	if(preface)	
 		jaspRCPP_parseEvalPreface(code);
 	
-	RInside::Proxy returnthis = rinside->parseEvalNT(__sinkMe(code)); //Not throwing is nice actually!
+	RInside::Proxy returnthis = rinside->parseEval(__sinkMe(code)); //Not throwing is nice actually! Well, unless you want to hear about missing modules etc...
 	jaspRCPP_logString("\n");
 
 	rinside->parseEvalQNT("sink();"); //back to normal!
-	
+
 	return returnthis;
 }
 


### PR DESCRIPTION

- adds a "reloadData"  command for the engine so that it does that
- Also tries to be more selective about pausing/resuming engines when loading data. Now it is only done for those that actually need the data.
- The rest are just given a signal to reload after the data has changed (such moduleInstallRequest or so)
- Add better event logging from JorisGoosen/jasp-desktop@slowdownHunter
- preferably kill longest idle engine first
- actually log output from R
- Only loading qml when dynamic module is ready for use solves all the crashing it seems
- show a loader while waiting for qml
- Enginewindow added where you can monitor what all the engines are doing (Ctrl+Shift+Alt+E or via prefs-advanced)

- startup better now make sure that shutdown works
- try and keep IPCChannel slaves finding its objects by giving it time. #It doesnt seem to help though and makes everything more complicated :(
-- This is not enough to solve all problems but allows for working around small timing problems
- to further avoid problems the channels are kept separate from the engine and are no long destroyed ever, this way the communication objects aren't lost.
- and anyhow this is only a problem when the max engine count is changed anyway.
- Make sure channel() isnt used when nullptr

- Engines can be killed in enginewindow with middlemouse
- same engine  for installing a module as running it please. This avoids all those "cannot open connection" errors
- make sure forms are destroyed before the rest of qml is so that we arent inundated with errormessages as it exhales its dying breath
- remove useless "initializing" state from Analysis
- fixes dragging issues
- uninstall developer module if path is changed

