### PR TITLE
Fixes to Modules.cmake

### DIFF
--- a/Modules/install-RInside.R.in
+++ b/Modules/install-RInside.R.in
@@ -1,0 +1,9 @@
+# Generated from install-RInside.R.in
+#
+# Installs `RInside` and `Rcpp`. While `Rcpp` is a dependency of the `RInside`, 
+# I've ran into situation where installing `RInside` doesn't install the `Rcpp`.
+# 
+
+options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
+Sys.setenv(RENV_PATHS_ROOT='@MODULES_RENV_ROOT_PATH@', RENV_PATHS_CACHE='@MODULES_RENV_CACHE_PATH@')
+renv::install(c('RInside', 'Rcpp'), library='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@')

--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -1,0 +1,44 @@
+# Generated from install-jaspBase.R.in
+#
+Sys.setenv(GITHUB_PAT="@GITHUB_PAT@")
+Sys.setenv(RENV_PATHS_ROOT="@MODULES_RENV_ROOT_PATH@")
+Sys.setenv(RENV_PATHS_CACHE="@MODULES_RENV_CACHE_PATH@")
+Sys.setenv(JASPENGINE_LOCATION="@JASP_ENGINE_PATH@/JASPEngine")
+
+# The R_LIBRARY_PATH might already be there, but depending on the configuration
+# of the CMake, we might be installing in a different location, so, I just add
+# it anyway! It gets to if-y.
+.libPaths(c("@R_LIBRARY_PATH@", .libPaths()))
+
+# The code below mimics what jaspBase::installModule does
+computeHash <- function(modulePkg) {
+  srcFiles <- c(
+    list.files(modulePkg,                    recursive=TRUE, full.names = TRUE, pattern = '(NAMESPACE|DESCRIPTION)$'),
+    # list.files(file.path(modulePkg, 'src'),  recursive=TRUE, full.names = TRUE, pattern = '(\\.(cpp|c|hpp|h)|(Makevars|Makevars\\.win))$'),
+    list.files(file.path(modulePkg, 'R'),    recursive=TRUE, full.names = TRUE, pattern = '\\.R$'),
+    # list.files(file.path(modulePkg, 'inst'), recursive=TRUE, full.names = TRUE, pattern = '\\.(qml|po|svg|png|jpg|md)$'),
+    # list.files(file.path(modulePkg, 'inst'), recursive=TRUE, full.names = TRUE, pattern = '\\qmldir$'),
+    list.files(modulePkg,                    recursive=TRUE, full.names = TRUE, pattern = 'renv\\.lock')
+  )
+  tools::md5sum(srcFiles)
+}
+
+hashPath <- file.path("@R_LIBRARY_PATH@", "jaspBase", "jaspBaseHash.rds")
+currentHash <- computeHash("@PROJECT_SOURCE_DIR@/Engine/jaspBase/")
+if (!(file.exists(hashPath) && "jaspBase" %in% installed.packages() && identical(currentHash, try(readRDS(hashPath))))) {
+  options(
+    install_opts = "--no-multiarch --no-docs --no-test-load",
+    renv.cache.linkable = TRUE
+  )
+  renv::install("@PROJECT_SOURCE_DIR@/Engine/jaspBase/", repos=NULL, library="@R_LIBRARY_PATH@")
+}
+if ("jaspBase" %in% installed.packages()) {
+  saveRDS(currentHash, hashPath)
+}
+
+# Converting the absolute symlinks to relative symlinks on macOS
+# Todo, I can do this using CMake like I do on Windows
+if (Sys.info()["sysname"] == "Darwin") {
+  source('@MODULES_BINARY_PATH@/symlinkTools.R')
+  convertAbsoluteSymlinksToRelative('@MODULES_BINARY_PATH@', '@MODULES_RENV_CACHE_PATH@')
+}

