### PR TITLE
GITHUB_PAT should not disappear when navigating with tab key

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/Database.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/Database.qml
@@ -131,13 +131,13 @@ For a local or toy database this is probably overkill, but use your own judgemen
 
                 PrefsTextInput
                 {
-                    id:				dbHostnameInput
-                    nextEl:			dbPortInput.textInput
-                    text:			fileMenuModel.database.hostname
-                    onTextChanged:	fileMenuModel.database.hostname = text;
+					id:					dbHostnameInput
+					nextEl:				dbPortInput.textInput
+					text:				fileMenuModel.database.hostname
+					onEditingFinished:	fileMenuModel.database.hostname = text;
 
-                    x:				dbHostnameLabel.width
-                    width:			parent.width - dbHostnameLabel.width
+					x:					dbHostnameLabel.width
+					width:				parent.width - dbHostnameLabel.width
                 }
             }
 
@@ -158,11 +158,11 @@ For a local or toy database this is probably overkill, but use your own judgemen
 
                 PrefsTextInput
                 {
-                    id:				dbPortInput
-                    nextEl:			dbNameInput.textInput
-                    text:			fileMenuModel.database.port
-					onTextChanged:	fileMenuModel.database.port = parsePortNum(text)
-                    textInput.validator: JASPDoubleValidator { id: intValidator; bottom: 0; top: 9999999999999; decimals: 0 }
+					id:						dbPortInput
+					nextEl:					dbNameInput.textInput
+					text:					fileMenuModel.database.port
+					onEditingFinished:		fileMenuModel.database.port = parsePortNum(text)
+					textInput.validator:	JASPDoubleValidator { id: intValidator; bottom: 0; top: 9999999999999; decimals: 0 }
 
                     x:				dbHostnameLabel.width
                     width:			dbHostnameInput.width
@@ -191,13 +191,13 @@ For a local or toy database this is probably overkill, but use your own judgemen
 
                 PrefsTextInput
                 {
-                    id:				dbNameInput
-					nextEl:			browseDbButton
-                    text:			fileMenuModel.database.database
-                    onTextChanged:	fileMenuModel.database.database = text;
+					id:					dbNameInput
+					nextEl:				browseDbButton
+					text:				fileMenuModel.database.database
+					onEditingFinished:	fileMenuModel.database.database = text;
 
-                    x:				dbHostnameLabel.width
-					width:			dbHostnameInput.width - (!browseDbButton.enabled ? 0 : browseDbButton.width + jaspTheme.generalAnchorMargin)
+					x:					dbHostnameLabel.width
+					width:				dbHostnameInput.width - (!browseDbButton.enabled ? 0 : browseDbButton.width + jaspTheme.generalAnchorMargin)
                 }
 
 				RoundedButton
@@ -229,13 +229,13 @@ For a local or toy database this is probably overkill, but use your own judgemen
 
                 PrefsTextInput
                 {
-                    id:				dbUsernameInput
-                    nextEl:			dbPasswordInput.textInput
-                    text:			fileMenuModel.database.username
-                    onTextChanged:	fileMenuModel.database.username = text;
+					id:					dbUsernameInput
+					nextEl:				dbPasswordInput.textInput
+					text:				fileMenuModel.database.username
+					onEditingFinished:	fileMenuModel.database.username = text;
 
-                    x:				dbHostnameLabel.width
-                    width:			dbHostnameInput.width
+					x:					dbHostnameLabel.width
+					width:				dbHostnameInput.width
                 }
             }
 
@@ -258,7 +258,7 @@ For a local or toy database this is probably overkill, but use your own judgemen
                     id:						dbPasswordInput
 					nextEl:					rememberMe
                     text:					fileMenuModel.database.password
-                    onTextChanged:			fileMenuModel.database.password = text;
+					onEditingFinished:		fileMenuModel.database.password = text;
 
                     textInput.echoMode:		TextInput.Password
 
@@ -313,7 +313,7 @@ For a local or toy database this is probably overkill, but use your own judgemen
                     id:						dbQuery
                     nextEl:					runQuery
                     text:					fileMenuModel.database.query
