### PR TITLE
FactorsForm does not need a source

### DIFF
--- a/QMLComponents/models/listmodelfactorsform.cpp
+++ b/QMLComponents/models/listmodelfactorsform.cpp
@@ -29,6 +29,7 @@ using namespace std;
 ListModelFactorsForm::ListModelFactorsForm(JASPListControl* listView)
 	: ListModel(listView)
 {
+	_needsSource = false;
 }
 
 QHash<int, QByteArray> ListModelFactorsForm::roleNames() const


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2214 
The FactorsForm is a form with an AvailableVariablesList and repeater with FactorList (a kind of AssignedVariablesList).
The FatorsForm has a model: the ListModelFactorsForm. This model does not need a source. 
Per default, a model needs a source, and if not set, it gets the DataSet source. When the DataSet is reset (by adding or removing a Computed column), the ListModelFactorsForm is reset, destroying and rebuilding the FactorLists. As the AvailableVariableList maintains a list of its AssignedVariablesList, this leads to a crash. 
Just set the _needsSource to false

