### PR TITLE
Scroll along whith focus changes due to tab/backtab

### DIFF
--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -569,20 +569,25 @@ DropArea
 					Connections
 					{
 						target: myForm
-						function onActiveItemChanged()
+						function onActiveJASPControlChanged()
 						{
-							if (!myForm || !myForm.activeItem)
+							if (!myForm || !myForm.activeJASPControl)
 								return;
 
-							const control = myForm.activeItem;
-							const coordinates = myForm.activeItem.mapToItem(scrollAnalyses, 0, 0);
-							const diffYBottom = coordinates.y + myForm.activeItem.height - scrollAnalyses.height;
-							const diffYTop = coordinates.y;
-							//check if the object is visisble in the scrollAnalyses and scroll to it if not
-							if (diffYBottom > 0 && !contentYBehaviour.animation.running)
-								backgroundFlickable.contentY = backgroundFlickable.contentY + diffYBottom;
-							if (diffYTop < 0 && !contentYBehaviour.animation.running)
-								backgroundFlickable.contentY = Math.max(0, backgroundFlickable.contentY + diffYTop);
+							const control = myForm.activeJASPControl;
+							if (control.focusReason === Qt.BacktabFocusReason || control.focusReason === Qt.TabFocusReason)
+							{
+								const coordinates = control.mapToItem(scrollAnalyses, 0, 0);
+								const diffYBottom = coordinates.y + control.height - scrollAnalyses.height;
+								const diffYTop = coordinates.y;
+								const margin = 50 * jaspTheme.uiScale;
+
+								//check if the object is visisble in the scrollAnalyses and scroll to it if not
+								if (diffYBottom > -margin && !contentYBehaviour.animation.running)
+									backgroundFlickable.contentY = backgroundFlickable.contentY + Math.max(0, diffYBottom + margin);
+								if (diffYTop < margin && !contentYBehaviour.animation.running)
+									backgroundFlickable.contentY = Math.max(0, backgroundFlickable.contentY + Math.min(0, diffYTop - margin));
+							}
 						}
 					}
 				}

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -578,14 +578,14 @@ DropArea
 							if (control.focusReason === Qt.BacktabFocusReason || control.focusReason === Qt.TabFocusReason)
 							{
 								const coordinates = control.mapToItem(scrollAnalyses, 0, 0);
-								const diffYBottom = coordinates.y + control.height - scrollAnalyses.height;
-								const diffYTop = coordinates.y;
+								const diffYBottom = coordinates.y + Math.min(control.height, scrollAnalyses.height) - scrollAnalyses.height; //positive if not visible
+								const diffYTop = coordinates.y; //negative if not visible
 								const margin = 50 * jaspTheme.uiScale;
 
-								//check if the object is visisble in the scrollAnalyses and scroll to it if not
-								if (diffYBottom > -margin && !contentYBehaviour.animation.running)
+								//check if the object is visisble in the scrollAnalyses (with margin) and scroll to it if not
+								if (diffYBottom > -margin && !contentYBehaviour.animation.running) // scroll up
 									backgroundFlickable.contentY = backgroundFlickable.contentY + Math.max(0, diffYBottom + margin);
-								if (diffYTop < margin && !contentYBehaviour.animation.running)
+								else if (diffYTop < margin && !contentYBehaviour.animation.running) //scroll down
 									backgroundFlickable.contentY = Math.max(0, backgroundFlickable.contentY + Math.min(0, diffYTop - margin));
 							}
 						}

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -583,9 +583,12 @@ DropArea
 								const margin = 50 * jaspTheme.uiScale;
 
 								//check if the object is visisble in the scrollAnalyses (with margin) and scroll to it if not
-								if (diffYBottom > -margin && !contentYBehaviour.animation.running) // scroll up
+								if(!contentYBehaviour.animation.running)
+									return;
+								
+								if (diffYBottom > -margin) // scroll up
 									backgroundFlickable.contentY = backgroundFlickable.contentY + Math.max(0, diffYBottom + margin);
-								else if (diffYTop < margin && !contentYBehaviour.animation.running) //scroll down
+								else if (diffYTop < margin) //scroll down
 									backgroundFlickable.contentY = Math.max(0, backgroundFlickable.contentY + Math.min(0, diffYTop - margin));
 							}
 						}

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -583,7 +583,7 @@ DropArea
 								const margin = 50 * jaspTheme.uiScale;
 
 								//check if the object is visisble in the scrollAnalyses (with margin) and scroll to it if not
-								if(!contentYBehaviour.animation.running)
+								if(contentYBehaviour.animation.running)
 									return;
 								
 								if (diffYBottom > -margin) // scroll up

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -13,6 +13,7 @@ DropArea
 
 	property alias		myIndex:				draggableItem.myIndex
 	property alias		myAnalysis:				formParent.myAnalysis
