### PR TITLE
Do not generate a formula without right hand side

### DIFF
--- a/QMLComponents/rsyntax/formulabase.cpp
+++ b/QMLComponents/rsyntax/formulabase.cpp
@@ -39,7 +39,7 @@ void FormulaBase::setUp()
 }
 
 // Generate the R Formula
-QString FormulaBase::toString() const
+QString FormulaBase::toString(bool &isNull) const
 {
 	if (!_rSyntax)
 		return "";
@@ -47,14 +47,17 @@ QString FormulaBase::toString() const
 	QString result = _rSyntax->FunctionOptionIndent + _name + " = ";
 	bool isEmpty = true;
 
-	for (FormulaSource* formulaSource : _leftFormulaSources + _rightFormulaSources)
+	for (FormulaSource* formulaSource : _rightFormulaSources)
 		if (isEmpty) isEmpty = formulaSource->isEmpty();
 
 	if (isEmpty)
 	{
+		isNull = true;
 		result += "NULL";
 		return result;
 	}
+
+	isNull = false;
 
 	auto addFormulaTerms = [] (const QVector<FormulaSource*>& formulaSources, bool isLhs) -> QString
 	{

--- a/QMLComponents/rsyntax/formulabase.h
+++ b/QMLComponents/rsyntax/formulabase.h
@@ -46,7 +46,7 @@ public:
 	QVariant			rhs()																const	{ return _rhs;				}
 	QString				name()																const	{ return _name;				}
 
-	QString				toString()															const;
+	QString				toString(bool &isNull)												const;
 	bool				parseRSyntaxOptions(Json::Value &options)							const;
 	RSyntax*			rSyntax()															const	{ return _rSyntax;			}
 	AnalysisForm	*	form()																const;

--- a/QMLComponents/rsyntax/rsyntax.cpp
+++ b/QMLComponents/rsyntax/rsyntax.cpp
@@ -81,17 +81,19 @@ QString RSyntax::generateSyntax(bool showAllOptions) const
 {
 	QString result;
 
-	QStringList formulaSources;
-	for (FormulaBase* formula : _formulas)
-		formulaSources.append(formula->modelSources());
-
 	result = _analysisFullName() + "(\n";
 	if (showAllOptions)
 		result += FunctionOptionIndent + "data = NULL,\n";
 	result += FunctionOptionIndent + "version = \"" + _form->version() + "\"";
 
+	QStringList formulaSources;
 	for (FormulaBase* formula : _formulas)
-		result += ",\n" + formula->toString();
+	{
+		bool isNull = false;
+		result += ",\n" + formula->toString(isNull);
+		if (!isNull)
+			formulaSources.append(formula->modelSources());
+	}
 
 	const Json::Value& boundValues = _form->boundValues();
 


### PR DESCRIPTION
A formula like `contNormal ~` gives a syntax error. So set the formula to NULL, and set the value of the left hand side control without using formula. 
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2222

