### PR TITLE
Add Traditional Chinese（繁體中文） as complete

### DIFF
--- a/Desktop/utilities/languagemodel.cpp
+++ b/Desktop/utilities/languagemodel.cpp
@@ -22,7 +22,7 @@ QMap<QString, bool> LanguageModel::LanguageInfo::_allowedLanguages =
 	{ "ja"		,	true	},
 	{ "es"		,	true	},
 	{ "zh_Hans"	,	true	},
-	{ "zh_Hant" ,	false	},
+	{ "zh_Hant" ,	true	},
 	{ "id"		,	false	},
 	{ "fr"		,	false   },
 	{ "ru"		,	false	},


### PR DESCRIPTION
After this https://github.com/jasp-stats/jasp-desktop/pull/5101 the JASP desktop language for _Traditional Chinese_ will be completed.