### PR TITLE
passing ppi, imageBackground and resultFont via settings

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -545,7 +545,7 @@ Json::Value Analysis::createAnalysisRequestJson()
 	json["revision"]			= revision();
 	json["rfile"]				= _moduleData == nullptr ? rfile() : "";
 	json["dynamicModuleCall"]	= _moduleData == nullptr ? "" : _moduleData->getFullRCall();
-	json["resultsFont"]			= PreferencesModel::prefs()->resultFont().toStdString();
+	json["resultFont"]			= PreferencesModel::prefs()->resultFont().toStdString();
 
 	if (!isAborted())
 	{

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -1035,6 +1035,7 @@ void EngineRepresentation::addSettingsToJson(Json::Value & msg)
 	msg["fixedDecimals"]		=	 PreferencesModel::prefs()->fixedDecimals();
 	msg["exactPValues"]			=	 PreferencesModel::prefs()->exactPValues();
 	msg["normalizedNotation"]	=	 PreferencesModel::prefs()->normalizedNotation();
+	msg["resultFont"]			= fq(PreferencesModel::prefs()->resultFont());
 }
 
 void EngineRepresentation::processSettingsReply()

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -61,6 +61,7 @@ EngineSync::EngineSync(QObject *parent)
 
 	connect(PreferencesModel::prefs(),	&PreferencesModel::plotPPIChanged,					this,						&EngineSync::settingsChanged					);
 	connect(PreferencesModel::prefs(),	&PreferencesModel::plotBackgroundChanged,			this,						&EngineSync::settingsChanged					);
+	connect(PreferencesModel::prefs(),	&PreferencesModel::resultFontChanged,				this,						&EngineSync::settingsChanged					);
 	connect(PreferencesModel::prefs(),	&PreferencesModel::languageCodeChanged,				this,						&EngineSync::settingsChanged					);
 	connect(PreferencesModel::prefs(),	&PreferencesModel::developerModeChanged,			this,						&EngineSync::settingsChanged					);
 	connect(PreferencesModel::prefs(),	&PreferencesModel::githubPatCustomChanged,			this,						&EngineSync::settingsChanged					);

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -104,7 +104,7 @@ void Engine::initialize()
 		std::string memoryName = "JASP-IPC-" + std::to_string(_parentPID);
 		_channel = new IPCChannel(memoryName, _slaveNo, true);
 
-		rbridge_init(SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _extraEncodings, _resultsFont.c_str());
+		rbridge_init(SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _extraEncodings, _resultFont.c_str());
 
 		Log::log() << "rbridge_init completed" << std::endl;
 	
@@ -554,7 +554,7 @@ void Engine::receiveAnalysisMessage(const Json::Value & jsonRequest)
 		_imageOptions			= jsonRequest.get("image",				Json::nullValue);
 		_analysisRFile			= jsonRequest.get("rfile",				"").asString();
 		_dynamicModuleCall		= jsonRequest.get("dynamicModuleCall",	"").asString();
-		_resultsFont			= jsonRequest.get("resultsFont",		"").asString();
+		_resultFont			= jsonRequest.get("resultsFont",		"").asString();
 		_engineState			= engineState::analysis;
 
 		Json::Value optionsEnc	= jsonRequest.get("options",			Json::nullValue);
