### PR TITLE
Fix destruction of radiobuttons outside of Form.

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -93,6 +93,7 @@ void Analysis::initAnalysis()
 
 Analysis::~Analysis()
 {
+	setRefreshBlocked(true);
 	if(form())
 		destroyForm();
 

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -157,7 +157,7 @@ ScrollView
 					id:					lightThemeButton
 					label:				qsTr("Light theme")
 					checked:			preferencesModel.currentThemeName === "lightTheme"
-					onCheckedChanged:	preferencesModel.currentThemeName  =  "lightTheme"
+					onCheckedChanged:	if (checked) preferencesModel.currentThemeName  =  "lightTheme"
 					toolTip:			qsTr("Switches to a light theme, this is the default and original flavour of JASP.")
 
 					KeyNavigation.tab:		darkThemeButton
@@ -168,7 +168,7 @@ ScrollView
 					id:					darkThemeButton
 					label:				qsTr("Dark theme")
 					checked:			preferencesModel.currentThemeName === "darkTheme"
-					onCheckedChanged:	preferencesModel.currentThemeName  =  "darkTheme"
+					onCheckedChanged:	if (checked) preferencesModel.currentThemeName  =  "darkTheme"
 					toolTip:			qsTr("Switches to a dark theme, makes JASP a lot easier on the eyes for those night owls out there.")
 					
 					KeyNavigation.tab:		languages

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -35,7 +35,7 @@ void AnalysisBase::destroyForm()
 		_analysisForm->setParent(		nullptr);
 		_analysisForm->setParentItem(	nullptr);
 
-		_analysisForm->deleteLater();
+		delete _analysisForm;
 		_analysisForm = nullptr;
 
 		emit formItemChanged();

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -35,7 +35,7 @@ void AnalysisBase::destroyForm()
 		_analysisForm->setParent(		nullptr);
 		_analysisForm->setParentItem(	nullptr);
 
-		delete _analysisForm;
+		_analysisForm->deleteLater();
 		_analysisForm = nullptr;
 
 		emit formItemChanged();

--- a/QMLComponents/components/JASP/Controls/RadioButtonGroup.qml
+++ b/QMLComponents/components/JASP/Controls/RadioButtonGroup.qml
@@ -85,5 +85,4 @@ RadioButtonsGroupBase
 		z:					-1
 		visible:			preferencesModel.developerMode
 	}
-
 }

--- a/QMLComponents/controls/radiobuttonbase.cpp
+++ b/QMLComponents/controls/radiobuttonbase.cpp
@@ -66,7 +66,7 @@ void RadioButtonBase::registerWithParent()
 
 void RadioButtonBase::unregisterRadioButton()
 {
-	if (_group)
+	if (_group && _form) //On destruction of static buttons outside of form values would change in RadioButtonGroup
 		_group->unregisterRadioButton(this);
 }
 


### PR DESCRIPTION
Fixes the Theme Buttons. 
Fixes RadioButtons outside of form
Disables bound value updates upon start of form deletion.

Note:
Dynamic radiobuttongroups outside of form will change value upon deletion of internal buttons. Use dropdown instead. 
