### PR TITLE
Add support for GITHUB_PAT_DEF

### DIFF
--- a/Desktop/CMakeLists.txt
+++ b/Desktop/CMakeLists.txt
@@ -24,6 +24,10 @@ if(APPLE)
                  ${CMAKE_BINARY_DIR}/Info.plist)
 endif()
 
+configure_file(${CMAKE_CURRENT_LIST_DIR}/gui/preferencesmodel.cpp.in
+	           ${CMAKE_CURRENT_LIST_DIR}/gui/preferencesmodel.cpp)
+message(STATUS "preferencesmodel.cpp is successfully generated...")
+
 
 file(GLOB_RECURSE HEADER_FILES "${CMAKE_CURRENT_LIST_DIR}/*.h")
 file(GLOB_RECURSE SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/*.cpp")

--- a/Desktop/gui/.gitignore
+++ b/Desktop/gui/.gitignore
@@ -1,0 +1,1 @@
+preferencesmodel.cpp

--- a/Desktop/gui/preferencesmodel.cpp.in
+++ b/Desktop/gui/preferencesmodel.cpp.in
@@ -179,7 +179,6 @@ QString PreferencesModel::githubPatResolved() const
 {
 	if(githubPatUseDefault())
 		return QProcessEnvironment::systemEnvironment().value("GITHUB_PAT", "@GITHUB_PAT_DEFINE@");
-        // TODO: Make sure that I can pass the Github PAT
 
 	return githubPatCustom();
 }

--- a/Tools/CMake/Config.cmake
+++ b/Tools/CMake/Config.cmake
@@ -237,28 +237,37 @@ endif()
 # I will consider turning this off, and letting Qt does it
 # when everything else worked properly
 
-set(GITHUB_PAT
-    ""
-    CACHE STRING "GitHub Personal Access Token")
+set(GITHUB_PAT     "" CACHE STRING "GitHub Personal Access Token to use during building")
+set(GITHUB_PAT_DEF "" CACHE STRING "GitHub Personal Access Token to use in released version as default")
 
-if(INSTALL_R_MODULES)
 
-  message(CHECK_START "Looking if its set as an environment variable.")
-  set(GITHUB_PAT $ENV{GITHUB_PAT})
+message(CHECK_START "Looking if GITHUB_PAT is set as an environment variable.")
+set(GITHUB_PAT      $ENV{GITHUB_PAT})
 
-  if(GITHUB_PAT STREQUAL "")
-    message(CHECK_FAIL "not found")
-    message(
-      FATAL_ERROR
-        "You probably need to set the GITHUB_PAT; otherwise CMAKE cannot effectively communicate with GitHub. If you are using Qt Creator, you can set a new environment GITHUB_PAT variable in Qt Creator."
-    )
-  endif()
-
-  message(CHECK_PASS "found")
-
+if(GITHUB_PAT STREQUAL "")
+  message(CHECK_FAIL "not found")
+  message(
+    FATAL_ERROR
+      "You probably need to set the GITHUB_PAT; otherwise CMAKE cannot effectively communicate with GitHub. If you are using Qt Creator, you can set a new environment GITHUB_PAT variable in Qt Creator."
+  )
 endif()
+message(CHECK_PASS "found")
 
-message(STATUS "GITHUB_PAT: ${GITHUB_PAT}")
+message(CHECK_START "Looking if GITHUB_PAT_DEF is set as an environment variable.")
+set(GITHUB_PAT_DEF      $ENV{GITHUB_PAT_DEF})
+
+if(GITHUB_PAT_DEF STREQUAL "")
+  message(CHECK_FAIL "not found")
+  set(GITHUB_PAT_DEF ${GITHUB_PAT})
+  message(
+    WARNING
+      "Your GITHUB_PAT is used as the default PAT for any JASP build with this config, if this is inteded as released software you will want to set GITHUB_PAT_DEF to something else than your personal PAT!"
+  )
+endif()
+message(CHECK_PASS "found")
+
+message(STATUS "GITHUB_PAT:     ${GITHUB_PAT}")
+message(STATUS "GITHUB_PAT_DEF: ${GITHUB_PAT_DEF}")
 
 if(CCACHE_EXECUTABLE
    AND USE_CCACHE


### PR DESCRIPTION
This was originally a feature of JASP, using a default GITHUB_PAT but the cmake switch lost control of that.

Here it is returned!

Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2074 (Default GITHUB_PAT totally broken)