### PR TITLE
The R Syntax setting should be kept

### DIFF
--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -402,7 +402,7 @@ DropArea
 					iconSource:			enabled ? jaspTheme.iconPath + "/R-roundbutton.svg" :  jaspTheme.iconPath + "/R-roundbutton-disabled.svg"
 					enabled:			expanderButton.expanded
 					onClicked:			if (formParent.myForm) formParent.myForm.toggleRSyntax();
-					toolTip:			qsTr("Show R syntax")
+					toolTip:			preferencesModel.showRSyntax ? qsTr("Hide R Syntax") : qsTr("Show R syntax")
 					radius:				height
 					opacity:			editButton.opacity
 					visible:            formParent.myForm && formParent.myForm.showRButton

--- a/Desktop/gui/preferencesmodel.cpp.in
+++ b/Desktop/gui/preferencesmodel.cpp.in
@@ -11,18 +11,14 @@
 #include "utilities/appdirs.h"
 #include "enginedefinitions.h"
 #include "columnutils.h"
+#include "preferencesmodelbase.h"
 #include <QQuickWindow>
 
 using namespace std;
 
-PreferencesModel * PreferencesModel::_singleton = nullptr;
-
 PreferencesModel::PreferencesModel(QObject *parent) :
-	QObject(parent)
+	PreferencesModelBase(parent)
 {	
-	assert(!_singleton);
-	_singleton = this;
-
 	connect(this,					&PreferencesModel::missingValuesChanged,		this, &PreferencesModel::updateUtilsMissingValues		);
 
 	connect(this,					&PreferencesModel::useDefaultPPIChanged,		this, &PreferencesModel::onUseDefaultPPIChanged			);
@@ -128,6 +124,8 @@ GET_PREF_FUNC_BOOL( dbShowWarning,				Settings::DB_SHOW_WARNING							)
 GET_PREF_FUNC_STR(  dataLabelNA,				Settings::DATA_LABEL_NA								)
 GET_PREF_FUNC_BOOL( guiQtTextRender,			Settings::GUI_USE_QT_TEXTRENDER						)
 GET_PREF_FUNC_BOOL( reportingMode,				Settings::REPORT_SHOW								)
+GET_PREF_FUNC_BOOL( showRSyntax,				Settings::SHOW_RSYNTAX								)
+GET_PREF_FUNC_BOOL( showAllROptions,			Settings::SHOW_ALL_R_OPTIONS						)
 
 int PreferencesModel::maxEngines() const
 {
@@ -258,6 +256,14 @@ void PreferencesModel::FUNC_NAME(TYPE newVal)							\
 	emit NOTIFY();														\
 }
 
+#define SET_PREF_FUNCTION_EMIT_NO_ARG(TYPE, FUNC_NAME, GET_FUNC, NOTIFY, SETTING)	\
+void PreferencesModel::FUNC_NAME(TYPE newVal)							\
+{																		\
+	if(GET_FUNC() == newVal) return;									\
+	Settings::setValue(SETTING, newVal);								\
+	emit NOTIFY();														\
+}
+
 void PreferencesModel::setCurrentThemeName(QString _currentThemeName)
 {
 	if (currentThemeName() == _currentThemeName) return;
@@ -268,35 +274,37 @@ void PreferencesModel::setCurrentThemeName(QString _currentThemeName)
 	emit currentThemeNameChanged(_currentThemeName);
 }
 
-SET_PREF_FUNCTION(bool,		setExactPValues,			exactPValues,				exactPValuesChanged,			Settings::EXACT_PVALUES								)
-SET_PREF_FUNCTION(bool,		setNormalizedNotation,		normalizedNotation,			normalizedNotationChanged,		Settings::NORMALIZED_NOTATION						)
-SET_PREF_FUNCTION(bool,		setDataAutoSynchronization, dataAutoSynchronization,	dataAutoSynchronizationChanged, Settings::DATA_AUTO_SYNCHRONIZATION					)
-SET_PREF_FUNCTION(bool,		setUseDefaultEditor,		useDefaultEditor,			useDefaultEditorChanged,		Settings::USE_DEFAULT_SPREADSHEET_EDITOR			)
-SET_PREF_FUNCTION(QString,	setCustomEditor,			customEditor,				customEditorChanged,			Settings::SPREADSHEET_EDITOR_NAME					)
-SET_PREF_FUNCTION(bool,		setUseDefaultPPI,			useDefaultPPI,				useDefaultPPIChanged,			Settings::PPI_USE_DEFAULT							)
-SET_PREF_FUNCTION(bool,		setDeveloperMode,			developerMode,				developerModeChanged,			Settings::DEVELOPER_MODE							)
-SET_PREF_FUNCTION(QString,	setDeveloperFolder,			developerFolder,			developerFolderChanged,			Settings::DEVELOPER_FOLDER							)
-SET_PREF_FUNCTION(int,		setCustomPPI,				customPPI,					customPPIChanged,				Settings::PPI_CUSTOM_VALUE							)
-SET_PREF_FUNCTION(bool,		setLogToFile,				logToFile,					logToFileChanged,				Settings::LOG_TO_FILE								)
-SET_PREF_FUNCTION(int,		setLogFilesMax,				logFilesMax,				logFilesMaxChanged,				Settings::LOG_FILES_MAX								)
-SET_PREF_FUNCTION(int,		setMaxFlickVelocity,		maxFlickVelocity,			maxFlickVelocityChanged,		Settings::QML_MAX_FLICK_VELOCITY					)
-SET_PREF_FUNCTION(bool,		setModulesRemember,			modulesRemember,			modulesRememberChanged,			Settings::MODULES_REMEMBER							)
-SET_PREF_FUNCTION(QString,	setCranRepoURL,				cranRepoURL,				cranRepoURLChanged,				Settings::CRAN_REPO_URL								)
-SET_PREF_FUNCTION(bool,		setGithubPatUseDefault,		githubPatUseDefault,		githubPatUseDefaultChanged,		Settings::GITHUB_PAT_USE_DEFAULT					)
-SET_PREF_FUNCTION(QString,	setPlotBackground,			plotBackground,				plotBackgroundChanged,			Settings::IMAGE_BACKGROUND							)
-SET_PREF_FUNCTION(bool,		setUseNativeFileDialog,		useNativeFileDialog,		useNativeFileDialogChanged,		Settings::USE_NATIVE_FILE_DIALOG					)
-SET_PREF_FUNCTION(bool,		setDisableAnimations,		disableAnimations,			disableAnimationsChanged,		Settings::DISABLE_ANIMATIONS						)
-SET_PREF_FUNCTION(bool,		setGenerateMarkdown,		generateMarkdown,			generateMarkdownChanged,		Settings::GENERATE_MARKDOWN_HELP					)
-SET_PREF_FUNCTION(QString,	setInterfaceFont,			interfaceFont,				interfaceFontChanged,			Settings::INTERFACE_FONT							)
-SET_PREF_FUNCTION(QString,	setCodeFont,				codeFont,					codeFontChanged,				Settings::CODE_FONT									)
-SET_PREF_FUNCTION(QString,	setResultFont,				resultFont,					resultFontChanged,				Settings::RESULT_FONT								)
-SET_PREF_FUNCTION(int,		setMaxEngines,				maxEngines,					maxEnginesChanged,				Settings::MAX_ENGINE_COUNT							)
-SET_PREF_FUNCTION(bool,		setWindowsNoBomNative,		windowsNoBomNative,			windowsNoBomNativeChanged,		Settings::WINDOWS_NO_BOM_NATIVE						)
-SET_PREF_FUNCTION(int,		setWindowsChosenCodePage,	windowsChosenCodePage,		windowsChosenCodePageChanged,	Settings::WINDOWS_CHOSEN_CODEPAGE					)
-SET_PREF_FUNCTION(bool,		setDbShowWarning,			dbShowWarning,				dbShowWarningChanged,			Settings::DB_SHOW_WARNING							)
-SET_PREF_FUNCTION(QString,	setDataLabelNA,				dataLabelNA,				dataLabelNAChanged,				Settings::DATA_LABEL_NA								)
-SET_PREF_FUNCTION(bool,		setGuiQtTextRender,			guiQtTextRender,			guiQtTextRenderChanged,			Settings::GUI_USE_QT_TEXTRENDER						)
-SET_PREF_FUNCTION(bool,		setReportingMode,			reportingMode,				reportingModeChanged,			Settings::REPORT_SHOW								)
+SET_PREF_FUNCTION(				bool,		setExactPValues,			exactPValues,				exactPValuesChanged,			Settings::EXACT_PVALUES								)
+SET_PREF_FUNCTION(				bool,		setNormalizedNotation,		normalizedNotation,			normalizedNotationChanged,		Settings::NORMALIZED_NOTATION						)
+SET_PREF_FUNCTION(				bool,		setDataAutoSynchronization, dataAutoSynchronization,	dataAutoSynchronizationChanged, Settings::DATA_AUTO_SYNCHRONIZATION					)
+SET_PREF_FUNCTION(				bool,		setUseDefaultEditor,		useDefaultEditor,			useDefaultEditorChanged,		Settings::USE_DEFAULT_SPREADSHEET_EDITOR			)
+SET_PREF_FUNCTION(				QString,	setCustomEditor,			customEditor,				customEditorChanged,			Settings::SPREADSHEET_EDITOR_NAME					)
+SET_PREF_FUNCTION(				bool,		setUseDefaultPPI,			useDefaultPPI,				useDefaultPPIChanged,			Settings::PPI_USE_DEFAULT							)
+SET_PREF_FUNCTION(				bool,		setDeveloperMode,			developerMode,				developerModeChanged,			Settings::DEVELOPER_MODE							)
+SET_PREF_FUNCTION(				QString,	setDeveloperFolder,			developerFolder,			developerFolderChanged,			Settings::DEVELOPER_FOLDER							)
+SET_PREF_FUNCTION(				int,		setCustomPPI,				customPPI,					customPPIChanged,				Settings::PPI_CUSTOM_VALUE							)
+SET_PREF_FUNCTION(				bool,		setLogToFile,				logToFile,					logToFileChanged,				Settings::LOG_TO_FILE								)
+SET_PREF_FUNCTION(				int,		setLogFilesMax,				logFilesMax,				logFilesMaxChanged,				Settings::LOG_FILES_MAX								)
+SET_PREF_FUNCTION_EMIT_NO_ARG(	int,		setMaxFlickVelocity,		maxFlickVelocity,			maxFlickVelocityChanged,		Settings::QML_MAX_FLICK_VELOCITY					)
+SET_PREF_FUNCTION(				bool,		setModulesRemember,			modulesRemember,			modulesRememberChanged,			Settings::MODULES_REMEMBER							)
+SET_PREF_FUNCTION(				QString,	setCranRepoURL,				cranRepoURL,				cranRepoURLChanged,				Settings::CRAN_REPO_URL								)
+SET_PREF_FUNCTION(				bool,		setGithubPatUseDefault,		githubPatUseDefault,		githubPatUseDefaultChanged,		Settings::GITHUB_PAT_USE_DEFAULT					)
+SET_PREF_FUNCTION(				QString,	setPlotBackground,			plotBackground,				plotBackgroundChanged,			Settings::IMAGE_BACKGROUND							)
+SET_PREF_FUNCTION(				bool,		setUseNativeFileDialog,		useNativeFileDialog,		useNativeFileDialogChanged,		Settings::USE_NATIVE_FILE_DIALOG					)
+SET_PREF_FUNCTION(				bool,		setDisableAnimations,		disableAnimations,			disableAnimationsChanged,		Settings::DISABLE_ANIMATIONS						)
+SET_PREF_FUNCTION(				bool,		setGenerateMarkdown,		generateMarkdown,			generateMarkdownChanged,		Settings::GENERATE_MARKDOWN_HELP					)
+SET_PREF_FUNCTION_EMIT_NO_ARG(	QString,	setInterfaceFont,			interfaceFont,				interfaceFontChanged,			Settings::INTERFACE_FONT							)
+SET_PREF_FUNCTION(				QString,	setCodeFont,				codeFont,					codeFontChanged,				Settings::CODE_FONT									)
+SET_PREF_FUNCTION(				QString,	setResultFont,				resultFont,					resultFontChanged,				Settings::RESULT_FONT								)
+SET_PREF_FUNCTION(				int,		setMaxEngines,				maxEngines,					maxEnginesChanged,				Settings::MAX_ENGINE_COUNT							)
+SET_PREF_FUNCTION(				bool,		setWindowsNoBomNative,		windowsNoBomNative,			windowsNoBomNativeChanged,		Settings::WINDOWS_NO_BOM_NATIVE						)
+SET_PREF_FUNCTION(				int,		setWindowsChosenCodePage,	windowsChosenCodePage,		windowsChosenCodePageChanged,	Settings::WINDOWS_CHOSEN_CODEPAGE					)
+SET_PREF_FUNCTION(				bool,		setDbShowWarning,			dbShowWarning,				dbShowWarningChanged,			Settings::DB_SHOW_WARNING							)
+SET_PREF_FUNCTION(				QString,	setDataLabelNA,				dataLabelNA,				dataLabelNAChanged,				Settings::DATA_LABEL_NA								)
+SET_PREF_FUNCTION(				bool,		setGuiQtTextRender,			guiQtTextRender,			guiQtTextRenderChanged,			Settings::GUI_USE_QT_TEXTRENDER						)
+SET_PREF_FUNCTION(				bool,		setReportingMode,			reportingMode,				reportingModeChanged,			Settings::REPORT_SHOW								)
+SET_PREF_FUNCTION_EMIT_NO_ARG(	bool,		setShowRSyntax,				showRSyntax,				showRSyntaxChanged,				Settings::SHOW_RSYNTAX								)
+SET_PREF_FUNCTION_EMIT_NO_ARG(	bool,		setShowAllROptions,			showAllROptions,			showAllROptionsChanged,			Settings::SHOW_ALL_R_OPTIONS						)
 
 void PreferencesModel::setGithubPatCustom(QString newPat)
 {
@@ -335,7 +343,7 @@ void PreferencesModel::setUiScale(double newUiScale)
 	Settings::setValue(Settings::UI_SCALE, newUiScale);
 	_uiScale = newUiScale;
 
-	emit uiScaleChanged(_uiScale);
+	emit uiScaleChanged();
 }
 
 void PreferencesModel::setModulesRemembered(QStringList newModulesRemembered)

--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -5,12 +5,13 @@
 #include <QFont>
 #include "column.h"
 #include "utilities/qutils.h"
+#include "preferencesmodelbase.h"
 
 class JaspTheme;
 
 ///
 /// Interface between QML and Settings, mostly templated functions to link through directly.
-class PreferencesModel : public QObject
+class PreferencesModel : public PreferencesModelBase
 {
 	Q_OBJECT
 
@@ -65,11 +66,14 @@ class PreferencesModel : public QObject
 	Q_PROPERTY(QString		dataLabelNA				READ dataLabelNA				WRITE setDataLabelNA				NOTIFY dataLabelNAChanged				)
 	Q_PROPERTY(bool			guiQtTextRender			READ guiQtTextRender			WRITE setGuiQtTextRender			NOTIFY guiQtTextRenderChanged			)
 	Q_PROPERTY(bool			reportingMode			READ reportingMode				WRITE setReportingMode				NOTIFY reportingModeChanged				)
+	Q_PROPERTY(bool			showRSyntax				READ showRSyntax				WRITE setShowRSyntax				NOTIFY showRSyntaxChanged				)
+	Q_PROPERTY(bool			showAllROptions			READ showAllROptions			WRITE setShowAllROptions			NOTIFY showAllROptionsChanged			)
+
 
 public:
 	explicit	 PreferencesModel(QObject *parent = 0);
 
-	static PreferencesModel * prefs() { return _singleton; }
+	static PreferencesModel * prefs() { return qobject_cast<PreferencesModel*>(_singleton); }
 
 	int			customPPI()								const;
 	int			numDecimals()							const;
@@ -83,7 +87,7 @@ public:
 	bool		useDefaultPPI()							const;
 	bool		whiteBackground()						const;
 	QString		plotBackground()						const;
-	double		uiScale()								;
+	double		uiScale()								override;
 	QString		customEditor()							const;
 	QString		developerFolder()						const;
 	QString		fixedDecimalsForJS()					const;
@@ -92,7 +96,7 @@ public:
 	int			thresholdScale()						const;
 	bool		logToFile()								const;
 	int			logFilesMax()							const;
-	int			maxFlickVelocity()						const;
+	int			maxFlickVelocity()						const override;
 	bool		modulesRemember()						const;
 	QStringList	modulesRemembered()						const;
 	bool		safeGraphics()							const;
@@ -122,13 +126,15 @@ public:
 	QString		dataLabelNA()							const;
 	bool		guiQtTextRender()						const;
 	bool		reportingMode()							const;
+	bool		showRSyntax()							const override;
+	bool		showAllROptions()						const override;
 	void		zoomIn();
 	void		zoomOut();
 	void		zoomReset();
 	int 		maxEnginesAdmin() 						const;
+	bool		developerMode()							const;
 
 public slots:
-	bool developerMode()								const; //Some 
 	void setUiScale(					double		uiScale);
 	void setCustomPPI(					int			customPPI);
 	void setDefaultPPI(					int			defaultPPI);
@@ -165,7 +171,7 @@ public slots:
 	void onUseDefaultPPIChanged(		bool		useDefault);
 	void onCustomPPIChanged(			int);
 	void onDefaultPPIChanged(			int);
-	void setCurrentThemeName(			QString		currentThemeName);
+	void setCurrentThemeName(			QString		currentThemeName)				override;
 	void setInterfaceFont(				QString		interfaceFont);
 	void setCodeFont(					QString		codeFont);
 	void setResultFont(					QString		resultFont);
@@ -181,6 +187,8 @@ public slots:
 	void setGuiQtTextRender(			bool		newGuiQtTextRender);
 	void onGuiQtTextRenderChanged(		bool		newGuiQtTextRenderSetting);
 	void setReportingMode(				bool		reportingMode);
+	void setShowRSyntax(				bool		showRSyntax)					override;
+	void setShowAllROptions(			bool		showAllROptions)				override;
 	void currentThemeNameHandler();
 	
 signals:
@@ -230,11 +238,6 @@ signals:
 	void dataLabelNAChanged(			QString		dataLabelNA);
 	void guiQtTextRenderChanged(		bool		guiQtTextRender);
 	void reportingModeChanged(			bool		reportingMode);
-	void uiScaleChanged(				float		uiScale);
-	void maxFlickVelocityChanged(		float		flickVelo);
-	void currentJaspThemeChanged();
-	void currentThemeReady();
-	void interfaceFontChanged(			QString		interfaceFont);
 
 private slots:
 	void dataLabelNAChangedSlot(QString label);
@@ -249,10 +252,7 @@ private:
 	bool			_githubPatCustom; //Should be initialized on prefs construction
 
 	void			_loadDatabaseFont();
-	QString			_checkFontList(QString fonts) const;
-
-	
-	static	PreferencesModel * _singleton;
+	QString			_checkFontList(QString fonts) const;	
 };
 
 #endif // PREFERENCESDIALOG_H

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -522,7 +522,7 @@ void MainWindow::loadQML()
 
 	setCurrentJaspTheme();
 
-	JaspTheme::initializeUIScales(_preferences->uiScale());
+	JaspTheme::initializeUIScales();
 
 	for(const auto & keyval : JaspTheme::themes())
 	{

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -84,7 +84,9 @@ const Settings::Setting Settings::Values[] = {
 	{"dbRememberMe",				false	},
 	{"dataNALabel",					""		},
 	{"guiQtTextRender",				true	},
-	{"showReports",					false	}
+	{"showReports",					false	},
+	{"showRSyntax",					false	},
+	{"showAllROptions",				false	}
 };	
 
 QVariant Settings::value(Settings::Type key)

--- a/Desktop/utilities/settings.h
+++ b/Desktop/utilities/settings.h
@@ -70,7 +70,9 @@ public:
 		DB_REMEMBER_ME,
 		DATA_LABEL_NA,
 		GUI_USE_QT_TEXTRENDER,
-		REPORT_SHOW
+		REPORT_SHOW,
+		SHOW_RSYNTAX,
+		SHOW_ALL_R_OPTIONS
 	};
 
 	static QVariant value(Settings::Type key);

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -56,7 +56,6 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(QString		helpMD					READ helpMD													NOTIFY helpMDChanged				)
 	Q_PROPERTY(QVariant		analysis				READ analysis												NOTIFY analysisInitialized			)
 	Q_PROPERTY(QVariantList	optionNameConversion	READ optionNameConversion	WRITE setOptionNameConversion	NOTIFY optionNameConversionChanged	)
-	Q_PROPERTY(bool			showRSyntax				READ showRSyntax											NOTIFY showRSyntaxChanged			)
 	Q_PROPERTY(bool			showRButton				READ showRButton											NOTIFY showRButtonChanged			)
 	Q_PROPERTY(bool			developerMode			READ developerMode											NOTIFY developerModeChanged			)
 	Q_PROPERTY(QString		rSyntaxText				READ rSyntaxText											NOTIFY rSyntaxTextChanged			)
@@ -87,11 +86,10 @@ public:
 	bool					hasVolatileNotes()				const	{ return _hasVolatileNotes;									}
 	bool					wasUpgraded()					const	{ return _analysis ? _analysis->wasUpgraded() : false;		}
 	bool					formCompleted()					const	{ return _formCompleted;	}
-	bool					showRSyntax()					const	{ return _showRSyntax;		}
 	bool					showRButton()					const	{ return _showRButton;		}
 	bool					developerMode()					const	{ return _developerMode;	}
-	QString					rSyntaxText()					const	{ return _rSyntaxText;		}
-	bool					showAllROptions()				const	{ return _showAllROptions;	}
+	QString					rSyntaxText()					const;
+	bool					showAllROptions()				const;
 
 public slots:
 	void					runScriptRequestDone(const QString& result, const QString& requestId, bool hasError);
@@ -100,13 +98,12 @@ public slots:
 	void					boundValueChangedHandler(JASPControl* control);
 	void					setOptionNameConversion(const QVariantList& conv);
 	void					setTitle(QString title);
-	void					setShowRSyntax(bool showRSyntax);
 	void					setShowRButton(bool showRButton);
 	void					setDeveloperMode(bool developerMode);
 	void					setRSyntaxText();
 	void					setShowAllROptions(bool showAllROptions);
 	void					sendRSyntax(QString text);
-	void					toggleRSyntax()		{ setShowRSyntax(!showRSyntax()); }
+	void					toggleRSyntax();
 
 signals:
 	void					formChanged(AnalysisBase* analysis);
@@ -125,7 +122,6 @@ signals:
 	void					rSourceChanged(const QString& name);
 	void					optionNameConversionChanged();
 	void					titleChanged();
-	void					showRSyntaxChanged();
 	void					showRButtonChanged();
 	void					developerModeChanged();
 	void					rSyntaxTextChanged();
@@ -234,10 +230,8 @@ private:
 	int												_valueChangedSignalsBlocked		= 0;
 	std::queue<std::tuple<QString, QString, bool>>	_waitingRScripts; //Sometimes signals are blocked, and thus rscripts. But they shouldnt just disappear right?
 	RSyntax										*	_rSyntax						= nullptr;
-	bool											_showRSyntax					= false,
-													_showRButton					= false,
-													_developerMode					= false,
-													_showAllROptions				= false;
+	bool											_showRButton					= false,
+													_developerMode					= false;
 	QString											_rSyntaxText;
 	JASPControl*									_activeJASPControl				= nullptr;
 };

