### PR TITLE
Double Validation can be too intrusive

### DIFF
--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
@@ -44,7 +44,7 @@ Column
 			label				: qsTr("Title");
 			fieldWidth			: 200
 			value				: axisModel.title
-			onEditingFinished	: if(axisModel) axisModel.title = value
+			onEditingFinished	: if(axisModel) axisModel.title = transientValue
 		}
 	}
 
@@ -97,7 +97,7 @@ Column
 				id					: axisBreaksRangeFrom
 				label				: qsTr("from")
 				value				: axisModel.from
-				onEditingFinished	: if(axisModel) axisModel.from = value
+				onEditingFinished	: if(axisModel) axisModel.from = transientValue
 				negativeValues		: true
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				max					: axisBreaksRangeSteps.value > 0 ? axisBreaksRangeTo.value : Infinity
@@ -107,7 +107,7 @@ Column
 				id					: axisBreaksRangeTo
 				label				: qsTr("to")
 				value				: axisModel.to
-				onEditingFinished	: if(axisModel) axisModel.to = value
+				onEditingFinished	: if(axisModel) axisModel.to = transientValue
 				negativeValues		: true
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				min					: axisBreaksRangeSteps.value > 0 ? axisBreaksRangeFrom.value : -Infinity
@@ -118,7 +118,7 @@ Column
 				label				: qsTr("steps")
 				value				: axisModel.steps
 				negativeValues		: true
-				onEditingFinished	: if(axisModel) axisModel.steps = value
+				onEditingFinished	: if(axisModel) axisModel.steps = transientValue
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 			}
 
@@ -178,7 +178,7 @@ Column
 					negativeValues		: true
 					max					: axisModel.limitUpper
 					value				: axisModel.limitLower
-					onEditingFinished	: if(axisModel) axisModel.limitLower = value
+					onEditingFinished	: if(axisModel) axisModel.limitLower = transientValue
 					decimals			: 20
 					fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				}
@@ -189,7 +189,7 @@ Column
 					negativeValues		: true
 					min					: axisModel.limitLower
 					value				: axisModel.limitUpper
-					onEditingFinished	: if(axisModel) axisModel.limitUpper = value
+					onEditingFinished	: if(axisModel) axisModel.limitUpper = transientValue
 					decimals			: 20
 					fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				}

--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
@@ -44,7 +44,7 @@ Column
 			label				: qsTr("Title");
 			fieldWidth			: 200
 			value				: axisModel.title
-			onEditingFinished	: if(axisModel) axisModel.title = transientValue
+			onEditingFinished	: if(axisModel) axisModel.title = displayValue
 		}
 	}
 
@@ -97,7 +97,7 @@ Column
 				id					: axisBreaksRangeFrom
 				label				: qsTr("from")
 				value				: axisModel.from
-				onEditingFinished	: if(axisModel) axisModel.from = transientValue
+				onEditingFinished	: if(axisModel) axisModel.from = displayValue
 				negativeValues		: true
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				max					: axisBreaksRangeSteps.value > 0 ? axisBreaksRangeTo.value : Infinity
@@ -107,7 +107,7 @@ Column
 				id					: axisBreaksRangeTo
 				label				: qsTr("to")
 				value				: axisModel.to
-				onEditingFinished	: if(axisModel) axisModel.to = transientValue
+				onEditingFinished	: if(axisModel) axisModel.to = displayValue
 				negativeValues		: true
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				min					: axisBreaksRangeSteps.value > 0 ? axisBreaksRangeFrom.value : -Infinity
@@ -118,7 +118,7 @@ Column
 				label				: qsTr("steps")
 				value				: axisModel.steps
 				negativeValues		: true
-				onEditingFinished	: if(axisModel) axisModel.steps = transientValue
+				onEditingFinished	: if(axisModel) axisModel.steps = displayValue
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 			}
 
@@ -178,7 +178,7 @@ Column
 					negativeValues		: true
 					max					: axisModel.limitUpper
 					value				: axisModel.limitLower
