### PR TITLE
resultFont, imageBackground and ppi should not be cleared

### DIFF
--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -179,7 +179,11 @@ void STDCALL jaspRCPP_init(const char* buildYear, const char* version, RBridgeCa
 	rInside[".numDecimals"]						= 3;
 	rInside[".fixedDecimals"]					= false;
 	rInside[".normalizedNotation"]				= true;
-	rInside[".exactPValues"]					= false;
+	rInside[".exactPValues"]					= false;	
+	rInside[".resultFont"]						= "Arial";
+	rInside[".imageBackground"]					= "transparent";
+	rInside[".ppi"]								= 300;
+
 
 	//jaspRCPP_parseEvalQNT("options(encoding = 'UTF-8')");
 


### PR DESCRIPTION
When the engine is made idle, it cleans R memory (via .cleanEngineMemory in memoryMaintenance.R). But is should not remove properties and functions of the global environment. The .resultFont, .imageBackground and .ppi are must be set in the global environment. For this just add default values in jaspRCPP_init (like for .numDecimals or .fixedDecimals for example)

