### PR TITLE
Guide for option names

### DIFF
--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -110,6 +110,79 @@ Section
 
 Here, we have a section for specifying marginal means. So every option starts with `marginalMean`. Further, the number of bootstrapping replicates is a child of the checkbox that enables bootstrapping, and so it starts with `marginalMeanBootstrap`.
 
+### Nested option names
+
+In the previous section we had options that are nested in the Qml file, but they are not nested in the R syntax. However, there are cases where an option is actually nested within the R syntax as well. In this case, special care needs to be taken to adhere to the style of "option names within options".
+
+#### Examples
+
+##### Radio Buttons
+
+We actually already saw this in the previous section. Radio Buttons are a special control because they result in a single argument in the syntax, but can take different character values. These character values need to adhere to the code style as well.
+
+```qml
+RabioButtonGroup
+{
+	name:	"alternative"
+	label:	qsTr("Alternative hypothesis")
+	RadioButton
+	{
+		name:		"twoSided"
+		label:		qsTr("Group 1 ≠ Group 2")
+		checked:	true
+	}
+	RadioButton
+	{
+		name:		"greater"
+		label:		qsTr("Group 1 > Group 2")
+	}
+	RadioButton
+	{
+		name:		"less"
+		label:		qsTr("Group 1 < Group 2")
+	}
+}
+```
+
+This results in an option in the R syntax defined as `analysis(..., alternative = c("twoSided", "greater", "less"))` and its use requires to specify one of the options, e.g. `analysis(..., alternative = "twoSided")`. Note: the use of `greater`, `twoSided`, `less` is defined in in the list of common option names below.
+
+##### TabView
+
+There are other, more complicated components than that. For example, `TabView` enables a collection of options that can be specified multiple times. A typical example is the SEM module which enables to specify multiple models in a single analysis.
+
+```qml
+TabView
+{
+	id: models
+	name: "models"
+	maximumItems: 9
+	newItemName: qsTr("Model 1")
+	optionKey: "name"
+
+	content: TextArea { name: "syntax"; width: models.width; textType: JASP.TextTypeLavaan }
+}
+```
+
+note that `name: "models"` names the option that can take a list of options. Each element of that list is a list that contains `modelName` and `syntax`, and will be used in R like this:
+
+```r
+jaspSem::sem(
+	models = list(
+		list(
+			name   = "Model 1 name",
+			syntax = "#sem syntax for model 1"
+		),
+		list(
+			name   = "Another model",
+			syntax = "#sem syntax for another model"
+		)
+	),
+	...
+)
+```
+
+Notice that the options are nested within another option both in Qml and in the R syntax. Therefore, we do not need to prepend the nested options with the name of the parent option, i.e., we do not need to name the `TextArea` as `modelSyntax` or the `optionKey` as `modelName`, as it is clear from the structure of the argument itself that `syntax` and `name` are a part of the `models` option.
+
 ### Reserved option names
 
 `data` and `formula` are reserved option names: **Do not use them for naming options in the Qml file.**

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -24,7 +24,7 @@ It should be possible from the option name (which is visible to the R users) to 
 
 #### Examples
 
-- if an option is labeled as `label: qsTr("Variables")`, the option name should be `name: "variables"`, and not `name: "dependent"` or `name: "variable"`.
+- if an option is labeled as `label: qsTr("Variables")`, the option name should be `name: "variables"`, and not `name: "dependent"`.
 - `kruskalWallisTerms` (not `kwTerms`)
 
 ### Abbreviations are a single word
