### PR TITLE
Custom Contrasts cannot be negative

### DIFF
--- a/Desktop/components/JASP/Controls/TableView.qml
+++ b/Desktop/components/JASP/Controls/TableView.qml
@@ -42,7 +42,7 @@ TableViewBase
 	property string	extraCol		: ""						//Used by ListModelFilteredDataEntry
 	property alias	rowNumberWidth	: theView.rowNumberWidth
 	property var	validator		: (itemType === JASP.Integer) ? intValidator : (itemType === JASP.Double ? doubleValidator : stringValidator)
-	property int	minimum			: 0
+	property double	minimum			: 0
 	property int	decimals		: 1
 	property int	colSelected		: -1
 	property int	rowSelected		: -1


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1704
Infinity is a double and cannot be used with an integer.
The minimum property of TableVIew is used in the JASPDoubleValidator bottom property, which is anyway a double, so the minimum property should be a double

