### PR TITLE
Cannot set custom data editor

### DIFF
--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1473,16 +1473,16 @@ void MainWindow::startDataEditor(QString path)
 	if (appname.isEmpty())
 		useDefaultSpreadsheetEditor = true;
 
-	QString startProcess;
 	if (!useDefaultSpreadsheetEditor)
 	{
+		QStringList args;
 #ifdef __APPLE__
-		appname = appname.mid(appname.lastIndexOf('/') + 1);
-		startProcess = "open -a \"" + appname + "\" \"" + path + "\"";
+		args = {"-a", appname, path};
+		appname = "open";
 #else
-		startProcess = "\"" + appname + "\" \"" + path + "\"";
+		args = {path};
 #endif
-		if (!QProcess::startDetached(startProcess))
+		if (!QProcess::startDetached(appname, args))
 			MessageForwarder::showWarning(tr("Start Editor"), tr("Unable to start the editor : %1. Please check your editor settings in the preference menu.").arg(appname));
 	}
 	else


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1696
If in the Data Preferences, you set the spreadsheet editor not to be the default one, but a custom one, then this editor does not start when you double-click the data in the data panel.