-					onEditingFinished	: if(axisModel) axisModel.limitLower = transientValue
+					onEditingFinished	: if(axisModel) axisModel.limitLower = displayValue
 					decimals			: 20
 					fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				}
@@ -189,7 +189,7 @@ Column
 					negativeValues		: true
 					min					: axisModel.limitLower
 					value				: axisModel.limitUpper
-					onEditingFinished	: if(axisModel) axisModel.limitUpper = transientValue
+					onEditingFinished	: if(axisModel) axisModel.limitUpper = displayValue
 					decimals			: 20
 					fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				}

--- a/QMLComponents/components/JASP/Controls/DoubleField.qml
+++ b/QMLComponents/components/JASP/Controls/DoubleField.qml
@@ -24,7 +24,7 @@ TextField
 {
 					id:					doubleField
 					defaultValue:		0
-	property string _prevDefaultValue:	"0"
+	property var	_prevDefaultValue:	0
 	property alias	doubleValidator:	doubleValidator
 	property bool	negativeValues:		false
 	property double	min:				negativeValues ? -Infinity : 0
@@ -38,11 +38,8 @@ TextField
 
 	onDefaultValueChanged:
 	{
-		if (_prevDefaultValue === value)
-		{
+		if (_prevDefaultValue == value)
 			value = defaultValue
-			doEditingFinished()
-		}
 
 		_prevDefaultValue = defaultValue;
 	}

--- a/QMLComponents/components/JASP/Controls/FactorLevelList.qml
+++ b/QMLComponents/components/JASP/Controls/FactorLevelList.qml
@@ -120,7 +120,7 @@ FactorLevelListBase
 					showBorder:						false
 					selectValueOnFocus:				true
 					control.horizontalAlignment:	model.type === "level" ? TextInput.AlignLeft : TextInput.AlignHCenter
-					onEditingFinished:				itemChanged(index, transientValue)
+					onEditingFinished:				itemChanged(index, displayValue)
 				}
 
 				Image

--- a/QMLComponents/components/JASP/Controls/FactorLevelList.qml
+++ b/QMLComponents/components/JASP/Controls/FactorLevelList.qml
@@ -120,7 +120,7 @@ FactorLevelListBase
 					showBorder:						false
 					selectValueOnFocus:				true
 					control.horizontalAlignment:	model.type === "level" ? TextInput.AlignLeft : TextInput.AlignHCenter
-					onEditingFinished:				itemChanged(index, value)
+					onEditingFinished:				itemChanged(index, transientValue)
 				}
 
 				Image

--- a/QMLComponents/components/JASP/Controls/Form.qml
+++ b/QMLComponents/components/JASP/Controls/Form.qml
@@ -219,7 +219,7 @@ AnalysisForm
 			CheckBox
 			{
 				id:					showAllROptionsCheckBox
-				anchors.top:		generateWrapperButton.visible ? undefined : warningMessagesBox.bottom
+				anchors.top:		generateWrapperButton.visible ? undefined : rSyntaxElement.top
 				anchors.bottom:		generateWrapperButton.visible ? generateWrapperButton.bottom : undefined
 				anchors.right:		rSyntaxElement.right
 				label:				qsTr("Show all options")

--- a/QMLComponents/components/JASP/Controls/InputListView.qml
+++ b/QMLComponents/components/JASP/Controls/InputListView.qml
@@ -149,7 +149,7 @@ InputListBase
 				showBorder:						false
 				selectValueOnFocus:				true
 				control.horizontalAlignment:	TextInput.AlignLeft
-				onEditingFinished:				inputListView.itemChanged(index, value)
+				onEditingFinished:				inputListView.itemChanged(index, transientValue)
 			}
 
 			Image

--- a/QMLComponents/components/JASP/Controls/InputListView.qml
+++ b/QMLComponents/components/JASP/Controls/InputListView.qml
@@ -149,7 +149,7 @@ InputListBase
 				showBorder:						false
 				selectValueOnFocus:				true
 				control.horizontalAlignment:	TextInput.AlignLeft
