### PR TITLE
ALTNavigation Fixes

### DIFF
--- a/Desktop/gui/ALTNavigation/altnavcontrol.cpp
+++ b/Desktop/gui/ALTNavigation/altnavcontrol.cpp
@@ -38,6 +38,21 @@ void ALTNavControl::registrate(ALTNavScope* scope, QObject *obj)
 
 void ALTNavControl::unregister(QObject *obj)
 {
+	auto it = _attachedScopeMap.find(obj);
+	if (it != _attachedScopeMap.end())
+	{
+		ALTNavScope* scope = it.value();
+		if (scope == _currentRoot)
+		{
+			setCurrentRoot(_defaultRoot);
+			resetAltNavInput();
+		}
+		if (scope == _currentNode)
+		{
+			setCurrentNode(_currentRoot);
+			setAltNavInput(_currentRoot->prefix());
+		}
+	}
 	_attachedScopeMap.remove(obj);
 }
 

--- a/Desktop/gui/ALTNavigation/altnavpostfixassignmentstrategy.cpp
+++ b/Desktop/gui/ALTNavigation/altnavpostfixassignmentstrategy.cpp
@@ -19,7 +19,7 @@ ALTNavPostfixAssignmentStrategy* ALTNavPostfixAssignmentStrategy::createStrategy
 	}
 };
 