+	property alias		myForm:					formParent.myForm
 	property alias		backgroundFlickable:	formParent.backgroundFlickable
 
 	onEntered: (drag)=>

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -569,25 +569,20 @@ DropArea
 					Connections
 					{
 						target: myForm
-						onActiveJASPControlChanged :
+						function onActiveItemChanged()
 						{
-							if (!myForm || !myForm.activeJASPControl)
+							if (!myForm || !myForm.activeItem)
 								return;
 
-							const control = myForm.activeJASPControl;
-							const margin = 50 * jaspTheme.uiScale;
-							const focusReason = myForm.activeJASPControl.focusReason;
-//							if (focusReason === Qt.TabFocusReason || focusReason === Qt.BacktabFocusReason)
-//							{
-								const coordinates = myForm.activeJASPControl.mapToItem(scrollAnalyses, 0, 0);
-								const diffYBottom = coordinates.y + myForm.activeJASPControl.height - scrollAnalyses.height;
-								const diffYTop = coordinates.y;
-								//check if the object is visisble in the scrollAnalyses and scroll to it if not
-								if (diffYBottom > -margin && !contentYBehaviour.animation.running)
-									backgroundFlickable.contentY = Math.min(scrollAnalyses.height, backgroundFlickable.contentY + diffYBottom + margin);
-								if (diffYTop < margin)
-									backgroundFlickable.contentY = Math.max(0, backgroundFlickable.contentY + diffYTop - margin);
-//							}
+							const control = myForm.activeItem;
+							const coordinates = myForm.activeItem.mapToItem(scrollAnalyses, 0, 0);
+							const diffYBottom = coordinates.y + myForm.activeItem.height - scrollAnalyses.height;
+							const diffYTop = coordinates.y;
+							//check if the object is visisble in the scrollAnalyses and scroll to it if not
+							if (diffYBottom > 0 && !contentYBehaviour.animation.running)
+								backgroundFlickable.contentY = backgroundFlickable.contentY + diffYBottom;
+							if (diffYTop < 0 && !contentYBehaviour.animation.running)
+								backgroundFlickable.contentY = Math.max(0, backgroundFlickable.contentY + diffYTop);
 						}
 					}
 				}

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -565,6 +565,31 @@ DropArea
 						if(myAnalysis)
 							myAnalysis.createForm(formParent); //Make sure Analysis knows where to create the form (and might even trigger the creation immediately)
 					}
+
+					Connections
+					{
+						target: myForm
+						onActiveJASPControlChanged :
+						{
+							if (!myForm || !myForm.activeJASPControl)
+								return;
+
+							const control = myForm.activeJASPControl;
+							const margin = 50 * jaspTheme.uiScale;
+							const focusReason = myForm.activeJASPControl.focusReason;
+//							if (focusReason === Qt.TabFocusReason || focusReason === Qt.BacktabFocusReason)
+//							{
+								const coordinates = myForm.activeJASPControl.mapToItem(scrollAnalyses, 0, 0);
+								const diffYBottom = coordinates.y + myForm.activeJASPControl.height - scrollAnalyses.height;
+								const diffYTop = coordinates.y;
+								//check if the object is visisble in the scrollAnalyses and scroll to it if not
+								if (diffYBottom > -margin && !contentYBehaviour.animation.running)
+									backgroundFlickable.contentY = Math.min(scrollAnalyses.height, backgroundFlickable.contentY + diffYBottom + margin);
+								if (diffYTop < margin)
+									backgroundFlickable.contentY = Math.max(0, backgroundFlickable.contentY + diffYTop - margin);
+//							}
+						}
+					}
 				}
 			}
 		}

--- a/Desktop/components/JASP/Widgets/AnalysisForms.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisForms.qml
@@ -136,28 +136,6 @@ FocusScope
 					}
 				}
 
-//				Window.onActiveFocusItemChanged:
-//				{
-//					const margin = 50 * jaspTheme.uiScale;
-//					const currentExpander = formRepeater.itemAt(analysesModel.currentAnalysisIndex)
-//					if(!currentExpander)
-//						return;
-
-//					const currentForm = currentExpander.myForm;
-//					if (currentForm && currentForm.activeJASPControl)
-//					{
-//						const coordinates = currentForm.activeJASPControl.mapToItem(scrollAnalyses, 0, 0);
-//						const diffYBottom = coordinates.y + currentForm.activeJASPControl.height - scrollAnalyses.height;
-//						const diffYTop = coordinates.y;
-//						//check if the object is visisble in the scrollAnalyses and scroll to it if not
-//						if (diffYBottom > -margin && !contentYBehaviour.animation.running)
-//							analysesFlickable.contentY = Math.min(scrollAnalyses.height, analysesFlickable.contentY + diffYBottom + margin);
-//						if (diffYTop < margin)
-//							analysesFlickable.contentY = Math.max(0, analysesFlickable.contentY + diffYTop - margin);
-//					}
-//				}
-
-
 				Column
 				{
 					id:				analysesColumn

--- a/Desktop/components/JASP/Widgets/AnalysisForms.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisForms.qml
@@ -136,27 +136,26 @@ FocusScope
 					}
 				}
 
