### PR TITLE
Scrollbar offset fix

### DIFF
--- a/Desktop/components/JASP/Widgets/AnalysisForms.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisForms.qml
@@ -35,7 +35,6 @@ FocusScope
 				left:		parent.left
 				right:		parent.right
 				bottom:		parent.bottom
-				margins:	parent.border.width
 			}
 
 			JASPScrollBar
@@ -59,7 +58,6 @@ FocusScope
 				contentWidth:	analysesColumn.width
 				contentHeight:	analysesColumn.height
 				boundsBehavior: Flickable.StopAtBounds
-				width:			parent.width - verticalScrollbar.breadth
 
 				anchors
 				{
@@ -67,8 +65,8 @@ FocusScope
 					//rightMargin:	verticalScrollbar.width
 					top:			parent.top
 					left:			parent.left
+					right:			verticalScrollbar.left
 					bottom:			parent.bottom
-					margins:		formsBackground.border.width
 				}
 
 				Behavior on contentY

--- a/Desktop/components/JASP/Widgets/AnalysisForms.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisForms.qml
@@ -8,7 +8,6 @@ FocusScope
 {
 	id:				analysisFormsFocusScope
 	implicitWidth:	analysesModel.visible ? jaspTheme.formWidth + 1 + (2 * formsBackground.border.width) + verticalScrollbar.visibleBreadth : 0
-	width:			implicitWidth
 
 	Behavior on width { enabled: preferencesModel.animationsOn; PropertyAnimation { duration: jaspTheme.fileMenuSlideDuration; easing.type: Easing.OutCubic  } }
 

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -171,7 +171,7 @@ Item
 		onArrowClicked:			analysesModel.visible = !analysesModel.visible
 		toolTipDrag:			hasData	? (handleAnalysesResults.pointingLeft	? qsTr("Resize data/results")	: qsTr("Drag to show data")) : ""
 		toolTipArrow:			analysesModel.visible							? qsTr("Hide input options")	: qsTr("Show input options")
-		removeLeftBorder:		!analysesModel.visible
+		removeLeftBorder:		true //!analysesModel.visible
 
 		Binding
 		{


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2164

Overlap of flickable with scrollbar fixed.
Right edge aligned with splitter left edge.

The scroll indicator still moves around when moving splitters depending on resolution and zoom level.
Probably not an easy fix. Good enough for now imo.