### PR TITLE
Makes multibridge work on macos Arm!

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -122,3 +122,7 @@
 	path = Modules/jaspPredictiveAnalytics
 	url = https://github.com/jasp-stats/jaspPredictiveAnalytics
 	branch = main
+[submodule "RPkgs/multibridge"]
+	path = RPkgs/multibridge
+	url = https://github.com/Asarafoglou/multibridge
+	branch = master

--- a/Modules/install-RInside.R.in
+++ b/Modules/install-RInside.R.in
@@ -7,3 +7,6 @@
 .libPaths(c("@R_LIBRARY_PATH@"))
 #We need building from source on linux in any case and on windows because otherwise lots of CRAN env-vars get baked into RInside...
 install.packages(c('RInside', 'Rcpp'), type = ifelse(Sys.info()["sysname"] == "Darwin", "binary", "source"), lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')
+
+install.packages(c('remotes'), lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')
+remotes::install_deps("@JASP_SOURCE_DIR@/RPkgs/multibridge", lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts=c("--html", "--no-multiarch", "--no-test-load"))

--- a/Modules/install-RInside.R.in
+++ b/Modules/install-RInside.R.in
@@ -9,4 +9,6 @@
 install.packages(c('RInside', 'Rcpp'), type = ifelse(Sys.info()["sysname"] == "Darwin", "binary", "source"), lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')
 
 install.packages(c('remotes'), lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')
-remotes::install_deps("@JASP_SOURCE_DIR@/RPkgs/multibridge", lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts=c("--html", "--no-multiarch", "--no-test-load"))
+
+if(.Platform$pkgType == "mac.binary.big-sur-arm64")
+  remotes::install_deps("@JASP_SOURCE_DIR@/RPkgs/multibridge", lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts=c("--html", "--no-multiarch", "--no-test-load"))

--- a/Modules/install-renv.R.in
+++ b/Modules/install-renv.R.in
@@ -3,6 +3,5 @@
 .libPaths(c("@R_LIBRARY_PATH@"))
 install.packages('renv', lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')
 
-install.packages('@JASP_SOURCE_DIR@/RPkgs/multibridge', lib='@R_LIBRARY_PATH@', repos=NULL, type='source', INSTALL_opts=c("--html", "--no-multiarch", "--no-test-load"))
-
-#remotes::install_github("", lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts=c("--html", "--no-multiarch", "--no-test-load"))
+if(.Platform$pkgType == "mac.binary.big-sur-arm64")
+  install.packages('@JASP_SOURCE_DIR@/RPkgs/multibridge', lib='@R_LIBRARY_PATH@', repos=NULL, type='source', INSTALL_opts=c("--html", "--no-multiarch", "--no-test-load"))

--- a/Modules/install-renv.R.in
+++ b/Modules/install-renv.R.in
@@ -2,3 +2,7 @@
 # 
 .libPaths(c("@R_LIBRARY_PATH@"))
 install.packages('renv', lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')
+
+install.packages('@JASP_SOURCE_DIR@/RPkgs/multibridge', lib='@R_LIBRARY_PATH@', repos=NULL, type='source', INSTALL_opts=c("--html", "--no-multiarch", "--no-test-load"))
+
+#remotes::install_github("", lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts=c("--html", "--no-multiarch", "--no-test-load"))

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -484,42 +484,6 @@ if(APPLE)
     message(CHECK_FAIL "not found in ${R_HOME_PATH}/lib")
   endif()
 
-  if(NOT EXISTS ${RENV_PATH})
-    message(STATUS "renv is not installed!")
-    message(CHECK_START "Installing 'renv'")
-
-    configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
-		           ${SCRIPT_DIRECTORY}/install-renv.R @ONLY)
-
-    set(ENV{JASP_R_HOME} ${R_HOME_PATH})
-
-    execute_process(
-	  COMMAND_ECHO STDERR
-	  #ERROR_QUIET OUTPUT_QUIET
-      WORKING_DIRECTORY ${R_HOME_PATH}
-	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save --file=${SCRIPT_DIRECTORY}/install-renv.R)
-
-    if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
-      message(CHECK_FAIL "unsuccessful.")
-      message(FATAL_ERROR "'renv' installation has failed!")
-    endif()
-
-    message(CHECK_PASS "successful.")
-
-    message(CHECK_START "Patching Frameworks/.../library")
-    execute_process(
-	  COMMAND_ECHO STDOUT
-	  #ERROR_QUIET OUTPUT_QUIET
-      WORKING_DIRECTORY ${R_HOME_PATH}
-      COMMAND
-        ${CMAKE_COMMAND} -D
-        NAME_TOOL_PREFIX_PATCHER=${PROJECT_SOURCE_DIR}/Tools/macOS/install_name_prefix_tool.sh
-        -D PATH=${R_HOME_PATH}/library -D R_HOME_PATH=${R_HOME_PATH} -D
-        R_DIR_NAME=${R_DIR_NAME} -D SIGNING_IDENTITY=${APPLE_CODESIGN_IDENTITY}
-        -D SIGNING=1 -D CODESIGN_TIMESTAMP_FLAG=${CODESIGN_TIMESTAMP_FLAG} -P
-        ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake)
-  endif()
-
   if(NOT EXISTS ${RINSIDE_PATH})
     message(STATUS "RInside is not installed!")
 
@@ -556,6 +520,42 @@ if(APPLE)
         -D SIGNING=1 -D CODESIGN_TIMESTAMP_FLAG=${CODESIGN_TIMESTAMP_FLAG} -P
         ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake)
 
+  endif()
+
+  if(NOT EXISTS ${RENV_PATH})
+    message(STATUS "renv is not installed!")
+    message(CHECK_START "Installing 'renv'")
+
+    configure_file(${MODULES_SOURCE_PATH}/install-renv.R.in
+		           ${SCRIPT_DIRECTORY}/install-renv.R @ONLY)
+
+    set(ENV{JASP_R_HOME} ${R_HOME_PATH})
+
+    execute_process(
+	  COMMAND_ECHO STDERR
+	  #ERROR_QUIET OUTPUT_QUIET
+      WORKING_DIRECTORY ${R_HOME_PATH}
+	  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save --file=${SCRIPT_DIRECTORY}/install-renv.R)
+
+    if(NOT EXISTS ${R_LIBRARY_PATH}/renv)
+      message(CHECK_FAIL "unsuccessful.")
+      message(FATAL_ERROR "'renv' installation has failed!")
+    endif()
+
+    message(CHECK_PASS "successful.")
+
+    message(CHECK_START "Patching Frameworks/.../library")
+    execute_process(
+	  COMMAND_ECHO STDOUT
+	  #ERROR_QUIET OUTPUT_QUIET
+      WORKING_DIRECTORY ${R_HOME_PATH}
+      COMMAND
+        ${CMAKE_COMMAND} -D
+        NAME_TOOL_PREFIX_PATCHER=${PROJECT_SOURCE_DIR}/Tools/macOS/install_name_prefix_tool.sh
+        -D PATH=${R_HOME_PATH}/library -D R_HOME_PATH=${R_HOME_PATH} -D
+        R_DIR_NAME=${R_DIR_NAME} -D SIGNING_IDENTITY=${APPLE_CODESIGN_IDENTITY}
+        -D SIGNING=1 -D CODESIGN_TIMESTAMP_FLAG=${CODESIGN_TIMESTAMP_FLAG} -P
+        ${PROJECT_SOURCE_DIR}/Tools/CMake/Patch.cmake)
   endif()
 
   message(CHECK_START "Checking for 'libRInside'")


### PR DESCRIPTION
To use this commit and actually have bug jasp-stats/jasp-test-release#2325 fixed
you need to remove `gmp` and `mpfr` as installed by `brew`.

Then download a snapshot of `gmp`: https://gmplib.org/download/snapshot/gmp-next/gmp-6.2.99-20221117121717.tar.zst
Build with:
./configure --enable-static --disable-shared --with-pic --enable-cxx
make -j
make check #These NEED to pass
sudo make install

Then build `mpfr` and use:
./configure --enable-static --disable-shared --with-pic --with-gmp=/usr/local
make -j
sudo make install

Then to make sure Qt creator can actually find pkg-config (sigh) you need to start it from a terminal

Make sure to `git submodule update --init` too

Then use a fresh buildfolder or remove at least `_cache`, `_deps`, `_scripts`, `Modules`, and `Frameworks`
Run cmake and verify `multibridge` is installed at the end, it will probably give some loading namespace errors during help generation but that can be ignored