-				onEditingFinished:				inputListView.itemChanged(index, transientValue)
+				onEditingFinished:				inputListView.itemChanged(index, displayValue)
 			}
 
 			Image

--- a/QMLComponents/components/JASP/Controls/IntegerField.qml
+++ b/QMLComponents/components/JASP/Controls/IntegerField.qml
@@ -23,7 +23,7 @@ TextField
 {
 					id:					textField
 					defaultValue:		0
-	property string	_prevDefaultValue:	"0"
+	property var	_prevDefaultValue:	0
 	property bool	negativeValues:		false
 	property int	min:				negativeValues ? -2147483647 : 0 // 2^32 - 1
 	property int	max:				2147483647
@@ -37,11 +37,8 @@ TextField
 
 	onDefaultValueChanged:
 	{
-		if (_prevDefaultValue === value)
-		{
+		if (_prevDefaultValue == value)
 			value = defaultValue
-			doEditingFinished()
-		}
 
 		_prevDefaultValue = defaultValue;
 	}

--- a/QMLComponents/components/JASP/Controls/Slider.qml
+++ b/QMLComponents/components/JASP/Controls/Slider.qml
@@ -115,9 +115,9 @@ SliderBase
 
 			onEditingFinished:
 			{
-				if (control.value != transientValue)
+				if (control.value != displayValue)
 				{
-					control.value = transientValue;
+					control.value = displayValue;
 					control.moved();
 				}
 			}

--- a/QMLComponents/components/JASP/Controls/Slider.qml
+++ b/QMLComponents/components/JASP/Controls/Slider.qml
@@ -115,9 +115,9 @@ SliderBase
 
 			onEditingFinished:
 			{
-				if (control.value != value)
+				if (control.value != transientValue)
 				{
-					control.value = value;
+					control.value = transientValue;
 					control.moved();
 				}
 			}

--- a/QMLComponents/components/JASP/Controls/TabView.qml
+++ b/QMLComponents/components/JASP/Controls/TabView.qml
@@ -120,7 +120,7 @@ ComponentsListBase
 				value				: model.name
 				fieldWidth			: parent.width
 				fieldHeight			: parent.height
-				onEditingFinished	: tabView.nameChanged(index, transientValue)
+				onEditingFinished	: tabView.nameChanged(index, displayValue)
 
 				onActiveFocusChanged: if (!activeFocus) visible = false
 			}

--- a/QMLComponents/components/JASP/Controls/TabView.qml
+++ b/QMLComponents/components/JASP/Controls/TabView.qml
@@ -120,7 +120,7 @@ ComponentsListBase
 				value				: model.name
 				fieldWidth			: parent.width
 				fieldHeight			: parent.height
-				onEditingFinished	: tabView.nameChanged(index, value)
+				onEditingFinished	: tabView.nameChanged(index, transientValue)
 
 				onActiveFocusChanged: if (!activeFocus) visible = false
 			}

--- a/QMLComponents/components/JASP/Controls/TableView.qml
+++ b/QMLComponents/components/JASP/Controls/TableView.qml
@@ -328,7 +328,7 @@ TableViewBase
 						onPressed:				tableView.colSelected = columnIndex
 						onEditingFinished:
 						{
-							tableView.itemChanged(columnIndex, rowIndex, displayalue, inputType)
+							tableView.itemChanged(columnIndex, rowIndex, displayValue, inputType)
 							tableView.setButtons()
 						}
 						editable:				itemEditable

--- a/QMLComponents/components/JASP/Controls/TableView.qml
+++ b/QMLComponents/components/JASP/Controls/TableView.qml
@@ -328,7 +328,7 @@ TableViewBase
 						onPressed:				tableView.colSelected = columnIndex
 						onEditingFinished:
 						{
-							tableView.itemChanged(columnIndex, rowIndex, value, inputType)
+							tableView.itemChanged(columnIndex, rowIndex, transientValue, inputType)
 							tableView.setButtons()
 						}
 						editable:				itemEditable

