### PR TITLE
make jaspBase cacheAble in renv to avoid double installs

### DIFF
--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -28,7 +28,7 @@ prompt        <- FALSE
 
 if (md5SumsChanged(modulePkg, moduleLibrary)) {
   options(
-    renv.cache.linkable = getOS() == "linux",
+    renv.cache.linkable = FALSE,
     configure.vars = c(jaspBase = "INCLUDE_DIR='@PROJECT_SOURCE_DIR@/Common/jaspColumnEncoder'")
   )
 
@@ -39,7 +39,7 @@ if (md5SumsChanged(modulePkg, moduleLibrary)) {
   options(renv.config.install.verbose = TRUE)
   renv::install(project = modulePkg, library = moduleLibrary, prompt = prompt)
 
-  correctlyInstalled <- installModulePkg(modulePkg, moduleLibrary, prompt, cacheAble=FALSE)
+  correctlyInstalled <- installModulePkg(modulePkg, moduleLibrary, prompt, cacheAble=TRUE) 
 
   if (correctlyInstalled)
     writeMd5Sums(modulePkg, moduleLibrary)

--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -28,7 +28,7 @@ prompt        <- FALSE
 
 if (md5SumsChanged(modulePkg, moduleLibrary)) {
   options(
-    renv.cache.linkable = FALSE,
+    renv.cache.linkable = getOS() == "linux",
     configure.vars = c(jaspBase = "INCLUDE_DIR='@PROJECT_SOURCE_DIR@/Common/jaspColumnEncoder'")
   )
 

--- a/Modules/install-module.R.in
+++ b/Modules/install-module.R.in
@@ -33,13 +33,6 @@ result <- jaspBase::installJaspModule("@MODULES_SOURCE_PATH@/@MODULE@",
 	onlyModPkg=FALSE,
 	frameworkLibrary="@R_LIBRARY_PATH@")
 
-jaspBasePath <- "@MODULES_BINARY_PATH@/@MODULE@/jaspBase"
-print(paste0("Was '", result, "' and will now remove jaspBase from module library at '", jaspBasePath , "' if it exists."))
-
-if(file.exists(jaspBasePath))
-	file.remove(jaspBasePath)
-
-
 if (result == "succes") {
 	cat(NULL, file="@MODULES_RENV_ROOT_PATH@/@MODULE@-installed-successfully.log")
 }

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -143,7 +143,7 @@ add_custom_target(
   DEPENDS ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds)
 
 configure_file("${PROJECT_SOURCE_DIR}/Modules/install-jaspBase.R.in"
-               ${MODULES_RENV_ROOT_PATH}/install-jaspBase.R @ONLY)
+	           ${SCRIPT_DIRECTORY}/install-jaspBase.R @ONLY)
 
 # I'm using a custom_command here to make sure that jaspBase is installed once
 # and only once before everything else. So, `install-jaspBase.R` creates an empty
@@ -159,7 +159,7 @@ if(APPLE)
 	  WORKING_DIRECTORY ${R_HOME_PATH}
 	  OUTPUT ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
 	  USES_TERMINAL
-	  COMMAND ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${MODULES_RENV_ROOT_PATH}/install-jaspBase.R
+	  COMMAND ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${SCRIPT_DIRECTORY}/install-jaspBase.R
 	  COMMENT "------ Installing 'jaspBase'")
 else()
 	add_custom_command(
@@ -167,7 +167,7 @@ else()
           OUTPUT ${R_HOME_PATH}/jaspBase_md5sums.rds
 	  USES_TERMINAL
 	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-	          --file=${MODULES_RENV_ROOT_PATH}/install-jaspBase.R
+	          --file=${SCRIPT_DIRECTORY}/install-jaspBase.R
 	  COMMENT "------ Installing 'jaspBase'")
 endif()
   
@@ -195,7 +195,7 @@ if(INSTALL_R_MODULES)
     # to set them up correctly
     make_directory(${MODULES_BINARY_PATH}/${MODULE})
     configure_file(${INSTALL_MODULE_TEMPLATE_FILE}
-                   ${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R @ONLY)
+		           ${SCRIPT_DIRECTORY}/install-${MODULE}.R @ONLY)
 			   
 if(APPLE)			   
     add_custom_target(
@@ -203,7 +203,7 @@ if(APPLE)
       USES_TERMINAL
       WORKING_DIRECTORY ${R_HOME_PATH}
 	  DEPENDS	${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
-	  COMMAND  ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
+	  COMMAND  ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${SCRIPT_DIRECTORY}/install-${MODULE}.R
       # COMMAND
       #   ${CMAKE_COMMAND} -D PATH=${MODULES_BINARY_PATH}/${MODULE} -D
       #   MODULES_BINARY_PATH=${MODULES_BINARY_PATH} -P
@@ -211,7 +211,6 @@ if(APPLE)
       BYPRODUCTS ${MODULES_BINARY_PATH}/${MODULE}
                  ${MODULES_BINARY_PATH}/${MODULE}_md5sums.rds
                  ${MODULES_BINARY_PATH}/${MODULE}-installed-successfully.log
-                 ${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
       COMMENT "------ Installing '${MODULE}'")
 
     add_dependencies(${MODULE} JASPEngine)
@@ -223,11 +222,10 @@ else()
       WORKING_DIRECTORY ${R_HOME_PATH}
       DEPENDS ${R_HOME_PATH}/jaspBase_md5sums.rds
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
+	          --file=${SCRIPT_DIRECTORY}/install-${MODULE}.R
       BYPRODUCTS ${MODULES_BINARY_PATH}/${MODULE}
                  ${MODULES_BINARY_PATH}/${MODULE}_md5sums.rds
                  ${MODULES_BINARY_PATH}/${MODULE}-installed-successfully.log
-                 ${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
       COMMENT "------ Installing '${MODULE}'")
 endif()
     # install(
@@ -249,7 +247,7 @@ endif()
 
     make_directory(${MODULES_BINARY_PATH}/${MODULE})
     configure_file(${INSTALL_MODULE_TEMPLATE_FILE}
-                   ${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R @ONLY)
+		           ${SCRIPT_DIRECTORY}/install-${MODULE}.R @ONLY)
 
 if(APPLE)			   
     add_custom_target(
@@ -261,7 +259,7 @@ if(APPLE)
         ${MODULES_BINARY_PATH}/jaspBase/jaspBaseHash.rds
         $<$<STREQUAL:"${MODULE}","jaspMetaAnalysis">:${jags_VERSION_H_PATH}>
         $<$<STREQUAL:"${MODULE}","jaspJags">:${jags_VERSION_H_PATH}>
-		COMMAND ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
+		COMMAND ${CMAKE_COMMAND}  -E env "JASP_R_HOME=${R_HOME_PATH}" ${R_EXECUTABLE} --slave --no-restore --no-save --file=${SCRIPT_DIRECTORY}/install-${MODULE}.R
       # COMMAND
       #   ${CMAKE_COMMAND} -D PATH=${MODULES_BINARY_PATH}/${MODULE} -D
       #   MODULES_BINARY_PATH=${MODULES_BINARY_PATH} -P
@@ -269,7 +267,7 @@ if(APPLE)
       BYPRODUCTS ${MODULES_BINARY_PATH}/${MODULE}
                  ${MODULES_BINARY_PATH}/${MODULE}_md5sums.rds
                  ${MODULES_BINARY_PATH}/${MODULE}-installed-successfully.log
-                 ${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
+				 ${SCRIPT_DIRECTORY}/install-${MODULE}.R
       COMMENT "------ Installing '${MODULE}'")
 else()
 	add_custom_target(
@@ -281,12 +279,12 @@ else()
         $<$<STREQUAL:"${MODULE}","jaspMetaAnalysis">:${jags_VERSION_H_PATH}>
         $<$<STREQUAL:"${MODULE}","jaspJags">:${jags_VERSION_H_PATH}>
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
+	          --file=${SCRIPT_DIRECTORY}/install-${MODULE}.R
 
       BYPRODUCTS ${MODULES_BINARY_PATH}/${MODULE}
                  ${MODULES_BINARY_PATH}/${MODULE}_md5sums.rds
                  ${MODULES_BINARY_PATH}/${MODULE}-installed-successfully.log
-                 ${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R
+				 ${SCRIPT_DIRECTORY}/install-${MODULE}.R
       COMMENT "------ Installing '${MODULE}'")
 endif()
     # install(
@@ -463,7 +461,7 @@ endif()
       # The install-jaspMetaAnalysis.R and/or install-jaspJags.R need to be reconfigured
       # for jags flags to be included as well
       configure_file(${INSTALL_MODULE_TEMPLATE_FILE}
-                     ${MODULES_RENV_ROOT_PATH}/install-${MODULE}.R @ONLY)
+		             ${SCRIPT_DIRECTORY}/install-${MODULE}.R @ONLY)
 
     endif()
 

--- a/Tools/CMake/Patch.cmake
+++ b/Tools/CMake/Patch.cmake
@@ -26,6 +26,11 @@
 #     because CMake cannot call its function inside a COMMAND section of `execute_process` or
 #     `add_custom_targets` and I needed to have that in a few situation.
 #
+# Notes by Joris:
+#   - This Patch.cmake emulates the behaviour of otoolstuff.h in jaspEngine, which is duplication of code.
+#     I am considering removing it, but it might be practical for cross-compiling on macos.
+#     This because JASPEngine is compiled for the system it runs on. So maybe some code-duplication isnt that bad.
+#     We still need it in JASPEngine to support dynamic modules
 
 cmake_policy(SET CMP0009 NEW)
 
@@ -37,7 +42,7 @@ else()
   file(
     GLOB_RECURSE
     LIBRARIES
-    FOLLOW_SYMLINKS
+    #FOLLOW_SYMLINKS #Turned this off because it got infinitely regressed
     "${PATH}/*.so"
     "${PATH}/*.dylib")
   list(

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -80,16 +80,10 @@ endif()
 
 # ------ Preparing Renv Paths
 #
-set(MODULES_SOURCE_PATH
-    ${PROJECT_SOURCE_DIR}/Modules
-    CACHE PATH "Location of JASP Modules")
-
-set(MODULES_BINARY_PATH
-    "${CMAKE_BINARY_DIR}/Modules"
-    CACHE PATH "Location of the renv libraries")
-set(MODULES_RENV_ROOT_PATH
-    "${PROJECT_BINARY_DIR}/_cache/renv-root"
-    CACHE PATH "Location of renv root directories")
+set(MODULES_SOURCE_PATH		${PROJECT_SOURCE_DIR}/Modules			CACHE PATH "Location of JASP Modules")
+set(MODULES_BINARY_PATH		${CMAKE_BINARY_DIR}/Modules				CACHE PATH "Location of the renv libraries")
+set(MODULES_RENV_ROOT_PATH  ${PROJECT_BINARY_DIR}/_cache/renv-root  CACHE PATH "Location of renv root directories")
+set(SCRIPT_DIRECTORY		${PROJECT_BINARY_DIR}/_scripts			CACHE PATH "Location of R scripts for building")
 
 if(FLATPAK_USED)
   set(MODULES_RENV_CACHE_PATH "/app/lib64/renv-cache" CACHE PATH "Location of renv cache directories")
@@ -485,7 +479,7 @@ if(APPLE)
     message(CHECK_START "Installing 'renv'")
 
     configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
-                   ${MODULES_RENV_ROOT_PATH}/install-renv.R @ONLY)
+		           ${SCRIPT_DIRECTORY}/install-renv.R @ONLY)
 
     set(ENV{JASP_R_HOME} ${R_HOME_PATH})
 
@@ -493,7 +487,7 @@ if(APPLE)
 	  COMMAND_ECHO STDERR
 	  #ERROR_QUIET OUTPUT_QUIET
       WORKING_DIRECTORY ${R_HOME_PATH}
-	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save --file=${SCRIPT_DIRECTORY}/install-renv.R)
 
     if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
       message(CHECK_FAIL "unsuccessful.")
@@ -522,14 +516,14 @@ if(APPLE)
     message(CHECK_START "Installing the 'RInside' and 'Rcpp'")
 
     configure_file(${MODULES_SOURCE_PATH}/install-RInside.R.in
-                   ${MODULES_RENV_ROOT_PATH}/install-RInside.R @ONLY)
+		           ${SCRIPT_DIRECTORY}/install-RInside.R @ONLY)
 
     execute_process(
       COMMAND_ECHO STDOUT
       #ERROR_QUIET OUTPUT_QUIET
       WORKING_DIRECTORY ${R_HOME_PATH}
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-RInside.R)
+	          --file=${SCRIPT_DIRECTORY}/install-RInside.R)
 
     if(NOT EXISTS ${R_LIBRARY_PATH}/RInside)
       message(CHECK_FAIL "unsuccessful.")
