### PR TITLE
Increase the stack size on windows

### DIFF
--- a/Desktop/utilities/appdirs.cpp
+++ b/Desktop/utilities/appdirs.cpp
@@ -197,7 +197,7 @@ QString AppDirs::renvCacheLocations()
 	QDir(renvRootLocation()).mkpath(renvCacheName); //create it if missing
 	
 	QString dynamicCache = renvRootLocation() + "/" + renvCacheName,
-			staticCache  = processPath(programDir().absoluteFilePath("renv-cache"));
+			staticCache  = processPath(programDir().absoluteFilePath("Modules/renv-cache"));
 	
 	const QChar separator =
 #ifdef WIN32

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -94,6 +94,9 @@ if(WINDOWS)
 
   target_link_libraries(JASPEngine PUBLIC ole32 oleaut32)
 
+  # increase the stack size so that recursive calls in renv when installing jasp modules do not cause stack overflows, see https://github.com/jasp-stats/INTERNAL-jasp/issues/2072
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:48000000")
+
   # These are mainly for R-Interface, and all build using the MinGW
   add_custom_command(
     TARGET JASPEngine

--- a/R-Interface/CMakeLists.txt
+++ b/R-Interface/CMakeLists.txt
@@ -117,10 +117,10 @@ if(WIN32)
     message(FATAL_ERROR "libRInside is required for building ")
   endif()
 
-  message(CHECK_START "Checking for 'libjsoncpp-24.dll'")
+  message(CHECK_START "Checking for 'libjsoncpp-25.dll'")
   find_file(
     RTOOLS_LIB_JSONCPP_DLL
-    NAMES libjsoncpp-24.dll
+    NAMES libjsoncpp-25.dll
     PATHS ${RTOOLS_PATH}/bin REQUIRED
     NO_DEFAULT_PATH)
 
@@ -129,7 +129,7 @@ if(WIN32)
     message(STATUS "  ${RTOOLS_LIB_JSONCPP_DLL}")
   else()
     message(CHECK_FAIL "not found in ${RTOOLS_PATH}/bin")
-    message(FATAL_ERROR "libjsoncpp-24.dll is required for building. If it is missing, you need to install it in your rtools42 ucrt64 environment using `pacman -Syu mingw-w64-ucrt-x86_64-jsoncpp`.")
+    message(FATAL_ERROR "libjsoncpp-25.dll is required for building. If it is missing, you need to install it in your rtools42 ucrt64 environment using `pacman -Syu mingw-w64-ucrt-x86_64-jsoncpp`.")
   endif()
 
   add_library(R-Interface SHARED ${SOURCE_FILES} ${HEADER_FILES})


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2072

I also bumped the expected version of libjsoncpp, otherwise we should add instructions to install an older version.

48000000 = 4MB btw. An R session started through a terminal has ~8MB, while inside RStudio an R session has ~1.875MB. 