### PR TITLE
Mac & Linux fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,9 @@ include(Modules)
 include(Install)
 
 # Packs and creates installer executable for Windows, and macOS
-include(Pack)
+if(NOT LINUX)
+	include(Pack)
+endif()
 
 if(NOT
    CMAKE_GENERATOR

--- a/Desktop/CMakeLists.txt
+++ b/Desktop/CMakeLists.txt
@@ -75,14 +75,18 @@ endif()
 
 target_include_directories(
   JASP
-  PUBLIC ${CMAKE_CURRENT_LIST_DIR}
-         ${PROJECT_SOURCE_DIR}/Common
-         ${PROJECT_SOURCE_DIR}/Common/jaspColumnEncoder
-         # ReadStat
-         $<$<PLATFORM_ID:Windows>:${MINGW_LIBREADSTAT_H}>
-         ${LIBREADSTAT_INCLUDE_DIRS}
-         # JSONCPP
-         $<$<PLATFORM_ID:Linux>:${_PKGCONFIG_LIB_JSONCPP_INCLUDEDIR}>)
+  PUBLIC 	${CMAKE_CURRENT_LIST_DIR}
+			${PROJECT_SOURCE_DIR}/Common
+			${PROJECT_SOURCE_DIR}/Common/jaspColumnEncoder
+			# ReadStat
+			$<$<PLATFORM_ID:Windows>:${MINGW_LIBREADSTAT_H}>
+			${LIBREADSTAT_INCLUDE_DIRS}
+			# JSONCPP
+			$<$<PLATFORM_ID:Linux>:${_PKGCONFIG_LIB_JSONCPP_INCLUDEDIR}>
+			$<$<BOOL:${FLATPAK_USED}>:/app/include/QtCore5Compat>
+			$<$<BOOL:${FLATPAK_USED}>:/app/include/QtWebEngineQuick>
+			$<$<BOOL:${FLATPAK_USED}>:/app/include/QtWebEngineCore>
+			)
 
 target_link_libraries(
   JASP
@@ -92,9 +96,10 @@ target_link_libraries(
          Qt::OpenGL
          Qt::Widgets
          Qt::Qml
-         Qt::WebEngineQuick
          $<$<NOT:$<BOOL:${FLATPAK_USED}>>:Qt::WebEngineQuick>
-         $<$<BOOL:${FLATPAK_USED}>:Qt6WebEngineQuick>
+         $<$<BOOL:${FLATPAK_USED}>:/app/lib/$ENV{FLATPAK_ARCH}-linux-gnu/libQt6WebEngineQuick.so>
+		 $<$<BOOL:${FLATPAK_USED}>:/app/lib/$ENV{FLATPAK_ARCH}-linux-gnu/libQt6WebEngineCore.so>
+		 $<$<BOOL:${FLATPAK_USED}>:/app/qml/QtWebEngine/libqtwebenginequickplugin.so>
          Qt::WebChannel
          Qt::Svg
          Qt::Network
@@ -106,7 +111,7 @@ target_link_libraries(
          Qt::QuickControls2Impl
          Qt::QuickWidgets
          $<$<NOT:$<BOOL:${FLATPAK_USED}>>:Qt::Core5Compat>
-         $<$<BOOL:${FLATPAK_USED}>:Qt6Core5Compat>
+         $<$<BOOL:${FLATPAK_USED}>:/app/lib/$ENV{FLATPAK_ARCH}-linux-gnu/libQt6Core5Compat.so>
          Qt::QuickTemplates2
          Qt::DBus
          Qt::QmlWorkerScript
@@ -125,6 +130,7 @@ target_link_libraries(
          $<$<PLATFORM_ID:Linux>:${_PKGCONFIG_LIB_JSONCPP_LINK_LIBRARIES}>
          # R-Framework --------------------------------
          $<$<PLATFORM_ID:Darwin>:${_R_Framework}>)
+
 
 target_compile_definitions(JASP PUBLIC JASP_USES_QT_HERE)
 

--- a/Modules/install-RInside.R.in
+++ b/Modules/install-RInside.R.in
@@ -4,7 +4,7 @@
 # I've ran into situation where installing `RInside` doesn't install the `Rcpp`.
 # 
 
-options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
+options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = FALSE)
 
 if (Sys.info()["sysname"] != "Darwin") {
   install.packages(c('RInside', 'Rcpp'), library='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@')

--- a/Modules/install-RInside.R.in
+++ b/Modules/install-RInside.R.in
@@ -6,9 +6,12 @@
 
 options(install.opts = '--no-multiarch --no-docs --no-test-load', pkgType = 'binary', renv.cache.linkable = TRUE)
 
-if (Sys.info()["sysname"] == "Darwin") {
+if (Sys.info()["sysname"] != "Darwin") {
+  install.packages(c('RInside', 'Rcpp'), library='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@')
+} else {
   Sys.setenv(RENV_PATHS_ROOT='@MODULES_RENV_ROOT_PATH@', RENV_PATHS_CACHE='@MODULES_RENV_CACHE_PATH@')
   renv::install(c('RInside', 'Rcpp'), library='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@')
-} else {
-  install.packages(c('RInside', 'Rcpp'), library='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@')
+
+  source('@MODULES_BINARY_PATH@/symlinkTools.R')
+  convertAbsoluteSymlinksToRelative('@R_LIBRARY_PATH@', '@MODULES_RENV_CACHE_PATH@')
 }

--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -46,6 +46,7 @@ if (!(file.exists(hashPath) && "jaspBase" %in% installed.packages() && identical
     devtools::install("@PROJECT_SOURCE_DIR@/Engine/jaspBase", repos=NULL, library="@R_LIBRARY_PATH@")
   }
 }
+
 if ("jaspBase" %in% installed.packages()) {
   saveRDS(currentHash, hashPath)
 }

--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -36,7 +36,7 @@ currentHash <- computeHash("@PROJECT_SOURCE_DIR@/Engine/jaspBase/")
 if (!(file.exists(hashPath) && "jaspBase" %in% installed.packages() && identical(currentHash, try(readRDS(hashPath))))) {
   options(
     install_opts = "--no-multiarch --no-docs --no-test-load",
-    renv.cache.linkable = TRUE
+    renv.cache.linkable = FALSE
   )
   if (Sys.info()["sysname"] == "Darwin") {
      renv::install("@PROJECT_SOURCE_DIR@/Engine/jaspBase", repos=NULL, library="@R_LIBRARY_PATH@")
@@ -53,7 +53,7 @@ if ("jaspBase" %in% installed.packages()) {
 
 # Converting the absolute symlinks to relative symlinks on macOS
 # Todo, I can do this using CMake like I do on Windows
-if (Sys.info()["sysname"] == "Darwin") {
-  source('@MODULES_BINARY_PATH@/symlinkTools.R')
-  convertAbsoluteSymlinksToRelative('@R_LIBRARY_PATH@', '@MODULES_RENV_CACHE_PATH@')
-}
+#if (Sys.info()["sysname"] == "Darwin") {
+#  source('@MODULES_BINARY_PATH@/symlinkTools.R')
+#  convertAbsoluteSymlinksToRelative('@R_LIBRARY_PATH@', '@MODULES_RENV_CACHE_PATH@')
+#}

--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -55,5 +55,5 @@ if ("jaspBase" %in% installed.packages()) {
 # Todo, I can do this using CMake like I do on Windows
 if (Sys.info()["sysname"] == "Darwin") {
   source('@MODULES_BINARY_PATH@/symlinkTools.R')
-  convertAbsoluteSymlinksToRelative('@MODULES_BINARY_PATH@', '@MODULES_RENV_CACHE_PATH@')
+  convertAbsoluteSymlinksToRelative('@R_LIBRARY_PATH@', '@MODULES_RENV_CACHE_PATH@')
 }

--- a/Modules/install-module.R.in
+++ b/Modules/install-module.R.in
@@ -13,6 +13,11 @@ if (@IS_LINUX_LOCAL_BUILD@) {
 	Sys.setenv(LD_LIBRARY_PATH="@jags_LIBRARY_DIRS@")
 }
 
+
+if (@IS_FLATPAK_USED@) {
+	source('/app/lib64/Rprofile.R');
+}
+
 # The R_LIBRARY_PATH might already be there, but depending on the configuration 
 # of the CMake, we might be installing in a different location, so, I just add
 # it anyway! It gets to if-y. 

--- a/R-Interface/R/symlinkTools.R
+++ b/R-Interface/R/symlinkTools.R
@@ -152,10 +152,10 @@ collectLinks <- function(modulesRoot, renvCache, isLink, getLink)
     {
       #path <- normalizePath(path) This follows the junction immediately...
       if(!grepl("renv-cache", path)){
-            print(paste0("Checking if path is link: ", path))
+            #print(paste0("Checking if path is link: ", path))
             if(isLink(path))
             {
-              print('is symlink')
+              #print('is symlink')
               symPath  <- getLink(path)
               if(!startsWith(symPath, ".")) #if starts with dot it is already relative
                 symlinks[nrow(symlinks)+1, ] <<- list(linkLocation=path, linkTarget=relativeer(path, symPath), originalTarget=symPath)

--- a/R-Interface/R/symlinkTools.R
+++ b/R-Interface/R/symlinkTools.R
@@ -49,7 +49,7 @@ determineOverlap <- function(targetRoot, sourceRoot)
     #tgtToSrc     <- paste0(tgtToSrc, .Platform$file.sep, ".")
 
     if(addRootToSource)
-      return(paste0(tgtToSrc, rootToSrc)) #We do not need to add the separator because it is there in tgtToSrc
+      return(pastePath(c(tgtToSrc, rootToSrc)))
     return(tgtToSrc)
   }
 
@@ -68,13 +68,8 @@ determineOverlap <- function(targetRoot, sourceRoot)
 # Use overlapfunctions as returned by determineOverlap to generate a function to turn target-path from absolute to relative
 getRelativityFunction <- function(modulesRoot, renvCache)
 {
-  
-  if (Sys.info()["sysname"] == "Darwin") {
-    modToRenvS <- pastePath(c("..", "renv-cache"))
-  } else {
-    modToRenvF <- determineOverlap(modulesRoot, renvCache)
-    modToRenvS <- modToRenvF$targetToSource(renvCache, TRUE)
-  }
+  modToRenvF <- determineOverlap(modulesRoot, renvCache)
+  modToRenvS <- modToRenvF$targetToSource(renvCache, TRUE)
 
   return(
     function(linkLocation, targetPath)
@@ -216,7 +211,7 @@ convertAbsoluteSymlinksToRelative <- function(modulesRoot, renvCache)
     {
       linkLoc <- symlinks[row, "linkLocation"]
       setwd(dirname(linkLoc))
-      #print(paste0("For link '", padToMax(symlinks[row, "linkLocation"], 1), "' will convert '", padToMax(symlinks[row, "originalTarget"], 2), "' to '", padToMax(symlinks[row, "linkTarget"], 3), "'"))
+      print(paste0("For link '", padToMax(symlinks[row, "linkLocation"], 1), "' will convert '", padToMax(symlinks[row, "originalTarget"], 2), "' to '", padToMax(symlinks[row, "linkTarget"], 3), "'"))
       file.symlink(from=symlinks[row, "linkTarget"], to=basename(linkLoc))
       
     }

--- a/Tools/CMake/Config.cmake
+++ b/Tools/CMake/Config.cmake
@@ -195,6 +195,9 @@ if(LINUX)
   if(FLATPAK_USED)
     set(LINUX_LOCAL_BUILD OFF)
     set(IS_LINUX_LOCAL_BUILD FALSE)
+    set(IS_FLATPAK_USED TRUE)
+  else()
+      set(IS_FLATPAK_USED FALSE)
   endif()
 
   # IS_LINUX_LOCAL_BUILD is a special variable that will be used in install-module.R

--- a/Tools/CMake/Config.cmake
+++ b/Tools/CMake/Config.cmake
@@ -223,7 +223,7 @@ if(LINUX)
 else()
 
   set(IS_LINUX_LOCAL_BUILD FALSE)
-
+  set(IS_FLATPAK_USED FALSE)
 endif()
 
 # I have a construct for this, and Qt often messes things up.

--- a/Tools/CMake/Install.cmake
+++ b/Tools/CMake/Install.cmake
@@ -164,11 +164,18 @@ if(LINUX)
   install(DIRECTORY ${MODULES_BINARY_PATH}/
           DESTINATION ${JASP_INSTALL_MODULEDIR})
 
-  install(DIRECTORY ${MODULES_RENV_ROOT_PATH}/
-          DESTINATION ${JASP_INSTALL_PREFIX}/lib64/renv-root)
+  # we do not need renv-root in an install
+  #install(DIRECTORY ${MODULES_RENV_ROOT_PATH}/
+  #        DESTINATION ${JASP_INSTALL_PREFIX}/lib64/renv-root)
 
+if(NOT FLATPAK_USED) #because flatpak already puts renv-cache in /app/lib64 anyway
   install(DIRECTORY ${MODULES_RENV_CACHE_PATH}/
           DESTINATION ${JASP_INSTALL_PREFIX}/lib64/renv-cache)
+endif()
+
+  #Flatpak wrapper that sets some environment variables that JASP needs
+  install(PROGRAMS ${CMAKE_SOURCE_DIR}/Tools/flatpak/org.jaspstats.JASP
+          DESTINATION ${JASP_INSTALL_BINDIR})
 
   # Flatpak Misc.
 

--- a/Tools/CMake/Libraries.cmake
+++ b/Tools/CMake/Libraries.cmake
@@ -115,19 +115,7 @@ if(NOT FLATPAK_USED)
 
 else()
 
-  find_package(
-    Qt6WebEngineQuick
-    REQUIRED
-    PATHS
-    ${Qt6WebEngineQuick_DIR}
-    NO_DEFAULT_PATH)
-
-  find_package(
-    Qt6Core5Compat
-    REQUIRED
-    PATHS
-    ${Qt6Core5Compat_DIR}
-    NO_DEFAULT_PATH)
+	message(STATUS "flatpak arch is $ENV{FLATPAK_ARCH}")
 
   find_package(
     Qt6 REQUIRED
@@ -150,6 +138,22 @@ else()
                QuickControls2Impl
                QmlWorkerScript
                QuickWidgets)
+
+  find_package(
+    Qt6WebEngineQuick
+    REQUIRED
+    PATHS
+    "/app/lib/$ENV{FLATPAK_ARCH}-linux-gnu/cmake/Qt6WebEngineQuick/"
+       ${Qt6WebEngineQuick_DIR}
+    NO_DEFAULT_PATH)
+
+  find_package(
+    Qt6Core5Compat
+    REQUIRED
+    PATHS
+	  "/app/lib/$ENV{FLATPAK_ARCH}-linux-gnu/cmake/Qt6Core5Compat/"
+	  ${Qt6Core5Compat_DIR}
+    NO_DEFAULT_PATH)
 
 endif()
 

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -25,7 +25,8 @@ set(JASP_COMMON_MODULES
     "jaspMixedModels"
     "jaspRegression"
     "jaspFrequencies"
-    "jaspFactor")
+    "jaspFactor"
+    )
 
 set(JASP_EXTRA_MODULES
     "jaspAudit"
@@ -45,7 +46,8 @@ set(JASP_EXTRA_MODULES
     "jaspSem"
     "jaspSummaryStatistics"
     "jaspVisualModeling"
-    "jaspProphet")
+    "jaspProphet"
+    )
 
 list(
   JOIN

--- a/Tools/CMake/Pack.cmake
+++ b/Tools/CMake/Pack.cmake
@@ -114,9 +114,10 @@ if(APPLE)
   add_custom_target(
     dmg
     VERBATIM
+    USES_TERMINAL
     DEPENDS ${CMAKE_BINARY_DIR}/Install/JASP.app/Contents/MacOS/JASP
     COMMAND
-      ${CREATE_DMG_EXECUTABLE} --volname "${CPACK_PACKAGE_FILE_NAME}" --volicon
+      ${CREATE_DMG_EXECUTABLE} --skip-jenkins --volname "${CPACK_PACKAGE_FILE_NAME}" --volicon
       "${CMAKE_SOURCE_DIR}/Tools/macOS/Volume.icns" --icon-size 96 --icon
       "JASP.app" 130 270 --background "${CPACK_DMG_BACKGROUND_IMAGE}"
       --window-size 527 454 --window-pos 200 200 --app-drop-link 430 270
@@ -139,9 +140,9 @@ if(APPLE)
     #              --password <secret_2FA_password>
     add_custom_target(
       notarise
+      USES_TERMINAL
       COMMAND xcrun notarytool submit "JASP/${CPACK_DMG_VOLUME_NAME}"
               --keychain-profile "AC_PASSWORD"
-              USES_TERMINAL
       COMMENT "Submitting the JASP/${CPACK_DMG_VOLUME_NAME} for notarisation")
 
   else()
@@ -150,11 +151,11 @@ if(APPLE)
     #            -p <secret_password>
     add_custom_target(
       notarise
+      USES_TERMINAL
       COMMAND
         xcrun altool --notarize-app --primary-bundle-id "org.jasp-stats.jasp"
         --password "@keychain:AC_PASSWORD" --file
         "JASP/${CPACK_DMG_VOLUME_NAME}"
-        USES_TERMINAL
       COMMENT "Submitting the JASP/${CPACK_DMG_VOLUME_NAME} for notarisation")
   endif()
 
@@ -165,6 +166,7 @@ if(APPLE)
 
   add_custom_target(
     upload
+    USES_TERMINAL
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMAND bash Upload.sh)
 

--- a/Tools/CMake/Pack.cmake
+++ b/Tools/CMake/Pack.cmake
@@ -117,7 +117,7 @@ if(APPLE)
     USES_TERMINAL
     DEPENDS ${CMAKE_BINARY_DIR}/Install/JASP.app/Contents/MacOS/JASP
     COMMAND
-      ${CREATE_DMG_EXECUTABLE} --skip-jenkins --volname "${CPACK_PACKAGE_FILE_NAME}" --volicon
+      ${CREATE_DMG_EXECUTABLE} --volname "${CPACK_PACKAGE_FILE_NAME}" --volicon
       "${CMAKE_SOURCE_DIR}/Tools/macOS/Volume.icns" --icon-size 96 --icon
       "JASP.app" 130 270 --background "${CPACK_DMG_BACKGROUND_IMAGE}"
       --window-size 527 454 --window-pos 200 200 --app-drop-link 430 270

--- a/Tools/CMake/Pack.cmake
+++ b/Tools/CMake/Pack.cmake
@@ -141,6 +141,7 @@ if(APPLE)
       notarise
       COMMAND xcrun notarytool submit "JASP/${CPACK_DMG_VOLUME_NAME}"
               --keychain-profile "AC_PASSWORD"
+              USES_TERMINAL
       COMMENT "Submitting the JASP/${CPACK_DMG_VOLUME_NAME} for notarisation")
 
   else()
@@ -153,6 +154,7 @@ if(APPLE)
         xcrun altool --notarize-app --primary-bundle-id "org.jasp-stats.jasp"
         --password "@keychain:AC_PASSWORD" --file
         "JASP/${CPACK_DMG_VOLUME_NAME}"
+        USES_TERMINAL
       COMMENT "Submitting the JASP/${CPACK_DMG_VOLUME_NAME} for notarisation")
   endif()
 

--- a/Tools/CMake/Pack.cmake
+++ b/Tools/CMake/Pack.cmake
@@ -116,7 +116,7 @@ if(APPLE)
     VERBATIM
     DEPENDS ${CMAKE_BINARY_DIR}/Install/JASP.app/Contents/MacOS/JASP
     COMMAND
-      ${CREATE_DMG_EXECUTABLE} --skip-jenkins --volname "${CPACK_PACKAGE_FILE_NAME}" --volicon
+      ${CREATE_DMG_EXECUTABLE} --volname "${CPACK_PACKAGE_FILE_NAME}" --volicon
       "${CMAKE_SOURCE_DIR}/Tools/macOS/Volume.icns" --icon-size 96 --icon
       "JASP.app" 130 270 --background "${CPACK_DMG_BACKGROUND_IMAGE}"
       --window-size 527 454 --window-pos 200 200 --app-drop-link 430 270

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -66,7 +66,7 @@ if(WIN32)
   endif()
 endif()
 
-# ------ Preparing REnv Paths
+# ------ Preparing Renv Paths
 #
 set(MODULES_SOURCE_PATH
     ${PROJECT_SOURCE_DIR}/Modules
@@ -78,9 +78,14 @@ set(MODULES_BINARY_PATH
 set(MODULES_RENV_ROOT_PATH
     "${PROJECT_BINARY_DIR}/_cache/renv-root"
     CACHE PATH "Location of renv root directories")
-set(MODULES_RENV_CACHE_PATH
-    "${MODULES_BINARY_PATH}/renv-cache"
-    CACHE PATH "Location of renv cache directories")
+
+if(FLATPAK_USED)
+  set(MODULES_RENV_CACHE_PATH "/app/lib64/renv-cache" CACHE PATH "Location of renv cache directories")
+else()
+  set(MODULES_RENV_CACHE_PATH "${MODULES_BINARY_PATH}/renv-cache" CACHE PATH "Location of renv cache directories")
+endif()
+
+
 set(JASP_ENGINE_PATH
     "${CMAKE_BINARY_DIR}/Desktop/"
     CACHE PATH "Location of the JASPEngine")

--- a/Tools/flatpak/org.jaspstats.JASP
+++ b/Tools/flatpak/org.jaspstats.JASP
@@ -1,0 +1,5 @@
+#!/bin/sh
+export LD_LIBRARY_PATH=/app/lib/x86_64-linux-gnu/ 
+export QML2_IMPORT_PATH=$QML2_IMPORT_PATH:/app/qml 
+
+JASP $1

--- a/Tools/flatpak/org.jaspstats.JASP.appdata.xml
+++ b/Tools/flatpak/org.jaspstats.JASP.appdata.xml
@@ -35,9 +35,12 @@
 	<url type="bugtracker">https://github.com/jasp-stats/jasp-issues/issues</url>
 	<url type="donation">https://jasp-stats.org/donate/</url>
 	<releases>
-	<release version="0.16.2" date="2022-02-25">
+	<release version="0.16.3" date="2022-05-17">
 			<description>
 				Using Qt 6 to fix problems like flatpak JASP crashing hard on filter/comp.column.
+				We also switched the buildsystem to cmake and related changes to that.
+
+				Also a whole bunch of new modules and analyses.
 			</description>
 		</release>
 		<release version="0.16.1" date="2022-02-15">

--- a/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
+++ b/Tools/flatpak/setup-rpkgs/R/flatpakGeneratePkgsList.R
@@ -57,7 +57,7 @@ jaspModules <- Filter(isJaspModule, list.dirs(file.path(jaspDir, "Modules"), rec
 names(jaspModules) <- basename(jaspModules)
 
 # | HERE | you can add modules to exclude
-jaspModules <- jaspModules[setdiff(names(jaspModules), c("jaspProcessControl"))]
+#jaspModules <- jaspModules[setdiff(names(jaspModules), c("jaspProcessControl"))]
 
 getModuleEnvironments(jaspModules)
 # system("beep_finished.sh")

--- a/Tools/macOS/Nightlies.sh.in
+++ b/Tools/macOS/Nightlies.sh.in
@@ -8,7 +8,6 @@ cd @JASP_SOURCE_DIR@
 
 mkdir build-x86_64-nightly
 cd build-x86_64-nightly
-cmake ..
 cmake .. -GNinja -DUSE_CONAN=ON -DCMAKE_PREFIX_PATH=@Qt6_DIR@ -DINSTALL_R_MODULES=ON -DCMAKE_OSX_ARCHITECTURES=x86_64
 cmake --build . --target JASP
 cmake --build . --target install
@@ -17,7 +16,6 @@ cmake --build . --target notarise
 
 mkdir build-arm64-nightly
 cd build-arm64-nightly
-cmake ..
 cmake .. -GNinja -DUSE_CONAN=ON -DCMAKE_PREFIX_PATH=@Qt6_DIR@ -DINSTALL_R_MODULES=ON -DCMAKE_OSX_ARCHITECTURES=arm64
 cmake --build . --target JASP
 cmake --build . --target install


### PR DESCRIPTION
Making sure the new cmake stuff also works for flatpak

If we are building flatpak we know where things are

I might know where it is

But writing it down correctly is a whole different matter...

we need to load the Rprofile for flatpak to build

FLATPAK_USED == "ON" :S

Make sure IS_FLATPAK_USED has a value

update release date

use correct submodules

separate qt modules should add include dirs

Dont do Pack.cmake on linux

maybe this works?

Include processcontrol in flatpak archive
disable most modules to debug better

maybe target_link_library helps?

endif...

using link_directories  /app/lib/x86_64-linux-gnu/

maybe specifying the path exactly helps?

should have libQt6Core5Compat.so

maybe the executable should just be JASP?

change output name to org.jaspstats.JASP

dont treat webenginequick special

look for core5compat after looking for qt6?

put webenginequick special cases back

well, it should then not be in the qt6 list...

almost groundhogday here with the lib...

include QtWebEngineCore as well

maybe not use renv for jaspBase on flatpak

lets try a wrapper then

install script as PROGRAMS to make sure it may execute

also turn on modules!