### PR TITLE
Add version to R Syntax

### DIFF
--- a/Common/version.cpp
+++ b/Common/version.cpp
@@ -29,6 +29,8 @@ Version::Version(std::string version)
 {
 	const static std::regex parseIt("(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\.(\\d+))?"); //(sub)groups: 1 3 5 7//0 is whole match/line
 
+	if (version.empty()) return; // Empty version.
+
 	std::smatch found;
 	if(!std::regex_match(version, found, parseIt))
 		throw encodingError(version);

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -39,7 +39,7 @@ Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::strin
 	  _moduleData(		analysisEntry),
 	  _dynamicModule(	_moduleData->dynamicModule())
 {
-	if(moduleVersion == "" && _dynamicModule)
+	if(_moduleVersion.isEmpty() && _dynamicModule)
 		_moduleVersion = _dynamicModule->version();
 
 	if (data)

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -37,7 +37,6 @@ Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::strin
 	  _titleDefault(	analysisEntry->title()),
 	  _title(			title == "" ? _titleDefault : title),
 	  _moduleVersion(	moduleVersion),
-	  _version(			AppInfo::version),
 	  _moduleData(		analysisEntry),
 	  _dynamicModule(	_moduleData->dynamicModule())
 {
@@ -54,7 +53,7 @@ Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::strin
 }
 
 Analysis::Analysis(size_t id, Analysis * duplicateMe)
-	: AnalysisBase(						Analyses::analyses()							)
+	: AnalysisBase(						Analyses::analyses(), duplicateMe				)
 	, _status(							duplicateMe->_status							)
 	, _optionsDotJASP(					duplicateMe->_optionsDotJASP					)
 	, _results(							duplicateMe->_results							)
@@ -70,14 +69,12 @@ Analysis::Analysis(size_t id, Analysis * duplicateMe)
 	, _title("Copy of "+				duplicateMe->_title								)
 	, _rfile(							duplicateMe->_rfile								)
 	, _isDuplicate(						true											)
-	, _version(							duplicateMe->_version							)
 	, _moduleData(						duplicateMe->_moduleData						)
 	, _dynamicModule(					duplicateMe->_dynamicModule						)
 	, _codedReferenceToAnalysisEntry(	duplicateMe->_codedReferenceToAnalysisEntry		)
 	, _helpFile(						duplicateMe->_helpFile							)
 	, _rSources(						duplicateMe->_rSources							)
 {
-	setBoundValues(duplicateMe->boundValues());
 	initAnalysis();
 }
 

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -102,7 +102,7 @@ public:
 	const	Json::Value		&	userData()			const				{ return _userData;							}
 	const	std::string		&	name()				const	override	{ return _name;								}
 	const	std::string		&	qml()				const				{ return _qml;								}
-	const	Version			&	version()			const				{ return _version;							}
+	const	Version			&	version()			const	override	{ return _version;							}
 	const	std::string		&	title()				const	override	{ return _title;							}
 	const	std::string		&	rfile()				const				{ return _rfile;							}
 	const	std::string		&	module()			const	override	{ return _moduleData->dynamicModule()->name();	}

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -102,7 +102,6 @@ public:
 	const	Json::Value		&	userData()			const				{ return _userData;							}
 	const	std::string		&	name()				const	override	{ return _name;								}
 	const	std::string		&	qml()				const				{ return _qml;								}
-	const	Version			&	version()			const	override	{ return _version;							}
 	const	std::string		&	title()				const	override	{ return _title;							}
 	const	std::string		&	rfile()				const				{ return _rfile;							}
 	const	std::string		&	module()			const	override	{ return _moduleData->dynamicModule()->name();	}
@@ -249,7 +248,6 @@ private:
 								_wasUpgraded					= false,
 								_tryToFixNotes					= false,
 								_hasReport						= false;
-	Version						_version;
 	int							_revision						= 0;
 
 	Modules::AnalysisEntry	*	_moduleData						= nullptr;

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -88,7 +88,6 @@ public:
 	void				setRFile(const std::string &file)							{ _rfile = file;								}
 	void				setRSources(const Json::Value& rSources);
 	void				setUserData(Json::Value userData);
-	void				setVersion(Version version, bool resetWasUpgraded = false);
 	void				setRefreshBlocked(bool block)								{ _refreshBlocked = block;						}
 	void				incrementRevision()											{ _revision++;									}
 
@@ -230,7 +229,7 @@ protected:
 								_progress			= Json::nullValue,
 								_oldUserData		= Json::nullValue,
 								_oldMetaData		= Json::nullValue;
-	std::string					_oldVersion			= "0";
+	std::string					_preUpgraderVersion	= "0";
 
 private:
 	size_t						_id,
@@ -241,7 +240,6 @@ private:
 								_title,
 								_rfile,
 								_showDepsName					= "",
-								_moduleVersion					= "",
 								_codedReferenceToAnalysisEntry	= "",
 								_lastQmlFormPath				= "";
 	bool						_isDuplicate					= false,

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -5,7 +5,16 @@
 
 const std::string AnalysisBase::emptyString;
 
-AnalysisBase::AnalysisBase(QObject* parent) : QObject(parent)
+AnalysisBase::AnalysisBase(QObject* parent)
+	: QObject(parent)
+	, _version(AppInfo::version)
+{
+}
+
+AnalysisBase::AnalysisBase(QObject* parent, AnalysisBase* duplicateMe)
+	: QObject(parent)
+	, _version(duplicateMe->version())
+	, _boundValues(duplicateMe->boundValues())
 {
 }
 

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -5,15 +5,15 @@
 
 const std::string AnalysisBase::emptyString;
 
-AnalysisBase::AnalysisBase(QObject* parent)
+AnalysisBase::AnalysisBase(QObject* parent, Version moduleVersion)
 	: QObject(parent)
-	, _version(AppInfo::version)
+	, _moduleVersion(moduleVersion)
 {
 }
 
 AnalysisBase::AnalysisBase(QObject* parent, AnalysisBase* duplicateMe)
 	: QObject(parent)
-	, _version(duplicateMe->version())
+	, _moduleVersion(duplicateMe->moduleVersion())
 	, _boundValues(duplicateMe->boundValues())
 {
 }

--- a/QMLComponents/analysisbase.h
+++ b/QMLComponents/analysisbase.h
@@ -16,6 +16,7 @@ class AnalysisBase : public QObject
 
 public:
 	explicit AnalysisBase(QObject *parent = nullptr);
+	AnalysisBase(QObject *parent, AnalysisBase* duplicateMe);
 
 	virtual bool isOwnComputedColumn(const std::string &col)				const	{ return false; }
 	virtual void refresh()															{}
@@ -28,7 +29,6 @@ public:
 	virtual const std::string & module()									const	{ return emptyString;		}
 	virtual const std::string & name()										const	{ return emptyString;		}
 	virtual const std::string & title()										const	{ return emptyString;		}
-	virtual const Version & version()										const	{ return AppInfo::version;	}
 	virtual void setTitle(const std::string& titel)									{}
 	virtual void preprocessMarkdownHelp(const QString& md)					const	{}
 	virtual QString helpFile()														{ return "";				}
@@ -52,6 +52,7 @@ public:
 	const	Json::Value	optionsMeta()										const	{ return _boundValues.get(".meta", Json::nullValue);	}
 	void				clearOptions()												{ _boundValues.clear();		}
 
+	const	Version	&	version()											const	{ return _version;			}
 
 	QQuickItem *	formItem()												const;
 
@@ -79,6 +80,7 @@ protected:
 
 	AnalysisForm*	_analysisForm		= nullptr;
 	QString			_qmlError;
+	Version			_version;
 
 private:
 	Json::Value		_boundValues		= Json::objectValue;

--- a/QMLComponents/analysisbase.h
+++ b/QMLComponents/analysisbase.h
@@ -15,7 +15,7 @@ class AnalysisBase : public QObject
 	Q_PROPERTY(QString				qmlError				READ qmlError			WRITE setQmlError			NOTIFY qmlErrorChanged			)
 
 public:
-	explicit AnalysisBase(QObject *parent = nullptr);
+	explicit AnalysisBase(QObject *parent = nullptr, Version moduleVersion = AppInfo::version);
 	AnalysisBase(QObject *parent, AnalysisBase* duplicateMe);
 
 	virtual bool isOwnComputedColumn(const std::string &col)				const	{ return false; }
@@ -52,7 +52,7 @@ public:
 	const	Json::Value	optionsMeta()										const	{ return _boundValues.get(".meta", Json::nullValue);	}
 	void				clearOptions()												{ _boundValues.clear();		}
 
-	const	Version	&	version()											const	{ return _version;			}
+	const	Version	&	moduleVersion()										const	{ return _moduleVersion;	}
 
 	QQuickItem *	formItem()												const;
 
@@ -80,7 +80,7 @@ protected:
 
 	AnalysisForm*	_analysisForm		= nullptr;
 	QString			_qmlError;
-	Version			_version;
+	Version			_moduleVersion;
 
 private:
 	Json::Value		_boundValues		= Json::objectValue;

--- a/QMLComponents/analysisbase.h
+++ b/QMLComponents/analysisbase.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <json/json.h>
 #include "controls/jaspcontrol.h"
+#include "appinfo.h"
 
 class AnalysisForm;
 
@@ -27,6 +28,7 @@ public:
 	virtual const std::string & module()									const	{ return emptyString;		}
 	virtual const std::string & name()										const	{ return emptyString;		}
 	virtual const std::string & title()										const	{ return emptyString;		}
+	virtual const Version & version()										const	{ return AppInfo::version;	}
 	virtual void setTitle(const std::string& titel)									{}
 	virtual void preprocessMarkdownHelp(const QString& md)					const	{}
 	virtual QString helpFile()														{ return "";				}

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -79,6 +79,7 @@ public:
 	QString					title()							const	{ return _analysis ? tq(_analysis->title())		: "";		}
 	QString					name()							const	{ return _analysis ? tq(_analysis->name())		: "";		}
 	QString					module()						const	{ return _analysis ? tq(_analysis->module())	: "";		}
+	QString					version()						const	{ return _analysis ? tq(_analysis->version().asString()) : "";	}
 	bool					hasVolatileNotes()				const	{ return _hasVolatileNotes;									}
 	bool					wasUpgraded()					const	{ return _analysis ? _analysis->wasUpgraded() : false;		}
 	bool					formCompleted()					const	{ return _formCompleted; }

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -155,6 +155,7 @@ public:
 	RSyntax*		rSyntax()				const	{ return _rSyntax;							}
 	QString			generateRSyntax()		const;
 	QVariantList	optionNameConversion()	const;
+	bool			isFormulaName(const QString& name)	const;
 
 	stringvecvec	getValuesFromRSource(const QString& sourceID, const QStringList& searchPath);
 	void			addColumnControl(JASPControl* control, bool isComputed);

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -79,7 +79,7 @@ public:
 	QString					title()							const	{ return _analysis ? tq(_analysis->title())		: "";		}
 	QString					name()							const	{ return _analysis ? tq(_analysis->name())		: "";		}
 	QString					module()						const	{ return _analysis ? tq(_analysis->module())	: "";		}
-	QString					version()						const	{ return _analysis ? tq(_analysis->version().asString()) : "";	}
+	QString					version()						const	{ return _analysis ? tq(_analysis->moduleVersion().asString()) : "";	}
 	bool					hasVolatileNotes()				const	{ return _hasVolatileNotes;									}
 	bool					wasUpgraded()					const	{ return _analysis ? _analysis->wasUpgraded() : false;		}
 	bool					formCompleted()					const	{ return _formCompleted; }

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -114,7 +114,7 @@ public:
 	QString				toolTip()					const	{ return _toolTip;				}
 	QString				helpMD(int howDeep = 2)		const;
 	bool				isBound()					const	{ return _isBound;				}
-	bool				nameMustBeUnique()			const	{ return _nameMustBeUnique;		}
+	bool				nameIsOptionValue()			const	{ return _nameIsOptionValue;	}
 	bool				indent()					const	{ return _indent;				}
 	bool				isDependency()				const	{ return _isDependency;			}
 	bool				initialized()				const	{ return _initialized;			}
@@ -194,8 +194,8 @@ public slots:
 
 	void	reconnectWithYourChildren();
 	void	parentListViewKeyChanged(const QString& oldName, const QString& newName);
+	void	setName(const QString& name);
 
-	GENERIC_SET_FUNCTION(Name					, _name					, nameChanged					, QString		)
 	GENERIC_SET_FUNCTION(Info					, _info					, infoChanged					, QString		)
 	GENERIC_SET_FUNCTION(ToolTip				, _toolTip				, toolTipChanged				, QString		)
 	GENERIC_SET_FUNCTION(Title					, _title				, titleChanged					, QString		)
@@ -216,6 +216,7 @@ private slots:
 	void	_resetBindingValue();
 	void	_setFocus();
 	void	_notifyFormOfActiveFocus();
+	void	_checkControlName();
 
 signals:
 	void setOptionBlockSignal(	bool blockSignal);
@@ -257,6 +258,7 @@ protected:
 	void				setParentDebugToChildren(bool debug);
 	void				focusInEvent(QFocusEvent* event) override;
 	bool				eventFilter(QObject *watched, QEvent *event) override;
+	bool				checkOptionName(const QString& name);
 
 protected:
 	ControlType				_controlType;
@@ -278,7 +280,7 @@ protected:
 							_useControlMouseArea		= true,
 							_shouldShowFocus			= false,
 							_shouldStealHover			= false,
-							_nameMustBeUnique			= true,
+							_nameIsOptionValue			= false,
 							_hasUserInteractiveValue	= true,
 							_hasActiveFocus				= false;
 	JASPListControl		*	_parentListView				= nullptr;
@@ -303,6 +305,7 @@ protected:
 	static QMap<QQmlEngine*, QQmlComponent*>		_mouseAreaComponentMap;
 	static QByteArray								_mouseAreaDef;
 	static QQmlComponent*							getMouseAreaComponent(QQmlEngine* engine);
+	static const QStringList						_optionReservedNames;
 };
 
 

--- a/QMLComponents/controls/radiobuttonbase.cpp
+++ b/QMLComponents/controls/radiobuttonbase.cpp
@@ -23,5 +23,5 @@ RadioButtonBase::RadioButtonBase(QQuickItem* item)
 {
 	_controlType		= ControlType::RadioButton;
 	_isBound			= false;
-	_nameMustBeUnique	= false;
+	_nameIsOptionValue	= true;
 }

--- a/QMLComponents/rsyntax/rsyntax.cpp
+++ b/QMLComponents/rsyntax/rsyntax.cpp
@@ -87,7 +87,7 @@ QString RSyntax::generateSyntax() const
 
 	result = _analysisFullName(true) + "(\n";
 	result += FunctionOptionIndent + "data = NULL\n";
-	result += FunctionOptionIndent + "version = \"" + tq(AppInfo::version.asString()) + "\"";
+	result += FunctionOptionIndent + "version = \"" + _form->version() + "\"";
 
 	for (FormulaBase* formula : _formulas)
 		result += ",\n" + formula->toString();
@@ -159,7 +159,7 @@ QString RSyntax::generateWrapper() const
 ";
 	result += _form->name() + "Wrapper <- function(\n";
 	result += FunctionOptionIndent + "data = NULL\n";
-	result += FunctionOptionIndent + "version = \"" + tq(AppInfo::version.asString()) + "\"";
+	result += FunctionOptionIndent + "version = \"" + form()->version() + "\"";
 	for (FormulaBase* formula : _formulas)
 		result += ",\n" + FunctionOptionIndent + formula->name() + " = NULL";
 
@@ -203,7 +203,8 @@ QString RSyntax::generateWrapper() const
 	+ FunctionLineIndent + "options <- lapply(options, eval)\n"
 	+ FunctionLineIndent + "defaults <- setdiff(names(defaultArgs), names(options))\n"
 	+ FunctionLineIndent + "options[defaults] <- defaultArgs[defaults]\n"
-	+ FunctionLineIndent + "options[[\"data\"]] <- NULL\n\n";
+	+ FunctionLineIndent + "options[[\"data\"]] <- NULL\n"
+	+ FunctionLineIndent + "options[[\"version\"]] <- NULL\n\n";
 
 	for (FormulaBase* formula : _formulas)
 	{
@@ -235,7 +236,7 @@ QString RSyntax::generateWrapper() const
 	}
 
 	result += ""
-	+ FunctionLineIndent + "return(jaspBase::runWrappedAnalysis(\"" + _analysisFullName() + "\", data, options))\n"
+	+ FunctionLineIndent + "return(jaspBase::runWrappedAnalysis(\"" + _analysisFullName() + "\", data, options, version))\n"
 	+ "}";
 
 	return result;

--- a/QMLComponents/rsyntax/rsyntax.cpp
+++ b/QMLComponents/rsyntax/rsyntax.cpp
@@ -86,7 +86,7 @@ QString RSyntax::generateSyntax() const
 		formulaSources.append(formula->modelSources());
 
 	result = _analysisFullName(true) + "(\n";
-	result += FunctionOptionIndent + "data = NULL\n";
+	result += FunctionOptionIndent + "data = NULL,\n";
 	result += FunctionOptionIndent + "version = \"" + _form->version() + "\"";
 
 	for (FormulaBase* formula : _formulas)
@@ -158,7 +158,7 @@ QString RSyntax::generateWrapper() const
 \n\
 ";
 	result += _form->name() + "Wrapper <- function(\n";
-	result += FunctionOptionIndent + "data = NULL\n";
+	result += FunctionOptionIndent + "data = NULL,\n";
 	result += FunctionOptionIndent + "version = \"" + form()->version() + "\"";
 	for (FormulaBase* formula : _formulas)
 		result += ",\n" + FunctionOptionIndent + formula->name() + " = NULL";

--- a/QMLComponents/rsyntax/rsyntax.h
+++ b/QMLComponents/rsyntax/rsyntax.h
@@ -43,7 +43,8 @@ public:
 	QString							getRSyntaxFromControlName(const QString& name)	const;
 	QString							getControlNameFromRSyntax(const QString& name)	const;
 	void							setUp();
-	void							addFormula(FormulaBase* formula)							{ _formulas.append(formula);	}
+	void							addFormula(FormulaBase* formula);
+	FormulaBase*					getFormula(const QString& name)					const;
 	bool							parseRSyntaxOptions(Json::Value& options)		const;
 	void							addError(const QString& msg)					const;
 	bool							hasError()										const;
@@ -62,7 +63,7 @@ private:
 	QString							_analysisFullName(bool wrapper = false)		const;
 
 	AnalysisForm*					_form							= nullptr;
-	QVector<FormulaBase*>				_formulas;
+	QVector<FormulaBase*>			_formulas;
 	QMap<QString, QString>			_controlNameToRSyntaxMap;
 	QMap<QString, QString>			_rSyntaxToControlNameMap;
 };


### PR DESCRIPTION
Also 'data' and 'version' should be forbidden as option names.
Better handling of the option name, so that they don't conflict with each other, a formula name, or a reserved word.
