### PR TITLE
Order of variables with components must be kept

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolbase.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolbase.cpp
@@ -149,15 +149,13 @@ void BoundControlBase::_readTableValue(const Json::Value &value, const std::stri
 	}
 }
 
-Json::Value BoundControlBase::_getTableValueOption(const ListModel::RowControlsValues& termsWithComponentValues, const std::string& key, bool hasMultipleTerms)
+Json::Value BoundControlBase::_getTableValueOption(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasMultipleTerms)
 {
 	Json::Value result(Json::arrayValue);
-	ListModel::RowControlsValuesIterator it(termsWithComponentValues);
-	while (it.hasNext())
+
+	for (const Term& term : terms)
 	{
-		it.next();
-		Term term = Term::readTerm(it.key());
-		QMap<QString, Json::Value> componentValues = it.value();
+		QMap<QString, Json::Value> componentValues = componentValuesMap[term.asQString()];
 
 		Json::Value rowValues(Json::objectValue);
 		if (hasMultipleTerms)
@@ -185,8 +183,8 @@ Json::Value BoundControlBase::_getTableValueOption(const ListModel::RowControlsV
 	return result;
 }
 
-void BoundControlBase::_setTableValue(const ListModel::RowControlsValues& termsWithComponentValues, const std::string& key, bool hasMultipleTerms)
+void BoundControlBase::_setTableValue(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasMultipleTerms)
 {
-	setBoundValue(_getTableValueOption(termsWithComponentValues, key, hasMultipleTerms));
+	setBoundValue(_getTableValueOption(terms, componentValuesMap, key, hasMultipleTerms));
 }
 

--- a/QMLComponents/boundcontrols/boundcontrolbase.h
+++ b/QMLComponents/boundcontrols/boundcontrolbase.h
@@ -46,8 +46,8 @@ public:
 protected:
 	std::string					getName()													const;
 
-	Json::Value					_getTableValueOption(const ListModel::RowControlsValues& termsWithComponentValues, const std::string& key, bool hasMultipleTerms);
-	void						_setTableValue(const ListModel::RowControlsValues& termsWithComponentValues, const std::string& key, bool hasMultipleTerms);
+	Json::Value					_getTableValueOption(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasMultipleTerms);
+	void						_setTableValue(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasMultipleTerms);
 
 	void						_readTableValue(const Json::Value& value, const std::string& key, bool hasMultipleTerms, Terms& terms, ListModel::RowControlsValues& allControlValues);
 

--- a/QMLComponents/boundcontrols/boundcontrolterms.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolterms.cpp
@@ -177,7 +177,7 @@ void BoundControlTerms::resetBoundValue()
 	const Terms& terms = _termsModel->terms();
 
 	if (_listView->hasRowComponent() || _listView->containsInteractions())
-		_setTableValue(_termsModel->getTermsWithComponentValues(), _optionKey, _listView->containsInteractions());
+		_setTableValue(terms, _termsModel->getTermsWithComponentValues(), _optionKey, _listView->containsInteractions());
 	else if (_isSingleRow)
 	{
 		std::string str = terms.size() > 0 ? terms[0].asString() : "";

--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -185,12 +185,12 @@ bool ComponentsListBase::isJsonValid(const Json::Value &value) const
 
 void ComponentsListBase::termsChangedHandler()
 {
-	_setTableValue(_termsModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions());
+	_setTableValue(_termsModel->terms(), _termsModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions());
 }
 
 Json::Value ComponentsListBase::getTableValueOptions(const ListModel::RowControlsValues &termsWithComponentValues)
 {
-	return _getTableValueOption(termsWithComponentValues, fq(_optionKey), containsInteractions());
+	return _getTableValueOption(_termsModel->terms(), termsWithComponentValues, fq(_optionKey), containsInteractions());
 }
 
 void ComponentsListBase::addItemHandler()

--- a/QMLComponents/controls/inputlistbase.cpp
+++ b/QMLComponents/controls/inputlistbase.cpp
@@ -112,7 +112,7 @@ bool InputListBase::isJsonValid(const Json::Value &value) const
 void InputListBase::termsChangedHandler()
 {
 	if (hasRowComponent())
-		_setTableValue(_inputModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions());
+		_setTableValue(_inputModel->terms(), _inputModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions());
 	else
 	{
 		const Terms& terms = _inputModel->terms();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2167

Problem is that the component values are stored in a map (RowControlsValues), and this map is used to set the option (in _getTableValueOption). 
To fix it, the terms of the Variables List is also sent to this function, and the order of the terms is used to generate the option.