--- a/QMLComponents/components/JASP/Controls/Form.qml
+++ b/QMLComponents/components/JASP/Controls/Form.qml
@@ -182,7 +182,7 @@ AnalysisForm
 			anchors.top:		warningMessagesBox.bottom
 			width:				parent.width
 			height:				visible ? rScriptArea.y + rScriptArea.height : 0
-			visible:			form.showRSyntax
+			visible:			preferencesModel.showRSyntax
 
 			Button
 			{
@@ -232,6 +232,7 @@ AnalysisForm
 			{
 				id:					rScriptArea
 				name:				form.rSyntaxControlName
+
 				anchors.top:		showAllROptionsCheckBox.bottom
 				anchors.topMargin:	jaspTheme.generalAnchorMargin
 				width:				parent.width
@@ -239,6 +240,8 @@ AnalysisForm
 				text:				form.rSyntaxText
 				isBound:			false
 				onApplyRequest:		form.sendRSyntax(text)
+
+				onInitializedChanged: if (preferencesModel.showRSyntax) control.forceActiveFocus() // If the textarea has already some large text, then it does not display it if it does not get temporarly the focus...
 			}
 		}
 

--- a/QMLComponents/jasptheme.cpp
+++ b/QMLComponents/jasptheme.cpp
@@ -1,6 +1,7 @@
 #include "jasptheme.h"
 #include "log.h"
 #include "utilities/qutils.h"
