### PR TITLE
Add SPSS zsav file import support

### DIFF
--- a/Common/utilenums.h
+++ b/Common/utilenums.h
@@ -2,7 +2,7 @@
 #define UTILENUMS_H
 #include "enumutilities.h"
 
-DECLARE_ENUM(FileTypeBase,	jasp = 0, html, csv, txt, tsv, sav, ods, pdf, sas7bdat, sas7bcat, por, xpt, dta, database, empty, unknown );
+DECLARE_ENUM(FileTypeBase,	jasp = 0, html, csv, txt, tsv, sav, zsav, ods, pdf, sas7bdat, sas7bcat, por, xpt, dta, database, empty, unknown );
 
 //const QStringList Database::dbTypes() const should be updated if DbType is changed.
 DECLARE_ENUM(DbType,		NOTCHOSEN, QDB2, /*QIBASE,*/ QMYSQL, QOCI, QODBC, QPSQL, QSQLITE /*, QSQLITE2, QTDS*/ );

--- a/Desktop/data/fileevent.cpp
+++ b/Desktop/data/fileevent.cpp
@@ -117,7 +117,7 @@ const std::string FileEvent::databaseStr() const
 
 QString FileEvent::getProgressMsg() const
 {
-	//jasp = 0, html, csv, txt, tsv, sav, ods, pdf, sas7bdat, sas7bcat, por, xpt, empty, unknown
+	//jasp = 0, html, csv, txt, tsv, sav, zsav, ods, pdf, sas7bdat, sas7bcat, por, xpt, empty, unknown
 	switch(_operation)
 	{
 	case FileEvent::FileOpen:
@@ -128,6 +128,7 @@ QString FileEvent::getProgressMsg() const
 		case Utils::FileType::tsv:
 		case Utils::FileType::ods:		return tr("Importing Data from %1").arg(FileTypeBaseToQString(_type).toUpper());
 		case Utils::FileType::sav:
+		case Utils::FileType::zsav:
 		case Utils::FileType::por:		return tr("Importing SPSS File");
 		case Utils::FileType::xpt:
 		case Utils::FileType::sas7bdat:

--- a/Desktop/data/importers/readstatimporter.cpp
+++ b/Desktop/data/importers/readstatimporter.cpp
@@ -62,7 +62,7 @@ int handle_value_label(const char *val_labels, readstat_value_t value, const cha
 
 bool ReadStatImporter::extSupported(const std::string & ext)
 {
-	static std::set<std::string> supportedExts({"dta", "por", "sav", "sas7bdat", "sas7bcat", "xpt", ".dta", ".por", ".sav", ".sas7bdat", ".sas7bcat", ".xpt"});
+	static std::set<std::string> supportedExts({"dta", "por", "sav", "zsav", "sas7bdat", "sas7bcat", "xpt", ".dta", ".por", ".sav", ".zsav", ".sas7bdat", ".sas7bcat", ".xpt"});
 	return supportedExts.count(ext) > 0;
 }
 
@@ -90,6 +90,7 @@ ImportDataSet* ReadStatImporter::loadFile(const std::string &locator, boost::fun
 	readstat_set_value_label_handler(	parser, &handle_value_label	);
 
 	if		(_ext == "sav")			error = readstat_parse_sav(		parser, locator.c_str(), data);
+	else if	(_ext == "zsav")		error = readstat_parse_sav(		parser, locator.c_str(), data);
 	else if	(_ext == "dta")			error = readstat_parse_dta(		parser, locator.c_str(), data);
 	else if	(_ext == "por")			error = readstat_parse_por(		parser, locator.c_str(), data);
 	else if	(_ext == "sas7bdat")	error = readstat_parse_sas7bdat(parser, locator.c_str(), data);

--- a/Desktop/widgets/filemenu/computer.cpp
+++ b/Desktop/widgets/filemenu/computer.cpp
@@ -39,7 +39,7 @@ FileEvent *Computer::browseOpen(const QString &path)
 	else
 		browsePath = path;
 
-	QString filter = "Data Sets (*.jasp *.csv *.txt *.tsv *.sav *.ods *.dta *.por *.sas7bdat *.sas7bcat *.xpt)";
+	QString filter = "Data Sets (*.jasp *.csv *.txt *.tsv *.sav *.zsav  *.ods *.dta *.por *.sas7bdat *.sas7bcat *.xpt)";
 	if (mode() == FileEvent::FileSyncData)
 		filter = "Data Sets (*.csv *.txt *.tsv *.sav *.ods)";
 

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -152,7 +152,7 @@ void FileMenu::sync()
 						tr("JASP has no associated data file to be synchronized with.\nDo you want to search for such a data file on your computer?\nNB: You can also set this data file via menu File/Sync Data.")))
 				return;
 	
-			path =  MessageForwarder::browseOpenFile(tr("Find Data File"), "", tr("Data File").arg("*.csv *.txt *.tsv *.sav *.ods *.dta *.por *.sas7bdat *.sas7bcat *.xpt"));
+			path =  MessageForwarder::browseOpenFile(tr("Find Data File"), "", tr("Data File").arg("*.csv *.txt *.tsv *.sav *.zsav *.ods *.dta *.por *.sas7bdat *.sas7bcat *.xpt"));
 		}
 	
 		_mainWindow->setCheckAutomaticSync(false);

--- a/Desktop/widgets/filemenu/osffilesystem.cpp
+++ b/Desktop/widgets/filemenu/osffilesystem.cpp
@@ -339,7 +339,7 @@ void OSFFileSystem::gotFilesAndFolders()
 					return false;
 				};
 
-				static const QStringList readStatFormats = {".sav", ".sas7bdat", ".sas7bcat", ".por", ".xpt", ".dta"};
+				static const QStringList readStatFormats = {".sav", ".zsav", ".sas7bdat", ".sas7bcat", ".por", ".xpt", ".dta"};
 
 				if (kind == "folder")									entryType = FileSystemEntry::Folder;
 				else if (endsWith({".jasp"}))							entryType = FileSystemEntry::JASP;


### PR DESCRIPTION
Close https://github.com/jasp-stats/jasp-issues/issues/200

.zsav file is a SPSS .sav like  compressed binary database , now using the implementation of .zsav files in ReadStat, [here](https://github.com/diazbastian/spss-sample-documents/blob/bfcb9795f1398019015d759d7a050c7c0fd0258e/data-files/created-with-spss/demo/demo_zsav.zsav) is a demo file for test.