### PR TITLE
Fix for export issue on darktheme

### DIFF
--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -282,11 +282,13 @@ Item
 
 				function onExportToPDF(pdfPath)
 				{
-					if(preferencesModel.currentThemeName !== "lightTheme")
-						resultsJsInterface.setThemeCss("lightTheme");
-
-					resultsJsInterface.unselect(); //Otherwise we get the selected analysis highlighted in the pdf...
 					resultsView.printToPdf(pdfPath);
+				}
+
+				function onPrepForExport()
+				{
+					//set light theme and unselect
+					resultsView.runJavaScript("window.unselect(); window.setTheme(\"lightTheme\");", function() { resultsJsInterface.exportPrepFinished(); });
 				}
 			}
 			onPdfPrintingFinished: (filePath)=>

--- a/Desktop/data/exporters/resultexporter.h
+++ b/Desktop/data/exporters/resultexporter.h
@@ -32,7 +32,12 @@ public:
 	void saveDataSet(const std::string &path, boost::function<void (int)> progressCallback) OVERRIDE;
 
 private:
+	bool prepareForExport();
+
+private:
 	QString			_pdfPath;
+	QMutex			_exportPrepMutex;
+	QWaitCondition	_exportPrep;
 	QMutex			_writingToPdfMutex;
 	QWaitCondition	_writingToPdf;
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -985,14 +985,6 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 	else if (event->operation() == FileEvent::FileExportResults)
 	{
 		connectFileEventCompleted(event);
-
-		if(!event->path().endsWith(".pdf"))
-		{
-			if(_preferences->currentThemeName() != "lightTheme")
-				_resultsJsInterface->setThemeCss("lightTheme");
-			_resultsJsInterface->exportHTML();
-		}
-
 		_loader->io(event);
 		showProgress();
 	}

--- a/Desktop/results/resultsjsinterface.h
+++ b/Desktop/results/resultsjsinterface.h
@@ -86,6 +86,9 @@ signals:
 	Q_INVOKABLE void removeAllAnalyses();
 	Q_INVOKABLE void pdfPrintingFinished(	QString pdfPath);
 	Q_INVOKABLE void exportToPDF(			QString pdfPath);
+	void prepForExport();
+	Q_INVOKABLE void exportPrepFinished();
+
 
 public slots:
 	void resultsDocumentChanged()		{ emit packageModified(); }


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/jasp-issues/issues/2031

Its an ugly fix since waiting is an anti pattern.
I wait for theme change and unset for results JS.
It doesn't seem to always work for unset somehow, so I add a small wait on the export thread.
Overall not a clean fix but it works.