+#include "preferencesmodelbase.h"
 #include <QFontDatabase>
 
 JaspTheme			*	JaspTheme::_currentTheme	= nullptr;
@@ -116,10 +117,10 @@ void JaspTheme::setCurrentThemeFromName(QString name)
 	setCurrentTheme(_themes[name]);
 }
 
-void JaspTheme::initializeUIScales(double uiScale)
+void JaspTheme::initializeUIScales()
 {
 	for(auto& keyval : _themes)
-		keyval.second->uiScaleHandler(uiScale);
+		keyval.second->uiScaleHandler();
 }
 
 void JaspTheme::setRibbonScaleHovered(float ribbonScaleHovered)
@@ -1274,15 +1275,15 @@ void JaspTheme::setIsDark(bool isDark)
 	emit isDarkChanged(_isDark);
 }
 
-void JaspTheme::uiScaleHandler(float newUiScale)
+void JaspTheme::uiScaleHandler()
 {
-	_uiScale = newUiScale;
+	_uiScale = PreferencesModelBase::preferences()->uiScale();
 	emit uiScaleChanged(_uiScale);
 }
 
-void JaspTheme::maxFlickVeloHandler(float maxFlickVelo)
+void JaspTheme::maxFlickVeloHandler()
 {
-	_maximumFlickVelocity = maxFlickVelo;
+	_maximumFlickVelocity = PreferencesModelBase::preferences()->maxFlickVelocity();
 	emit maximumFlickVelocityChanged();
 }
 

