### PR TITLE
Double Validator should accept value with exponential notation

### DIFF
--- a/Desktop/analysis/jaspdoublevalidator.cpp
+++ b/Desktop/analysis/jaspdoublevalidator.cpp
@@ -28,7 +28,7 @@ QValidator::State JASPDoubleValidator::validate(QString& s, int& pos) const
 		return QValidator::Intermediate;
 	}
 
-	if (s.contains("-") && bottom() >= 0)
+	if (s.startsWith("-") && bottom() >= 0)
 		return QValidator::Invalid; 
 	
 	// check length of decimal places

--- a/Desktop/widgets/textinputbase.cpp
+++ b/Desktop/widgets/textinputbase.cpp
@@ -84,15 +84,7 @@ void TextInputBase::bindTo(const Json::Value& value)
 		if (_inputType == TextInputType::PercentIntputType)
 			_value = _getPercentValue(dblVal);
 		else
-		{
-			// Ensure the the option does not have more decimals than authorized for backwards compatibility
-			int decimals = property("decimals").toInt();
-			int pow = 1;
-			for (int i = 0; i < decimals; i++) pow = pow * 10;
-			dblVal = (round(dblVal * pow))/pow;
-
 			_value = tq(Utils::doubleToString(dblVal));
-		}
 
 		break;
 	}


### PR DESCRIPTION
An exponential notation can have a min sign: but if the value should be positive, the Double Validator does not accept it. The min sign should be forbidden only as first character. 
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2001