-				Window.onActiveFocusItemChanged:
-				{
-					const margin = 50;
-					var item = Window.activeFocusItem;
-					var form = item.parent.analysisform;
-					if (form === formRepeater.itemAt(analysesModel.currentAnalysisIndex).myForm)
-					{
-						var coordinates = item.mapToItem(scrollAnalyses, 0, 0);
-						var diffYBottom = coordinates.y - scrollAnalyses.height;
-						var diffYTop = coordinates.y;
-						if (diffYBottom > -margin && !contentYBehaviour.animation.running)
-							analysesFlickable.contentY = Math.min(scrollAnalyses.height, analysesFlickable.contentY + diffYBottom + margin);
-						if (diffYTop < margin)
-							analysesFlickable.contentY = Math.max(0, analysesFlickable.contentY + diffYTop - margin);
-//						console.log(coordinates.y)
-//						console.log(analysesFlickable.contentY)
-//						console.log(diffYBottom)
-//						console.log("\n")
-					}
+//				Window.onActiveFocusItemChanged:
+//				{
+//					const margin = 50 * jaspTheme.uiScale;
+//					const currentExpander = formRepeater.itemAt(analysesModel.currentAnalysisIndex)
+//					if(!currentExpander)
+//						return;
 
-				}
+//					const currentForm = currentExpander.myForm;
+//					if (currentForm && currentForm.activeJASPControl)
+//					{
+//						const coordinates = currentForm.activeJASPControl.mapToItem(scrollAnalyses, 0, 0);
+//						const diffYBottom = coordinates.y + currentForm.activeJASPControl.height - scrollAnalyses.height;
+//						const diffYTop = coordinates.y;
+//						//check if the object is visisble in the scrollAnalyses and scroll to it if not
+//						if (diffYBottom > -margin && !contentYBehaviour.animation.running)
+//							analysesFlickable.contentY = Math.min(scrollAnalyses.height, analysesFlickable.contentY + diffYBottom + margin);
+//						if (diffYTop < margin)
+//							analysesFlickable.contentY = Math.max(0, analysesFlickable.contentY + diffYTop - margin);
+//					}
+//				}
 
 
 				Column

--- a/Desktop/components/JASP/Widgets/AnalysisForms.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisForms.qml
@@ -136,6 +136,29 @@ FocusScope
 					}
 				}
 
+				Window.onActiveFocusItemChanged:
+				{
+					const margin = 50;
+					var item = Window.activeFocusItem;
+					var form = item.parent.analysisform;
+					if (form === formRepeater.itemAt(analysesModel.currentAnalysisIndex).myForm)
+					{
+						var coordinates = item.mapToItem(scrollAnalyses, 0, 0);
+						var diffYBottom = coordinates.y - scrollAnalyses.height;
+						var diffYTop = coordinates.y;
+						if (diffYBottom > -margin && !contentYBehaviour.animation.running)
+							analysesFlickable.contentY = Math.min(scrollAnalyses.height, analysesFlickable.contentY + diffYBottom + margin);
+						if (diffYTop < margin)
+							analysesFlickable.contentY = Math.max(0, analysesFlickable.contentY + diffYTop - margin);
+//						console.log(coordinates.y)
+//						console.log(analysesFlickable.contentY)
+//						console.log(diffYBottom)
+//						console.log("\n")
+					}
+
+				}
+
+
 				Column
 				{
 					id:				analysesColumn

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -963,4 +963,11 @@ void AnalysisForm::sendRSyntax(QString text)
 	_analysis->sendRScript(text, rSyntaxControlName, false);
 }
 
-
+void AnalysisForm::setActiveJASPControl(JASPControl* control)
+{
+	//currently set control still has active focus
+	if(!control && _activeJASPControl && _activeJASPControl->hasActiveFocus())
+		return;
+	_activeJASPControl = control;
+	emit activeJASPControlChanged();
+}

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -963,11 +963,20 @@ void AnalysisForm::sendRSyntax(QString text)
 	_analysis->sendRScript(text, rSyntaxControlName, false);
 }
 
-void AnalysisForm::setActiveJASPControl(JASPControl* control)
+void AnalysisForm::setActiveJASPControl(JASPControl* control, bool hasActiveFocus)
 {
-	//currently set control still has active focus
-	if(!control && _activeJASPControl && _activeJASPControl->hasActiveFocus())
-		return;
-	_activeJASPControl = control;
-	emit activeJASPControlChanged();
+	bool emitSignal = false;
+	if (hasActiveFocus)
+	{
+		 if (_activeJASPControl != control) emitSignal = true;
+		 _activeJASPControl = control;
+	}
+	else if (control == _activeJASPControl)
+	{
+		 if (_activeJASPControl) emitSignal = true;
+		 _activeJASPControl = nullptr;
+	}
+
+	if (emitSignal)
+		emit activeJASPControlChanged();
 }

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -963,11 +963,11 @@ void AnalysisForm::sendRSyntax(QString text)
 	_analysis->sendRScript(text, rSyntaxControlName, false);
 }
 
-void AnalysisForm::setActiveItem(QQuickItem* control)
+void AnalysisForm::setActiveJASPControl(JASPControl* control)
 {
 	//currently set control still has active focus
-	if(!control && _activeItem && _activeItem->hasActiveFocus())
+	if(!control && _activeJASPControl && _activeJASPControl->hasActiveFocus())
 		return;
-	_activeItem = control;
-	emit activeItemChanged();
+	_activeJASPControl = control;
+	emit activeJASPControlChanged();
 }

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -963,11 +963,11 @@ void AnalysisForm::sendRSyntax(QString text)
 	_analysis->sendRScript(text, rSyntaxControlName, false);
 }
 
