### PR TITLE
Small mistake in tooltip logic for textfields

### DIFF
--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -153,7 +153,7 @@ TextInputBase
 		ToolTip.text		: control.text
 		ToolTip.timeout		: jaspTheme.toolTipTimeout
 		ToolTip.delay		: !hovered ? 0 : jaspTheme.toolTipDelay
-		ToolTip.visible		: hovered || (contentWidth > width - leftPadding - rightPadding && control.activeFocus)
+		ToolTip.visible		: contentWidth > width - leftPadding - rightPadding && (hovered || control.activeFocus)
 
 		// The acceptableInput is checked even if the user is still typing in the TextField.
 		// In this case, the error should not appear immediately (only when the user is pressing the return key, or going out of focus),


### PR DESCRIPTION
should only show when contentwidth > width