### PR TITLE
Remove japBase after module install adds it

### DIFF
--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -470,12 +470,12 @@ void DynamicModule::unpackage()
 
 std::string DynamicModule::getLibPathsToUse()
 {
-	std::string libPathsToUse = "c('" + shortenWinPaths(moduleRLibrary()).toStdString()	+ "')";
+	std::string libPathsToUse = "c('" + AppDirs::rHome().toStdString() + "/library', '" + shortenWinPaths(moduleRLibrary()).toStdString()	+ "')";
 
-	std::vector<std::string> requiredLibPaths = fq(DynamicModules::dynMods()->requiredModulesLibPaths(tq(_name)));
+	//std::vector<std::string> requiredLibPaths = fq(DynamicModules::dynMods()->requiredModulesLibPaths(tq(_name)));
 
-	for(const std::string & path : requiredLibPaths)
-		libPathsToUse += ", '" + path + "'";
+	//for(const std::string & path : requiredLibPaths)
+	//	libPathsToUse += ", '" + path + "'";
 
 	//libPathsToUse += ", '" + AppDirs::rHome().toStdString() + "/library" + "'";
 

--- a/Modules/install-module.R.in
+++ b/Modules/install-module.R.in
@@ -31,8 +31,13 @@ result <- jaspBase::installJaspModule("@MODULES_SOURCE_PATH@/@MODULE@",
 	moduleLibrary="@MODULES_BINARY_PATH@/@MODULE@", 
 	onlyModPkg=FALSE,
 	frameworkLibrary="@R_LIBRARY_PATH@")
-	
-print(result)
+
+jaspBasePath <- "@MODULES_BINARY_PATH@/@MODULE@/jaspBase"
+print(paste0("Was '", result, "' and will now remove jaspBase from module library at '", jaspBasePath , "' if it exists."))
+
+if(file.exists(jaspBasePath))
+	file.remove(jaspBasePath)
+
 
 if (result == "succes") {
 	cat(NULL, file="@MODULES_RENV_ROOT_PATH@/@MODULE@-installed-successfully.log")


### PR DESCRIPTION
This way bundled modules always use bundled jaspBase, to ensure this we add the main library first to .libPaths()