-void AnalysisForm::setActiveJASPControl(JASPControl* control)
+void AnalysisForm::setActiveItem(QQuickItem* control)
 {
 	//currently set control still has active focus
-	if(!control && _activeJASPControl && _activeJASPControl->hasActiveFocus())
+	if(!control && _activeItem && _activeItem->hasActiveFocus())
 		return;
-	_activeJASPControl = control;
-	emit activeJASPControlChanged();
+	_activeItem = control;
+	emit activeItemChanged();
 }

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -168,7 +168,7 @@ public:
 	QString			getSyntaxName(const QString& name)				const;
 	void			setHasVolatileNotes(bool hasVolatileNotes);
 	bool			parseOptions(Json::Value& options);
-	void			setActiveJASPControl(JASPControl* control);
+	void			setActiveJASPControl(JASPControl* control, bool hasActiveFocus);
 	JASPControl*	getActiveJASPControl()	{ return _activeJASPControl; }
 
 	static const QString	rSyntaxControlName;

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -59,7 +59,7 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(bool			showRSyntax				READ showRSyntax			WRITE setShowRSyntax			NOTIFY showRSyntaxChanged			)
 	Q_PROPERTY(QString		rSyntaxText				READ rSyntaxText											NOTIFY rSyntaxTextChanged			)
 	Q_PROPERTY(QString		rSyntaxControlName		MEMBER rSyntaxControlName	CONSTANT															)
-
+	Q_PROPERTY(JASPControl*	activeJASPControl		READ getActiveJASPControl									NOTIFY activeJASPControlChanged		)
 public:
 	explicit				AnalysisForm(QQuickItem * = nullptr);
 							~AnalysisForm();
@@ -116,6 +116,7 @@ signals:
 	void					titleChanged();
 	void					showRSyntaxChanged();
 	void					rSyntaxTextChanged();
+	void					activeJASPControlChanged();
 
 public:
 	ListModel			*	getModel(const QString& modelName)								const	{ return _modelMap.count(modelName) > 0 ? _modelMap[modelName] : nullptr;	} // Maps create elements if they do not exist yet
@@ -167,6 +168,8 @@ public:
 	QString			getSyntaxName(const QString& name)				const;
 	void			setHasVolatileNotes(bool hasVolatileNotes);
 	bool			parseOptions(Json::Value& options);
+	void			setActiveJASPControl(JASPControl* control);
+	JASPControl*	getActiveJASPControl()	{ return _activeJASPControl; }
 
 	static const QString	rSyntaxControlName;
 
@@ -218,6 +221,7 @@ private:
 	RSyntax										*	_rSyntax						= nullptr;
 	bool											_showRSyntax					= false;
 	QString											_rSyntaxText;
+	JASPControl*									_activeJASPControl				= nullptr;
 };
 
 #endif // ANALYSISFORM_H

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -59,7 +59,7 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(bool			showRSyntax				READ showRSyntax			WRITE setShowRSyntax			NOTIFY showRSyntaxChanged			)
 	Q_PROPERTY(QString		rSyntaxText				READ rSyntaxText											NOTIFY rSyntaxTextChanged			)
 	Q_PROPERTY(QString		rSyntaxControlName		MEMBER rSyntaxControlName	CONSTANT															)
-	Q_PROPERTY(QQuickItem*	activeItem				READ getActiveItem											NOTIFY activeItemChanged		)
+	Q_PROPERTY(JASPControl*	activeJASPControl		READ getActiveJASPControl									NOTIFY activeJASPControlChanged		)
 public:
 	explicit				AnalysisForm(QQuickItem * = nullptr);
 							~AnalysisForm();
@@ -116,7 +116,7 @@ signals:
 	void					titleChanged();
 	void					showRSyntaxChanged();
 	void					rSyntaxTextChanged();
-	void					activeItemChanged();
+	void					activeJASPControlChanged();
 
 public:
 	ListModel			*	getModel(const QString& modelName)								const	{ return _modelMap.count(modelName) > 0 ? _modelMap[modelName] : nullptr;	} // Maps create elements if they do not exist yet
@@ -168,8 +168,8 @@ public:
 	QString			getSyntaxName(const QString& name)				const;
 	void			setHasVolatileNotes(bool hasVolatileNotes);
 	bool			parseOptions(Json::Value& options);
-	void			setActiveItem(QQuickItem* control);
-	QQuickItem*		getActiveItem()	{ return _activeItem; }
+	void			setActiveJASPControl(JASPControl* control);
+	JASPControl*	getActiveJASPControl()	{ return _activeJASPControl; }
 
 	static const QString	rSyntaxControlName;
 
@@ -221,7 +221,7 @@ private:
 	RSyntax										*	_rSyntax						= nullptr;
 	bool											_showRSyntax					= false;
 	QString											_rSyntaxText;
-	QQuickItem*										_activeItem						= nullptr;
+	JASPControl*									_activeJASPControl				= nullptr;
 };
 
 #endif // ANALYSISFORM_H

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -59,7 +59,7 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(bool			showRSyntax				READ showRSyntax			WRITE setShowRSyntax			NOTIFY showRSyntaxChanged			)
 	Q_PROPERTY(QString		rSyntaxText				READ rSyntaxText											NOTIFY rSyntaxTextChanged			)
 	Q_PROPERTY(QString		rSyntaxControlName		MEMBER rSyntaxControlName	CONSTANT															)
-	Q_PROPERTY(JASPControl*	activeJASPControl		READ getActiveJASPControl									NOTIFY activeJASPControlChanged		)
+	Q_PROPERTY(QQuickItem*	activeItem				READ getActiveItem											NOTIFY activeItemChanged		)
 public:
 	explicit				AnalysisForm(QQuickItem * = nullptr);
 							~AnalysisForm();