--- a/QMLComponents/jasptheme.h
+++ b/QMLComponents/jasptheme.h
@@ -183,7 +183,7 @@ public:
 
 	static void setCurrentTheme(JaspTheme * theme);
 	static void setCurrentThemeFromName(QString name);
-	static void initializeUIScales(double uiScale = 1);
+	static void initializeUIScales();
 
 	static JaspTheme								* currentTheme()	{ return _currentTheme; }
 	static QFontMetricsF							& fontMetrics()		{ return _fontMetrics;  } //For qml interface font used everywhere (in particular in datasetview though)
@@ -582,8 +582,8 @@ public slots:
 	void setFontCode(QFont fontCode);
 	void setFontALTNavTag(QFont fontALTNavTag);
 	void setIsDark(bool isDark);
-	void uiScaleHandler(float newUiScale);
-	void maxFlickVeloHandler(float maxFlickVelo);
+	void uiScaleHandler();
+	void maxFlickVeloHandler();
 
 private:
 	void connectSizeDistancesToUiScaleChanged();

--- a/QMLComponents/preferencesmodelbase.cpp
+++ b/QMLComponents/preferencesmodelbase.cpp
@@ -1,0 +1,23 @@
+#include "preferencesmodelbase.h"
+#include "jasptheme.h"
+
+PreferencesModelBase* PreferencesModelBase::_singleton = nullptr;
+
+PreferencesModelBase::PreferencesModelBase(QObject *parent)
+	: QObject{parent}
+{
+	_singleton = this;
+}
+
+PreferencesModelBase *PreferencesModelBase::preferences()
+{
+	if (_singleton == nullptr)
+		_singleton = new PreferencesModelBase();
+
+	return _singleton;
+}
+
+void PreferencesModelBase::currentThemeNameHandler()
+{
+	setCurrentThemeName(JaspTheme::currentTheme()->themeName());
+}

