### PR TITLE
Fixes the case where jaspBase installation might on macOS

### DIFF
--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -10,6 +10,14 @@ Sys.setenv(JASPENGINE_LOCATION="@JASP_ENGINE_PATH@/JASPEngine")
 # it anyway! It gets to if-y.
 .libPaths(c("@R_LIBRARY_PATH@", .libPaths()))
 
+# This is to avoid any surprises during the installation of `jaspBase`.
+# E.g., if one of the packages suddenly needs building, then the build
+# might fails since we didn't have time to sign all the previous libraries
+# yet.
+if (Sys.info()["sysname"] == "Darwin") {
+  options(install.packages.compile.from.source = "never")
+}
+
 # The code below mimics what jaspBase::installModule does
 computeHash <- function(modulePkg) {
   srcFiles <- c(

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -201,7 +201,7 @@ if(INSTALL_R_MODULES)
 
     add_custom_target(
       ${MODULE}
-      JOB_POOL sequential
+      USES_TERMINAL
       WORKING_DIRECTORY ${R_HOME_PATH}
       DEPENDS ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
@@ -247,7 +247,7 @@ if(INSTALL_R_MODULES)
 
     add_custom_target(
       ${MODULE}
-      JOB_POOL sequential
+      USES_TERMINAL
       WORKING_DIRECTORY ${R_HOME_PATH}
       DEPENDS
         ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds


### PR DESCRIPTION
This is to avoid any surprises during the installation of `jaspBase`. E.g., if one of the packages suddenly needs building, then the build might fails since we didn't have time to sign all the previous libraries yet.