### PR TITLE
Docs: Update dependent library on Linux

### DIFF
--- a/Docs/development/jasp-build-guide-linux.md
+++ b/Docs/development/jasp-build-guide-linux.md
@@ -24,7 +24,7 @@ Based on your system, you can install the mentioned libraries using your package
 On Ubuntu, you can use `apt`. 
 
 ```
-sudo apt install libboost libjsoncpp-dev libarchive-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential r-base
+sudo apt install libboost libjsoncpp25 libarchive13 autoconf zlib1g zlib1g-dev cmake gfortran build-essential r-base
 ```
 
 > ⚠️ Some of these libraries might not be up-to-date and as a result JASP will complain. If this happens, you need to download, make and install those libraries individually. Alternatively, you can use the [Linux version of Homebrew](https://docs.brew.sh/Homebrew-on-Linux) and install the up-to-dated libraries locally.

--- a/Docs/development/jasp-build-guide-linux.md
+++ b/Docs/development/jasp-build-guide-linux.md
@@ -24,7 +24,7 @@ Based on your system, you can install the mentioned libraries using your package
 On Ubuntu, you can use `apt`. 
 
 ```
-sudo apt install libboost-dev libjsoncpp25 libjsoncpp-dev libarchive13 libarchive-dev libxcb-xkb-dev libxcb-xkb1 libxkbcommon-dev libxkbcommon-x11-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential r-base
+sudo apt install libboost-dev libjsoncpp25 libjsoncpp-dev libarchive13 libarchive-dev libxcb-xkb-dev libxcb-xkb1 libxcb-xinerama0 libxkbcommon-dev libxkbcommon-x11-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential flex libssl-dev libgl1-mesa-dev libsqlite3-dev r-base
 ```
 
 > ⚠️ Some of these libraries might not be up-to-date and as a result JASP will complain. If this happens, you need to download, make and install those libraries individually. Alternatively, you can use the [Linux version of Homebrew](https://docs.brew.sh/Homebrew-on-Linux) and install the up-to-dated libraries locally.

--- a/Docs/development/jasp-build-guide-linux.md
+++ b/Docs/development/jasp-build-guide-linux.md
@@ -24,7 +24,7 @@ Based on your system, you can install the mentioned libraries using your package
 On Ubuntu, you can use `apt`. 
 
 ```
-sudo apt install libboost-dev libjsoncpp25 libjsoncpp-dev libarchive13 libarchive-dev libxcb-xkb-dev libxcb-xkb1 libxcb-xinerama0 libxcb-cursor0 libxkbcommon-dev libxkbcommon-x11-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential flex libssl-dev libgl1-mesa-dev libsqlite3-dev r-base
+sudo apt install libboost-dev libjsoncpp25 libjsoncpp-dev libarchive13 libarchive-dev libxcb-xkb-dev libxcb-xkb1 libxcb-xinerama0 libxcb-cursor0 libxkbcommon-dev libxkbcommon-x11-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential flex libssl-dev libgl1-mesa-dev libsqlite3-dev r-base libglpk-dev
 ```
 
 > ⚠️ Some of these libraries might not be up-to-date and as a result JASP will complain. If this happens, you need to download, make and install those libraries individually. Alternatively, you can use the [Linux version of Homebrew](https://docs.brew.sh/Homebrew-on-Linux) and install the up-to-dated libraries locally.

--- a/Docs/development/jasp-build-guide-linux.md
+++ b/Docs/development/jasp-build-guide-linux.md
@@ -24,7 +24,7 @@ Based on your system, you can install the mentioned libraries using your package
 On Ubuntu, you can use `apt`. 
 
 ```
-sudo apt install libboost-dev libjsoncpp25 libjsoncpp-dev libarchive13 libarchive-dev libxcb-xkb-dev libxcb-xkb1 libxcb-xinerama0 libxkbcommon-dev libxkbcommon-x11-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential flex libssl-dev libgl1-mesa-dev libsqlite3-dev r-base
+sudo apt install libboost-dev libjsoncpp25 libjsoncpp-dev libarchive13 libarchive-dev libxcb-xkb-dev libxcb-xkb1 libxcb-xinerama0 libxcb-cursor0 libxkbcommon-dev libxkbcommon-x11-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential flex libssl-dev libgl1-mesa-dev libsqlite3-dev r-base
 ```
 
 > ⚠️ Some of these libraries might not be up-to-date and as a result JASP will complain. If this happens, you need to download, make and install those libraries individually. Alternatively, you can use the [Linux version of Homebrew](https://docs.brew.sh/Homebrew-on-Linux) and install the up-to-dated libraries locally.

--- a/Docs/development/jasp-build-guide-linux.md
+++ b/Docs/development/jasp-build-guide-linux.md
@@ -24,7 +24,7 @@ Based on your system, you can install the mentioned libraries using your package
 On Ubuntu, you can use `apt`. 
 
 ```
-sudo apt install libboost libjsoncpp25 libarchive13 autoconf zlib1g zlib1g-dev cmake gfortran build-essential r-base
+sudo apt install libboost-dev libjsoncpp25 libjsoncpp-dev libarchive13 libarchive-dev libxcb-xkb-dev libxcb-xkb1 libxkbcommon-dev libxkbcommon-x11-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential r-base
 ```
 
 > ⚠️ Some of these libraries might not be up-to-date and as a result JASP will complain. If this happens, you need to download, make and install those libraries individually. Alternatively, you can use the [Linux version of Homebrew](https://docs.brew.sh/Homebrew-on-Linux) and install the up-to-dated libraries locally.

--- a/Docs/development/jasp-build-guide-linux.md
+++ b/Docs/development/jasp-build-guide-linux.md
@@ -24,7 +24,7 @@ Based on your system, you can install the mentioned libraries using your package
 On Ubuntu, you can use `apt`. 
 
 ```
-sudo apt install boost jsoncpp libarchive autoconf zlib cmake gfortran build-essential r-base
+sudo apt install libboost libjsoncpp-dev libarchive-dev autoconf zlib1g zlib1g-dev cmake gfortran build-essential r-base
 ```
 
 > ⚠️ Some of these libraries might not be up-to-date and as a result JASP will complain. If this happens, you need to download, make and install those libraries individually. Alternatively, you can use the [Linux version of Homebrew](https://docs.brew.sh/Homebrew-on-Linux) and install the up-to-dated libraries locally.


### PR DESCRIPTION
Updates for Debian/Ubuntu distribution, some library names didn't seem to match. 
tested with Ubuntu 22.04 LTS.(you can also search them in the [Debian packages repository](https://www.debian.org/distrib/packages)).

