### PR TITLE
Update jasp-building-guide.md

### DIFF
--- a/Docs/development/jasp-building-guide.md
+++ b/Docs/development/jasp-building-guide.md
@@ -1,7 +1,7 @@
 Guide for Building JASP
 ======================
 
-Before you start building JASP, you need to clone its repository. If you are not familiar with Git, and GitHub, you may want to read our brief [git tutorial](Docs/development/git-guide.md). 
+Before you start building JASP, you need to clone its repository. If you are not familiar with Git, and GitHub, you may want to read our brief [git tutorial](git-guide.md). 
 
 If you know how git work, then we are going to start by cloning the `jasp-desktop` repository by writing the following commands into your terminal:
 
@@ -18,6 +18,6 @@ git update submodule --init
 
 Now that we have everything downloaded and updated, you can continue to your our system specific build guides, 
 
-- [macOS](Docs/development/jasp-build-guide-macos.md)
-- [Linux](Docs/development/jasp-build-guide-linux.md)
-- [Windows](Docs/development/jasp-build-guide-windows.md)
+- [macOS](jasp-build-guide-macos.md)
+- [Linux](jasp-build-guide-linux.md)
+- [Windows](jasp-build-guide-windows.md)


### PR DESCRIPTION
- [x] Fix unreasonable relative path specification in `jasp-building-guide.md` documentation.
- [x] By the way, the availability of other links in documentation has been checked
- [ ]  I'm not sure if `jasp-upgrade-json.md` is in development but it can not be found under the `/Docs/development `directory, which would be related to the availability of the [jasp-upgrade-json.md](https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/jasp-upgrade-json.md) links(404 for now) in [jasp-qml-guide.md](https://github.com/jasp-stats/jasp-desktop/blob/development/Docs/development/jasp-qml-guide.md). anyone can take a look?

