### PR TITLE
Make sure we use UTF-8 support from R 4.2.1 on windows

### DIFF
--- a/Common/dirs.cpp
+++ b/Common/dirs.cpp
@@ -60,11 +60,12 @@ string Dirs::tempDir()
 	boost::filesystem::path pa;
 
 #ifdef _WIN32
-	char buffer[MAX_PATH];
-	if ( ! SUCCEEDED(SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, buffer)))
+    wchar_t buffer[MAX_PATH];
+    if ( ! SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, buffer)))
 		throw Exception("App Data directory could not be retrieved");
 
-	dir = std::string(buffer);
+    dir = Utils::wstringToString(buffer);
+
 	dir += "/JASP/temp";
 
 	pa = (dir);

--- a/Common/dirs.cpp
+++ b/Common/dirs.cpp
@@ -60,11 +60,11 @@ string Dirs::tempDir()
 	boost::filesystem::path pa;
 
 #ifdef _WIN32
-    wchar_t buffer[MAX_PATH];
-    if ( ! SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, buffer)))
+	wchar_t buffer[MAX_PATH];
+	if ( ! SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, buffer)))
 		throw Exception("App Data directory could not be retrieved");
 
-    dir = Utils::wstringToString(buffer);
+	dir = Utils::wstringToString(buffer);
 
 	dir += "/JASP/temp";
 
@@ -179,8 +179,8 @@ string Dirs::exeDir()
 	}
 #else
 
-    char buf[512];
-    char linkname[512]; /* /proc/<pid>/exe */
+	char buf[512];
+	char linkname[512]; /* /proc/<pid>/exe */
 	pid_t pid;
 	int ret;
 
@@ -202,13 +202,13 @@ string Dirs::exeDir()
 	//std::cout << "looking for exeDir in buff: '" << buf << "'\n" << std::flush;
 
 	for (int i = ret-1; i > 0; i--)
-    {
-        if (buf[i] == '/')
-        {
-            buf[i] = '\0'; // add null terminator
-            break;
-        }
-    }
+	{
+		if (buf[i] == '/')
+		{
+			buf[i] = '\0'; // add null terminator
+			break;
+		}
+	}
 
 	std::string exe = string(buf);
 

--- a/Common/enginedefinitions.h
+++ b/Common/enginedefinitions.h
@@ -13,7 +13,6 @@ DECLARE_ENUM(performType,			run, abort, saveImg, editImg, rewriteImgs);
 DECLARE_ENUM(analysisResultStatus,	validationError, fatalError, imageSaved, imageEdited, imagesRewritten, complete, running, changed, waiting);
 DECLARE_ENUM(moduleStatus,			initializing, installNeeded, installModPkgNeeded, loadingNeeded, unloadingNeeded, readyForUse, error);
 DECLARE_ENUM(engineAnalysisStatus,	empty, toRun, running, changed, complete, error, exception, aborted, stopped, saveImg, editImg, rewriteImgs, synchingData);
-DECLARE_ENUM(winLcCtypeSetting,		check, alwaysC, neverC);
 
 struct unexpectedEngineReply  : public std::runtime_error
 {

--- a/Common/utils.cpp
+++ b/Common/utils.cpp
@@ -124,11 +124,11 @@ long Utils::getFileModificationTime(const std::string &filename)
 	return modificationTime;
 
 #else
-    struct stat attrib;
-    stat(filename.c_str(), &attrib);
-    time_t modificationTime = attrib.st_mtim.tv_sec;
+	struct stat attrib;
+	stat(filename.c_str(), &attrib);
+	time_t modificationTime = attrib.st_mtim.tv_sec;
 
-    return modificationTime;
+	return modificationTime;
 #endif
 }
 
@@ -231,7 +231,7 @@ void Utils::sleep(int ms)
 {
 
 #ifdef _WIN32
-    Sleep(DWORD(ms));
+	Sleep(DWORD(ms));
 #else
 	struct timespec ts = { ms / 1000, (ms % 1000) * 1000 * 1000 };
 	nanosleep(&ts, NULL);
@@ -445,45 +445,45 @@ std::wstring Utils::getShortPathWin(const std::wstring & longPath)
 {
 	//See: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getshortpathnamew
 	long     length = 0;
-    TCHAR*   buffer = NULL;
+	TCHAR*   buffer = NULL;
 
 // First obtain the size needed by passing NULL and 0.
 
-    length = GetShortPathName(longPath.c_str(), NULL, 0);
-    if (length == 0) 
+	length = GetShortPathName(longPath.c_str(), NULL, 0);
+	if (length == 0) 
 		return longPath;
 
 // Dynamically allocate the correct size 
 // (terminating null char was included in length)
 
-    buffer = new TCHAR[length];
+	buffer = new TCHAR[length];
 
 // Now simply call again using same long path.
 
-    length = GetShortPathName(longPath.c_str(), buffer, length);
-    if (length == 0)
+	length = GetShortPathName(longPath.c_str(), buffer, length);
+	if (length == 0)
 		return longPath;
 
 	std::wstring shortPath(buffer, length);
-    
-    delete [] buffer;
 	
-    return shortPath;
+	delete [] buffer;
+	
+	return shortPath;
 }
 
 string Utils::wstringToString(const std::wstring & wstr)
 {
-    std::string str;
+	std::string str;
 
-    //get size of buffer we need
-    int requiredSize = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, NULL, 0, NULL, NULL );
-    str.resize(requiredSize);
+	//get size of buffer we need
+	int requiredSize = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, NULL, 0, NULL, NULL );
+	str.resize(requiredSize);
 
-    //convert it
-    WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, str.data(), str.size(), NULL, NULL );
-    str.resize(requiredSize-1);//drop /nul
+	//convert it
+	WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, str.data(), str.size(), NULL, NULL );
+	str.resize(requiredSize-1);//drop /nul
 
-    return str;
+	return str;
 
 }
 #endif

