### PR TITLE
Custom Contrast is not updated when the data is filtered

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1433,8 +1433,38 @@ QStringList DataSetPackage::getColumnLabelsAsStringList(size_t columnIndex)	cons
 	QStringList list;
 	if(columnIndex < 0 || columnIndex >= columnCount()) return list;
 
-	for(const Label & label : _dataSet->column(columnIndex).labels())
-		list.append(tq(label.text()));
+	Column& col = _dataSet->column(columnIndex);
+	QVector<bool> filterRows;
+	bool hasFilter = false;
+	for (int i = 0; i < _dataSet->rowCount(); i++)
+	{
+		bool filtered = getRowFilter(i);
+		hasFilter |= !filtered;
+		filterRows.push_back(filtered);
+	}
+
+	for(const Label & label : col.labels())
+	{
+		bool add = true;
+		QString labelText = tq(label.text());
+		if (hasFilter)
+		{
+			add = false;
+			for (int i = 0; i < col.rowCount(); i++)
+			{
+				if (filterRows[i])
+				{
+					QString val = tq(col[i]);
+					if (val == labelText)
+					{
+						add = true;
+						break;
+					}
+				}
+			}
+		}
+		if (add) list.append(labelText);
+	}
 
 	return list;
 }

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1433,38 +1433,8 @@ QStringList DataSetPackage::getColumnLabelsAsStringList(size_t columnIndex)	cons
 	QStringList list;
 	if(columnIndex < 0 || columnIndex >= columnCount()) return list;
 
-	Column& col = _dataSet->column(columnIndex);
-	QVector<bool> filterRows;
-	bool hasFilter = false;
-	for (int i = 0; i < _dataSet->rowCount(); i++)
-	{
-		bool filtered = getRowFilter(i);
-		hasFilter |= !filtered;
-		filterRows.push_back(filtered);
-	}
-
-	for(const Label & label : col.labels())
-	{
-		bool add = true;
-		QString labelText = tq(label.text());
-		if (hasFilter)
-		{
-			add = false;
-			for (int i = 0; i < col.rowCount(); i++)
-			{
-				if (filterRows[i])
-				{
-					QString val = tq(col[i]);
-					if (val == labelText)
-					{
-						add = true;
-						break;
-					}
-				}
-			}
-		}
-		if (add) list.append(labelText);
-	}
+	for (const Label & label : _dataSet->column(columnIndex).labels())
+		list.append(tq(label.text()));
 
 	return list;
 }

--- a/Desktop/data/datasettablemodel.cpp
+++ b/Desktop/data/datasettablemodel.cpp
@@ -51,3 +51,23 @@ bool DataSetTableModel::filterAcceptsRow(int source_row, const QModelIndex & sou
 {
 	return (_showInactive || DataSetPackage::pkg()->getRowFilter(source_row));
 }
+
+QStringList DataSetTableModel::getColumnLabelsAsStringList(int col) const
+{
+	QStringList labels = DataSetPackage::pkg()->getColumnLabelsAsStringList(col);
+	QStringList notUsedLabels = labels;
+	int max = rowCount();
+
+	for (int i = 0; i < max; i++)
+	{
+		QString value = data(index(i, col)).toString();
+		notUsedLabels.removeAll(value);
+		if (notUsedLabels.count() == 0) break;
+	}
+
+	// The order of the labels must be kept.
+	for (const QString& notUsedLabel : notUsedLabels)
+		labels.removeAll(notUsedLabel);
+
+	return labels;
+}

--- a/Desktop/data/datasettablemodel.h
+++ b/Desktop/data/datasettablemodel.h
@@ -51,7 +51,7 @@ public:
 	columnType				getColumnType(size_t column)			const				{ return DataSetPackage::pkg()->getColumnType(column);								}
 	std::string				getColumnName(size_t col)				const				{ return DataSetPackage::pkg()->getColumnName(col);									}
 	int						getColumnIndex(const std::string& col)	const				{ return DataSetPackage::pkg()->getColumnIndex(col);								}
-	QStringList				getColumnLabelsAsStringList(int col)	const				{ return DataSetPackage::pkg()->getColumnLabelsAsStringList(col);					}
+	QStringList				getColumnLabelsAsStringList(int col)	const;
 	size_t					getMaximumColumnWidthInCharacters(int index) const			{ return DataSetPackage::pkg()->getMaximumColumnWidthInCharacters(index);			}
 	QModelIndex				parentModelForType(parIdxType type, int column = 0)	const	{ return DataSetPackage::pkg()->parentModelForType(type, column);					}
 	bool					synchingData()							const				{ return DataSetPackage::pkg()->synchingData();										}

--- a/Desktop/widgets/listmodelcustomcontrasts.cpp
+++ b/Desktop/widgets/listmodelcustomcontrasts.cpp
@@ -42,6 +42,7 @@ ListModelCustomContrasts::ListModelCustomContrasts(TableViewBase *parent) : List
 	connect(ColumnsModel::singleton(), &ColumnsModel::labelsChanged,	this,		&ListModelCustomContrasts::sourceLabelsChanged);
 	connect(ColumnsModel::singleton(), &ColumnsModel::labelsReordered,	this,		&ListModelCustomContrasts::sourceLabelsReordered);
 	connect(ColumnsModel::singleton(), &ColumnsModel::columnsChanged,	this,		&ListModelCustomContrasts::sourceColumnsChanged);
+	connect(ColumnsModel::singleton(), &ColumnsModel::modelReset	,	this,		&ListModelCustomContrasts::sourceTermsReset);
 }
 
 void ListModelCustomContrasts::sourceTermsReset()


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1795
2 problems: the Custom Contrast model was not aware of filter changes, and the labels were read not taking into account of the filter.

