### PR TITLE
Repeated Measures ANOVA fix

### DIFF
--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -366,7 +366,7 @@ void AnalysisForm::bindTo(const Json::Value & defaultOptions)
 			// As their assigned models are not yet bound, resetTermsFromSourceModels (with updateAssigned argument set to true) must be called afterwards.
 			if (availableModel)
 			{
-				if (defaultOptions != Json::nullValue || _analysis->isDuplicate())
+				if (defaultOptions.size() != 0 || _analysis->isDuplicate())
 					availableModel->resetTermsFromSources(false);
 				else
 					availableModelsToBeReset.push_back(availableModel);
@@ -376,7 +376,7 @@ void AnalysisForm::bindTo(const Json::Value & defaultOptions)
 		if (boundControl)
 		{
 			std::string name = control->name().toStdString();
-			Json::Value optionValue =  defaultOptions != Json::nullValue ? defaultOptions[name] : Json::nullValue;
+			Json::Value optionValue =  defaultOptions.size() != 0 ? defaultOptions[name] : Json::nullValue;
 
 			if (optionValue != Json::nullValue && !boundControl->isJsonValid(optionValue))
 			{

--- a/QMLComponents/models/listmodelavailableinterface.cpp
+++ b/QMLComponents/models/listmodelavailableinterface.cpp
@@ -111,6 +111,8 @@ void ListModelAvailableInterface::sourceNamesChanged(QMap<QString, QString> map)
 {
 	ListModelDraggable::sourceNamesChanged(map);
 
+	// Not only the terms must be changed, but also the allTerms: allTerms keeps all terms that an
+	// available model can have: this is its own terms and the terms assigned in its assigned models.
 	QMap<QString, QString>	allTermsChangedMap;
 	QMapIterator<QString, QString> it(map);
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1987

There were 2 problems:
. when the Repeated Measures ANOVA is started, it starts with one default factor. This factor should be set per default in the Model terms. This does not work anymore.
. when changing the name of a factor, this factor and its interactions with other variables should stay in the model terms (if they already there). The factor (and its interactions) are now removed when changing its name: this must be also fixed