### PR TITLE
Make sure install to ProgramFiles64Folder

### DIFF
--- a/Tools/wix/JASP.wxs
+++ b/Tools/wix/JASP.wxs
@@ -9,7 +9,7 @@
 	<?define ApplicationName="JASP $(var.VersionNumber)" ?>
 
 	<Product Id="*" Name="$(var.ApplicationName)" Language="1033" Version="$(var.VersionNumber)" Manufacturer="Universiteit van Amsterdam" UpgradeCode="$(var.UpgradeCode)">
-		<Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine"/>
+		<Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" Platform="x64"/>
 		<Media Id="1" Cabinet="media1.cab" EmbedCab="yes" CompressionLevel="high"/>
 
 		<Upgrade Id="$(var.UpgradeCode)">
@@ -39,7 +39,7 @@
 
 	<Directory Id="TARGETDIR" Name="SourceDir">
 
-		<Directory Id="ProgramFilesFolder">
+		<Directory Id="ProgramFiles64Folder">
 			<Directory Id="APPLICATIONFOLDER" Name="JASP">
 				<!-- files added in JASPFilesFragment.wxs -->
 			</Directory>


### PR DESCRIPTION
Related to https://github.com/jasp-stats/jasp-issues/issues/1974

I've had this problem before, maybe more efficient to do like this. although I think it's not a big deal to install in `C:\Program Files (x86)\ ` path.

While testing, also need to pay attention to whether msi installer can find the existing old version installation when uninstalling and upgrading:-)