### PR TITLE
Hardset libpaths before running analysis

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -621,6 +621,7 @@ Json::Value Analysis::createAnalysisRequestJson()
 	json["rfile"]				= _moduleData == nullptr ? rfile() : "";
 	json["dynamicModuleCall"]	= _moduleData == nullptr ? "" : _moduleData->getFullRCall();
 	json["resultsFont"]			= PreferencesModel::prefs()->resultFont().toStdString();
+	json["libPathsToUse"]		= _moduleData ? _moduleData->dynamicModule()->getLibPathsToUse() : ""; //temporary hack for fixing https://github.com/jasp-stats/jasp-test-release/issues/1953 and the like. can be removed once new dynamic moudles stuff is merged from development
 
 	if (!isAborted())
 	{

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -524,6 +524,7 @@ void Engine::receiveAnalysisMessage(const Json::Value & jsonRequest)
 		_imageOptions			= jsonRequest.get("image",				Json::nullValue);
 		_analysisRFile			= jsonRequest.get("rfile",				"").asString();
 		_dynamicModuleCall		= jsonRequest.get("dynamicModuleCall",	"").asString();
+		_libPathsToUse			= jsonRequest.get("libPathsToUse",		"").asString();
 		_resultsFont			= jsonRequest.get("resultsFont",		"").asString();
 		_engineState			= engineState::analysis;
 
@@ -586,7 +587,7 @@ void Engine::runAnalysis()
 
 	Log::log() << "Analysis will be run now." << std::endl;
 
-	_analysisResultsString = rbridge_runModuleCall(_analysisName, _analysisTitle, _dynamicModuleCall, _analysisDataKey, _analysisOptions, _analysisStateKey, _ppi, _analysisId, _analysisRevision, _imageBackground, _developerMode, _resultsFont);
+	_analysisResultsString = rbridge_runModuleCall(_analysisName, _analysisTitle, _dynamicModuleCall, _analysisDataKey, _analysisOptions, _analysisStateKey, _ppi, _analysisId, _analysisRevision, _imageBackground, _developerMode, _resultsFont, _libPathsToUse);
 
 	switch(_analysisStatus)
 	{

--- a/Engine/engine.h
+++ b/Engine/engine.h
@@ -136,6 +136,7 @@ private: // Data:
 						_imageBackground	= "white",
 						_analysisRFile		= "",
 						_dynamicModuleCall	= "",
+						_libPathsToUse		= "", //temp hack
 						_langR				= "en";
 
 	Json::Value			_imageOptions,

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -290,13 +290,13 @@ extern "C" bool STDCALL rbridge_runCallback(const char* in, int progress, const 
 	return true;
 }
 
-std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont)
+std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont, const std::string & libPathsToUse)
 {
 	rbridge_callback	= NULL; //Only jaspResults here so callback is not needed
 	if (rbridge_dataSet != nullptr)
 		rbridge_dataSet		= rbridge_dataSetSource();
 
-	return jaspRCPP_runModuleCall(name.c_str(), title.c_str(), moduleCall.c_str(), dataKey.c_str(), options.c_str(), stateKey.c_str(), ppi, analysisID, analysisRevision, imageBackground.c_str(), developerMode, resultsFont.c_str());
+	return jaspRCPP_runModuleCall(name.c_str(), title.c_str(), moduleCall.c_str(), dataKey.c_str(), options.c_str(), stateKey.c_str(), ppi, analysisID, analysisRevision, imageBackground.c_str(), developerMode, resultsFont.c_str(), libPathsToUse.c_str());
 }
 
 extern "C" RBridgeColumn* STDCALL rbridge_readFullDataSet(size_t * colMax)

--- a/Engine/rbridge.h
+++ b/Engine/rbridge.h
@@ -88,7 +88,7 @@ extern "C" {
 	void rbridge_setDataSetSource(			boost::function<DataSet *()> source);
 	void rbridge_memoryCleaning();
 
-	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont);
+	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont, const std::string & libPathsToUse);
 
 	void rbridge_setColumnFunctionSources(			boost::function<int (const std::string &)																		> getTypeSource,
 													boost::function<bool(const std::string &, const std::vector<double>&)											> scaleSource,

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -244,7 +244,7 @@ void _setJaspResultsInfo(int analysisID, int analysisRevision, bool developerMod
 	jaspRCPP_parseEvalQNT("jaspBase:::setWriteSealLocation(\"" + root + "\", \"" + relativePath + "\");");
 }
 
-const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont)
+const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont, const char * libPathsToUse)
 {
 	RInside &rInside			= rinside->instance();
 
@@ -261,6 +261,11 @@ const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, 
 	rInside[".resultsFont"]		= resultsFont;
 
 	_setJaspResultsInfo(analysisID, analysisRevision, developerMode);
+
+	std::string libP = libPathsToUse;
+
+	if(libP != "")
+		jaspRCPP_parseEvalQNT(".libPaths(" + libP + ");");
 
 	SEXP results = jaspRCPP_parseEval("jaspBase::runJaspResults(name=name, title=title, dataKey=dataKey, options=options, stateKey=stateKey, functionCall=moduleCall)", true);
 

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -124,7 +124,7 @@ typedef size_t			(*logWriteDef)			(const void * buf, size_t len);
 // Calls from rbridge to jaspRCPP
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,	EnDecodeDef nativeToUtf8);
 
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont);
+RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont, const char * libPathsToUse);
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_saveImage(const char *data, const char *type, const int height, const int width, const int ppi, const char* imageBackground);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_editImage(const char *name, const char *optionsJson, const int ppi, const char* imageBackground, int analysisID);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1953 and possibly others

This fix can be removed once current `development` is `stable`

