### PR TITLE
Unknown value for a Radio Button leads to a crash

### DIFF
--- a/Desktop/widgets/radiobuttonsgroupbase.cpp
+++ b/Desktop/widgets/radiobuttonsgroupbase.cpp
@@ -82,18 +82,17 @@ void RadioButtonsGroupBase::bindTo(const Json::Value &jsonValue)
 {
 	BoundControlBase::bindTo(jsonValue);
 
-	string value = jsonValue.asString();
-	if (!value.empty())
+	QString value = tq(jsonValue.asString());
+	if (!value.isEmpty())
 	{
-		RadioButtonBase* button = _buttons[tq(value)];
-		if (!button)
+		if (!_buttons.contains(value))
 		{
-			addControlError(tr("No radio button corresponding to name %1").arg(QString::fromStdString(value)));
+			addControlError(tr("No radio button corresponding to name %1").arg(value));
 			QStringList names = _buttons.keys();
 			Log::log()  << "Known button: " << names.join(',').toStdString() << std::endl;
 		}
 		else
-			_setCheckedButton(button);
+			_setCheckedButton(_buttons[value]);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2026 This fixes the crash. The upgrade will be done in another PR.

The problem is that to ask whether a key exists in a map, you should call the 'contains' method, and not checking whether the map has a value with this key: this adds a new key in the map with an empty value. Thsi was done with the _buttons map, and the code expects always to have a not-null value in this map.

