### PR TITLE
Factors with same levels are not added in Repeated Measures Cells

### DIFF
--- a/QMLComponents/models/listmodelfactorlevels.cpp
+++ b/QMLComponents/models/listmodelfactorlevels.cpp
@@ -163,7 +163,7 @@ void ListModelFactorLevels::_setAllLevelsCombinations()
 		}		
 	}
 	
-	_allLevelsCombinations.set(allLevelsCombinations);
+	_allLevelsCombinations.set(allLevelsCombinations, false);
 }
 
 QStringList ListModelFactorLevels::_getAllFactors() const

--- a/QMLComponents/models/terms.cpp
+++ b/QMLComponents/models/terms.cpp
@@ -62,61 +62,61 @@ Terms::Terms(Terms *parent)
 	_parent = parent;
 }
 
-void Terms::set(const std::vector<Term> &terms)
+void Terms::set(const std::vector<Term> &terms, bool isUnique)
 {
 	_terms.clear();
 
 	for(const Term &term : terms)
-		add(term);
+		add(term, isUnique);
 }
 
-void Terms::set(const std::vector<string> &terms)
+void Terms::set(const std::vector<string> &terms, bool isUnique)
 {
 	_terms.clear();
 
 	for(const Term &term : terms)
-		add(term);
+		add(term, isUnique);
 }
 
-void Terms::set(const std::vector<std::vector<string> > &terms)
+void Terms::set(const std::vector<std::vector<string> > &terms, bool isUnique)
 {
 	_terms.clear();
 
 	for(const Term &term : terms)
-		add(term);
+		add(term, isUnique);
 }
 
-void Terms::set(const QList<Term> &terms)
+void Terms::set(const QList<Term> &terms, bool isUnique)
 {
 	_terms.clear();
 
 	for(const Term &term : terms)
-		add(term);
+		add(term, isUnique);
 }
 
-void Terms::set(const Terms &terms)
+void Terms::set(const Terms &terms, bool isUnique)
 {
 	_terms.clear();
 	_hasDuplicate = terms.hasDuplicate();
 
 	for(const Term &term : terms)
-		add(term);
+		add(term, isUnique);
 }
 
-void Terms::set(const QList<QList<QString> > &terms)
+void Terms::set(const QList<QList<QString> > &terms, bool isUnique)
 {
 	_terms.clear();
 
 	for(const QList<QString> &term : terms)
-		add(Term(term));
+		add(Term(term), isUnique);
 }
 
-void Terms::set(const QList<QString> &terms)
+void Terms::set(const QList<QString> &terms, bool isUnique)
 {
 	_terms.clear();
 
 	for(const QString &term : terms)
-		add(Term(term));
+		add(Term(term), isUnique);
 }
 
 void Terms::setSortParent(const Terms &parent)
@@ -451,7 +451,7 @@ bool Terms::operator!=(const Terms &terms) const
 	return _terms != terms._terms;
 }
 
-void Terms::set(const QByteArray & array)
+void Terms::set(const QByteArray & array, bool isUnique)
 {
 	QDataStream stream(array);
 
@@ -467,7 +467,7 @@ void Terms::set(const QByteArray & array)
 	{
 		QStringList variable;
 		stream >> variable;
-		add(Term(variable));
+		add(Term(variable), isUnique);
 	}
 }
 

--- a/QMLComponents/models/terms.h
+++ b/QMLComponents/models/terms.h
@@ -49,14 +49,14 @@ public:
 	Terms(const QList<Term>									& terms,	Terms *parent = nullptr);
 	Terms(																Terms *parent = nullptr);
 
-	void set(const QList<QList<QString> >					& terms);
-	void set(const QList<QString>							& terms);
-	void set(const std::vector<Term>						& terms);
-	void set(const std::vector<std::string>					& terms);
-	void set(const std::vector<std::vector<std::string> >	& terms);
-	void set(const QList<Term>								& terms);
-	void set(const Terms									& terms);
-	void set(const QByteArray								& array);
+	void set(const QList<QList<QString> >					& terms, bool isUnique = true);
+	void set(const QList<QString>							& terms, bool isUnique = true);
+	void set(const std::vector<Term>						& terms, bool isUnique = true);
+	void set(const std::vector<std::string>					& terms, bool isUnique = true);
+	void set(const std::vector<std::vector<std::string> >	& terms, bool isUnique = true);
+	void set(const QList<Term>								& terms, bool isUnique = true);
+	void set(const Terms									& terms, bool isUnique = true);
+	void set(const QByteArray								& array, bool isUnique = true);
 
 	void removeParent();
 	void setSortParent(const Terms &parent);

--- a/QMLComponents/rsyntax/rsyntax.cpp
+++ b/QMLComponents/rsyntax/rsyntax.cpp
@@ -125,7 +125,7 @@ QString RSyntax::generateSyntax(bool showAllOptions) const
 				if (listControl && !listControl->hasRowComponent() && listControl->containsInteractions())
 					result += _transformInteractionTerms(listControl->model());
 				else
-					result += transformJsonToR(foundValue, defaultValue);
+					result += transformJsonToR(foundValue);
 			}
 		}
 	}
@@ -190,7 +190,7 @@ QString RSyntax::generateWrapper() const
 		}
 
 		const Json::Value& defaultValue = boundControl->defaultBoundValue();
-		result += ",\n" + FunctionOptionIndent + getRSyntaxFromControlName(control) + " = " + transformJsonToR(defaultValue, Json::Value::null);
+		result += ",\n" + FunctionOptionIndent + getRSyntaxFromControlName(control) + " = " + transformJsonToR(defaultValue);
 
 		JASPListControl* listControl = qobject_cast<JASPListControl*>(control);
 		if (listControl)
@@ -350,7 +350,7 @@ bool RSyntax::hasError() const
 	return _form->hasError();
 }
 
-QString RSyntax::transformJsonToR(const Json::Value &json, const Json::Value& comparedValue)
+QString RSyntax::transformJsonToR(const Json::Value &json)
 {
 	QString result;
 
@@ -386,7 +386,6 @@ QString RSyntax::transformJsonToR(const Json::Value &json, const Json::Value& co
 				for (const Json::Value& val : json)
 				{
 					index++;
-					if (!comparedValue.isNull() && comparedValue.isArray() && comparedValue[index] == val) continue;
 					if (!first) result += ", ";
 					result += transformJsonToR(val);
 					first = false;
@@ -401,7 +400,6 @@ QString RSyntax::transformJsonToR(const Json::Value &json, const Json::Value& co
 			for (const std::string& member : json.getMemberNames())
 			{
 				const Json::Value& val = json.get(member, Json::Value::null);
-				if (!comparedValue.isNull() && comparedValue.isObject() && comparedValue.get(member, Json::Value::null) == val) continue;
 				if (!first) result += ", ";
 				result += tq(member) + " = " + transformJsonToR(val);
 				first = false;

--- a/QMLComponents/rsyntax/rsyntax.h
+++ b/QMLComponents/rsyntax/rsyntax.h
@@ -51,7 +51,7 @@ public:
 
 	static QString					FunctionOptionIndent,
 									FunctionLineIndent;
-	static QString					transformJsonToR(const Json::Value& json, const Json::Value& comparedValue = Json::nullValue);
+	static QString					transformJsonToR(const Json::Value& json);
 
 signals:
 	void							somethingChanged();


### PR DESCRIPTION
In ANOVA Repeated Measures. if you add a factor, no extra cell is created. Also when applying the R Syntax, it removes the default values of the Repeated measures cells.