@@ -116,7 +116,7 @@ signals:
 	void					titleChanged();
 	void					showRSyntaxChanged();
 	void					rSyntaxTextChanged();
-	void					activeJASPControlChanged();
+	void					activeItemChanged();
 
 public:
 	ListModel			*	getModel(const QString& modelName)								const	{ return _modelMap.count(modelName) > 0 ? _modelMap[modelName] : nullptr;	} // Maps create elements if they do not exist yet
@@ -168,8 +168,8 @@ public:
 	QString			getSyntaxName(const QString& name)				const;
 	void			setHasVolatileNotes(bool hasVolatileNotes);
 	bool			parseOptions(Json::Value& options);
-	void			setActiveJASPControl(JASPControl* control);
-	JASPControl*	getActiveJASPControl()	{ return _activeJASPControl; }
+	void			setActiveItem(QQuickItem* control);
+	QQuickItem*		getActiveItem()	{ return _activeItem; }
 
 	static const QString	rSyntaxControlName;
 
@@ -221,7 +221,7 @@ private:
 	RSyntax										*	_rSyntax						= nullptr;
 	bool											_showRSyntax					= false;
 	QString											_rSyntaxText;
-	JASPControl*									_activeJASPControl				= nullptr;
+	QQuickItem*										_activeItem						= nullptr;
 };
 
 #endif // ANALYSISFORM_H

--- a/QMLComponents/components/JASP/Controls/Slider.qml
+++ b/QMLComponents/components/JASP/Controls/Slider.qml
@@ -11,6 +11,7 @@ SliderBase
 	implicitWidth:		columnLayout.implicitWidth
 	innerControl:		textField
 	title:				controlLabel.text
+	focusOnTab:			false
 
 	property alias	control:		textField
 	property int	decimals:		2
@@ -52,6 +53,7 @@ SliderBase
 			value:				0.5
 			stepSize:			1 / slider.power
 			orientation:		slider.verticalInt
+			activeFocusOnTab:	false
 
 			background: Rectangle
 			{

--- a/QMLComponents/components/JASP/Controls/VariablesForm.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesForm.qml
@@ -33,7 +33,15 @@ VariablesFormBase
 	preferredHeight				: implicitHeight
 	preferredWidth				: implicitWidth
 	Layout.preferredHeight		: preferredHeight // Cannot set Layout attached property in c++
-	focusOnTab					: false
+
+	onActiveFocusChanged		:
+	{
+		if (activeFocus) {
+			availableVariablesList.forceActiveFocus();
+			//the first button knows the way out...
+			availableVariablesList.KeyNavigation.backtab = assignButtonRepeater.itemAt(0).nextItemInFocusChain(false);
+		}
+	}
 
 	default property alias	content				: items.children
 			property int	listWidth			: width * 2 / 5
@@ -186,8 +194,6 @@ VariablesFormBase
 	function setTabOrder()
 	{
 		availableVariablesList.KeyNavigation.tab = assignButtonRepeater.itemAt(0);
-		assignButtonRepeater.itemAt(0).KeyNavigation.backtab = availableVariablesList;
-
 		for (var i = 0; i < allAssignedVariablesList.length - 1; i++)
 			assignButtonRepeater.itemAt(i).KeyNavigation.tab = assignButtonRepeater.itemAt(i + 1);
 
@@ -195,6 +201,6 @@ VariablesFormBase
 			assignButtonRepeater.itemAt(allAssignedVariablesList.length - 1).KeyNavigation.tab = allAssignedVariablesList[0]
 
 		for (var j = 0; j < allAssignedVariablesList.length - 1; j++)
-			allAssignedVariablesList[j] = allAssignedVariablesList[j + 1];
+			allAssignedVariablesList[j].KeyNavigation.tab = allAssignedVariablesList[j + 1];
 	}
 }

--- a/QMLComponents/components/JASP/Controls/VariablesForm.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesForm.qml
@@ -36,10 +36,11 @@ VariablesFormBase
 
 	onActiveFocusChanged		:
 	{
-		if (activeFocus) {
+		if (activeFocus)
+		{
 			availableVariablesList.forceActiveFocus();
-			//the first button knows the way out...
-			availableVariablesList.KeyNavigation.backtab = assignButtonRepeater.itemAt(0).nextItemInFocusChain(false);
+			//first child can calculate previous item in focus chain using Qt default
+			availableVariablesList.KeyNavigation.backtab = children[0].nextItemInFocusChain(false);
 		}
 	}
 

--- a/QMLComponents/components/JASP/Controls/VariablesForm.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesForm.qml
@@ -39,8 +39,7 @@ VariablesFormBase
 		if (activeFocus)
 		{
 			availableVariablesList.forceActiveFocus();
-			//first child can calculate previous item in focus chain using Qt default
-			availableVariablesList.KeyNavigation.backtab = children[0].nextItemInFocusChain(false);
+			availableVariablesList.KeyNavigation.backtab = variablesForm.nextItemInFocusChain(false);
 		}
 	}
 

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -6,6 +6,8 @@
 #include <QQmlProperty>
 #include <QQmlContext>
 #include <QTimer>
