### PR TITLE
Upgrader should not throw error if not a developer module

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -719,10 +719,8 @@ bool Analysis::readyToCreateForm() const
 
 const stringvec & Analysis::upgradeMsgsForOption(const std::string & name) const
 {
-	static stringvec emptyDummy;
-
 	if(_msgs.count(name) == 0)
-		return emptyDummy;
+		return emptyStringVec;
 
 	return _msgs.at(name);
 }

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -154,7 +154,7 @@ public:
 
 	void					setUpgradeMsgs(const Modules::UpgradeMsgs & msgs);
 
-	const stringvec &		upgradeMsgsForOption(const std::string & name)		const;
+	const stringvec &		upgradeMsgsForOption(const std::string & name)		const	override;
 
 	const QList<std::string>	&	computedColumns()							const				{ return _computedColumns; }
 	const Json::Value			&	getRSource(const std::string & name)		const	override	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -282,6 +282,8 @@ Upgrades * DynamicModule::instantiateUpgradesQml(const QString & upgradesTxt, co
 
 	//Log::log() << "Dynamic module " << moduleName << " got upgrades? " << ( upgrades ? "yes!" : "no...") << std::endl;
 
+	upgrades->setModule(tq(moduleName));
+
 	return upgrades;
 }
 

--- a/Desktop/modules/upgrader/changecopy.cpp
+++ b/Desktop/modules/upgrader/changecopy.cpp
@@ -18,7 +18,7 @@ void ChangeCopy::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
 						newName = fq(_to);
 
 	if(!options.isMember(oldName))
-		throw upgradeError("Could not copy option '" + oldName + "' to '" + newName + "' because options does not contain '" + oldName + "'");
+		throw upgradeError("Could not copy option '" + oldName + "' to '" + newName + "' because options does not contain '" + oldName + "'", true);
 
 	options[newName]	= options[oldName];
 	msgs[newName]		= msgs[oldName];

--- a/Desktop/modules/upgrader/changejs.cpp
+++ b/Desktop/modules/upgrader/changejs.cpp
@@ -18,7 +18,7 @@ void ChangeJS::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
 		throw upgradeError("Could not apply ChangeJS to option '" + name + "' because the function cannot be called...");
 
 	if(!options.isMember(name))
-		throw upgradeError("Could not apply ChangeJS for option '" + name + "' because options does not contain '" + name + "'");
+		throw upgradeError("Could not apply ChangeJS for option '" + name + "' because options does not contain '" + name + "'", true);
 
 	QJSValue	copyFunc	= _jsFunction, //To avoid const clashing with javascript "flexibility"
 				result		= copyFunc.call( { tqj(options, this) } );

--- a/Desktop/modules/upgrader/changeremove.cpp
+++ b/Desktop/modules/upgrader/changeremove.cpp
@@ -14,7 +14,7 @@ void ChangeRemove::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
 	const std::string name = fq(_name);
 
 	if(!options.isMember(name))
-		throw upgradeError("Could not erase option '" + name + "' because options does not contain it.");
+		throw upgradeError("Could not erase option '" + name + "' because options does not contain it.", true);
 
 	options.removeMember(name);
 	msgs.erase(name);

--- a/Desktop/modules/upgrader/changerename.cpp
+++ b/Desktop/modules/upgrader/changerename.cpp
@@ -19,7 +19,7 @@ void ChangeRename::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
 		throw upgradeError("Could not rename option '" + oldName + "' to '" + newName + "' because options already contains '" + newName + "'");
 
 	if(!options.isMember(oldName))
-		throw upgradeError("Could not rename option '" + oldName + "' to '" + newName + "' because options does not contain '" + oldName + "'");
+		throw upgradeError("Could not rename option '" + oldName + "' to '" + newName + "' because options does not contain '" + oldName + "'", true);
 
 	options[newName] = options[oldName];
 	options.removeMember(oldName);

--- a/Desktop/modules/upgrader/upgrade.cpp
+++ b/Desktop/modules/upgrader/upgrade.cpp
@@ -51,12 +51,18 @@ void Upgrade::applyUpgrade(const std::string & function, const Version & version
 		{
 			Log::log() << "Change had a" << ( error.isWarning ? " warning" : "n error") <<  ": " << error.what() << std::endl;
 
-			if(module && module->isDevMod())
+			if(isModuleDev())
 				throw error;
+			
 			if (!error.isWarning)
 				msgs[""].push_back(error.what());
 		}
 
+}
+
+bool Upgrade::isModuleDev() const
+{
+	return DynamicModules::developmentModuleName() == fq(module());
 }
 
 QString Upgrade::toString() 