--- a/QMLComponents/components/JASP/Controls/TableView.qml
+++ b/QMLComponents/components/JASP/Controls/TableView.qml
@@ -328,7 +328,7 @@ TableViewBase
 						onPressed:				tableView.colSelected = columnIndex
 						onEditingFinished:
 						{
-							tableView.itemChanged(columnIndex, rowIndex, transientValue, inputType)
+							tableView.itemChanged(columnIndex, rowIndex, displayalue, inputType)
 							tableView.setButtons()
 						}
 						editable:				itemEditable

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -33,7 +33,7 @@ TextInputBase
 	
 	property alias	control:			control
 	property alias	text:				textField.label
-	property alias	value:				control.text
+	property alias	transientValue:		control.text
 	property string lastValidValue:		defaultValue
 	property int	fieldWidth:			jaspTheme.textFieldWidth
 	property int	fieldHeight:		0
@@ -58,9 +58,9 @@ TextInputBase
 
 	function doEditingFinished()
 	{
-		if (control.text === "" && defaultValue !== undefined && String(defaultValue) !== "")
-			control.text = defaultValue;
-		lastValidValue = control.text
+		if (transientValue === "" && defaultValue !== undefined && String(defaultValue) !== "")
+			transientValue = defaultValue;
+		lastValidValue = transientValue
 		editingFinished();
 	}
 	
@@ -101,9 +101,9 @@ TextInputBase
 		if (resetLastValidValue)
 		{
 			if (textField.useLastValidValue)
-				control.text = textField.lastValidValue
+				value = textField.lastValidValue
 			msg += "<br><br>"
-			msg += qsTr("Restoring last correct value: %1").arg(control.text);
+			msg += qsTr("Restoring last correct value: %1").arg(value);
 			addControlErrorTemporary(msg)
 		}
 		else

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -33,7 +33,7 @@ TextInputBase
 	
 	property alias	control:			control
 	property alias	text:				textField.label
-	property alias	displayValue:		control.text
+	property alias	displayValue:		control.text	///< Only use in onEditingFinished!
 	property var	lastValidValue:		defaultValue
 	property int	fieldWidth:			jaspTheme.textFieldWidth
 	property int	fieldHeight:		0

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -33,8 +33,8 @@ TextInputBase
 	
 	property alias	control:			control
 	property alias	text:				textField.label
-	property alias	transientValue:		control.text
-	property string lastValidValue:		defaultValue
+	property alias	displayValue:		control.text
+	property var	lastValidValue:		defaultValue
 	property int	fieldWidth:			jaspTheme.textFieldWidth
 	property int	fieldHeight:		0
 	property bool	useExternalBorder:	!parentListView
@@ -58,9 +58,9 @@ TextInputBase
 
 	function doEditingFinished()
 	{
-		if (transientValue === "" && defaultValue !== undefined && String(defaultValue) !== "")
-			transientValue = defaultValue;
-		lastValidValue = transientValue
+		if (displayValue === "" && defaultValue !== undefined && String(defaultValue) !== "")
+			displayValue = defaultValue;
+		lastValidValue = displayValue
 		editingFinished();
 	}
 	

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -33,7 +33,7 @@ TextInputBase
 	
 	property alias	control:			control
 	property alias	text:				textField.label
-	property alias	displayValue:		control.text	///< Only use in onEditingFinished!
+	property alias	displayValue:		control.text	///< In onEditingFinished this contains the "value" entered by the user
 	property var	lastValidValue:		defaultValue
 	property int	fieldWidth:			jaspTheme.textFieldWidth
 	property int	fieldHeight:		0
@@ -51,7 +51,7 @@ TextInputBase
 
 	property double controlXOffset:		0
 
-	signal editingFinished()
+	signal editingFinished()	///< To get the entered value use `displayValue` in the slot instead of `value`
 	signal textEdited()
 	signal pressed(var event)
 	signal released(var event)

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -73,7 +73,8 @@ TextInputBase
 		control.textEdited.connect(textEdited);
 		control.pressed.connect(pressed);
 		control.released.connect(released);