@@ -617,7 +617,7 @@ void Engine::runAnalysis()
 	Log::log() << "Analysis will be run now." << std::endl;
 
 	_analysisResultsString = rbridge_runModuleCall(_analysisName, _analysisTitle, _dynamicModuleCall, _analysisDataKey, _analysisOptions, _analysisStateKey,
-												   _ppi, _analysisId, _analysisRevision, _imageBackground, _developerMode, _resultsFont);
+												   _analysisId, _analysisRevision, _developerMode);
 
 	switch(_analysisStatus)
 	{
@@ -660,7 +660,7 @@ void Engine::saveImage()
 				width	= _imageOptions.get("width",	Json::nullValue).asInt();
 	std::string data	= _imageOptions.get("data",		Json::nullValue).asString(),
 				type	= _imageOptions.get("type",		Json::nullValue).asString(),
-				result	= jaspRCPP_saveImage(data.c_str(), type.c_str(), height, width, _ppi, _imageBackground.c_str());
+				result	= jaspRCPP_saveImage(data.c_str(), type.c_str(), height, width);
 
 	Json::Reader().parse(result, _analysisResults, false);
 
@@ -682,7 +682,7 @@ void Engine::saveImage()
 void Engine::editImage()
 {
 	std::string optionsJson	= _imageOptions.toStyledString(),
-				result		= jaspRCPP_editImage(_analysisName.c_str(), optionsJson.c_str(), _ppi, _imageBackground.c_str(), _analysisId);
+				result		= jaspRCPP_editImage(_analysisName.c_str(), optionsJson.c_str(), _analysisId);
 
 	// JSONCPP_STRING          err;
 	// Json::CharReaderBuilder jsonReaderBuilder;
@@ -705,7 +705,7 @@ void Engine::editImage()
 
 void Engine::rewriteImages()
 {
-	jaspRCPP_rewriteImages(_analysisName.c_str(), _ppi, _imageBackground.c_str(), _resultsFont.c_str(), _analysisId);
+	jaspRCPP_rewriteImages(_analysisName.c_str(), _analysisId);
 
 	/* Already sent from R! (Through jaspResultsCPP$send())
 	_analysisStatus				= Status::complete;
@@ -984,6 +984,7 @@ void Engine::absorbSettings(const Json::Value & jsonRequest)
 	_fixedDecimals		= jsonRequest.get("fixedDecimals",		_fixedDecimals		).asBool();
 	_exactPValues		= jsonRequest.get("exactPValues",		_exactPValues		).asBool();
 	_normalizedNotation	= jsonRequest.get("normalizedNotation",	_normalizedNotation	).asBool();
+	_resultFont			= jsonRequest.get("resultFont",			_resultFont		).asString();
 
 	const char	* PAT	= std::getenv("GITHUB_PAT");
 	
@@ -994,6 +995,7 @@ void Engine::absorbSettings(const Json::Value & jsonRequest)
 #endif
 	rbridge_setLANG(_langR);
 	jaspRCPP_setDecimalSettings(_numDecimals, _fixedDecimals, _normalizedNotation, _exactPValues);
+	jaspRCPP_setFontAndPlotSettings(_resultFont.c_str(), _ppi, _imageBackground.c_str());
 }
 
 

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -554,7 +554,7 @@ void Engine::receiveAnalysisMessage(const Json::Value & jsonRequest)
 		_imageOptions			= jsonRequest.get("image",				Json::nullValue);
 		_analysisRFile			= jsonRequest.get("rfile",				"").asString();
 		_dynamicModuleCall		= jsonRequest.get("dynamicModuleCall",	"").asString();
-		_resultFont			= jsonRequest.get("resultsFont",		"").asString();
+		_resultFont			= jsonRequest.get("resultFont",		"").asString();
 		_engineState			= engineState::analysis;
 
 		Json::Value optionsEnc	= jsonRequest.get("options",			Json::nullValue);

--- a/Engine/engine.h
+++ b/Engine/engine.h
@@ -138,7 +138,7 @@ private: // Data:
 						_analysisResultsMeta,
 						_analysisStateKey,
 						_analysisResultsString,
-						_resultsFont,
+						_resultFont,
 						_imageBackground	= "white",
 						_analysisRFile		= "",
 						_dynamicModuleCall	= "",

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -293,13 +293,13 @@ extern "C" bool STDCALL rbridge_runCallback(const char* in, int progress, const 
 	return true;
 }
 
-std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont)
+std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int analysisID, int analysisRevision, bool developerMode)
 {
 	rbridge_callback	= NULL; //Only jaspResults here so callback is not needed
 	if (rbridge_dataSet != nullptr)
 		rbridge_dataSet		= rbridge_dataSetSource();
 
-	return jaspRCPP_runModuleCall(name.c_str(), title.c_str(), moduleCall.c_str(), dataKey.c_str(), options.c_str(), stateKey.c_str(), ppi, analysisID, analysisRevision, imageBackground.c_str(), developerMode, resultsFont.c_str());
+	return jaspRCPP_runModuleCall(name.c_str(), title.c_str(), moduleCall.c_str(), dataKey.c_str(), options.c_str(), stateKey.c_str(), analysisID, analysisRevision, developerMode);
 }
 
 extern "C" RBridgeColumn* STDCALL rbridge_readFullDataSet(size_t * colMax)

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -69,7 +69,7 @@ size_t _logWriteFunction(const void * buf, size_t len)
 	return len;
 }
 
-void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * extraEncoder, const char * resultsFont)
+void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * extraEncoder, const char * resultFont)
 {
 	JASPTIMER_SCOPE(rbridge_init);
 	
@@ -117,7 +117,7 @@ void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMes
 					_logWriteFunction,
 					rbridge_system,
 					rbridge_moduleLibraryFixer,
-					resultsFont,
+					resultFont,
 					rbridge_nativeToUtf8,
 					tempDirStatic.c_str()
 	);

--- a/Engine/rbridge.h
+++ b/Engine/rbridge.h
@@ -78,7 +78,7 @@ extern "C" {
 
 	typedef boost::function<std::string (const std::string &, int progress)> RCallback;
 
-	void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * encoder, const char * resultsFont);
+	void rbridge_init(sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * encoder, const char * resultFont);
 	void rbridge_junctionHelper(bool collectNotRestore, const std::string & folder);
 
 	void rbridge_setFileNameSource(			boost::function<void(const std::string &, std::string &, std::string &)> source);

--- a/Engine/rbridge.h
+++ b/Engine/rbridge.h
@@ -88,7 +88,7 @@ extern "C" {
 	void rbridge_setDataSetSource(			boost::function<DataSet *()> source);
 	void rbridge_memoryCleaning();
 
-	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int ppi, int analysisID, int analysisRevision, const std::string &imageBackground, bool developerMode, const std::string &resultsFont);
+	std::string rbridge_runModuleCall(const std::string &name, const std::string &title, const std::string &moduleCall, const std::string &dataKey, const std::string &options, const std::string &stateKey, int analysisID, int analysisRevision, bool developerMode);
 
 	void rbridge_setColumnFunctionSources(			boost::function<int (const std::string &)																		> getTypeSource,
 													boost::function<bool(const std::string &, const std::vector<double>&)											> scaleSource,

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -158,7 +158,6 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	char baseCitation[200];
 	sprintf(baseCitation, baseCitationFormat, buildYear, version);
 	rInside[".baseCitation"]		= baseCitation;
-	rInside[".resultsFont"]			= resultsFont;
 
 	//XPtr doesnt like it if it can't run a finalizer so here are some dummy variables:
 	static logFuncDef			_logFuncDef					= jaspRCPP_logString;
@@ -259,23 +258,31 @@ void STDCALL jaspRCPP_setDecimalSettings(int numDecimals, bool fixedDecimals, bo
 	rInside[".exactPValues"]		= exactPValues;
 }
 
+void STDCALL jaspRCPP_setFontAndPlotSettings(const char * resultsFont, const int ppi, const char* imageBackground)
+{
+	RInside &rInside			= rinside->instance();
+
+	rInside[".resultsFont"]			= resultsFont;
+	rInside[".imageBackground"]		= imageBackground;
+	rInside[".ppi"]					= ppi;
+
+	jaspRCPP_parseEvalQNT("jaspBase::registerFonts()");
+}
+
 const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options,
-										   const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode,
-										   const char* resultsFont)
+										   const char* stateKey, int analysisID, int analysisRevision, bool developerMode)
 {
 	RInside &rInside			= rinside->instance();
 
 	rInside["name"]					= name;
 	rInside["title"]				= title;
 	rInside["options"]				= options;
-	rInside[".ppi"]					= ppi;
 	rInside["dataKey"]				= dataKey;
 	rInside["stateKey"]				= stateKey;
 	rInside["moduleCall"]			= moduleCall;
 	rInside["resultsMeta"]			= "null";
 	rInside["requiresInit"]			= false;
-	rInside[".imageBackground"]		= imageBackground;
-	rInside[".resultsFont"]			= resultsFont;
+	
 
 	_setJaspResultsInfo(analysisID, analysisRevision, developerMode);
 
@@ -383,31 +390,27 @@ void STDCALL jaspRCPP_freeArrayPointer(bool ** arrayPointer)
 	free(*arrayPointer);
 }
 
-const char* STDCALL jaspRCPP_saveImage(const char * data, const char *type, const int height, const int width, const int ppi, const char* imageBackground)
+const char* STDCALL jaspRCPP_saveImage(const char * data, const char *type, const int height, const int width)
 {
 	RInside &rInside = rinside->instance();
 
-	rInside[".imageBackground"]		= imageBackground;
 	rInside["plotName"]				= data;
 	rInside["format"]				= type;
 	rInside["height"]				= height;
 	rInside["width"]				= width;
-	rInside[".ppi"]					= ppi;
 
 	static std::string staticResult;
 	staticResult = jaspRCPP_parseEvalStringReturn("jaspBase:::saveImage(plotName, format, height, width)", true);
 	return staticResult.c_str();
 }
 
-const char* STDCALL jaspRCPP_editImage(const char * name, const char * optionsJson, const int ppi, const char* imageBackground, int analysisID)
+const char* STDCALL jaspRCPP_editImage(const char * name, const char * optionsJson, int analysisID)
 {
 
 	RInside &rInside = rinside->instance();
 
-	rInside[".imageBackground"]		= imageBackground;
 	rInside[".editImgOptions"]		= optionsJson;
 	rInside[".analysisName"]		= name;
-	rInside[".ppi"]					= ppi;
 
 	_setJaspResultsInfo(analysisID, 0, false);
 
@@ -418,15 +421,12 @@ const char* STDCALL jaspRCPP_editImage(const char * name, const char * optionsJs
 }
 
 
-void STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, const char* resultsFont, int analysisID)
+void STDCALL jaspRCPP_rewriteImages(const char * name, int analysisID)
 {
 
 	RInside &rInside = rinside->instance();
 
-	rInside[".ppi"]					= ppi;
-	rInside[".imageBackground"]		= imageBackground;
 	rInside[".analysisName"]		= name;
-	rInside[".resultsFont"]			= resultsFont;
 
 	_setJaspResultsInfo(analysisID, 0, false);
 

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -70,7 +70,7 @@ extern "C" {
 void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks* callbacks,
 	sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction,
 	logFlushDef logFlushFunction, logWriteDef logWriteFunction,
-	systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,
+	systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultFont,
 	EnDecodeDef nativeToUtf8, const char * tempDir)
 {
 	_logFlushFunction		= logFlushFunction;
@@ -258,11 +258,11 @@ void STDCALL jaspRCPP_setDecimalSettings(int numDecimals, bool fixedDecimals, bo
 	rInside[".exactPValues"]		= exactPValues;
 }
 
-void STDCALL jaspRCPP_setFontAndPlotSettings(const char * resultsFont, const int ppi, const char* imageBackground)
+void STDCALL jaspRCPP_setFontAndPlotSettings(const char * resultFont, const int ppi, const char* imageBackground)
 {
 	RInside &rInside			= rinside->instance();
 
-	rInside[".resultsFont"]			= resultsFont;
+	rInside[".resultFont"]			= resultFont;
 	rInside[".imageBackground"]		= imageBackground;
 	rInside[".ppi"]					= ppi;
 

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -266,7 +266,7 @@ void STDCALL jaspRCPP_setFontAndPlotSettings(const char * resultFont, const int 
 	rInside[".imageBackground"]		= imageBackground;
 	rInside[".ppi"]					= ppi;
 
-	jaspRCPP_parseEvalQNT("jaspBase::registerFonts()");
+	jaspRCPP_parseEvalQNT("jaspBase:::registerFonts()");
 }
 
 const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options,

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -122,9 +122,9 @@ typedef size_t			(*logWriteDef)			(const void * buf, size_t len);
 
 
 // Calls from rbridge to jaspRCPP
-RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,	EnDecodeDef nativeToUtf8, const char * tempDir);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultFont,	EnDecodeDef nativeToUtf8, const char * tempDir);
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_setDecimalSettings(int numDecimals, bool fixedDecimals, bool normalizedNotation, bool exactPValues);
-RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_setFontAndPlotSettings(const char * resultsFont, const int ppi, const char* imageBackground);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_setFontAndPlotSettings(const char * resultFont, const int ppi, const char* imageBackground);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int analysisID, int analysisRevision, bool developerMode);
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_saveImage(const char *data, const char *type, const int height, const int width);

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -124,12 +124,12 @@ typedef size_t			(*logWriteDef)			(const void * buf, size_t len);
 // Calls from rbridge to jaspRCPP
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCallBacks *calbacks, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, logFlushDef logFlushFunction, logWriteDef logWriteFunction, systemDef systemFunc, libraryFixerDef libraryFixerFunc, const char* resultsFont,	EnDecodeDef nativeToUtf8, const char * tempDir);
 RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_setDecimalSettings(int numDecimals, bool fixedDecimals, bool normalizedNotation, bool exactPValues);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_setFontAndPlotSettings(const char * resultsFont, const int ppi, const char* imageBackground);
+RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int analysisID, int analysisRevision, bool developerMode);
 
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options, const char* stateKey, int ppi, int analysisID, int analysisRevision, const char* imageBackground, bool developerMode, const char* resultsFont);
-
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_saveImage(const char *data, const char *type, const int height, const int width, const int ppi, const char* imageBackground);
-RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_editImage(const char *name, const char *optionsJson, const int ppi, const char* imageBackground,		int analysisID);
-RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_rewriteImages(const char * name, const int ppi, const char* imageBackground, const char* resultsFont,	int analysisID);
+RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_saveImage(const char *data, const char *type, const int height, const int width);
+RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_editImage(const char *name, const char *optionsJson, int analysisID);
+RBRIDGE_TO_JASP_INTERFACE void			STDCALL jaspRCPP_rewriteImages(const char * name, int analysisID);
 
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_evalRCode(			const char *rCode, bool setWd);
 RBRIDGE_TO_JASP_INTERFACE const char*	STDCALL jaspRCPP_evalRCodeCommander(const char *rCode);


### PR DESCRIPTION
instead of in each function again and agin

this cleans up the api a bit and makes transitioning to some kind of jaspOptions R object much easier in the future
changing the settings in jasp nows triggers `registerFonts()` after setting .resultsFont

depends on https://github.com/jasp-stats/jaspBase/pull/113 (Although I also pushed it to https://github.com/jasp-stats/jaspBase/tree/fixSaveAsPdf for easy `git submodule update` pleasure.

These changes let `pdf` work on macos and I assume they dont mess up Windows but cnt really test that at the moment.

Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2136