### PR TITLE
Rscript on macos fixes

### DIFF
--- a/Desktop/utilities/processhelper.cpp
+++ b/Desktop/utilities/processhelper.cpp
@@ -67,8 +67,9 @@ QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine()
 	//Also setting this breaks the check for the output of R CMD config CC we use to avoid problems on mac...
 
 #elif __APPLE__
-
+	env.insert("PATH",				rHome.absoluteFilePath("bin") + ":" + env.value("PATH"));
 	env.insert("R_HOME",			rHome.absolutePath());
+	env.insert("RHOME",				rHome.absolutePath()); //For Rscript
 	env.insert("JASP_R_HOME",		rHome.absolutePath()); //Used by the modified R script in jasp-required-files/Framework/etc/bin to make sure we use the actual R of JASP! (https://github.com/jasp-stats/INTERNAL-jasp/issues/452)
 	env.insert("R_LIBS",			rHome.absoluteFilePath("library") + ":" + programDir.absoluteFilePath("R/library"));
 	env.insert("JAGS_HOME",			rHome.absolutePath() + "/opt/jags/lib/JAGS/");

--- a/Modules/install-module.R.in
+++ b/Modules/install-module.R.in
@@ -1,5 +1,7 @@
 # Generated from install-module.R.in
 #
+Sys.setenv(PATH=paste0("@R_HOME_PATH@/bin;", Sys.getenv("PATH"))) #Make sure any Rscript calls use ours
+Sys.setenv(RHOME="@R_HOME_PATH@") #Rscript looks for RHOME not R_HOME
 Sys.setenv(GITHUB_PAT="@GITHUB_PAT@")
 Sys.setenv(RENV_PATHS_ROOT="@MODULES_RENV_ROOT_PATH@")
 Sys.setenv(RENV_PATHS_CACHE="@MODULES_RENV_CACHE_PATH@")


### PR DESCRIPTION
Rscript can be called during installing of pkgs, such as jfa. On macos however the Rscript executable has a builtin R_HOME and ignores whatever was set in the environment To be sure we use *our* Rscript we put the build-R first in PATH And because Rscript looks at RHOME envvar instead of R_HOME for some reason we have to set that as well...

