### PR TITLE
When Tab name changes, the bound value should be first updated

### DIFF
--- a/Desktop/widgets/componentslistbase.cpp
+++ b/Desktop/widgets/componentslistbase.cpp
@@ -191,6 +191,18 @@ void ComponentsListBase::nameChangedHandler(int index, QString name)
 
 	name = _makeUnique(name, index);
 
+	if (isBound())
+	{
+		// The name is the key value that allows to distinguish the elements of the components list.
+		// So this must be also updated in the bound value.
+		Json::Value val = boundValue();
+		if (val.isArray() && val.size() > index)
+		{
+			val[index][fq(_optionKey)] = fq(name);
+			setBoundValue(val, false);
+		}
+	}
+
 	_termsModel->changeTerm(index, name);
 }
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1822

When the name of a tab is changed, the nameChangedHandler of the ComponentsListBase is called, which calls the changeTerm method of its model. But as the name of a tab is also the key value of the bound value, this value must be first changed in the bound value so that the other control values of the tab can be found.

