### PR TITLE
Fix analysis title paste overwriting in result page

### DIFF
--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -827,7 +827,7 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 
 		element.focus();
 
-		element.on("paste", function (event) {
+		element.on("focus", "paste", function (event) {
 			var pastedData = event.originalEvent.clipboardData.getData('text/plain');
 			this.innerHTML = pastedData;
 			event.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/638
Fixes https://github.com/jasp-stats/jasp-issues/issues/1612

Analysis title edit should always get focus when pasting.