### PR TITLE
Compare 2 terms should take account size of the terms

### DIFF
--- a/QMLComponents/models/term.cpp
+++ b/QMLComponents/models/term.cpp
@@ -112,7 +112,7 @@ bool Term::operator==(const Term &other) const
 	if (this == &other)
 		return true;
 
-	return containsAll(other);
+	return (other.size() == size()) && containsAll(other);
 }
 
 bool Term::operator!=(const Term &other) const


### PR DESCRIPTION
A term a * b is now equal to term a, because a * b contains a This is bad

