### PR TITLE
Fixing computed columns and more

### DIFF
--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -32,7 +32,7 @@ if (md5SumsChanged(modulePkg, moduleLibrary)) {
     configure.vars = c(jaspBase = "INCLUDE_DIR='@PROJECT_SOURCE_DIR@/Common/jaspColumnEncoder'")
   )
 
-#  Sys.setenv(INCLUDE_DIR="@PROJECT_SOURCE_DIR@/Common/jaspColumnEncoder")
+  Sys.setenv(JASP_R_INTERFACE_LIBRARY="Oh yes indeed")
   setupRenv("@R_LIBRARY_PATH@", modulePkg)
 
   renv::hydrate(library = moduleLibrary, project = modulePkg, sources=moduleLibrary)

--- a/Modules/install-module.R.in
+++ b/Modules/install-module.R.in
@@ -7,6 +7,7 @@ Sys.setenv(JASPENGINE_LOCATION="@JASP_ENGINE_PATH@/JASPEngine")
 Sys.setenv(JAGS_PREFIX="@jags_HOME@")
 Sys.setenv(JAGS_INCLUDEDIR="@jags_INCLUDE_DIRS@")
 Sys.setenv(JAGS_LIBDIR="@jags_LIBRARY_DIRS@")
+Sys.setenv(JASP_R_INTERFACE_LIBRARY="Yes, do it")
 
 if (@IS_LINUX_LOCAL_BUILD@) {
 	# Only set when building using LINUX_LOCAL_BUILD. This is to help jags finds its libraries

--- a/R-Interface/jasprcpp.h
+++ b/R-Interface/jasprcpp.h
@@ -88,6 +88,12 @@ void jaspRCPP_setColumnDataHelper_FactorsLevels(Rcpp::Vector<INTSXP> data, int *
 //Calls from JASPresult (from R)
 typedef void (*sendFuncDef)(const char *);
 
+//Calls from jaspBase
+typedef void			(*logFuncDef)(const std::string &);
+typedef bool			(*setColumnDataFuncDef)	(std::string, Rcpp::RObject);
+typedef columnType		(*getColumnTypeFuncDef)	(std::string);
+
+
 RBridgeColumnType* jaspRCPP_marshallSEXPs(SEXP columns, SEXP columnsAsNumeric, SEXP columnsAsOrdinal, SEXP columnsAsNominal, SEXP allColumns, size_t * colMax);
 
 Rcpp::IntegerVector jaspRCPP_makeFactor(Rcpp::IntegerVector v, char** levels, int nbLevels, bool ordinal = false);


### PR DESCRIPTION
Set environment variable JASP_R_INTERFACE_LIBRARY to something during jaspBase and jaspModule installs. jaspBase checks for it and sets the corresponding define if not ""

Passes pointers to some jaspRcpp functions to jaspBase so we do not need the header there (or JASP)

Also couldnt resist removing all the workaround code for utf-8 on windows...

