### PR TITLE
Added more help info in preferences

### DIFF
--- a/Resources/Help/preferences/PrefsData.md
+++ b/Resources/Help/preferences/PrefsData.md
@@ -30,8 +30,16 @@ This means that if you have fewer (or equal) than 10 different integers in the d
 gets the Ordinal type (Nominal type if only 2 different integers are found) else it will get the Scale type. Be aware that this value is used when
 importing the data, so data needs to be reloaded (or synchronized) to take effect.
 
+### Show missing values as
+
+JASP shows missing values as blank in cells by default, you can also label them as others (e.g., it can even be defined as "😀" or other characters) in text field to display friendly on data pane. Note that this is different from a valid value label and means it won't appear in the results.
+
 ### Missing Value List
 
 In this list you can specify when observations in your datafile should be treated as missing (e.g., if you coded missing observations to be 999, you can add this value here and JASP will treat all cells with the value 999 as missing).
 You can delete values from this list by selecting them and pressing the minus button.
 Clicking on "Reset" will restore all the default values.
+
+### Windows workaround
+
+Option here specifically for importing CSV files on Windows. JASP usually try to import `.csv` data file in UTF encoding and/or with a BOM. Changed this option and re-import, JASP will assume a CSV in native encoding with no BOM, and some garbled characters problems may be resolved in this cases.

--- a/Resources/Help/preferences/PrefsResults.md
+++ b/Resources/Help/preferences/PrefsResults.md
@@ -13,7 +13,7 @@ Here you can specify if p-values should be shown as "< .001" or if an exact valu
 
 ### Use exponent notation
 
-Here you can specify if scientific numbers should be displayed with exponent notation, 1×10<sup>-10</sup> instead of being displayed using the E notation, 1e-10.
+Here you can specify if scientific numbers should be displayed with exponent notation as in 1e-10, or normalized like 1×10<sup>-10</sup>.
 
 ### Fix the number of decimals
 

--- a/Resources/Help/preferences/PrefsResults.md
+++ b/Resources/Help/preferences/PrefsResults.md
@@ -13,7 +13,7 @@ Here you can specify if p-values should be shown as "< .001" or if an exact valu
 
 ### Use exponent notation
 
-Here you can specify if scientific numbers should be displayed with exponent notation as in 1e-10, or normalized like 1×10<sup>-10</sup>.
+Here you can specify if scientific numbers should be displayed with exponent notation as in 1e-10, instead of normalized like 1×10<sup>-10</sup>.
 
 ### Fix the number of decimals
 

--- a/Resources/Help/preferences/PrefsResults.md
+++ b/Resources/Help/preferences/PrefsResults.md
@@ -11,9 +11,9 @@ Regarding analysis results in JASP you can choose the following options:
 
 Here you can specify if p-values should be shown as "< .001" or if an exact value should be given.
 
-### Use normalized notation
+### Use exponent notation
 
-Here you can specify if scientific numbers should be displayed with normalized notation, 1×10<sup>-10</sup> instead of being displayed using the E notation, 1e-10.
+Here you can specify if scientific numbers should be displayed with exponent notation, 1×10<sup>-10</sup> instead of being displayed using the E notation, 1e-10.
 
 ### Fix the number of decimals
 

--- a/Resources/Help/preferences/PrefsUI.md
+++ b/Resources/Help/preferences/PrefsUI.md
@@ -8,7 +8,7 @@ With the user interface parameters in JASP you can specify the following options
 ### Fonts
 Here you can specify which font will be used by the interface (File Menu, Ribbon bar, Analysis options panel), the R, Lavaan or JAGS Code, or the results. If no choice is made, the default font is used.
 
-Use Qt's textrendering: JASP using Qt to render interface text by default. JASP will use native text rendering  when unchecked this. try to check/uncheck this if you find that the text on JASP looks terrible(blurry or fuzzy...). This will take effect after restarting JASP
+Use Qt's textrendering: JASP using Qt to render interface text by default. JASP will use native text rendering when the option unchecked. Try to check/uncheck this if you find that the text on JASP looks terrible(blurry or fuzzy...). This will take effect after restarting JASP.
 
 ### Themes
 Here you can specify if you would like to have a "light" or a "dark" theme on the interface of JASP. The dark theme is much easier on the eyes if you are in a dark environment while the light (and default) theme is clearer in bright light.

--- a/Resources/Help/preferences/PrefsUI.md
+++ b/Resources/Help/preferences/PrefsUI.md
@@ -8,6 +8,8 @@ With the user interface parameters in JASP you can specify the following options
 ### Fonts
 Here you can specify which font will be used by the interface (File Menu, Ribbon bar, Analysis options panel), the R, Lavaan or JAGS Code, or the results. If no choice is made, the default font is used.
 
+Use Qt's textrendering: JASP using Qt to render interface text by default. JASP will use native text rendering  when unchecked this. try to check/uncheck this if you find that the text on JASP looks terrible(blurry or fuzzy...). This will take effect after restarting JASP
+
 ### Themes
 Here you can specify if you would like to have a "light" or a "dark" theme on the interface of JASP. The dark theme is much easier on the eyes if you are in a dark environment while the light (and default) theme is clearer in bright light.
 


### PR DESCRIPTION
Added more and improved help files in preferences helpfile

- [x] missing value labels, part of [jasp-issues#1708 ](https://github.com/jasp-stats/jasp-issues/issues/1708)
- [x] Windows workaround
- [x] normalized notation ->exponent notation
- [x] Use Qt's textrendering

to be added:

- [ ] maximum engine count [INTERNAL-jasp#2121 (comment)](https://github.com/jasp-stats/INTERNAL-jasp/issues/2121#issuecomment-1264394844)
- [ ] Netherlands languages in _nl.md

anybody could review and add more info directly against this PR?