### PR TITLE
Allow Allowed & Suggested columns to be changed dynamically

### DIFF
--- a/Docs/development/jasp-qml-guide.md
+++ b/Docs/development/jasp-qml-guide.md
@@ -434,11 +434,14 @@ Properties
 - `name`: identifier of the particular variable field (in your R code you will be able to retrieve the assigned variable(s) through this identifier)
 - `label`: [optional, default: `""`] text that will be shown above the variable field
 - `columns`: [optional, default: 1] number of columns of the list.
-- `allowedColumns`: [optional, default: empty, possible values: `["scale", "ordinal", "nominal"]` ] array specifying the allowed column types
-- `suggestedColumns`: [optional, default: empty, possible values: `["scale", "ordinal", "nominal"]` ] array specifying the suggested column types. These types will be displayed as icons at the bottom-right of the AssignedVariablesList. If `suggestedColumns` is empty and `allowedColumns` is specified, then `suggestedColumns` get automatically the value of `allowedColumns`. If `allowedColumns` is empty and `suggestedColumns` is specified, then the following rules apply:
-    * `scale` allows Nominal Integer and Ordinal columns
-    * `nominal` allows all Nominal columns (Integer or String), and Ordinal column
-    * if no `suggestedColumns` and no `allowedColumns` is specified, then all types of columns are allowed
+- `allowedColumns`: [optional, default: empty, possible values: `["scale", "ordinal", "nominal", "nominalText"]` ] array specifying the allowed column types. The difference between `nominal` and `nominalText` is that `nominal` uses integers to label the values, and `nominalText` uses strings.
+- `suggestedColumns`: [optional, default: empty, possible values: `["scale", "ordinal", "nominal", "nominalText"]` ] array specifying the suggested column types. The difference between `allowedColumns` and `suggestedColumns` is that `allowedColumns` sets explicitly the types that are allowed, and `suggestedColumns` sets the allowed types in a looser way, with these rules:
+    * if `suggestedColumns` contains the `scale` type, then `nominal` and `ordinal` types are also allowed
+    * if `suggestedColumns` contains the `nominal` type, then `nominalText`and `ordinal` tyes are also allowed
+
+The `suggestedColumns` types are displayed as icons at the bottom-right of the VariablesList, indicating which kind of columns may be added in this VariablesList. If `suggestedColumns` is empty and `allowedColumns` is specified, then the `allowedColumns` is used to display the type icons.
+If `suggestedColumns` and `allowedColumns` are empty, then all column types are allowed.\
+To avoid confusion, use either the `allowedColumns` property or the `suggestedColumns` property, and not both properties, to set which columns might be inserted in the VariablesList. `allowedColumns` sets the types explicitly, `suggestedColumns` indicates more which types should be used, but permits other types that can be converted implicitly to the right type.
 - `maxRows`: [optional, default: `-1`] maximum number of rows the list can accept. -1 means no limit.
 - `singleVariable`: [optional, default: `false`] if true, set the maxRows to 1
 - `listViewType`: [optional] enumerative that specifies the type of `AssignedVariablesList`, when omitted we get a normal list, options are `JASP.Layers` (see Contingency Tables), `JASP.Interaction` (see ANOVA) and `JASP.RepeatedMeasures` (see Repeated Measures ANOVA)

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -65,7 +65,7 @@ public:
 			void				setUp()						override;
 			void				cleanUp()					override;
 	
-			int					variableTypesAllowed()		const			{ return _variableTypesAllowed; }
+	const QSet<columnType>&		variableTypesAllowed()		const			{ return _variableTypesAllowed; }
 
 	const QVector<SourceItem*>& sourceItems()				const			{ return _sourceItems; }
 			void				applyToAllSources(std::function<void(SourceItem *sourceItem, const Terms& terms)> applyThis);
@@ -136,7 +136,7 @@ protected slots:
 
 protected:
 	QVector<SourceItem*>	_sourceItems;
-	int						_variableTypesAllowed	= 0xff;
+	QSet<columnType>		_variableTypesAllowed;
 	QString					_optionKey				= "value";
 	QVariant				_source;
 	QVariant				_rSource;

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -108,7 +108,7 @@ protected slots:
 	void interactionHighOrderHandler(JASPControl* checkBoxControl);
 
 private:
-	int							_getAllowedColumnsTypes();
+	int							_getColumnsTypes(const QStringList& types);
 	void						_setAllowedVariables();
 	void						_setRelations();
 

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -108,7 +108,6 @@ protected slots:
 	void interactionHighOrderHandler(JASPControl* checkBoxControl);
 
 private:
-	int							_getColumnsTypes(const QStringList& types);
 	void						_setAllowedVariables();
 	void						_setRelations();
 

--- a/QMLComponents/models/listmodeldraggable.cpp
+++ b/QMLComponents/models/listmodeldraggable.cpp
@@ -121,13 +121,12 @@ bool ListModelDraggable::isAllowed(const Term &term) const
 			return false;
 	}
 
-	int variableTypesAllowed = listView()->variableTypesAllowed();
+	const QSet<columnType>& variableTypesAllowed = listView()->variableTypesAllowed();
 
-	if (variableTypesAllowed == 0xff || term.size() > 1)
+	if (variableTypesAllowed.empty() || term.size() > 1)
 		return true;
 	
-	QVariant	v				= requestInfo(VariableInfo::VariableType, term.asQString());
-	int			variableType	= v.toInt();
+	columnType	variableType = (columnType)requestInfo(VariableInfo::VariableType, term.asQString()).toInt();
 
-	return variableType == 0 || variableType & variableTypesAllowed;
+	return variableTypesAllowed.contains(variableType);
 }


### PR DESCRIPTION
This is a request from @fqixiang 

The _setAllowedVariables function must be connected to the allowedColumnsChanged & suggestedColumnsChanged signals.
Moreover _setAllowedVariables should not mix up the _allowColumns & _suggestedColumns property: these properties should not be set in this function, only _variableTypesAllowed & _suggestedColumnsIcons should be set: _variableTypesAllowed is used to check which column is really allowed, and _suggestedColumnsIcons is used to set the icons in the VariablesList.

