### PR TITLE
also add utf-8 active codepage manifest for jasp.exe

### DIFF
--- a/Desktop/CMakeLists.txt
+++ b/Desktop/CMakeLists.txt
@@ -40,7 +40,9 @@ qt_add_executable(
   ${HEADER_FILES}
   ${BUNDLE_RESOURCES}
   $<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_LIST_DIR}/icon.rc>
-  $<$<PLATFORM_ID:Darwin>:${_R_Framework}>)
+  $<$<PLATFORM_ID:Darwin>:${_R_Framework}>
+  $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/Desktop/JASP.exe.manifest>)
+
 
 if(IWYU_EXECUTABLE AND RUN_IWYU)
   set_target_properties(JASP PROPERTIES CXX_INCLUDE_WHAT_YOU_USE

--- a/Desktop/JASP.exe.manifest
+++ b/Desktop/JASP.exe.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="JASP" version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2013 (Cannot export unicode in filename html)

Im not so sure what this will do to importing datafiles in local codepage such as mentioned https://github.com/jasp-stats/INTERNAL-jasp/issues/1894 but we'll see later. This change is a good idea anyway