### PR TITLE
commit edit on editFinished + navigation + name change

### DIFF
--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -130,7 +130,7 @@ FocusScope
 					color:					itemActive ? jaspTheme.textEnabled : jaspTheme.textDisabled
 					font:					jaspTheme.font
 					verticalAlignment:		Text.AlignVCenter
-					onTextEdited:			dataTableView.view.editFinishedKeepEditing(index, text);
+					onEditingFinished:		dataTableView.view.commitEdit(index, text);
 					z:						10
 					readOnly:				!itemEditable
 
@@ -194,8 +194,13 @@ FocusScope
 
 						case Qt.Key_Up:		if(rowI > 0)										{ arrowPressed = true; arrowIndex   = dataTableView.model.index(rowI - 1,	colI);		} break;
 						case Qt.Key_Down:	if(rowI	< dataTableView.model.rowCount()    - 1)	{ arrowPressed = true; arrowIndex   = dataTableView.model.index(rowI + 1,	colI);		} break;
-						case Qt.Key_Left:	if(colI	> 0)										{ arrowPressed = true; arrowIndex   = dataTableView.model.index(rowI,		colI - 1);	} break;
-						case Qt.Key_Right:	if(colI	< dataTableView.model.columnCount() - 1)	{ arrowPressed = true; arrowIndex   = dataTableView.model.index(rowI,		colI + 1);	} break;
+						case Qt.Key_Left:	if(colI	> 0 && editItem.cursorPosition <= 0)		{ arrowPressed = true; arrowIndex   = dataTableView.model.index(rowI,		colI - 1);	} break;
+						case Qt.Key_Right:	if(colI	< dataTableView.model.columnCount() - 1 && editItem.cursorPosition >= editItem.text.length)	{ arrowPressed = true; arrowIndex = dataTableView.model.index(rowI, colI + 1);} break;
+
+						case Qt.Key_Backtab: if(colI > 0)									{ arrowPressed = true; arrowIndex = dataTableView.model.index(rowI, colI - 1);	shiftPressed = false; } break;
+						case Qt.Key_Tab:	 if(colI < dataTableView.model.columnCount())	{ arrowPressed = true; arrowIndex = dataTableView.model.index(rowI, colI + 1);	} break;
+
+
 						}
 
 						if(arrowPressed)

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1436,7 +1436,10 @@ void DataSetView::edit(QModelIndex here)
 	Log::log() << "DataSetView::edit(row=" << here.row() << ", col=" << here.column() << ")" << std::endl;
 
 	if(editing())
+	{
+		commitEdit(_model->index(_prevEditRow, _prevEditCol), _editItemContextual->item->property("text"));
 		destroyEditItem();
+	}
 
 	setEditing(true);
 
@@ -1444,11 +1447,11 @@ void DataSetView::edit(QModelIndex here)
 
 }
 
-void DataSetView::editFinishedKeepEditing(QModelIndex here, QVariant editedValue)
+void DataSetView::commitEdit(QModelIndex here, QVariant editedValue)
 {
 	if(!editing())
 	{
-		Log::log() << "editFinishedKeepEditing called while not editing..." << std::endl;
+		Log::log() << "commitEdit called while not editing..." << std::endl;
 	}
 	else
 	{
@@ -1470,7 +1473,7 @@ void DataSetView::editFinished(QModelIndex here, QVariant editedValue)
 	}
 	else
 	{
-		editFinishedKeepEditing(here, editedValue);
+		commitEdit(here, editedValue);
 
 		setEditing(false);
 

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1437,7 +1437,8 @@ void DataSetView::edit(QModelIndex here)
 
 	if(editing())
 	{
-		commitEdit(_model->index(_prevEditRow, _prevEditCol), _editItemContextual->item->property("text"));
+		if(_prevEditRow != -1 && _prevEditCol != -1 && _editItemContextual && _editItemContextual->item)
+			commitEdit(_model->index(_prevEditRow, _prevEditCol), _editItemContextual->item->property("text"));
 		destroyEditItem();
 	}
 

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -216,7 +216,7 @@ public slots:
 	void		edit(QModelIndex here);
 	void		destroyEditItem(bool restoreItem=true);
 	void		editFinished(			QModelIndex here, QVariant editedValue);
-	void		editFinishedKeepEditing(QModelIndex here, QVariant editedValue);
+	void		commitEdit(QModelIndex here, QVariant editedValue);
 	void		onDataModeChanged(bool dataMode);
 	void		contextMenuClickedAtIndex(QModelIndex index);
 


### PR DESCRIPTION
Commit edit on editFinished instead of textEdit, this solves a myriad of issues for scalar columns. 
Alter navigation so cursor can actually be  moved over text content in cells .
Add shift tab and tab

+ small name change.

@boutinb prefers this navigation/editing behavior to the ones seen in excel, libre.
I dont mind it.


