### PR TITLE
Fixes for normalized notation

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
@@ -44,10 +44,9 @@ ScrollView
 			CheckBox
 			{
 				id:						useNormalizedNotation
-				label:					qsTr("Use normalized notation")
-				labelTextFormat:		Text.RichText
-				checked:				preferencesModel.normalizedNotation
-				onCheckedChanged:		preferencesModel.normalizedNotation = checked
+				label:					qsTr("Use exponent notation") //the default now is normalizedNotation. https://github.com/jasp-stats/INTERNAL-jasp/issues/1872
+				checked:				!preferencesModel.normalizedNotation
+				onCheckedChanged:		preferencesModel.normalizedNotation = !checked
 				KeyNavigation.tab:		fixDecs
 				KeyNavigation.down:		fixDecs
 			}

--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -21,9 +21,10 @@ $(document).ready(function () {
 
 	// Global settings for analysis output. Add here if making new setting.
 	window.globSet = {
-		"pExact" :		false,
-		"decimals":		"",
-		"tempFolder":	""
+		"pExact" :				false,
+		"decimals":				"",
+		"tempFolder":			"",
+		"normalizedNotation":	true
 	}
 
 	var selectedAnalysisId	= -1;

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -357,6 +357,8 @@ void MainWindow::makeConnections()
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_resultsJsInterface,	&ResultsJsInterface::setFontFamily							);
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_engineSync,			&EngineSync::refreshAllPlots								);
 	connect(_preferences,			&PreferencesModel::restartAllEngines,				_engineSync,			&EngineSync::haveYouTriedTurningItOffAndOnAgain				);
+	connect(_preferences,			&PreferencesModel::normalizedNotationChanged,		_resultsJsInterface,	&ResultsJsInterface::setNormalizedNotationHandler			);
+
 
 	connect(_filterModel,			&FilterModel::refreshAllAnalyses,					_analyses,				&Analyses::refreshAllAnalyses,								Qt::QueuedConnection);
 	connect(_filterModel,			&FilterModel::updateColumnsUsedInConstructedFilter, _package,				&DataSetPackage::setColumnsUsedInEasyFilter					);

--- a/Desktop/results/resultsjsinterface.h
+++ b/Desktop/results/resultsjsinterface.h
@@ -118,16 +118,16 @@ signals:
 
 
 public slots:
-	void setExactPValuesHandler(	bool			exact);
-	void setNormalizedNotationHandler(		bool			notation);
-	void setFixDecimalsHandler(		QString			numDecimals);
-	void analysisImageEditedHandler(Analysis	*	analysis);
-	void cancelImageEdit(			int				id);
-	void exportSelected(	const	QString		&	filename);
-	void setResultsPageUrl(			QString			resultsPageUrl);
+	void setExactPValuesHandler(		bool			exact);
+	void setNormalizedNotationHandler(	bool			notation);
+	void setFixDecimalsHandler(			QString			numDecimals);
+	void analysisImageEditedHandler(	Analysis	*	analysis);
+	void cancelImageEdit(				int				id);
+	void exportSelected(		const	QString		&	filename);
+	void setResultsPageUrl(				QString			resultsPageUrl);
 	void setZoomInWebEngine();
-	void setResultsLoaded(			bool			resultsLoaded);
-	void setScrollAtAll(			bool			scrollAtAll);
+	void setResultsLoaded(				bool			resultsLoaded);
+	void setScrollAtAll(				bool			scrollAtAll);
 	
 private:
 	void	setGlobalJsValues();

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -8,7 +8,7 @@ const char *	Settings::defaultMissingValues = "NaN|nan|.|NA";
 const Settings::Setting Settings::Values[] = {
 	{"numDecimals",					3},
 	{"exactPVals",					0},
-	{"normalizedNotation",			0},
+	{"normalizedNotation",			true},
 	{"dataAutoSynchronization",		1},
 	{"useDefaultSpreadsheetEditor",	1},
 	{"spreadsheetEditorName",		""},


### PR DESCRIPTION
- preferencesModel changes werent connect to results, this is fixed now. fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1872
- also renamed the checkbox to "Use exponent notation"
- made using normalized notation the default