--- a/Common/utils.cpp
+++ b/Common/utils.cpp
@@ -468,6 +468,22 @@ std::wstring Utils::getShortPathWin(const std::wstring & longPath)
     
     delete [] buffer;
 	
-	return shortPath;	 
+    return shortPath;
+}
+
+string Utils::wstringToString(const std::wstring & wstr)
+{
+    std::string str;
+
+    //get size of buffer we need
+    int requiredSize = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, NULL, 0, NULL, NULL );
+    str.resize(requiredSize);
+
+    //convert it
+    WideCharToMultiByte(CP_UTF8, 0, wstr.data(), -1, str.data(), str.size(), NULL, NULL );
+    str.resize(requiredSize-1);//drop /nul
+
+    return str;
+
 }
 #endif

--- a/Common/utils.h
+++ b/Common/utils.h
@@ -47,7 +47,7 @@ public:
 	static bool removeFile(				const std::string &path);
 
 	static boost::filesystem::path osPath(const std::string &path);
-    static std::string osPath(const boost::filesystem::path &path);
+	static std::string osPath(const boost::filesystem::path &path);
 
 	static void remove(std::vector<std::string> &target, const std::vector<std::string> &toRemove);
 	static void sleep(int ms);
@@ -76,7 +76,7 @@ public:
 
 #ifdef _WIN32
 	static std::wstring	getShortPathWin(const std::wstring & path);
-    static std::string  wstringToString(const std::wstring & wstr);
+	static std::string  wstringToString(const std::wstring & wstr);
 #endif
 	
 private:

--- a/Common/utils.h
+++ b/Common/utils.h
@@ -76,6 +76,7 @@ public:
 
 #ifdef _WIN32
 	static std::wstring	getShortPathWin(const std::wstring & path);
+    static std::string  wstringToString(const std::wstring & wstr);
 #endif
 	
 private:

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -204,60 +204,10 @@ ScrollView
 				toolTip:			qsTr("This will erase the 'renv' and 'Modules' folders in the appdata.")
 				onClicked:			mainWindow.clearModulesFoldersUser();
 
-				KeyNavigation.tab:		checkForLC_CTYPE_C
+				KeyNavigation.tab:		logToFile
 			}
 		}
 		
-		PrefsGroupRect
-		{
-			id:			windowsSpecific
-			visible:	WINDOWS
-			enabled:	WINDOWS
-			title:		qsTr("Windows workarounds")
-			
-			RadioButtonGroup
-			{
-				title:	qsTr("Handling LC_CTYPE");
-			
-				RadioButton
-				{
-					id:					checkForLC_CTYPE_C
-					label:				qsTr("Let JASP guess the best setting for LC_CTYPE (recommended!)")		
-					toolTip:			qsTr("Check the install and user directory path for compatibility with LC_CTYPE=\"C\" and set if reasonable.")
-					checked:			preferencesModel.lcCtypeWin == 0
-					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 0
-
-					KeyNavigation.tab:		alwaysSetLC_CTYPE_C
-				}
-				
-				RadioButton
-				{
-					id:					alwaysSetLC_CTYPE_C
-					label:				qsTr("Always set LC_CTYPE to \"C\"")		
-					toolTip:			qsTr("See the documentation for more info.")
-					info:				qsTr("If this is enabled and you have non-ascii characters in your install path JASP won't work anymore.  If you only have non-ascii characters in your username then installing modules will probably break.")
-					checked:			preferencesModel.lcCtypeWin == 1
-					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 1
-
-					KeyNavigation.tab:		neverSetLC_CTYPE_C
-				}
-				
-				RadioButton
-				{
-					id:					neverSetLC_CTYPE_C
-					label:				qsTr("Keep LC_CTYPE at system default")		
-					toolTip:			qsTr("See the documentation for more info.")
-					info:				qsTr("Enabling this will make certain characters in the results look weird, but at least you can use JASP if you installed it in a folder with non-ascii characters in the path. Sorry for the inconvenience, we are working on it and hopefully have this fixed next release.")
-					checked:			preferencesModel.lcCtypeWin == 2
-					onCheckedChanged:	if(checked) preferencesModel.lcCtypeWin = 2
-
-					KeyNavigation.tab:		logToFile
-				}
-			}
-			
-			
-		}
-
 		PrefsGroupRect
 		{
 			id:		loggingGroup

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -500,7 +500,7 @@ void EngineSync::fixPATHForWindows(QProcessEnvironment & env)
 
 	Log::log() << "Windows PATH was changed to: '" << env.value("PATH", "???") << "'" << std::endl;
 }
-#endif
+#endif 
 
 //Should this function go to EngineRepresentation?
 QProcess * EngineSync::startSlaveProcess(int channel)
@@ -508,7 +508,7 @@ QProcess * EngineSync::startSlaveProcess(int channel)
 	JASPTIMER_SCOPE(EngineSync::startSlaveProcess);
 	QDir programDir			= AppDirs::programDir();
 	QString engineExe		= programDir.absoluteFilePath("JASPEngine");
-	QProcessEnvironment env = ProcessHelper::getProcessEnvironmentForJaspEngine(true, PreferencesModel::prefs()->setLC_CTYPE_C());
+	QProcessEnvironment env = ProcessHelper::getProcessEnvironmentForJaspEngine(PreferencesModel::prefs()->setLC_CTYPE_C());
 	
 #ifdef _WIN32 
 	fixPATHForWindows(env);

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -508,7 +508,7 @@ QProcess * EngineSync::startSlaveProcess(int channel)
 	JASPTIMER_SCOPE(EngineSync::startSlaveProcess);
 	QDir programDir			= AppDirs::programDir();
 	QString engineExe		= programDir.absoluteFilePath("JASPEngine");
-	QProcessEnvironment env = ProcessHelper::getProcessEnvironmentForJaspEngine(PreferencesModel::prefs()->setLC_CTYPE_C());
+	QProcessEnvironment env = ProcessHelper::getProcessEnvironmentForJaspEngine();
 	
 #ifdef _WIN32 
 	fixPATHForWindows(env);

