### PR TITLE
Controls without name should work correctly

### DIFF
--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -47,6 +47,7 @@ AnalysisForm::AnalysisForm(QQuickItem *parent) : QQuickItem(parent)
 	connect(this,					&AnalysisForm::formCompletedSignal,	this, &AnalysisForm::formCompletedHandler,	Qt::QueuedConnection);
 	connect(this,					&AnalysisForm::analysisChanged,		this, &AnalysisForm::knownIssuesUpdated,	Qt::QueuedConnection);
 	connect(KnownIssues::issues(),	&KnownIssues::knownIssuesUpdated,	this, &AnalysisForm::knownIssuesUpdated,	Qt::QueuedConnection);
+	connect(this,					&AnalysisForm::showAllROptionsChanged, this, &AnalysisForm::setRSyntaxText,		Qt::QueuedConnection);
 }
 
 AnalysisForm::~AnalysisForm()
@@ -171,6 +172,12 @@ void AnalysisForm::addControl(JASPControl *control)
 		else
 			_controls[name] = control;
 	}
+	else if (name.isEmpty())
+	{
+		control->setUp();
+		control->setInitialized();
+	}
+
 }
 
 void AnalysisForm::addColumnControl(JASPControl* control, bool isComputed)
@@ -255,7 +262,6 @@ void AnalysisForm::_setUp()
 {
 	QList<JASPControl*> controls = _controls.values();
 
-	// set the order of the BoundItems according to their dependencies (for binding purpose)
 	for (JASPControl* control : controls)
 		control->setUp();
 

--- a/QMLComponents/components/JASP/Controls/Form.qml
+++ b/QMLComponents/components/JASP/Controls/Form.qml
@@ -223,6 +223,7 @@ AnalysisForm
 				anchors.bottom:		generateWrapperButton.visible ? generateWrapperButton.bottom : undefined
 				anchors.right:		rSyntaxElement.right
 				label:				qsTr("Show all options")
+				isBound:			false
 				checked:			showAllROptions
 				onClicked:			setShowAllROptions(!showAllROptions)
 			}

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -196,6 +196,9 @@ void TextInputBase::setUp()
 		// We have then to set back the value from the option
 		connect(form(), &AnalysisForm::languageChanged, this, &TextInputBase::setDisplayValue);
 
+	if (_value.isNull()) // If the value is not directly set, use the default value.
+		setValue(_defaultValue);
+
 	JASPControl::setUp(); // It might need the _inputType, so call it after it is set.
 }
 
@@ -348,12 +351,6 @@ Json::Value TextInputBase::_getJsonValue(const QVariant& value) const
 
 void TextInputBase::valueChangedSlot()
 {
-	if (!isBound() && _inputType != TextInputType::FormulaType && _inputType != TextInputType::FormulaArrayType)
-		// In a TabView, if the name of the tab is edited and, before validating, a new tab is added, the model is first changed because of adding a tab,
-		// possibly making the QML item of the TextField invalid (as this TextField depends on the TabView model).
-		// But as this TextField is not bound, and is not a Formula, we don't need to fetch the value of the item anyway.
-		return;
-
 	setValue(property("displayValue"));
 }
 

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -88,8 +88,8 @@ private:
 							_afterLabel;
 
 	bool					_parseDefaultValue	= true;
-	QVariant				_defaultValue,
-							_value;
+	QVariant				_defaultValue		= "",
+							_value;				// value should not be set: we can then make the difference whether the QML sets directly the value or not
 	bool					_hasScriptError		= false;
 };
 


### PR DESCRIPTION
It should be possible to use controls without name. Actually already the CheckBox that is used to show all options in R Syntax has no name
To be able to have a control without name, the `isBound` property should be set to false: a bound control must have a name. An error should occur if a control has no name and is bound.
A control without name was not set up correctly: this is fixed is this PR.
A special case is also handled here: when in a TabView, a user changes a title of a Tab, and directly afterwards add a new Tab. This was handled in a really hacky way, that prevents controls without name to be handled correctly.

