### PR TITLE
Cannot open the Column Filter when filter icon is visible

### DIFF
--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -94,9 +94,7 @@ FocusScope
 					anchors.left:			parent.left
 					anchors.margins:		4
 
-					function myColumnType() {return dataSetModel.columnIcon(columnIndex)}
-
-					source: jaspTheme.iconPath + dataSetModel.getColumnTypesWithCorrespondingIcon()[myColumnType()]
+					source: jaspTheme.iconPath + dataSetModel.getColumnTypesWithCorrespondingIcon()[columnType]
 					width:	headerRoot.__iconDim
 					height: headerRoot.__iconDim
 
@@ -104,11 +102,11 @@ FocusScope
 									height:	height * 2 }
 
 
-					function setColumnType(columnType)
+					function setColumnType(newColumnType)
 					{
-						dataSetModel.setColumnTypeFromQML(columnIndex, columnType)
+						dataSetModel.setColumnTypeFromQML(columnIndex, newColumnType)
 
-						if(labelModel.chosenColumn === columnIndex && colIcon.myColumnType() === columnTypeScale)
+						if(labelModel.chosenColumn === columnIndex && columnType === columnTypeScale)
 							labelModel.visible = false;
 					}
 
@@ -204,12 +202,29 @@ FocusScope
 				{
 					id:			colIsInvalidated
 
-					width:		headerRoot.__iconDim
+
+					width:		columnIsInvalidated ? headerRoot.__iconDim : 0
 					visible:	columnIsInvalidated
 
 					anchors.right:			colFilterOn.left
 					anchors.verticalCenter:	parent.verticalCenter
 					anchors.margins:		visible ? 1 : 0
+				}
+
+				Image
+				{
+					id:						colFilterOn
+
+					width:					columnIsFiltered ? headerRoot.__iconDim : 0
+					height:					headerRoot.__iconDim
+
+					source:					jaspTheme.iconPath + "filter.png"
+					sourceSize {	width:	headerRoot.__iconDim * 2
+									height:	headerRoot.__iconDim * 2 }
+
+					anchors.right:			colHasError.left
+					anchors.margins:		columnIsFiltered ? 1 : 0
+					anchors.verticalCenter:	parent.verticalCenter
 				}
 
 				Image
@@ -224,7 +239,7 @@ FocusScope
 					sourceSize {	width:	headerRoot.__iconDim * 2
 									height:	headerRoot.__iconDim * 2 }
 
-					anchors.right:			colIsInvalidated.left
+					anchors.right:			parent.right
 					anchors.verticalCenter:	parent.verticalCenter
 					anchors.margins:		visible ? 1 : 0
 
@@ -244,22 +259,6 @@ FocusScope
 
 				}
 
-				Image
-				{
-					id:						colFilterOn
-
-					width:					columnIsFiltered ? headerRoot.__iconDim : 0
-					height:					headerRoot.__iconDim
-
-					source:					jaspTheme.iconPath + "filter.png"
-					sourceSize {	width:	headerRoot.__iconDim * 2
-									height:	headerRoot.__iconDim * 2 }
-
-					anchors.right:			parent.right
-					anchors.margins:		columnIsFiltered ? 1 : 0
-					anchors.verticalCenter:	parent.verticalCenter
-				}
-
 				MouseArea
 				{
 					anchors.left:	colIsComputed.right
@@ -271,7 +270,7 @@ FocusScope
 						if(columnIndex >= 0)
 						{
 
-							if(dataSetModel.columnIcon(columnIndex)  !== columnTypeScale)
+							if(columnType  !== columnTypeScale)
 							{
 								var changedIndex		= labelModel.chosenColumn	!== columnIndex
 								labelModel.chosenColumn	= columnIndex;
@@ -286,11 +285,11 @@ FocusScope
 						}
 
 					hoverEnabled:		true
-					ToolTip.visible:	containsMouse && dataSetModel.columnIcon(columnIndex)  !== columnTypeScale
+					ToolTip.visible:	containsMouse && (columnType !== columnTypeScale)
 					ToolTip.text:		qsTr("Click here to change labels") + (columnIsFiltered ? qsTr(" or inspect filter") : "" )
 					ToolTip.timeout:	3000
 					ToolTip.delay:		500
-					cursorShape:		dataSetModel.columnIcon(columnIndex)  !== columnTypeScale || dataSetModel.columnUsedInEasyFilter(columnIndex) ? Qt.PointingHandCursor : Qt.ArrowCursor
+					cursorShape:		(columnType !== columnTypeScale) || dataSetModel.columnUsedInEasyFilter(columnIndex) ? Qt.PointingHandCursor : Qt.ArrowCursor
 				}
 			}
 		}

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -438,6 +438,7 @@ QVariant DataSetPackage::headerData(int section, Qt::Orientation orientation, in
 	case int(specialRoles::columnIsComputed):				return isColumnComputed(section);
 	case int(specialRoles::computedColumnError):			return tq(getComputedColumnError(section));
 	case int(specialRoles::computedColumnIsInvalidated):	return isColumnInvalidated(section);
+	case int(specialRoles::columnType):						return int(getColumnType(section));
 	}
 
 	return QVariant();

