### PR TITLE
Zoom on auxiliary windows and build fixes

### DIFF
--- a/Common/ipcchannel.h
+++ b/Common/ipcchannel.h
@@ -66,7 +66,7 @@ public:
 
 private:
 	bool tryWait(int timeout = 0);
-    void catchAndRepeat(const std::string & taskDescription, std::function<void()> doThis);
+	void catchAndRepeat(const std::string & taskDescription, std::function<void()> doThis);
 
 	void doubleMemoryOut();
 	void rebindMemoryInIfSizeChanged();

--- a/Common/ipcchannel.h
+++ b/Common/ipcchannel.h
@@ -36,6 +36,7 @@
 
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/container/string.hpp>
+#include <functional>
 
 typedef boost::interprocess::allocator<char,	boost::interprocess::managed_shared_memory::segment_manager	> CharAllocator;
 typedef boost::container::basic_string<char,	std::char_traits<char>, CharAllocator						> String;
@@ -65,7 +66,7 @@ public:
 
 private:
 	bool tryWait(int timeout = 0);
-	void catchAndRepeat(const std::string & taskDescription, std::function<void()> doThis);
+    void catchAndRepeat(const std::string & taskDescription, std::function<void()> doThis);
 
 	void doubleMemoryOut();
 	void rebindMemoryInIfSizeChanged();

--- a/Desktop/components/JASP/Widgets/HelpWindow.qml
+++ b/Desktop/components/JASP/Widgets/HelpWindow.qml
@@ -8,7 +8,7 @@ Window
 {
 	id:					helpWindowRoot
 	width:				400 * preferencesModel.uiScale
-    height:				Math.min(700 * preferencesModel.uiScale, Screen.desktopAvailableHeight * 0.8)
+	height:				Math.min(700 * preferencesModel.uiScale, Screen.desktopAvailableHeight * 0.8)
 	minimumWidth:		200 * preferencesModel.uiScale
 	minimumHeight:		minimumWidth
 	visible:			helpModel.visible
@@ -16,9 +16,9 @@ Window
 	title:				qsTr("JASP Help")
 	color:				jaspTheme.uiBackground
 
-	Shortcut { onActivated: helpWindowRoot.close();				sequences: ["Ctrl+W", Qt.Key_Close];					}
-	Shortcut { onActivated: helpWindowRoot.toggleFullScreen();	sequences: ["Ctrl+M"];											}
-	Shortcut { onActivated: searchBar.startSearching();			sequences: ["Ctrl+F", Qt.Key_Search];							}
+	Shortcut { onActivated: helpWindowRoot.close();				sequences: ["Ctrl+W", Qt.Key_Close];			}
+	Shortcut { onActivated: helpWindowRoot.toggleFullScreen();	sequences: ["Ctrl+M"];							}
+	Shortcut { onActivated: searchBar.startSearching();			sequences: ["Ctrl+F", Qt.Key_Search];			}
 
 
 	Connections

--- a/Desktop/components/JASP/Widgets/HelpWindow.qml
+++ b/Desktop/components/JASP/Widgets/HelpWindow.qml
@@ -8,7 +8,7 @@ Window
 {
 	id:					helpWindowRoot
 	width:				400 * preferencesModel.uiScale
-	height:				Math.min(700 * preferencesModel.uiScale, Screen.desktopAvailableHeight * 0.8)
+	height:				Math.min(700 * preferencesModel.uiScale, Screen.desktopAvailableHeight) //If bigger than screenheight weird jumping behaviour observed by Rens
 	minimumWidth:		200 * preferencesModel.uiScale
 	minimumHeight:		minimumWidth
 	visible:			helpModel.visible

--- a/Desktop/components/JASP/Widgets/HelpWindow.qml
+++ b/Desktop/components/JASP/Widgets/HelpWindow.qml
@@ -7,8 +7,8 @@ import JASP.Controls	1.0
 Window
 {
 	id:					helpWindowRoot
-	width:				400
-	height:				700
+	width:				400 * preferencesModel.uiScale
+    height:				Math.min(700 * preferencesModel.uiScale, Screen.desktopAvailableHeight * 0.8)
 	minimumWidth:		200 * preferencesModel.uiScale
 	minimumHeight:		minimumWidth
 	visible:			helpModel.visible
@@ -16,10 +16,7 @@ Window
 	title:				qsTr("JASP Help")
 	color:				jaspTheme.uiBackground
 
-	Shortcut { onActivated: mainWindow.zoomInKeyPressed();		sequences: [Qt.Key_ZoomIn, "Ctrl+Plus", "Ctrl+\+", "Ctrl+\="];	}
-	Shortcut { onActivated: mainWindow.zoomOutKeyPressed();		sequences: [Qt.Key_ZoomOut, "Ctrl+Minus", "Ctrl+\-"];			}
-	Shortcut { onActivated: mainWindow.zoomResetKeyPressed();	sequences: ["Ctrl+0"];											}
-	Shortcut { onActivated: helpWindowRoot.close();				sequences: ["Ctrl+Q", "Ctrl+W", Qt.Key_Close];					}
+	Shortcut { onActivated: helpWindowRoot.close();				sequences: ["Ctrl+W", Qt.Key_Close];					}
 	Shortcut { onActivated: helpWindowRoot.toggleFullScreen();	sequences: ["Ctrl+M"];											}
 	Shortcut { onActivated: searchBar.startSearching();			sequences: ["Ctrl+F", Qt.Key_Search];							}
 

--- a/QMLComponents/CMakeLists.txt
+++ b/QMLComponents/CMakeLists.txt
@@ -29,6 +29,7 @@ target_include_directories(
 target_link_libraries(
   QMLComponents
   PUBLIC
+         Common
          Qt::Core
          Qt::Gui
          Qt::Widgets


### PR DESCRIPTION
Fixes a build error due to missing include
Fixes a linker error on Linux.

Fixes zoom on R-command and Help-windows.
Scales Help-window when zooming to keep text readable.
Makes CTRL-Q close the application on these windows. 