### PR TITLE
Make decimal settings available in R

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -543,7 +543,6 @@ Json::Value Analysis::createAnalysisRequestJson()
 	json["rfile"]				= _moduleData == nullptr ? rfile() : "";
 	json["dynamicModuleCall"]	= _moduleData == nullptr ? "" : _moduleData->getFullRCall();
 	json["resultsFont"]			= PreferencesModel::prefs()->resultFont().toStdString();
-	json["libPathsToUse"]		= _moduleData ? _moduleData->dynamicModule()->getLibPathsToUse() : ""; //temporary hack for fixing https://github.com/jasp-stats/jasp-test-release/issues/1953 and the like. can be removed once new dynamic moudles stuff is merged from development
 
 	if (!isAborted())
 	{

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -1024,11 +1024,15 @@ void EngineRepresentation::sendReloadData()
 
 void EngineRepresentation::addSettingsToJson(Json::Value & msg)
 {
-	msg["ppi"]				= PreferencesModel::prefs()->plotPPI();
-	msg["developerMode"]	= PreferencesModel::prefs()->developerMode();
-	msg["imageBackground"]	= fq(PreferencesModel::prefs()->plotBackground());
-	msg["languageCode"]		= fq(PreferencesModel::prefs()->languageCode());
-	msg["GITHUB_PAT"]		= fq(PreferencesModel::prefs()->githubPatResolved());
+	msg["ppi"]					=	 PreferencesModel::prefs()->plotPPI();
+	msg["developerMode"]		=	 PreferencesModel::prefs()->developerMode();
+	msg["imageBackground"]		= fq(PreferencesModel::prefs()->plotBackground());
+	msg["languageCode"]			= fq(PreferencesModel::prefs()->languageCode());
+	msg["GITHUB_PAT"]			= fq(PreferencesModel::prefs()->githubPatResolved());
+	msg["numDecimals"]			=	 PreferencesModel::prefs()->numDecimals();
+	msg["fixedDecimals"]		=	 PreferencesModel::prefs()->fixedDecimals();
+	msg["exactPValues"]			=	 PreferencesModel::prefs()->exactPValues();
+	msg["normalizedNotation"]	=	 PreferencesModel::prefs()->normalizedNotation();
 }
 
 void EngineRepresentation::processSettingsReply()

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -66,6 +66,11 @@ EngineSync::EngineSync(QObject *parent)
 	connect(PreferencesModel::prefs(),	&PreferencesModel::githubPatCustomChanged,			this,						&EngineSync::settingsChanged					);
 	connect(PreferencesModel::prefs(),	&PreferencesModel::githubPatUseDefaultChanged,		this,						&EngineSync::settingsChanged					);
 
+	connect(PreferencesModel::prefs(),	&PreferencesModel::numDecimalsChanged,				this,						&EngineSync::settingsChanged					);
+	connect(PreferencesModel::prefs(),	&PreferencesModel::fixedDecimalsChanged,			this,						&EngineSync::settingsChanged					);
+	connect(PreferencesModel::prefs(),	&PreferencesModel::exactPValuesChanged,				this,						&EngineSync::settingsChanged					);
+	connect(PreferencesModel::prefs(),	&PreferencesModel::normalizedNotationChanged,		this,						&EngineSync::settingsChanged					);
+
 	// delay start so as not to increase program start up time 10sec is better than 100ms, because they are orphaned anyway
 	// Except, that it might somehow cause a crash? If the timer goes off while waiting for a download from OSF than it might remove the files while making them..
 	// So lets put it on 500ms...
@@ -524,6 +529,9 @@ void EngineSync::processSettingsChanged()
 	for(auto * engine : _engines)
 		if(engine->shouldSendSettings())
 			engine->sendSettings();
+
+	if(_rCmder && _rCmder->shouldSendSettings())
+		_rCmder->sendSettings();
 }
 
 void EngineSync::processReloadData()
@@ -531,6 +539,9 @@ void EngineSync::processReloadData()
 	for(auto * engine : _engines)
 		if(engine->needsReloadData())
 			engine->sendReloadData();