--- a/Desktop/modules/upgrader/upgrade.cpp
+++ b/Desktop/modules/upgrader/upgrade.cpp
@@ -4,6 +4,7 @@
 #include "upgrades.h"
 #include "upgrade.h"
 #include "log.h"
+#include "modules/dynamicmodules.h"
 
 namespace Modules
 {
@@ -48,12 +49,14 @@ void Upgrade::applyUpgrade(const std::string & function, const Version & version
 		}
 		catch(upgradeError & error)
 		{
-			//If we are not in developermode it would be better to keep going instead of crashing the whole upgradeprocess
-			if(PreferencesModel::prefs()->developerMode())
+			Log::log() << "Change had a problem: " << error.what() << std::endl;
+
+			if(module && module->isDevMod())
 				throw error;
-			else
-				Log::log() << "Change had a problem: " << error.what() << std::endl;
+			if (!error.isWarning)
+				msgs[""].push_back(error.what());
 		}
+
 }
 
 QString Upgrade::toString() 

--- a/Desktop/modules/upgrader/upgrade.cpp
+++ b/Desktop/modules/upgrader/upgrade.cpp
@@ -49,7 +49,7 @@ void Upgrade::applyUpgrade(const std::string & function, const Version & version
 		}
 		catch(upgradeError & error)
 		{
-			Log::log() << "Change had a problem: " << error.what() << std::endl;
+			Log::log() << "Change had a" << ( error.isWarning ? " warning" : "n error") <<  ": " << error.what() << std::endl;
 
 			if(module && module->isDevMod())
 				throw error;

--- a/Desktop/modules/upgrader/upgrade.h
+++ b/Desktop/modules/upgrader/upgrade.h
@@ -42,6 +42,7 @@ public:
 	QString toVersionQ()		const { return _toVersion;			}
 	Version toVersion()			const;
 	QString module()			const;
+	bool	isModuleDev()		const;
 
 	const QString &msg() const;
 	void setMsg(const QString &newMsg);

--- a/Desktop/modules/upgrader/upgradeDefinitions.h
+++ b/Desktop/modules/upgrader/upgradeDefinitions.h
@@ -19,7 +19,7 @@ extern const char			*	logId;
 struct upgradeError  : public std::runtime_error
 {
 	bool isWarning = false;
-	upgradeError(std::string msg, bool _isWarning = false) : std::runtime_error(msg) { isWarning = _isWarning; }
+	upgradeError(std::string msg, bool isWarning = false) : std::runtime_error(msg), isWarning(isWarning) {}
 	const char* what() const noexcept override;
 };
 

--- a/Desktop/modules/upgrader/upgradeDefinitions.h
+++ b/Desktop/modules/upgrader/upgradeDefinitions.h
@@ -18,9 +18,11 @@ extern const char			*	logId;
 
 struct upgradeError  : public std::runtime_error
 {
-	upgradeError(std::string msg) : std::runtime_error(msg) {}
+	bool isWarning = false;
+	upgradeError(std::string msg, bool _isWarning = false) : std::runtime_error(msg) { isWarning = _isWarning; }
 	const char* what() const noexcept override;
 };
+
 
 struct upgradeLoadError  : public std::runtime_error
 {

--- a/Desktop/modules/upgrader/upgradechange.cpp
+++ b/Desktop/modules/upgrader/upgradechange.cpp
@@ -210,7 +210,7 @@ void UpgradeChange::applyRename(Json::Value & options, const std::string & oldNa
 		throw upgradeError("Could not rename option '" + oldName + "' to '" + newName + "' because options already contains '" + newName + "'");
 
 	if(!options.isMember(oldName))
-		throw upgradeError("Could not rename option '" + oldName + "' to '" + newName + "' because options does not contain '" + oldName + "'");
+		throw upgradeError("Could not rename option '" + oldName + "' to '" + newName + "' because options does not contain '" + oldName + "'", true);
 
 	options[newName] = options[oldName];
 	options.removeMember(oldName);
@@ -226,7 +226,7 @@ void UpgradeChange::applyCopy(Json::Value & options, const std::string & oldName
 	//It is ok to overwrite whatever is in newName? Because it is a sort of "set value"
 
 	if(!options.isMember(oldName))
-		throw upgradeError("Could not copy option '" + oldName + "' to '" + newName + "' because options does not contain '" + oldName + "'");
+		throw upgradeError("Could not copy option '" + oldName + "' to '" + newName + "' because options does not contain '" + oldName + "'", true);
 
 	options[newName]	= options[oldName];
 	msgs[newName]		= msgs[oldName];
@@ -237,7 +237,7 @@ void UpgradeChange::applyCopy(Json::Value & options, const std::string & oldName
 void UpgradeChange::applyRemove(Json::Value & options, const std::string & name, UpgradeMsgs & msgs) const
 {
 	if(!options.isMember(name))
-		throw upgradeError("Could not erase option '" + name + "' because options does not contain it.");
+		throw upgradeError("Could not erase option '" + name + "' because options does not contain it.", true);
 
 	options.removeMember(name);
 	msgs.erase(name);
@@ -283,7 +283,7 @@ void UpgradeChange::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) cons
 void UpgradeChange::applyModifier(Json::Value & options, const std::string & name,	const ModifyType modifier, UpgradeMsgs & msgs) const
 {
 	if(!options.isMember(name))
-		throw upgradeError("Could not modify option '" + name + "' with operation '"+ ModifyTypeToString(modifier) +"' because options does not contain it.");
+		throw upgradeError("Could not modify option '" + name + "' with operation '"+ ModifyTypeToString(modifier) +"' because options does not contain it.", true);
 
 	switch(modifier)
 	{

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -4,6 +4,7 @@
 #include "utilities/qmlutils.h"
 
 const std::string AnalysisBase::emptyString;
+const stringvec AnalysisBase::emptyStringVec;
 
 AnalysisBase::AnalysisBase(QObject* parent, Version moduleVersion)
 	: QObject(parent)

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -4,7 +4,7 @@
 #include "utilities/qmlutils.h"
 
 const std::string AnalysisBase::emptyString;
-const stringvec AnalysisBase::emptyStringVec;
+const stringvec AnalysisBase::emptyStringVec = {""};
 
 AnalysisBase::AnalysisBase(QObject* parent, Version moduleVersion)
 	: QObject(parent)

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -4,7 +4,7 @@
 #include "utilities/qmlutils.h"
 
 const std::string AnalysisBase::emptyString;
-const stringvec AnalysisBase::emptyStringVec = {""};
+const stringvec AnalysisBase::emptyStringVec;
 
 AnalysisBase::AnalysisBase(QObject* parent, Version moduleVersion)
 	: QObject(parent)

--- a/QMLComponents/analysisbase.h
+++ b/QMLComponents/analysisbase.h
@@ -32,7 +32,7 @@ public:
 	virtual void setTitle(const std::string& titel)									{}
 	virtual void preprocessMarkdownHelp(const QString& md)					const	{}
 	virtual QString helpFile()														{ return "";				}
-	virtual stringvec upgradeMsgsForOption(std::string name)						{ return {""};				}
+	virtual const stringvec & upgradeMsgsForOption(const std::string& name) const	{ return emptyStringVec;	}
 	virtual const Json::Value & optionsFromJASPFile()						const	{ return Json::Value::null;	}
 	virtual const Json::Value & resultsMeta()								const 	{ return Json::Value::null;	}
 	virtual const Json::Value & getRSource(const std::string& name)			const 	{ return Json::Value::null;	}
@@ -88,8 +88,9 @@ private:
 
 
 
-private:
-	static const std::string emptyString; ///< Otherwise we return references to a temporary object (std::string(""))
+protected:
+	static const std::string	emptyString; ///< Otherwise we return references to a temporary object (std::string(""))
+	static const stringvec		emptyStringVec;
 };
 
 #endif // ANALYSISBASE_H


### PR DESCRIPTION
- The errors were not send to the form: this was due to a wrong overriding of the upgradeMsgsForOption method. 
- An error message box should pop up only if the module is a Developer Module.
- Make a difference between error and warning: If the issue comes from the fact that an option is not found in the JASP file, this is just a warning and should not be displayed in the form, only log it.