--- a/Desktop/data/datasettablemodel.h
+++ b/Desktop/data/datasettablemodel.h
@@ -41,9 +41,7 @@ public:
 				int			columnsFilteredCount()					const				{ return DataSetPackage::pkg()->columnsFilteredCount();								}
 	Q_INVOKABLE bool		isColumnNameFree(QString name)								{ return DataSetPackage::pkg()->isColumnNameFree(name);								}
 	Q_INVOKABLE	QVariant	columnTitle(int column)					const				{ return DataSetPackage::pkg()->getColumnTitle(column);								}
-	Q_INVOKABLE QVariant	columnIcon(int column)					const				{ return DataSetPackage::pkg()->getColumnIcon(column);								}
 	Q_INVOKABLE QVariant	getColumnTypesWithCorrespondingIcon()	const				{ return DataSetPackage::pkg()->getColumnTypesWithCorrespondingIcon();				}
-	Q_INVOKABLE bool		columnHasFilter(int column)				const				{ return DataSetPackage::pkg()->getColumnHasFilter(column);							}
 	Q_INVOKABLE bool		columnUsedInEasyFilter(int column)		const				{ return DataSetPackage::pkg()->isColumnUsedInEasyFilter(column);					}
 	Q_INVOKABLE void		resetAllFilters()											{		 DataSetPackage::pkg()->resetAllFilters();									}
 	Q_INVOKABLE int			setColumnTypeFromQML(int columnIndex, int newColumnType)	{ return DataSetPackage::pkg()->setColumnTypeFromQML(columnIndex, newColumnType);	}

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -749,7 +749,8 @@ QQuickItem * DataSetView::createColumnHeader(int col)
 									_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["columnIsComputed"]).toBool(),
 									_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["computedColumnIsInvalidated"]).toBool(),
 									_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["filter"]).toBool(),
-									_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["computedColumnError"]).toString());
+									_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["computedColumnError"]).toString(),
+									_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["columnType"]).toInt());
 		}
 		else
 		{
@@ -764,7 +765,8 @@ QQuickItem * DataSetView::createColumnHeader(int col)
 												_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["columnIsComputed"]).toBool(),
 												_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["computedColumnIsInvalidated"]).toBool(),
 												_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["filter"]).toBool(),
-												_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["computedColumnError"]).toString()));
+												_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["computedColumnError"]).toString(),
+												_model->headerData(col, Qt::Orientation::Horizontal, _roleNameToRole["columnType"]).toInt()));
 
 			_columnHeaderDelegate->create(localIncubator, itemCon->context);
 			columnHeader = qobject_cast<QQuickItem*>(localIncubator.object());
@@ -902,7 +904,7 @@ QQmlContext * DataSetView::setStyleDataRowNumber(QQmlContext * previousContext, 
 	return previousContext;
 }
 
-QQmlContext * DataSetView::setStyleDataColumnHeader(QQmlContext * previousContext, QString text, int column, bool isComputed, bool isInvalidated, bool isFiltered, QString computedError)
+QQmlContext * DataSetView::setStyleDataColumnHeader(QQmlContext * previousContext, QString text, int column, bool isComputed, bool isInvalidated, bool isFiltered, QString computedError, int columnType)
 {
 	if(previousContext == nullptr)
 		previousContext = new QQmlContext(qmlContext(this), this);
@@ -913,6 +915,7 @@ QQmlContext * DataSetView::setStyleDataColumnHeader(QQmlContext * previousContex
 	previousContext->setContextProperty("columnIsInvalidated",	isInvalidated);
 	previousContext->setContextProperty("columnIsFiltered",		isFiltered);
 	previousContext->setContextProperty("columnError",			computedError);
+	previousContext->setContextProperty("columnType",			columnType);
 
 	return previousContext;
 }

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -177,7 +177,7 @@ protected:
 
 	QQmlContext * setStyleDataItem(			QQmlContext * previousContext, bool active, size_t col, size_t row);
 	QQmlContext * setStyleDataRowNumber(	QQmlContext * previousContext, QString text, int row);
-	QQmlContext * setStyleDataColumnHeader(	QQmlContext * previousContext, QString text, int column, bool isComputed, bool isInvalidated, bool isFiltered,  QString computedError);
+	QQmlContext * setStyleDataColumnHeader(	QQmlContext * previousContext, QString text, int column, bool isComputed, bool isInvalidated, bool isFiltered,  QString computedError, int columnType);
 
 	void addLine(float x0, float y0, float x1, float y1);
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1661

The problem was that the width of the LoadingIndicator of the column (in DataTableView) was not set to 0 when invisible.
The MouseArea that opens the Labels and Filters should also contain the Filter icon.
Also set the columnType as context variable: seems more logical.

