### PR TITLE
Better CRYPT_KEY

### DIFF
--- a/Common/appinfo.cpp.in
+++ b/Common/appinfo.cpp.in
@@ -28,14 +28,8 @@ const Version AppInfo::version = Version(@JASP_VERSION_MAJOR@, @JASP_VERSION_MIN
 const std::string AppInfo::name = "JASP";
 const std::string AppInfo::builddate = __DATE__ " " __TIME__ " (Netherlands)" ;
 
-// see https://gcc.gnu.org/onlinedocs/gcc-4.8.5/cpp/Stringification.html
-#define xstr(s) str(s)
-#define str(s)  #s
-
-//If the following do not work and you are on Windows, make sure that either Git is installed to "C:\Program Files\Git" or change the environment variable GIT_LOCATION (under projects build-env) to the path it is.
-const std::string AppInfo::gitBranch = xstr("@GIT_CURRENT_BRANCH@");
-const std::string AppInfo::gitCommit = xstr("@GIT_CURRENT_COMMIT@");
-
+const std::string AppInfo::gitBranch = "@GIT_CURRENT_BRANCH@";
+const std::string AppInfo::gitCommit = "@GIT_CURRENT_COMMIT@";
 
 std::string AppInfo::getShortDesc()
 {
@@ -61,4 +55,9 @@ std::string AppInfo::getRDirName()
 std::string AppInfo::getSigningIdentity()
 {
 	return "@APPLE_CODESIGN_IDENTITY@";
+}
+
+long long AppInfo::getSimpleCryptKey()
+{
+	return @CRYPT_KEY@;
 }

--- a/Common/appinfo.h
+++ b/Common/appinfo.h
@@ -38,6 +38,7 @@ public:
 	static std::string getRVersion();
 	static std::string getRDirName();
 	static std::string getSigningIdentity();
+	static long long   getSimpleCryptKey();
 };
 
 #endif // APPINFO_H

--- a/Desktop/CMakeLists.txt
+++ b/Desktop/CMakeLists.txt
@@ -28,10 +28,6 @@ configure_file(${CMAKE_CURRENT_LIST_DIR}/utilities/appdirs.h.in
                ${CMAKE_CURRENT_LIST_DIR}/utilities/appdirs.h)
 message(STATUS "appdirs.h is successfully generated...")
 
-configure_file(${CMAKE_CURRENT_LIST_DIR}/utilities/simplecryptkey.h.in
-               ${CMAKE_CURRENT_LIST_DIR}/utilities/simplecryptkey.h)
-message(STATUS "simplecryptkey.h is successfully generated...")
-
 file(GLOB_RECURSE SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
 
 file(GLOB_RECURSE BUNDLE_RESOURCES "${CMAKE_SOURCE_DIR}/Resources/*")

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -21,7 +21,7 @@
 #include <boost/uuid/uuid.hpp>
 
 #include "common.h"
-#include "../Common/version.h"
+#include "version.h"
 
 #include "enginedefinitions.h"
 #include "jaspcontrol.h"

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -24,7 +24,7 @@
 #include <QUrl>
 #include "common.h"
 #include "dataset.h"
-#include "../Common/version.h"
+#include "version.h"
 #include <map>
 #include <json/json.h>
 #include "computedcolumns.h"

--- a/Desktop/data/exporters/jaspexporter.cpp
+++ b/Desktop/data/exporters/jaspexporter.cpp
@@ -28,7 +28,7 @@
 #include <archive_entry.h>
 #include <json/json.h>
 #include "archivereader.h"
-#include "../Common/version.h"
+#include "version.h"
 #include "tempfiles.h"
 #include "appinfo.h"
 #include "log.h"

--- a/Desktop/osf/onlinedatamanager.cpp
+++ b/Desktop/osf/onlinedatamanager.cpp
@@ -27,8 +27,8 @@
 #include "onlineusernodeosf.h"
 #include "gui/messageforwarder.h"
 #include "utilities/simplecrypt.h"
-#include "utilities/simplecryptkey.h"
 #include "utilities/settings.h"
+#include "appinfo.h"
 
 
 OnlineDataManager::OnlineDataManager(QObject *parent):

--- a/Desktop/utilities/qutils.cpp
+++ b/Desktop/utilities/qutils.cpp
@@ -21,8 +21,8 @@
 #include <QQmlContext>
 #include <QStringList>
 #include <QDateTime>
+#include "appinfo.h"
 #include "simplecrypt.h"
-#include "simplecryptkey.h"
 #include "utils.h"
 
 using namespace std;
@@ -67,7 +67,7 @@ QString getShortCutKey()
 
 QString encrypt(const QString &input)
 {
-	long long key = SIMPLECRYPTKEY;
+	long long key = AppInfo::getSimpleCryptKey();
 	SimpleCrypt crypto(key); //some random number
 	
 	return crypto.encryptToString(input);	
@@ -75,7 +75,7 @@ QString encrypt(const QString &input)
 
 QString decrypt(const QString &input)
 {	
-	long long key = SIMPLECRYPTKEY;
+	long long key = AppInfo::getSimpleCryptKey();
 	SimpleCrypt crypto(key); //some random number
 	
 	return crypto.decryptToString(input);

--- a/Desktop/utilities/simplecryptkey.h.in
+++ b/Desktop/utilities/simplecryptkey.h.in
@@ -1,6 +1,0 @@
-#ifndef SIMPLECRYPTKEY
-
-#define SIMPLECRYPTKEY (@CRYPT_KEY@)
-
-#endif
-

--- a/Desktop/utilities/simplecryptkey.h.in
+++ b/Desktop/utilities/simplecryptkey.h.in
@@ -1,10 +1,6 @@
-#ifndef SIMPLECRYPTKEY //Can be set from an environment variable as well, the value here is only for testing!
+#ifndef SIMPLECRYPTKEY
 
-#ifdef ENVIRONMENT_CRYPTKEY
 #define SIMPLECRYPTKEY (@CRYPT_KEY@)
-#else
-#define SIMPLECRYPTKEY (0x0c2ad4a4acb9f023)
-#endif
 
 #endif
 

--- a/Tools/CMake/JASP.cmake
+++ b/Tools/CMake/JASP.cmake
@@ -94,23 +94,25 @@ set(CRYPT_KEY
     CACHE STRING "")
 
 if(CRYPT_KEY STREQUAL "")
-	# lets see if the user set something in the environment
+  # Let's see if the user has set something in the environment
   set(CRYPT_KEY $ENV{CRYPTKEY})
 
   if(CRYPT_KEY STREQUAL "")
-	  message(CHECK_PASS "found default.")
-	  
-    message(WARNING "CRYPT_KEY is not found, using default replace if this is to go out to users!")
-	set(CRYPT_KEY "0x0c2ad4a4acb9f023")
-	
+
+    message(CHECK_PASS "set to default.")
+
+    set(CRYPT_KEY "0x0c2ad4a4acb9f023")
+
   else()
+
     message(CHECK_PASS "found in environment.")
-    message(STATUS "  ${CRYPT_KEY}")
-	
+
   endif()
 
+  message(STATUS "  ${CRYPT_KEY}")
+
 else()
-	message(CHECK_PASS "set by user in cmake config.")
+  message(CHECK_PASS "set by user in cmake config.")
 endif()
 
 # Dealing with Git submodules

--- a/Tools/CMake/JASP.cmake
+++ b/Tools/CMake/JASP.cmake
@@ -92,19 +92,25 @@ message(CHECK_START "Checking for CRYPT_KEY")
 set(CRYPT_KEY
     ""
     CACHE STRING "")
+
 if(CRYPT_KEY STREQUAL "")
-  set(CRYPT_KEY $ENV{ENVIRONMENT_CRYPTKEY})
+	# lets see if the user set something in the environment
+  set(CRYPT_KEY $ENV{CRYPTKEY})
 
   if(CRYPT_KEY STREQUAL "")
-    message(CHECK_FAIL "not found.")
-    message(WARNING "CRYPT_KEY is not found.")
+	  message(CHECK_PASS "found default.")
+	  
+    message(WARNING "CRYPT_KEY is not found, using default replace if this is to go out to users!")
+	set(CRYPT_KEY "0x0c2ad4a4acb9f023")
+	
   else()
-    message(CHECK_PASS "found.")
+    message(CHECK_PASS "found in environment.")
     message(STATUS "  ${CRYPT_KEY}")
-
-    add_definitions(-DENVIRONMENT_CRYPTKEY)
+	
   endif()
 
+else()
+	message(CHECK_PASS "set by user in cmake config.")
 endif()
 
 # Dealing with Git submodules


### PR DESCRIPTION
Previously if you set `CRYPT_KEY` in `cmake` options it would just be ignored because `ENVIRONMENT_CRYPTKEY` wasn't set...
And the cryptkey in the environment was actually called `CRYPTKEY`so let's use that.

With the new logic it will use whatever you pass on to cmake first, then from `CRYPTKEY` in environment and lastly the default value as a fallback.
This way it also cannot fail which is nice and friendly.