+
+	if(_rCmder && _rCmder->needsReloadData())
+		_rCmder->sendReloadData();
 }
 
 

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -554,7 +554,6 @@ void Engine::receiveAnalysisMessage(const Json::Value & jsonRequest)
 		_imageOptions			= jsonRequest.get("image",				Json::nullValue);
 		_analysisRFile			= jsonRequest.get("rfile",				"").asString();
 		_dynamicModuleCall		= jsonRequest.get("dynamicModuleCall",	"").asString();
-		_libPathsToUse			= jsonRequest.get("libPathsToUse",		"").asString();
 		_resultsFont			= jsonRequest.get("resultsFont",		"").asString();
 		_engineState			= engineState::analysis;
 
@@ -617,7 +616,8 @@ void Engine::runAnalysis()
 
 	Log::log() << "Analysis will be run now." << std::endl;
 
-	_analysisResultsString = rbridge_runModuleCall(_analysisName, _analysisTitle, _dynamicModuleCall, _analysisDataKey, _analysisOptions, _analysisStateKey, _ppi, _analysisId, _analysisRevision, _imageBackground, _developerMode, _resultsFont, _libPathsToUse);
+	_analysisResultsString = rbridge_runModuleCall(_analysisName, _analysisTitle, _dynamicModuleCall, _analysisDataKey, _analysisOptions, _analysisStateKey,
+												   _ppi, _analysisId, _analysisRevision, _imageBackground, _developerMode, _resultsFont);
 
 	switch(_analysisStatus)
 	{
@@ -655,7 +655,7 @@ void Engine::runAnalysis()
 }
 
 void Engine::saveImage()
-{
+{	
 	int			height	= _imageOptions.get("height",	Json::nullValue).asInt(),
 				width	= _imageOptions.get("width",	Json::nullValue).asInt();
 	std::string data	= _imageOptions.get("data",		Json::nullValue).asString(),
@@ -976,10 +976,14 @@ void Engine::receiveLogCfg(const Json::Value & jsonRequest)
 
 void Engine::absorbSettings(const Json::Value & jsonRequest)
 {
-	_ppi				= jsonRequest.get("ppi",				_ppi			).asInt();
-	_developerMode		= jsonRequest.get("developerMode",		_developerMode	).asBool();
-	_imageBackground	= jsonRequest.get("imageBackground",	_imageBackground).asString();
-	_langR				= jsonRequest.get("languageCode",		_langR			).asString();
+	_ppi				= jsonRequest.get("ppi",				_ppi				).asInt();
+	_developerMode		= jsonRequest.get("developerMode",		_developerMode		).asBool();
+	_imageBackground	= jsonRequest.get("imageBackground",	_imageBackground	).asString();
+	_langR				= jsonRequest.get("languageCode",		_langR				).asString();
+	_numDecimals		= jsonRequest.get("numDecimals",		_numDecimals		).asInt();
+	_fixedDecimals		= jsonRequest.get("fixedDecimals",		_fixedDecimals		).asBool();
+	_exactPValues		= jsonRequest.get("exactPValues",		_exactPValues		).asBool();
+	_normalizedNotation	= jsonRequest.get("normalizedNotation",	_normalizedNotation	).asBool();
 
 	const char	* PAT	= std::getenv("GITHUB_PAT");
 	
@@ -989,6 +993,7 @@ void Engine::absorbSettings(const Json::Value & jsonRequest)
 	setenv		("GITHUB_PAT",  jsonRequest.get("GITHUB_PAT",			PAT ? PAT : "").asCString(), 1);
 #endif
 	rbridge_setLANG(_langR);
+	jaspRCPP_setDecimalSettings(_numDecimals, _fixedDecimals, _normalizedNotation, _exactPValues);
 }
 
 

--- a/Engine/engine.h
+++ b/Engine/engine.h
@@ -123,9 +123,13 @@ private: // Data:
 	int					_analysisId,
 						_analysisRevision,
 						_progress,
-						_ppi		= 96;
+						_ppi		= 96,
+						_numDecimals = 3;
 
-	bool				_developerMode		= false;
+	bool				_developerMode		= false,
+						_fixedDecimals		= false,
+						_exactPValues		= false,
+						_normalizedNotation	= true;
 
 	std::string			_analysisName,
 						_analysisTitle,
@@ -138,7 +142,6 @@ private: // Data:
 						_imageBackground	= "white",
 						_analysisRFile		= "",
 						_dynamicModuleCall	= "",
-						_libPathsToUse		= "", //temp hack
 						_langR				= "en";
 
 	Json::Value			_imageOptions,

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -293,13 +293,13 @@ extern "C" bool STDCALL rbridge_runCallback(const char* in, int progress, const 
 	return true;
 }
 
-std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont, const std::string & libPathsToUse)
+std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont)
 {
 	rbridge_callback	= NULL; //Only jaspResults here so callback is not needed
 	if (rbridge_dataSet != nullptr)
 		rbridge_dataSet		= rbridge_dataSetSource();
 
-	return jaspRCPP_runModuleCall(name.c_str(), title.c_str(), moduleCall.c_str(), dataKey.c_str(), options.c_str(), stateKey.c_str(), ppi, analysisID, analysisRevision, imageBackground.c_str(), developerMode, resultsFont.c_str(), libPathsToUse.c_str());
+	return jaspRCPP_runModuleCall(name.c_str(), title.c_str(), moduleCall.c_str(), dataKey.c_str(), options.c_str(), stateKey.c_str(), ppi, analysisID, analysisRevision, imageBackground.c_str(), developerMode, resultsFont.c_str());
 }
 
 extern "C" RBridgeColumn* STDCALL rbridge_readFullDataSet(size_t * colMax)
