### PR TITLE
Catch exception on version parse failure

### DIFF
--- a/Desktop/gui/jaspversionchecker.cpp
+++ b/Desktop/gui/jaspversionchecker.cpp
@@ -50,14 +50,20 @@ void JASPVersionChecker::downloadVersionFinished()
 
 	if(version != "")
 	{
+		try
+		{
+			Version cv		= AppInfo::version,
+					lv		= version.toStdString();
+			long	cur		= cv.major()*1000000 + cv.minor()*100000 + cv.release()*1000 + cv.fourth(),
+					latest	= lv.major()*1000000 + lv.minor()*100000 + lv.release()*1000 + lv.fourth();
 
-		Version cv		= AppInfo::version,
-				lv		= version.toStdString();
-		long	cur		= cv.major()*1000000 + cv.minor()*100000 + cv.release()*1000 + cv.fourth(),
-				latest	= lv.major()*1000000 + lv.minor()*100000 + lv.release()*1000 + lv.fourth();
-
-		if (latest > cur)
-			emit showDownloadButton(downloadfile);
+			if (latest > cur)
+				emit showDownloadButton(downloadfile);
+		}
+		catch(std::runtime_error& e)
+		{
+			Log::log() << "Unable to parse version number:\n " << e.what() << std::endl;
+		}
 	}
 
 	if(KnownIssues::issues()->downloadNeededOrLoad())	downloadKnownIssues();

--- a/Desktop/gui/jaspversionchecker.cpp
+++ b/Desktop/gui/jaspversionchecker.cpp
@@ -73,7 +73,14 @@ void JASPVersionChecker::downloadVersionFinished()
 void JASPVersionChecker::downloadIssuesFinished()
 {
 	Log::log() << "New version of knownIssues downloaded!" << std::endl;
-	KnownIssues::issues()->loadJson(_networkReply->readAll().trimmed(), true);
+	try
+	{
+		KnownIssues::issues()->loadJson(_networkReply->readAll().trimmed(), true);
+	}
+	catch (...)
+	{
+		Log::log() << "Something went wrong parsing the known issues" << std::endl;
+	}
 
 	deleteLater(); //Remove yourself!
 }


### PR DESCRIPTION
Should Mitigate: https://github.com/jasp-stats/jasp-issues/issues/1986

I could not reproduce the issue on any platform with all kinds of network shenanigans.
So I just catch the exception and leave it at that.