### PR TITLE
Enter now stops the editing of unbound textfields

### DIFF
--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -16,7 +16,7 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-import QtQuick			2.11
+import QtQuick
 import QtQuick.Controls 2.4
 import QtQuick.Layouts	1.3
 import JASP				1.0
@@ -84,7 +84,7 @@ TextInputBase
 
 	function checkValue(resetLastValidValue, addErrorIfNotFocussed)
 	{
-		if (!initialized) return false
+		if (!initialized && isBound) return false
 
 		if (control.acceptableInput)
 		{


### PR DESCRIPTION
I'm not sure why:
`if (!initialized) return false`
 the check is needed at all though 