### PR TITLE
Fix helpbutton in RM ANOVA

### DIFF
--- a/QMLComponents/components/JASP/Controls/Form.qml
+++ b/QMLComponents/components/JASP/Controls/Form.qml
@@ -31,6 +31,8 @@ AnalysisForm
 	
 	default property alias	content		: contentArea.children
 	property alias	form				: form
+	property alias	jaspForm			: form
+	property alias	jaspAnalysis		: form.analysis
 	property alias	_contentArea		: contentArea
 	property real	minimumYMsgs		: warningMessagesBox.height + warningMessagesBox.y
 	property int	majorVersion		: 1

--- a/QMLComponents/components/JASP/Controls/HelpButton.qml
+++ b/QMLComponents/components/JASP/Controls/HelpButton.qml
@@ -31,5 +31,5 @@ MenuButton
 	buttonPadding:		2 * preferencesModel.uiScale
 	_scaledDim:			22 * preferencesModel.uiScale
 	Layout.alignment: 	Qt.AlignRight
-	onClicked: 			helpModel.showOrToggleParticularPageForAnalysis(analysis, helpPage)
+	onClicked: 			helpModel.showOrToggleParticularPageForAnalysis(jaspAnalysis, helpPage)
 }


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/2265

ANOVA declares a property "analysis", due to this the form property "analysis" can not be reached by internal components (it also defines an id "form" :( ).

We should discourage the use of names in Modules of form properties we reference in QML components or we should alias them as jaspPropertyName in form.qml as I propose in this PR.
