### PR TITLE
Improvements to "info" field

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -306,7 +306,7 @@ void Analysis::imagesRewritten(const Json::Value & results)
 Analysis::Status Analysis::parseStatus(std::string name)
 {
 	if		(name == "empty")			return Analysis::Empty;
-	else if (name == "initializing")	return Analysis::Empty;		//For backwards compatibility ?
+	else if (name == "initializing")	return Analysis::Empty;		//For backwards compatibility
 	else if (name == "waiting")			return Analysis::Running;	//For backwards compatibility
 	else if (name == "running")			return Analysis::Running;
 	else if (name == "runningImg")		return Analysis::RunningImg;

--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -427,8 +427,8 @@ DropArea
 					enabled:			expanderButton.expanded
 					onClicked:			if(preferencesModel.generateMarkdown || !helpModel.pageExists(formParent.myAnalysis.helpFile()))
 										{
-											if(helpModel.markdown !== formParent.myForm.helpMD)
-												helpModel.markdown = Qt.binding(function(){ return formParent.myForm.helpMD; });
+											if(formParent.myForm && helpModel.markdown !== formParent.myForm.helpMD)
+												helpModel.markdown  = Qt.binding(function(){ return formParent.myForm.helpMD; });
 											else
 												helpModel.visible  = false;
 											

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -48,13 +48,21 @@ void AnalysisBase::createForm(QQuickItem* parentItem)
 	Log::log() << "Analysis(" << this << ")::createForm() called with parentItem " << parentItem << std::endl;
 
 	setQmlError("");
+	
+	if(parentItem)
+		_parentItem = parentItem;
 
 	if(_analysisForm)
 	{
 		Log::log() << "It already has a form, so we destroy it." << std::endl;
-		if (!parentItem) parentItem = _analysisForm->parentItem();
+		
+		if (!parentItem) 
+			parentItem = _analysisForm->parentItem();
+		
 		destroyForm();
 	}
+	else if(!parentItem)
+		parentItem = _parentItem;
 
 	try
 	{
@@ -75,7 +83,12 @@ void AnalysisBase::createForm(QQuickItem* parentItem)
 
 		emit formItemChanged();
 	}
-	catch(std::exception e)
+	catch(qmlLoadError & e)
+	{
+		setQmlError(e.what());
+		_analysisForm = nullptr;
+	}
+	catch(std::exception & e)
 	{
 		setQmlError(e.what());
 		_analysisForm = nullptr;

--- a/QMLComponents/analysisbase.h
+++ b/QMLComponents/analysisbase.h
@@ -79,6 +79,7 @@ protected:
 
 
 	AnalysisForm*	_analysisForm		= nullptr;
+	QQuickItem	*	_parentItem			= nullptr;
 	QString			_qmlError;
 	Version			_moduleVersion;
 

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -912,8 +912,11 @@ QString AnalysisForm::helpMD() const
 
 	QList<JASPControl*> orderedControls = JASPControl::getChildJASPControls(this);
 
+	std::set<const JASPControl *> markdowned;
+
 	for(JASPControl * control : orderedControls)
-		markdown.push_back(control->helpMD());
+		if(!markdowned.count(control))
+			markdown.push_back(control->helpMD(markdowned));
 
 	markdown.push_back(metaHelpMD());
 	

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -715,40 +715,6 @@ bool AnalysisForm::needsRefresh() const
 	return _analysis ? _analysis->needsRefresh() : false;
 }
 
-QString AnalysisForm::metaHelpMD() const
-{
-	std::function<QString(const Json::Value & meta, int deep)> metaMDer = [&metaMDer](const Json::Value & meta, int deep)
-	{
-		QStringList markdown;
-
-		for(const Json::Value & entry : meta)
-		{
-			std::string entryType	= entry.get("type", "").asString();
-			//Sadly enough the following "meta-types" aren't defined properly anywhere, this would be good to do at some point. The types are: table, image, collection, and optionally: htmlNode, column, json
-			QString friendlyObject	= entryType == "table"		? tr("Table")
-									: entryType == "image"		? tr("Plot")
-									: entryType == "collection"	? tr("Collection")
-									: tr("Result"); //Anything else we just call "Result"
-
-			if(entry.get("info", "") != "")
-			{
-				for(int i=0; i<deep; i++) markdown << "#";
-				markdown << " " << friendlyObject;
-				if(entry.get("title", "") != "")	markdown << tq(" - *" + entry["title"].asString() + "*:\n");
-				else								markdown << "\n";
-				markdown << tq(entry["info"].asString() + "\n");
-			}
-
-			if(entry.get("meta", Json::nullValue).isArray())
-				markdown << "\n" << metaMDer(entry["meta"], deep + 1);
-		}
-
-		return markdown.join("");
-	};
-
-	return "---\n# " + tr("Output") + "\n\n" + metaMDer(_analysis->resultsMeta(), 2);
-}
-
 bool AnalysisForm::isFormulaName(const QString& name) const
 {
 	return _rSyntax->getFormula(name) != nullptr;
@@ -898,6 +864,7 @@ std::set<string> AnalysisForm::usedVariables()
 	return result;
 }
 
+///Generates documentation based on the "info" entered on each component
 QString AnalysisForm::helpMD() const
 {
 	if(!_analysis) return "";
@@ -907,7 +874,7 @@ QString AnalysisForm::helpMD() const
 		title(), "\n",
 		"=====================\n",
 		_info, "\n\n",
-		"---\n# ", tr("Input"), "\n"
+		"---\n# ", tr("Options"), "\n"
 	};
 
 	QList<JASPControl*> orderedControls = JASPControl::getChildJASPControls(this);
@@ -926,6 +893,42 @@ QString AnalysisForm::helpMD() const
 		_analysis->preprocessMarkdownHelp(md);
 	
 	return md;
+}
+
+///Collects "info" from results and lists them underneath the output in the help-md window
+QString AnalysisForm::metaHelpMD() const
+{
+	std::function<QString(const Json::Value & meta, int deep)> metaMDer = [&metaMDer](const Json::Value & meta, int deep)
+	{
+		QStringList markdown;
+
+		for(const Json::Value & entry : meta)
+		{
+			std::string entryType	= entry.get("type", "").asString();
+			//Sadly enough the following "meta-types" aren't defined properly anywhere, this would be good to do at some point. The types are: table, image, collection, and optionally: htmlNode, column, json
+			QString friendlyObject	= entryType == "table"		? tr("Table")
+									: entryType == "image"		? tr("Plot")
+									: entryType == "collection"	? tr("Collection")
+									: tr("Result"); //Anything else we just call "Result"
+
+			if(entry.get("info", "") != "")
+			{
+				for(int i=0; i<deep; i++) markdown << "#";
+				markdown << " " << friendlyObject;
+				if(entry.get("title", "") != "")	markdown << tq(" - *" + entry["title"].asString() + "*:\n");
+				else								markdown << "\n";
+				markdown << tq(entry["info"].asString() + "\n");
+			}
+
+			if(entry.get("meta", Json::nullValue).isArray())
+				markdown << "\n" << metaMDer(entry["meta"], deep + 1);
+		}
+
+		return markdown.join("");
+	};
+
+	QString meta = metaMDer(_analysis->resultsMeta(), 2);
+	return meta.isEmpty() ? "" : "---\n# " + tr("Output") + "\n\n" + meta;
 }
 
 void AnalysisForm::setShowRSyntax(bool showRSyntax)

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -60,6 +60,7 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(QString		rSyntaxText				READ rSyntaxText											NOTIFY rSyntaxTextChanged			)
 	Q_PROPERTY(QString		rSyntaxControlName		MEMBER rSyntaxControlName	CONSTANT															)
 	Q_PROPERTY(JASPControl*	activeJASPControl		READ getActiveJASPControl									NOTIFY activeJASPControlChanged		)
+
 public:
 	explicit				AnalysisForm(QQuickItem * = nullptr);
 							~AnalysisForm();

--- a/QMLComponents/components/JASP/Controls/BasicThreeButtonTableView.qml
+++ b/QMLComponents/components/JASP/Controls/BasicThreeButtonTableView.qml
@@ -42,6 +42,7 @@ Item
     property	alias	tableView			: tableView
 	property	alias	factorsSource		: tableView.factorsSource
 	property	alias	control				: tableView //Needed for RowComponent
+	property	alias	info				: tableView.info
 
 	property	alias	itemType			: tableView.itemType
 	property	alias	itemTypePerColumn	: tableView.itemTypePerColumn

--- a/QMLComponents/components/JASP/Controls/ExpanderButton.qml
+++ b/QMLComponents/components/JASP/Controls/ExpanderButton.qml
@@ -35,6 +35,7 @@ FocusScope
 				property alias	childControlsArea		: expanderArea
 				property alias	spacing					: expanderArea.rowSpacing
 				property alias	text					: expanderButton.title
+				property alias	info					: expanderButton.info
 				property alias  title					: expanderButton.title
 				property bool	expanded				: false
 				property alias	debug					: expanderButton.debug

--- a/QMLComponents/components/JASP/Controls/TabView.qml
+++ b/QMLComponents/components/JASP/Controls/TabView.qml
@@ -33,6 +33,7 @@ ComponentsListBase
 	addItemManually			: !source
 	minimumItems			: 1
 	newItemName				: qsTr("New tab")
+	controlType				: JASPControl.TabView
 
 	property alias	label				: tabView.title
 	property bool	showAddIcon			: addItemManually

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -32,8 +32,7 @@ TextInputBase
 	title:				text
 	
 	property alias	control:			control
-	property alias	label:				beforeLabel.text
-	property alias	text:				beforeLabel.text
+	property alias	text:				textField.label
 	property alias	value:				control.text
 	property string lastValidValue:		defaultValue
 	property int	fieldWidth:			jaspTheme.textFieldWidth
@@ -46,7 +45,6 @@ TextInputBase
 
 	property alias	validator:			control.validator
 	property alias	controlLabel:		beforeLabel
-	property alias	afterLabel:			afterLabel.text
 	property string	inputType:			"string"
 	property bool	useLastValidValue:	true
 	property bool	editable:			true
@@ -128,6 +126,7 @@ TextInputBase
 			font:					jaspTheme.font
 			anchors.verticalCenter: parent.verticalCenter
 			color:					enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
+			text:					textField.label
 		}
 	}
 