-		lastValidValue = control.text;
+		if (control.text)
+			lastValidValue = control.text;
 	}
 
 	// The value should be checked only when the control is initialized.
@@ -102,7 +103,7 @@ TextInputBase
 			if (textField.useLastValidValue)
 				control.text = textField.lastValidValue
 			msg += "<br><br>"
-			msg += qsTr("Restoring last correct value: %1").arg(text);
+			msg += qsTr("Restoring last correct value: %1").arg(control.text);
 			addControlErrorTemporary(msg)
 		}
 		else
@@ -156,7 +157,7 @@ TextInputBase
 
 		// The acceptableInput is checked even if the user is still typing in the TextField.
 		// In this case, the error should not appear immediately (only when the user is pressing the return key, or going out of focus),
-		// so the the checkValue is called with addErrorIfNotFocussed set to true: it should not display an error if in focus.
+		// so the checkValue is called with addErrorIfNotFocussed set to true: it should not display an error if in focus.
 		// In not in focus, the acceptableInput can be changed because another control has changed the constraint of this control: in this case, the error should be displayed.
 		onAcceptableInputChanged: checkValue(false, true)
 

--- a/QMLComponents/controls/jaspdoublevalidator.cpp
+++ b/QMLComponents/controls/jaspdoublevalidator.cpp
@@ -22,8 +22,6 @@
 
 QValidator::State JASPDoubleValidator::validate(QString& s, int& pos) const
 {
-	if (top() <= bottom()) return QValidator::Acceptable; // This may happen when 2 controls specify the bottom and top for each other. Just ignore it, the values will get eventually the right values.
-
 	if (s.isEmpty() || (s.startsWith("-") && s.length() == 1 && bottom() < 0))
 	{
 		// allow empty field or standalone minus sign

--- a/QMLComponents/controls/jaspdoublevalidator.cpp
+++ b/QMLComponents/controls/jaspdoublevalidator.cpp
@@ -22,6 +22,8 @@
 
 QValidator::State JASPDoubleValidator::validate(QString& s, int& pos) const
 {
+	if (top() <= bottom()) return QValidator::Acceptable; // This may happen when 2 controls specify the bottom and top for each other. Just ignore it, the values will get eventually the right values.
+
 	if (s.isEmpty() || (s.startsWith("-") && s.length() == 1 && bottom() < 0))
 	{
 		// allow empty field or standalone minus sign

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -145,7 +145,7 @@ void TextInputBase::bindTo(const Json::Value& value)
 	}
 	}
 
-	setTransientValue();
+	setDisplayValue();
 	emit valueChanged();
 
 	BoundControlBase::bindTo(value);
@@ -153,7 +153,7 @@ void TextInputBase::bindTo(const Json::Value& value)
 
 Json::Value TextInputBase::createJson() const
 {
-	QVariant value = property("transientValue");
+	QVariant value = property("displayValue");
 	if (value.toString() == "" && !_defaultValue.isNull())	value = _defaultValue;
 
 	return _getJsonValue(value);
@@ -194,14 +194,14 @@ void TextInputBase::setUp()
 	if (form())
 		// For unknown reason, when the language is changed, QML reset the default value.
 		// We have then to set back the value from the option
-		connect(form(), &AnalysisForm::languageChanged, this, &TextInputBase::setTransientValue);
+		connect(form(), &AnalysisForm::languageChanged, this, &TextInputBase::setDisplayValue);
 
 	JASPControl::setUp(); // It might need the _inputType, so call it after it is set.
 }
 
-void TextInputBase::setTransientValue()
+void TextInputBase::setDisplayValue()
 {
-	setProperty("transientValue", _value);
+	setProperty("displayValue", _value);
 }
 
 void TextInputBase::rScriptDoneHandler(const QString &result)
@@ -354,7 +354,7 @@ void TextInputBase::valueChangedSlot()
 		// But as this TextField is not bound, and is not a Formula, we don't need to fetch the value of the item anyway.
 		return;
 
-	setValue(property("transientValue"));
+	setValue(property("displayValue"));
 }
 
 void TextInputBase::setValue(const QVariant &value)
@@ -362,7 +362,7 @@ void TextInputBase::setValue(const QVariant &value)
 	bool hasChanged = _value != value;
 	_value = value;
 
-	setTransientValue();
+	setDisplayValue();
 
 	if (hasChanged)
 	{

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -30,6 +30,7 @@ class TextInputBase : public JASPControl, public BoundControlBase
 	Q_PROPERTY( QVariant	defaultValue		READ defaultValue			WRITE setDefaultValue		NOTIFY defaultValueChanged			)
 	Q_PROPERTY( QString		label				READ label					WRITE setLabel				NOTIFY labelChanged					)
 	Q_PROPERTY( QString		afterLabel			READ afterLabel				WRITE setAfterLabel			NOTIFY afterLabelChanged			)
+	Q_PROPERTY( QVariant	value				READ value					WRITE setValue				NOTIFY valueChanged					)
 
 public:
 	enum TextInputType { IntegerInputType = 0, StringInputType, NumberInputType, PercentIntputType, IntegerArrayInputType, DoubleArrayInputType, ComputedColumnType, AddColumnType, FormulaType, FormulaArrayType};
@@ -48,29 +49,29 @@ public:
 	QString			friendlyName() const override;
 	bool			hasScriptError()						const	{ return _hasScriptError;		}
 	QVariant		defaultValue()							const	{ return _defaultValue;			}
+	QVariant		value()									const	{ return _value;				}
 
-	const QString &label() const;
-	void setLabel(const QString &newLabel);
-
-	const QString &afterLabel() const;
-	void setAfterLabel(const QString &newAfterLabel);
+	const QString &label()									const	{ return _label;				}
+	const QString &afterLabel()								const	{ return _afterLabel;			}
 
 signals:
 	void		formulaCheckSucceeded();
 	void		hasScriptErrorChanged();
 	void		defaultValueChanged();
-
-	void labelChanged();
-
-	void afterLabelChanged();
+	void		valueChanged();
+	void		labelChanged();
+	void		afterLabelChanged();
 
 public slots:
 	GENERIC_SET_FUNCTION(HasScriptError,	_hasScriptError,	hasScriptErrorChanged,	bool		)
 	GENERIC_SET_FUNCTION(DefaultValue,		_defaultValue,		defaultValueChanged,	QVariant	)
+	GENERIC_SET_FUNCTION(Label,				_label,				labelChanged,			QString		)
+	GENERIC_SET_FUNCTION(AfterLabel,		_afterLabel,		afterLabelChanged,		QString		)
+	void setValue(const QVariant &value);
 
 private slots:
-	void		textChangedSlot();
-	void		resetValue();
+	void		valueChangedSlot();
+	void		setTransientValue();
 
 private:
 	Json::Value	_getJsonValue(const QVariant& value) const;
@@ -80,13 +81,15 @@ private:
 	QString		_getIntegerArrayValue(const std::vector<int>& intValues);
 	QString		_getDoubleArrayValue(const std::vector<double>& dblValues);
 
+	void		_setBoundValue();
+
 	TextInputType			_inputType;
-	QString					_value,
-							_label,
+	QString					_label,
 							_afterLabel;
 
 	bool					_parseDefaultValue	= true;
-	QVariant				_defaultValue;
+	QVariant				_defaultValue,
+							_value;
 	bool					_hasScriptError		= false;
 };
 

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -71,7 +71,7 @@ public slots:
 
 private slots:
 	void		valueChangedSlot();
-	void		setTransientValue();
+	void		setDisplayValue();
 
 private:
 	Json::Value	_getJsonValue(const QVariant& value) const;


### PR DESCRIPTION
When 2 DoubleFields determine the min and max of each other (to simulate a range), if the user changes the value of one field, the min can temporary exceed the max of one DoubleField, though the user did not finish editing the value.. As long a user did not finish editing a value, no error messages should be displayed.

Fixes https://github.com/jasp-stats/jasp-test-release/issues/2170