@@ -975,4 +975,3 @@ extern "C" const char ** STDCALL rbridge_allColumnNames(size_t & numCols, bool e
 	
 	return names;
 }
-

--- a/Engine/rbridge.h
+++ b/Engine/rbridge.h
@@ -88,7 +88,7 @@ extern "C" {
 	void rbridge_setDataSetSource(			boost::function<DataSet *()> source);
 	void rbridge_memoryCleaning();
 
-	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont, const std::string & libPathsToUse);
+	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont);
 
 	void rbridge_setColumnFunctionSources(			boost::function<int (const std::string &)																		> getTypeSource,
 													boost::function<bool(const std::string &, const std::vector<double>&)											> scaleSource,

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -177,6 +177,10 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	rInside[".setColumnDataAsNominalPtr"]		= Rcpp::XPtr<setColumnDataFuncDef>(	& _setColumnDataAsOrdinal);
 	rInside[".setColumnDataAsNominalTextPtr"]	= Rcpp::XPtr<setColumnDataFuncDef>(	& _setColumnDataAsNominalText);
 	rInside[".baseCitation"]					= baseCitation;
+	rInside[".numDecimals"]						= 3;
+	rInside[".fixedDecimals"]					= false;
+	rInside[".normalizedNotation"]				= true;
+	rInside[".exactPValues"]					= false;
 
 	//jaspRCPP_parseEvalQNT("options(encoding = 'UTF-8')");
 
@@ -245,21 +249,33 @@ void _setJaspResultsInfo(int analysisID, int analysisRevision, bool developerMod
 	jaspRCPP_parseEvalQNT("jaspBase:::setWriteSealLocation(\"" + root + "\", \"" + relativePath + "\");");
 }
 
-const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont, const char * libPathsToUse)
+void STDCALL jaspRCPP_setDecimalSettings(int numDecimals, bool fixedDecimals, bool normalizedNotation, bool exactPValues)
 {
 	RInside &rInside			= rinside->instance();
 
-	rInside["name"]				= name;
-	rInside["title"]			= title;
-	rInside["options"]			= options;
-	rInside[".ppi"]				= ppi;
-	rInside["dataKey"]			= dataKey;
-	rInside["stateKey"]			= stateKey;
-	rInside["moduleCall"]		= moduleCall;
-	rInside["resultsMeta"]		= "null";
-	rInside["requiresInit"]		= false;
-	rInside[".imageBackground"]	= imageBackground;
-	rInside[".resultsFont"]		= resultsFont;
+	rInside[".numDecimals"]			= numDecimals;
+	rInside[".fixedDecimals"]		= fixedDecimals;
+	rInside[".normalizedNotation"]	= normalizedNotation;
+	rInside[".exactPValues"]		= exactPValues;
+}
+
+const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options,
+										   const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode,
+										   const char* resultsFont)
+{
+	RInside &rInside			= rinside->instance();
+
+	rInside["name"]					= name;
+	rInside["title"]				= title;
+	rInside["options"]				= options;
+	rInside[".ppi"]					= ppi;
+	rInside["dataKey"]				= dataKey;
+	rInside["stateKey"]				= stateKey;
+	rInside["moduleCall"]			= moduleCall;
+	rInside["resultsMeta"]			= "null";
+	rInside["requiresInit"]			= false;
+	rInside[".imageBackground"]		= imageBackground;
+	rInside[".resultsFont"]			= resultsFont;
 
 	_setJaspResultsInfo(analysisID, analysisRevision, developerMode);
 
@@ -371,12 +387,12 @@ const char* STDCALL jaspRCPP_saveImage(const char * data, const char *type, cons
 {
 	RInside &rInside = rinside->instance();
 
-	rInside[".imageBackground"] = imageBackground;
-	rInside["plotName"]			= data;
-	rInside["format"]			= type;
-	rInside["height"]			= height;
-	rInside["width"]			= width;
-	rInside[".ppi"]				= ppi;
+	rInside[".imageBackground"]		= imageBackground;
+	rInside["plotName"]				= data;
+	rInside["format"]				= type;
+	rInside["height"]				= height;
+	rInside["width"]				= width;
+	rInside[".ppi"]					= ppi;
 
 	static std::string staticResult;
 	staticResult = jaspRCPP_parseEvalStringReturn("jaspBase:::saveImage(plotName, format, height, width)", true);
@@ -388,10 +404,10 @@ const char* STDCALL jaspRCPP_editImage(const char * name, const char * optionsJs
 
 	RInside &rInside = rinside->instance();
 
-	rInside[".imageBackground"] = imageBackground;
-	rInside[".editImgOptions"]	= optionsJson;
-	rInside[".analysisName"]	= name;
-	rInside[".ppi"]				= ppi;
+	rInside[".imageBackground"]		= imageBackground;
+	rInside[".editImgOptions"]		= optionsJson;
+	rInside[".analysisName"]		= name;
+	rInside[".ppi"]					= ppi;
 
 	_setJaspResultsInfo(analysisID, 0, false);
 
@@ -407,10 +423,10 @@ void STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char
 
 	RInside &rInside = rinside->instance();
 
-	rInside[".ppi"]				= ppi;
-	rInside[".imageBackground"] = imageBackground;
-	rInside[".analysisName"]	= name;
-	rInside[".resultsFont"]     = resultsFont;
+	rInside[".ppi"]					= ppi;
+	rInside[".imageBackground"]		= imageBackground;
+	rInside[".analysisName"]		= name;
+	rInside[".resultsFont"]			= resultsFont;
 
 	_setJaspResultsInfo(analysisID, 0, false);
 

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -123,12 +123,13 @@ typedef size_t			(*logWriteDef)			(const void * buf, size_t len);
 
 // Calls from rbridge to jaspRCPP
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,	EnDecodeDef nativeToUtf8, const char * tempDir);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_setDecimalSettings(int numDecimals, bool fixedDecimals, bool normalizedNotation, bool exactPValues);
 
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont, const char * libPathsToUse);
+RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont);
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_saveImage(const char *data, const char *type, const int height, const int width, const int ppi, const char* imageBackground);
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_editImage(const char *name, const char *optionsJson, const int ppi, const char* imageBackground, int analysisID);
-RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, const char* resultsFont, int analysisID);
+RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_editImage(const char *name, const char *optionsJson, const int ppi, const char* imageBackground,		int analysisID);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, const char* resultsFont,	int analysisID);
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_evalRCode(			const char *rCode, bool setWd);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_evalRCodeCommander(const char *rCode);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2172 Also adds some small default values in jaspBase for when not in JASP

This makes the following global values available in R:
- .fixedDecimals        (BOOL -> should decimals be fixed to a certain number?)
- .numDecimals          (INT  -> if above is TRUE then how many decimals)
- .normalizedNotation   (BOOl -> 10^n notation vs exponent notation)
- .exactPValues         (BOOL -> whether to show all decimals for p-values ( or at least 4 ) and not APA style (if Im reading the code correctly)

See also: https://github.com/jasp-stats/jaspBase/pull/111 but that isnt necessary for running this in normal JASP

