### PR TITLE
Setting panel in the Plot Editor should have a minimum width

### DIFF
--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
@@ -164,9 +164,9 @@ Popup
 				Item
 				{
 					id:						axes
-					Layout.preferredWidth:	parent.width * .3
-					Layout.minimumWidth:	parent.width * .3
-					Layout.maximumWidth:	parent.width * .9
+					SplitView.preferredWidth:	parent.width * .3
+					SplitView.minimumWidth:	parent.width * .3
+					SplitView.maximumWidth:	parent.width * .9
 
 					property real	tabBarHeight:		28 * preferencesModel.uiScale
 					property real	tabButtonRadius:	5 * preferencesModel.uiScale


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1784
In Qt 6, the item width in a SplitView should be set with the SplitView attached properties and not the Layout attached properties.