@@ -670,14 +664,14 @@ elseif(WIN32)
     message(CHECK_START "Installing 'renv'")
 
     configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
-                   ${MODULES_RENV_ROOT_PATH}/install-renv.R @ONLY)
+		           ${SCRIPT_DIRECTORY}/install-renv.R @ONLY)
 
     execute_process(
       COMMAND_ECHO STDOUT
       #ERROR_QUIET OUTPUT_QUIET
       WORKING_DIRECTORY ${R_HOME_PATH}
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+	          --file=${SCRIPT_DIRECTORY}/install-renv.R)
 
     if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
       message(CHECK_FAIL "unsuccessful.")
@@ -693,14 +687,14 @@ elseif(WIN32)
     message(CHECK_START "Installing the 'RInside' and 'Rcpp'")
 
     configure_file(${MODULES_SOURCE_PATH}/install-RInside.R.in
-                   ${MODULES_RENV_ROOT_PATH}/install-RInside.R @ONLY)
+		           ${SCRIPT_DIRECTORY}/install-RInside.R @ONLY)
 
     execute_process(
       COMMAND_ECHO STDOUT
       #ERROR_QUIET OUTPUT_QUIET
       WORKING_DIRECTORY ${R_BIN_PATH}
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-RInside.R)
+	          --file=${SCRIPT_DIRECTORY}/install-RInside.R)
 
     if(NOT EXISTS ${R_LIBRARY_PATH}/RInside)
       message(CHECK_FAIL "unsuccessful.")
