### PR TITLE
The source of a Dropdown should be fetched before its value is set

### DIFF
--- a/Desktop/analysis/analysisform.h
+++ b/Desktop/analysis/analysisform.h
@@ -157,7 +157,6 @@ private:
 	void		setControlMustContain(	QString controlName, QStringList containThis);
 	void		setControlIsDependency(	std::string controlName, bool isDependency)					{ setControlIsDependency(tq(controlName), isDependency);	}
 	void		setControlMustContain(	std::string controlName, std::set<std::string> containThis)	{ setControlMustContain(tq(controlName), tql(containThis)); }
-	QQuickItem* _getControlErrorMessageOfControl(JASPControl* jaspControl);
 	void		setAnalysisUp();
 	std::vector<std::vector<std::string> > _getValuesFromJson(const Json::Value& jsonValues, const QStringList& searchPath);
 

--- a/Desktop/components/JASP/Widgets/ControlErrorMessage.qml
+++ b/Desktop/components/JASP/Widgets/ControlErrorMessage.qml
@@ -47,6 +47,7 @@ Rectangle
 	{
 		control.hasError	= false;
 		control.hasWarning	= false;
+		control				= null;
 		parent				= null;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1780
This solves 2 problems:
. a dropdown with a source is not set properly when a JASP file is read: if the dropdown was set with a value coming from the source, when reading the JASP file, if the values of the source are not yet read, setting the dropdown generates an error. This is the case in the ANOVA analysis: the 'Reference model for weight ratios' dropdown in the Order Restriction, has for source the titles of the tabs of the Order Restriction models. If the dropdown is set with one of these values, reading a JASP file with this setting will lead to an error.
. if an error is set to a control, removing this error lets the analysis is an error state, and the analysis cannot run anymore.
In AnalysisForm, the terms of an available model (which is the case for a dropdown) should be fetched before the value of the dropdown is set.

Also remove the _getControlErrorMessageOfControl method which is not used anymore.
In ControlErrorMessage, when the message is closed, its association with its control should be removed: in this way the AnalysisForm::hasError becomes false.

