### PR TITLE
Make sure editing is quick and analyses are hidden in dataMode

### DIFF
--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -39,7 +39,7 @@ Item
 	// position of the rest)
 
 	property bool hasData:		mainWindow.dataAvailable
-	property bool hasAnalysis:	mainWindow.analysesAvailable
+	property bool hasAnalysis:	mainWindow.analysesAvailable && !ribbonModel.dataMode
 
 	function minimizeDataPanel()
 	{

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -963,9 +963,7 @@ void EngineSync::heartbeatTempFiles()
 }
 
 void EngineSync::stopEngines()
-{
-	_stopProcessing = true; 
-	
+{	
 	auto timeout = QDateTime::currentSecsSinceEpoch() + 10;
 
 	for(EngineRepresentation * e : _engines)
@@ -1030,8 +1028,6 @@ void EngineSync::resumeEngines()
 	for(EngineRepresentation * engine : _engines)
 		startStoppedEngine(engine);
 	
-	_stopProcessing = false;
-
 	while(!allEnginesResumed())
 		for (auto * engine : _engines)
 			engine->processReplies();
@@ -1071,13 +1067,19 @@ bool EngineSync::allEnginesInitializing(std::set<EngineRepresentation *> these)
 
 void EngineSync::dataModeChanged(bool dataMode)
 {
+	_stopProcessing = dataMode;
+
 	if(!dataMode)
 	{
-		Log::log() << "Data mode turned off, so restarting engines." << std::endl;
-
-		pauseEngines();
+		Log::log() << "Data mode turned off, resuming engines." << std::endl;
 		resumeEngines();
 	}
+	else
+	{
+		Log::log() << "Data mode turned on, pausing engines." << std::endl;
+		pauseEngines();
+	}
+
 }
 
 void EngineSync::enginesPrepareForData()

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -652,6 +652,12 @@ void MainWindow::setCurrentJaspTheme()
 	_qml->rootContext()->setContextProperty("jaspTheme", JaspTheme::currentTheme());
 }
 
+void MainWindow::onDataModeChanged(bool dataMode)
+{
+	if(dataMode && welcomePageVisible())
+		setWelcomePageVisible(false);
+}
+
 void MainWindow::initLog()
 {
 	assert(_engineSync != nullptr && _preferences != nullptr);

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -237,7 +237,7 @@ private slots:
 
 	void resetQmlCache();
 	void setCurrentJaspTheme();
-	void onDataModeChanged(bool dataMode) { if(dataMode && welcomePageVisible()) setWelcomePageVisible(false); }
+	void onDataModeChanged(bool dataMode);
 	void printQmlWarnings(const QList<QQmlError> &warnings);
 	void setQmlImportPaths();
 


### PR DESCRIPTION
This should make entering data into data-editing mode pretty much instantaneous again.
Also hides analyses+results if editing.

However, the "new data" dialog still fails to properly register the rowcount if you:
1. Enter columncount
2. click in textfield rows
3. enter rowcount
4. press "Resize"

It the ignores the rowcount, but this is a) not a big problem as the workaround is either tabbing to "Resize" or simply clicking in "Columns textfield" first. But if Bruno sees a nice way to fix this it would be good ofc

This is all to help @JTPetter create a build for the SKF/QC version.