--- a/Modules/install-renv.R.in
+++ b/Modules/install-renv.R.in
@@ -1,0 +1,4 @@
+# Generated from install-renv.R.in
+# 
+
+install.packages('renv', lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs')

--- a/R-Interface/CMakeLists.txt
+++ b/R-Interface/CMakeLists.txt
@@ -62,6 +62,7 @@ if(WIN32)
 
   set(RCPP_PATH "${R_LIBRARY_PATH}/Rcpp")
   set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
+  set(RENV_PATH "${R_LIBRARY_PATH}/renv")
 
   include(FetchContent)
   include(ExternalProject)

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -149,15 +149,14 @@ add_custom_target(
   jaspBase
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/R-Interface
   DEPENDS ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
-          ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log
-          )
+          ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log)
 
 # This happens during the configuration!
 file(
   WRITE ${MODULES_RENV_ROOT_PATH}/install-jaspBase.R
   "
-    .libPaths('${${R_LIBRARY_PATH}}') # make sure to only look in our local library
-	
+    .libPaths('${R_LIBRARY_PATH}') # make sure to only look in our local library
+
     if ('jaspBase' %in% installed.packages()) {
       cat(NULL, file='${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log')
     } else {
@@ -176,25 +175,14 @@ file(
 file(
   WRITE ${MODULES_RENV_ROOT_PATH}/install-jaspGraphs.R
   "
-  .libPaths('${${R_LIBRARY_PATH}}') # make sure to only look in our local library
-  
+    .libPaths('${R_LIBRARY_PATH}') # make sure to only look in our local library
+
     if ('jaspGraphs' %in% installed.packages()) {
       cat(NULL, file='${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log')
     } else {
       install.packages('${PROJECT_SOURCE_DIR}/Engine/jaspGraphs/', type='source', repos=NULL ${USE_LOCAL_R_LIBS_PATH}, INSTALL_opts='--no-multiarch --no-docs --no-test-load')
     }
     ")
-
-# We do not in fact need jaspTools
-#file(
-#  WRITE ${MODULES_RENV_ROOT_PATH}/install-jaspTools.R
-# "
-#    if ('jaspTools' %in% installed.packages()) {
-#      cat(NULL, file='${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log')
-#    } else {
-#      install.packages('${PROJECT_SOURCE_DIR}/Tools/jaspTools/', type='source', repos=NULL ${USE_LOCAL_R_LIBS_PATH}, INSTALL_opts='--no-multiarch --no-docs --no-test-load')
-#    }
-#    ")
 
 # I'm using a custom_command here to make sure that jaspBase is installed once
 # and only once before everything else. So, `install-jaspBase.R` creates an empty
@@ -233,23 +221,6 @@ add_custom_command(
     SIGNING=${IS_SIGNING} -D CODESIGN_TIMESTAMP_FLAG=${CODESIGN_TIMESTAMP_FLAG}
     -P ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake
   COMMENT "------ Installing 'jaspGraphs'")
-
-#add_custom_command(
-#  WORKING_DIRECTORY ${R_HOME_PATH}
-#  DEPENDS ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
-#          ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log
-#  OUTPUT ${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log
-#  JOB_POOL sequential
-#  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-#          --file=${MODULES_RENV_ROOT_PATH}/install-jaspTools.R
-#  COMMAND
-#    ${CMAKE_COMMAND} -D
-#    NAME_TOOL_PREFIX_PATCHER=${PROJECT_SOURCE_DIR}/Tools/macOS/install_name_prefix_tool.sh
-#    -D PATH=${R_HOME_PATH}/library -D R_HOME_PATH=${R_HOME_PATH} -D
-#    R_DIR_NAME=${R_DIR_NAME} -D SIGNING_IDENTITY=${APPLE_CODESIGN_IDENTITY} -D
-#    SIGNING=${IS_SIGNING} -D CODESIGN_TIMESTAMP_FLAG=${CODESIGN_TIMESTAMP_FLAG}
-#    -P ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake
-#  COMMENT "------ Installing 'jaspTools'")
 
 if(INSTALL_R_MODULES)
 

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -145,11 +145,7 @@ execute_process(
   COMMAND ${CMAKE_COMMAND} -E copy_if_different R/symlinkTools.R
           ${MODULES_BINARY_PATH}/)
 
-add_custom_target(
-  jaspBase
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/R-Interface
-  DEPENDS ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
-          ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log)
+add_custom_target(jaspBase WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/R-Interface)
 
 # This happens during the configuration!
 file(
@@ -157,19 +153,16 @@ file(
   "
     .libPaths('${R_LIBRARY_PATH}') # make sure to only look in our local library
 
-    if ('jaspBase' %in% installed.packages()) {
-      cat(NULL, file='${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log')
-    } else {
-      install.packages(c('ggplot2', 'gridExtra', 'gridGraphics',
-                        'jsonlite', 'modules', 'officer', 'pkgbuild',
-                        'plyr', 'qgraph', 'ragg', 'R6', 'renv',
-                        'rjson', 'rvg', 'svglite', 'systemfonts',
-                        'withr', 'testthat',
-                        'data.table', 'httr', 'lifecycle',
-                        'pkgload', 'remotes', 'stringi', 'stringr',
-                        'vdiffr'), type='${R_PKG_TYPE}', repos='${R_REPOSITORY}' ${USE_LOCAL_R_LIBS_PATH})
-      install.packages('${PROJECT_SOURCE_DIR}/Engine/jaspBase/', type='source', repos=NULL ${USE_LOCAL_R_LIBS_PATH}, INSTALL_opts='--no-multiarch --no-docs --no-test-load')
-    }
+    install.packages(c('ggplot2', 'gridExtra', 'gridGraphics',
+                      'jsonlite', 'modules', 'officer', 'pkgbuild',
+                      'plyr', 'qgraph', 'ragg', 'R6', 'renv',
+                      'rjson', 'rvg', 'svglite', 'systemfonts',
+                      'withr', 'testthat',
+                      'data.table', 'httr', 'lifecycle',
+                      'pkgload', 'remotes', 'stringi', 'stringr',
+                      'vdiffr'), type='${R_PKG_TYPE}', repos='${R_REPOSITORY}' ${USE_LOCAL_R_LIBS_PATH})
+    install.packages('${PROJECT_SOURCE_DIR}/Engine/jaspBase/', type='source', repos=NULL, INSTALL_opts='--no-multiarch --no-docs --no-test-load' ${USE_LOCAL_R_LIBS_PATH})
+
     ")
 
 file(
@@ -177,11 +170,7 @@ file(
   "
     .libPaths('${R_LIBRARY_PATH}') # make sure to only look in our local library
 
-    if ('jaspGraphs' %in% installed.packages()) {
-      cat(NULL, file='${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log')
-    } else {
-      install.packages('${PROJECT_SOURCE_DIR}/Engine/jaspGraphs/', type='source', repos=NULL ${USE_LOCAL_R_LIBS_PATH}, INSTALL_opts='--no-multiarch --no-docs --no-test-load')
-    }
+    install.packages('${PROJECT_SOURCE_DIR}/Engine/jaspGraphs/', type='source', repos=NULL, INSTALL_opts='--no-multiarch --no-docs --no-test-load' ${USE_LOCAL_R_LIBS_PATH})
     ")
 
 # I'm using a custom_command here to make sure that jaspBase is installed once
@@ -194,7 +183,7 @@ file(
 add_custom_command(
   WORKING_DIRECTORY ${R_HOME_PATH}
   OUTPUT ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
-  JOB_POOL sequential
+  USES_TERMINAL
   COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
           --file=${MODULES_RENV_ROOT_PATH}/install-jaspBase.R
   COMMAND
@@ -210,7 +199,7 @@ add_custom_command(
   WORKING_DIRECTORY ${R_HOME_PATH}
   DEPENDS ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
   OUTPUT ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log
-  JOB_POOL sequential
+  USES_TERMINAL
   COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
           --file=${MODULES_RENV_ROOT_PATH}/install-jaspGraphs.R
   COMMAND

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -153,7 +153,6 @@ add_custom_target(
 configure_file("${PROJECT_SOURCE_DIR}/Modules/install-jaspBase.R.in"
                ${MODULES_RENV_ROOT_PATH}/install-jaspBase.R @ONLY)
 
-
 # I'm using a custom_command here to make sure that jaspBase is installed once
 # and only once before everything else. So, `install-jaspBase.R` creates an empty
 # file, i.e., `jaspBase-installed-successfully.log` and all other Modules look for
@@ -175,7 +174,6 @@ add_custom_command(
     SIGNING=${IS_SIGNING} -D CODESIGN_TIMESTAMP_FLAG=${CODESIGN_TIMESTAMP_FLAG}
     -P ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake
   COMMENT "------ Installing 'jaspBase'")
-
 
 if(INSTALL_R_MODULES)
 

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -150,12 +150,14 @@ add_custom_target(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/R-Interface
   DEPENDS ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
           ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log
-          ${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log)
+          )
 
 # This happens during the configuration!
 file(
   WRITE ${MODULES_RENV_ROOT_PATH}/install-jaspBase.R
   "
+    .libPaths('${${R_LIBRARY_PATH}}') # make sure to only look in our local library
+	
     if ('jaspBase' %in% installed.packages()) {
       cat(NULL, file='${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log')
     } else {
@@ -174,6 +176,8 @@ file(
 file(
   WRITE ${MODULES_RENV_ROOT_PATH}/install-jaspGraphs.R
   "
+  .libPaths('${${R_LIBRARY_PATH}}') # make sure to only look in our local library
+  
     if ('jaspGraphs' %in% installed.packages()) {
       cat(NULL, file='${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log')
     } else {
@@ -181,15 +185,16 @@ file(
     }
     ")
 
-file(
-  WRITE ${MODULES_RENV_ROOT_PATH}/install-jaspTools.R
-  "
-    if ('jaspTools' %in% installed.packages()) {
-      cat(NULL, file='${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log')
-    } else {
-      install.packages('${PROJECT_SOURCE_DIR}/Tools/jaspTools/', type='source', repos=NULL ${USE_LOCAL_R_LIBS_PATH}, INSTALL_opts='--no-multiarch --no-docs --no-test-load')
-    }
-    ")
+# We do not in fact need jaspTools
+#file(
+#  WRITE ${MODULES_RENV_ROOT_PATH}/install-jaspTools.R
+# "
+#    if ('jaspTools' %in% installed.packages()) {
+#      cat(NULL, file='${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log')
+#    } else {
+#      install.packages('${PROJECT_SOURCE_DIR}/Tools/jaspTools/', type='source', repos=NULL ${USE_LOCAL_R_LIBS_PATH}, INSTALL_opts='--no-multiarch --no-docs --no-test-load')
+#    }
+#    ")
 
 # I'm using a custom_command here to make sure that jaspBase is installed once
 # and only once before everything else. So, `install-jaspBase.R` creates an empty
@@ -229,22 +234,22 @@ add_custom_command(
     -P ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake
   COMMENT "------ Installing 'jaspGraphs'")
 
-add_custom_command(
-  WORKING_DIRECTORY ${R_HOME_PATH}
-  DEPENDS ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
-          ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log
-  OUTPUT ${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log
-  JOB_POOL sequential
-  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-          --file=${MODULES_RENV_ROOT_PATH}/install-jaspTools.R
-  COMMAND
-    ${CMAKE_COMMAND} -D
-    NAME_TOOL_PREFIX_PATCHER=${PROJECT_SOURCE_DIR}/Tools/macOS/install_name_prefix_tool.sh
-    -D PATH=${R_HOME_PATH}/library -D R_HOME_PATH=${R_HOME_PATH} -D
-    R_DIR_NAME=${R_DIR_NAME} -D SIGNING_IDENTITY=${APPLE_CODESIGN_IDENTITY} -D
-    SIGNING=${IS_SIGNING} -D CODESIGN_TIMESTAMP_FLAG=${CODESIGN_TIMESTAMP_FLAG}
-    -P ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake
-  COMMENT "------ Installing 'jaspTools'")
+#add_custom_command(
+#  WORKING_DIRECTORY ${R_HOME_PATH}
+#  DEPENDS ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
+#          ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log
+#  OUTPUT ${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log
+#  JOB_POOL sequential
+#  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
+#          --file=${MODULES_RENV_ROOT_PATH}/install-jaspTools.R
+#  COMMAND
+#    ${CMAKE_COMMAND} -D
+#    NAME_TOOL_PREFIX_PATCHER=${PROJECT_SOURCE_DIR}/Tools/macOS/install_name_prefix_tool.sh
+#    -D PATH=${R_HOME_PATH}/library -D R_HOME_PATH=${R_HOME_PATH} -D
+#    R_DIR_NAME=${R_DIR_NAME} -D SIGNING_IDENTITY=${APPLE_CODESIGN_IDENTITY} -D
+#    SIGNING=${IS_SIGNING} -D CODESIGN_TIMESTAMP_FLAG=${CODESIGN_TIMESTAMP_FLAG}
+#    -P ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake
+#  COMMENT "------ Installing 'jaspTools'")
 
 if(INSTALL_R_MODULES)
 
@@ -277,7 +282,6 @@ if(INSTALL_R_MODULES)
       WORKING_DIRECTORY ${R_HOME_PATH}
       DEPENDS ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
               ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log
-              ${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
               --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
       COMMAND
@@ -326,7 +330,6 @@ if(INSTALL_R_MODULES)
       DEPENDS
         ${MODULES_BINARY_PATH}/jaspBase-installed-successfully.log
         ${MODULES_BINARY_PATH}/jaspGraphs-installed-successfully.log
-        ${MODULES_BINARY_PATH}/jaspTools-installed-successfully.log
         $<$<STREQUAL:"${MODULE}","jaspMetaAnalysis">:${jags_VERSION_H_PATH}>
         $<$<STREQUAL:"${MODULE}","jaspJags">:${jags_VERSION_H_PATH}>
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -165,7 +165,6 @@ add_custom_command(
   WORKING_DIRECTORY ${R_HOME_PATH}
   OUTPUT ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
   USES_TERMINAL
-  JOB_POOL sequential
   COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
           --file=${MODULES_RENV_ROOT_PATH}/install-jaspBase.R
   COMMAND

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -458,26 +458,26 @@ if(APPLE)
   endif()
 
   if(NOT EXISTS ${RENV_PATH})
-	message(STATUS "renv is not installed!")
-	message(CHECK_START
+    message(STATUS "renv is not installed!")
+    message(CHECK_START
             "Installing 'renv' within the R.framework")
-	file(
-	  WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
-	  "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
-	)
-	execute_process(
-	  # COMMAND_ECHO STDOUT
-	  ERROR_QUIET OUTPUT_QUIET
-	  WORKING_DIRECTORY ${R_HOME_PATH}
-	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-			  --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+    file(
+      WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
+      "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
+    )
+    execute_process(
+      # COMMAND_ECHO STDOUT
+      ERROR_QUIET OUTPUT_QUIET
+      WORKING_DIRECTORY ${R_HOME_PATH}
+      COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
+              --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
 
-	if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
-	  message(CHECK_FAIL "unsuccessful.")
-	  message(FATAL_ERROR "'renv' installation has failed!")
-	endif()
+    if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
+      message(CHECK_FAIL "unsuccessful.")
+      message(FATAL_ERROR "'renv' installation has failed!")
+    endif()
 
-	message(CHECK_PASS "successful.")
+    message(CHECK_PASS "successful.")
   endif()
 
   if(NOT EXISTS ${RINSIDE_PATH})
@@ -649,26 +649,26 @@ elseif(WIN32)
   endif()
 
   if(NOT EXISTS ${RENV_PATH})
-	message(STATUS "renv is not installed!")
-	message(CHECK_START
+    message(STATUS "renv is not installed!")
+    message(CHECK_START
             "Installing 'renv' within the R.framework")
-	file(
-	  WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
-	  "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
-	)
-	execute_process(
-	  # COMMAND_ECHO STDOUT
-	  ERROR_QUIET OUTPUT_QUIET
-	  WORKING_DIRECTORY ${R_HOME_PATH}
-	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-			  --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+    file(
+      WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
+      "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
+    )
+    execute_process(
+      # COMMAND_ECHO STDOUT
+      ERROR_QUIET OUTPUT_QUIET
+      WORKING_DIRECTORY ${R_HOME_PATH}
+      COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
+              --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
 
-	if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
-	  message(CHECK_FAIL "unsuccessful.")
-	  message(FATAL_ERROR "'renv' installation has failed!")
-	endif()
+    if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
+      message(CHECK_FAIL "unsuccessful.")
+      message(FATAL_ERROR "'renv' installation has failed!")
+    endif()
 
-	message(CHECK_PASS "successful.")
+    message(CHECK_PASS "successful.")
   endif()
 
   if(NOT EXISTS ${RINSIDE_PATH})
@@ -809,26 +809,26 @@ elseif(LINUX)
   endif()
 
   if(NOT EXISTS ${RENV_PATH})
-	message(STATUS "renv is not installed!")
-	message(CHECK_START
+    message(STATUS "renv is not installed!")
+    message(CHECK_START
             "Installing 'renv' within the R.framework")
-	file(
-	  WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
-	  "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
-	)
-	execute_process(
-	  # COMMAND_ECHO STDOUT
-	  ERROR_QUIET OUTPUT_QUIET
-	  WORKING_DIRECTORY ${R_HOME_PATH}
-	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-			  --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+    file(
+      WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
+      "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
+    )
+    execute_process(
+      # COMMAND_ECHO STDOUT
+      ERROR_QUIET OUTPUT_QUIET
+      WORKING_DIRECTORY ${R_HOME_PATH}
+      COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
+              --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
 
-	if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
-	  message(CHECK_FAIL "unsuccessful.")
-	  message(FATAL_ERROR "'renv' installation has failed!")
-	endif()
+    if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
+      message(CHECK_FAIL "unsuccessful.")
+      message(FATAL_ERROR "'renv' installation has failed!")
+    endif()
 
-	message(CHECK_PASS "successful.")
+    message(CHECK_PASS "successful.")
   endif()
 
   if(NOT EXISTS ${RINSIDE_PATH})

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -488,7 +488,11 @@ if(APPLE)
 
     file(
       WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-	  "options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary'); renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')"
+      "
+       options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
+       Sys.setenv(RENV_PATHS_ROOT='${MODULES_RENV_ROOT_PATH}', RENV_PATHS_CACHE='${MODULES_RENV_CACHE_PATH}')
+       renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')
+      "
     )
 
     execute_process(
@@ -674,7 +678,11 @@ elseif(WIN32)
 
     file(
       WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-	  "options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary'); renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')"
+      "
+      options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
+      Sys.setenv(RENV_PATHS_ROOT='${MODULES_RENV_ROOT_PATH}', RENV_PATHS_CACHE='${MODULES_RENV_CACHE_PATH}')
+      renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')
+      "
     )
 
     execute_process(
@@ -830,7 +838,11 @@ elseif(LINUX)
 
     file(
       WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-	  "options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary'); renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')"
+      "
+      options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
+      Sys.setenv(RENV_PATHS_ROOT='${MODULES_RENV_ROOT_PATH}', RENV_PATHS_CACHE='${MODULES_RENV_CACHE_PATH}')
+      renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')
+      "
     )
 
     execute_process(

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -106,6 +106,7 @@ if(APPLE)
   set(R_INCLUDE_PATH "${R_HOME_PATH}/include")
   set(RCPP_PATH "${R_LIBRARY_PATH}/Rcpp")
   set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
+  set(RENV_PATH "${R_LIBRARY_PATH}/renv")
 
   cmake_print_variables(R_FRAMEWORK_PATH)
   cmake_print_variables(R_HOME_PATH)
@@ -114,6 +115,7 @@ if(APPLE)
   cmake_print_variables(R_EXECUTABLE)
   cmake_print_variables(RCPP_PATH)
   cmake_print_variables(RINSIDE_PATH)
+  cmake_print_variables(RENV_PATH)
 
   if(INSTALL_R_FRAMEWORK AND (NOT EXISTS
                               ${CMAKE_BINARY_DIR}/Frameworks/R.framework))
@@ -455,6 +457,29 @@ if(APPLE)
     message(CHECK_FAIL "not found in ${R_HOME_PATH}/lib")
   endif()
 
+  if(NOT EXISTS ${RENV_PATH})
+	message(STATUS "renv is not installed!")
+	message(CHECK_START
+            "Installing 'renv' within the R.framework")
+	file(
+	  WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
+	  "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
+	)
+	execute_process(
+	  # COMMAND_ECHO STDOUT
+	  ERROR_QUIET OUTPUT_QUIET
+	  WORKING_DIRECTORY ${R_HOME_PATH}
+	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
+			  --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+
+	if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
+	  message(CHECK_FAIL "unsuccessful.")
+	  message(FATAL_ERROR "'renv' installation has failed!")
+	endif()
+
+	message(CHECK_PASS "successful.")
+  endif()
+
   if(NOT EXISTS ${RINSIDE_PATH})
     message(STATUS "RInside is not installed!")
 
@@ -463,7 +488,7 @@ if(APPLE)
 
     file(
       WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-      "install.packages(c('RInside', 'Rcpp'), type='binary', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs --no-test-load')"
+	  "options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary'); renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')"
     )
 
     execute_process(
@@ -534,6 +559,7 @@ elseif(WIN32)
   set(R_INCLUDE_PATH "${R_HOME_PATH}/include")
   set(RCPP_PATH "${R_LIBRARY_PATH}/Rcpp")
   set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
+  set(RENV_PATH "${R_LIBRARY_PATH}/renv")
 
   # This will be added to the install.packages calls
   set(USE_LOCAL_R_LIBS_PATH ", lib='${R_LIBRARY_PATH}'")
@@ -546,6 +572,7 @@ elseif(WIN32)
 
   cmake_print_variables(RCPP_PATH)
   cmake_print_variables(RINSIDE_PATH)
+  cmake_print_variables(RENV_PATH)
 
   message(CHECK_START "Checking for R/")
 
@@ -617,6 +644,29 @@ elseif(WIN32)
 
   endif()
 
+  if(NOT EXISTS ${RENV_PATH})
+	message(STATUS "renv is not installed!")
+	message(CHECK_START
+            "Installing 'renv' within the R.framework")
+	file(
+	  WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
+	  "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
+	)
+	execute_process(
+	  # COMMAND_ECHO STDOUT
+	  ERROR_QUIET OUTPUT_QUIET
+	  WORKING_DIRECTORY ${R_HOME_PATH}
+	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
+			  --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+
+	if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
+	  message(CHECK_FAIL "unsuccessful.")
+	  message(FATAL_ERROR "'renv' installation has failed!")
+	endif()
+
+	message(CHECK_PASS "successful.")
+  endif()
+
   if(NOT EXISTS ${RINSIDE_PATH})
     message(STATUS "RInside is not installed!")
 
@@ -624,7 +674,7 @@ elseif(WIN32)
 
     file(
       WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-      "install.packages(c('RInside', 'Rcpp'), type='binary', repos='${R_REPOSITORY}' ${USE_LOCAL_R_LIBS_PATH}, INSTALL_opts='--no-multiarch --no-docs --no-test-load')"
+	  "options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary'); renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')"
     )
 
     execute_process(
@@ -706,6 +756,7 @@ elseif(LINUX)
   set(R_EXECUTABLE "${R_HOME_PATH}/bin/R")
   set(RCPP_PATH "${R_LIBRARY_PATH}/Rcpp")
   set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
+  set(RENV_PATH "${R_LIBRARY_PATH}/renv")
 
   set(USE_LOCAL_R_LIBS_PATH ", lib='${R_LIBRARY_PATH}'")
 
@@ -733,6 +784,7 @@ elseif(LINUX)
   cmake_print_variables(R_EXECUTABLE)
   cmake_print_variables(RCPP_PATH)
   cmake_print_variables(RINSIDE_PATH)
+  cmake_print_variables(RENV_PATH)
 
   message(CHECK_START "Checking for 'libR'")
   find_library(
@@ -748,6 +800,29 @@ elseif(LINUX)
     message(CHECK_FAIL "not found in ${R_HOME_PATH}/lib")
   endif()
 
+  if(NOT EXISTS ${RENV_PATH})
+	message(STATUS "renv is not installed!")
+	message(CHECK_START
+            "Installing 'renv' within the R.framework")
+	file(
+	  WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
+	  "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
+	)
+	execute_process(
+	  # COMMAND_ECHO STDOUT
+	  ERROR_QUIET OUTPUT_QUIET
+	  WORKING_DIRECTORY ${R_HOME_PATH}
+	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
+			  --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+
+	if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
+	  message(CHECK_FAIL "unsuccessful.")
+	  message(FATAL_ERROR "'renv' installation has failed!")
+	endif()
+
+	message(CHECK_PASS "successful.")
+  endif()
+
   if(NOT EXISTS ${RINSIDE_PATH})
     message(STATUS "RInside is not installed!")
 
@@ -755,7 +830,7 @@ elseif(LINUX)
 
     file(
       WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-      "install.packages(c('RInside', 'Rcpp'), repos='${R_REPOSITORY}' ${USE_LOCAL_R_LIBS_PATH}, INSTALL_opts='--no-multiarch --no-docs --no-test-load')"
+	  "options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary'); renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')"
     )
 
     execute_process(

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -459,12 +459,11 @@ if(APPLE)
 
   if(NOT EXISTS ${RENV_PATH})
     message(STATUS "renv is not installed!")
-    message(CHECK_START
-            "Installing 'renv' within the R.framework")
-    file(
-      WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
-      "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
-    )
+    message(CHECK_START "Installing 'renv'")
+
+    configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
+                   ${MODULES_RENV_ROOT_PATH}/install-renv.R @ONLY)
+
     execute_process(
       # COMMAND_ECHO STDOUT
       ERROR_QUIET OUTPUT_QUIET
@@ -483,17 +482,10 @@ if(APPLE)
   if(NOT EXISTS ${RINSIDE_PATH})
     message(STATUS "RInside is not installed!")
 
-    message(CHECK_START
-            "Installing the 'RInside' and 'Rcpp' within the R.framework")
+    message(CHECK_START "Installing the 'RInside' and 'Rcpp'")
 
-    file(
-      WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-      "
-       options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
-       Sys.setenv(RENV_PATHS_ROOT='${MODULES_RENV_ROOT_PATH}', RENV_PATHS_CACHE='${MODULES_RENV_CACHE_PATH}')
-       renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')
-      "
-    )
+    configure_file(${MODULES_SOURCE_PATH}/install-RInside.R.in
+                   ${MODULES_RENV_ROOT_PATH}/install-RInside.R @ONLY)
 
     execute_process(
       # COMMAND_ECHO STDOUT
@@ -650,12 +642,11 @@ elseif(WIN32)
 
   if(NOT EXISTS ${RENV_PATH})
     message(STATUS "renv is not installed!")
-    message(CHECK_START
-            "Installing 'renv' within the R.framework")
-    file(
-      WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
-      "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
-    )
+    message(CHECK_START "Installing 'renv'")
+
+    configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
+                   ${MODULES_RENV_ROOT_PATH}/install-renv.R @ONLY)
+
     execute_process(
       # COMMAND_ECHO STDOUT
       ERROR_QUIET OUTPUT_QUIET
@@ -676,14 +667,8 @@ elseif(WIN32)
 
     message(CHECK_START "Installing the 'RInside' and 'Rcpp'")
 
-    file(
-      WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-      "
-      options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
-      Sys.setenv(RENV_PATHS_ROOT='${MODULES_RENV_ROOT_PATH}', RENV_PATHS_CACHE='${MODULES_RENV_CACHE_PATH}')
-      renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')
-      "
-    )
+    configure_file(${MODULES_SOURCE_PATH}/install-RInside.R.in
+                   ${MODULES_RENV_ROOT_PATH}/install-RInside.R @ONLY)
 
     execute_process(
       # COMMAND_ECHO STDOUT
@@ -810,12 +795,11 @@ elseif(LINUX)
 
   if(NOT EXISTS ${RENV_PATH})
     message(STATUS "renv is not installed!")
-    message(CHECK_START
-            "Installing 'renv' within the R.framework")
-    file(
-      WRITE ${MODULES_RENV_ROOT_PATH}/install-renv.R
-      "install.packages('renv', lib='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}', INSTALL_opts='--no-multiarch --no-docs')"
-    )
+    message(CHECK_START "Installing 'renv'")
+
+    configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
+                   ${MODULES_RENV_ROOT_PATH}/install-renv.R @ONLY)
+
     execute_process(
       # COMMAND_ECHO STDOUT
       ERROR_QUIET OUTPUT_QUIET
@@ -836,14 +820,8 @@ elseif(LINUX)
 
     message(CHECK_START "Installing the 'RInside' and 'Rcpp'")
 
-    file(
-      WRITE ${MODULES_RENV_ROOT_PATH}/install-RInside.R
-      "
-      options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
-      Sys.setenv(RENV_PATHS_ROOT='${MODULES_RENV_ROOT_PATH}', RENV_PATHS_CACHE='${MODULES_RENV_CACHE_PATH}')
-      renv::install(c('RInside', 'Rcpp'), library='${R_LIBRARY_PATH}', repos='${R_REPOSITORY}')
-      "
-    )
+    configure_file(${MODULES_SOURCE_PATH}/install-RInside.R.in
+                   ${MODULES_RENV_ROOT_PATH}/install-RInside.R @ONLY)
 
     execute_process(
       ERROR_QUIET OUTPUT_QUIET


### PR DESCRIPTION
we do not need jaspTools at all in JASP.

Also, not setting `.libPaths(...)` means it will check for the normal R-library on your system as well..
So here locally for me building JASP I didnt get `jaspBase` because the check considered it fulfilled, jaspBase was already installed.
But then when running JASP (at least in the Install folder or in the resulting actual install of it) jaspBase was missing and no results showed up...
On a clean system this isnt a problem but I rarely work on a clean system and for people using jaspTools this will be the same.
So this