-                    onTextChanged:			fileMenuModel.database.query = text
+					onEditingFinished:		fileMenuModel.database.query = text
                     LQ.Layout.fillWidth:	true
                 }
 

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -74,13 +74,13 @@ ScrollView
 				
 				PrefsTextInput
 				{
-					id:				developerFolderText
+					id:					developerFolderText
 					
-					text:			preferencesModel.developerFolder
-					onTextChanged:	preferencesModel.developerFolder = text
-					nextEl:			cranRepoUrl.textInput
+					text:				preferencesModel.developerFolder
+					onEditingFinished:	preferencesModel.developerFolder = text
+					nextEl:				cranRepoUrl.textInput
 					
-					height:			browseDeveloperFolderButton.height
+					height:				browseDeveloperFolderButton.height
 					anchors
 					{
 						left:			browseDeveloperFolderButton.right
@@ -111,20 +111,20 @@ ScrollView
 				
 				PrefsTextInput
 				{
-					id:				cranRepoUrl
+					id:					cranRepoUrl
 					
-					text:			preferencesModel.cranRepoURL
-					onTextChanged:	preferencesModel.cranRepoURL = text
-					nextEl:			githubPatDefault
+					text:				preferencesModel.cranRepoURL
+					onEditingFinished:	preferencesModel.cranRepoURL = text
+					nextEl:				githubPatDefault
 					
-					height:			browseDeveloperFolderButton.height
+					height:				browseDeveloperFolderButton.height
 					anchors
 					{
-						left:		cranRepoUrlLabel.right
-						right:		parent.right
+						left:			cranRepoUrlLabel.right
+						right:			parent.right
 					}
 
-					KeyNavigation.tab:		githubPatDefault
+					KeyNavigation.tab:	githubPatDefault
 				}
 			}
 			
@@ -165,22 +165,22 @@ ScrollView
 				
 				PrefsTextInput
 				{
-					id:				githubPatCustomToken
+					id:					githubPatCustomToken
 					
-					text:			preferencesModel.githubPatCustom
-					onTextChanged:	preferencesModel.githubPatCustom = text
+					text:				preferencesModel.githubPatCustom
+					onEditingFinished:	preferencesModel.githubPatCustom = text
 
-					nextEl:			generateMarkdown
+					nextEl:				generateMarkdown
 					
-					height:			browseDeveloperFolderButton.height
+					height:				browseDeveloperFolderButton.height
 					anchors
 					{
-						left:		githubPatCustomLabel.right
-						right:		parent.right
-						margins:	jaspTheme.generalAnchorMargin
+						left:			githubPatCustomLabel.right
+						right:			parent.right
+						margins:		jaspTheme.generalAnchorMargin
 					}
 
-					textInput.echoMode:	TextInput.PasswordEchoOnEdit
+					textInput.echoMode:	TextInput.Password
 
 					KeyNavigation.tab:		generateMarkdown
 				}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -202,11 +202,11 @@ ScrollView
 
 				PrefsTextInput
 				{
-					id:				missingValueDataLabelInput
+					id:					missingValueDataLabelInput
 
-					text:			preferencesModel.dataLabelNA
-					onTextChanged:	preferencesModel.dataLabelNA = text
-					nextEl:			missingValuesList.firstComponent
+					text:				preferencesModel.dataLabelNA
+					onEditingFinished:	preferencesModel.dataLabelNA = text
+					nextEl:				missingValuesList.firstComponent
 
 					anchors
 					{

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsTextInput.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsTextInput.qml
@@ -8,6 +8,9 @@ Rectangle
 	property var	nextEl:		null
 	
 	signal onTextChanged();
+	signal editingFinished();
+
+	Component.onCompleted: textInput.editingFinished.connect(editingFinished)
 	
 	id:					root
 	implicitHeight:		textInput.implicitHeight + jaspTheme.generalAnchorMargin * 2


### PR DESCRIPTION
Solves https://github.com/jasp-stats/INTERNAL-jasp/issues/2193

The TextInout echoMode property set to TextInput.PasswordEchoOnEdit provokes this problem. Using the echoMode to TextInput.Password solves this problem

Also use the editingFinished in place of textChanged signal with the PrefsTextInput control: textChanged is emitted for each key stroke, editingFinished is emitter with enter/return key or when the focus has gone.