+#include <QQuickWindow>
+
 
 QMap<QQmlEngine*, QQmlComponent*> JASPControl::_mouseAreaComponentMap;
 QByteArray JASPControl::_mouseAreaDef = "\
@@ -640,7 +642,6 @@ void JASPControl::_setFocus()
 		setFocus(false);
 }
 
-#include <QQuickWindow>
 void JASPControl::_notifyFormOfActiveFocus()
 {
 	if (_form)

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -437,7 +437,7 @@ void JASPControl::setParentDebugToChildren(bool debug)
 {
 	if (_childControlsArea)
 		for (JASPControl* childControl : getChildJASPControls(_childControlsArea))
-		childControl->setParentDebug(debug);
+			childControl->setParentDebug(debug);
 }
 
 void JASPControl::focusInEvent(QFocusEvent *event)
@@ -447,6 +447,7 @@ void JASPControl::focusInEvent(QFocusEvent *event)
 	_activeJASPControl = true;
 }
 
+//Installed of innercontrol and non JASPControl children to capture focus reason
 bool JASPControl::eventFilter(QObject *watched, QEvent *event)
 {
 	if (event->type() == QEvent::FocusIn)

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -255,13 +255,6 @@ void JASPControl::componentComplete()
 
 	if (_form)
 		connect(this, &JASPControl::boundValueChanged, _form, &AnalysisForm::boundValueChangedHandler);
-
-	//capture focus reason
-	for (QQuickItem* childItem : childItems())
-	{
-		if (!qobject_cast<JASPControl*>(childItem))
-			childItem->installEventFilter(this);
-	}
 }
 
 void JASPControl::setCursorShape(int shape)
@@ -444,7 +437,7 @@ void JASPControl::focusInEvent(QFocusEvent *event)
 {
 	QQuickItem::focusInEvent(event);
 	_focusReason = event->reason();
-	_activeJASPControl = true;
+	_hasActiveFocus = true;
 }
 
 //Installed of innercontrol and non JASPControl children to capture focus reason
@@ -454,7 +447,7 @@ bool JASPControl::eventFilter(QObject *watched, QEvent *event)
 	{
 		QFocusEvent* focusEvent = static_cast<QFocusEvent*>(event);
 		_focusReason = focusEvent->reason();
-		_activeJASPControl = true;
+		_hasActiveFocus = true;
 	}
 	#ifdef __APPLE__
 	if (event->type() == QEvent::MouseButtonPress)
@@ -682,14 +675,9 @@ void JASPControl::_setFocus()
 
 void JASPControl::_notifyFormOfActiveFocus()
 {
+	if (!hasActiveFocus())
+		_hasActiveFocus = false;
+
 	if (_form)
-	{
-		if (!hasActiveFocus())
-		{
-			_form->setActiveJASPControl(nullptr);
-			_activeJASPControl = false;
-		}
-		if(_activeJASPControl)
-			_form->setActiveJASPControl(this);
-	}
+		_form->setActiveJASPControl(this, hasActiveFocus());
 }

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -62,11 +62,8 @@ JASPControl::JASPControl(QQuickItem *parent) : QQuickItem(parent)
 	connect(this, &JASPControl::parentDebugChanged,		[this] () { _setBackgroundColor(); _setVisible(); } );
 	connect(this, &JASPControl::toolTipChanged,			[this] () { QQmlProperty(this, "ToolTip.text", qmlContext(this)).write(toolTip()); } );
 	connect(this, &JASPControl::boundValueChanged,		this, &JASPControl::_resetBindingValue);
-<<<<<<< HEAD
 	connect(this, &JASPControl::activeFocusChanged,		this, &JASPControl::_setFocus);
-=======
 	connect(this, &JASPControl::activeFocusChanged,		this, &JASPControl::_notifyFormOfActiveFocus);
->>>>>>> 5cff37b70 (scrolling almost implemented. Click detection needed)
 }
 
 JASPControl::~JASPControl()
@@ -643,42 +640,16 @@ void JASPControl::_setFocus()
 		setFocus(false);
 }
 
-  void JASPControl::_notifyFormOfActiveFocus()
+#include <QQuickWindow>
+void JASPControl::_notifyFormOfActiveFocus()
 {
-	if (_form && getChildJASPControls(this).length() == 0)
+	if (_form)
 	{
 		if (!hasActiveFocus())
-			_form->setActiveJASPControl(nullptr);
-		else
-			_form->setActiveJASPControl(this);
+			_form->setActiveItem(nullptr);
+		else if (this ==  window()->activeFocusItem())
+			_form->setActiveItem(this);
+		else if (scopedFocusItem() ==  window()->activeFocusItem())
+			_form->setActiveItem(scopedFocusItem());
 	}
-}
-
-
-//void JASPControl::_notifyFormOfActiveFocus()
-//{
-//	if (_form)
-//	{
-//		if (!hasActiveFocus()) {
-//			_form->setActiveJASPControl(nullptr);
-//			return;
-//		}
-
-//		auto childControls = getChildJASPControls(this);
-//		bool childActive = false;
-//		for (const auto& child : childControls)
-//		{
-//			childActive |=	child->hasActiveFocus();
-//		}
-//		if (!childActive)
-//			_form->setActiveJASPControl(this);
-//	}
-//}
-
-
-void JASPControl::focusInEvent(QFocusEvent * event)
-{
-	_focusReason = event->reason();
-	QQuickItem::focusInEvent(event);
-	Log::log() << "focus ve" << std::endl;
 }

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -62,7 +62,11 @@ JASPControl::JASPControl(QQuickItem *parent) : QQuickItem(parent)
 	connect(this, &JASPControl::parentDebugChanged,		[this] () { _setBackgroundColor(); _setVisible(); } );
 	connect(this, &JASPControl::toolTipChanged,			[this] () { QQmlProperty(this, "ToolTip.text", qmlContext(this)).write(toolTip()); } );
 	connect(this, &JASPControl::boundValueChanged,		this, &JASPControl::_resetBindingValue);