-void PriorityStrategy::assignPostfixes(const QObjectList &children, QString prefix)
+void PriorityStrategy::assignPostfixes(QList<ALTNavScope*>& children, QString prefix)
 {
 
 	//handle postfix requests
@@ -29,7 +29,7 @@ void PriorityStrategy::assignPostfixes(const QObjectList &children, QString pref
 	ALTNavScope* assignments[26] = { 0 };
 	for (auto it = children.rbegin(); it != children.rend() ;it++)
 	{
-		ALTNavScope* scope = qobject_cast<ALTNavScope*>(*it);
+		ALTNavScope* scope = *it;
 		QString request = scope->getRequestedPostfix();
 		if (request != "" && request[0].isLetter() && request[0].isUpper())
 		{
@@ -107,12 +107,11 @@ void PriorityStrategy::assignPostfixes(const QObjectList &children, QString pref
 	}
 }
 
-void IndexedStrategy::assignPostfixes(const QObjectList &children, QString prefix)
+void IndexedStrategy::assignPostfixes(QList<ALTNavScope*>& children, QString prefix)
 {
 	int maxLeadingZeros = std::log10((double)children.size()); //if needed I can write a fast integer version that never fails but I doubt it will really matter for reasonable input sizes
-	for (auto* child : children)
+	for (ALTNavScope* scope : children)
 	{
-		ALTNavScope* scope = qobject_cast<ALTNavScope*>(child);
 		int n = scope->getIndex() + 1; //get rid of 0 index
 		int numLeadingZeros = maxLeadingZeros - (int)std::log10((double)n);
 		QString tag = QString("0").repeated(numLeadingZeros) + QString::number(n);
@@ -120,12 +119,11 @@ void IndexedStrategy::assignPostfixes(const QObjectList &children, QString prefi
 	}
 }
 
-void PassthroughStrategy::assignPostfixes(const QObjectList &children, QString prefix)
+void PassthroughStrategy::assignPostfixes(QList<ALTNavScope*>& children, QString prefix)
 {
 	assert(children.length() <= 1);
-	for (auto* child : children)
+	for (ALTNavScope* scope : children)
 	{
-		ALTNavScope* scope = qobject_cast<ALTNavScope*>(child);
 		scope->setPrefix(prefix);
 	}
 }

--- a/Desktop/gui/ALTNavigation/altnavpostfixassignmentstrategy.h
+++ b/Desktop/gui/ALTNavigation/altnavpostfixassignmentstrategy.h
@@ -20,7 +20,7 @@ public:
 	 * \param children
 	 * \param prefix parent prefix
 	 */
-	virtual void assignPostfixes(QObjectList const&  children, QString prefix) = 0;
+	virtual void assignPostfixes(QList<ALTNavScope*>&  children, QString prefix) = 0;
 
 	/*!
 	 * \brief The AssignmentStrategy enum defines all strategies
@@ -49,7 +49,7 @@ class PriorityStrategy : public ALTNavPostfixAssignmentStrategy
 public:
 	PriorityStrategy(){};
 	~PriorityStrategy(){};
-	void assignPostfixes(QObjectList const&  children, QString prefix);
+	void assignPostfixes(QList<ALTNavScope*>&  children, QString prefix);
 
 };
 
@@ -62,7 +62,7 @@ class IndexedStrategy : public ALTNavPostfixAssignmentStrategy
 public:
 	IndexedStrategy(){};
 	~IndexedStrategy(){};
-	void assignPostfixes(QObjectList const&  children, QString prefix);
+	void assignPostfixes(QList<ALTNavScope*>&  children, QString prefix);
 };
 
 /*!
@@ -73,7 +73,7 @@ class PassthroughStrategy : public ALTNavPostfixAssignmentStrategy
 public:
 	PassthroughStrategy(){};
 	~PassthroughStrategy(){};
-	void assignPostfixes(QObjectList const&  children, QString prefix);
+	void assignPostfixes(QList<ALTNavScope*>&  children, QString prefix);
 };
 
 #endif // ALTNAVPOSTFIXASSIGNMENTSTRATEGY_H

--- a/Desktop/gui/ALTNavigation/altnavscope.cpp
+++ b/Desktop/gui/ALTNavigation/altnavscope.cpp
@@ -32,10 +32,8 @@ ALTNavScope::ALTNavScope(QObject* attachee)
 
 ALTNavScope::~ALTNavScope()
 {
-	setForeground(false);
 	ALTNavControl::getInstance()->unregister(_attachee);
 	delete _postfixBroker;
-
 }
 
 void ALTNavScope::registerWithParent()
@@ -145,7 +143,7 @@ void ALTNavScope::setScopeActive(bool value)
 
 void ALTNavScope::setChildrenActive(bool value)
 {
-	for(auto child : children())
+	for(auto* child : children())
 	{
 		qobject_cast<ALTNavScope*>(child)->setScopeActive(value);
 	}
@@ -165,15 +163,18 @@ void ALTNavScope::setForeground(bool onForeground)
 		ctrl->setCurrentNode(this);
 		ctrl->setAltNavInput(_prefix);
 	}
-	else if (ctrl->getCurrentNode() == this) //we are the currentNode but lost foreground reset to root
+	else
 	{
-		ctrl->setCurrentNode(ctrl->getCurrentRoot());
-		ctrl->setAltNavInput(ctrl->getCurrentRoot()->prefix());
-	}
-	else if (_root && ctrl->getCurrentRoot() == this) //we are the current root but we lost foreground so unset ourselfs
-	{
-		ctrl->setCurrentRoot(ctrl->getDefaultRoot());
-		ctrl->resetAltNavInput();
+		if (_root && ctrl->getCurrentRoot() == this) //we are the current root but we lost foreground so unset ourselfs
+		{
+			ctrl->setCurrentRoot(ctrl->getDefaultRoot());
+			ctrl->resetAltNavInput();
+		}
+		if (ctrl->getCurrentNode() == this) //we are the currentNode but lost foreground reset to root
+		{
+			ctrl->setCurrentNode(ctrl->getCurrentRoot());
+			ctrl->setAltNavInput(ctrl->getCurrentRoot()->prefix());
+		}
 	}
 	emit foregroundChanged();
 }

--- a/Desktop/gui/ALTNavigation/altnavscope.cpp
+++ b/Desktop/gui/ALTNavigation/altnavscope.cpp
@@ -43,13 +43,13 @@ void ALTNavScope::registerWithParent()
 		return;
 
 	ALTNavControl* ctrl = ALTNavControl::getInstance();
-	ALTNavScope* parentScope = nullptr;
+	ALTNavScope* newParentScope = nullptr;
 
 	if(_parentOverride)
-		parentScope = ctrl->getAttachedScope(_parentScopeAttachee);
+		newParentScope = ctrl->getAttachedScope(_parentScopeAttachee);
 
 	//no parent scope was set explicitly so lets find one
-	if(_attachee && !parentScope)
+	if(_attachee && !newParentScope)
 	{
 		QQuickItem* curr = _attachee->parentItem();
 		while (curr)
@@ -57,7 +57,7 @@ void ALTNavScope::registerWithParent()
 			ALTNavScope* scope = ctrl->getAttachedScope(curr);
 			if(scope) //found a different valid valid scope
 			{
-				parentScope = scope;
+				newParentScope = scope;
 				break;
 			}
 			curr = curr->parentItem();
@@ -65,13 +65,13 @@ void ALTNavScope::registerWithParent()
 	}
 
 	//no ancestors were registered so set default root
-	if(!parentScope)
+	if(!newParentScope)
 	{
-		parentScope = ctrl->getDefaultRoot();
+		newParentScope = ctrl->getDefaultRoot();
 	}
 
-	if(parentScope != parent())
-		setParentScope(parentScope);
+	if(newParentScope != _parentScope)
+		setParentScope(newParentScope);
 }
 
 void ALTNavScope::addChild(ALTNavScope *child)
@@ -309,9 +309,8 @@ void ALTNavScope::setIndex(int index)
 {
 	_index = index;
 	//indices changed recalc prefixes
-	ALTNavScope* parentScope = qobject_cast<ALTNavScope*>(parent());
-	if (parentScope)
-		parentScope->setChildrenPrefix();
+	if (_parentScope)
+		_parentScope->setChildrenPrefix();
 }
 
 void ALTNavScope::setStrategy(AssignmentStrategy strategy)

--- a/Desktop/gui/ALTNavigation/altnavscope.cpp
+++ b/Desktop/gui/ALTNavigation/altnavscope.cpp
@@ -31,7 +31,7 @@ ALTNavScope::ALTNavScope(QObject* attachee)
 ALTNavScope::~ALTNavScope()
 {
 	setParentScope(nullptr);
-	for (ALTNavScope* child : _children)
+	for (ALTNavScope* child : _childScopes)
 		child->setParentScope(nullptr);
 	ALTNavControl::getInstance()->unregister(_attachee);
 	delete _postfixBroker;
@@ -76,7 +76,7 @@ void ALTNavScope::registerWithParent()
 
 void ALTNavScope::addChild(ALTNavScope *child)
 {
-	_children.push_back(child);
+	_childScopes.push_back(child);
 	ALTNavControl* ctrl = ALTNavControl::getInstance();
 	if(ctrl->dynamicTreeUpdate())
 	{
@@ -87,7 +87,7 @@ void ALTNavScope::addChild(ALTNavScope *child)
 
 void ALTNavScope::removeChild(ALTNavScope *child)
 {
-	_children.removeOne(child);
+	_childScopes.removeOne(child);
 	ALTNavControl* ctrl = ALTNavControl::getInstance();
 	if(ctrl->dynamicTreeUpdate())
 	{
@@ -122,7 +122,7 @@ void ALTNavScope::traverse(QString input)
 	ALTNavControl* ctrl = ALTNavControl::getInstance();
 
 	bool matchPossible = false;
-	for(ALTNavScope* scope : qAsConst(_children))
+	for(ALTNavScope* scope : qAsConst(_childScopes))
 	{
 		//total match, progress in tree
 		if(scope->_prefix == input)
@@ -165,7 +165,7 @@ void ALTNavScope::setPrefix(QString prefix)
 void ALTNavScope::setChildrenPrefix()
 {
 	if(_postfixBroker)
-		_postfixBroker->assignPostfixes(_children, _prefix);
+		_postfixBroker->assignPostfixes(_childScopes, _prefix);
 }
 
 void ALTNavScope::setScopeActive(bool value)
@@ -179,7 +179,7 @@ void ALTNavScope::setScopeActive(bool value)
 
 void ALTNavScope::setChildrenActive(bool value)
 {
-	for(ALTNavScope* child : _children)
+	for(ALTNavScope* child : _childScopes)
 	{
 		child->setScopeActive(value);
 	}

--- a/Desktop/gui/ALTNavigation/altnavscope.h
+++ b/Desktop/gui/ALTNavigation/altnavscope.h
@@ -148,7 +148,7 @@ private:
 	bool _parentOverride = false;
 	bool _initialized = false;
 
-	QList<ALTNavScope*> _children;
+	QList<ALTNavScope*> _childScopes;
 	ALTNavScope* _parentScope = nullptr;
 
 

--- a/Desktop/gui/ALTNavigation/altnavscope.h
+++ b/Desktop/gui/ALTNavigation/altnavscope.h
@@ -102,7 +102,6 @@ public:
 
 
 protected:
-	void childEvent(QChildEvent *event) override;
 	void setParentAttachee(QObject* parent);
 	void setRequestedPostfix(QString postfix);
 	void setScopePriority(int priority);
@@ -120,6 +119,10 @@ private slots:
 	 *		  Registers with default root otherwise. May be overruled by setting parent property
 	 */
 	void registerWithParent();
+
+	void addChild(ALTNavScope* child);
+	void removeChild(ALTNavScope* child);
+	void setParentScope(ALTNavScope* parent);
 
 
 protected:
@@ -144,6 +147,9 @@ private:
 	QQuickItem* _parentScopeAttachee = nullptr;
 	bool _parentOverride = false;
 	bool _initialized = false;
+
+	QList<ALTNavScope*> _children;
+	ALTNavScope* _parentScope = nullptr;
 
 
 	ALTNavPostfixAssignmentStrategy* _postfixBroker = nullptr;


### PR DESCRIPTION
Now actively managing my own Tree.
Using QT Object tree wasn't a great success.
Event Loop Timings were a bit hacky to get around.
\+ setting the attachee as the attached scope QObject parent is simply sane.

Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/2196 