@@ -823,14 +817,14 @@ elseif(LINUX)
     message(CHECK_START "Installing 'renv'")
 
     configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
-                   ${MODULES_RENV_ROOT_PATH}/install-renv.R @ONLY)
+		           ${SCRIPT_DIRECTORY}/install-renv.R @ONLY)
 
     execute_process(
       COMMAND_ECHO STDOUT
       #ERROR_QUIET OUTPUT_QUIET
       WORKING_DIRECTORY ${R_HOME_PATH}
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-renv.R)
+	          --file=${SCRIPT_DIRECTORY}/install-renv.R)
 
     if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
       message(CHECK_FAIL "unsuccessful.")
@@ -846,13 +840,13 @@ elseif(LINUX)
     message(CHECK_START "Installing the 'RInside' and 'Rcpp'")
 
     configure_file(${MODULES_SOURCE_PATH}/install-RInside.R.in
-                   ${MODULES_RENV_ROOT_PATH}/install-RInside.R @ONLY)
+		           ${SCRIPT_DIRECTORY}/install-RInside.R @ONLY)
 
     execute_process(
       COMMAND_ECHO STDOUT
       #ERROR_QUIET OUTPUT_QUIET
       COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save
-              --file=${MODULES_RENV_ROOT_PATH}/install-RInside.R)
+	          --file=${SCRIPT_DIRECTORY}/install-RInside.R)
 
     if(NOT EXISTS ${R_LIBRARY_PATH}/RInside)
       message(CHECK_FAIL "unsuccessful.")


### PR DESCRIPTION
@JorisGoosen we made this not linkable because there were issues on macOS with signing (if I remember correctly). This change makes jaspBase linkable but only on Linux. 

This fixes a bug when building on flatpak. Because jaspBase is not linkable, we now install it twice. Once when installing jaspBase, and a second time when installing the first module (because it never ended up in the cache). The second time we're installing it, we haven't set the include dir so we end up with a compilation failure because jaspBase tries to clone jaspColumnEncoder which obviously fails on the flatpak buildbot.

Alternatively, we can set the include dir also in installModule.R.in, but I prefer this solution.