### PR TITLE
JAGS checks too strict

### DIFF
--- a/QMLComponents/boundcontrols/boundcontroljagstextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontroljagstextarea.cpp
@@ -50,7 +50,7 @@ bool BoundControlJAGSTextArea::isJsonValid(const Json::Value &value) const
 	if (!value["modelOriginal"].isString())	return false;
 	if (!value["model"].isString())			return false;
 	//if (!value["columns"].isArray())		return false;
-	if (!value["parameters"].isArray())		return false;
+	//if (!value["parameters"].isArray())		return false;
 
 	return true;
 }


### PR DESCRIPTION
When running JAGS from the R Script with model
```
model{
  theta ~ dbeta(1,1)
}
```
JASP rejects, because the `parameters` parameter is a string instead of an array. The check is too strict. Just remove it

