### PR TITLE
Userdefined label for missing values in data

### DIFF
--- a/Common/column.cpp
+++ b/Common/column.cpp
@@ -1011,31 +1011,31 @@ bool Column::isValueEqual(int row, const string &value)
 	return false;
 }
 
-string Column::_getScaleValue(int row)
+string Column::_getScaleValue(int row, bool forDisplay)
 {
 	double v = AsDoubles[row];
 
-	if (v > std::numeric_limits<double>::max())					return string({ (char)0xE2, (char)0x88, (char)0x9E, 0 });
-	else if (v < std::numeric_limits<double>::lowest())			return string({ (char)0x2D, (char)0xE2, (char)0x88, (char)0x9E, 0 });
-	else if (Utils::isEmptyValue(v))							return Utils::emptyValue;
+	if (v > std::numeric_limits<double>::max())					return "∞";
+	else if (v < std::numeric_limits<double>::lowest())			return "-∞";
+	else if (Utils::isEmptyValue(v))							return forDisplay ? Utils::emptyValue : "";
 	else														return Utils::doubleToString(v);
 }
 
 string Column::getOriginalValue(int row)
 {
-	string result = Utils::emptyValue;
+	string result = "";
 
 	if (row < _rowCount)
 	{
 		if (_columnType == columnType::scale)
 		{
-			result = _getScaleValue(row);
+			result = _getScaleValue(row, false);
 		}
 		else
 		{
 			int key = AsInts[row];
 			if (key == std::numeric_limits<int>::lowest())
-				result = Utils::emptyValue;
+				result = "";
 			else
 				result = _labels.getValueFromKey(key);
 		}
@@ -1053,7 +1053,7 @@ string Column::operator [](int row)
 	{
 		if (_columnType == columnType::scale)
 		{
-			result = _getScaleValue(row);
+			result = _getScaleValue(row, true);
 		}
 		else
 		{

--- a/Common/column.cpp
+++ b/Common/column.cpp
@@ -203,7 +203,7 @@ bool Column::_resetEmptyValuesForScale(std::map<int, string> &emptyValuesMap)
 				}
 				else
 				{
-					values.push_back(Utils::emptyValue);
+					values.push_back("");
 				}
 			}
 			else
@@ -309,7 +309,7 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 			}
 			else //if we couldnt find the "row" in the emptyValuesMap?
 			{
-				values.push_back(Utils::emptyValue);
+				values.push_back("");
 
 				if (canBeConvertedToIntegers)		intValues.push_back(std::numeric_limits<int>::lowest());
 				else if (canBeConvertedToDoubles)	doubleValues.push_back(NAN);
@@ -317,7 +317,7 @@ bool Column::_resetEmptyValuesForNominalText(std::map<int, string> &emptyValuesM
 		}
 		else if (key == std::numeric_limits<int>::lowest())
 		{
-			values.push_back(Utils::emptyValue);
+			values.push_back("");
 
 			if (canBeConvertedToIntegers)		intValues.push_back(std::numeric_limits<int>::lowest());
 			else if (canBeConvertedToDoubles)	doubleValues.push_back(NAN);
@@ -523,7 +523,7 @@ columnTypeChangeResult Column::_changeColumnToNominalOrOrdinal(enum columnType n
 			std::vector<string> values;
 
 			for (double doubleValue : AsDoubles)
-				if (std::isnan(doubleValue))	values.push_back(Utils::emptyValue);
+				if (std::isnan(doubleValue))	values.push_back("");
 				else							values.push_back(Utils::doubleToString(doubleValue));
 
 			setColumnAsNominalText(values);

--- a/Common/column.h
+++ b/Common/column.h
@@ -222,7 +222,7 @@ private:
 
 	void		_setRowCount(int rowCount);
 	std::string	_getLabelFromKey(int key) const;
-	std::string	_getScaleValue(int row);
+	std::string	_getScaleValue(int row, bool forDisplay);
 
 	void		_convertVectorIntToDouble(std::vector<int> &intValues, std::vector<double> &doubleValues);
 

--- a/Common/labels.cpp
+++ b/Common/labels.cpp
@@ -380,6 +380,7 @@ std::string Labels::getLabelFromRow(int row) const
 		return "";
 	}
 	const Label & label = _labels.at(row);
+
 	return label.text();
 }
 

--- a/Common/labels.cpp
+++ b/Common/labels.cpp
@@ -338,7 +338,7 @@ string Labels::_getOrgValueFromLabel(const Label &label) const
 	map<int, string> &orgStringValues	= getOrgStringValues();
 	map<int, string>::const_iterator it = orgStringValues.find(label.value());
 
-	if (it == orgStringValues.end())	return label.text();
+	if (it == orgStringValues.end())	return label.value() == std::numeric_limits<int>::lowest() ? "" : label.text(); //If missing value show nothing, not a label
 	else								return it->second;
 }
 
@@ -351,8 +351,8 @@ string Labels::getValueFromKey(int key) const
 	}
 	catch (const labelNotFound & e)
 	{
-		Log::log() << "Label not found, msg: " << e.what() << ", returning emptyValue\n";
-		return Utils::emptyValue;
+		Log::log() << "Label not found for getValueFromKey, msg: " << e.what() << ", returning emptyValue\n";
+		return "";
 	}
 }
 

