### PR TITLE
These fixes stop JASP from crashing on linux

### DIFF
--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -205,11 +205,10 @@ MainWindow::~MainWindow()
 	try
 	{
 		//Clean up all QML to get rid of warnings and hopefully fix https://github.com/jasp-stats/jasp-issues/issues/667
-		QList<QObject *> rootObjs = _qml->rootObjects();
-
 		//Going backwards to make sure the theme isnt deleted before everything that depends on it
-		for(int i=rootObjs.size() - 1; i >= 0; i--)
-			delete rootObjs[i];
+		for(int i=_qml->rootObjects().size() - 1; i >= 0; i--)
+			delete _qml->rootObjects().at(i);
+
 
 		delete _qml;
 

--- a/Desktop/modules/description/description.cpp
+++ b/Desktop/modules/description/description.cpp
@@ -18,9 +18,7 @@ Description::Description(QQuickItem *parent) : QQuickItem(parent)
 
 Description::~Description()
 {
-	for(EntryBase * entry : _entries)
-		delete entry;
-
+	//We let qml handle destroying the children
 	_entries.clear();
 }
 


### PR DESCRIPTION
And the behaviour should still be fine

The fix in `Description` is only useful when doubleclicking a jaspModule.tar.gz with the `enginePerModule` branch (Which I will rebase on this).

The fix in the mainwindow destructor is to not make a copy of the list of root-objects because apparently some of them get destroyed through the other ones. So be requesting a new list all the time we avoid a crash.

But maybe Im the only one with this crash?
On Arch linux with Qt 6.3