### PR TITLE
Double switch  default when compiling with gcc

### DIFF
--- a/Common/log.cpp
+++ b/Common/log.cpp
@@ -158,11 +158,6 @@ std::ostream & Log::log(bool addTimestamp)
 {
 	switch(_where)
 	{
-#ifndef __clang__
-#ifdef __GNUG__
-	default:				//Gcc is stupid and is not aware that the next three cases cover all
-#endif
-#endif
 	case logType::null:
 	{
 		return *_nullStream;


### PR DESCRIPTION
Cant compile current stable  with gcc.
Probably a left over from before the new default statement was added. It will compile on Mac so went unnoticed.