--- a/Common/utils.cpp
+++ b/Common/utils.cpp
@@ -42,6 +42,14 @@ using namespace std;
 using namespace boost::posix_time;
 using namespace boost;
 
+///Internally the following actual missing values are used for scalar, ordinal/nominal and text:  NAN, std::numeric_limits<int>::lowest() and ""
+/// However, users might like to see something else hence we allow `emptyValue` to be changed through the settings.
+	  string			Utils::emptyValue					= "";
+const vector<string>	Utils::_defaultEmptyValues			= {"NaN", "nan", ".", "NA"};
+vector<double>			Utils::_currentDoubleEmptyValues	= {};
+vector<string>			Utils::_currentEmptyValues			= Utils::_defaultEmptyValues;
+
+
 Utils::FileType Utils::getTypeFromFileName(const std::string &path)
 {
 
@@ -229,11 +237,6 @@ void Utils::sleep(int ms)
 	nanosleep(&ts, NULL);
 #endif
 }
-
-const string			Utils::emptyValue					= "";
-const vector<string>	Utils::_defaultEmptyValues			= {"NaN", "nan", ".", "NA"};
-vector<double>			Utils::_currentDoubleEmptyValues	= {};
-vector<string>			Utils::_currentEmptyValues			= Utils::_defaultEmptyValues;
 
 void Utils::setEmptyValues(const vector<string> &emptyvalues)
 {

--- a/Common/utils.h
+++ b/Common/utils.h
@@ -52,7 +52,7 @@ public:
 	static void remove(std::vector<std::string> &target, const std::vector<std::string> &toRemove);
 	static void sleep(int ms);
 
-	static const std::string emptyValue;
+	static       std::string emptyValue;
 	static const std::vector<std::string>	& getEmptyValues()			{ return _currentEmptyValues;		}
 	static const std::vector<std::string>	& getDefaultEmptyValues()	{ return _defaultEmptyValues;		}
 	static const std::vector<double>		& getDoubleEmptyValues()	{ return _currentDoubleEmptyValues;	}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -164,13 +164,52 @@ ScrollView
 					onValueChanged:		preferencesModel.thresholdScale = value
 					visible:			preferencesModel.customThresholdScale
 
-					KeyNavigation.down:	missingFileList.firstComponent
-					KeyNavigation.tab:	missingFileList.firstComponent
+					KeyNavigation.down:	missingValueDataLabelInput
+					KeyNavigation.tab:	missingValueDataLabelInput
 					anchors
 					{
 						left:			customThreshold.right
 						leftMargin:		jaspTheme.generalAnchorMargin
 						verticalCenter:	parent.verticalCenter
+					}
+				}
+			}
+
+			Item
+			{
+				id:				missingValueDataLabelItem
+				height:			missingValueDataLabelInput.height
+				anchors
+				{
+					left:		parent.left
+					right:		parent.right
+					margins:	jaspTheme.generalAnchorMargin
+				}
+
+				Label
+				{
+					id:					missingValueDataLabelLabel
+					text:				qsTr("Show missing values as: ")
+
+					anchors
+					{
+						left:			parent.left
+						verticalCenter:	parent.verticalCenter
+					}
+				}
+
+				PrefsTextInput
+				{
+					id:				missingValueDataLabelInput
+
+					text:			preferencesModel.dataLabelNA
+					onTextChanged:	preferencesModel.dataLabelNA = text
+					nextEl:			missingFileList.firstComponent
+
+					anchors
+					{
+						left:		missingValueDataLabelLabel.right
+						right:		parent.right
 					}
 				}
 			}

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1183,7 +1183,7 @@ void DataSetPackage::writeDataSetToOStream(std::ostream & out, bool includeCompu
 			Column *column = cols[i];
 
 			std::string value = column->getOriginalValue(r);
-			if (value != ".")
+			if (value != "")
 			{
 				if (stringUtils::escapeValue(value))	out << '"' << value << '"';
 				else									out << value;

--- a/Desktop/data/importers/importcolumn.cpp
+++ b/Desktop/data/importers/importcolumn.cpp
@@ -63,7 +63,7 @@ bool ImportColumn::convertVecToDouble(const std::vector<std::string> &values, st
 		{
 			doubleValues.push_back(doubleValue);
 
-			if (std::isnan(doubleValue) && value != Utils::emptyValue)
+			if (std::isnan(doubleValue) && value != "")
 				emptyValuesMap.insert(std::make_pair(row, value));
 		}
 		else

--- a/Desktop/data/importers/readstat/readstatimportcolumn.cpp
+++ b/Desktop/data/importers/readstat/readstatimportcolumn.cpp
@@ -25,11 +25,11 @@ size_t ReadStatImportColumn::size() const
 
 std::string ReadStatImportColumn::valueAsString(size_t row) const
 {
-	if(row >= size())	return Utils::emptyValue;
+	if(row >= size())	return missingValueString();
 
 	switch(_type)
 	{
-	default:						return Utils::emptyValue;
+	default:						return missingValueString();
 	case columnType::scale:			return Utils::doubleToString(_doubles[row]);
 	case columnType::ordinal:		[[fallthrough]];
 	case columnType::nominal:		return std::to_string(_ints[row]);
@@ -432,12 +432,12 @@ void ReadStatImportColumn::addMissingValue()
 
 bool ReadStatImportColumn::isMissingValue(std::string s)
 {
-	return s == Utils::emptyValue;
+	return s == missingValueString();
 }
 
 std::string  ReadStatImportColumn::missingValueString()
 {
-	return Utils::emptyValue;
+	return "";
 }
 
 std::string ReadStatImportColumn::readstatValueToString(const readstat_value_t & value)

--- a/Desktop/gui/preferencesmodel.cpp
+++ b/Desktop/gui/preferencesmodel.cpp
@@ -38,10 +38,13 @@ PreferencesModel::PreferencesModel(QObject *parent) :
 
 	connect(this,					&PreferencesModel::safeGraphicsChanged,			this, &PreferencesModel::animationsOnChanged			); // So animationsOn *might* not be changed, but it  doesnt matter
 	connect(this,					&PreferencesModel::disableAnimationsChanged,	this, &PreferencesModel::animationsOnChanged			);
+	connect(this,					&PreferencesModel::dataLabelNAChanged,			this, &PreferencesModel::dataLabelNAChangedSlot			);
 
 	connect(LanguageModel::lang(),	&LanguageModel::currentLanguageChanged,			this, &PreferencesModel::languageCodeChanged			);
 
 	_loadDatabaseFont();
+
+	dataLabelNAChangedSlot(dataLabelNA());
 }
 
 void PreferencesModel::browseSpreadsheetEditor()
@@ -121,6 +124,7 @@ GET_PREF_FUNC_BOOL(	generateMarkdown,			Settings::GENERATE_MARKDOWN_HELP					)
 GET_PREF_FUNC_INT(	maxEnginesAdmin,            Settings::MAX_ENGINE_COUNT_ADMIN                    )
 GET_PREF_FUNC_BOOL( windowsNoBomNative,			Settings::WINDOWS_NO_BOM_NATIVE						)
 GET_PREF_FUNC_BOOL( dbShowWarning,				Settings::DB_SHOW_WARNING							)
+GET_PREF_FUNC_STR(  dataLabelNA,				Settings::DATA_LABEL_NA								)
 
 int PreferencesModel::maxEngines() const
 {
@@ -272,6 +276,7 @@ SET_PREF_FUNCTION(QString,	setResultFont,				resultFont,					resultFontChanged,	
 SET_PREF_FUNCTION(int,		setMaxEngines,				maxEngines,					maxEnginesChanged,				Settings::MAX_ENGINE_COUNT							)
 SET_PREF_FUNCTION(bool,		setWindowsNoBomNative,		windowsNoBomNative,			windowsNoBomNativeChanged,		Settings::WINDOWS_NO_BOM_NATIVE						)
 SET_PREF_FUNCTION(bool,		setDbShowWarning,			dbShowWarning,				dbShowWarningChanged,			Settings::DB_SHOW_WARNING							)
+SET_PREF_FUNCTION(QString,	setDataLabelNA,				dataLabelNA,				dataLabelNAChanged,				Settings::DATA_LABEL_NA								)
 
 void PreferencesModel::setGithubPatCustom(QString newPat)
 {
@@ -542,3 +547,10 @@ bool PreferencesModel::setLC_CTYPE_C() const
 	case winLcCtypeSetting::alwaysC:	return true;
 	}
 }
+
+
+void PreferencesModel::dataLabelNAChangedSlot(QString dataLabelNA)
+{
+	Utils::emptyValue = fq(dataLabelNA);
+}
+

--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -230,16 +230,12 @@ signals:
 	void maxEnginesChanged(				int			maxEngines);
 	void windowsNoBomNativeChanged(		bool		windowsNoBomNative);
 	void dbShowWarningChanged(			bool		dbShowWarning);
-<<<<<<< HEAD
 	void maxEnginesAdminChanged();
-
-=======
 	void dataLabelNAChanged(			QString		dataLabelNA);
 
 private slots:
 	void dataLabelNAChangedSlot(		QString		dataLabelNA);
 	
->>>>>>> 1b9e6fceb (Userdefined label for missing values in data)
 private:
 	static PreferencesModel * _singleton;
 

--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -63,6 +63,7 @@ class PreferencesModel : public QObject
 	Q_PROPERTY(int			maxEnginesAdmin			READ maxEnginesAdmin												NOTIFY maxEnginesAdminChanged			)
 	Q_PROPERTY(bool			windowsNoBomNative		READ windowsNoBomNative			WRITE setWindowsNoBomNative			NOTIFY windowsNoBomNativeChanged		)
 	Q_PROPERTY(bool			dbShowWarning			READ dbShowWarning				WRITE setDbShowWarning				NOTIFY dbShowWarningChanged				)
+	Q_PROPERTY(QString		dataLabelNA				READ dataLabelNA				WRITE setDataLabelNA				NOTIFY dataLabelNAChanged				)
 
 public:
 	static PreferencesModel * prefs() { return _singleton; }
@@ -120,6 +121,7 @@ public:
 	int			maxEngines()				const;
 	bool		windowsNoBomNative()		const;
 	bool		dbShowWarning()				const;
+	QString		dataLabelNA()				const;
 
 	void		zoomIn();
 	void		zoomOut();
@@ -179,6 +181,7 @@ public slots:
 	void setMaxEngines(					int			maxEngines);
 	void setWindowsNoBomNative(			bool		windowsNoBomNative);
 	void setDbShowWarning(				bool		dbShowWarning);
+	void setDataLabelNA(				QString		dataLabelNA);
 	
 	
 signals:
@@ -227,8 +230,16 @@ signals:
 	void maxEnginesChanged(				int			maxEngines);
 	void windowsNoBomNativeChanged(		bool		windowsNoBomNative);
 	void dbShowWarningChanged(			bool		dbShowWarning);
+<<<<<<< HEAD
 	void maxEnginesAdminChanged();
 
+=======
+	void dataLabelNAChanged(			QString		dataLabelNA);
+
+private slots:
+	void dataLabelNAChangedSlot(		QString		dataLabelNA);
+	
+>>>>>>> 1b9e6fceb (Userdefined label for missing values in data)
 private:
 	static PreferencesModel * _singleton;
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -345,6 +345,8 @@ void MainWindow::makeConnections()
 	connect(_loader,				&AsyncLoader::checkDoSync,							this,					&MainWindow::checkDoSync,									Qt::BlockingQueuedConnection);
 
 	connect(_preferences,			&PreferencesModel::missingValuesChanged,			_package,				&DataSetPackage::emptyValuesChangedHandler					);
+	connect(_preferences,			&PreferencesModel::dataLabelNAChanged,				_package,				&DataSetPackage::refresh,									Qt::QueuedConnection);
+
 	connect(_preferences,			&PreferencesModel::plotBackgroundChanged,			this,					&MainWindow::setImageBackgroundHandler						);
 	connect(_preferences,			&PreferencesModel::plotPPIChanged,					this,					&MainWindow::plotPPIChangedHandler							);
 	connect(_preferences,			&PreferencesModel::dataAutoSynchronizationChanged,	_fileMenu,				&FileMenu::dataAutoSynchronizationChanged					);

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -74,7 +74,8 @@ const Settings::Setting Settings::Values[] = {
 	{"dbImportQuery",				""		},
 	{"dbImportInterval",			0		},
 	{"dbShowWarning",				true	},
-	{"dbRememberMe",				false	}
+	{"dbRememberMe",				false	},
+	{"dataNALabel",					""		}
 	
 };	
 

--- a/Desktop/utilities/settings.h
+++ b/Desktop/utilities/settings.h
@@ -70,7 +70,7 @@ public:
 		DB_IMPORT_INTERVAL,
 		DB_SHOW_WARNING,
 		DB_REMEMBER_ME,
-		REPORT_SHOW
+		DATA_LABEL_NA
 	};
 
 	static QVariant value(Settings::Type key);


### PR DESCRIPTION
Implements https://github.com/jasp-stats/jasp-issues/issues/1708

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/29062713/185442301-57f1b087-c462-4d7b-b319-98f3dd81ffaa.png">

From JASP with love:
<img width="565" alt="image" src="https://user-images.githubusercontent.com/29062713/185442696-850dd716-56f5-4f6c-85bd-3c659ab14dfa.png">

<img width="959" alt="image" src="https://user-images.githubusercontent.com/29062713/185442909-a09fabcb-438c-4fa7-9947-b5dcb81af616.png">

Haha, I like this feature + unicode support, such a colorful data view ^^

