### PR TITLE
[WIP] Update supported win OS for installer

### DIFF
--- a/Tools/wix/JASP.wxs
+++ b/Tools/wix/JASP.wxs
@@ -22,9 +22,12 @@
 		<Merge Id="VCRedist" SourceFile="$(var.RedistMergeModule)" DiskId="1" Language="0"/>
 	</DirectoryRef>
 
-	<Condition Message="JASP only supports Windows 7 and newer!">
-		<![CDATA[Installed OR (VersionNT >= 601)]]>
+	<Condition Message="JASP is only supported on Windows 10 or newer!">
+		<![CDATA[Installed OR (VersionNT64 >= 1000)]]>
 	</Condition>
+
+	<Condition Message="This application is only supported on 64 bit x86 platforms."> 
+		 %PROCESSOR_ARCHITECTURE="AMD64" 
 
 	<CustomAction Id="NewerVersionFound" Error="A newer version of JASP is already installed!" />
 	<InstallExecuteSequence>

--- a/Tools/wix/JASP.wxs
+++ b/Tools/wix/JASP.wxs
@@ -23,7 +23,7 @@
 	</DirectoryRef>
 
         <Condition Message="JASP is only supported on Windows 10 version 1809 or newer!">
-                <![CDATA[Installed OR (VersionNT >= 603)]]>
+                <![CDATA[Installed OR (VersionNT >= 1000)]]>
         </Condition>
         
         <Condition Message="JASP can only be installed on 64-bit OS.">

--- a/Tools/wix/JASP.wxs
+++ b/Tools/wix/JASP.wxs
@@ -22,12 +22,13 @@
 		<Merge Id="VCRedist" SourceFile="$(var.RedistMergeModule)" DiskId="1" Language="0"/>
 	</DirectoryRef>
 
-	<Condition Message="JASP is only supported on Windows 10 or newer!">
-		<![CDATA[Installed OR (VersionNT64 >= 1000)]]>
-	</Condition>
-
-	<Condition Message="This application is only supported on 64 bit x86 platforms."> 
-		 %PROCESSOR_ARCHITECTURE="AMD64" 
+        <Condition Message="JASP is only supported on Windows 10 version 1809 or newer!">
+                <![CDATA[Installed OR (VersionNT >= 603)]]>
+        </Condition>
+        
+        <Condition Message="JASP can only be installed on 64-bit OS.">
+          <![CDATA[VersionNT64]]>
+        </Condition>
 
 	<CustomAction Id="NewerVersionFound" Error="A newer version of JASP is already installed!" />
 	<InstallExecuteSequence>


### PR DESCRIPTION
Sould avoid https://github.com/jasp-stats/jasp-issues/issues/2061 and https://github.com/jasp-stats/jasp-issues/issues/1822 during install step but not a crash or something.

Could you trigger a build for this before merge? I will have a test on VM for OS support, I don't have a arm CPU ...