### PR TITLE
Integer Field shows wrong error

### DIFF
--- a/Desktop/analysis/jaspcontrol.cpp
+++ b/Desktop/analysis/jaspcontrol.cpp
@@ -246,6 +246,18 @@ void JASPControl::componentComplete()
 
 	if (_form)
 		connect(this, &JASPControl::boundValueChanged, _form, &AnalysisForm::boundValueChangedHandler);
+
+	if (_innerControl)
+	{
+		// Needed when the QML file has wrong default value
+		QVariant acceptableInput = _innerControl->property("acceptableInput");
+		if (acceptableInput.isValid() && !acceptableInput.toBool())
+		{
+			setHasError(true);
+			_setFocusBorder();
+		}
+	}
+
 }
 
 void JASPControl::setCursorShape(int shape)
@@ -384,7 +396,8 @@ void JASPControl::_setFocusBorder()
 
 		if (!qFuzzyCompare(border->property("width").toFloat(), borderWidth))
 		{
-			if (qFuzzyCompare(borderWidth, _defaultBorderWidth)) {
+			if (!_form || !_form->initialized() || qFuzzyCompare(borderWidth, _defaultBorderWidth))
+			{
 				_borderAnimation.stop();
 				border->setProperty("width", borderWidth); // No animation when coming back to normal.
 			}

--- a/Desktop/components/JASP/Controls/TextField.qml
+++ b/Desktop/components/JASP/Controls/TextField.qml
@@ -55,8 +55,8 @@ TextInputBase
 
 	signal editingFinished()
 	signal textEdited()
-	signal pressed()
-	signal released()
+	signal pressed(var event)
+	signal released(var event)
 
 	function doEditingFinished()
 	{
@@ -128,8 +128,7 @@ TextInputBase
 			height:				parent.height + jaspTheme.jaspControlHighlightWidth
 			width:				parent.width  + jaspTheme.jaspControlHighlightWidth
 			color:				"transparent"
-			border.width:		control.acceptableInput ? 0 : 3 //See comment below
-			border.color:		jaspTheme.red // Needed when the QML file has wrong default value
+			border.width:		0
 			anchors.centerIn:	parent
 			opacity:			debug ? .3 : 1
 			visible:			textField.useExternalBorder

--- a/Desktop/components/JASP/Controls/TextField.qml
+++ b/Desktop/components/JASP/Controls/TextField.qml
@@ -128,7 +128,7 @@ TextInputBase
 			height:				parent.height + jaspTheme.jaspControlHighlightWidth
 			width:				parent.width  + jaspTheme.jaspControlHighlightWidth
 			color:				"transparent"
-			border.width:		0
+			border.width:		0		//Changed from JASPControl::_setFocusBorder() (like border.color)
 			anchors.centerIn:	parent
 			opacity:			debug ? .3 : 1
 			visible:			textField.useExternalBorder


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2076

When an IntegerField (or a DoubleFiled) has a constraint (min or max for example), the control may show sometimes a red border as if it has wrong value, even if the value is OK.
This is due to a wrong fix made some time ago that activates this red border for controls that have wrong default value. This was done by assigning a width and a color to the focus indicator when the control was still initializing. This is wrong since the control gets then wrong default values for its width and color border.
The check whether the control has wrong default value must be done just after it is initialized.

