### PR TITLE
Row controls depending on a source should be disconnected when not used

### DIFF
--- a/Desktop/widgets/listmodel.cpp
+++ b/Desktop/widgets/listmodel.cpp
@@ -161,10 +161,12 @@ void ListModel::setUpRowControls()
 	if (_rowComponent == nullptr)
 		return;
 
+	QStringList keys;
 	int row = 0;
 	for (const Term& term : terms())
 	{
 		const QString& key = term.asQString();
+		keys.append(key);
 		if (!_rowControlsMap.contains(key))
 		{
 			bool hasOptions = _rowControlsValues.contains(key);
@@ -176,6 +178,12 @@ void ListModel::setUpRowControls()
 			_rowControlsMap[key]->setContext(row, key);
 		row++;
 	}
+
+	for (const QString& key : _rowControlsMap.keys())
+		if (!keys.contains(key))
+			// If some row controls are not used anymore, if they use some sources, they must be disconnected from these sources
+			// If a source changes and emits a signal, these controls should not be activated (cf. https://github.com/jasp-stats/jasp-test-release/issues/1786)
+			_rowControlsMap[key]->disconnectControls();
 }
 
 JASPControl *ListModel::getRowControl(const QString &key, const QString &name) const

--- a/Desktop/widgets/rowcontrols.cpp
+++ b/Desktop/widgets/rowcontrols.cpp
@@ -20,6 +20,7 @@
 #include "analysis/analysisform.h"
 #include "analysis/jaspcontrol.h"
 #include "jasplistcontrol.h"
+#include "sourceitem.h"
 
 #include "log.h"
 
@@ -92,7 +93,11 @@ void RowControls::_setupControls(bool reuseBoundValue)
 			// If a ListView depends on a source, it has to be initialized by this source
 			// For this just call the sourceTermsChanged handler.
 			if (listView && listView->hasSource())
+			{
+				for (SourceItem* source : listView->sourceItems())
+					source->connectModels(); // If the source was disconnected, reconnect it.
 				listView->model()->sourceTermsReset();
+			}
 		}
 	}
 
@@ -126,4 +131,17 @@ bool RowControls::addJASPControl(JASPControl *control)
 		_rowJASPControlMap[control->name()] = control;
 
 	return success;
+}
+
+void RowControls::disconnectControls()
+{
+	// If a control depends on a source, disconnect this source with this control.
+	JASPListControl* parentControl = _parentModel->listView();
+	for (JASPControl* control : _rowJASPControlMap.values())
+	{
+		JASPListControl* listControl = qobject_cast<JASPListControl*>(control);
+		if (listControl)
+			for (SourceItem* source : listControl->sourceItems())
+				source->disconnectModels();
+	}
 }

--- a/Desktop/widgets/rowcontrols.h
+++ b/Desktop/widgets/rowcontrols.h
@@ -48,6 +48,7 @@ public:
 	const QMap<QString, JASPControl*>&			getJASPControlsMap()						const	{ return _rowJASPControlMap;	}
 	JASPControl*								getJASPControl(const QString& name)					{ return _rowJASPControlMap.contains(name) ? _rowJASPControlMap[name] : nullptr; }
 	bool										addJASPControl(JASPControl* control);
+	void										disconnectControls();
 
 private:
 

--- a/Desktop/widgets/sourceitem.cpp
+++ b/Desktop/widgets/sourceitem.cpp
@@ -100,15 +100,15 @@ void SourceItem::connectModels()
 	if (_isRSource && form)
 		connect(form,	&AnalysisForm::rSourceChanged,				this, &SourceItem::_rSourceChanged);
 
-	if (!_nativeModel) return;
-
 	ColumnsModel* columnsModel = qobject_cast<ColumnsModel*>(_nativeModel);
-
-	connect(_nativeModel, &QAbstractItemModel::dataChanged,			this, &SourceItem::_dataChangedHandler);
-	connect(_nativeModel, &QAbstractItemModel::rowsInserted,		this, &SourceItem::_resetModel);
-	connect(_nativeModel, &QAbstractItemModel::rowsRemoved,			this, &SourceItem::_resetModel);
-	connect(_nativeModel, &QAbstractItemModel::rowsMoved,			this, &SourceItem::_resetModel);
-	connect(_nativeModel, &QAbstractItemModel::modelReset,			this, &SourceItem::_resetModel);
+	if (_nativeModel)
+	{
+		connect(_nativeModel, &QAbstractItemModel::dataChanged,			this, &SourceItem::_dataChangedHandler);
+		connect(_nativeModel, &QAbstractItemModel::rowsInserted,		this, &SourceItem::_resetModel);
+		connect(_nativeModel, &QAbstractItemModel::rowsRemoved,			this, &SourceItem::_resetModel);
+		connect(_nativeModel, &QAbstractItemModel::rowsMoved,			this, &SourceItem::_resetModel);
+		connect(_nativeModel, &QAbstractItemModel::modelReset,			this, &SourceItem::_resetModel);
+	}
 
 	if (columnsModel)
 	{
@@ -141,9 +141,8 @@ void SourceItem::disconnectModels()
 	if (_isRSource && form)
 		disconnect(form,	&AnalysisForm::rSourceChanged,				this, &SourceItem::_rSourceChanged);
 
-	if (!_nativeModel) return;
-
-	_nativeModel->disconnect(this);
+	if (_nativeModel)
+		_nativeModel->disconnect(this);
 
 	ColumnsModel* columnsModel = qobject_cast<ColumnsModel*>(_nativeModel);
 	if (columnsModel)

--- a/Desktop/widgets/sourceitem.h
+++ b/Desktop/widgets/sourceitem.h
@@ -72,6 +72,9 @@ public:
 	QAbstractItemModel*		nativeModel()						{ return _nativeModel;				}
 	Terms					getTerms();
 
+
+	void									connectModels();
+	void									disconnectModels();
 	static QVector<SourceItem*>				readAllSources(JASPListControl* _listControl);
 
 private:
@@ -86,7 +89,6 @@ private:
 	Terms									_readAllTerms();
 
 private slots:
-	void									_connectModels();
 	void									_resetModel();
 	void									_dataChangedHandler(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>());
 	void									_rSourceChanged(const QString& name);
@@ -109,6 +111,7 @@ private:
 	QString							_conditionExpression;
 	QVector<ConditionVariable>		_conditionVariables;
 	QSet<QString>					_usedControls;
+	bool							_connected				= false;
 };
 
 #endif // SOURCEITEM_H


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1786

The MixedModels model uses a  ComponentsList with VariablesList having a source from another VariablesList. As the ComponentsList caches its controls, it must care that if a control has a source, changes in this source should not affect this control: the signals should be disconnected.

