### PR TITLE
Fix for options clear upon translation

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -340,10 +340,10 @@ void Analyses::rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * mod
 				Analysis * a = keyval.second;
 
 				//This function is called once after 300 ms upon translation due to delayedUpdate in description
-				//and causes the set analysis options to be cleared without this additional boolean
-				if(a->readyToCreateForm() && !a->justTranslated())
+				//and causes the set analysis options to be cleared without this additional flag check set at the start of translations
+				if(a->readyToCreateForm() && !a->beingTranslated())
 					a->createForm();
-				a->aboutToBeTranslated(false);
+				a->setBeingTranslated(false);
 			}
 		}
 
@@ -767,7 +767,7 @@ void Analyses::prepareForLanguageChange()
 {
 	applyToAll([&](Analysis * a)
 	{ 
-		a->aboutToBeTranslated(true);
+		a->setBeingTranslated(true);
 		a->setRefreshBlocked(true); 
 		a->abort();
 	});

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -339,6 +339,8 @@ void Analyses::rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * mod
 			{
 				Analysis * a = keyval.second;
 
+				//This function is called once after 300 ms upon translation due to delayedUpdate in description
+				//and causes the set analysis options to be cleared without this additional boolean
 				if(a->readyToCreateForm() && !a->justTranslated())
 					a->createForm();
 				a->aboutToBeTranslated(false);

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -339,8 +339,9 @@ void Analyses::rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * mod
 			{
 				Analysis * a = keyval.second;
 
-				if(a->readyToCreateForm())
+				if(a->readyToCreateForm() && !a->justTranslated())
 					a->createForm();
+				a->setJustTranslated(false);
 			}
 		}
 
@@ -775,6 +776,7 @@ void Analyses::languageChangedHandler()
 	applyToAll([&](Analysis * a)
 	{
 		a->setRefreshBlocked(false);
+		a->setJustTranslated(true);
 		emit a->form()->languageChanged();
 	});
 	refreshAllAnalyses();

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -341,7 +341,7 @@ void Analyses::rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * mod
 
 				if(a->readyToCreateForm() && !a->justTranslated())
 					a->createForm();
-				a->setJustTranslated(false);
+				a->aboutToBeTranslated(false);
 			}
 		}
 
@@ -765,6 +765,7 @@ void Analyses::prepareForLanguageChange()
 {
 	applyToAll([&](Analysis * a)
 	{ 
+		a->aboutToBeTranslated(true);
 		a->setRefreshBlocked(true); 
 		a->abort();
 	});
@@ -776,7 +777,6 @@ void Analyses::languageChangedHandler()
 	applyToAll([&](Analysis * a)
 	{
 		a->setRefreshBlocked(false);
-		a->setJustTranslated(true);
 		emit a->form()->languageChanged();
 	});
 	refreshAllAnalyses();

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -339,6 +339,8 @@ void Analysis::createForm(QQuickItem* parentItem)
 
 		emit analysisInitialized();
 	}
+
+	_lastQmlFormPath = qmlFormPath(false, true); //dont leave this uninitialized
 }
 
 Analysis::Status Analysis::analysisResultsStatusToAnalysisStatus(analysisResultStatus result)

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -116,8 +116,8 @@ public:
 			bool				isDuplicate()		const	override	{ return _isDuplicate;						}
 			bool				utilityRunAllowed() const				{ return  isSaveImg() || isEditImg() || isRewriteImgs();							}
 			bool				shouldRun()								{ return !isWaitingForModule() && ( utilityRunAllowed() || isEmpty() ) && form();	}
-			bool				justTranslated()                        { return _justTranslated; };
-			void				setJustTranslated(bool value)           { _justTranslated = value; };
+			bool				justTranslated()                        { return _aboutToBeTranslated; };
+			void				aboutToBeTranslated(bool value)           { _aboutToBeTranslated = value; };
 	const	Json::Value		&	resultsMeta()		const	override	{ return _resultsMeta;						}
 			void				setTitle(const std::string& title)	override;
 			void				run()						override;
@@ -244,7 +244,7 @@ private:
 								_wasUpgraded					= false,
 								_tryToFixNotes					= false,
 								_hasReport						= false,
-								_justTranslated					= false;
+	_aboutToBeTranslated					= false;
 	int							_revision						= 0;
 
 	Modules::AnalysisEntry	*	_moduleData						= nullptr;

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -116,6 +116,8 @@ public:
 			bool				isDuplicate()		const	override	{ return _isDuplicate;						}
 			bool				utilityRunAllowed() const				{ return  isSaveImg() || isEditImg() || isRewriteImgs();							}
 			bool				shouldRun()								{ return !isWaitingForModule() && ( utilityRunAllowed() || isEmpty() ) && form();	}
+			bool				justTranslated()                        { return _justTranslated; };
+			void				setJustTranslated(bool value)           { _justTranslated = value; };
 	const	Json::Value		&	resultsMeta()		const	override	{ return _resultsMeta;						}
 			void				setTitle(const std::string& title)	override;
 			void				run()						override;
@@ -123,7 +125,6 @@ public:
 			void				reloadForm()				override;
 			void				exportResults()				override;
 			void				remove();
-
 			Json::Value			asJSON(bool withRSources = false)	const;
 			void				checkDefaultTitleFromJASPFile(	const Json::Value & analysisData);
 			void				loadResultsUserdataAndRSourcesFromJASPFile(const Json::Value & analysisData, Status status);
@@ -242,7 +243,8 @@ private:
 	bool						_isDuplicate					= false,
 								_wasUpgraded					= false,
 								_tryToFixNotes					= false,
-								_hasReport						= false;
+								_hasReport						= false,
+								_justTranslated					= false;
 	int							_revision						= 0;
 
 	Modules::AnalysisEntry	*	_moduleData						= nullptr;

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -116,8 +116,8 @@ public:
 			bool				isDuplicate()		const	override	{ return _isDuplicate;						}
 			bool				utilityRunAllowed() const				{ return  isSaveImg() || isEditImg() || isRewriteImgs();							}
 			bool				shouldRun()								{ return !isWaitingForModule() && ( utilityRunAllowed() || isEmpty() ) && form();	}
-			bool				justTranslated()                        { return _aboutToBeTranslated; };
-			void				aboutToBeTranslated(bool value)           { _aboutToBeTranslated = value; };
+			bool				beingTranslated()                        { return _beingTranslated; };
+			void				setBeingTranslated(bool value)           { _beingTranslated = value; };
 	const	Json::Value		&	resultsMeta()		const	override	{ return _resultsMeta;						}
 			void				setTitle(const std::string& title)	override;
 			void				run()						override;
@@ -244,7 +244,7 @@ private:
 								_wasUpgraded					= false,
 								_tryToFixNotes					= false,
 								_hasReport						= false,
-	_aboutToBeTranslated					= false;
+								_beingTranslated				= false;
 	int							_revision						= 0;
 
 	Modules::AnalysisEntry	*	_moduleData						= nullptr;


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/2262

Its not a nice solution but its pragmatic.
A nice fix would be quite involved due to a delayed signal in description.cpp that other parts seem to require.