+<<<<<<< HEAD
 	connect(this, &JASPControl::activeFocusChanged,		this, &JASPControl::_setFocus);
+=======
+	connect(this, &JASPControl::activeFocusChanged,		this, &JASPControl::_notifyFormOfActiveFocus);
+>>>>>>> 5cff37b70 (scrolling almost implemented. Click detection needed)
 }
 
 JASPControl::~JASPControl()
@@ -633,9 +637,48 @@ void JASPControl::rScriptDoneHandler(const QString &)
 	throw std::runtime_error("runRScript done but handler not implemented!\nImplement an override for RScriptDoneHandler\n");
 }
 
-
 void JASPControl::_setFocus()
 {
 	if (!hasActiveFocus())
 		setFocus(false);
+}
+
+  void JASPControl::_notifyFormOfActiveFocus()
+{
+	if (_form && getChildJASPControls(this).length() == 0)
+	{
+		if (!hasActiveFocus())
+			_form->setActiveJASPControl(nullptr);
+		else
+			_form->setActiveJASPControl(this);
+	}
+}
+
+
+//void JASPControl::_notifyFormOfActiveFocus()
+//{
+//	if (_form)
+//	{
+//		if (!hasActiveFocus()) {
+//			_form->setActiveJASPControl(nullptr);
+//			return;
+//		}
+
+//		auto childControls = getChildJASPControls(this);
+//		bool childActive = false;
+//		for (const auto& child : childControls)
+//		{
+//			childActive |=	child->hasActiveFocus();
+//		}
+//		if (!childActive)
+//			_form->setActiveJASPControl(this);
+//	}
+//}
+
+
+void JASPControl::focusInEvent(QFocusEvent * event)
+{
+	_focusReason = event->reason();
+	QQuickItem::focusInEvent(event);
+	Log::log() << "focus ve" << std::endl;
 }

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -456,6 +456,14 @@ bool JASPControl::eventFilter(QObject *watched, QEvent *event)
 		_focusReason = focusEvent->reason();
 		_activeJASPControl = true;
 	}
+	#ifdef __APPLE__
+	if (event->type() == QEvent::MouseButtonPress)
+	{
+		QQuickItem* item = qobject_cast<QQuickItem*>(watched);
+		if(item)
+			item->forceActiveFocus(Qt::FocusReason::MouseFocusReason);
+	}
+	#endif
 	return false;
 }
 

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -280,7 +280,7 @@ protected:
 							_shouldStealHover			= false,
 							_nameMustBeUnique			= true,
 							_hasUserInteractiveValue	= true,
-							_activeJASPControl			= false;
+							_hasActiveFocus				= false;
 	JASPListControl		*	_parentListView				= nullptr;
 	QQuickItem			*	_childControlsArea			= nullptr,
 						*	_innerControl				= nullptr,

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -48,7 +48,8 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( int									cursorShape				READ cursorShape			WRITE setCursorShape												)
 	Q_PROPERTY( bool								hovered					READ hovered												NOTIFY hoveredChanged				)
 	Q_PROPERTY( int									alignment				READ alignment				WRITE setAlignment													)
-	Q_PROPERTY( QQuickItem*									analysisform           	READ form													)
+	Q_PROPERTY( QQuickItem*							analysisform           	READ form																						)
+	Q_PROPERTY( Qt::FocusReason 					focusReason           	READ focusReason																				)
 
 	typedef std::set<JASPControl*> Set;
 
@@ -143,6 +144,8 @@ public:
 	int					cursorShape()				const	{ return _cursorShape;			}
 	bool				hovered()					const;
 	int					alignment()					const	{ return _alignment;			}
+	Qt::FocusReason	    focusReason()				const	{ return _focusReason;			} //Qt does not have focus reason outside of Controls?
+
 
 	QString				humanFriendlyLabel()		const;
 	void				setInitialized(bool byFile = false);
@@ -213,6 +216,7 @@ private slots:
 	void	_hoveredChangedSlot() { emit hoveredChanged(); }
 	void	_resetBindingValue();
 	void	_setFocus();
+	void	_notifyFormOfActiveFocus();
 
 signals:
 	void setOptionBlockSignal(	bool blockSignal);
@@ -252,6 +256,7 @@ protected:
 	void				_setType();
 	void				setCursorShape(int shape);
 	void				setParentDebugToChildren(bool debug);
+	void				focusInEvent(QFocusEvent * event) override;
 
 protected:
 	ControlType				_controlType;
@@ -292,6 +297,7 @@ protected:
 	QQuickItem			*	_mouseAreaObj				= nullptr;
 	int						_cursorShape				= Qt::PointingHandCursor;
 	int						_alignment					= Qt::AlignTop | Qt::AlignLeft;
