### PR TITLE
Comparing 2 terms should not be dependent on the order of their components

### DIFF
--- a/QMLComponents/models/term.cpp
+++ b/QMLComponents/models/term.cpp
@@ -112,7 +112,7 @@ bool Term::operator==(const Term &other) const
 	if (this == &other)
 		return true;
 
-	return components() == other.components();
+	return containsAll(other);
 }
 
 bool Term::operator!=(const Term &other) const


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2197