@@ -34,8 +34,8 @@ Abbreviations should not be used in general, except for common option names (see
 #### Examples
 
 - `mcmcMethod`: `mcmc` is an abbreviation of markov chain monte carlo, and it is treated as a word. Do not do `MCMCMethod`
-- `marginalMeansCi`: `Ci` is an abbreviation of confidence interval, and so is treated as a word. Do not do `marginalMeansCI`
-- `contrastsSeMethod`: `Se` is an abbreviation of a standard error, and so is treated as a word. Do not do `contrastsSEMethod`
+- `marginalMeanCi`: `Ci` is an abbreviation of confidence interval, and so is treated as a word. Do not do `marginalMeanCI`
+- `contrastSeMethod`: `Se` is an abbreviation of a standard error, and so is treated as a word. Do not do `contrastSEMethod`
 
 
 ### Correspondence between options
@@ -50,17 +50,17 @@ If several options functionally belong together (e.g., relate to the same output
 CheckBox
 {
 	label:		qsTr("Display error bars")
-	name:		"errorBars"
+	name:		"errorBar"
 	RadioButtonGroup
 	{
-		name: "errorBarsType"
+		name: "errorBarType"
 		RadioButton
 		{
 			value:					"ci"
 			label:					qsTr("Confidence interval"); 
 			checked: 				true
 			childrenOnSameRow:		true
-			CIField { name: "errorBarsCiLevel" }
+			CIField { name: "errorBarCiLevel" }
 		}
 		RadioButton
 		{ 
@@ -71,10 +71,10 @@ CheckBox
 }
 ```
 
-Here, the `CheckBox` `errorBars` is a parent to the the radio button control and the `CIField`. To make this clear, we use the `"errorBars"` as an indication that the rest of the options are related to the checkbox. The reason for this is that when the user calls the analysis from R, the relationship between the arguments is clear from the names:
+Here, the `CheckBox` of name `errorBar` is a parent to the the radio button control and the `CIField` component. To make this clear, we use the `"errorBar"` as an indication that the rest of the options are related to the checkbox. The reason for this is that when the user calls the analysis from R, the relationship between the arguments is clear from the names:
 
 ```r
-analysis(errorBars = TRUE, errorBarsType = "ci", errorBarsCiLevel = 0.95, ...)
+analysis(errorBar = TRUE, errorBarType = "ci", errorBarCiLevel = 0.95, ...)
 ```
 
 ##### Options are grouped in a `Section{}`
@@ -88,17 +88,17 @@ Section
 	VariablesForm
 	{
 		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
-		AvailableVariablesList { name: "marginalMeansTermsAvailable"; source: "modelTerms" }
-		AssignedVariablesList {  name: "marginalMeansTerms" }
+		AvailableVariablesList { name: "marginalMeanTermsAvailable"; source: "modelTerms" }
+		AssignedVariablesList {  name: "marginalMeanTerms" }
 	}
 
 	CheckBox
 	{
-		name: "marginalMeansBootstrap"; label: qsTr("From")
+		name: "marginalMeanBootstrap"; label: qsTr("From")
 		childrenOnSameRow: true
 		IntegerField
 		{
-			name: "marginalMeansBootstrapSamples"
+			name: "marginalMeanBootstrapSamples"
 			defaultValue: 1000
 			fieldWidth: 50
 			min: 100
@@ -108,16 +108,37 @@ Section
 }
 ```
 
-Here, we have a section for specifying marginal means. So every option starts with `marginalMeans`. Further, the number of bootstrapping replicates is a child of the checkbox that enables bootstrapping, and so it starts with `marginalMeansBootstrap`.
+Here, we have a section for specifying marginal means. So every option starts with `marginalMean`. Further, the number of bootstrapping replicates is a child of the checkbox that enables bootstrapping, and so it starts with `marginalMeanBootstrap`.
 
 ### Reserved option names
 
 `data` and `formula` are reserved option names: **Do not use them for naming options in the Qml file.**
 
+### Singular vs. plural form
+
+Prefer singular form for names that relate to the output, *even if the output features multiple instances of the object*. Using plural is useful for indicating to the R syntax user that the argument of the analysis function accepts *multiple specification*.  
+
+#### Examples
+
+- `Ci` not `Cis` for confidence intervals (even if the output could feature multiple intervals)
+- `pValue` not `pValues` for p-values (even if the output could feature multiple p-values)
+- `marginalMeanTerms`: use singular `marginalMean` as an indicator of the output (regardles that there may be more marginal means in the output), but use plural `Terms` to indicate to the user that they may specify multiple terms.
+- `variable`: use singular in case that the `AssignedVariableList` in Qml specifies `singleVariable: true` to indicate to the user that only one variable is allowed. On the other hand, if it's possible to specify multiple variables, use plural `variables` (and similarly, `fixedFactors`, `randomFactors`, `covariates`, etc.)
+- And exception can be when the input is a number, such as in `bootstrapSamples`. In this case, the input is still a singular object (a number), but the plural indicates that it expects just that: a number.
+
+### Rephrain from using verbs for options
+
+Option names should preferably be nouns and not verbs. 
+
+#### Examples
+
+- `histrogramPlot`, not `plotHistogram`
+- `errorBars`, not `displayErrorBars`
+- `marginalMean` not `computeMarginalMean`
 
 ### Long option names are not evil
 
-Combining the basic principles above may seem to be silly and annoying because they can lead to long option names - and a lot of typing. This is true, but given that most of the time, people use autocomplete features of text editors, it is a small price to pay for enhanced clarity - the best state of code documentation is when the user does not need additional documentation to understand what the code does. In the other extreme, the users would need to bury themselves in the documentation to understand what the arguments mean - which takes much more time than simply typing up a couple of extra letters.
+Combining the basic principles above may seem to be silly and annoying because they can lead to long option names - and a lot of typing. This is true, but given that most of the time people use autocomplete features in text editors, it is a small price to pay for enhanced clarity - the best state of code documentation is when the user does not need additional documentation to understand what the code does. In the other extreme, the users would need to bury themselves in the documentation to understand what the arguments mean - which takes much more time than simply typing up a couple of extra letters.
 
 ## List of common option names
 
@@ -132,9 +153,9 @@ Combining the basic principles above may seem to be silly and annoying because t
 - `randomFactors`: for specifying Random Factors variable list
 - `covariates`: for specifying covariates
 - `weights`: variable specifying weights
-- `terms`: for specifying terms (allowing interactions). This can be combined with what the terms relate to, e.g., `modelTerms`, `marginalMeansTerms`, `plotTerms`, etc.
-- `naAction`: name for an option that specifies the action to take with missing values. The option values can be for example, `pairwise` for pairwise deletion, `listwise` for listwise deletion, `perAnalysis` for deleting per analysis, `perDependent` for deleting per dependent variable, so that the analysis can be called as `analysis(..., naAction = "pairwise")`, for example.
-- `alternative`: name for the option specifying the alternative hypothesis. This is to ensure consistency with base R. Typical values of this option would be `greater`, `less`, `two.sided` for hypotheses such as "> Test Value" (consistency with base R functions). For hypotheses such as "Group one > Group two" use `greater`, for "Group one < Group two" use `less` and for "Group one != Group two" use `two.sided`. This needs to be explained further in the documentation (`info` fields).
+- `terms`: for specifying terms (allowing interactions). This can be combined with what the terms relate to, e.g., `modelTerms`, `marginalMeanTerms`, `plotTerms`, etc.
+- `naAction`: name for an option that specifies the action to take with missing values. The option values can be, for example, `pairwise` for pairwise deletion, `listwise` for listwise deletion, `perAnalysis` for deleting per analysis, `perDependent` for deleting per dependent variable, so that the analysis can be called as `analysis(..., naAction = "pairwise")`, for example.
+- `alternative`: name for the option specifying the alternative hypothesis. Typical values of this option would be `greater`, `less`, `twoSided` for hypotheses such as "> Test Value". For hypotheses such as "Group one > Group two" use `greater`, for "Group one < Group two" use `less` and for "Group one != Group two" use `twoSided`. 
 - `testValue`: name for the option specifying the test value
 - `vovkSellke`: name for the Vovk-Sellke maximum p-ratio checkbox
 - `bootstrap`: checkbox for enabling bootstrapping
@@ -170,55 +191,3 @@ Combining the basic principles above may seem to be silly and annoying because t
 - `tPriorLocation`: location of the t prior
 - `tPriorScale`: scale of the t prior
 - `tPriorDf`: df of the t prior
-
-## Points of contention
-
-### Rephrain from using verbs for options
-
-Option names should preferably be nouns. 
-
-#### Examples
-
-- `histrogramPlot`, not `plotHistogram`
-- `errorBars`, not `displayErrorBars`
-
-- `descriptiveTableTransposed`, not `transposeDescriptiveTable`??
-- `residualsExport`, not `exportResiduals`??
-
-
-### Consistency with underlying analysis packages
-
-In some cases, an option name/value is selected so that it is directly compatible with option names/values of the underlying package. For example, consider the following excerpt from a SEM analysis:
-
-```qml
-DropDown
-{
-	name:	"emulation"
-	label:	qsTr("Emulation")
-	values: [
-		{ value: "lavaan",	label: qsTr("None") 	},
-		{ value: "Mplus",	label: qsTr("Mplus") 	},
-		{ value: "EQS",		label: qsTr("EQS") 		}
-	] 
-}
-```
-
-Here we see a schism between the value of the option (`lavaan`) and the label of the option ("None"). This is because the value of the option `emulation` is directly feeded into the lavaan functions under argument `mimic`. The programmer now need to make a conscious decision: Do we need and want to keep consistency with the underlying analysis package? If the answer is yes, then it is adviseable to make the consistency as tight as possible. This means that slight deviations from the our style-guide is possible if this helps keeping consistent with the underlying package. In this case, we could change the component accordingly
-
-```qml
-DropDown
-{
-	name:	"mimic"
-	label:	qsTr("Mimic")
-	info:	qsTr("Obtain results based on emulating popular SEM software. The option corresponds to the lavaan's `mimic` arument.")
-	values: [
-		{ value: "lavaan",	label: qsTr("Lavaan") 	},
-		{ value: "Mplus",	label: qsTr("Mplus") 	},
-		{ value: "EQS",		label: qsTr("EQS") 		}
-	] 
-}
-```
-
-Notice that we changed the option name to `mimic` so that the argument is called the same as in the `lavaan` package that runs the analysis. Further, we changed the label of value `lavaan` from "None" to "Lavaan" to still keep consistency between what is shown to the user in JASP, and what is shown to the user in R. Notice that we slightly deviate from our camelCasing rule for values `Mplus` and `EQS` for consistency with `lavaan`.
-
-Such small deviations are permissible if they improve understanding of what out analysis does. We advise thinking critically about where to push this.The primary goal of the options are to make them as clear as possible to JASP and R users, and R packages not necessarily design their arguments to be easily translatable into a good GUI programme. If that is the case, consistency and clarity of the JASP programme and the JASP code should always take precedence above consistency with the underlying R package that runs the analysis.

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -186,7 +186,7 @@ Option names should preferably be nouns.
 - `residualsExport`, not `exportResiduals`??
 
 
-## Consistency with underlying analysis packages
+### Consistency with underlying analysis packages
 
 In some cases, an option name/value is selected so that it is directly compatible with option names/values of the underlying package. For example, consider the following excerpt from a SEM analysis:
 

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -17,7 +17,7 @@ That is, the name is written in lowercase letters except of the first letter in 
 - `modelTerms` (not `ModelTerms` or `model_terms`)
 - `mean` (not `Mean`)
 - `qqPlot` (not `QQplot` or `QQPlot`)
-- `qpPlot` (not `Ppplot` or `PPPlot`)
+- `ppPlot` (not `Ppplot` or `PPPlot`)
 
 ### Correspondence between option name and label
 

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -163,7 +163,7 @@ TabView
 }
 ```
 
-note that `name: "models"` names the option that can take a list of options. Each element of that list is a list that contains `Name` and `syntax` elements, and will be used in R like this:
+note that `name: "models"` names the option that can take a list of options. Each element of that list is a list that contains `name` and `syntax` elements, and will be used in R like this:
 
 ```r
 jaspSem::sem(

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -110,43 +110,6 @@ Section
 
 Here, we have a section for specifying marginal means. So every option starts with `marginalMeans`. Further, the number of bootstrapping replicates is a child of the checkbox that enables bootstrapping, and so it starts with `marginalMeansBootstrap`.
 
-## Consistency with underlying analysis packages
-
-In some cases, an option name/value is selected so that it is directly compatible with option names/values of the underlying package. For example, consider the following excerpt from a SEM analysis:
-
-```qml
-DropDown
-{
-	name:	"emulation"
-	label:	qsTr("Emulation")
-	values: [
-		{ value: "lavaan",	label: qsTr("None") 	},
-		{ value: "Mplus",	label: qsTr("Mplus") 	},
-		{ value: "EQS",		label: qsTr("EQS") 		}
-	] 
-}
-```
-
-Here we see a schism between the value of the option (`lavaan`) and the label of the option ("None"). This is because the value of the option `emulation` is directly feeded into the lavaan functions under argument `mimic`. The programmer now need to make a conscious decision: Do we need and want to keep consistency with the underlying analysis package? If the answer is yes, then it is adviseable to make the consistency as tight as possible. This means that slight deviations from the our style-guide is possible if this helps keeping consistent with the underlying package. In this case, we could change the component accordingly
-
-```qml
-DropDown
-{
-	name:	"mimic"
-	label:	qsTr("Mimic")
-	info:	qsTr("Obtain results based on emulating popular SEM software. The option corresponds to the lavaan's `mimic` arument.")
-	values: [
-		{ value: "lavaan",	label: qsTr("Lavaan") 	},
-		{ value: "Mplus",	label: qsTr("Mplus") 	},
-		{ value: "EQS",		label: qsTr("EQS") 		}
-	] 
-}
-```
-
-Notice that we changed the option name to `mimic` so that the argument is called the same as in the `lavaan` package that runs the analysis. Further, we changed the label of value `lavaan` from "None" to "Lavaan" to still keep consistency between what is shown to the user in JASP, and what is shown to the user in R. Notice that we slightly deviate from our camelCasing rule for values `Mplus` and `EQS` for consistency with `lavaan`.
-
-Such small deviations are permissible if they improve understanding of what out analysis does. We advise thinking critically about where to push this.The primary goal of the options are to make them as clear as possible to JASP and R users, and R packages not necessarily design their arguments to be easily translatable into a good GUI programme. If that is the case, consistency and clarity of the JASP programme and the JASP code should always take precedence above consistency with the underlying R package that runs the analysis.
-
 ### Reserved option names
 
 `data` and `formula` are reserved option names: **Do not use them for naming options in the Qml file.**
@@ -221,3 +184,41 @@ Option names should preferably be nouns.
 
 - `descriptiveTableTransposed`, not `transposeDescriptiveTable`??
 - `residualsExport`, not `exportResiduals`??
+
+
+## Consistency with underlying analysis packages
+
+In some cases, an option name/value is selected so that it is directly compatible with option names/values of the underlying package. For example, consider the following excerpt from a SEM analysis:
+
+```qml
+DropDown
+{
+	name:	"emulation"
+	label:	qsTr("Emulation")
+	values: [
+		{ value: "lavaan",	label: qsTr("None") 	},
+		{ value: "Mplus",	label: qsTr("Mplus") 	},
+		{ value: "EQS",		label: qsTr("EQS") 		}
+	] 
+}
+```
+
+Here we see a schism between the value of the option (`lavaan`) and the label of the option ("None"). This is because the value of the option `emulation` is directly feeded into the lavaan functions under argument `mimic`. The programmer now need to make a conscious decision: Do we need and want to keep consistency with the underlying analysis package? If the answer is yes, then it is adviseable to make the consistency as tight as possible. This means that slight deviations from the our style-guide is possible if this helps keeping consistent with the underlying package. In this case, we could change the component accordingly
+
+```qml
+DropDown
+{
+	name:	"mimic"
+	label:	qsTr("Mimic")
+	info:	qsTr("Obtain results based on emulating popular SEM software. The option corresponds to the lavaan's `mimic` arument.")
+	values: [
+		{ value: "lavaan",	label: qsTr("Lavaan") 	},
+		{ value: "Mplus",	label: qsTr("Mplus") 	},
+		{ value: "EQS",		label: qsTr("EQS") 		}
+	] 
+}
+```
+
+Notice that we changed the option name to `mimic` so that the argument is called the same as in the `lavaan` package that runs the analysis. Further, we changed the label of value `lavaan` from "None" to "Lavaan" to still keep consistency between what is shown to the user in JASP, and what is shown to the user in R. Notice that we slightly deviate from our camelCasing rule for values `Mplus` and `EQS` for consistency with `lavaan`.
+
+Such small deviations are permissible if they improve understanding of what out analysis does. We advise thinking critically about where to push this.The primary goal of the options are to make them as clear as possible to JASP and R users, and R packages not necessarily design their arguments to be easily translatable into a good GUI programme. If that is the case, consistency and clarity of the JASP programme and the JASP code should always take precedence above consistency with the underlying R package that runs the analysis.

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -167,17 +167,17 @@ note that `name: "models"` names the option that can take a list of options. Eac
 
 ```r
 jaspSem::sem(
-	models = list(
-		list(
-			name   = "Model 1 name",
-			syntax = "#sem syntax for model 1"
-		),
-		list(
-			name   = "Another model",
-			syntax = "#sem syntax for another model"
-		)
-	),
-	...
+    models = list(
+        list(
+            name   = "Model 1 name",
+            syntax = "#sem syntax for model 1"
+        ),
+        list(
+            name   = "Another model",
+            syntax = "#sem syntax for another model"
+        )
+    ),
+    ...
 )
 ```
 

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -46,7 +46,7 @@ If several options functionally belong together (e.g., relate to the same output
 
 ##### One option is a child of another option
 
-```
+```qml
 CheckBox
 {
 	label:		qsTr("Display error bars")
@@ -73,13 +73,13 @@ CheckBox
 
 Here, the `CheckBox` `errorBars` is a parent to the the radio button control and the `CIField`. To make this clear, we use the `"errorBars"` as an indication that the rest of the options are related to the checkbox. The reason for this is that when the user calls the analysis from R, the relationship between the arguments is clear from the names:
 
-```
+```r
 analysis(errorBars = TRUE, errorBarsType = "ci", errorBarsCiLevel = 0.95, ...)
 ```
 
 ##### Options are grouped in a `Section{}`
 
-```
+```qml
 Section
 {
 	title: qsTr("Marginal Means")

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -16,8 +16,8 @@ That is, the name is written in lowercase letters except of the first letter in 
 
 - `modelTerms` (not `ModelTerms` or `model_terms`)
 - `mean` (not `Mean`)
-- `QqPlot` (not `QQplot` or `QQPlot`)
-- `PpPlot` (not `Ppplot` or `PPPlot`)
+- `qqPlot` (not `QQplot` or `QQPlot`)
+- `qpPlot` (not `Ppplot` or `PPPlot`)
 
 ### Correspondence between option name and label
 

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -1,0 +1,148 @@
+# Guide for consistent option names
+
+This guide is aimed to help us in using consistent option names across JASP. 
+
+In the past, option names were used only internally and never shown to the user - and so while we generally followed some general principles, complete consistency was never enforced. However, now we are heading towards syntax mode in JASP, which will result in exposing these option names to the user as arguments to the analysis function in R. Hence, we not only need to stick to good habits in naming the options, we also need to use consistent naming conventions for inputs that are used across JASP in different analyses.
+
+This guide first goes through the basic principles of how to write option names. Then, it lists common options and how to name them.
+
+## Basic principles
+
+### Use camelCase
+
+That is, the name is written in lowercase letters except of the first letter in each word which is in UPPERCASE to distinguish between different words (except for the first word that is always lowercase). No underscores are allowed. 
+
+#### Examples
+
+- `modelTerms` (not `ModelTerms` or `model_terms`)
+- `mean` (not `Mean`)
+- `QqPlot` (not `QQplot` or `QQPlot`)
+- `PpPlot` (not `Ppplot` or `PPPlot`)
+
+### Correspondence between option name and label
+
+It should be possible from the option name to deduce the option label, and vice versa. This also includes avoiding shortcuts or acronyms except for standardized option names (see below).
+
+#### Examples
+
+- if an option is labeled as `label: qsTr("Variables")`, the option name should be `name: "variables"`, and not `name: "dependent"` or `name: "variable"`.
+- `kruskalWallisTerms` (not `kwTerms`)
+
+
+### Correspondence between options
+
+If several options functionally belong together (e.g., relate to the same output), if they are grouped together in a `Section{}`, or if one option is a "child" of another option, it is often beneficial to use common naming so that it is clear that the options belong together.
+
+#### Examples
+
+##### One option is a child of another option
+
+```
+CheckBox
+{
+	label:		qsTr("Display error bars")
+	name:		"errorBars"
+	RadioButtonGroup
+	{
+		name: "errorBarsType"
+		RadioButton
+		{
+			value:					"ci"
+			label:					qsTr("Confidence interval"); 
+			checked: 				true
+			childrenOnSameRow:		true
+			CIField { name: "errorBarsCiLevel" }
+		}
+		RadioButton
+		{ 
+			value: "se";	
+			label: qsTr("Standard error") }
+		}	
+	}
+}
+```
+
+Here, the `CheckBox` `errorBars` is a parent to the the radio button control and the `CIField`. To make this clear, we use the `"errorBars"` as an indication that the rest of the options are related to the checkbox. The reason for this is that when the user calls the analysis from R, the relationship between the arguments is clear from the names:
+
+```
+analysis(errorBars = TRUE, errorBarsType = "ci", errorBarsCiLevel = 0.95, ...)
+```
+
+##### Options are grouped in a `Section{}`
+
+```
+Section
+{
+	title: qsTr("Marginal Means")
+	columns: 1
+		
+	VariablesForm
+	{
+		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
+		AvailableVariablesList { name: "marginalMeansTermsAvailable"; source: "modelTerms" }
+		AssignedVariablesList {  name: "marginalMeansTerms" }
+	}
+
+	CheckBox
+	{
+		name: "marginalMeansBootstrap"; label: qsTr("From")
+		childrenOnSameRow: true
+		IntegerField
+		{
+			name: "marginalMeansBootstrapSamples"
+			defaultValue: 1000
+			fieldWidth: 50
+			min: 100
+			afterLabel: qsTr("bootstraps")
+		}
+	}
+}
+```
+
+Here, we have a section for specifying marginal means. So every option starts with `marginalMeans`. Further, the number of bootstrapping replicates is a child of the checkbox that enables bootstrapping, and so it starts with `marginalMeansBootstrap`.
+
+
+### Long option names are not evil
+
+Combining the basic principles above may seem to be silly and annoying because they can lead to long option names - and a lot of typing. This is true, but given that most of the time, people use autocomplete features of text editors, it is a small price to pay for enhanced clarity - the best state of code documentation is when the user does not need additional documentation to understand what the code does. In the other extreme, the users would need to bury themselves in the documentation to understand what the arguments mean - which takes much more time than simply typing up a couple of extra letters.
+
+## List of common option names
+
+- `ci`: confidence (or credible) interval checkbox
+- `ciLevel`: confidence (or credible) level of the confidence (credible) interval
+- `se`: standard error
+- `pi`: prediction interval
+- `piLevel`: confidence level of a prediction interval
+- `dependent`: for specifying the dependent variable
+- `fixedFactors`: for specifying Fixed Factors variable list
+- `randomFactors`: for specifying Random Factors variable list
+- `covariates`: for specifying covariates
+- `weights`: variable specifying weights
+- `terms`: for specifying terms (allowing interactions). This can be combined with what the terms relate to, e.g., `modelTerms`, `marginalMeansTerms`, `plotTerms`, etc.
+- `naAction`: name for an option that specifies the action to take with missing values. The option arguments can be for example, `pairwise` for pairwise deletion, `listwise` for listwise deletion, `perAnalysis` for deleting per analysis, `perDependent` for deleting per dependent variable.
+- `alternative`: name for the option specifying the alternative hypothesis. This is to ensure consistency with base R.
+- `testValue`: name for the option specifying the test value
+- `vovkSellke`: name for the Vovk-Sellke maximum p-ratio checkbox
+- `bootstrap`: checkbox for enabling bootstrapping
+- `bootstrapSamples`: number of bootstrap samples
+- `bootstrapType`: type of bootstrap
+- `setSeed`: checkbox for setting seed for reproducibility
+- `seed`: specifying the seed for reproducibility
+
+### Specific to Bayesian analyses
+
+- `sampling`: radiobutton for selecting type of MCMC sampling (e.g., `auto`, `manual`, `bas`, `mcmc`, etc.)
+- `samples`: number of MCMC iterations for Bayesian analyses
+- `bayesFactor`: Bayes factor
+- `priorAndPosterior`: checkbox for prior and posterior
+- `robustnessCheck`: checkbox for robustness check
+- `cauchyPrior`: Cauchy prior checkbox/radiobutton
+- `cauchyPriorLocation`: Location of the cauchy prior
+- `cauchyPriorScale`: Scale of the cauchy prior
+- `normalPrior`: Normal prior checkbox/radiobutton
+- `normalPriorMean`: Mean of the normal prior
+- `normalPriorSd`: SD of the normal prior
+- `tPrior`: t-distribution prior checkbox/radiobutton
+- `tPriorLocation`: location of the t prior
+- `tPriorScale`: scale of the t prior
+- `tPriorDf`: df of the t prior

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -15,18 +15,27 @@ That is, the name is written in lowercase letters except of the first letter in 
 #### Examples
 
 - `modelTerms` (not `ModelTerms` or `model_terms`)
-- `mean` (not `Mean`)
 - `qqPlot` (not `QQplot` or `QQPlot`)
 - `ppPlot` (not `Ppplot` or `PPPlot`)
 
 ### Correspondence between option name and label
 
-It should be possible from the option name to deduce the option label, and vice versa. This also includes avoiding shortcuts or acronyms except for standardized option names (see below).
+It should be possible from the option name (which is visible to the R users) to deduce the option label (which is visible to the JASP users), and vice versa. This also includes avoiding shortcuts or abbreviations except for standardized option names (see below).
 
 #### Examples
 
 - if an option is labeled as `label: qsTr("Variables")`, the option name should be `name: "variables"`, and not `name: "dependent"` or `name: "variable"`.
 - `kruskalWallisTerms` (not `kwTerms`)
+
+### Abbreviations are a single word
+
+Abbreviations should not be used in general, except for common option names (see below). For these cases an abbreviation is treated as a single word - which is important to keep in mind with respect to the camelCase.
+
+#### Examples
+
+- `mcmcMethod`: `mcmc` is an abbreviation of markov chain monte carlo, and it is treated as a word. Do not do `MCMCMethod`
+- `marginalMeansCi`: `Ci` is an abbreviation of confidence interval, and so is treated as a word. Do not do `marginalMeansCI`
+- `contrastsSeMethod`: `Se` is an abbreviation of a standard error, and so is treated as a word. Do not do `contrastsSEMethod`
 
 
 ### Correspondence between options
@@ -111,16 +120,16 @@ Combining the basic principles above may seem to be silly and annoying because t
 - `ci`: confidence (or credible) interval checkbox
 - `ciLevel`: confidence (or credible) level of the confidence (credible) interval
 - `se`: standard error
-- `pi`: prediction interval
-- `piLevel`: confidence level of a prediction interval
+- `predictionInterval`: prediction interval
+- `predictionIntervalLevel`: confidence level of a prediction interval
 - `dependent`: for specifying the dependent variable
 - `fixedFactors`: for specifying Fixed Factors variable list
 - `randomFactors`: for specifying Random Factors variable list
 - `covariates`: for specifying covariates
 - `weights`: variable specifying weights
 - `terms`: for specifying terms (allowing interactions). This can be combined with what the terms relate to, e.g., `modelTerms`, `marginalMeansTerms`, `plotTerms`, etc.
-- `naAction`: name for an option that specifies the action to take with missing values. The option arguments can be for example, `pairwise` for pairwise deletion, `listwise` for listwise deletion, `perAnalysis` for deleting per analysis, `perDependent` for deleting per dependent variable.
-- `alternative`: name for the option specifying the alternative hypothesis. This is to ensure consistency with base R.
+- `naAction`: name for an option that specifies the action to take with missing values. The option values can be for example, `pairwise` for pairwise deletion, `listwise` for listwise deletion, `perAnalysis` for deleting per analysis, `perDependent` for deleting per dependent variable, so that the analysis can be called as `analysis(..., naAction = "pairwise")`, for example.
+- `alternative`: name for the option specifying the alternative hypothesis. This is to ensure consistency with base R. Typical values of this option would be `greater`, `less`, `two.sided` for consistency with base R functions.
 - `testValue`: name for the option specifying the test value
 - `vovkSellke`: name for the Vovk-Sellke maximum p-ratio checkbox
 - `bootstrap`: checkbox for enabling bootstrapping
@@ -146,3 +155,17 @@ Combining the basic principles above may seem to be silly and annoying because t
 - `tPriorLocation`: location of the t prior
 - `tPriorScale`: scale of the t prior
 - `tPriorDf`: df of the t prior
+
+## Points of contention
+
+### Rephrain from using verbs for options
+
+Option names should preferably be nouns. 
+
+#### Examples
+
+- `histrogramPlot`, not `plotHistogram`
+- `errorBars`, not `displayErrorBars`
+
+- `descriptiveTableTransposed`, not `transposeDescriptiveTable`??
+- `residualsExport`, not `exportResiduals`??

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -1,4 +1,4 @@
-# Guide for consistent option names
+# Option names style guide: Towards consistency in the syntax mode
 
 This guide is aimed to help us in using consistent option names across JASP. 
 
@@ -146,6 +146,10 @@ DropDown
 Notice that we changed the option name to `mimic` so that the argument is called the same as in the `lavaan` package that runs the analysis. Further, we changed the label of value `lavaan` from "None" to "Lavaan" to still keep consistency between what is shown to the user in JASP, and what is shown to the user in R. Notice that we slightly deviate from our camelCasing rule for values `Mplus` and `EQS` for consistency with `lavaan`.
 
 Such small deviations are permissible if they improve understanding of what out analysis does. We advise thinking critically about where to push this.The primary goal of the options are to make them as clear as possible to JASP and R users, and R packages not necessarily design their arguments to be easily translatable into a good GUI programme. If that is the case, consistency and clarity of the JASP programme and the JASP code should always take precedence above consistency with the underlying R package that runs the analysis.
+
+### Reserved option names
+
+`data` and `formula` are reserved option names: **Do not use them for naming options in the Qml file.**
 
 
 ### Long option names are not evil

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -144,7 +144,7 @@ RabioButtonGroup
 }
 ```
 
-This results in an option in the R syntax defined as `analysis(..., alternative = c("twoSided", "greater", "less"))` and its use requires to specify one of the options, e.g. `analysis(..., alternative = "twoSided")`. Note: the use of `greater`, `twoSided`, `less` is defined in in the list of common option names below.
+This results in an option in the R syntax defined as `analysis(..., alternative = c("twoSided", "greater", "less"))` and its use requires to specify one of the options, e.g. `analysis(..., alternative = "greater")`. Note: the use of `greater`, `twoSided`, `less` is defined in the list of common option names below.
 
 ##### TabView
 
@@ -163,7 +163,7 @@ TabView
 }
 ```
 
-note that `name: "models"` names the option that can take a list of options. Each element of that list is a list that contains `modelName` and `syntax`, and will be used in R like this:
+note that `name: "models"` names the option that can take a list of options. Each element of that list is a list that contains `Name` and `syntax` elements, and will be used in R like this:
 
 ```r
 jaspSem::sem(

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -120,7 +120,7 @@ Prefer singular form for names that relate to the output, *even if the output fe
 
 #### Examples
 
-- `Ci` not `Cis` for confidence intervals (even if the output could feature multiple intervals)
+- `ci` not `cis` for confidence intervals (even if the output could feature multiple intervals)
 - `pValue` not `pValues` for p-values (even if the output could feature multiple p-values)
 - `marginalMeanTerms`: use singular `marginalMean` as an indicator of the output (regardles that there may be more marginal means in the output), but use plural `Terms` to indicate to the user that they may specify multiple terms.
 - `variable`: use singular in case that the `AssignedVariableList` in Qml specifies `singleVariable: true` to indicate to the user that only one variable is allowed. On the other hand, if it's possible to specify multiple variables, use plural `variables` (and similarly, `fixedFactors`, `randomFactors`, `covariates`, etc.)
@@ -132,7 +132,7 @@ Option names should preferably be nouns and not verbs.
 
 #### Examples
 
-- `histrogramPlot`, not `plotHistogram`
+- `histogramPlot`, not `plotHistogram`
 - `errorBars`, not `displayErrorBars`
 - `marginalMean` not `computeMarginalMean`
 

--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -110,6 +110,43 @@ Section
 
 Here, we have a section for specifying marginal means. So every option starts with `marginalMeans`. Further, the number of bootstrapping replicates is a child of the checkbox that enables bootstrapping, and so it starts with `marginalMeansBootstrap`.
 
+## Consistency with underlying analysis packages
+
+In some cases, an option name/value is selected so that it is directly compatible with option names/values of the underlying package. For example, consider the following excerpt from a SEM analysis:
+
+```qml
+DropDown
+{
+	name:	"emulation"
+	label:	qsTr("Emulation")
+	values: [
+		{ value: "lavaan",	label: qsTr("None") 	},
+		{ value: "Mplus",	label: qsTr("Mplus") 	},
+		{ value: "EQS",		label: qsTr("EQS") 		}
+	] 
+}
+```
+
+Here we see a schism between the value of the option (`lavaan`) and the label of the option ("None"). This is because the value of the option `emulation` is directly feeded into the lavaan functions under argument `mimic`. The programmer now need to make a conscious decision: Do we need and want to keep consistency with the underlying analysis package? If the answer is yes, then it is adviseable to make the consistency as tight as possible. This means that slight deviations from the our style-guide is possible if this helps keeping consistent with the underlying package. In this case, we could change the component accordingly
+
+```qml
+DropDown
+{
+	name:	"mimic"
+	label:	qsTr("Mimic")
+	info:	qsTr("Obtain results based on emulating popular SEM software. The option corresponds to the lavaan's `mimic` arument.")
+	values: [
+		{ value: "lavaan",	label: qsTr("Lavaan") 	},
+		{ value: "Mplus",	label: qsTr("Mplus") 	},
+		{ value: "EQS",		label: qsTr("EQS") 		}
+	] 
+}
+```
+
+Notice that we changed the option name to `mimic` so that the argument is called the same as in the `lavaan` package that runs the analysis. Further, we changed the label of value `lavaan` from "None" to "Lavaan" to still keep consistency between what is shown to the user in JASP, and what is shown to the user in R. Notice that we slightly deviate from our camelCasing rule for values `Mplus` and `EQS` for consistency with `lavaan`.
+
+Such small deviations are permissible if they improve understanding of what out analysis does. We advise thinking critically about where to push this.The primary goal of the options are to make them as clear as possible to JASP and R users, and R packages not necessarily design their arguments to be easily translatable into a good GUI programme. If that is the case, consistency and clarity of the JASP programme and the JASP code should always take precedence above consistency with the underlying R package that runs the analysis.
+
 
 ### Long option names are not evil
 
@@ -120,6 +157,7 @@ Combining the basic principles above may seem to be silly and annoying because t
 - `ci`: confidence (or credible) interval checkbox
 - `ciLevel`: confidence (or credible) level of the confidence (credible) interval
 - `se`: standard error
+- `sd`: standard deviation
 - `predictionInterval`: prediction interval
 - `predictionIntervalLevel`: confidence level of a prediction interval
 - `dependent`: for specifying the dependent variable
@@ -129,7 +167,7 @@ Combining the basic principles above may seem to be silly and annoying because t
 - `weights`: variable specifying weights
 - `terms`: for specifying terms (allowing interactions). This can be combined with what the terms relate to, e.g., `modelTerms`, `marginalMeansTerms`, `plotTerms`, etc.
 - `naAction`: name for an option that specifies the action to take with missing values. The option values can be for example, `pairwise` for pairwise deletion, `listwise` for listwise deletion, `perAnalysis` for deleting per analysis, `perDependent` for deleting per dependent variable, so that the analysis can be called as `analysis(..., naAction = "pairwise")`, for example.
-- `alternative`: name for the option specifying the alternative hypothesis. This is to ensure consistency with base R. Typical values of this option would be `greater`, `less`, `two.sided` for consistency with base R functions.
+- `alternative`: name for the option specifying the alternative hypothesis. This is to ensure consistency with base R. Typical values of this option would be `greater`, `less`, `two.sided` for hypotheses such as "> Test Value" (consistency with base R functions). For hypotheses such as "Group one > Group two" use `greater`, for "Group one < Group two" use `less` and for "Group one != Group two" use `two.sided`. This needs to be explained further in the documentation (`info` fields).
 - `testValue`: name for the option specifying the test value
 - `vovkSellke`: name for the Vovk-Sellke maximum p-ratio checkbox
 - `bootstrap`: checkbox for enabling bootstrapping
@@ -137,11 +175,21 @@ Combining the basic principles above may seem to be silly and annoying because t
 - `bootstrapType`: type of bootstrap
 - `setSeed`: checkbox for setting seed for reproducibility
 - `seed`: specifying the seed for reproducibility
+- `xAxis`, `yAxis`: name of the variable on the x- and y-axes, respectivelly
+- `xAxisLabel`, `yAxisLabel`: name of the text field specifying the axis labels
+- `rSquared`: name for R^2
+- `effectSize`: effect size
+- `pValue`: p-value
+- `max`: maximum
+- `min`: minimum
 
 ### Specific to Bayesian analyses
 
 - `sampling`: radiobutton for selecting type of MCMC sampling (e.g., `auto`, `manual`, `bas`, `mcmc`, etc.)
 - `samples`: number of MCMC iterations for Bayesian analyses
+- `burnin`: number of burnin samples
+- `thinning`: thinning factor
+- `chains`: number of chains
 - `bayesFactor`: Bayes factor
 - `priorAndPosterior`: checkbox for prior and posterior
 - `robustnessCheck`: checkbox for robustness check

--- a/Docs/development/jasp-qml-guide.md
+++ b/Docs/development/jasp-qml-guide.md
@@ -14,41 +14,42 @@ For more explanation on QML, you can read [wikipedia on QML](https://en.wikipedi
 To write a QML form you should follow the [styleguide](jasp-qml-style-example.qml).
 
 Table of Contents:
-- [Components](#components)
-  * [General Input](#general-input)
-    + [CheckBox](#checkbox)
-    + [RadioButton](#radiobutton)
-    + [DropDown](#dropdown)
-    + [Slider](#slider)
-    + [DoubleField](#doublefield)
-    + [IntegerField](#integerfield)
-    + [PercentField](#percentfield)
-    + [CIField](#cifield)
-    + [TextField](#textfield)
-    + [FormulaField](#formulafield)
-    + [TextArea](#textarea)
-  * [Variable Specification](#variable-specification)
-    + [AvailableVariablesList](#availablevariableslist)
-    + [AssignedVariablesList](#assignedvariableslist)
-	+ [FactorLevelList](#factorlevellist)
-  * [Complex Components](#complex-components)
-    + [ComponentsList](#componentslist)
-    + [TabView](#tabview)
-    + [InputListView](#inputlistview)
-    + [TableView](#tableview)
-  * [Grouping](#grouping)
-    + [Group](#group)
-    + [Section](#section)
-- [Layout of Components](#layout-of-components)
-    + [Layout.rowSpan](#layoutrowspan)
-    + [Layout.columnSpan](#layoutcolumnspan)
-- [Connecting Multiple Components](#connecting-multiple-components)
-- [An Example](#an-example)
-  * [1. Specifying Imports](#1-specifying-imports)
-  * [2. Adding the Form](#2-adding-the-form)
-  * [3. Adding the Components](#3-adding-the-components)
-- [Advanced Usage](#advanced-usage)
-- [Custom Imports](#custom-imports)
+- [Guide to writing an analysis interface in QML](#guide-to-writing-an-analysis-interface-in-qml)
+  - [Components](#components)
+    - [General Input](#general-input)
+      - [CheckBox](#checkbox)
+      - [RadioButton](#radiobutton)
+      - [DropDown](#dropdown)
+      - [Slider](#slider)
+      - [DoubleField](#doublefield)
+      - [IntegerField](#integerfield)
+      - [PercentField](#percentfield)
+      - [CIField](#cifield)
+      - [TextField](#textfield)
+      - [FormulaField](#formulafield)
+      - [TextArea](#textarea)
+    - [Variable Specification](#variable-specification)
+      - [AvailableVariablesList](#availablevariableslist)
+      - [AssignedVariablesList](#assignedvariableslist)
+      - [FactorLevelList](#factorlevellist)
+    - [Complex components](#complex-components)
+      - [ComponentsList](#componentslist)
+      - [TabView](#tabview)
+      - [InputListView](#inputlistview)
+      - [TableView](#tableview)
+    - [Grouping](#grouping)
+      - [Group](#group)
+      - [Section](#section)
+  - [Layout of Components](#layout-of-components)
+      - [Layout.rowSpan](#layoutrowspan)
+      - [Layout.columnSpan](#layoutcolumnspan)
+  - [Connecting Multiple Components](#connecting-multiple-components)
+  - [An Example](#an-example)
+    - [1. Specifying Imports](#1-specifying-imports)
+    - [2. Adding the Form](#2-adding-the-form)
+    - [3. Adding the Components](#3-adding-the-components)
+  - [Advanced Usage](#advanced-usage)
+  - [Custom Imports](#custom-imports)
 
 
 ## Components
@@ -835,6 +836,21 @@ We can begin actual work on the QML file, first we have to tell the engine where
 
 </details>
 
+In the future, we will require using qualified namespace for the import statements for the JASP QML modules [see here](https://doc.qt.io/qt-5/qtqml-syntax-imports.html#importing-into-a-qualified-local-namespace).
+
+<details>
+	<summary>Code</summary>
+
+  ```qml
+  import QtQuick          2.11
+  import QtQuick.Layouts  1.3
+  import JASP.Controls    1.0 as JC
+  import JASP.Theme	      1.0 as JT
+  import JASP.Widgets     1.0 as JW
+  ```
+</details>
+
+This means that a JASP control, theme or a widget needs to be prepended with the qualifier, e.g., `JC.CheckBox` instead of just `CheckBox`.
 
 ### 2. Adding the Form
 At this point we add a `Form` which will hold all our input components:

--- a/Docs/development/project-renaming-options-for-syntax.md
+++ b/Docs/development/project-renaming-options-for-syntax.md
@@ -34,7 +34,7 @@ To facilitate consistency in naming options, we created an [option names style g
 
 ### 2. Qml files
 
-The first 
+Open the analysis Qml file that you need to check for consistency. Edit the option names (or values) according to the style guide.
 
 #### Moving documentation to `info`
 
@@ -42,11 +42,30 @@ Should we do this at this stage or not? Should we do it in two waves instead?
 
 ### 3. R files
 
+If you changed any option name in the Qml files, now it is time to make sure that the changes are also reflected in the R files. Edit the R files.
+
+The option names need to be also updated in the test files in the `tests/testthat/` folder!
+
+**Note**. Be careful with using "find and replace all" especially if there is a chance of changing code that you did not intend to change, e.g., due to partial matching. An easy way to prevent this to happen is to use wider context of the text to replace. E.g. if we renamed an option from `old_option_name` to `newOptionName`, you can run find: `options[["old_option_name"]]` and replace all: `options[["newOptionName"]]` to avoid any surprises. You still need to check manually whether there is anything that you missed.
+
 #### Run tests
+
+After you have made all your changes, run the tests using `jaspTools::testAll()` to test whether anything is broken. 
 
 ### 4. Upgrades.qml 
 
+Renaming options means that .jasp files saved with an older JASP version will no longer be compatible. To ensure backwards compatibility, the changes made to the option names need to be listed in the upgrades file in `inst/Upgrades.qml`. Follow the [guide for option ugrades](jasp-upgrade-qml.md).
+
 #### Test upgrades
+
+After you specified the upgrades in the `Upgrades.qml`, test whether they work. 
+
+1. Open the analysis you are modifying using the latest official release of JASP. 
+2. Run an analysis using all options that you changes during this process. 
+3. Save the .jasp file. Close the file.
+4. Install your current version of the module you are working on as a developer module.
+5. Open the .jasp file you saved. Refresh the file. If the analysis looks like before, everything went smoothly.
+
 
 ### 5. Make a PR
 

--- a/Docs/development/project-renaming-options-for-syntax.md
+++ b/Docs/development/project-renaming-options-for-syntax.md
@@ -1,0 +1,59 @@
+# Preparing analyses options for the syntax mode
+
+One of the long term plans for JASP is to provide a "Syntax mode" that will allow users to call JASP analyses from R in a convenient way (if you are interested in the plan of the project, see the [Syntax wiki](https://github.com/jasp-stats/INTERNAL-jasp/wiki/Syntax-Mode)). An important part of the project is to provide wrappers around each of the analyses in JASP that can be called in a straightforward way. The end goal is that the wrappers will be easily understandeable for R users. For example, running a t-test in R will look something like
+
+```r
+jaspTTests::IndependentSamplesTTest(
+    data              = dataset, 
+    dependent         = "contNormal", 
+    group             = "contBinom", 
+    tests             = c("student", "welch"), 
+    effectSize        = TRUE, 
+    effectSizeType    = "cohen", 
+    effectSizeCi      = TRUE, 
+    effectSizeCiLevel = 0.99)
+```
+
+These wrappers will be generated automatically from the Qml files that define the analysis options in JASP. In order for us to provide consistent syntax across all of JASP analyses, and that we are also able to generate helpful and consistent documentation both in JASP and in R, we need to make systematic changes to the current Qml files in all JASP modules.
+
+This document serves as a guide for what needs to be done.
+
+## Renaming options
+
+Each option in the Qml file has the `name` and `label` (or `title`) property. The `label` is displayed to the user of JASP in the input form. `name` on the other hand, is the option name in R. For example
+
+```qml
+CheckBox{ name: "effectSize";   label:  qsTr("Effect Size")}
+```
+
+In JASP, the user sees the string "Effect Size" (or its translation), whereas the analysis functions in R see the option as part of the `options` list, i.e., `options[["effectSize"]]`. Up until this point, there was not much attention paid to how we use the `name` property, as the options were never exposed to the user and usually pertain to only one specific analysis. However, when we generate the analysis wrappers, the `name` property will be used as the name of the argument of the option in the analysis wrapper. This means that the `name`s will be exposed to syntax users. Hence, we need to ensure that the names are used consistently across all of JASP analyses, which requires us to go through all Qml files and rename the options as necessary. 
+
+### 1. Read the style guide
+
+To facilitate consistency in naming options, we created an [option names style guide](guide-option-names.md). **Read it carefully and make sure to follow it when you define new option names!** 
+
+### 2. Qml files
+
+The first 
+
+#### Moving documentation to `info`
+
+Should we do this at this stage or not? Should we do it in two waves instead?
+
+### 3. R files
+
+#### Run tests
+
+### 4. Upgrades.qml 
+
+#### Test upgrades
+
+### 5. Make a PR
+
+Follow the [git guide](git-guide.md) to make a clean PR. Assign @Kucharssim or @AlexanderLy as reviewers.
+
+
+
+
+
+

--- a/Docs/development/project-renaming-options-for-syntax.md
+++ b/Docs/development/project-renaming-options-for-syntax.md
@@ -36,9 +36,6 @@ To facilitate consistency in naming options, we created an [option names style g
 
 Open the analysis Qml file that you need to check for consistency. Edit the option names (or values) according to the style guide.
 
-#### Moving documentation to `info`
-
-Should we do this at this stage or not? Should we do it in two waves instead?
 
 ### 3. R files
 


### PR DESCRIPTION
We will use this in the upcoming project when we rename option names in JASP for consistency in the syntax mode.

The new addition to the `jasp-qml-guide.md` only introduces how to use qualified namespaces in QML as pointed out by @amirmasoudabdol. It is not related to the upcoming project. It may also change in the future depending how we settle the debate about QML syntax style (see https://github.com/jasp-stats/INTERNAL-jasp/issues/1794).