### PR TITLE
R syntax in results

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -704,6 +704,16 @@ void Analyses::moveAnalysesResults(Analysis* fromAnalysis, int index)
 		emit moveAnalyses(fromAnalysis->id(), toAnalysis->id());
 }
 
+void Analyses::showRSyntaxInResults(bool show)
+{
+	Settings::setValue(Settings::SHOW_RSYNTAX_IN_RESULTS, show);
+
+	applyToAll([&](Analysis * a)
+	{
+		a->setRSyntaxTextInResult();
+	});
+}
+
 void Analyses::analysisTitleChangedInResults(int id, QString title)
 {
 	Analysis * analysis = get(id);

--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -136,6 +136,7 @@ public slots:
 	void resultsMetaChanged(QString json);
 	void allUserDataChanged(QString json);
 	void moveAnalysesResults(Analysis* fromAnalysis, int index);
+	void showRSyntaxInResults(bool show);
 
 signals:
 	void analysesUnselected();

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -331,9 +331,9 @@ void Analysis::createForm(QQuickItem* parentItem)
 		connect(this,					&Analysis::refreshTableViewModels,	_analysisForm,	&AnalysisForm::refreshTableViewModels		);
 		connect(this, 					&Analysis::titleChanged,			_analysisForm,	&AnalysisForm::titleChanged					);
 		connect(this,					&Analysis::needsRefreshChanged,		_analysisForm,	&AnalysisForm::needsRefreshChanged			);
-		connect(this,					&Analysis::boundValuesChanged,		_analysisForm,	&AnalysisForm::setRSyntaxText,		Qt::QueuedConnection	);
-		connect(this,					&Analysis::boundValuesChanged,		this,			&Analysis::setRSyntaxTextInResult,	Qt::QueuedConnection	);
+		connect(this,					&Analysis::boundValuesChanged,		this,			&Analysis::setRSyntaxTextInResult,		Qt::QueuedConnection	);
 
+		setRSyntaxTextInResult();
 		_analysisForm->setShowRButton(_moduleData->hasWrapper());
 		_analysisForm->setDeveloperMode(_dynamicModule->isDevMod());
 
@@ -1016,7 +1016,7 @@ void Analysis::analysisQMLFileChanged()
 
 void Analysis::setRSyntaxTextInResult()
 {
-	if (!form() || !_moduleData->hasWrapper()) return;
+	if (!form() || !_moduleData->hasWrapper() || !form()->initialized()) return;
 
 	bool generateRSyntax = Settings::value(Settings::SHOW_RSYNTAX_IN_RESULTS).toBool();
 	ResultsJsInterface::singleton()->setRSyntax(id(), generateRSyntax ? form()->generateRSyntax(true) : "");

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -193,6 +193,7 @@ public slots:
 	void					requestColumnCreationHandler(			const std::string & columnName, columnType colType)	override	{ emit requestColumnCreation(columnName, this, colType); }
 	void					requestComputedColumnDestructionHandler(const std::string & columnName)						override;
 	void					analysisQMLFileChanged();
+	void					setRSyntaxTextInResult();
 
 protected:
 	void					abort();

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
@@ -142,10 +142,29 @@ ScrollView
 					onCheckedChanged:	preferencesModel.whiteBackground = !checked
 					toolTip:			qsTr("This makes the background of all plots transparent, quite useful if you want to use it seamlessly on any background that isn't white.")
 
-					KeyNavigation.tab:		displayExactPVals
+					KeyNavigation.tab:		showRSyntaxInResults
 				}
 			}
 		}
