### PR TITLE
Fix RSyntax with CFA

### DIFF
--- a/QMLComponents/components/JASP/Controls/FactorsList.qml
+++ b/QMLComponents/components/JASP/Controls/FactorsList.qml
@@ -3,7 +3,7 @@ import JASP.Controls	1.0
 
 AssignedVariablesList
 {
-	property alias editableTitle: titleField.value
+	property alias editableTitle: titleField.displayValue
 	signal titleIsChanged()
 	title: " " //dummy
 

--- a/QMLComponents/controls/factorsformbase.cpp
+++ b/QMLComponents/controls/factorsformbase.cpp
@@ -30,6 +30,7 @@ FactorsFormBase::FactorsFormBase(QQuickItem *parent)
 {
 	_controlType			= ControlType::FactorsForm;
 	_useControlMouseArea	= false;
+	_containsVariables		= true;
 }
 
 void FactorsFormBase::setUpModel()
@@ -40,7 +41,7 @@ void FactorsFormBase::setUpModel()
 
 	_availableVariablesListName = property("availableVariablesListName").toString();
 	QVariant availableListVariant = property("availableVariablesList");
-	_availableVariablesListItem = dynamic_cast<JASPControl*>(qobject_cast<QQuickItem *>(availableListVariant.value<QObject *>()));
+	_availableVariablesListItem = qobject_cast<JASPListControl *>(availableListVariant.value<QObject *>());
 
 	connect(this, &FactorsFormBase::initializedChanged, this, &FactorsFormBase::countVariablesChanged);
 }

--- a/QMLComponents/controls/factorsformbase.h
+++ b/QMLComponents/controls/factorsformbase.h
@@ -46,8 +46,9 @@ public:
 	Q_INVOKABLE void	titleChanged(int index, QString title)						{ _factorsModel->titleChangedSlot(index, title);	}
 	Q_INVOKABLE void	factorAdded(int index, QVariant item);
 
-	int	initNumberFactors()										const				{ return _initNumberFactors;						}
-	int countVariables()										const				{ return _initialized ? _factorsModel->countVariables() : 0; }
+	int					initNumberFactors()						const				{ return _initNumberFactors;						}
+	int					countVariables()						const				{ return _initialized ? _factorsModel->countVariables() : 0; }
+	JASPListControl*	availableVariablesList()				const				{ return _availableVariablesListItem;				}
 
 signals:
 	void initNumberFactorsChanged();
@@ -62,7 +63,7 @@ protected:
 private:
 	ListModelFactorsForm*	_factorsModel				= nullptr;
 	QString					_availableVariablesListName;
-	JASPControl*			_availableVariablesListItem	= nullptr;
+	JASPListControl*		_availableVariablesListItem	= nullptr;
 	int						_initNumberFactors			= 1;
 };
 

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -76,7 +76,7 @@ void JASPListControl::_setupSources()
 
 void JASPListControl::setContainsVariables()
 {
-	bool containsVariables = false;
+	bool containsVariables = _containsVariables;
 
 	ListModelAssignedInterface* assignedModel = qobject_cast<ListModelAssignedInterface*>(model());
 	if (assignedModel && assignedModel->availableModel())

--- a/QMLComponents/models/listmodelavailableinterface.h
+++ b/QMLComponents/models/listmodelavailableinterface.h
@@ -55,6 +55,7 @@ public slots:
 			bool sourceLabelsChanged(QString columnName, QMap<QString, QString> = {})		override;
 			bool sourceLabelsReordered(QString columnName)									override;
 			void removeAssignedModel(ListModelDraggable* model);
+			void clearAssignedModels() { _assignedModels.clear(); }
 
 protected:
 	Terms								_allTerms;

--- a/QMLComponents/models/listmodelfactorsform.h
+++ b/QMLComponents/models/listmodelfactorsform.h
@@ -23,6 +23,7 @@
 
 class JASPListControl;
 class VariablesListBase;
+class FactorsFormBase;
 
 class ListModelFactorsForm : public ListModel
 {
@@ -69,7 +70,9 @@ protected:
 		Factor(const QString& _name, const QString& _title, std::vector<std::string> _initTerms = std::vector<std::string>()) :
 			name(_name), title(_title), listView(nullptr), initTerms(_initTerms) {}
 	};
+
 	QVector<Factor*>	_factors;
+	FactorsFormBase*	_factorsForm = nullptr;
 	
 };
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2203 

Different problems here:

- When rebinding new values (what does Apply R-Syntax does), the available VariablesList was not reset correctly, and had still references to old assigned VariablesList.
- The _factors property of the ListModelFactorsForm gets references to the assigned VariablesLists (listView), only when these ListViews are created. But before these ListViews are created, factors can be already already requested. In this case, just give the initial values (initTerms).
- The FactorForm did not encode its variables anymore. This is because I have set it (in a previous commit), that it does not need a source (_needsSource is false): this cause JASP to think that the model does not have variables. Just set _containdVariables to true solves this problem.
- The title could not be changed anymore: this is because the editableTitle refers to the TextField value, and should refer instead the displayValue.

