### PR TITLE
Error when adding a Mixed Model analysis

### DIFF
--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -188,9 +188,13 @@ void ComponentsListBase::termsChangedHandler()
 	_setTableValue(_termsModel->terms(), _termsModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions());
 }
 
-Json::Value ComponentsListBase::getTableValueOptions(const ListModel::RowControlsValues &termsWithComponentValues)
+Json::Value ComponentsListBase::getJsonFromComponentValues(const ListModel::RowControlsValues &termsWithComponentValues)
 {
-	return _getTableValueOption(_termsModel->terms(), termsWithComponentValues, fq(_optionKey), containsInteractions());
+	Terms terms;
+	for (const QString& term : termsWithComponentValues.keys())
+		terms.add(Term::readTerm(term));
+
+	return _getTableValueOption(terms, termsWithComponentValues, fq(_optionKey), containsInteractions());
 }
 
 void ComponentsListBase::addItemHandler()

--- a/QMLComponents/controls/componentslistbase.h
+++ b/QMLComponents/controls/componentslistbase.h
@@ -50,7 +50,7 @@ public:
 	QList<QVariant>	defaultValues()						const			{ return _defaultValues;		}
 	bool			duplicateWhenAdding()				const			{ return _duplicateWhenAdding;	}
 
-	Json::Value		getTableValueOptions(const ListModel::RowControlsValues& termsWithComponentValues);
+	Json::Value		getJsonFromComponentValues(const ListModel::RowControlsValues& termsWithComponentValues);
 signals:
 	void			addItem();
 	void			removeItem(int index);

--- a/QMLComponents/rsyntax/formulasource.cpp
+++ b/QMLComponents/rsyntax/formulasource.cpp
@@ -620,7 +620,7 @@ FormulaParser::ParsedTerms FormulaSource::_fillOptionsWithRandomTerms(const Form
 	for (auto sourceMainTermsIt : sourceMainTermsMap)
 		_addTermsToOptions(sourceMainTermsIt.first, options, sourceMainTermsIt.second);
 
-	options[fq(_sourceName)] = _randomEffects.componentsList->getTableValueOptions(randomTermsMap);
+	options[fq(_sourceName)] = _randomEffects.componentsList->getJsonFromComponentValues(randomTermsMap);
 
 	return remainingParsedTerms;
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2198

The RSyntax object tries to generate the (json) options from the formula. For the Mixed Model, the formula can be quite complex. In the JASP form the options are determine by the RandomEffects ComponentsList which is a list of rows of CheckBox and VariablesList (which has also a CheckBox). The Json structure of this option is quite complex, so a method has been added in ComponentsListBase, the getJsonFromComponentValues(RowControlsValues) method that transforms the values found in the formula to a proper json option format.
The error is that the getJsonFromComponentValues method should not use the terms of the models (which depends on the current state of the model), but the terms should be deduced from its argument (termsWithComponentValues map), which is in this case just the keys of this map.