+
+		PrefsGroupRect
+		{
+			title:				qsTr("Miscellaneous options")
+
+			CheckBox
+			{
+				id:					showRSyntaxInResults
+				label:				qsTr("Show R syntax")
+				checked:			preferencesModel.showRSyntaxInResults
+				onCheckedChanged:	preferencesModel.showRSyntaxInResults = checked
+				height:				implicitHeight * preferencesModel.uiScale
+				toolTip:			qsTr("Add R syntax for each analysis")
+				focus:				true
+
+				KeyNavigation.tab:		displayExactPVals
+			}
+		}
+
 
 		Item
 		{

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -342,6 +342,7 @@ Item
 				function setResultsMetaFromJavascript(json)			{ resultsJsInterface.setResultsMetaFromJavascript(json)			}
 				function duplicateAnalysis(id)						{ resultsJsInterface.duplicateAnalysis(id)						}
 				function showDependenciesInAnalysis(id, optName)	{ resultsJsInterface.showDependenciesInAnalysis(id, optName)	}
+				function showRSyntaxInResults(show)					{ resultsJsInterface.showRSyntaxInResults(show)					}
 
 				function showAnalysesMenu(options)
 				{

--- a/Desktop/gui/preferencesmodel.cpp.in
+++ b/Desktop/gui/preferencesmodel.cpp.in
@@ -126,6 +126,7 @@ GET_PREF_FUNC_BOOL( guiQtTextRender,			Settings::GUI_USE_QT_TEXTRENDER						)
 GET_PREF_FUNC_BOOL( reportingMode,				Settings::REPORT_SHOW								)
 GET_PREF_FUNC_BOOL( showRSyntax,				Settings::SHOW_RSYNTAX								)
 GET_PREF_FUNC_BOOL( showAllROptions,			Settings::SHOW_ALL_R_OPTIONS						)
+GET_PREF_FUNC_BOOL( showRSyntaxInResults,		Settings::SHOW_RSYNTAX_IN_RESULTS					)
 
 int PreferencesModel::maxEngines() const
 {
@@ -305,6 +306,7 @@ SET_PREF_FUNCTION(				bool,		setGuiQtTextRender,			guiQtTextRender,			guiQtTextR
 SET_PREF_FUNCTION(				bool,		setReportingMode,			reportingMode,				reportingModeChanged,			Settings::REPORT_SHOW								)
 SET_PREF_FUNCTION_EMIT_NO_ARG(	bool,		setShowRSyntax,				showRSyntax,				showRSyntaxChanged,				Settings::SHOW_RSYNTAX								)
 SET_PREF_FUNCTION_EMIT_NO_ARG(	bool,		setShowAllROptions,			showAllROptions,			showAllROptionsChanged,			Settings::SHOW_ALL_R_OPTIONS						)
+SET_PREF_FUNCTION(				bool,		setShowRSyntaxInResults,	showRSyntaxInResults,		showRSyntaxInResultsChanged,	Settings::SHOW_RSYNTAX_IN_RESULTS					)
 
 void PreferencesModel::setGithubPatCustom(QString newPat)
 {

--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -68,6 +68,7 @@ class PreferencesModel : public PreferencesModelBase
 	Q_PROPERTY(bool			reportingMode			READ reportingMode				WRITE setReportingMode				NOTIFY reportingModeChanged				)
 	Q_PROPERTY(bool			showRSyntax				READ showRSyntax				WRITE setShowRSyntax				NOTIFY showRSyntaxChanged				)
 	Q_PROPERTY(bool			showAllROptions			READ showAllROptions			WRITE setShowAllROptions			NOTIFY showAllROptionsChanged			)
+	Q_PROPERTY(bool			showRSyntaxInResults	READ showRSyntaxInResults		WRITE setShowRSyntaxInResults		NOTIFY showRSyntaxInResultsChanged		)
 
 
 public:
@@ -128,6 +129,7 @@ public:
 	bool		reportingMode()							const;
 	bool		showRSyntax()							const override;
 	bool		showAllROptions()						const override;
+	bool		showRSyntaxInResults()					const;
 	void		zoomIn();
 	void		zoomOut();
 	void		zoomReset();
@@ -189,6 +191,7 @@ public slots:
 	void setReportingMode(				bool		reportingMode);
 	void setShowRSyntax(				bool		showRSyntax)					override;
 	void setShowAllROptions(			bool		showAllROptions)				override;
+	void setShowRSyntaxInResults(		bool		showRSyntax);
 	void currentThemeNameHandler();
 	
 signals:
@@ -238,6 +241,7 @@ signals:
 	void dataLabelNAChanged(			QString		dataLabelNA);
 	void guiQtTextRenderChanged(		bool		guiQtTextRender);
 	void reportingModeChanged(			bool		reportingMode);
+	void showRSyntaxInResultsChanged(	bool		showRSyntax);
 
 private slots:
 	void dataLabelNAChangedSlot(QString label);

--- a/Desktop/html/css/darkTheme-jasp.css
+++ b/Desktop/html/css/darkTheme-jasp.css
@@ -202,6 +202,10 @@ div.jasp-image-image.no-data.error {
   color:			#5c5c5c;
 }
 
+.jasp-rsyntax-container {
+    background-color: #555
+}
+
 
 /* Track */
 ::-webkit-scrollbar-track {

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -561,6 +561,13 @@ pre {
     font-style: italic;
 }
 
+.jasp-rsyntax-container {
+    padding-left: 0.6em;
+    padding-top: 0.3em;
+    padding-bottom: 0.3em;
+    border-style: ridge;
+}
+
 /*.jasp-indent {
 	margin-left: .5em ;
 	padding-left: 0.8em ;

--- a/Desktop/html/css/lightTheme-jasp.css
+++ b/Desktop/html/css/lightTheme-jasp.css
@@ -210,6 +210,9 @@ div.jasp-image-image.no-data.error {
 	color: gray;
 }
 
+.jasp-rsyntax-container {
+    background-color: rgb(235, 235, 235);
+}
 
 /* Track */
 ::-webkit-scrollbar-track {

--- a/Desktop/html/js/analysis.js
+++ b/Desktop/html/js/analysis.js
@@ -621,6 +621,8 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 		this.destroyViews();
 
+		this.views.push(this.rSyntaxView)
+
 		this.views.push(this.viewNotes.firstNoteNoteBox);
 
 		$innerElement.empty();

--- a/Desktop/html/js/analysis.js
+++ b/Desktop/html/js/analysis.js
@@ -104,6 +104,9 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		this.model.on("ShowDependencies:clicked",	function (optName)			{											this.trigger("showDependencies",	this.model.get("id"), optName)	},	this);
 
 		this.$el.on("changed:userData",	this, this.onUserDataChanged);
+
+		var rSyntaxModel = new JASPWidgets.RSyntaxModel({analysis: this});
+		this.rSyntaxView = new JASPWidgets.RSyntaxView({ model: rSyntaxModel})
 	},
 
 	onUserDataChanged: function (event, details, dataValues) {
@@ -644,6 +647,9 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		this.viewNotes.firstNoteNoteBox.render();
 		$innerElement.prepend(this.viewNotes.firstNoteNoteBox.$el);
 
+		this.rSyntaxView.render();
+		$innerElement.prepend(this.rSyntaxView.$el);
+
 		this.toolbar.setStatus(this.model.get("status"));
 		this.toolbar.render();
 		$innerElement.prepend(this.toolbar.$el);
@@ -657,6 +663,14 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 			this.setHeightErroredAnalysis($innerElement);
 
 		return this;
+	},
+
+	setRSyntax: function(syntax) {
+		if (syntax) {
+			this.rSyntaxView.setScript(syntax);
+			this.rSyntaxView.setVisibility(true)
+		} else
+			this.rSyntaxView.setVisibility(false)
 	},
 
 	unselect: function () {

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -972,6 +972,7 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 			hasRemoveAllAnalyses:	parent.menuName			=== 'All',
 			hasRefreshAllAnalyses:	parent.menuName			=== 'All',
 			hasExportResults:		parent.menuName			=== 'All',
+			hasShowRSyntax:			parent.menuName			=== 'All',
 
 			objectName:				parent.menuName
 		};
@@ -1008,6 +1009,73 @@ JASPWidgets.Toolbar = JASPWidgets.View.extend({
 		this.setFixedness(0);
 	}
 })
+
+JASPWidgets.RSyntaxModel = Backbone.Model.extend({
+	defaults: {
+		analysis: {},
+		script: ""
+	},
+	getFromAnalysis: function(item) {
+		return this.attributes.analysis.model.get(item);
+	}
+
+});
+
+JASPWidgets.RSyntaxView = JASPWidgets.View.extend({
+	initialize: function() {
+		this.$el.addClass("jasp-rsyntax-container");
+		this.$el.addClass("jasp-hide");
+		this.$el.addClass("jasp-code");
+		this._insertRSyntax()
+	},
+	setVisibility: function (value) {
+		var self = this;
+		self.$el.css("opacity", value ? 0 : 1);
+
+		if (value === true) {
+			self.$el.slideDown(200, function () {
+				self._setVisibility(value);
+				self.$el.animate({ "opacity": 1 }, 200, "easeOutCubic", function () {
+					window.scrollIntoView(self.$el, function () {});
+				});
+			});
+		}
+		else {
+			self.$el.slideUp(200, function () {
+				self._setVisibility(value);
+			});
+		}
+	},
+
+	_setVisibility: function(value) {
+		this.visible = value
+		if (value)
+			this.$el.removeClass('jasp-hide');
+		else
+			this.$el.addClass('jasp-hide');
+	},
+	render: function() {
+		this.$el.find(".jasp-rsyntax").html(this.model.get("script"));
+		return this;
+	},
+	_insertRSyntax: function() {
+		$script = $("<span/>");
+		$script.attr({
+		  class: "jasp-rsyntax",
+		  id: "rsyntax-" + this.model.getFromAnalysis("id")
+		});
+
+		this.$el.append($script);
+	},
+	setScript: function(value) {
+		this.model.set("script", value);
+		this.render();
+	},
+	clear: function() {
+		this.$el.empty();
+		this.initialize();
+	}
+});
 
 JASPWidgets.Progressbar = Backbone.Model.extend({
 	defaults: {

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -1074,7 +1074,31 @@ JASPWidgets.RSyntaxView = JASPWidgets.View.extend({
 	clear: function() {
 		this.$el.empty();
 		this.initialize();
+	},
+
+	exportBegin: function (exportParams, completedCallback) {
+		if (exportParams == undefined)
+			exportParams = new JASPWidgets.Exporter.params();
+		else if (exportParams.error)
+			return false;
+
+		var callback = this.exportComplete;
+		if (completedCallback !== undefined)
+			callback = completedCallback;
+
+		var html = '';
+		if (this.visible === true) {
+			html += '<div ' + JASPWidgets.Exporter.getStyles(this.$el, ["padding", "border", "background-color", "font-size", "font", "font-weight", "display"]) + '>' + this.$el.get(0).innerHTML + '</div>';
+		}
+
+		callback.call(this, exportParams, new JASPWidgets.Exporter.data(null, html));
+	},
+
+	exportComplete: function (exportParams, exportContent) {
+		if (!exportParams.error)
+			pushHTMLToClipboard(exportContent, exportParams);
 	}
+
 });
 
 JASPWidgets.Progressbar = Backbone.Model.extend({

--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -159,7 +159,16 @@ $(document).ready(function () {
 		window.menuObject = null;
 	}
 
+	window.showRSyntaxClicked = function (show) {
+		jasp.showRSyntaxInResults(show);
+	}
 
+	window.setRSyntaxText = function (id, syntax) {
+		var analysis = analyses.getAnalysis(id);
+		if (analysis === undefined) return;
+
+		analysis.setRSyntax(syntax);
+	}
 
 	window.analysisMenuHidden = function () {
 		if (window.menuObject !== undefined && window.menuObject !== null) {

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -379,6 +379,7 @@ void MainWindow::makeConnections()
 	connect(_preferences,			&PreferencesModel::restartAllEngines,				_engineSync,			&EngineSync::haveYouTriedTurningItOffAndOnAgain				);
 	connect(_preferences,			&PreferencesModel::normalizedNotationChanged,		_resultsJsInterface,	&ResultsJsInterface::setNormalizedNotationHandler			);
 	connect(_preferences,			&PreferencesModel::developerFolderChanged,			_dynamicModules,		&DynamicModules::uninstallJASPDeveloperModule				);
+	connect(_preferences,			&PreferencesModel::showRSyntaxInResultsChanged,		_analyses,				&Analyses::showRSyntaxInResults								);
 
 	//Needed to allow for a hard split between Desktop/QMLComps:
 	connect(_preferences,						&PreferencesModel::uiScaleChanged,					DesktopCommunicator::singleton(),	&DesktopCommunicator::uiScaleChanged			);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -331,6 +331,7 @@ void MainWindow::makeConnections()
 	connect(_resultsJsInterface,	&ResultsJsInterface::resultsMetaChanged,			_analyses,				&Analyses::resultsMetaChanged								);
 	connect(_resultsJsInterface,	&ResultsJsInterface::allUserDataChanged,			_analyses,				&Analyses::allUserDataChanged								);
 	connect(_resultsJsInterface,	&ResultsJsInterface::resultsPageLoadedSignal,		_languageModel,			&LanguageModel::resultsPageLoaded							);
+	connect(_resultsJsInterface,	&ResultsJsInterface::showRSyntaxInResults,			_analyses,				&Analyses::showRSyntaxInResults								);
 
 	connect(_analyses,				&Analyses::countChanged,							this,					&MainWindow::analysesCountChangedHandler					);
 	connect(_analyses,				&Analyses::analysisResultsChanged,					this,					&MainWindow::analysisResultsChangedHandler					);

--- a/Desktop/results/resultmenumodel.cpp
+++ b/Desktop/results/resultmenumodel.cpp
@@ -24,7 +24,7 @@
 
 ResultMenuModel::ResultMenuModel(QObject *parent) : QAbstractListModel(parent),
 	_entriesOrder({"hasCollapse", "hasEditTitle", "hasCopy", "hasLaTeXCode", "hasCite", "hasSaveImg", "hasExportResults",
-				"hasEditImg", "hasNotes", "hasDuplicate", "hasRemove", "hasRemoveAllAnalyses", "hasRefreshAllAnalyses", "hasShowDeps"})
+				"hasEditImg", "hasNotes", "hasDuplicate", "hasRemove", "hasRemoveAllAnalyses", "hasRefreshAllAnalyses", "hasShowRSyntax", "hasShowDeps"})
 {
 	_generateCorrectlyTranslatedResultEntries();
 
@@ -48,7 +48,8 @@ void ResultMenuModel::_generateCorrectlyTranslatedResultEntries()
 		{	"hasRemoveAllAnalyses",		ResultMenuEntry(tr("Remove All"),			"hasRemoveAllAnalyses",		"close-button.png",			"")									},
 		{	"hasRefreshAllAnalyses",	ResultMenuEntry(tr("Refresh All"),			"hasRefreshAllAnalyses",	"",							"")									},
 		{	"hasShowDeps",				ResultMenuEntry(tr("Show Dependencies"),	"hasShowDeps",				"",							"window.showDependenciesClicked()")	},
-		{	"hasExportResults",			ResultMenuEntry(tr("Export Results"),		"hasExportResults",			"",							"")									}
+		{	"hasExportResults",			ResultMenuEntry(tr("Export Results"),		"hasExportResults",			"",							"")									},
+		{	"hasShowRSyntax",			ResultMenuEntry(tr("Show R Syntax"),		"hasShowRSyntax",			"R-roundbutton.svg",		"")									}
    };
 }
 
@@ -133,8 +134,20 @@ void ResultMenuModel::setOptions(QString options, QStringList selected)
 				entries.push_back(entry);
 			}
 		}
+		else if (key == "hasShowRSyntax")
+		{
+			entries.push_back(separator);
+			bool shown = Settings::value(Settings::SHOW_RSYNTAX_IN_RESULTS).toBool();
+
+			QString jsFunction = QString("window.showRSyntaxClicked(%1);").arg(shown ? "false" : "true");
+			entry.setJSFunction(jsFunction);
+			entry.setDisplayText(shown ? tr("Hide R Syntax") : tr("Show R Syntax"));
+
+			entries.push_back(entry);
+
+		}
 		else
-				entries.push_back(entry);
+			entries.push_back(entry);
 	}
 
 	_resultMenuEntries = entries;

--- a/Desktop/results/resultsjsinterface.cpp
+++ b/Desktop/results/resultsjsinterface.cpp
@@ -303,6 +303,11 @@ void ResultsJsInterface::resetResults()
 	emit resultsPageUrlChanged(_resultsPageUrl);
 }
 
+void ResultsJsInterface::setRSyntax(int id, const QString &syntax)
+{
+	runJavaScript("window.setRSyntaxText(" + QString::number(id) + ", '" + escapeJavascriptString(syntax) + "')");
+}
+
 void ResultsJsInterface::unselect()
 {
 	runJavaScript("window.unselect()");
@@ -431,6 +436,7 @@ void ResultsJsInterface::runJavaScript(const QString & js)
 	if(_resultsLoaded)	emit runJavaScriptSignal(js);
 	else				_delayedJs.push(js);
 }
+
 
 void ResultsJsInterface::dequeueJsQueue()
 {

--- a/Desktop/results/resultsjsinterface.h
+++ b/Desktop/results/resultsjsinterface.h
@@ -56,6 +56,7 @@ public:
 	void exportPreviewHTML();
 	void exportHTML();
 	void resetResults();
+	void setRSyntax(		int			id, const QString& syntax);
 
 	QString			resultsPageUrl()	const { return _resultsPageUrl;	}
 	double			zoom()				const { return _webEngineZoom;	}
@@ -88,6 +89,7 @@ signals:
 	Q_INVOKABLE void exportToPDF(			QString pdfPath);
 	void prepForExport();
 	Q_INVOKABLE void exportPrepFinished();
+	Q_INVOKABLE void showRSyntaxInResults(	bool show);
 
 
 public slots:

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -86,8 +86,9 @@ const Settings::Setting Settings::Values[] = {
 	{"guiQtTextRender",				true	},
 	{"showReports",					false	},
 	{"showRSyntax",					false	},
-	{"showAllROptions",				false	}
-};	
+	{"showAllROptions",				false	},
+	{"showRSyntaxInResults",		false	}
+};
 
 QVariant Settings::value(Settings::Type key)
 {

--- a/Desktop/utilities/settings.h
+++ b/Desktop/utilities/settings.h
@@ -72,7 +72,8 @@ public:
 		GUI_USE_QT_TEXTRENDER,
 		REPORT_SHOW,
 		SHOW_RSYNTAX,
-		SHOW_ALL_R_OPTIONS
+		SHOW_ALL_R_OPTIONS,
+		SHOW_RSYNTAX_IN_RESULTS
 	};
 
 	static QVariant value(Settings::Type key);

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -46,12 +46,12 @@ AnalysisForm::AnalysisForm(QQuickItem *parent) : QQuickItem(parent)
 	// _startRSyntaxTimer is used to call setRSyntaxText only once in a event loop.
 	connect(this,									&AnalysisForm::infoChanged,					this, &AnalysisForm::helpMDChanged			);
 	connect(this,									&AnalysisForm::formCompletedSignal,			this, &AnalysisForm::formCompletedHandler,	Qt::QueuedConnection);
-	connect(this,									&AnalysisForm::analysisInitialized,			this, &AnalysisForm::knownIssuesUpdated,	Qt::QueuedConnection);
+	connect(this,									&AnalysisForm::analysisChanged,				this, &AnalysisForm::knownIssuesUpdated,	Qt::QueuedConnection);
 	connect(KnownIssues::issues(),					&KnownIssues::knownIssuesUpdated,			this, &AnalysisForm::knownIssuesUpdated,	Qt::QueuedConnection);
 	connect(this,									&AnalysisForm::showAllROptionsChanged,		this, &AnalysisForm::setRSyntaxText,		Qt::QueuedConnection);
 	connect(PreferencesModelBase::preferences(),	&PreferencesModelBase::showRSyntaxChanged,	this, &AnalysisForm::setRSyntaxText,		Qt::QueuedConnection);
 	connect(PreferencesModelBase::preferences(),	&PreferencesModelBase::showAllROptionsChanged,	this, &AnalysisForm::showAllROptionsChanged, Qt::QueuedConnection	);
-	connect(this,									&AnalysisForm::analysisInitialized,			this, &AnalysisForm::setRSyntaxText,		Qt::QueuedConnection);
+	connect(this,									&AnalysisForm::analysisChanged,				this, &AnalysisForm::setRSyntaxText,		Qt::QueuedConnection);
 }
 
 AnalysisForm::~AnalysisForm()
@@ -616,7 +616,11 @@ void AnalysisForm::setAnalysisUp()
 
 	_initialized = true;
 
-	emit analysisInitialized();
+	// Don't bind boundValuesChanged before it is initialized: each setup of all controls will generate a boundValuesChanged
+	connect(_analysis,					&AnalysisBase::boundValuesChanged,		this,			&AnalysisForm::setRSyntaxText,				Qt::QueuedConnection	);
+
+	setRSyntaxText();
+	emit analysisChanged();
 }
 
 void AnalysisForm::knownIssuesUpdated()

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -745,9 +745,9 @@ bool AnalysisForm::isFormulaName(const QString& name) const
 	return _rSyntax->getFormula(name) != nullptr;
 }
 
-QString AnalysisForm::generateRSyntax() const
+QString AnalysisForm::generateRSyntax(bool useHtml) const
 {
-	return _rSyntax->generateSyntax(showAllROptions());
+	return _rSyntax->generateSyntax(!useHtml && showAllROptions(), useHtml);
 }
 
 QVariantList AnalysisForm::optionNameConversion() const
@@ -982,12 +982,10 @@ void AnalysisForm::setRSyntaxText()
 		return;
 
 	QString text = generateRSyntax();
-	Log::log() << "setRSyntaxText: " << text << std::endl;
 
 	if (text != _rSyntaxText)
 	{
 		_rSyntaxText = text;
-		Log::log() << "EMIT rSyntaxTextChanged" << std::endl;
 		emit rSyntaxTextChanged();
 	}
 }

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -54,7 +54,7 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(bool			runOnChange				READ runOnChange			WRITE setRunOnChange			NOTIFY runOnChangeChanged			)
 	Q_PROPERTY(QString		info					READ info					WRITE setInfo					NOTIFY infoChanged					)
 	Q_PROPERTY(QString		helpMD					READ helpMD													NOTIFY helpMDChanged				)
-	Q_PROPERTY(QVariant		analysis				READ analysis												NOTIFY analysisInitialized			)
+	Q_PROPERTY(QVariant		analysis				READ analysis												NOTIFY analysisChanged				)
 	Q_PROPERTY(QVariantList	optionNameConversion	READ optionNameConversion	WRITE setOptionNameConversion	NOTIFY optionNameConversionChanged	)
 	Q_PROPERTY(bool			showRButton				READ showRButton											NOTIFY showRButtonChanged			)
 	Q_PROPERTY(bool			developerMode			READ developerMode											NOTIFY developerModeChanged			)
@@ -118,7 +118,7 @@ signals:
 	void					helpMDChanged();
 	void					errorsChanged();
 	void					warningsChanged();
-	void					analysisInitialized();
+	void					analysisChanged();
 	void					rSourceChanged(const QString& name);
 	void					optionNameConversionChanged();
 	void					titleChanged();

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -163,7 +163,7 @@ public:
 	QString			warnings()				const	{ return msgsListToString(_formWarnings);	}
 	QVariant		analysis()				const	{ return QVariant::fromValue(_analysis);	}
 	RSyntax*		rSyntax()				const	{ return _rSyntax;							}
-	QString			generateRSyntax()		const;
+	QString			generateRSyntax(bool useHtml = false) const;
 	QVariantList	optionNameConversion()	const;
 	bool			isFormulaName(const QString& name)	const;
 

--- a/QMLComponents/rsyntax/formulabase.cpp
+++ b/QMLComponents/rsyntax/formulabase.cpp
@@ -39,12 +39,12 @@ void FormulaBase::setUp()
 }
 
 // Generate the R Formula
-QString FormulaBase::toString(bool &isNull) const
+QString FormulaBase::toString(const QString& newLine, const QString& indent, bool &isNull) const
 {
 	if (!_rSyntax)
 		return "";
 
-	QString result = _rSyntax->FunctionOptionIndent + _name + " = ";
+	QString result = indent + _name + " = ";
 	bool isEmpty = true;
 
 	for (FormulaSource* formulaSource : _rightFormulaSources)
@@ -91,9 +91,9 @@ QString FormulaBase::toString(bool &isNull) const
 		for (const QString& key : extraOptions.keys())
 		{
 			if (!result.isEmpty())	
-				result += ",\n";
+				result += "," + newLine;
 
-			result += _rSyntax->FunctionOptionIndent + _rSyntax->getRSyntaxFromControlName(key) + " = " + extraOptions[key];
+			result += indent + _rSyntax->getRSyntaxFromControlName(key) + " = " + extraOptions[key];
 		}
 	}
 
@@ -111,9 +111,9 @@ QString FormulaBase::toString(bool &isNull) const
 			continue;
 
 		if (!result.isEmpty())	
-			result += ",\n";
+			result += "," + newLine;
 
-		result += _rSyntax->FunctionOptionIndent + _rSyntax->getRSyntaxFromControlName(optionToSpecify) + " = ";
+		result += indent + _rSyntax->getRSyntaxFromControlName(optionToSpecify) + " = ";
 
 		if (elements.length() == 0)			result += "\"\"";
 		else if (elements.length() == 1)	result += "\"" + elements[0] + "\"";

--- a/QMLComponents/rsyntax/formulabase.h
+++ b/QMLComponents/rsyntax/formulabase.h
@@ -46,7 +46,7 @@ public:
 	QVariant			rhs()																const	{ return _rhs;				}
 	QString				name()																const	{ return _name;				}
 
-	QString				toString(bool &isNull)												const;
+	QString				toString(const QString& newLine, const QString& indent, bool &isNull) const;
 	bool				parseRSyntaxOptions(Json::Value &options)							const;
 	RSyntax*			rSyntax()															const	{ return _rSyntax;			}
 	AnalysisForm	*	form()																const;

--- a/QMLComponents/rsyntax/rsyntax.cpp
+++ b/QMLComponents/rsyntax/rsyntax.cpp
@@ -77,20 +77,24 @@ bool RSyntax::setControlNameToRSyntaxMap(const QVariantList &conversions)
 	return false;
 }
 
