### PR TITLE
Remove erroneous results window scroll command

### DIFF
--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -1053,9 +1053,7 @@ JASPWidgets.RSyntaxView = JASPWidgets.View.extend({
 		if (value === true) {
 			self.$el.slideDown(200, function () {
 				self._setVisibility(value);
-				self.$el.animate({ "opacity": 1 }, 200, "easeOutCubic", function () {
-					window.scrollIntoView(self.$el, function () {});
-				});
+				self.$el.animate({ "opacity": 1 }, 200, "easeOutCubic", function () {});
 			});
 		}
 		else {


### PR DESCRIPTION
Fixes:  https://github.com/jasp-stats/jasp-test-release/issues/2291

That scroll into view was copied over from another piece of code by accident.