--- a/Desktop/gui/preferencesmodel.cpp
+++ b/Desktop/gui/preferencesmodel.cpp
@@ -517,42 +517,6 @@ void PreferencesModel::resetRememberedModules(bool setToRemember)
 	setModulesRemembered(!setToRemember ? QStringList({}) : RibbonModel::singleton()->getModulesEnabled());
 }
 
-void PreferencesModel::setLcCtypeWin(int lcCtypeWin)
-{
-	winLcCtypeSetting	current = Settings::getWinLcCtypeSetting(),
-						newSet	= winLcCtypeSetting(lcCtypeWin);
-	
-	if(current != newSet)
-	{
-		Settings::setValue(Settings::LC_CTYPE_C_WIN, winLcCtypeSettingToQString(newSet));
-		
-		emit lcCtypeChanged();
-		emit restartAllEngines();
-	}
-}
-
-int PreferencesModel::lcCtypeWin() const
-{
-	winLcCtypeSetting	current = Settings::getWinLcCtypeSetting();
-	
-	return static_cast<int>(current);
-}
-
-bool PreferencesModel::setLC_CTYPE_C() const
-{
-#ifndef _WIN32
-	//throw std::runtime_error("PreferencesModel::setLC_CTYPE_C() should only be used on Windows.");
-	return false; //The result is interpreted as "force LC_CTYPE to C". I guess the "neverC" enum is also a bit misleading then... But all of this can be thrown away once utf-8 is supported on win.
-#endif
-	
-	switch(Settings::getWinLcCtypeSetting())
-	{
-	case winLcCtypeSetting::check:		return pathIsSafeForR(AppDirs::rHome());
-	case winLcCtypeSetting::neverC:		return false;
-	case winLcCtypeSetting::alwaysC:	return true;
-	}
-}
-
 void PreferencesModel::dataLabelNAChangedSlot(QString dataLabelNA)
 {
 	Utils::emptyValue = fq(dataLabelNA);

--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -48,7 +48,6 @@ class PreferencesModel : public QObject
 	Q_PROPERTY(bool			useNativeFileDialog		READ useNativeFileDialog		WRITE setUseNativeFileDialog		NOTIFY useNativeFileDialogChanged		)
 	Q_PROPERTY(bool			disableAnimations		READ disableAnimations			WRITE setDisableAnimations			NOTIFY disableAnimationsChanged			)
 	Q_PROPERTY(bool			generateMarkdown		READ generateMarkdown			WRITE setGenerateMarkdown			NOTIFY generateMarkdownChanged			)
-	Q_PROPERTY(int			lcCtypeWin				READ lcCtypeWin					WRITE setLcCtypeWin					NOTIFY lcCtypeChanged					)
 	Q_PROPERTY(QStringList	missingValues			READ missingValues													NOTIFY missingValuesChanged				)
 	Q_PROPERTY(int			plotPPI					READ plotPPI														NOTIFY plotPPIPropChanged				)
 	Q_PROPERTY(bool			animationsOn			READ animationsOn													NOTIFY animationsOnChanged				)
@@ -117,8 +116,6 @@ public:
 	QString		defaultResultFont()			const;
 	QString		defaultInterfaceFont()		const;
 	QString		defaultCodeFont()			const;
-	bool		setLC_CTYPE_C()				const;
-	int			lcCtypeWin()				const;
 	int			maxEngines()				const;
 	bool		windowsNoBomNative()		const;
 	bool		dbShowWarning()				const;
@@ -180,7 +177,6 @@ public slots:
 	void setGenerateMarkdown(			bool		generateMarkdown);
 	void onCurrentThemeNameChanged(		QString		newThemeName);
 	void resetRememberedModules(		bool		clear);
-	void setLcCtypeWin(					int			lcCtypeWin);
 	void setMaxEngines(					int			maxEngines);
 	void setWindowsNoBomNative(			bool		windowsNoBomNative);
 	void setDbShowWarning(				bool		dbShowWarning);

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -47,7 +47,7 @@ const std::string	jaspExtension		= ".jasp",
 bool runJaspEngineJunctionFixer(int argc, char *argv[], bool removeJunctions = false, bool exitAfterwards = true)
 {
 	QApplication	*	app		= exitAfterwards ? new QApplication(argc, argv) : nullptr;
-	QProcessEnvironment env		= ProcessHelper::getProcessEnvironmentForJaspEngine(false, false);
+	QProcessEnvironment env		= ProcessHelper::getProcessEnvironmentForJaspEngine(false);
 	QString				workDir = QFileInfo( QCoreApplication::applicationFilePath() ).absoluteDir().absolutePath();
 	
 	QProcess engine;
@@ -316,10 +316,6 @@ void recursiveFileOpener(QFileInfo file, int & failures, int & total, int & time
 
 int main(int argc, char *argv[])
 {
-#ifdef _WIN32
-	setlocale(LC_ALL, ".UTF8"); //use utf8
-#endif
-
 	std::string filePath;
 	bool		unitTest,
 				dirTest,

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -519,11 +519,9 @@ std::string DynamicModule::generateModuleLoadingR(bool shouldReturnSucces)
 {
 	std::stringstream R;
 
-    setLoadLog("Module " + _name + " is loading from " + _moduleFolder.absolutePath().toStdString() + "\n");
+	setLoadLog("Module " + _name + " is loading from " + _moduleFolder.absolutePath().toStdString() + "\n");
 
-    R << "print(getwd())\n";
-
-    //Add the  module name to the "do not remove from global env" list in R. See jaspRCPP_purgeGlobalEnvironment
+	//Add the  module name to the "do not remove from global env" list in R. See jaspRCPP_purgeGlobalEnvironment
 	R << "jaspBase:::.addModuleToDoNotRemove('" << _name << _modulePostFix << "');\n";
 
 	R << _name << _modulePostFix << " <- modules::module({\n" << standardRIndent << ".libPaths(" << getLibPathsToUse() <<");\n\n";

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -519,9 +519,11 @@ std::string DynamicModule::generateModuleLoadingR(bool shouldReturnSucces)
 {
 	std::stringstream R;
 
-	setLoadLog("Module " + _name + " is loading from " + _moduleFolder.absolutePath().toStdString() + "\n");
+    setLoadLog("Module " + _name + " is loading from " + _moduleFolder.absolutePath().toStdString() + "\n");
 
-	//Add the module name to the "do not remove from global env" list in R. See jaspRCPP_purgeGlobalEnvironment
+    R << "print(getwd())\n";
+
+    //Add the  module name to the "do not remove from global env" list in R. See jaspRCPP_purgeGlobalEnvironment
 	R << "jaspBase:::.addModuleToDoNotRemove('" << _name << _modulePostFix << "');\n";
 
 	R << _name << _modulePostFix << " <- modules::module({\n" << standardRIndent << ".libPaths(" << getLibPathsToUse() <<");\n\n";

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -547,18 +547,8 @@ void DynamicModules::uninstallJASPModule(const QString & moduleName)
 	uninstallModule(moduleName.toStdString());
 }
 
-void DynamicModules::checkAndWarnForLC_CTYPE_C() const
-{
-#ifdef _WIN32
-	if(PreferencesModel::prefs()->setLC_CTYPE_C() && !pathIsSafeForR(AppDirs::userModulesDir()))
-		MessageForwarder::showWarning(tr("Path cannot be handled by R"), tr("You are trying to install a module but because the path '%1' contains non-ascii characters (or a space) R might have some trouble installing there. If the installation of this module fails you can work around this by changing your username (or making a new username) that only contains ascii-characters and no spaces. Or you can disable \"LC_CTYPE-set-to-C\" under Preferences->Advanced->DeveloperMode."));
-#endif
-}
-
 void DynamicModules::installJASPModule(const QString & moduleZipFilename)
-{
-	checkAndWarnForLC_CTYPE_C();
-	
+{	
 	if(!QFile(moduleZipFilename).exists())
 	{
 		MessageForwarder::showWarning(tr("Cannot install module because %1 does not exist.").arg(moduleZipFilename));
@@ -607,8 +597,6 @@ void DynamicModules::installJASPDeveloperModule()
 		MessageForwarder::showWarning(tr("Select a folder"), tr("To install a development module you need to select the folder you want to watch and load, you can do this under the filemenu, Preferences->Advanced."));
 		return;
 	}
-	
-	checkAndWarnForLC_CTYPE_C();
 
 	setDevelopersModuleInstallButtonEnabled(false);
 

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -837,7 +837,7 @@ Json::Value	DynamicModules::getJsonForReloadingActiveModules()
 		const std::string & modName = _moduleNames[i];
 
 		if(_modules[modName]->readyForUse()) //should be loaded again
-			loadingCode << _modules[modName]->generateModuleLoadingR(i == _moduleNames.size() - 1) << "\n";
+            loadingCode << _modules[modName]->generateModuleLoadingR(i == _moduleNames.size() - 1) << "\n";
 	}
 
 	if(loadingCode.str() != "")

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -825,7 +825,7 @@ Json::Value	DynamicModules::getJsonForReloadingActiveModules()
 		const std::string & modName = _moduleNames[i];
 
 		if(_modules[modName]->readyForUse()) //should be loaded again
-            loadingCode << _modules[modName]->generateModuleLoadingR(i == _moduleNames.size() - 1) << "\n";
+        	loadingCode << _modules[modName]->generateModuleLoadingR(i == _moduleNames.size() - 1) << "\n";
 	}
 
 	if(loadingCode.str() != "")

--- a/Desktop/modules/dynamicmodules.h
+++ b/Desktop/modules/dynamicmodules.h
@@ -160,7 +160,6 @@ private:
 	void						devModWatchFolder(QString folder, QFileSystemWatcher * & watcher);
 	void						regenerateDeveloperModuleRPackage();
 	void						registerForInstallingSubFunc(const std::string & moduleName, bool onlyModPkg);
-	void						checkAndWarnForLC_CTYPE_C() const;
 	bool						requiredModulesForModuleReady(const std::string & moduleName)	const;
 
 private:

--- a/Desktop/utilities/processhelper.cpp
+++ b/Desktop/utilities/processhelper.cpp
@@ -5,7 +5,7 @@
 #include "utils.h"
 #include "log.h"
 
-QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool forceLC_CTYPE_C)
+QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine()
 {
 	QDir				programDir	= AppDirs::programDir();
 	QString				engineExe	= programDir.absoluteFilePath("JASPEngine");
@@ -61,16 +61,7 @@ QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool force
 	env.insert("R_ENVIRON_USER",	"something-which-doesn't-exist");
 
     //Lets set LC_ALL to utf8 before the process starts.
-    env.insert("LC_ALL", ".UTF8");
-	
-	/*if(forceLC_CTYPE_C)
-	{
-		Log::log() << "Setting LC_CTYPE to C!" << std::endl;
-		env.insert("LC_CTYPE",			"C"); //To force utf-8 output from gettext et al.
-	}
-	else
-		Log::log() << "Leaving LC_CTYPE at systemdefault" << std::endl;*/
-					  
+    env.insert("LC_ALL", ".UTF8");			  
 
 #elif __APPLE__
 
@@ -91,8 +82,6 @@ QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool force
 	env.insert("LD_LIBRARY_PATH",	rHome.absoluteFilePath("lib") + ":" + rHome.absoluteFilePath("library/RInside/lib") + ":" + rHome.absoluteFilePath("library/Rcpp/lib") + ":" + rHome.absoluteFilePath("site-library/RInside/lib") + ":" + rHome.absoluteFilePath("site-library/Rcpp/lib") + ":/app/lib/:/app/lib64/");
 	env.insert("R_HOME",			rHome.absolutePath());
 	env.insert("R_LIBS",			programDir.absoluteFilePath("R/library") + custom_R_library + ":" + rHome.absoluteFilePath("library") + ":" + rHome.absoluteFilePath("site-library"));
-
-	//Let's just trust linux and *not set* LC_CTYPE at all. It'll be fine.
 #endif
 
 	env.insert("TZDIR",				TZDIR);

--- a/Desktop/utilities/processhelper.cpp
+++ b/Desktop/utilities/processhelper.cpp
@@ -60,8 +60,8 @@ QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine()
 	env.insert("R_PROFILE_USER",	"something-which-doesn't-exist");
 	env.insert("R_ENVIRON_USER",	"something-which-doesn't-exist");
 
-    //Lets set LC_ALL to utf8 before the process starts.
-    env.insert("LC_ALL", ".UTF8");			  
+	//Lets set LC_ALL to utf8 before the process starts.
+	env.insert("LC_ALL", ".UTF8");			  
 
 #elif __APPLE__
 

--- a/Desktop/utilities/processhelper.cpp
+++ b/Desktop/utilities/processhelper.cpp
@@ -5,14 +5,11 @@
 #include "utils.h"
 #include "log.h"
 
-QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool withTmpDir, bool forceLC_CTYPE_C)
+QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool forceLC_CTYPE_C)
 {
 	QDir				programDir	= AppDirs::programDir();
 	QString				engineExe	= programDir.absoluteFilePath("JASPEngine");
 	QProcessEnvironment env			= QProcessEnvironment::systemEnvironment();
-
-	if(withTmpDir)
-		env.insert("TMPDIR",						tq(TempFiles::createTmpFolder()));
 	
 	env.insert("R_REMOTES_NO_ERRORS_FROM_WARNINGS", "true"); //Otherwise installing dependencies for modules can crap out on ridiculous warnings
 	env.insert("RENV_PATHS_ROOT",					AppDirs::renvRootLocation());
@@ -62,14 +59,17 @@ QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool withT
 	env.insert("R_PROFILE",			"something-which-doesn't-exist");
 	env.insert("R_PROFILE_USER",	"something-which-doesn't-exist");
 	env.insert("R_ENVIRON_USER",	"something-which-doesn't-exist");
+
+    //Lets set LC_ALL to utf8 before the process starts.
+    env.insert("LC_ALL", ".UTF8");
 	
-	if(forceLC_CTYPE_C)
+	/*if(forceLC_CTYPE_C)
 	{
 		Log::log() << "Setting LC_CTYPE to C!" << std::endl;
 		env.insert("LC_CTYPE",			"C"); //To force utf-8 output from gettext et al.
 	}
 	else
-		Log::log() << "Leaving LC_CTYPE at systemdefault" << std::endl;
+		Log::log() << "Leaving LC_CTYPE at systemdefault" << std::endl;*/
 					  
 
 #elif __APPLE__

--- a/Desktop/utilities/processhelper.h
+++ b/Desktop/utilities/processhelper.h
@@ -10,7 +10,7 @@ class ProcessHelper
 {
 public:
 	
-	static QProcessEnvironment getProcessEnvironmentForJaspEngine(bool withTmpDir, bool forceLC_CTYPE_C = false);
+    static QProcessEnvironment getProcessEnvironmentForJaspEngine(bool forceLC_CTYPE_C = false);
 	
 private:
 	ProcessHelper(){}

--- a/Desktop/utilities/processhelper.h
+++ b/Desktop/utilities/processhelper.h
@@ -10,7 +10,7 @@ class ProcessHelper
 {
 public:
 	
-    static QProcessEnvironment getProcessEnvironmentForJaspEngine(bool forceLC_CTYPE_C = false);
+    static QProcessEnvironment getProcessEnvironmentForJaspEngine();
 	
 private:
 	ProcessHelper(){}

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -65,7 +65,6 @@ const Settings::Setting Settings::Values[] = {
 #else // Linux and brave people compiling Jasp on other OSes
 	{"resultFont",					"freesans,sans-serif"},
 #endif
-	{"win_LC_CTYPE_C",				"check" }, //"check" should be an actual value in the underlying enum that is defined in preferencesmodel.h
 	{"maxEngineCount",				4		}, //In debug always 1
 	{"maxEngineCountAdmin",			0		}, //If set to something >0 it will be the max allowed max engine count. This is here to allow admins to override the number of processes spawned as they might each consume quite some RAM.
 	{"GITHUB_PAT_Custom",			""		},
@@ -117,19 +116,4 @@ QSettings *Settings::getSettings()
 	if (!_settings)
 		_settings = new QSettings();
 	return _settings;
-}
-
-winLcCtypeSetting Settings::getWinLcCtypeSetting()
-{
-	QString lcCtypeSetting = Settings::value(Settings::LC_CTYPE_C_WIN).toString();
-	
-	winLcCtypeSetting val = winLcCtypeSetting::check;
-	
-	try
-	{
-		val = winLcCtypeSettingFromQString(lcCtypeSetting);	
-	}
-	catch(missingEnumVal & e) {} //Just keep it at check then
-	
-	return val;
 }

--- a/Desktop/utilities/settings.h
+++ b/Desktop/utilities/settings.h
@@ -5,8 +5,6 @@
 #include <QString>
 #include <QLocale>
 
-enum class winLcCtypeSetting;
-
 ///
 /// Sometimes a class-name says more than a thousand comments
 class Settings {
@@ -54,7 +52,6 @@ public:
 		INTERFACE_FONT,
 		CODE_FONT,
 		RESULT_FONT,
-		LC_CTYPE_C_WIN,
 		MAX_ENGINE_COUNT,
 		MAX_ENGINE_COUNT_ADMIN,
 		GITHUB_PAT_CUSTOM,
@@ -82,8 +79,6 @@ public:
 	static QSettings* getSettings();
 	static const char *	defaultMissingValues;
 	
-	static winLcCtypeSetting getWinLcCtypeSetting();
-
 private:
 	struct Setting {
 		QString type;

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -24,7 +24,12 @@ file(GLOB JASPRESULTS_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/jaspBase/src/*.cpp
 # this target is not compiled and only exists so that the sources and headers of jaspResults show up in the project and can be opened with Ctrl+k
 add_custom_target(jaspResults ALL SOURCES ${JASPRESULTS_SOURCE_FILES} ${JASPRESULTS_HEADER_FILES})
 
-add_executable(JASPEngine ${SOURCE_FILES} ${HEADER_FILES})
+add_executable(
+    JASPEngine
+    ${SOURCE_FILES}
+    ${HEADER_FILES}
+    $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/Engine/JASPEngine.exe.manifest>
+)
 
 add_dependencies(JASPEngine R-Interface)
 
@@ -33,7 +38,7 @@ target_include_directories(
   PUBLIC ${PROJECT_SOURCE_DIR}/R-Interface
          ${PROJECT_SOURCE_DIR}/Common
          # Conan
-         $<$<BOOL:${USE_CONAN}>:${CONAN_INCLUDE_DIRS_JSONCPP}>
+         #$<$<BOOL:${USE_CONAN}>:${CONAN_INCLUDE_DIRS_JSONCPP}>
          #
          ${Boost_INCLUDE_DIRS})
 

--- a/Engine/JASPEngine.exe.manifest
+++ b/Engine/JASPEngine.exe.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="JASPEngine" version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2013-2018 University of Amsterdam
 //
 // This program is free software: you can redistribute it and/or modify
@@ -444,9 +444,9 @@ void Engine::receiveModuleRequestMessage(const Json::Value & jsonRequest)
 	
 	Log::log() << "About to run module request for module '" << moduleName << "' and code to run:\n'" << moduleCode << "'" << std::endl; 
 
-    std::string		result			= jaspRCPP_evalRCode(moduleCode.c_str(), false);
+	std::string		result			= jaspRCPP_evalRCode(moduleCode.c_str(), false);
 	bool			succes			= result == "succes!"; //Defined in DynamicModule::succesResultString()
-	
+
 	Log::log() << "Was " << (succes ? "succesful" : "a failure") << ", now crafting answer." << std::endl;
 
 	Json::Value		jsonAnswer		= Json::objectValue;

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -444,7 +444,7 @@ void Engine::receiveModuleRequestMessage(const Json::Value & jsonRequest)
 	
 	Log::log() << "About to run module request for module '" << moduleName << "' and code to run:\n'" << moduleCode << "'" << std::endl; 
 
-	std::string		result			= jaspRCPP_evalRCode(moduleCode.c_str(), false);
+    std::string		result			= jaspRCPP_evalRCode(moduleCode.c_str(), false);
 	bool			succes			= result == "succes!"; //Defined in DynamicModule::succesResultString()
 	
 	Log::log() << "Was " << (succes ? "succesful" : "a failure") << ", now crafting answer." << std::endl;

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -51,16 +51,12 @@ void openConsoleOutput(unsigned long slaveNo, unsigned parentPID)
 #ifdef _WIN32
 int wmain( int argc, wchar_t *argv[ ], wchar_t *envp[ ] )
 {
-   // setlocale(LC_ALL, ".UTF8"); //use utf8
-
-   // Utils::sleep(3000);
-
 	if(argc > 4)
 	{
 		unsigned long	slaveNo			= wcstoul(argv[1], NULL, 10),
 						parentPID		= wcstoul(argv[2], NULL, 10);
-        std::string		logFileBase		= Utils::wstringToString(argv[3]),
-                        logFileWhere	= Utils::wstringToString(argv[4]);
+		std::string		logFileBase		= Utils::wstringToString(argv[3]),
+						logFileWhere	= Utils::wstringToString(argv[4]);
 			
 #else
 int main(int argc, char *argv[])
@@ -114,9 +110,9 @@ int main(int argc, char *argv[])
 		Engine e(0, 0); //It needs to start to make sure rbridge functions work
 
 #ifdef _WIN32
-        _moduleLibraryFixer(Utils::wstringToString(argv[1]), true, true);
+	_m	oduleLibraryFixer(Utils::wstringToString(argv[1]), true, true);
 #else
-        _moduleLibraryFixer(argv[1], true, true);
+		_moduleLibraryFixer(argv[1], true, true);
 #endif
 
 		exit(0);
@@ -124,7 +120,7 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
 	else if(argc == 3)
 	{
-        std::string arg1(Utils::wstringToString(argv[1])), arg2(Utils::wstringToString(argv[2]));
+		std::string arg1(Utils::wstringToString(argv[1])), arg2(Utils::wstringToString(argv[2]));
 		const std::string junctionCollectArg("--collectJunctions"), junctionRecreateArg("--recreateJunctions"), junctionRemoveArg("--removeJunctions");
 		
 		if(arg1 == junctionRemoveArg || arg1 == junctionRecreateArg) //Also remove the old modules if it already exists and we are asked to recreate them, because it might be the old ones (previous install)

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
 		Engine e(0, 0); //It needs to start to make sure rbridge functions work
 
 #ifdef _WIN32
-	_m	oduleLibraryFixer(Utils::wstringToString(argv[1]), true, true);
+		_moduleLibraryFixer(Utils::wstringToString(argv[1]), true, true);
 #else
 		_moduleLibraryFixer(argv[1], true, true);
 #endif

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -47,20 +47,22 @@ void openConsoleOutput(unsigned long slaveNo, unsigned parentPID)
 }
 #endif
 
-/* THe following code might be useful if we ever want to get a bunch of utf16 from windows instead of local MBCS codepage crap
- #ifdef _WIN32
+
+#ifdef _WIN32
 int wmain( int argc, wchar_t *argv[ ], wchar_t *envp[ ] )
 {
+   // setlocale(LC_ALL, ".UTF8"); //use utf8
+
+   // Utils::sleep(3000);
+
 	if(argc > 4)
 	{
-		std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> strCvt;
-		
 		unsigned long	slaveNo			= wcstoul(argv[1], NULL, 10),
 						parentPID		= wcstoul(argv[2], NULL, 10);
-		std::string		logFileBase		= strCvt.to_bytes(argv[3]),
-						logFileWhere	= strCvt.to_bytes(argv[4]);	
+        std::string		logFileBase		= Utils::wstringToString(argv[3]),
+                        logFileWhere	= Utils::wstringToString(argv[4]);
 			
-#else*/
+#else
 int main(int argc, char *argv[])
 {
 	if(argc > 4)
@@ -69,6 +71,8 @@ int main(int argc, char *argv[])
 						parentPID		= strtoul(argv[2], NULL, 10);
 		std::string		logFileBase		= argv[3],
 						logFileWhere	= argv[4];
+
+#endif
 
 		Log::logFileNameBase = logFileBase;
 		Log::initRedirects();
@@ -109,14 +113,18 @@ int main(int argc, char *argv[])
 
 		Engine e(0, 0); //It needs to start to make sure rbridge functions work
 
-		_moduleLibraryFixer(argv[1], true, true);
+#ifdef _WIN32
+        _moduleLibraryFixer(Utils::wstringToString(argv[1]), true, true);
+#else
+        _moduleLibraryFixer(argv[1], true, true);
+#endif
 
 		exit(0);
 	}
 #ifdef _WIN32
 	else if(argc == 3)
 	{
-		std::string arg1(argv[1]), arg2(argv[2]);
+        std::string arg1(Utils::wstringToString(argv[1])), arg2(Utils::wstringToString(argv[2]));
 		const std::string junctionCollectArg("--collectJunctions"), junctionRecreateArg("--recreateJunctions"), junctionRemoveArg("--removeJunctions");
 		
 		if(arg1 == junctionRemoveArg || arg1 == junctionRecreateArg) //Also remove the old modules if it already exists and we are asked to recreate them, because it might be the old ones (previous install)

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -104,6 +104,8 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 	};
 
 	JASPTIMER_START(jaspRCPP_init);
+
+    static std::string tempDirStatic = TempFiles::createTmpFolder();
 	
 	Log::log() << "Entering jaspRCPP_init." << std::endl;
 	jaspRCPP_init(	AppInfo::getBuildYear()		.c_str(),
@@ -116,7 +118,8 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 					rbridge_system,
 					rbridge_moduleLibraryFixer,
 					resultsFont,
-					rbridge_nativeToUtf8
+                    rbridge_nativeToUtf8,
+                    tempDirStatic.c_str()
 	);
 	JASPTIMER_STOP(jaspRCPP_init);
 

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -105,7 +105,7 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 
 	JASPTIMER_START(jaspRCPP_init);
 
-    static std::string tempDirStatic = TempFiles::createTmpFolder();
+	static std::string tempDirStatic = TempFiles::createTmpFolder();
 	
 	Log::log() << "Entering jaspRCPP_init." << std::endl;
 	jaspRCPP_init(	AppInfo::getBuildYear()		.c_str(),
@@ -118,8 +118,8 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 					rbridge_system,
 					rbridge_moduleLibraryFixer,
 					resultsFont,
-                    rbridge_nativeToUtf8,
-                    tempDirStatic.c_str()
+					rbridge_nativeToUtf8,
+					tempDirStatic.c_str()
 	);
 	JASPTIMER_STOP(jaspRCPP_init);
 

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -91,7 +91,7 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction,
 	logFlushDef logFlushFunction, logWriteDef logWriteFunction,
 	systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,
-    EnDecodeDef nativeToUtf8, const char * tempDir)
+	EnDecodeDef nativeToUtf8, const char * tempDir)
 {
 	_logFlushFunction		= logFlushFunction;
 	_logWriteFunction		= logWriteFunction;
@@ -100,11 +100,11 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	_libraryFixerFunc		= libraryFixerFunc;
 	_stringNativeToUtf8		= nativeToUtf8;
 
-    jaspRCPP_logString("Creating RInside.\n");
+	jaspRCPP_logString("Creating RInside.\n");
 
-    rinside = new RInside();
+	rinside = new RInside();
 
-    R_TempDir = (char*)tempDir;
+	R_TempDir = (char*)tempDir;
 	
 	RInside &rInside = rinside->instance();
 
@@ -1110,7 +1110,7 @@ void jaspRCPP_parseEvalPreface(const std::string & code, const char * msg = "Eva
 
 std::string __sinkMe(const std::string code)
 {
-    return	"sink(.outputSink);\n\n" + code; //default type = c('message', 'output') anyway
+	return	"sink(.outputSink);\n\n" + code; //default type = c('message', 'output') anyway
 }
 
 void jaspRCPP_setWorkingDirectory()

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -17,6 +17,7 @@
 
 #include "jasprcpp.h"
 #include <fstream>
+#include "tempfiles.h"
 
 static const	std::string NullString			= "null";
 static			std::string lastErrorMessage	= "";
@@ -82,13 +83,15 @@ std::string jaspNativeToUtf8(const Rcpp::String & in)
 #endif
 }
 
+//Terribly hack to work around windows messing up environment variables when local+codepage+utf8
+extern char * R_TempDir;
 
 extern "C" {
 void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks* callbacks,
 	sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction,
 	logFlushDef logFlushFunction, logWriteDef logWriteFunction,
 	systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,
-	EnDecodeDef nativeToUtf8)
+    EnDecodeDef nativeToUtf8, const char * tempDir)
 {
 	_logFlushFunction		= logFlushFunction;
 	_logWriteFunction		= logWriteFunction;
@@ -97,8 +100,11 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	_libraryFixerFunc		= libraryFixerFunc;
 	_stringNativeToUtf8		= nativeToUtf8;
 
-	jaspRCPP_logString("Creating RInside.\n");
-	rinside = new RInside();
+    jaspRCPP_logString("Creating RInside.\n");
+
+    rinside = new RInside();
+
+    R_TempDir = (char*)tempDir;
 	
 	RInside &rInside = rinside->instance();
 
@@ -174,6 +180,8 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	rInside[".sendToDesktopFunction"]	= Rcpp::XPtr<sendFuncDef>(&sendToDesktopFunction);
 	rInside[".pollMessagesFunction"]	= Rcpp::XPtr<pollMessagesFuncDef>(&pollMessagesFunction);
 	rInside[".baseCitation"]			= baseCitation;
+
+	//jaspRCPP_parseEvalQNT("options(encoding = 'UTF-8')");
 	jaspRCPP_parseEvalQNT("jaspBase:::setSendFunc(.sendToDesktopFunction)");
 	jaspRCPP_parseEvalQNT("jaspBase:::setPollMessagesFunc(.pollMessagesFunction)");
 	jaspRCPP_parseEvalQNT("jaspBase:::setBaseCitation(.baseCitation)");
@@ -1102,7 +1110,7 @@ void jaspRCPP_parseEvalPreface(const std::string & code, const char * msg = "Eva
 
 std::string __sinkMe(const std::string code)
 {
-	return	"sink(.outputSink);\n\n" + code; //default type = c('message', 'output') anyway
+    return	"sink(.outputSink);\n\n" + code; //default type = c('message', 'output') anyway
 }
 
 void jaspRCPP_setWorkingDirectory()
@@ -1110,6 +1118,7 @@ void jaspRCPP_setWorkingDirectory()
 	std::string root = requestTempRootNameCB();
 	std::string code = "setwd(\"" + root + "\"); sink();";
 	rinside->parseEvalQNT(__sinkMe(code));
+	rinside->parseEvalQNT("sink();"); //Back to normal!
 }
 
 void jaspRCPP_parseEvalQNT(const std::string & code, bool setWd, bool preface)
@@ -1218,6 +1227,7 @@ Rcpp::String jaspRCPP_decodeAllColumnNames(const Rcpp::String & in)
 
 
 ///Makes sure that whatever string encoding it got, it comes out as utf-8. At least when it is ran *inside* jasp(engine)
+///It's probably obsolete
 std::string jaspRCPP_nativeToUtf8(const Rcpp::String & string)
 {
 #ifdef JASP_R_INTERFACE_LIBRARY

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -122,7 +122,7 @@ typedef size_t			(*logWriteDef)			(const void * buf, size_t len);
 
 
 // Calls from rbridge to jaspRCPP
-RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,	EnDecodeDef nativeToUtf8);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,	EnDecodeDef nativeToUtf8, const char * tempDir);
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont, const char * libPathsToUse);
 

--- a/Resources/Help/preferences/PrefsAdvanced.md
+++ b/Resources/Help/preferences/PrefsAdvanced.md
@@ -33,24 +33,6 @@ Please *DO NOT* give this personal access token **any permissions** at all, beca
 
 Otherwise you can set it specifically in JASP by unchecking "Use default PAT" and then copying your token-code into the custom GITHUB_PAT textbox, this is probably the easiest if you do not know what an environment variable is.
 
-## Windows workarounds
-
-### LC_CTYPE 
-LC_CTYPE is a setting for the so-called "locale" and it determines, on windows, how characters are encoded. 
-This is used internally by R and sadly enough it cannot handle international characters very well on Windows.
-Setting this to "C" makes sure that all the output in the results looks good and can support all characters (unicode).
-
-The problem is when you are running in a different locale, such as Korean, and you have a username that contains special characters from that locale.
-In that scenario things might break if you install JASP per-user or if you try to install a dynamic module.
-To work around that problem we will then not set LC_CTYPE to "C" but keep it as is, then JASP works.
-The drawback is that some characters in the output will look bad.
-Installing JASP in a different place (per-machine) should fix that.
-
-The default setting "Let JASP guess the best setting for LC_CTYPE" handles this for you, our advice is to leave it enabled.
-
-We apologize for this small inconvenience, we are working on it and hopefully have this fixed next release.
-
-
 ## Logging options
 
 ### Log to file

--- a/Resources/Help/preferences/PrefsAdvanced_nl.md
+++ b/Resources/Help/preferences/PrefsAdvanced_nl.md
@@ -19,23 +19,6 @@ Modules van ontwikkelaars kunnen direct worden toegevoegd uit deze map, of modul
 De CRAN repository URL bepaald waar JASP de benodigde pacakges gespecificeerd in de module van download. 
 De standaardoptie is `https://cloud.r-project.org`, maar een goed alternatief (wanneer packages bijvoorbeeld niet lijken te installeren) is `cran.r-project.org`. 
 
-## Windows Workarounds
-
-### LC_CTYPE
-LC_CTYPE is een instelling mbt zogenoemde "locales" en het bepaald, op windows, hoe bepaalde karakters geëncodeerd worden.
-Dit wordt intern gebruikt door R en kan jammer genoeg niet goed omgaan met internationale karakters onder Windows.
-Deze instelling wordt in principe op "C" gezet door JASP zodat alle karakters in de resultaten worden ondersteund (unicode).
-
-Er is echter een probleem in het geval dat je in een andere locale draait, zoals Duits, en je gebruikernaam bevat speciale karakters zoals ringel-s.
-In dat scenario kan JASP niet starten als het per-gebruiker is geïnstalleerd of als je een dynamische module probeert te installeren.
-Om dat te voorkomen herkent JASP deze situatie en stelt het LC_CTYPE niet in op "C" maar houdt het zoals het is en JASP werkt dan gewoon.
-Helaas zullen dan niet alle karakters in de resultaten er goed uitzien.
-JASP op een andere plek installeren (dus per-machine) zal dat verhelpen.
-
-De standaard instelling hier is de beste en wij raden iedereen dan ook aan dit gewoon aangevinkt te laten.
-
-Onze excuses voor dit kleine ongemak en we hopen het bij de volgende versie opgelost te hebben.
-
 ## Logopties
 
 ### Log naar Bestand


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1758 (engine crash on nonlatin characters in username on windows)

ps. All the nativeToUtf8 workaround functions can also be removed, but there is no hurry