### PR TITLE
Move preprocess of %HELP_FOLDER% in markdown to HelpModel::setMarkdown

### DIFF
--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -467,18 +467,22 @@ DropArea
 					onClicked:			if(preferencesModel.generateMarkdown || !helpModel.pageExists(formParent.myAnalysis.helpFile()))
 										{
 											if(formParent.myForm && helpModel.markdown !== formParent.myForm.helpMD)
+											{
+												helpModel.analysis	= formParent.myAnalysis;
 												helpModel.markdown  = Qt.binding(function(){ return formParent.myForm.helpMD; });
+											}
 											else
 											{
 												helpModel.visible  = false;
 												helpModel.markdown = ""; //break binding
+												helpModel.analysis = null
 											}
 											
 												
 										}
 										else
 										{
-											helpModel.markdown = "";	
+											helpModel.markdown = "";
 											helpModel.showOrTogglePageForAnalysis(formParent.myAnalysis)
 										}
 										

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -530,6 +530,7 @@ void DynamicModule::preprocessMarkdownHelp(QString & md) const
 	md.replace("%HELP_FOLDER%",  helpFolderPath());
 }
 
+
 AnalysisEntry* DynamicModule::retrieveCorrespondingAnalysisEntry(const Json::Value & jsonFromJaspFile) const
 {
 	std::string moduleName		= jsonFromJaspFile.get("moduleName", "Modulename wasn't actually filled!").asString(),

--- a/Desktop/utilities/helpmodel.cpp
+++ b/Desktop/utilities/helpmodel.cpp
@@ -66,6 +66,9 @@ void HelpModel::setMarkdown(QString markdown)
 		_pagePath = "";
 	
 	_markdown = markdown;
+
+	if(_analysis != nullptr)
+		_analysis->dynamicModule()->preprocessMarkdownHelp(_markdown);
 	
 	emit markdownChanged(_markdown);
 }
@@ -141,6 +144,7 @@ void HelpModel::showOrToggleParticularPageForAnalysis(Analysis * analysis, QStri
 {
 	if(!analysis)
 	{
+		setAnalysis(nullptr);
 		setVisible(false);
 		return;
 	}
@@ -157,13 +161,11 @@ void HelpModel::showOrToggleParticularPageForAnalysis(Analysis * analysis, QStri
 	else 
 	{
 		_analysis = analysis;
+		emit analysisChanged();
 		
 		if((loadHelpContent(pagePath, false, renderFunc, contentMD) || loadHelpContent(pagePath, true, renderFunc, contentMD)) && renderFunc == "window.render")
 		{
-			//If we get here the file exists and it is a markdown file.			
-			if(analysis->dynamicModule())
-				analysis->dynamicModule()->preprocessMarkdownHelp(contentMD);
-			
+			//If we get here the file exists and it is a markdown file.
 			setMarkdown(contentMD);
 			setVisible(true);
 			
@@ -240,7 +242,6 @@ bool HelpModel::loadHelpContent(const QString & pagePath, bool ignorelanguage, Q
 
 	if (fileHTML.exists())
 	{
-
 		fileHTML.open(QFile::ReadOnly);
 		content = QString::fromUtf8(fileHTML.readAll());
 		fileHTML.close();
@@ -266,4 +267,12 @@ void HelpModel::loadMarkdown(QString md)
 
 	setVisible(true);
 	runJavaScript("window.render", md);
+}
+
+void HelpModel::setAnalysis(Analysis *newAnalysis)
+{
+	if (_analysis == newAnalysis)
+		return;
+	_analysis = newAnalysis;
+	emit analysisChanged();
 }

--- a/Desktop/utilities/helpmodel.h
+++ b/Desktop/utilities/helpmodel.h
@@ -13,21 +13,25 @@
 class HelpModel : public QObject
 {
 	Q_OBJECT
-	Q_PROPERTY(bool		visible		READ visible	WRITE setVisible	NOTIFY visibleChanged	)
-	Q_PROPERTY(QString	pagePath	READ pagePath	WRITE setPagePath	NOTIFY pagePathChanged	)
-	Q_PROPERTY(QString	markdown	READ markdown	WRITE setMarkdown	NOTIFY markdownChanged	)
+	Q_PROPERTY(bool				visible		READ visible	WRITE setVisible	NOTIFY visibleChanged	)
+	Q_PROPERTY(QString			pagePath	READ pagePath	WRITE setPagePath	NOTIFY pagePathChanged	)
+	Q_PROPERTY(QString			markdown	READ markdown	WRITE setMarkdown	NOTIFY markdownChanged	)
+	Q_PROPERTY(Analysis		*	analysis	READ analysis	WRITE setAnalysis	NOTIFY analysisChanged	)
 
 public:
-			HelpModel(QObject * parent);
+					HelpModel(QObject * parent);
 
-	bool	visible()	const { return _visible;  }
-	QString pagePath()	const { return _pagePath; }
-	QString markdown()	const { return _markdown; }
-	void	runJavaScript(QString renderFunc, QString content);
+	void			runJavaScript(QString renderFunc, QString content);
+
+	bool			visible()	const { return _visible;  }
+	QString			pagePath()	const { return _pagePath; }
+	QString			markdown()	const { return _markdown; }
+	Analysis	*	analysis()	const { return _analysis; }
 
 public slots:
 	void	setVisible(bool visible);
 	void	setPagePath(QString pagePath);
+	void	setAnalysis(Analysis *newAnalysis);
 	void	setAnalysispagePath(QString analysisName) { setPagePath("analyses/" + analysisName); }
 	void	generateJavascript();
 	void	showOrTogglePage(QString pagePath);
@@ -43,16 +47,16 @@ public slots:
 	bool	pageExists(QString pagePath);
 
 signals:
-	void renderCode(QString javascript);
-	void visibleChanged(bool visible);
-	void pagePathChanged(QString pagePath);
-	void runJavaScriptSignal(QString helpJS);
-
-	void markdownChanged(QString markdown);
+	void	renderCode(QString javascript);
+	void	visibleChanged(bool visible);
+	void	pagePathChanged(QString pagePath);
+	void	runJavaScriptSignal(QString helpJS);
+	void	markdownChanged(QString markdown);
+	void	analysisChanged();
 
 private:
 	QString convertPagePathToLower(const QString & pagePath);
-	bool loadHelpContent(const QString & pagePath, bool ignorelanguage, QString &renderFunc, QString &content);
+	bool	loadHelpContent(const QString & pagePath, bool ignorelanguage, QString &renderFunc, QString &content);
 
 private:
 	bool		_visible	= false;


### PR DESCRIPTION
Otherwise its only applied to the helpfile-mds.

This should be a fairly harmless change that could be useful for having people switch over to using `info:`