### PR TITLE
 A bunch of fixes to make installing a module work on macOS

### DIFF
--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -387,16 +387,16 @@ Json::Value	DynamicModule::requestJsonForPackageLoadingRequest()
 
 std::string DynamicModule::getLibPathsToUse()
 {
-	std::string libPathsToUse = "c('" + shortenWinPaths(moduleRLibrary()).toStdString()	+ "'";
+	std::string libPathsToUse = "c('" + shortenWinPaths(moduleRLibrary()).toStdString()	+ "')";
 
 	/*std::vector<std::string> requiredLibPaths = fq(DynamicModules::dynMods()->requiredModulesLibPaths(tq(_name)));
 
 	for(const std::string & path : requiredLibPaths)
 		libPathsToUse += ", '" + path + "'";*/
 
-	libPathsToUse += ", '" + AppDirs::rHome().toStdString() + "/library" + "'";
+	//libPathsToUse += ", '" + AppDirs::rHome().toStdString() + "/library" + "'";
 
-	libPathsToUse += ", .libPaths())";
+	//libPathsToUse += ", .libPaths())";
 
 	return libPathsToUse;
 }

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -20,7 +20,7 @@ file(GLOB_RECURSE SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
 
 add_executable(JASPEngine ${SOURCE_FILES} ${HEADER_FILES})
 
-add_dependencies(JASPEngine R-Interface jaspBase)
+add_dependencies(JASPEngine R-Interface)
 
 target_include_directories(
   JASPEngine

--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -5,6 +5,11 @@ Sys.setenv(RENV_PATHS_ROOT="@MODULES_RENV_ROOT_PATH@")
 Sys.setenv(RENV_PATHS_CACHE="@MODULES_RENV_CACHE_PATH@")
 Sys.setenv(JASPENGINE_LOCATION="@JASP_ENGINE_PATH@/JASPEngine")
 
+#Load the post-install fixes from jaspBase. Think Baron von Munchausen ;)
+source("@PROJECT_SOURCE_DIR@/Engine/jaspBase/R/utility.R")
+source("@PROJECT_SOURCE_DIR@/Engine/jaspBase/R/assignFunctionInPackage.R")
+source("@PROJECT_SOURCE_DIR@/Engine/jaspBase/R/moduleInstall.R")
+
 # The R_LIBRARY_PATH might already be there, but depending on the configuration
 # of the CMake, we might be installing in a different location, so, I just add
 # it anyway! It gets to if-y.
@@ -36,6 +41,7 @@ if (!(file.exists(hashPath) && "jaspBase" %in% installed.packages() && identical
     renv.cache.linkable = FALSE
   )
   
+  setupRenv("@R_LIBRARY_PATH@")
   renv::install("@PROJECT_SOURCE_DIR@/Engine/jaspBase", repos=NULL, library="@R_LIBRARY_PATH@")
 
 }

--- a/Modules/install-module.R.in
+++ b/Modules/install-module.R.in
@@ -21,7 +21,7 @@ if (@IS_FLATPAK_USED@) {
 # The R_LIBRARY_PATH might already be there, but depending on the configuration 
 # of the CMake, we might be installing in a different location, so, I just add
 # it anyway! It gets to if-y. 
-.libPaths(c("@R_LIBRARY_PATH@", .libPaths()))
+.libPaths(c("@R_LIBRARY_PATH@"))
 
 # Related to the comment above, there is variable here called, 
 # `libPathsToUse` but it is not connected to anything. If this works,

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -1115,7 +1115,7 @@ std::string __sinkMe(const std::string code)
 void jaspRCPP_setWorkingDirectory()
 {
 	std::string root = requestTempRootNameCB();
-	std::string code = "setwd(\"" + root + "\")";
+	std::string code = "setwd(\"" + root + "\"); sink();";
 	rinside->parseEvalQNT(__sinkMe(code));
 }
 

--- a/Tools/CMake/Install.cmake
+++ b/Tools/CMake/Install.cmake
@@ -100,19 +100,29 @@ if(APPLE)
 
   install(SCRIPT ${CMAKE_BINARY_DIR}/Deploy.mac.cmake)
 
+  set(R_PROGRAMS_PATTERN ".*/bin/(BATCH|build|check|COMPILE|config|exec/R|fc-cache|INSTALL|javareconf|libtool|LINK|mkinstalldirs|pager|qpdf|R|Rcmd|Rd2pdf|Rdconv|Rdiff|REMOVE|Rprof|Rscript|rtags|SHLIB|Stangle|Sweave)")
+
   install(
     DIRECTORY ${_R_Framework}
     DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}
     REGEX ${FILES_EXCLUDE_PATTERN} EXCLUDE
     REGEX ${FOLDERS_EXCLUDE_PATTERN} EXCLUDE
-    REGEX ".*/bin/R(Script)?$" EXCLUDE
-    )
+    REGEX ${R_PROGRAMS_PATTERN} EXCLUDE
+  )
 
-    #copy R(Script) separately as a program so they have execution permissions
-    install(
-      PROGRAMS ${_R_Framework}/Resources/bin/R ${_R_Framework}/Resources/bin/RScript
-      DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/bin/
-    )
+    #copy R executables separately as PROGRAMS so they have execution permissions
+	file(GLOB R_EXECUTABLES LIST_DIRECTORIES false "${_R_Framework}/Resources/bin/*")
+  install(
+    PROGRAMS ${R_EXECUTABLES} 
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/bin/
+  )
+
+  install(
+    PROGRAMS ${_R_Framework}/Resources/bin/exec/R
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/bin/exec/
+  )
+
+    
 
   # I had to do this manually, since `macdeployqt` misses it.
   # See here: https://bugreports.qt.io/browse/QTBUG-100686

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -106,7 +106,7 @@ message(STATUS "If necessary, 'jags' will be installed at ${jags_HOME}")
 
 if(NOT EXISTS ${MODULES_SOURCE_PATH})
   message(WARNING "Modules sources are not available. If you are planning
-       to install them during the build, make sure that they are avialble in
+	   to install them during the build, make sure that they are available in
        the jasp-desktop folder.")
 endif()
 
@@ -163,12 +163,13 @@ configure_file("${PROJECT_SOURCE_DIR}/Modules/install-jaspBase.R.in"
 #   - [ ] The following commands can be turned into a function or a macro, but
 #         for now, I would like to keep a granular control over differnt steps
 if(APPLE)
+	add_dependencies(jaspBase JASPEngine)
+
 	add_custom_command(
 	  WORKING_DIRECTORY ${R_HOME_PATH}
 	  OUTPUT ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
 	  USES_TERMINAL
-	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-			  --file=${MODULES_RENV_ROOT_PATH}/install-jaspBase.R
+	  COMMAND ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${MODULES_RENV_ROOT_PATH}/install-jaspBase.R
 	  COMMAND
 		${CMAKE_COMMAND} -D
 		NAME_TOOL_PREFIX_PATCHER=${PROJECT_SOURCE_DIR}/Tools/macOS/install_name_prefix_tool.sh
@@ -218,9 +219,8 @@ if(APPLE)
       ${MODULE}
       USES_TERMINAL
       WORKING_DIRECTORY ${R_HOME_PATH}
-      DEPENDS ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
-      COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
+	  DEPENDS	${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
+	  COMMAND  ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
       COMMAND
         ${CMAKE_COMMAND} -D
         NAME_TOOL_PREFIX_PATCHER=${PROJECT_SOURCE_DIR}/Tools/macOS/install_name_prefix_tool.sh
@@ -238,6 +238,9 @@ if(APPLE)
                  ${MODULES_BINARY_PATH}/${MODULE}-installed-successfully.log
                  ${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
       COMMENT "------ Installing '${MODULE}'")
+
+    add_dependencies(${MODULE} JASPEngine)
+
 else()
 	add_custom_target(
       ${MODULE}
@@ -279,11 +282,11 @@ if(APPLE)
       USES_TERMINAL
       WORKING_DIRECTORY ${R_HOME_PATH}
       DEPENDS
+	    JASPEngine
         ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
         $<$<STREQUAL:"${MODULE}","jaspMetaAnalysis">:${jags_VERSION_H_PATH}>
         $<$<STREQUAL:"${MODULE}","jaspJags">:${jags_VERSION_H_PATH}>
-      COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
+		COMMAND ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
       COMMAND
         ${CMAKE_COMMAND} -D
         NAME_TOOL_PREFIX_PATCHER=${PROJECT_SOURCE_DIR}/Tools/macOS/install_name_prefix_tool.sh
@@ -324,18 +327,12 @@ endif()
     #   DESTINATION ${CMAKE_INSTALL_PREFIX}/Modules/
     #   COMPONENT ${MODULE})
 
-    # To fix the Rpath stuff
-    if(APPLE)
-      add_dependencies(${MODULE} JASPEngine)
-    endif()
-
     # Making sure that CMake doesn't parallelize the installation of the modules
 
     add_dependencies(Modules ${MODULE})
 
     # We can add other specific dependencies here:
-    if((${MODULE} STREQUAL "jaspMetaAnalysis") OR (${MODULE} STREQUAL "jaspJags"
-                                                  ))
+	if((${MODULE} STREQUAL "jaspMetaAnalysis") OR (${MODULE} STREQUAL "jaspJags"))
       # ----- jags -----
       #
       # - JAGS needs GNU Bison v3, https://www.gnu.org/software/bison.

--- a/Tools/CMake/PatchR.cmake
+++ b/Tools/CMake/PatchR.cmake
@@ -30,7 +30,12 @@ macro(patch_r)
   execute_process(
     WORKING_DIRECTORY ${R_HOME_PATH}/bin
     COMMAND sed -i.bak -e
-            "s/R_HOME_DIR=.*/R_HOME_DIR=${build_r_home_for_sed}/g" R)
+            "s/R_HOME_DIR=.*/R_HOME_DIR=$JASP_R_HOME/g" R)
+
+  execute_process(
+    WORKING_DIRECTORY ${R_HOME_PATH}/bin
+    COMMAND sed -i.bak -e
+            "s|echo \\\"WARNING: ignoring environment value of R_HOME\\\"|echo \\\"Dont show a warning please\\\" > /dev/null|g" R)
 
   execute_process(
     WORKING_DIRECTORY ${R_HOME_PATH}/bin
@@ -48,8 +53,8 @@ macro(patch_r)
             R)
 
   # Commenting all instances of ldpaths call
-  execute_process(WORKING_DIRECTORY ${R_HOME_PATH}/bin
-                  COMMAND sed -i.bak "/ldpaths/s/^/#/g" R)
+ # execute_process(WORKING_DIRECTORY ${R_HOME_PATH}/bin
+ #                 COMMAND sed -i.bak "/ldpaths/s/^/#/g" R)
 
   execute_process(
     WORKING_DIRECTORY ${R_HOME_PATH}/etc

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -55,6 +55,7 @@ set(R_BINARY_HASHES
 	"05370dd000f0fded68594fc95334808ee25a8e91"
 	"37cfb7702a7be00abd64bef8e2ae4252821e5cfc")
 
+
 list(APPEND CMAKE_MESSAGE_CONTEXT R)
 
 set(R_VERSION
@@ -123,6 +124,8 @@ if(APPLE)
   set(RCPP_PATH "${R_LIBRARY_PATH}/Rcpp")
   set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
   set(RENV_PATH "${R_LIBRARY_PATH}/renv")
+  set(ENV{JASP_R_HOME} ${R_HOME_PATH})
+  set(ENV{R_HOME} ${R_HOME_PATH})
 
   cmake_print_variables(R_FRAMEWORK_PATH)
   cmake_print_variables(R_HOME_PATH)
@@ -481,12 +484,13 @@ if(APPLE)
     configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
                    ${MODULES_RENV_ROOT_PATH}/install-renv.R @ONLY)
 
+    set(ENV{JASP_R_HOME} ${R_HOME_PATH})
+
     execute_process(
-      # COMMAND_ECHO STDOUT
-      ERROR_QUIET OUTPUT_QUIET
+	  #COMMAND_ECHO STDERR
+	  ERROR_QUIET OUTPUT_QUIET
       WORKING_DIRECTORY ${R_HOME_PATH}
-      COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
 
     if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
       message(CHECK_FAIL "unsuccessful.")
@@ -573,6 +577,7 @@ elseif(WIN32)
   set(RCPP_PATH "${R_LIBRARY_PATH}/Rcpp")
   set(RINSIDE_PATH "${R_LIBRARY_PATH}/RInside")
   set(RENV_PATH "${R_LIBRARY_PATH}/renv")
+  
 
   # This will be added to the install.packages calls
   set(USE_LOCAL_R_LIBS_PATH ", lib='${R_LIBRARY_PATH}'")


### PR DESCRIPTION
Turned out we needed to set executable permissions on everything in the 'bin' folder of R (obvious in hindsight)
Also the patching of /bin/R didnt add JASP_R_HOME baked in a path to the buildsystem...
and some tweaks here and there to make it all come together