### PR TITLE
Add tooltip for checkbox and radiobutton

### DIFF
--- a/QMLComponents/components/JASP/Controls/CheckBox.qml
+++ b/QMLComponents/components/JASP/Controls/CheckBox.qml
@@ -49,6 +49,7 @@ CheckBoxBase
 			property alias	columns:				childControlsArea.columns
 			property bool	enableChildrenOnChecked: true
 			property bool	forwardKeys:			false
+			property string toolTip: 				""
 
 	function click()	{ control.toggle(); }
 	function toggle()	{ control.toggle(); }
@@ -67,7 +68,12 @@ CheckBoxBase
 		Keys.forwardTo:			forwardKeys ? [checkBox] : [] // If a forward is set on the parent we want to hook on that chain, eg modules menu
 
 		// When the user clicks on the CheckBox, the clicked signal of the parent (CheckBoxBase) must be emitted.
-		Component.onCompleted: control.clicked.connect(checkBox.clicked)
+		Component.onCompleted: 	control.clicked.connect(checkBox.clicked)
+
+        ToolTip.text:			checkBox.toolTip
+        ToolTip.timeout:		jaspTheme.toolTipTimeout
+        ToolTip.delay:			jaspTheme.toolTipDelay
+        ToolTip.visible:		checkBox.toolTip !== "" && hovered
 
 		indicator: Rectangle
 		{

--- a/QMLComponents/components/JASP/Controls/RadioButton.qml
+++ b/QMLComponents/components/JASP/Controls/RadioButton.qml
@@ -47,6 +47,7 @@ RadioButtonBase
 	property alias	columns:				childControlsArea.columns
 	property bool	enableChildrenOnChecked: true
 	property bool	indentChildren:			true
+	property string toolTip: 				""
 
 	function click() { clicked(); }
 	onClicked: { radioButton.clickHandler(); }
@@ -59,6 +60,11 @@ RadioButtonBase
 		focus:				true
 
 		onCheckedChanged:	if (checked) radioButton.clicked()
+
+		ToolTip.text:		radioButton.toolTip
+        ToolTip.timeout:	jaspTheme.toolTipTimeout
+        ToolTip.delay:		jaspTheme.toolTipDelay
+        ToolTip.visible:	radioButton.toolTip !== "" && hovered
 
 		indicator: Rectangle
 		{


### PR DESCRIPTION
This may fix tooltip text was not showing in preference buttons,such as [here](https://github.com/jasp-stats/jasp-desktop/blob/03ed0bfb070731694e7f4ef8ab650e8d3c5000aa/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml#L140)