### PR TITLE
Read values for JAGS can lead to inconsistency

### DIFF
--- a/QMLComponents/boundcontrols/boundcontroljagstextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontroljagstextarea.cpp
@@ -49,7 +49,7 @@ bool BoundControlJAGSTextArea::isJsonValid(const Json::Value &value) const
 	if (!value.isObject())					return false;
 	if (!value["modelOriginal"].isString())	return false;
 	if (!value["model"].isString())			return false;
-	if (!value["columns"].isArray())		return false;
+	//if (!value["columns"].isArray())		return false;
 	if (!value["parameters"].isArray())		return false;
 
 	return true;


### PR DESCRIPTION
R Syntax simplifies the arguments. The columns arguments is not always an array, but can be just a string, if only one column is used. So don't refuse a string to represent the columns.

