### PR TITLE
Properly clean up mem-mapped files at shutdown and fix long pause crashes due to their accidental removal

### DIFF
--- a/Common/tempfiles.cpp
+++ b/Common/tempfiles.cpp
@@ -28,6 +28,7 @@
 #include "log.h"
 using namespace std;
 
+const long 				outOfDateDelta = 24 * 3600;
 long					TempFiles::_sessionId		= 0;
 std::string				TempFiles::_sessionDirName	= "";
 std::string				TempFiles::_statusFileName	= "";
@@ -122,7 +123,6 @@ void TempFiles::deleteOrphans()
 
 	try
 	{
-		long outOfDateDelta = 24 * 3600;
 		std::filesystem::path tempPath		= Utils::osPath(Dirs::tempDir());
 		std::filesystem::path sessionPath	= Utils::osPath(_sessionDirName); 
 		stringvec aliveIDs;

--- a/Common/tempfiles.cpp
+++ b/Common/tempfiles.cpp
@@ -122,9 +122,10 @@ void TempFiles::deleteOrphans()
 
 	try
 	{
-
+		long outOfDateDelta = 24 * 3600;
 		std::filesystem::path tempPath		= Utils::osPath(Dirs::tempDir());
-		std::filesystem::path sessionPath	= Utils::osPath(_sessionDirName);
+		std::filesystem::path sessionPath	= Utils::osPath(_sessionDirName); 
+		stringvec aliveIDs;
 
 		std::filesystem::directory_iterator itr(tempPath, error);
 
@@ -134,6 +135,7 @@ void TempFiles::deleteOrphans()
 			return;
 		}
 
+		//find the Dirs that must be deleted and store their PIDs (name)
 		for (; itr != std::filesystem::directory_iterator(); itr++)
 		{
 			std::filesystem::path p = itr->path();
@@ -149,26 +151,8 @@ void TempFiles::deleteOrphans()
 			if (error)
 				continue;
 
-			if (!is_directory)
+			if (is_directory)
 			{
-				if (fileName.substr(0, 5).compare("JASP-") == 0)
-				{
-					long modTime	= Utils::getFileModificationTime(Utils::osPath(p));
-					long now		= Utils::currentSeconds();
-
-					if (now - modTime > 24 * 3600)
-					{
-						Log::log() << "Try to delete: " << fileName << std::endl;
-						std::filesystem::remove(p, error);
-
-						if (error)
-							Log::log() << "Error when deleting file: " << error.message() << std::endl;
-					}
-				}
-			}
-			else
-			{
-
 				if (std::atoi(fileName.c_str()) == 0)
 					continue;
 
@@ -179,23 +163,26 @@ void TempFiles::deleteOrphans()
 					long modTime	= Utils::getFileModificationTime(Utils::osPath(statusFile));
 					long now		= Utils::currentSeconds();
 
-					if (now - modTime > 24 * 3600)
+					if (now - modTime > outOfDateDelta)
 					{
 						std::filesystem::remove_all(p, error);
-
 						if (error)
 							Log::log() << "Error when deleting directory: " << error.message() << std::endl;
 					}
+					else
+						aliveIDs.push_back(p.filename().string());
 				}
 				else // no status file
 				{
 					std::filesystem::remove_all(p, error);
-
 					if (error)
 						Log::log() << "Error when deleting directory, had no status file and " << error.message() << std::endl;
 				}
 			}
 		}
+
+		//Delete files in the root not associated with the IDs that have been active for x time
+		deleteStrayRootFiles(aliveIDs, outOfDateDelta);
 
 	}
 	catch (runtime_error e)
@@ -204,6 +191,8 @@ void TempFiles::deleteOrphans()
 		return;
 	}
 }
+
+
 
 
 void TempFiles::heartbeat()
@@ -339,3 +328,55 @@ void TempFiles::deleteList(const vector<string> &files)
 	}
 }
 
