### PR TITLE
Fix JASP note editor for link input

### DIFF
--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -537,7 +537,7 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 
         	// Change example link from quilljs.com to a sample link
         	var linkInput = quillTooltipTheme.root.querySelector('input[data-link]');
-        	linkInput.dataset.link = 'https://example.com';
+        	linkInput.dataset.link = 'https://jasp-stats.org';
 
 		// Add tooltips to the toolbar buttons
 		// Quilljs website mentions changing the toolbar html element (https://quilljs.com/playground/#snow-toolbar-tooltips),

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -10,6 +10,12 @@ if(insideJASP)
 
 
 	Quill.register('formats/linebreak', LineBreakClass);
+	
+	// See https://github.com/quilljs/quill/issues/262
+	var Link = Quill.import('formats/link');
+	Link.sanitize = function(url) {
+	return url;
+	}
 }
 
 JASPWidgets.Encodings = {
@@ -525,6 +531,13 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 
 		this.$quillToolbar     = this.$el.find(".ql-toolbar").get(0);
 		let quillEditorElement = this.$el.find(".ql-editor").get(0);
+		
+		this.$quillTooltip     = this.$el.find(".ql-tooltip");
+        	var quillTooltipTheme  = this.$quill.theme.tooltip;
+
+        	// Change example link from quilljs.com to a sample link
+        	var linkInput = quillTooltipTheme.root.querySelector('input[data-link]');
+        	linkInput.dataset.link = 'https://example.com';
 
 		// Add tooltips to the toolbar buttons
 		// Quilljs website mentions changing the toolbar html element (https://quilljs.com/playground/#snow-toolbar-tooltips),
@@ -563,7 +576,12 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 		});
 
 		quillEditorElement.addEventListener('focusout', (event) => {
+		    // Always keep editor available while a tooltip editor show
+		    if (this.$quillTooltip.is(':visible')) {
+			return;
+		    } else {
 			self.setQuillToolbarVisibility('none');
+		    }
 		});
 
 		if (this.model.get('deltaAvailable')) {


### PR DESCRIPTION
This was discovered when I introduced the Latex Formula editor (almost complete and this will also be effective for it), and I think I can move this fix to the next release?

Before: not work
After:
![image](https://user-images.githubusercontent.com/10348402/232457848-76bff3db-3f23-4f9e-8934-00bc3504f464.png)
