### PR TITLE
Remove Wrapper in wrapper function

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -331,6 +331,9 @@ void Analysis::createForm(QQuickItem* parentItem)
 		connect(this,					&Analysis::needsRefreshChanged,		_analysisForm,	&AnalysisForm::needsRefreshChanged			);
 		connect(this,					&Analysis::boundValuesChanged,		_analysisForm,	&AnalysisForm::setRSyntaxText, Qt::QueuedConnection	);
 
+		_analysisForm->setShowRButton(_moduleData->hasWrapper());
+		_analysisForm->setDeveloperMode(_dynamicModule->isDevMod());
+
 		emit analysisInitialized();
 	}
 }

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -358,6 +358,27 @@ DropArea
 
 				MenuButton
 				{
+					id:					rSyntaxButton
+					width:				height
+					iconSource:			jaspTheme.iconPath + "/R.png"
+					enabled:			expanderButton.expanded
+					onClicked:			if (formParent.myForm) formParent.myForm.toggleRSyntax();
+					toolTip:			qsTr("Show R Syntax")
+					radius:				height
+					opacity:			editButton.opacity
+					visible:            formParent.myForm.showRButton
+					anchors
+					{
+						top:			parent.top
+						right:			editButton.left
+						bottom:			parent.bottom
+						topMargin:		editButton.anchors.topMargin
+						bottomMargin:	editButton.anchors.bottomMargin
+					}
+				}
+
+				MenuButton
+				{
 					id:					editButton
 					width:				height
 					iconSource:			jaspTheme.iconPath + "/edit-pencil.png" // Icon made by Chanut from https://www.flaticon.com/
@@ -389,33 +410,12 @@ DropArea
 					anchors
 					{
 						top:			parent.top
-						right:			rSyntaxButton.left
-						bottom:			parent.bottom
-						topMargin:		editButton.anchors.topMargin
-						bottomMargin:	editButton.anchors.bottomMargin
-					}
-				}
-
-				MenuButton
-				{
-					id:					rSyntaxButton
-					width:				height
-					iconSource:			jaspTheme.iconPath + "/R.png"
-					enabled:			expanderButton.expanded
-					onClicked:			if (formParent.myForm) formParent.myForm.toggleRSyntax();
-					toolTip:			qsTr("Show R Syntax")
-					radius:				height
-					opacity:			editButton.opacity
-					anchors
-					{
-						top:			parent.top
 						right:			helpButton.left
 						bottom:			parent.bottom
 						topMargin:		editButton.anchors.topMargin
 						bottomMargin:	editButton.anchors.bottomMargin
 					}
 				}
-
 
 				MenuButton
 				{

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -366,7 +366,7 @@ DropArea
 					toolTip:			qsTr("Show R Syntax")
 					radius:				height
 					opacity:			editButton.opacity
-					visible:            formParent.myForm.showRButton
+					visible:            formParent.myForm && formParent.myForm.showRButton
 					anchors
 					{
 						top:			parent.top

--- a/Desktop/components/JASP/Widgets/RCommanderWindow.qml
+++ b/Desktop/components/JASP/Widgets/RCommanderWindow.qml
@@ -210,6 +210,8 @@ Window
 							Shortcut { onActivated: runButton.runCode();	sequences: ["Ctrl+Enter", "Ctrl+Return", Qt.Key_F5];}
 							Shortcut { onActivated: codeEntry.undo();		sequences: ["Ctrl+Z", ];}
 							Shortcut { onActivated: codeEntry.selectAll();	sequences: ["Ctrl+A", ];}
+
+							onTextChanged: rCmd.checkRCode(text)
 						}
 					}
 
@@ -297,7 +299,7 @@ Window
 				onClicked:	addAnalysis()
 				width:		clearOutput.width
 				height:		runButton.height