+void TempFiles::deleteStrayRootFiles(const stringvec& validIDs, long outOfDateDelta)
+{
+	std::filesystem::path tempPath = Utils::osPath(Dirs::tempDir());
+	std::error_code error;
+	std::filesystem::directory_iterator itr(tempPath, error);
+
+	if (error)
+	{
+		Log::log() << error.message() << std::endl;
+		return;
+	}
+
+	for (; itr != std::filesystem::directory_iterator(); itr++)
+	{
+		std::filesystem::path p = itr->path();
+
+		Log::log() << "looking at file " << p.string() << std::endl;
+
+		string fileName		= Utils::osPath(p.filename());
+		bool is_directory	= std::filesystem::is_directory(p, error);
+
+		if (error)
+			continue;
+
+		if (!is_directory)
+		{					
+			long modTime	= Utils::getFileModificationTime(Utils::osPath(p));
+			long now		= Utils::currentSeconds();
+
+			if (now - modTime <= outOfDateDelta || fileName.substr(0, 5).compare("JASP-") != 0)
+				continue;
+
+			bool valid = false;
+			for (auto& id : validIDs)
+			{
+				if (fileName.find(id) != std::string::npos)
+				{
+					valid = true;
+					break;
+				}
+			}
+			if (valid)
+				continue;
+
+			Log::log() << "Try to delete: " << fileName << std::endl;
+			std::filesystem::remove(p, error);
+
+			if (error)
+				Log::log() << "Error when deleting file: " << error.message() << std::endl;
+		}
+	}
+}

--- a/Common/tempfiles.h
+++ b/Common/tempfiles.h
@@ -60,6 +60,8 @@ public:
 	static void			deleteAll(int id = -1);
 	static void			deleteOrphans();
 
+	static void			deleteStrayRootFiles(const stringvec& validIDs, long outOfDateDelta);
+
 private:
 						TempFiles() {}
 	static long			_sessionId;

--- a/CommonData/sharedmemory.cpp
+++ b/CommonData/sharedmemory.cpp
@@ -118,8 +118,13 @@ void SharedMemory::deleteDataSet(DataSet *dataSet)
 	_memory->destroy_ptr(dataSet);
 }
 
-void SharedMemory::unloadDataSet()
+void SharedMemory::unloadDataSet(bool owner)
 {
+	if (owner)
+	{
+		interprocess::shared_memory_object::remove(_memoryName.c_str());
+		return;
+	}
 	Log::log() << "SharedMemory::unloadDataSet " << _memoryName << ( _memory ? "" : " but it wasn't loaded.") << std::endl;
 	delete _memory;
 	_memory = nullptr;

--- a/CommonData/sharedmemory.h
+++ b/CommonData/sharedmemory.h
@@ -36,7 +36,7 @@ public:
 	static DataSet	*retrieveDataSet(unsigned long parentPID = 0);
 	static DataSet	*enlargeDataSet(DataSet *dataSet);
 	static void		deleteDataSet(DataSet *dataSet);
-	static void		unloadDataSet();
+	static void		unloadDataSet(bool owner = false);
 private:
 
 	static std::string _memoryName;

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -94,6 +94,9 @@ EngineSync::~EngineSync()
 	_moduleEngines.clear();
 	_engines.clear();
 
+	for(auto* channel : _channels)
+		delete channel;
+	_channels.clear();
 
 	delete _rCmderChannel;
 	_rCmderChannel	= nullptr;

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -240,7 +240,7 @@ MainWindow::~MainWindow()
 
 		delete _resultsJsInterface;
 
-//probably to late for signals
+//probably too late for signals
 //		if (_package->hasDataSet())
 //			_package->reset();
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -240,8 +240,11 @@ MainWindow::~MainWindow()
 
 		delete _resultsJsInterface;
 
-		if (_package->hasDataSet())
-			_package->reset();
+//probably to late for signals
+//		if (_package->hasDataSet())
+//			_package->reset();
+
+		SharedMemory::unloadDataSet(true);
 
 		//delete _engineSync; it will be deleted by Qt!
 	}

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -133,12 +133,8 @@ void Engine::initialize()
 
 Engine::~Engine()
 {
-	TempFiles::deleteAll();
-
 	delete _channel; //shared memory files will be removed in jaspDesktop
 	_channel = nullptr;
-
-
 }
 
 void Engine::run()


### PR DESCRIPTION
For a less involved dirty fix see PR: https://github.com/jasp-stats/jasp-desktop/pull/5002
But with that patch the trash pile will mount in the temp folder for 24 hours which could be GBs if the user uses large files.
We are currently not properly cleaning up at shutdown  on MacOS. This PR fixes this.

On MacOS crucial memory mapped files of other instances are deleted upon start up. 
This PR should fix the unnecessary removal of the temp files which can lead to crashing engine and entering eternal resume-crash loop.

This PR builds in safety margin by extending time limit to 24 hours and fastening the heartbeat to guard against possible hidden bugs, likely related to post sleep and app-nap interference with timers on MacOS. 

This PR needs to be tested heavily on all platforms

Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2241