@@ -234,6 +233,7 @@ TextInputBase
 			font:		jaspTheme.font
 			anchors.verticalCenter: parent.verticalCenter
 			color:		enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
+			text:		textField.afterLabel
 		}
 	}
 }

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -248,7 +248,7 @@ QString	ComboBoxBase::helpMD(SetConst & markdowned, int howDeep, bool) const
 	if (values().isValid() && !values().isNull())
 	{
 		bool isInteger = false;
-		int count =  values().toInt(&isInteger);
+		values().toInt(&isInteger);
 
 		if (!isInteger)
 		{
@@ -263,7 +263,7 @@ QString	ComboBoxBase::helpMD(SetConst & markdowned, int howDeep, bool) const
 						QString label = labelValueInfoTriplet[labelRole()].toString(),
 								info  = labelValueInfoTriplet["info"].toString();
 
-						md << ( QString{howDeep, ' '} + "- " + label + ": " + info);
+						md << ( QString{howDeep, ' '} + "- *" + label + "*: " + info);
 					}
 				}
 			}

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -238,3 +238,38 @@ void ComboBoxBase::_setCurrentProperties(int index, bool bindValue)
 
 	if (bindValue && initialized())	setBoundValue(fq(_currentValue));
 }
+
+
+QString	ComboBoxBase::helpMD(SetConst & markdowned, int howDeep, bool) const
+{
+	QStringList md = { JASPControl::helpMD(markdowned, howDeep, false) };
+	howDeep++;
+
+	if (values().isValid() && !values().isNull())
+	{
+		bool isInteger = false;
+		int count =  values().toInt(&isInteger);
+
+		if (!isInteger)
+		{
+			QList<QVariant> list = values().toList();
+			if (!list.isEmpty())
+			{
+				for (const QVariant& itemVariant : list)
+				{
+					QMap<QString, QVariant> labelValueInfoTriplet = itemVariant.toMap();
+					if (labelValueInfoTriplet.contains(labelRole()) && labelValueInfoTriplet.contains("info"))
+					{
+						QString label = labelValueInfoTriplet[labelRole()].toString(),
+								info  = labelValueInfoTriplet["info"].toString();
+
+						md << ( QString{howDeep, ' '} + "- " + label + ": " + info);
+					}
+				}
+			}
+		}
+	}
+
+
+	return md.join("\n");
+}

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -44,6 +44,8 @@ public:
 	void				setUp()												override;
 	ListModel*			model()										const	override	{ return _model;				}
 	void				setUpModel()										override;
