### PR TITLE
Fix loading images in results

### DIFF
--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -28,6 +28,7 @@
 #include "timers.h"
 #include <QMessageBox>
 #include "utilities/plotschemehandler.h"
+#include "utilities/imgschemehandler.h"
 #include <json/json.h>
 
 #ifdef linux
@@ -406,6 +407,7 @@ int main(int argc, char *argv[])
 			}
 
 			PlotSchemeHandler::createUrlScheme(); //Needs to be done *before* creating PlotSchemeHandler instance and also before QApplication is instantiated
+			ImgSchemeHandler::createUrlScheme();
 
 			QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 			QCoreApplication::setAttribute(Qt::AA_SynthesizeTouchForUnhandledMouseEvents, false); //To avoid weird splitterbehaviour with QML and a touchscreen
@@ -447,6 +449,7 @@ int main(int argc, char *argv[])
 			std::cout << "Application initialized" << std::endl;
 
 			PlotSchemeHandler plotSchemeHandler; //Makes sure plots can still be loaded in webengine with Qt6
+			ImgSchemeHandler  imgSchemeHandler;
 
 #ifdef _WIN32
 			// Since we introduced renv to JASP the win installer needs to recreate the junctions from Modules -> renv-cache on install. Because they do not support relative paths

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -398,6 +398,19 @@ Json::Value	DynamicModules::getJsonForPackageInstallationRequest(const std::stri
 	return _modules[installMe]->requestJsonForPackageInstallationRequest(onlyModPkg);
 }
 
