### PR TITLE
Load a JASP file with a Network or Cochrane analysis rerun automatically

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -123,7 +123,7 @@ Analysis* Analyses::create(const Json::Value & analysisData, Modules::AnalysisEn
 	storeAnalysis(analysis, id, notifyAll);
 	bindAnalysisHandler(analysis);
 	
-	if(!analysisData.isNull())	analysis->loadResultsUserdataAndRSourcesFromJASPFile(analysisData);
+	if(!analysisData.isNull())	analysis->loadResultsUserdataAndRSourcesFromJASPFile(analysisData, status);
 	else						analysis->setResults(analysisEntry->getDefaultResults(), status);
 	
 

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -419,11 +419,11 @@ void Analysis::checkDefaultTitleFromJASPFile(const Json::Value & analysisData)
 	_oldVersion		= analysisData.get("preUpgradeVersion", _results.get("version", AppInfo::version.asString())).asString();
 }
 
-void Analysis::loadResultsUserdataAndRSourcesFromJASPFile(const Json::Value & analysisData)
+void Analysis::loadResultsUserdataAndRSourcesFromJASPFile(const Json::Value & analysisData, Status status)
 {
 	Log::log() << "Now loading userdata results and R Sources for analysis " << _name << " from file." << std::endl;
 	setUserData(analysisData["userdata"]);
-	setResults(analysisData["results"], _status);
+	setResults(analysisData["results"], status);
 	setRSources(analysisData["rSources"]);
 
 	//The rest is already taken in from Analyses::createFromJaspFileEntry

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -130,7 +130,7 @@ public:
 
 			Json::Value			asJSON(bool withRSources = false)	const;
 			void				checkDefaultTitleFromJASPFile(	const Json::Value & analysisData);
-			void				loadResultsUserdataAndRSourcesFromJASPFile(const Json::Value & analysisData);
+			void				loadResultsUserdataAndRSourcesFromJASPFile(const Json::Value & analysisData, Status status);
 			Json::Value			createAnalysisRequestJson();
 
 	static	Status				parseStatus(std::string name);


### PR DESCRIPTION
Save a JASP file with a Network or a Cochrane analysis. Reload the JASP file: the analysis is run again.
This is due to the fact that the status property is not well set when reading the JASP file.

