### PR TITLE
Copy LaTeX of table does not copy html code 

### DIFF
--- a/Desktop/results/resultsjsinterface.cpp
+++ b/Desktop/results/resultsjsinterface.cpp
@@ -206,7 +206,11 @@ void ResultsJsInterface::pushToClipboard(const QString &mimeType, const QString 
 	if ( ! html.isEmpty())
 	{
 		mimeData->setHtml(html);
-		mimeData->setText(html);
+
+		if (mimeType != "text/plain")
+		{
+			mimeData->setText(html);
+		}
 	}
 
 	QClipboard *clipboard = QApplication::clipboard();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2201

Not sure if this is the ideal point where to fix this, but this gets rid of the unwanted html tags in the copied LaTeX code and does not break any other copying functionality that I know of and managed to test.

The other issues in https://github.com/jasp-stats/INTERNAL-jasp/issues/2201 (i.e., copy table to word, copy citations) seem to be already fixed.

Just out of curiosity, the bug seems to have been introduced in https://github.com/jasp-stats/jasp-desktop/commit/997bc6a132390e5525e36ed4df4850b6d0078e08 marked to solve https://github.com/jasp-stats/INTERNAL-jasp/issues/296. However, either I am doing something wrong or the issue in https://github.com/jasp-stats/INTERNAL-jasp/issues/296 still persists. Am I right we need to reopen the issue?