--- a/QMLComponents/preferencesmodelbase.h
+++ b/QMLComponents/preferencesmodelbase.h
@@ -1,0 +1,40 @@
+#ifndef PREFERENCESMODELBASE_H
+#define PREFERENCESMODELBASE_H
+
+#include <QObject>
+
+class PreferencesModelBase : public QObject
+{
+	Q_OBJECT
+public:
+	explicit PreferencesModelBase(QObject *parent = nullptr);
+	~PreferencesModelBase() { _singleton = nullptr; }
+
+	virtual double	uiScale()						{ return 1;		}
+	virtual int		maxFlickVelocity()		const	{ return 808;	}
+	virtual bool	showRSyntax()			const	{ return false; }
+	virtual bool	showAllROptions()		const	{ return false; }
+
+	static PreferencesModelBase* preferences();
+
+public slots:
+	void			currentThemeNameHandler();
+	virtual void	setCurrentThemeName(QString currentThemeName)	{}
+	virtual void	setShowRSyntax(bool showRSyntax)				{}
+	virtual void	setShowAllROptions(bool showAllROptions)		{}
+
+signals:
+	void uiScaleChanged();
+	void maxFlickVelocityChanged();
+	void currentJaspThemeChanged();
+	void currentThemeReady();
+	void interfaceFontChanged();
+	void showRSyntaxChanged();
+	void showAllROptionsChanged();
+
+protected:
+	static PreferencesModelBase* _singleton;
+
+};
+
+#endif // PREFERENCESMODELBASE_H


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2239

If the R Syntax is displayed on one analysis, then it is automatically displayed on all analyses, and also when JASP is started again. In the same way the 'Show All R Options' is kept.

Also the PreferencesModelBase dummy object is added in order to make QMLComponents independent of the rest of JASP.