+DynamicModule *DynamicModules::dynamicModuleLowerCased(QString moduleName) const
+{
+	moduleName = moduleName.toLower(); //just enforce it
+
+	for(const std::string & modName : _moduleNames)
+		if(tq(modName).toLower() == moduleName)
+		{
+			return dynamicModule(modName);
+		}
+
+	return nullptr;
+}
+
 
 void DynamicModules::installationPackagesFailed(const QString & moduleName, const QString & errorMessage)
 {

--- a/Desktop/modules/dynamicmodules.h
+++ b/Desktop/modules/dynamicmodules.h
@@ -77,8 +77,9 @@ public:
 
 	Json::Value				getJsonForPackageInstallationRequest(const std::string & module = "???");
 
-	Modules::DynamicModule*	dynamicModule(	const std::string & moduleName)	const { return _modules.count(moduleName) == 0 ? nullptr : _modules.at(moduleName); }
-	Modules::DynamicModule*	operator[](		const std::string & moduleName)	const { return dynamicModule(moduleName); }
+	Modules::DynamicModule*	dynamicModuleLowerCased(	  QString		moduleName)	const;
+	Modules::DynamicModule*	dynamicModule(			const std::string & moduleName)	const { return _modules.count(moduleName) == 0 ? nullptr : _modules.at(moduleName); }
+	Modules::DynamicModule*	operator[](				const std::string & moduleName)	const { return dynamicModule(moduleName); }
 
 	Modules::AnalysisEntry* retrieveCorrespondingAnalysisEntry(const Json::Value & jsonFromJaspFile);
 

--- a/Desktop/utilities/imgschemehandler.cpp
+++ b/Desktop/utilities/imgschemehandler.cpp
@@ -1,0 +1,66 @@
+#include "imgschemehandler.h"
+#include <QWebEngineUrlScheme>
+#include <QQuickWebEngineProfile>
+#include <QWebEngineUrlRequestJob>
+#include <QFile>
+#include <QIODevice>
+#include "modules/dynamicmodules.h"
+#include "log.h"
+
+using namespace Modules;
+
+ImgSchemeHandler::ImgSchemeHandler(QObject *parent)
+	: QWebEngineUrlSchemeHandler{parent}
+{
+	QQuickWebEngineProfile::defaultProfile()->installUrlSchemeHandler("img", this);
+}
+
+void ImgSchemeHandler::createUrlScheme()
+{
+	QWebEngineUrlScheme imgScheme = QWebEngineUrlScheme("img");
+	imgScheme.setFlags(QWebEngineUrlScheme::ContentSecurityPolicyIgnored);
+	imgScheme.setSyntax(QWebEngineUrlScheme::Syntax::Path);
+	QWebEngineUrlScheme::registerScheme(imgScheme);
+}
+
+void ImgSchemeHandler::requestStarted(QWebEngineUrlRequestJob *request)
+{
+	QString filePath	= request->requestUrl().toString(QUrl::RemoveScheme | QUrl::RemoveQuery);
+
+	Log::log() << "ImgSchemeHandler got file: " << filePath << std::endl;
+
+	QStringList filePathElements = filePath.split("/");
+
+	DynamicModule * mod = filePathElements.size() > 0 ? DynamicModules::dynMods()->dynamicModuleLowerCased(filePathElements[0])  : nullptr;
+
+	if(!mod)
+	{
+		Log::log() <<  "Url is invalid, #" << filePathElements.size() << " elements, and first is: " << (filePathElements.size() > 0 ? filePathElements[0] : "...") << std::endl;
+		request->fail(QWebEngineUrlRequestJob::Error::UrlInvalid);
+		return;
+	}
+
+	if(filePath.indexOf(".png") == -1 && filePath.indexOf(".svg") == -1)
+	{
+		Log::log() << "Url is invalid because it doesnt end in .svg or .png" << std::endl;
+		request->fail(QWebEngineUrlRequestJob::Error::UrlInvalid);
+		return;
+	}
+
+	//So its both correctly identifying a module and refers to a png or svg. Now to load it
+	const QString moduleName = filePathElements[0];
+	filePathElements.remove(0);
+	filePath =  tq(DynamicModules::dynMods()->dynamicModuleLowerCased(moduleName)->moduleInstFolder()) + filePathElements.join(QDir::separator());
+
+	Log::log() << "Is img from module " << moduleName << " and reconstructed imgpath is: " << filePath << std::endl;
+
+	QFile * img = new QFile(filePath, request);
+	if(!img->exists())
+		{
+			request->fail(QWebEngineUrlRequestJob::Error::UrlNotFound);
+			return;
+		}
+	img->open(QIODevice::ReadOnly);
+
+	request->reply(filePath.indexOf(".png") != -1 ? "image/png" : "image/svg", img);
+}

--- a/Desktop/utilities/imgschemehandler.h
+++ b/Desktop/utilities/imgschemehandler.h
@@ -1,0 +1,18 @@
+#ifndef IMGSCHEMEHANDLER_H
+#define IMGSCHEMEHANDLER_H
+
+#include <QWebEngineUrlSchemeHandler>
+
+///Like PlotSchemeHandler but for images in jaspHtml/results, https://github.com/jasp-stats/jasp-test-release/issues/2321
+/// Supports svg and png only
+class ImgSchemeHandler : public QWebEngineUrlSchemeHandler
+{
+  public:
+	explicit ImgSchemeHandler(QObject *parent = nullptr);
+
+	static void createUrlScheme();
+
+	void requestStarted(QWebEngineUrlRequestJob *request) override;
+};
+
+#endif // IMGSCHEMEHANDLER_H

--- a/Desktop/utilities/plotschemehandler.cpp
+++ b/Desktop/utilities/plotschemehandler.cpp
@@ -1,4 +1,5 @@
 #include "plotschemehandler.h"
+#include "tempfiles.h"
 
 PlotSchemeHandler::PlotSchemeHandler(QObject *parent) : QWebEngineUrlSchemeHandler(parent)
 {

--- a/Desktop/utilities/plotschemehandler.h
+++ b/Desktop/utilities/plotschemehandler.h
@@ -1,7 +1,6 @@
 #ifndef PLOTSCHEMEHANDLER_H
 #define PLOTSCHEMEHANDLER_H
 
-#include "tempfiles.h"
 #include <QWebEngineUrlRequestJob>
 #include <QWebEngineUrlScheme>
 #include <QWebEngineUrlSchemeHandler>

--- a/Docs/development/r-analyses-guide.md
+++ b/Docs/development/r-analyses-guide.md
@@ -50,6 +50,7 @@ Table of Contents:
   * [Computing Results](#computing-results)
   * [Storing Results in the State](#storing-results-in-the-state)
   * [Retrieving the State Object](#retrieving-the-state-object)
+- [ADDENDUM III - Images](#addendum-iii---images)
 
 ## Step 1 - Creating the Main Analysis Function
 Each analysis in JASP needs a main analysis function. This function will provide an overview of all output elements and steps that are needed to conduct the full analysis. The name of your analysis must match the (case sensitive) name you specified in your description.json file under `"function":`.
@@ -1269,3 +1270,18 @@ And now we can call `.binomFillTableMain()` with the added `binomResults` argume
   ```
 
 </details>
+
+ADDENDUM III - Images
+---------------------------------------------------------
+It is possible to ship images in your R-package (in inst/), these can be either png or svg.
+They can then be used as desired in `<img>`'s in  `jaspHtml` to clarify things like introductory texts.
+An example would be:
+
+```
+createJaspHtml(title="an image", text="<img src = "img:jaspLearnBayes/icons/bayes.png", width="500">")
+```
+
+As you might or might not have noticed, it doesnt say "file://" but "img:", this is important because JASP has to understand the path.
+The first element of the path must always be the name of the module that shipped the image, in this case `jaspLearnBayes`.
+JASP then replaces that part with the actual directory on the users computer. 
+The end result is an image in the results, enjoy! 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2321 No images in Binary Class in learn bayes

This adds a special scheme handler for "img:" that can be used by package authors to easily load images from their module package. something like: `img:%moduleName%/path/to/img.(svg|png)" I added an addendum, thats got a nice rhythm btw, to the r-analyses-guide

Ill also open a teensie-weensie PR to jaspLearnBayes