### PR TITLE
Closing a dataset may crash if it contains an analysis having its own computed columns

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -78,11 +78,14 @@ Analysis::Analysis(size_t id, Analysis * duplicateMe)
 
 Analysis::~Analysis()
 {
-	const auto & cols = computedColumns();
+	if(DataSetPackage::pkg()->hasDataSet())
+	{
+		const auto & cols = computedColumns();
 
-	if(cols.size() > 0)
-		for(const std::string & col : cols)
-			emit requestComputedColumnDestruction(col);
+		if(cols.size() > 0)
+			for(const std::string & col : cols)
+				emit requestComputedColumnDestruction(col);
+	}
 }
 
 void Analysis::clearOptions()

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -79,13 +79,8 @@ Analysis::Analysis(size_t id, Analysis * duplicateMe)
 Analysis::~Analysis()
 {
 	if(DataSetPackage::pkg()->hasDataSet())
-	{
-		const auto & cols = computedColumns();
-
-		if(cols.size() > 0)
-			for(const std::string & col : cols)
-				emit requestComputedColumnDestruction(col);
-	}
+		for(const std::string & col : computedColumns())
+			emit requestComputedColumnDestruction(col);
 }
 
 void Analysis::clearOptions()

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -177,7 +177,8 @@ public:
 	const QList<std::string>	& computedColumns()								const	{ return _computedColumns; }
 	const Json::Value			& getRSource(const std::string& name)			const	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }
 	Json::Value				rSources()											const;
-	
+	void					removeOwnComputedColumn(const std::string& col)				{ _computedColumns.removeAll(col); }
+
 signals:
 	void				nameChanged();
 	void				helpFileChanged();
@@ -227,7 +228,6 @@ public slots:
 protected:
 	void					abort();
 	void					addOwnComputedColumn(const std::string& col)				{ _computedColumns.push_back(col); }
-	void					removeOwnComputedColumn(const std::string& col)				{ _computedColumns.removeAll(col); }
 
 private:
 	void					processResultsForDependenciesToBeShown();

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -177,7 +177,6 @@ public:
 	const QList<std::string>	& computedColumns()								const	{ return _computedColumns; }
 	const Json::Value			& getRSource(const std::string& name)			const	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }
 	Json::Value				rSources()											const;
-	void					removeOwnComputedColumn(const std::string& col)				{ _computedColumns.removeAll(col); }
 
 signals:
 	void				nameChanged();
@@ -228,6 +227,7 @@ public slots:
 protected:
 	void					abort();
 	void					addOwnComputedColumn(const std::string& col)				{ _computedColumns.push_back(col); }
+	void					removeOwnComputedColumn(const std::string& col)				{ _computedColumns.removeAll(col); }
 
 private:
 	void					processResultsForDependenciesToBeShown();

--- a/Desktop/data/computedcolumnsmodel.cpp
+++ b/Desktop/data/computedcolumnsmodel.cpp
@@ -496,10 +496,7 @@ void ComputedColumnsModel::analysisRemoved(Analysis * analysis)
 			colsToRemove.insert(QString::fromStdString(col->name()));
 
 	for(const QString & col : colsToRemove)
-	{
 		requestComputedColumnDestruction(fq(col));
-		analysis->removeOwnComputedColumn(fq(col));
-	}
 }
 
 void ComputedColumnsModel::setShowThisColumn(QString showThisColumn)

--- a/Desktop/data/computedcolumnsmodel.cpp
+++ b/Desktop/data/computedcolumnsmodel.cpp
@@ -444,7 +444,8 @@ void ComputedColumnsModel::requestComputedColumnDestruction(const std::string& c
 
 	computedColumns()->removeComputedColumn(columnName);
 
-	emit headerDataChanged(Qt::Horizontal, index, DataSetPackage::pkg()->columnCount() + 1);
+	if (DataSetPackage::pkg()->hasDataSet())
+		emit headerDataChanged(Qt::Horizontal, index, DataSetPackage::pkg()->columnCount() + 1);
 
 	checkForDependentColumnsToBeSent(columnName);
 
@@ -495,7 +496,10 @@ void ComputedColumnsModel::analysisRemoved(Analysis * analysis)
 			colsToRemove.insert(QString::fromStdString(col->name()));
 
 	for(const QString & col : colsToRemove)
+	{
 		requestComputedColumnDestruction(fq(col));
+		analysis->removeOwnComputedColumn(fq(col));
+	}
 }
 
 void ComputedColumnsModel::setShowThisColumn(QString showThisColumn)

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1109,6 +1109,7 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 		if (event->isSuccessful())
 		{
 			_analyses->setVisible(false);
+			_package->setDataSet(nullptr); // Prevent analyses to change the dataset if they have computed columns.
 			_analyses->clear();
 			_package->reset();
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1826

The destruction of a computed column emits an event to change the dataset, but this should not be send if the dataset does not exist anymore.
Moreover, the computed columns of an analysis are destroyed twice, because their destruction did not remove their reference in the analysis.

