### PR TITLE
When a Radio Button is removed, it should not have a group anymore

### DIFF
--- a/QMLComponents/controls/radiobuttonbase.cpp
+++ b/QMLComponents/controls/radiobuttonbase.cpp
@@ -67,7 +67,10 @@ void RadioButtonBase::registerWithParent()
 void RadioButtonBase::unregisterRadioButton()
 {
 	if (_group && _form) //On destruction of static buttons outside of form values would change in RadioButtonGroup
+	{
 		_group->unregisterRadioButton(this);
+		_group = nullptr;
+	}
 }
 
 void RadioButtonBase::clickHandler()


### PR DESCRIPTION
When a Radio Button is removed, it unregisters itself from its group, but it keeps its internal reference to the group (_group). So when it is reused with the same group, it does not register itself again to the group as _group is already set to the right reference.

Test added in https://github.com/jasp-stats/jaspTestModule/pull/55

