### PR TITLE
Fix long pause crashes.

### DIFF
--- a/Common/tempfiles.cpp
+++ b/Common/tempfiles.cpp
@@ -156,7 +156,7 @@ void TempFiles::deleteOrphans()
 					long modTime	= Utils::getFileModificationTime(Utils::osPath(p));
 					long now		= Utils::currentSeconds();
 
-					if (now - modTime > 70)
+					if (now - modTime > 24 * 3600)
 					{
 						Log::log() << "Try to delete: " << fileName << std::endl;
 						std::filesystem::remove(p, error);
@@ -179,7 +179,7 @@ void TempFiles::deleteOrphans()
 					long modTime	= Utils::getFileModificationTime(Utils::osPath(statusFile));
 					long now		= Utils::currentSeconds();
 
-					if (now - modTime > 70)
+					if (now - modTime > 24 * 3600)
 					{
 						std::filesystem::remove_all(p, error);
 

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -306,7 +306,7 @@ void EngineSync::start(int )
 	connect(timerBeat,		&QTimer::timeout, this, &EngineSync::heartbeatTempFiles,	Qt::QueuedConnection);
 
 	timerProcess->start(50);
-	timerBeat->start(30000);
+	timerBeat->start(50);
 }
 
 void EngineSync::restartEngines()


### PR DESCRIPTION
For an actual Fix of the underlying problem see PR: https://github.com/jasp-stats/jasp-desktop/pull/5001
There are many issues with cleanup.
Trash may mount in the GBs within the tmp folder when large datasets are used on MacOS.
But this gets rid of the crashes within a 24 hour window and possibly beyond.

Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2241