### PR TITLE
Fix helpwindow reopen on analysis expander state change

### DIFF
--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -449,7 +449,10 @@ DropArea
 											if(formParent.myForm && helpModel.markdown !== formParent.myForm.helpMD)
 												helpModel.markdown  = Qt.binding(function(){ return formParent.myForm.helpMD; });
 											else
+											{
 												helpModel.visible  = false;
+												helpModel.markdown = ""; //break binding
+											}
 											
 												
 										}

--- a/Desktop/components/JASP/Widgets/HelpWindow.qml
+++ b/Desktop/components/JASP/Widgets/HelpWindow.qml
@@ -20,6 +20,7 @@ Window
 	Shortcut { onActivated: helpWindowRoot.toggleFullScreen();	sequences: ["Ctrl+M"];							}
 	Shortcut { onActivated: searchBar.startSearching();			sequences: ["Ctrl+F", Qt.Key_Search];			}
 
+	onClosing: { helpModel.markdown = ""; } //break binding
 
 	Connections
 	{


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/1856#issuecomment-1362296011

Break the binding when the window closes.