+	QString				helpMD(SetConst & markdowned,
+							   int howDeep = 2, bool asList=true)	const	override;
 
 	const QString&		currentText()								const				{ return _currentText;			}
 	const QString&		currentValue()								const				{ return _currentValue;			}
@@ -53,6 +55,8 @@ public:
 	int					currentIndex()								const				{ return _currentIndex;			}
 
 	std::vector<std::string> usedVariables()						const	override;
+
+
 signals:
 	void currentTextChanged();
 	void currentValueChanged();

--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -203,20 +203,25 @@ void ComponentsListBase::addItemHandler()
 	if (_duplicateWhenAdding)
 	{
 		QMap<QString, Json::Value> jsonValues;
-		const Json::Value& boundVal = boundValue();
-		int currentIndex = property("currentIndex").toInt();
-		const Terms& terms = _termsModel->terms();
+		
+		const Json::Value	&	boundVal		= boundValue();
+		int						currentIndex	= property("currentIndex").toInt();
+		const Terms			&	terms			= _termsModel->terms();
+		
 		if (boundVal.isArray() && int(terms.size()) >= currentIndex)
 		{
 			std::string keyString = terms.at(size_t(currentIndex)).asString();
+			
 			for (const Json::Value& jsonVal : boundVal)
 			{
 				const Json::Value& keyVal = jsonVal.get(fq(_optionKey), Json::nullValue);
+				
 				if (keyVal.asString() == keyString)
 				{
 					for (const std::string& member : jsonVal.getMemberNames())
 						jsonValues[tq(member)] = jsonVal.get(member, Json::nullValue);
 				}
+				
 				jsonValues[_optionKey] = fq(newTerm);
 			}
 		}
@@ -265,8 +270,9 @@ void ComponentsListBase::nameChangedHandler(int index, QString name)
 QString ComponentsListBase::_changeLastNumber(const QString &val) const
 {
 	QString result = val;
-	int index = val.length() - 1;
-	for (; index >= 0 ; index--)
+	
+	int index;
+	for (index = val.length() - 1; index >= 0 ; index--)
 	{
 		if (!val.at(index).isDigit())
 			break;

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -533,7 +533,7 @@ QString JASPControl::ControlTypeToFriendlyString(ControlType controlType)
 	case ControlType::TextField:					return tr("Entry Field");			break;
 	case ControlType::RadioButton:					return tr("Radio Button");			break;
 	case ControlType::RadioButtonGroup:				return tr("Radio Buttons");			break;
-	case ControlType::VariablesListView:			return tr("Variables");				break;
+	case ControlType::VariablesListView:			return tr("Variables List");		break;
 	case ControlType::ComboBox:						return tr("ComboBox");				break;
 	case ControlType::FactorLevelList:				return tr("Factor Level List");		break;
 	case ControlType::InputListView:				return tr("Input ListView");		break;
@@ -544,6 +544,8 @@ QString JASPControl::ControlTypeToFriendlyString(ControlType controlType)
 	case ControlType::FactorsForm:					return tr("Factors Form");			break;
 	case ControlType::ComponentsList:				return tr("List of Components");	break;
 	case ControlType::GroupBox:						return tr("Group Box");				break;
+	case ControlType::TabView:						return tr("Tab View");				break;
+	case ControlType::VariablesForm:				return tr("Variables Form");		break;
 	}
 }
 
@@ -551,14 +553,21 @@ QString JASPControl::helpMD(int howDeep) const
 {
 	if(!isVisible())
 		return "";
+		
+	Log::log() << "Generating markdown for control by name '" << name() << "', title '" << title() << "' and type: '" << JASPControl::ControlTypeToFriendlyString(controlType()) << "'.\n";
+		
+	if(controlType() == JASPControl::ControlType::VariablesForm)
+		Log::log() << "varform!\n";
 
 	howDeep++;
 	QStringList markdown, childMDs;
 
 	//First we determine if we have children, and if so if they contain anything.
-	QList<JASPControl*> children = _childControlsArea ? getChildJASPControls(_childControlsArea) : QList<JASPControl*>();
+	QList<JASPControl*> children =  getChildJASPControls(_childControlsArea ? _childControlsArea : this);
 
 	bool aControlThatEncloses = children.size() > 0;
+		
+	Log::log() << "Control encloses #" << children.size() << " children." << std::endl;
 
 	for (JASPControl* childControl : children)
 		childMDs << childControl->helpMD(howDeep);
@@ -590,7 +599,11 @@ QString JASPControl::helpMD(int howDeep) const
 
 	markdown << childMD;
 
-	return markdown.join("") + "\n\n";
+	QString md = markdown.join("") + "\n\n";
+		
+	Log::log() << "Generated: '" << md << "'\n";
+		
+	return md;
 }
 
 void JASPControl::setChildControlsArea(QQuickItem * childControlsArea)

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -605,7 +605,7 @@ QString JASPControl::helpMD(SetConst & markdowned, int howDeep, bool asList) con
 
 	//If on the other hand we are a simply radiobutton we can just turn it into a list entry
 	if(controlType() == ControlType::RadioButton && !aControlThatEncloses)
-		return "- *" + title() + "* " + info() + "\n";
+		return "- *" + title() + "*: " + info() + "\n";
 
 	//And otherwise we go the full mile, header + title + info and all followed by whatever children we have
 	if(aControlThatEncloses)

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -589,8 +589,10 @@ QString JASPControl::helpMD(int howDeep) const
 	if(howDeep > 6) markdown << "- "; //Headers in html only got 6 sizes so below that I guess we just turn it into bulletpoints?
 	else			markdown << QString{howDeep, '#'} + " "; // ;)
 
-	//Ok removing the check for existence of wrapper because
-	markdown << friendlyName();
+	//Would be better to show something like "Assigned vars" or "Available var list" or something like that
+	//if(controlType() != ControlType::VariablesListView)		
+		markdown << friendlyName();
+	//else													markdown << qobject_cast<JASPListControl*>(this)->
 
 	if(title() != "")	markdown << " - *" + title() + "*:\n";
 	else				markdown << "\n";

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -112,7 +112,8 @@ public:
 	QString				title()						const	{ return _title;				}
 	QString				info()						const	{ return _info;					}
 	QString				toolTip()					const	{ return _toolTip;				}
-	QString				helpMD(int howDeep = 2)		const;
+	QString				helpMD(int howDeep = 2,
+							   bool asList = false)	const;
 	bool				isBound()					const	{ return _isBound;				}
 	bool				nameIsOptionValue()			const	{ return _nameIsOptionValue;	}
 	bool				indent()					const	{ return _indent;				}

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -25,7 +25,7 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( QString								title					READ title					WRITE setTitle					NOTIFY titleChanged					) //Basically whatever a human sees on their screen when they look at this specific item.
 	Q_PROPERTY( QString								info					READ info					WRITE setInfo					NOTIFY infoChanged					)
 	Q_PROPERTY( QString								toolTip					READ toolTip				WRITE setToolTip				NOTIFY toolTipChanged				)
-	Q_PROPERTY( QString								helpMD					READ helpMD													NOTIFY helpMDChanged				)
+	Q_PROPERTY( QString								helpMD					READ helpMDControl											NOTIFY helpMDChanged				)
 	Q_PROPERTY( bool								isBound					READ isBound				WRITE setIsBound				NOTIFY isBoundChanged				)
 	Q_PROPERTY( bool								indent					READ indent					WRITE setIndent					NOTIFY indentChanged				)
 	Q_PROPERTY( bool								isDependency			READ isDependency			WRITE setIsDependency			NOTIFY isDependencyChanged			)
@@ -50,8 +50,9 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( int									alignment				READ alignment				WRITE setAlignment													)
 	Q_PROPERTY( Qt::FocusReason						focusReason				READ getFocusReason																				)
 
-
-	typedef std::set<JASPControl*> Set;
+protected:
+	typedef std::set<JASPControl*>			Set;
+	typedef std::set<const JASPControl*>	SetConst;
 
 public:
 	struct ParentKey
@@ -107,45 +108,45 @@ public:
 	JASPControl(QQuickItem *parent = nullptr);
 	~JASPControl(); //Disconnecting signals right before destroying the object avoids some crashes with qt >= 6.3 on macos m1
 
-	ControlType			controlType()				const	{ return _controlType;			}
-	const QString	&	name()						const	{ return _name;					}
-	QString				title()						const	{ return _title;				}
-	QString				info()						const	{ return _info;					}
-	QString				toolTip()					const	{ return _toolTip;				}
-	QString				helpMD(int howDeep = 2,
-							   bool asList = false)	const;
-	bool				isBound()					const	{ return _isBound;				}
-	bool				nameIsOptionValue()			const	{ return _nameIsOptionValue;	}
-	bool				indent()					const	{ return _indent;				}
-	bool				isDependency()				const	{ return _isDependency;			}
-	bool				initialized()				const	{ return _initialized;			}
+	ControlType			controlType()				const	{ return _controlType;				}
+	const QString	&	name()						const	{ return _name;						}
+	QString				title()						const	{ return _title;					}
+	QString				info()						const	{ return _info;						}
+	QString				toolTip()					const	{ return _toolTip;					}
+	QString				helpMDControl()				const	{ SetConst tmp; return helpMD(tmp);	} ///< If someone want to get it from qml they can this way.
+	virtual QString		helpMD(SetConst & markdowned, int howDeep = 2, bool asList = false)	const;
+	bool				isBound()					const	{ return _isBound;					}
+	bool				nameIsOptionValue()			const	{ return _nameIsOptionValue;		}
+	bool				indent()					const	{ return _indent;					}
+	bool				isDependency()				const	{ return _isDependency;				}
+	bool				initialized()				const	{ return _initialized;				}
 	bool				initializedFromJaspFile()	const	{ return _initializedFromJaspFile;	}
-	bool				shouldShowFocus()			const	{ return _shouldShowFocus;		}
-	bool				shouldStealHover()			const	{ return _shouldStealHover;		}
-	bool				debug()						const	{ return _debug;				}
-	bool				parentDebug()				const	{ return _parentDebug;			}
+	bool				shouldShowFocus()			const	{ return _shouldShowFocus;			}
+	bool				shouldStealHover()			const	{ return _shouldStealHover;			}
+	bool				debug()						const	{ return _debug;					}
+	bool				parentDebug()				const	{ return _parentDebug;				}
 	bool				hasError()					const;
 	bool				hasWarning()				const;
 	bool				childHasError()				const;
 	bool				childHasWarning()			const;
-	bool				focusOnTab()				const	{ return activeFocusOnTab();	}
+	bool				focusOnTab()				const	{ return activeFocusOnTab();		}
 	bool				hasUserInteractiveValue()	const	{ return _hasUserInteractiveValue;	}
 
-	AnalysisForm	*	form()						const	{ return _form;					}
-	QQuickItem		*	childControlsArea()			const	{ return _childControlsArea;	}
-	JASPListControl	*	parentListView()			const	{ return _parentListView;		}
+	AnalysisForm	*	form()						const	{ return _form;						}
+	QQuickItem		*	childControlsArea()			const	{ return _childControlsArea;		}
+	JASPListControl	*	parentListView()			const	{ return _parentListView;			}
 	JASPControl		*	parentListViewEx()			const;
-	QString				parentListViewKey()			const	{ return _parentListViewKey;	}
-	QQuickItem		*	innerControl()				const	{ return _innerControl;			}
-	QQuickItem		*	background()				const	{ return _background;			}
-	QQuickItem		*	focusIndicator()			const	{ return _focusIndicator;		}
-	QStringList			dependencyMustContain()		const	{ return _dependencyMustContain; }
-	int					preferredHeight()			const	{ return _preferredHeight;		}
-	int					preferredWidth()			const	{ return _preferredWidth;		}
-	int					cursorShape()				const	{ return _cursorShape;			}
+	QString				parentListViewKey()			const	{ return _parentListViewKey;		}
+	QQuickItem		*	innerControl()				const	{ return _innerControl;				}
+	QQuickItem		*	background()				const	{ return _background;				}
+	QQuickItem		*	focusIndicator()			const	{ return _focusIndicator;			}
+	QStringList			dependencyMustContain()		const	{ return _dependencyMustContain;	}
+	int					preferredHeight()			const	{ return _preferredHeight;			}
+	int					preferredWidth()			const	{ return _preferredWidth;			}
+	int					cursorShape()				const	{ return _cursorShape;				}
 	bool				hovered()					const;
-	int					alignment()					const	{ return _alignment;			}
-	Qt::FocusReason		getFocusReason()			const	{ return _focusReason;			}
+	int					alignment()					const	{ return _alignment;				}
+	Qt::FocusReason		getFocusReason()			const	{ return _focusReason;				}
 
 	QString				humanFriendlyLabel()		const;
 	void				setInitialized(bool byFile = false);
@@ -171,7 +172,6 @@ public:
 
 protected:
 	Set								_depends; //So Joris changed this to a set instead of a vector because that is what it seemed to be, the order isn't important right?
-
 
 public slots:
 	void	setControlType(			ControlType			controlType)		{ _controlType = controlType; }

--- a/QMLComponents/controls/sourceitem.cpp
+++ b/QMLComponents/controls/sourceitem.cpp
@@ -356,6 +356,7 @@ JASPListControl::LabelValueMap SourceItem::_readValues(JASPListControl* listCont
 		{
 			for (const QVariant& itemVariant : list)
 			{
+				//It is called labelValuePair but it might in fact also contain "info"
 				QMap<QString, QVariant> labelValuePair = itemVariant.toMap();
 				if (labelValuePair.isEmpty())
 				{

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -261,6 +261,24 @@ QString TextInputBase::friendlyName() const
 	}
 }
 
+QString	TextInputBase::helpMD(SetConst & markdowned, int howDeep, bool) const
+{
+	markdowned.insert(this);
+
+	if(info() == "" || (label() == "" && afterLabel() == ""))
+		return "";
+
+	QStringList md;
+
+	md	<< QString{howDeep, '#' } << " " << friendlyName() << "\n"
+		<< "`" << label() << " ... " << afterLabel() << "`\n\n"
+		<< info() << "\n";
+
+
+	return md.join("");
+}
+
+
 bool TextInputBase::_formulaResultInBounds(double result)
 {
 	double min			= property("min").toDouble();
@@ -355,4 +373,30 @@ void TextInputBase::textChangedSlot()
 		}
 	}
 	else setBoundValue(_getJsonValue(_value));
+}
+
+const QString &TextInputBase::label() const
+{
+	return _label;
+}
+
+void TextInputBase::setLabel(const QString &newLabel)
+{
+	if (_label == newLabel)
+		return;
+	_label = newLabel;
+	emit labelChanged();
+}
+
+const QString &TextInputBase::afterLabel() const
+{
+	return _afterLabel;
+}
+
+void TextInputBase::setAfterLabel(const QString &newAfterLabel)
+{
+	if (_afterLabel == newAfterLabel)
+		return;
+	_afterLabel = newAfterLabel;
+	emit afterLabelChanged();
 }

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -28,7 +28,8 @@ class TextInputBase : public JASPControl, public BoundControlBase
 
 	Q_PROPERTY( bool		hasScriptError		READ hasScriptError			WRITE setHasScriptError		NOTIFY hasScriptErrorChanged		)
 	Q_PROPERTY( QVariant	defaultValue		READ defaultValue			WRITE setDefaultValue		NOTIFY defaultValueChanged			)
-
+	Q_PROPERTY( QString		label				READ label					WRITE setLabel				NOTIFY labelChanged					)
+	Q_PROPERTY( QString		afterLabel			READ afterLabel				WRITE setAfterLabel			NOTIFY afterLabelChanged			)
 
 public:
 	enum TextInputType { IntegerInputType = 0, StringInputType, NumberInputType, PercentIntputType, IntegerArrayInputType, DoubleArrayInputType, ComputedColumnType, AddColumnType, FormulaType, FormulaArrayType};
@@ -40,16 +41,28 @@ public:
 	void		bindTo(const Json::Value& value)					override;
 	void		setUp()												override;
 	void		rScriptDoneHandler(const QString& result)			override;
+	QString		helpMD(SetConst & markdowned,
+					   int howDeep = 2, bool asList=true)	const	override;
 
-	TextInputType	inputType()	{ return _inputType; }
+	TextInputType	inputType()										{ return _inputType; }
 	QString			friendlyName() const override;
 	bool			hasScriptError()						const	{ return _hasScriptError;		}
 	QVariant		defaultValue()							const	{ return _defaultValue;			}
+
+	const QString &label() const;
+	void setLabel(const QString &newLabel);
+
+	const QString &afterLabel() const;
+	void setAfterLabel(const QString &newAfterLabel);
 
 signals:
 	void		formulaCheckSucceeded();
 	void		hasScriptErrorChanged();
 	void		defaultValueChanged();
+
+	void labelChanged();
+
+	void afterLabelChanged();
 
 public slots:
 	GENERIC_SET_FUNCTION(HasScriptError,	_hasScriptError,	hasScriptErrorChanged,	bool		)
@@ -68,12 +81,13 @@ private:
 	QString		_getDoubleArrayValue(const std::vector<double>& dblValues);
 
 	TextInputType			_inputType;
-	QString					_value;
+	QString					_value,
+							_label,
+							_afterLabel;
 
 	bool					_parseDefaultValue	= true;
 	QVariant				_defaultValue;
 	bool					_hasScriptError		= false;
-
 };
 
 #endif // TEXTINPUTBASE_H


### PR DESCRIPTION
This should make at least all components show up as markdown when Info is filled.
To test this you can use the `jaspTestModule` and analysis "info testing"

Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1554 at least partly.