-QString RSyntax::generateSyntax(bool showAllOptions) const
+QString RSyntax::generateSyntax(bool showAllOptions, bool useHtml) const
 {
 	QString result;
 
-	result = _analysisFullName() + "(\n";
+	QString newLine = useHtml ? "<br>" : "\n",
+			indent = useHtml ? "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" : FunctionOptionIndent;
+
+
+	result = _analysisFullName() + "(" + newLine;
 	if (showAllOptions)
-		result += FunctionOptionIndent + "data = NULL,\n";
-	result += FunctionOptionIndent + "version = \"" + _form->version() + "\"";
+		result += indent + "data = NULL," + newLine;
+	result += indent + "version = \"" + _form->version() + "\"";
 
 	QStringList formulaSources;
 	for (FormulaBase* formula : _formulas)
 	{
 		bool isNull = false;
-		result += ",\n" + formula->toString(isNull);
+		result += "," + newLine + formula->toString(newLine, indent, isNull);
 		if (!isNull)
 			formulaSources.append(formula->modelSources());
 	}
@@ -121,7 +125,7 @@ QString RSyntax::generateSyntax(bool showAllOptions) const
 				isDifferent = !qFuzzyCompare(defaultValue.asDouble(), foundValue.asDouble());
 			if (isDifferent)
 			{
-				result += ",\n" + FunctionOptionIndent + getRSyntaxFromControlName(control) + " = ";
+				result += "," + newLine + indent + getRSyntaxFromControlName(control) + " = ";
 
 				JASPListControl* listControl = qobject_cast<JASPListControl*>(control);
 				if (listControl && !listControl->hasRowComponent() && listControl->containsInteractions())

--- a/QMLComponents/rsyntax/rsyntax.h
+++ b/QMLComponents/rsyntax/rsyntax.h
@@ -37,7 +37,7 @@ public:
 	QVariantList					controlNameToRSyntaxMap()						const;
 	bool							setControlNameToRSyntaxMap(const QVariantList& conv);
 
-	QString							generateSyntax(bool showAllOptions = true)		const;
+	QString							generateSyntax(bool showAllOptions = true, bool useHtml = false) const;
 	QString							generateWrapper()								const;
 	QString							getRSyntaxFromControlName(JASPControl* control)	const;
 	QString							getRSyntaxFromControlName(const QString& name)	const;

--- a/Resources/Help/preferences/PrefsResults.md
+++ b/Resources/Help/preferences/PrefsResults.md
@@ -29,3 +29,9 @@ Here you can specify the number of pixels per inch your plots should have. By de
 ### Image background colour
 
 This option let's you toggle the background colour of plots between white and transparant. You may find this especially useful when copying and/or pasting plots.
+
+## Miscellaneous options
+
+### Show R syntax
+
+Add R syntax for each analysis

--- a/Resources/Help/preferences/PrefsResults_nl.md
+++ b/Resources/Help/preferences/PrefsResults_nl.md
@@ -24,3 +24,9 @@ Hier kan worden gespecificeerd hoeveel pixels per inch een grafiek zou moeten he
 ### Achtergrondkleur van afbeeldingen
 
 Deze optie laat de gebruiker kiezen of grafieken met een witte of transparante worden gegenereerd. Dit kan erg handig zijn voor het kopiëren en plakken van grafieken.  
+
+## Overige Opties
+
+### Toon R syntax
+
+Voeg R syntax toe voor elke analyse


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/2008

R Syntax can be now displayed in the results, either via the popup menu of the title of the result, or via the preferences/Results settings. This displays (or hides) the R syntax for all analyses.

This works in light and dark theme, and the syntax is also exported in HTML or PDF.