+	Qt::FocusReason			_focusReason                = Qt::FocusReason::NoFocusReason;
 
 	static QMap<QQmlEngine*, QQmlComponent*>		_mouseAreaComponentMap;
 	static QByteArray								_mouseAreaDef;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -48,6 +48,8 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( int									cursorShape				READ cursorShape			WRITE setCursorShape												)
 	Q_PROPERTY( bool								hovered					READ hovered												NOTIFY hoveredChanged				)
 	Q_PROPERTY( int									alignment				READ alignment				WRITE setAlignment													)
+	Q_PROPERTY( Qt::FocusReason						focusReason				READ getFocusReason																				)
+
 
 	typedef std::set<JASPControl*> Set;
 
@@ -142,6 +144,7 @@ public:
 	int					cursorShape()				const	{ return _cursorShape;			}
 	bool				hovered()					const;
 	int					alignment()					const	{ return _alignment;			}
+	Qt::FocusReason		getFocusReason()			const	{ return _focusReason;			}
 
 	QString				humanFriendlyLabel()		const;
 	void				setInitialized(bool byFile = false);
@@ -252,6 +255,8 @@ protected:
 	void				_setType();
 	void				setCursorShape(int shape);
 	void				setParentDebugToChildren(bool debug);
+	void				focusInEvent(QFocusEvent* event) override;
+	bool				eventFilter(QObject *watched, QEvent *event) override;
 
 protected:
 	ControlType				_controlType;
@@ -274,7 +279,8 @@ protected:
 							_shouldShowFocus			= false,
 							_shouldStealHover			= false,
 							_nameMustBeUnique			= true,
-							_hasUserInteractiveValue	= true;
+							_hasUserInteractiveValue	= true,
+							_activeJASPControl			= false;
 	JASPListControl		*	_parentListView				= nullptr;
 	QQuickItem			*	_childControlsArea			= nullptr,
 						*	_innerControl				= nullptr,
@@ -292,6 +298,7 @@ protected:
 	QQuickItem			*	_mouseAreaObj				= nullptr;
 	int						_cursorShape				= Qt::PointingHandCursor;
 	int						_alignment					= Qt::AlignTop | Qt::AlignLeft;
+	Qt::FocusReason			_focusReason				= Qt::FocusReason::NoFocusReason;
 
 	static QMap<QQmlEngine*, QQmlComponent*>		_mouseAreaComponentMap;
 	static QByteArray								_mouseAreaDef;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -49,7 +49,6 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( bool								hovered					READ hovered												NOTIFY hoveredChanged				)
 	Q_PROPERTY( int									alignment				READ alignment				WRITE setAlignment													)
 	Q_PROPERTY( QQuickItem*							analysisform           	READ form																						)
-	Q_PROPERTY( Qt::FocusReason 					focusReason           	READ focusReason																				)
 
 	typedef std::set<JASPControl*> Set;
 
@@ -144,8 +143,6 @@ public:
 	int					cursorShape()				const	{ return _cursorShape;			}
 	bool				hovered()					const;
 	int					alignment()					const	{ return _alignment;			}
-	Qt::FocusReason	    focusReason()				const	{ return _focusReason;			} //Qt does not have focus reason outside of Controls?
-
 
 	QString				humanFriendlyLabel()		const;
 	void				setInitialized(bool byFile = false);
@@ -256,7 +253,6 @@ protected:
 	void				_setType();
 	void				setCursorShape(int shape);
 	void				setParentDebugToChildren(bool debug);
-	void				focusInEvent(QFocusEvent * event) override;
 
 protected:
 	ControlType				_controlType;
@@ -297,7 +293,6 @@ protected:
 	QQuickItem			*	_mouseAreaObj				= nullptr;
 	int						_cursorShape				= Qt::PointingHandCursor;
 	int						_alignment					= Qt::AlignTop | Qt::AlignLeft;
-	Qt::FocusReason			_focusReason                = Qt::FocusReason::NoFocusReason;
 
 	static QMap<QQmlEngine*, QQmlComponent*>		_mouseAreaComponentMap;
 	static QByteArray								_mouseAreaDef;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -48,7 +48,6 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( int									cursorShape				READ cursorShape			WRITE setCursorShape												)
 	Q_PROPERTY( bool								hovered					READ hovered												NOTIFY hoveredChanged				)
 	Q_PROPERTY( int									alignment				READ alignment				WRITE setAlignment													)
-	Q_PROPERTY( QQuickItem*							analysisform           	READ form																						)
 
 	typedef std::set<JASPControl*> Set;
 

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -48,6 +48,7 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( int									cursorShape				READ cursorShape			WRITE setCursorShape												)
 	Q_PROPERTY( bool								hovered					READ hovered												NOTIFY hoveredChanged				)
 	Q_PROPERTY( int									alignment				READ alignment				WRITE setAlignment													)
+	Q_PROPERTY( QQuickItem*									analysisform           	READ form													)
 
 	typedef std::set<JASPControl*> Set;
 


### PR DESCRIPTION
Uses a filter on _innercontrol to catch the focus reason so that we can discern between mouse click and tabs.
If you really dislike it I can revert to the simpler version.

adds focus reason property to JASPControls
adds activeJASPControl property to analysis forms.
Implements a little logic for scrolling in to view.