### PR TITLE
Set a default value for the value property of a Text/Integer/Double Field

### DIFF
--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -49,7 +49,7 @@ public:
 	QString			friendlyName() const override;
 	bool			hasScriptError()						const	{ return _hasScriptError;		}
 	QVariant		defaultValue()							const	{ return _defaultValue;			}
-	QVariant		value()									const	{ return _value;				}
+	QVariant		value()									const	{ return _value.isNull() ? _defaultValue : _value; } // Sometimes the value is asked before the control is setup, so in this case give the default value
 
 	const QString &label()									const	{ return _label;				}
 	const QString &afterLabel()								const	{ return _afterLabel;			}


### PR DESCRIPTION
Text/Integer/Double Field value when the control is setup, but the value property can be used before it is setup (in a QML binding). In this case just give the defaultValue. 
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2273