-				enabled:	codeEntry.text != "" && !rCmd.running
+				enabled:	rCmd.isAnalysisCode && !rCmd.running
 
 				anchors
 				{

--- a/Desktop/modules/analysisentry.cpp
+++ b/Desktop/modules/analysisentry.cpp
@@ -23,25 +23,6 @@
 namespace Modules
 {
 
-AnalysisEntry::AnalysisEntry(Json::Value & analysisEntry, DynamicModule * dynamicModule, bool defaultRequiresData) :
-	_title(				analysisEntry.get("title",			"???").asString()				),
-	_function(			analysisEntry.get("function",		"???").asString()				),
-	_qml(				analysisEntry.get("qml",			_function != "???" ? _function + ".qml" : "???").asString()			),
-	_menu(				analysisEntry.get("menu",			_title).asString()				),
-	_dynamicModule(		dynamicModule														),
-	_isSeparator(		true),
-	_requiresData(		analysisEntry.get("requiresData",	defaultRequiresData).asBool()	),
-	_icon(				analysisEntry.get("icon",			"").asString()					)
-{
-	for (size_t i = 0; i < _title.length(); ++i)
-		if (_title[i] != '-') _isSeparator = false;
-
-	_isGroupTitle	= !_isSeparator && !(analysisEntry.isMember("qml") || analysisEntry.isMember("function"));
-	_isAnalysis		= !_isGroupTitle && !_isSeparator;
-}
-
-AnalysisEntry::AnalysisEntry(){}
-
 DynamicModule*	AnalysisEntry::dynamicModule() const
 {
 	return _dynamicModule;
@@ -62,7 +43,7 @@ std::string AnalysisEntry::icon() const
 
 std::string AnalysisEntry::getFullRCall() const
 {
-	return dynamicModule()->rModuleCall(_function);
+	return dynamicModule()->rModuleCall(functionInternal());
 }
 
 Json::Value AnalysisEntry::getDefaultResults() const
@@ -86,7 +67,7 @@ Json::Value AnalysisEntry::getDefaultResults() const
 
 Json::Value AnalysisEntry::asJsonForJaspFile()	const
 {
-	return dynamicModule()->asJsonForJaspFile(_function);
+	return dynamicModule()->asJsonForJaspFile(function());
 }
 
 std::string AnalysisEntry::codedReference() const

--- a/Desktop/modules/analysisentry.cpp
+++ b/Desktop/modules/analysisentry.cpp
@@ -43,7 +43,7 @@ std::string AnalysisEntry::icon() const
 
 std::string AnalysisEntry::getFullRCall() const
 {
-	return dynamicModule()->rModuleCall(functionInternal());
+	return dynamicModule()->rModuleCall(function() + (hasWrapper() ? "Internal" : ""));
 }
 
 Json::Value AnalysisEntry::getDefaultResults() const

--- a/Desktop/modules/analysisentry.h
+++ b/Desktop/modules/analysisentry.h
@@ -41,7 +41,6 @@ public:
 	std::string		menu()					const { return _menu;									}
 	std::string		title()					const { return _title;									}
 	std::string		function()				const { return _function;								}
-	std::string		functionInternal()		const { return _functionInternal;						}
 	std::string		qml()					const { return _qml != "" ? _qml : _function + ".qml";	}
 	std::string		icon()					const;
 	bool			isSeparator()			const { return _isSeparator;		}
@@ -64,7 +63,6 @@ public:
 private:
 	std::string		_title			= "???",
 					_function		= "???",
-					_functionInternal = "???",
 					_qml			= "???",
 					_menu			= "???";
 	DynamicModule*	_dynamicModule	= nullptr;

--- a/Desktop/modules/analysisentry.h
+++ b/Desktop/modules/analysisentry.h
@@ -36,18 +36,19 @@ class AnalysisEntry
 {
 	friend EntryBase;
 public:
-	AnalysisEntry(Json::Value & analysisEntry, DynamicModule * dynamicModule, bool defaultRequiresData = true);
-	AnalysisEntry();
+	AnalysisEntry() {}
 
 	std::string		menu()					const { return _menu;									}
 	std::string		title()					const { return _title;									}
 	std::string		function()				const { return _function;								}
+	std::string		functionInternal()		const { return _functionInternal;						}
 	std::string		qml()					const { return _qml != "" ? _qml : _function + ".qml";	}
 	std::string		icon()					const;
 	bool			isSeparator()			const { return _isSeparator;		}
 	bool			isGroupTitle()			const { return _isGroupTitle;		}
 	bool			isAnalysis()			const { return _isAnalysis;			}
 	bool			isEnabled()				const { return _isEnabled;			}
+	bool			hasWrapper()			const { return _hasWrapper;			}
 	bool			requiresData()			const { return _requiresData;		}
 	bool			shouldBeExposed()		const { return _isAnalysis && !_isSeparator && _function != "???"; }
 
@@ -63,6 +64,7 @@ public:
 private:
 	std::string		_title			= "???",
 					_function		= "???",
+					_functionInternal = "???",
 					_qml			= "???",
 					_menu			= "???";
 	DynamicModule*	_dynamicModule	= nullptr;
@@ -72,6 +74,7 @@ private:
 					_isEnabled		= true,
 					_requiresData	= true;
 	std::string		_icon			= "";
+	bool			_hasWrapper		= false;
 };
 
 typedef std::vector<AnalysisEntry*> AnalysisEntries;

--- a/Desktop/modules/description/description.cpp
+++ b/Desktop/modules/description/description.cpp
@@ -215,7 +215,7 @@ std::vector<AnalysisEntry*> Description::menuEntries() const
 	{
 		if(entry->shouldBeAdded())
 		{
-			AnalysisEntry *analysisEntry = entry->convertToAnalysisEntry(requiresDataDef(), hasWrappers());
+			AnalysisEntry *analysisEntry = entry->convertToAnalysisEntry(requiresDataDef());
 			if (analysisEntry != nullptr)
 			{
 				if (analysisEntry->isGroupTitle() && previousEntry != nullptr && !previousEntry->isSeparator())

--- a/Desktop/modules/description/description.cpp
+++ b/Desktop/modules/description/description.cpp
@@ -66,6 +66,7 @@ void Description::connectChangesToDelay()
 	connect(this, &Description::requiresDataDefChanged,	this, &Description::delayedUpdate);
 	connect(this, &Description::dynModChanged,			this, &Description::delayedUpdate);
 	connect(this, &Description::childChanged,			this, &Description::delayedUpdate);
+	connect(this, &Description::hasWrappersChanged,		this, &Description::delayedUpdate);
 }
 
 void Description::addChild(DescriptionChildBase * child)
@@ -183,6 +184,15 @@ void Description::setRequiresDataDef(bool requiresData)
 	emit requiresDataDefChanged(_requiresDataDef);
 }
 
+void Description::setHasWrappers(bool hasWrappers)
+{
+	if (_hasWrappers == hasWrappers)
+		return;
+
+	_hasWrappers = hasWrappers;
+	emit hasWrappersChanged(_hasWrappers);
+}
+
 void Description::setDynMod(DynamicModule * dynMod)
 {
 	if (_dynMod == dynMod)
@@ -205,7 +215,7 @@ std::vector<AnalysisEntry*> Description::menuEntries() const
 	{
 		if(entry->shouldBeAdded())
 		{
-			AnalysisEntry *analysisEntry = entry->convertToAnalysisEntry(requiresDataDef());
+			AnalysisEntry *analysisEntry = entry->convertToAnalysisEntry(requiresDataDef(), hasWrappers());
 			if (analysisEntry != nullptr)
 			{
 				if (analysisEntry->isGroupTitle() && previousEntry != nullptr && !previousEntry->isSeparator())

--- a/Desktop/modules/description/description.h
+++ b/Desktop/modules/description/description.h
@@ -38,6 +38,7 @@ class Description : public QQuickItem
 	///requiresData should really be called defaultRequiresData or something. Because that is what it does. But it would be a lot of work to change all the qmls...
 	Q_PROPERTY(bool						requiresData	READ requiresDataDef	WRITE setRequiresDataDef	NOTIFY requiresDataDefChanged	)
 	Q_PROPERTY(Modules::DynamicModule *	dynMod			READ dynMod				WRITE setDynMod				NOTIFY dynModChanged			)
+	Q_PROPERTY(bool						hasWrappers		READ hasWrappers		WRITE setHasWrappers		NOTIFY hasWrappersChanged		)
 
 public:
 	Description(QQuickItem *parent = nullptr);
@@ -54,6 +55,7 @@ public:
 	QString			license()			const { return _license;					}
 	bool			requiresDataDef()	const { return _requiresDataDef;			}
 	DynamicModule * dynMod()			const { return _dynMod;						}
+	bool			hasWrappers()		const { return _hasWrappers;				}
 
 	void	addChild(	DescriptionChildBase * child);
 	void	removeChild(DescriptionChildBase * child);
@@ -74,6 +76,7 @@ public slots:
 	void setRequiresDataDef(	bool							defRequiresData	);
 	void setDynMod(				Modules::DynamicModule		*	dynMod			);
 	void delayedUpdate();
+	void setHasWrappers(		bool							hasWrappers		);
 
 signals:
 	void titleChanged(				QString						title			);
@@ -86,6 +89,7 @@ signals:
 	void licenseChanged(			QString						license			);
 	void nameChanged(				QString						name			);
 	void requiresDataDefChanged(	bool						defRequiresData	);
+	void hasWrappersChanged(		bool						hasWrappers		);
 	void dynModChanged(				Modules::DynamicModule	*	dynMod			);
 	void iShouldBeUpdated(			Modules::Description	*	desc			);
 	void childChanged();
@@ -103,7 +107,8 @@ private:
 							_license;
 	QUrl					_website;
 	Version					_version;
-	bool					_requiresDataDef	= true;
+	bool					_requiresDataDef	= true,
+							_hasWrappers		= false;
 	DynamicModule		*	_dynMod				= nullptr;
 	QList<EntryBase*>		_entries;
 	QTimer					_timer;

--- a/Desktop/modules/description/entrybase.cpp
+++ b/Desktop/modules/description/entrybase.cpp
@@ -20,7 +20,6 @@ EntryBase::EntryBase(EntryType entryType) : DescriptionChildBase(), _entryType(e
 	connect(this, &EntryBase::menuChanged,			this, &EntryBase::somethingChanged);
 	connect(this, &EntryBase::titleChanged,			this, &EntryBase::somethingChanged);
 	connect(this, &EntryBase::functionChanged,		this, &EntryBase::somethingChanged);
-	connect(this, &EntryBase::functionInternalChanged, this, &EntryBase::somethingChanged);
 	connect(this, &EntryBase::iconChanged,			this, &EntryBase::somethingChanged);
 	connect(this, &EntryBase::entryTypeChanged,		this, &EntryBase::somethingChanged);
 	connect(this, &EntryBase::requiresDataChanged,	this, &EntryBase::somethingChanged);
@@ -45,7 +44,6 @@ QString EntryBase::toString() const
 		return	"-- analysis '"		+ title()
 				+ ( menu() != title() ? " menu: '" + menu() + "'" : "" )
 				+ ", function: '"	+ function() + "'"
-				+ ", functionInternal: '"	+ functionInternal() + "'"
 				+ ", qml: '"		+ qml() + "'"
 				+ ", hasWrapper: "	+ (hasWrapper() ? "TRUE" : "FALSE")
 				+ ", reqData: "		+ (requiresData() ? "yes":"no")
@@ -96,18 +94,6 @@ void EntryBase::setFunction(QString function)
 
 	_function = function;
 	emit functionChanged();
-}
-
-void EntryBase::setFunctionInternal(QString functionInternal)
-{
-	if(_entryType != EntryType::analysis)
-		throw EntryError("You cannot set 'func(tion)' of an entry that is not of type 'analysis'.");
-
-	if (_functionInternal == functionInternal)
-		return;
-
-	_functionInternal = functionInternal;
-	emit functionInternalChanged();
 }
 
 void EntryBase::setIcon(QString icon)
@@ -172,7 +158,7 @@ void EntryBase::setHasWrapper(bool hasWrapper)
 	emit hasWrapperChanged();
 }
 
-AnalysisEntry * EntryBase::convertToAnalysisEntry(bool requiresDataDefault, bool hasWrappers) const
+AnalysisEntry * EntryBase::convertToAnalysisEntry(bool requiresDataDefault) const
 {
 	AnalysisEntry * entry = new AnalysisEntry();
 
@@ -187,8 +173,7 @@ AnalysisEntry * EntryBase::convertToAnalysisEntry(bool requiresDataDefault, bool
 	entry->_isAnalysis		= _entryType == EntryType::analysis;
 	entry->_isSeparator		= _entryType == EntryType::separator;
 	entry->_isGroupTitle	= _entryType == EntryType::groupTitle;
-	entry->_hasWrapper		= hasWrappers || _hasWrapper;
-	entry->_functionInternal = functionInternal().isEmpty() ? (entry->_function + (entry->_hasWrapper ? "Internal" : "")) : fq(functionInternal());
+	entry->_hasWrapper		= _description->hasWrappers() || _hasWrapper;
 	entry->_dynamicModule	= _description->dynMod();
 	
 	//Log::log()<<"convertToAnalysisEntry has title '"<<title()<<"'"<<std::endl;

--- a/Desktop/modules/description/entrybase.h
+++ b/Desktop/modules/description/entrybase.h
@@ -23,15 +23,17 @@ class EntryBase : public DescriptionChildBase
 {
 	Q_OBJECT
 
-	Q_PROPERTY(QString		menu			READ menu			WRITE setMenu			NOTIFY menuChanged			)
-	Q_PROPERTY(QString		title			READ title			WRITE setTitle			NOTIFY titleChanged			)
-	Q_PROPERTY(QString		func			READ function		WRITE setFunction		NOTIFY functionChanged		)
-	Q_PROPERTY(QString		icon			READ icon			WRITE setIcon			NOTIFY iconChanged			)
-	Q_PROPERTY(QString		qml				READ qml			WRITE setQml			NOTIFY qmlChanged			)
-	Q_PROPERTY(EntryType	entryType		READ entryType								NOTIFY entryTypeChanged		) //Entry type can only be set in constructor, to keep things manageable
-	Q_PROPERTY(bool			requiresData	READ requiresData	WRITE setRequiresData	NOTIFY requiresDataChanged	)
-	Q_PROPERTY(bool			enabled			READ enabled		WRITE setEnabled		NOTIFY enabledChanged		) //Hmm, this already exists in QQuickItem, maybe a problem?
-	Q_PROPERTY(bool			debug			READ debug			WRITE setDebug			NOTIFY debugChanged			)
+	Q_PROPERTY(QString		menu			READ menu				WRITE setMenu				NOTIFY menuChanged				)
+	Q_PROPERTY(QString		title			READ title				WRITE setTitle				NOTIFY titleChanged				)
+	Q_PROPERTY(QString		func			READ function			WRITE setFunction			NOTIFY functionChanged			)
+	Q_PROPERTY(QString		funcInternal	READ functionInternal	WRITE setFunctionInternal	NOTIFY functionInternalChanged	)
+	Q_PROPERTY(QString		icon			READ icon				WRITE setIcon				NOTIFY iconChanged				)
+	Q_PROPERTY(QString		qml				READ qml				WRITE setQml				NOTIFY qmlChanged				)
+	Q_PROPERTY(EntryType	entryType		READ entryType										NOTIFY entryTypeChanged			) //Entry type can only be set in constructor, to keep things manageable
+	Q_PROPERTY(bool			requiresData	READ requiresData		WRITE setRequiresData		NOTIFY requiresDataChanged		)
+	Q_PROPERTY(bool			enabled			READ enabled			WRITE setEnabled			NOTIFY enabledChanged			) //Hmm, this already exists in QQuickItem, maybe a problem?
+	Q_PROPERTY(bool			debug			READ debug				WRITE setDebug				NOTIFY debugChanged				)
+	Q_PROPERTY(bool			hasWrapper		READ hasWrapper			WRITE setHasWrapper			NOTIFY hasWrapperChanged		)
 
 public:
 	enum class EntryType {unknown, separator, groupTitle, analysis};
@@ -39,20 +41,22 @@ public:
 
 	EntryBase(EntryType entryType);
 
-	QString		menu()			const { return _menu;			}
-	QString		title()			const { return _title;			}
-	QString		function()		const { return _function;		}
-	QString		icon()			const { return _icon;			}
-	EntryType	entryType()		const { return _entryType;		}
-	bool		requiresData()	const { return _requiresData;	}
-	bool		enabled()		const { return _enabled;		}
-	QString		qml()			const { return _qml;			}
-	bool		debug()			const { return _debug;			}
-	QString		toString()		const;
-	bool		shouldBeAdded()	const;
+	QString		menu()				const { return _menu;				}
+	QString		title()				const { return _title;				}
+	QString		function()			const { return _function;			}
+	QString		functionInternal()	const { return _functionInternal;	}
+	QString		icon()				const { return _icon;				}
+	EntryType	entryType()			const { return _entryType;			}
+	bool		requiresData()		const { return _requiresData;		}
+	bool		enabled()			const { return _enabled;			}
+	QString		qml()				const { return _qml;				}
+	bool		debug()				const { return _debug;				}
+	bool		hasWrapper()		const { return _hasWrapper;			}
+	QString		toString()			const;
+	bool		shouldBeAdded()		const;
 
 	///This function is a stopgap and these two classes must be merged together later
-	AnalysisEntry * convertToAnalysisEntry(bool requiresDataDefault) const;
+	AnalysisEntry * convertToAnalysisEntry(bool requiresDataDefault, bool hasWrappers) const;
 
 
 
@@ -60,35 +64,41 @@ public slots:
 	void setMenu(			QString menu);
 	void setTitle(			QString title);
 	void setFunction(		QString function);
+	void setFunctionInternal(QString functionInternal);
 	void setIcon(			QString icon);
 	void setQml(			QString qml);
 	void setRequiresData(	bool	requiresData);
 	void setEnabled(		bool	enabled);
 	void setDebug(			bool	debug);
 	void devModeChanged(	bool	devMode);
+	void setHasWrapper(		bool	hasWrapper);
 
 signals:
 	void menuChanged();
 	void titleChanged();
 	void functionChanged();
+	void functionInternalChanged();
 	void iconChanged();
 	void entryTypeChanged();
 	void requiresDataChanged();
 	void enabledChanged();
 	void qmlChanged();
 	void debugChanged();
+	void hasWrapperChanged();
 
 private:
 	QString			_menu					= "",
 					_title					= "???",
 					_function				= "",
+					_functionInternal		= "",
 					_icon					= "",
 					_qml					= "";
 	EntryType		_entryType				= EntryType::unknown;
 	bool			_requiresData			= false,
 					_useDefaultRequiresData = true, //will be set to false whenever a value is set through setRequiresData
 					_enabled				= true,
-					_debug					= false;
+					_debug					= false,
+					_hasWrapper				= false;
 };
 
 #define MAKE_ENTRY_CLASS(CLASS_NAME, ENTRYTYPENAME) class CLASS_NAME : public EntryBase \

--- a/Desktop/modules/description/entrybase.h
+++ b/Desktop/modules/description/entrybase.h
@@ -26,7 +26,6 @@ class EntryBase : public DescriptionChildBase
 	Q_PROPERTY(QString		menu			READ menu				WRITE setMenu				NOTIFY menuChanged				)
 	Q_PROPERTY(QString		title			READ title				WRITE setTitle				NOTIFY titleChanged				)
 	Q_PROPERTY(QString		func			READ function			WRITE setFunction			NOTIFY functionChanged			)
-	Q_PROPERTY(QString		funcInternal	READ functionInternal	WRITE setFunctionInternal	NOTIFY functionInternalChanged	)
 	Q_PROPERTY(QString		icon			READ icon				WRITE setIcon				NOTIFY iconChanged				)
 	Q_PROPERTY(QString		qml				READ qml				WRITE setQml				NOTIFY qmlChanged				)
 	Q_PROPERTY(EntryType	entryType		READ entryType										NOTIFY entryTypeChanged			) //Entry type can only be set in constructor, to keep things manageable
@@ -44,7 +43,6 @@ public:
 	QString		menu()				const { return _menu;				}
 	QString		title()				const { return _title;				}
 	QString		function()			const { return _function;			}
-	QString		functionInternal()	const { return _functionInternal;	}
 	QString		icon()				const { return _icon;				}
 	EntryType	entryType()			const { return _entryType;			}
 	bool		requiresData()		const { return _requiresData;		}
@@ -56,7 +54,7 @@ public:
 	bool		shouldBeAdded()		const;
 
 	///This function is a stopgap and these two classes must be merged together later
-	AnalysisEntry * convertToAnalysisEntry(bool requiresDataDefault, bool hasWrappers) const;
+	AnalysisEntry * convertToAnalysisEntry(bool requiresDataDefault) const;
 
 
 
@@ -64,7 +62,6 @@ public slots:
 	void setMenu(			QString menu);
 	void setTitle(			QString title);
 	void setFunction(		QString function);
-	void setFunctionInternal(QString functionInternal);
 	void setIcon(			QString icon);
 	void setQml(			QString qml);
 	void setRequiresData(	bool	requiresData);
@@ -77,7 +74,6 @@ signals:
 	void menuChanged();
 	void titleChanged();
 	void functionChanged();
-	void functionInternalChanged();
 	void iconChanged();
 	void entryTypeChanged();
 	void requiresDataChanged();
@@ -90,7 +86,6 @@ private:
 	QString			_menu					= "",
 					_title					= "???",
 					_function				= "",
-					_functionInternal		= "",
 					_icon					= "",
 					_qml					= "";
 	EntryType		_entryType				= EntryType::unknown;

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -341,6 +341,7 @@ void DynamicModule::loadInfoFromDescriptionItem(Description * description)
 	_maintainer						= fq(description->maintainer());
 	_descriptionTxt					= fq(description->description());
 	_version						= fq(description->version());
+	_hasWrappers					= description->hasWrappers();
 
 	for(auto * menuEntry : _menuEntries)
 		delete menuEntry;

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -110,6 +110,7 @@ public:
 	std::string			description()		const { return _descriptionTxt;							}
 	std::string			modulePackage()		const { return _modulePackage;							}
 	bool				isCommon()			const { return _isCommon;								}
+	bool				hasWrappers()		const { return _hasWrappers;							}
 
 	bool				isDevMod()			const { return _isDeveloperMod;							}
 	bool				error()				const { return _status == moduleStatus::error;			}
@@ -243,7 +244,8 @@ private:
 						_isDeveloperMod		= false,
 						_initialized		= false,
 						_bundled			= false,
-						_isCommon			= false;
+						_isCommon			= false,
+						_hasWrappers		= false;
 	AnalysisEntries		_menuEntries;
 	stringset			_importsR;
 	Description		*	_description		= nullptr;

--- a/Desktop/qquick/rcommander.cpp
+++ b/Desktop/qquick/rcommander.cpp
@@ -76,10 +76,8 @@ bool RCommander::parseAnalysisCode(const QString& code, QString& moduleName, QSt
 	if (!module) return false;
 
 	for (const Modules::AnalysisEntry* entry : module->menu())
-	{
 		if (entry->isAnalysis() && entry->isEnabled() && entry->hasWrapper() && entry->function() == fq(analysisName))
 			return true;
-	}
 
 	return false;
 }

--- a/Desktop/qquick/rcommander.cpp
+++ b/Desktop/qquick/rcommander.cpp
@@ -63,15 +63,13 @@ bool RCommander::addAnalysis(const QString &code)
 
 	setRunning(true);
 
-	// Temporary solution: check whether the code starts with '<moduleName>::<analysisNameWrapper>(...'
+	// Temporary solution: check whether the code starts with '<moduleName>::<analysisName>(...'
 	QString codeTrimmed = code.trimmed();
 	QStringList analysisParts = codeTrimmed.mid(0, codeTrimmed.indexOf("(")).split("::");
 
 	if (analysisParts.length() == 2)
 	{
 		QString moduleName = analysisParts[0], analysisName = analysisParts[1];
-		if (analysisName.endsWith("Wrapper"))
-			analysisName = analysisName.mid(0, analysisName.lastIndexOf("Wrapper"));
 
 		if (!moduleName.isEmpty() && !analysisName.isEmpty())
 		{

--- a/Desktop/qquick/rcommander.cpp
+++ b/Desktop/qquick/rcommander.cpp
@@ -1,6 +1,7 @@
 #include "rcommander.h"
 #include "engine/enginesync.h"
 #include "mainwindow.h"
+#include "modules/dynamicmodules.h"
 
 RCommander * RCommander::_lastCommander = nullptr;
 
@@ -56,6 +57,33 @@ bool RCommander::runCode(const QString & code)
 	return true;
 }
 
+bool RCommander::parseAnalysisCode(const QString& code, QString& moduleName, QString& analysisName) const
+{
+	// Check whether the code starts with '<moduleName>::<analysisName>(...)'
+	QString codeTrimmed = code.trimmed();
+	int startBracket = codeTrimmed.indexOf('(');
+
+	if (startBracket < 0) return false;
+	if (codeTrimmed.indexOf(')', startBracket) < 0 ) return false;
+
+	QStringList analysisParts = codeTrimmed.mid(0, startBracket).split("::");
+	if (analysisParts.length() != 2) return false;
+
+	moduleName = analysisParts[0];
+	analysisName = analysisParts[1];
+
+	Modules::DynamicModule* module = Modules::DynamicModules::dynMods()->dynamicModule(moduleName);
+	if (!module) return false;
+
+	for (const Modules::AnalysisEntry* entry : module->menu())
+	{
+		if (entry->isAnalysis() && entry->isEnabled() && entry->hasWrapper() && entry->function() == fq(analysisName))
+			return true;
+	}
+
+	return false;
+}
+
 bool RCommander::addAnalysis(const QString &code)
 {
 	if(running() || !_engine->idle() || code == "")
@@ -63,30 +91,40 @@ bool RCommander::addAnalysis(const QString &code)
 
 	setRunning(true);
 
-	// Temporary solution: check whether the code starts with '<moduleName>::<analysisName>(...'
-	QString codeTrimmed = code.trimmed();
-	QStringList analysisParts = codeTrimmed.mid(0, codeTrimmed.indexOf("(")).split("::");
-
-	if (analysisParts.length() == 2)
+	QString moduleName, analysisName;
+	if (parseAnalysisCode(code, moduleName, analysisName))
 	{
-		QString moduleName = analysisParts[0], analysisName = analysisParts[1];
-
-		if (!moduleName.isEmpty() && !analysisName.isEmpty())
-		{
-			Analysis* analysis = Analyses::analyses()->createAnalysis(moduleName, analysisName);
-			if (analysis)
-				analysis->sendRScript(code, AnalysisForm::rSyntaxControlName, false);
-		}
-		setRunning(false);
+		Analysis* analysis = Analyses::analyses()->createAnalysis(moduleName, analysisName);
+		if (analysis)
+			analysis->sendRScript(code, AnalysisForm::rSyntaxControlName, false);
+		else
+			appendToOutput("> " + tr("Analysis not found"));
 	}
 	else
-		_engine->runScriptOnProcess(code);
+		appendToOutput("> " + tr("Not an analysis function: <module name>::<analysis name>(...)"));
 
+	setRunning(false);
 	setLastCmd(code);
 
 	appendToOutput("> " + code);
 
 	return true;
+}
+
+void RCommander::setIsAnalysisCode(bool isAnalysisCode)
+{
+	if (_isAnalysisCode == isAnalysisCode)
+		return;
+
+	_isAnalysisCode = isAnalysisCode;
+
+	emit isAnalysisCodeChanged(_isAnalysisCode);
+}
+
+void RCommander::checkRCode(const QString &code)
+{
+	QString moduleName, analysisName;
+	setIsAnalysisCode(parseAnalysisCode(code, moduleName, analysisName));
 }
 
 void RCommander::rCodeReturned(const QString & result, int, bool)

--- a/Desktop/qquick/rcommander.h
+++ b/Desktop/qquick/rcommander.h
@@ -11,17 +11,19 @@ class EngineRepresentation;
 class RCommander : public QQuickItem
 {
 	Q_OBJECT
-	Q_PROPERTY(QString	output	READ output		WRITE setOutput		NOTIFY outputChanged	)
-	Q_PROPERTY(bool		running READ running	WRITE setRunning	NOTIFY runningChanged	)
-	Q_PROPERTY(QString	lastCmd READ lastCmd	WRITE setLastCmd	NOTIFY lastCmdChanged	)
+	Q_PROPERTY(QString	output			READ output				WRITE setOutput		NOTIFY outputChanged			)
+	Q_PROPERTY(bool		running			READ running			WRITE setRunning	NOTIFY runningChanged			)
+	Q_PROPERTY(bool		isAnalysisCode	READ isAnalysisCode							NOTIFY isAnalysisCodeChanged	)
+	Q_PROPERTY(QString	lastCmd			READ lastCmd			WRITE setLastCmd	NOTIFY lastCmdChanged			)
 
 public:
 	RCommander();
 	~RCommander();
 
-	QString output()	const { return _output;		}
-	bool	running()	const { return _running;	}
-	QString lastCmd()	const { return _lastCmd;	}
+	QString output()			const { return _output;			}
+	bool	running()			const { return _running;		}
+	QString lastCmd()			const { return _lastCmd;		}
+	bool	isAnalysisCode()	const { return _isAnalysisCode; }
 
 	static	bool opened()		{ return _lastCommander; }
 	static	void makeActive();
@@ -29,6 +31,7 @@ public:
 public slots:
 	bool runCode(			const QString & code);
 	bool addAnalysis(		const QString & code);
+	void checkRCode(		const QString & code);
 	void setOutput(			const QString & output);
 	void rCodeReturned(		const QString & result, int requestId, bool hasError);
 	void rCodeReturnedLog(	const QString & log, bool hasError);
@@ -41,17 +44,22 @@ public slots:
 signals:
 	void outputChanged(QString output);
 	void runningChanged(bool running);
+	void isAnalysisCodeChanged(bool changed);
 	void lastCmdChanged(QString lastCmd);
 	void scrollDown();
 	void closeWindow();
 	void activated();
 
 private:
+	bool parseAnalysisCode(const QString& code, QString& moduleName, QString& analysisName) const;
+	void setIsAnalysisCode(bool isAnalysisCode);
+
 	static RCommander		*	_lastCommander;
 	QString						_output			= "", //Set in qml to have it be translatable
 								_lastCmd		= "";
 	EngineRepresentation	*	_engine			= nullptr;
-	bool						_running		= false;
+	bool						_running		= false,
+								_isAnalysisCode = false;
 	QTimer					*	_scrollTimer	= nullptr;
 };
 

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -937,6 +937,26 @@ void AnalysisForm::setShowRSyntax(bool showRSyntax)
 
 }
 
+void AnalysisForm::setShowRButton(bool showRButton)
+{
+	if (_showRButton == showRButton)
+		return;
+
+	_showRButton = showRButton;
+
+	emit showRButtonChanged();
+}
+
+void AnalysisForm::setDeveloperMode(bool developerMode)
+{
+	if (_developerMode == developerMode)
+		return;
+
+	_developerMode = developerMode;
+
+	emit developerModeChanged();
+}
+
 void AnalysisForm::setRSyntaxText()
 {
 	if (!_showRSyntax)

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -56,7 +56,9 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(QString		helpMD					READ helpMD													NOTIFY helpMDChanged				)
 	Q_PROPERTY(QVariant		analysis				READ analysis												NOTIFY analysisChanged				)
 	Q_PROPERTY(QVariantList	optionNameConversion	READ optionNameConversion	WRITE setOptionNameConversion	NOTIFY optionNameConversionChanged	)
-	Q_PROPERTY(bool			showRSyntax				READ showRSyntax			WRITE setShowRSyntax			NOTIFY showRSyntaxChanged			)
+	Q_PROPERTY(bool			showRSyntax				READ showRSyntax											NOTIFY showRSyntaxChanged			)
+	Q_PROPERTY(bool			showRButton				READ showRButton											NOTIFY showRButtonChanged			)
+	Q_PROPERTY(bool			developerMode			READ developerMode											NOTIFY developerModeChanged			)
 	Q_PROPERTY(QString		rSyntaxText				READ rSyntaxText											NOTIFY rSyntaxTextChanged			)
 	Q_PROPERTY(QString		rSyntaxControlName		MEMBER rSyntaxControlName	CONSTANT															)
 	Q_PROPERTY(JASPControl*	activeJASPControl		READ getActiveJASPControl									NOTIFY activeJASPControlChanged		)
@@ -84,6 +86,8 @@ public:
 	bool					wasUpgraded()					const	{ return _analysis ? _analysis->wasUpgraded() : false;		}
 	bool					formCompleted()					const	{ return _formCompleted; }
 	bool					showRSyntax()					const	{ return _showRSyntax;	}
+	bool					showRButton()					const	{ return _showRButton;	}
+	bool					developerMode()					const	{ return _developerMode; }
 	QString					rSyntaxText()					const	{ return _rSyntaxText;	}
 
 public slots:
@@ -94,6 +98,8 @@ public slots:
 	void					setOptionNameConversion(const QVariantList& conv);
 	void					setTitle(QString title);
 	void					setShowRSyntax(bool showRSyntax);
+	void					setShowRButton(bool showRButton);
+	void					setDeveloperMode(bool developerMode);
 	void					setRSyntaxText();
 	void					sendRSyntax(QString text);
 	void					toggleRSyntax()		{ setShowRSyntax(!showRSyntax()); }
@@ -116,6 +122,8 @@ signals:
 	void					optionNameConversionChanged();
 	void					titleChanged();
 	void					showRSyntaxChanged();
+	void					showRButtonChanged();
+	void					developerModeChanged();
 	void					rSyntaxTextChanged();
 	void					activeJASPControlChanged();
 
@@ -221,7 +229,9 @@ private:
 	int												_valueChangedSignalsBlocked		= 0;
 	std::queue<std::tuple<QString, QString, bool>>	_waitingRScripts; //Sometimes signals are blocked, and thus rscripts. But they shouldnt just disappear right?
 	RSyntax										*	_rSyntax						= nullptr;
-	bool											_showRSyntax					= false;
+	bool											_showRSyntax					= false,
+													_showRButton					= false,
+													_developerMode					= false;
 	QString											_rSyntaxText;
 	JASPControl*									_activeJASPControl				= nullptr;
 };

--- a/QMLComponents/components/JASP/Controls/Form.qml
+++ b/QMLComponents/components/JASP/Controls/Form.qml
@@ -180,6 +180,7 @@ AnalysisForm
 			Button
 			{
 				id:					generateWrapperButton
+				visible:            DEBUG_MODE || form.developerMode
 				label:				"Generate Wrapper"
 				onClicked:			popup.open()
 

--- a/QMLComponents/components/JASP/Controls/Form.qml
+++ b/QMLComponents/components/JASP/Controls/Form.qml
@@ -181,6 +181,7 @@ AnalysisForm
 			{
 				id:					generateWrapperButton
 				visible:            DEBUG_MODE || form.developerMode
+				height:				visible ? implicitHeight : 0
 				label:				"Generate Wrapper"
 				onClicked:			popup.open()
 
@@ -207,6 +208,7 @@ AnalysisForm
 					}
 				}
 			}
+
 			TextArea
 			{
 				id:					rScriptArea

--- a/QMLComponents/components/JASP/Controls/TextArea.qml
+++ b/QMLComponents/components/JASP/Controls/TextArea.qml
@@ -77,7 +77,11 @@ TextAreaBase
 					if (event.modifiers & Qt.ControlModifier)
 					{
 						if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
+						{
 							userEnteredInput();
+							event.accepted = true;
+						}
+
 					}
 					else if ( event.key === Qt.Key_Tab)
 					{

--- a/QMLComponents/rsyntax/rsyntax.cpp
+++ b/QMLComponents/rsyntax/rsyntax.cpp
@@ -85,7 +85,7 @@ QString RSyntax::generateSyntax() const
 	for (FormulaBase* formula : _formulas)
 		formulaSources.append(formula->modelSources());
 
-	result = _analysisFullName(true) + "(\n";
+	result = _analysisFullName() + "(\n";
 	result += FunctionOptionIndent + "data = NULL,\n";
 	result += FunctionOptionIndent + "version = \"" + _form->version() + "\"";
 
@@ -157,7 +157,7 @@ QString RSyntax::generateWrapper() const
 # This is a generated file. Don't change it\n\
 \n\
 ";
-	result += _form->name() + "Wrapper <- function(\n";
+	result += _form->name() + " <- function(\n";
 	result += FunctionOptionIndent + "data = NULL,\n";
 	result += FunctionOptionIndent + "version = \"" + form()->version() + "\"";
 	for (FormulaBase* formula : _formulas)
@@ -197,7 +197,7 @@ QString RSyntax::generateWrapper() const
 	}
 
 	result += ") {\n\n"
-	+ FunctionLineIndent + "defaultArgCalls <- formals(" + _analysisFullName(true) + ")\n"
+	+ FunctionLineIndent + "defaultArgCalls <- formals(" + _analysisFullName() + ")\n"
 	+ FunctionLineIndent + "defaultArgs <- lapply(defaultArgCalls, eval)\n"
 	+ FunctionLineIndent + "options <- as.list(match.call())[-1L]\n"
 	+ FunctionLineIndent + "options <- lapply(options, eval)\n"
@@ -445,10 +445,9 @@ QString RSyntax::transformInteractionTerms(const Terms& terms, bool useFormula)
 	return result;
 }
 
-QString RSyntax::_analysisFullName(bool wrapper) const
+QString RSyntax::_analysisFullName() const
 {
-
-	return _form->module() + "::" + _form->name() + (wrapper ? "Wrapper" : "");
+	return _form->module() + "::" + _form->name();
 }
 
 QString RSyntax::getRSyntaxFromControlName(JASPControl *control) const

--- a/QMLComponents/rsyntax/rsyntax.h
+++ b/QMLComponents/rsyntax/rsyntax.h
@@ -60,7 +60,7 @@ signals:
 
 private:
 
-	QString							_analysisFullName(bool wrapper = false)		const;
+	QString							_analysisFullName()								const;
 
 	AnalysisForm*					_form							= nullptr;
 	QVector<FormulaBase*>			_formulas;


### PR DESCRIPTION
Add in Descriptions.qml boolean hasWrappers, and for each analysis, the boolean hasWrapper and functionInternal properties. 
If hasWrappers is true for the module, then all analyses have hasWrapper set to true. 
If functionInternal is not set, then it takes the name of function with as suffix 'Internal' if hasWrapper is true. 
When an analysis is called, the functionInternal is called: so this work for analysis having a wrapper or not. No upgrade is needed, since the name of the analysis stays the same. 
In R Syntax the R code generated does not use the 'Wrapper' suffix anymore

