### PR TITLE
Add Undo/Redo functionality

### DIFF
--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -162,6 +162,8 @@ public:
 
 			void					checkForLoopInDependencies(std::string code);
 			const	stringset	 &	dependsOnColumns(bool refresh = true);
+			Json::Value				serialize()																const;
+			void					deserialize(const Json::Value& info);
 
 protected:
 			void					_checkForDependencyLoop(stringset foundNames, std::list<std::string> loopList);

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -1241,7 +1241,7 @@ void DatabaseInterface::labelsLoad(Column * column)
 		reader.parse(originalValueJsonStr, originalValueJson);
 		
 		if(column->labels().size() == row)	column->labelsAdd(value, label, filterAllows, description, originalValueJson, order, id);
-		else								column->labels()[row]->setInformationFromDB(column, id, order, label, value, filterAllows, description, originalValueJson);
+		else								column->labels()[row]->setInformation(column, id, order, label, value, filterAllows, description, originalValueJson);
 
 	};
 

--- a/CommonData/label.cpp
+++ b/CommonData/label.cpp
@@ -86,7 +86,7 @@ void Label::dbUpdate()
 	}
 }
 
-void Label::setInformationFromDB(Column * column, int id, int order, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue)
+void Label::setInformation(Column * column, int id, int order, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue)
 {
 	_id				= id;
 	_order			= order;
@@ -95,6 +95,21 @@ void Label::setInformationFromDB(Column * column, int id, int order, const std::
 	_filterAllows	= filterAllows;
 	_description	= description;
 	_originalValue	= originalValue;
+}
+
+Json::Value Label::serialize() const
+{
+	Json::Value json(Json::objectValue);
+
+	json["id"]				= _id;
+	json["order"]			= _order;
+	json["label"]			= _label;
+	json["value"]			= _value;
+	json["filterAllows"]	= _filterAllows;
+	json["description"]		= _description;
+	json["originalValue"]	= _originalValue;
+
+	return json;
 }
 
 void Label::setValue(int value)

--- a/CommonData/label.h
+++ b/CommonData/label.h
@@ -52,7 +52,9 @@ public:
 			void				setOriginalValue(	const Json::Value & originalValue);
 			void				setDescription(		const std::string & description);
 			void				setFilterAllows(	bool allowFilter);
-			void				setInformationFromDB(Column * column, int id, int order, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue);
+			void				setInformation(Column * column, int id, int order, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue);
+
+			Json::Value			serialize()	const;
 
 			DatabaseInterface	& db();
 	const	DatabaseInterface	& db() const;

--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -115,6 +115,22 @@ FocusScope
 			rightMargin:	Math.min(0, computedColumnContainer.width - minWidthCollector.minWidth)
 		}
 
+		Keys.onPressed: (event) =>
+		{
+			var controlPressed	= Boolean(event.modifiers & Qt.ControlModifier)
+			var shiftPressed	= Boolean(event.modifiers & Qt.ShiftModifier  )
+
+			if (event.key === Qt.Key_Z && controlPressed)
+			{
+				if (shiftPressed)
+					computedColumnsInterface.redo()
+				else
+					computedColumnsInterface.undo()
+
+				event.accepted = true;
+			}
+		}
+
 		Text
 		{
 			id:							computeColumnTitle

--- a/Desktop/components/JASP/Widgets/CustomMenu.qml
+++ b/Desktop/components/JASP/Widgets/CustomMenu.qml
@@ -271,7 +271,7 @@ FocusScope
 								id:		menuItem
 								width:	initWidth
 								height: jaspTheme.menuItemHeight
-								color:	(model.modelData === undefined) && !model.isEnabled
+								color:	(model.modelData === undefined) && !menuItem.itemEnabled
 												? "transparent"
 												: mouseArea.pressed || index == currentIndex
 													? jaspTheme.buttonColorPressed
@@ -279,6 +279,7 @@ FocusScope
 														? jaspTheme.buttonColorHovered
 														: "transparent"
 
+								property bool itemEnabled: menu.props.hasOwnProperty("enabled") ? menu.props["enabled"][index] : (model.modelData !== undefined || model.isEnabled)
 								property int padding: 4 + (menu.hasIcons ? 1 : 0) + (menuItemShortcut.text ? 1 : 0)
 								property double initWidth: (menu.hasIcons ? menuItemImage.width : 0) + menuItemText.implicitWidth + menuItemShortcut.implicitWidth + menu._iconPad * padding
 
@@ -303,7 +304,7 @@ FocusScope
 									id					: menuItemText
 									text				: model.modelData !== undefined ? model.modelData : displayText
 									font				: jaspTheme.font
-									color				: model.modelData !== undefined || isEnabled ? jaspTheme.black : jaspTheme.gray
+									color				: menuItem.itemEnabled ? jaspTheme.black : jaspTheme.gray
 									anchors
 									{
 										left			: menu.hasIcons ? menuItemImage.right : parent.left
@@ -317,7 +318,7 @@ FocusScope
 									id					: menuItemShortcut
 									text				: menu.props.hasOwnProperty("shortcut") ? menu.props["shortcut"][index] : ""
 									font				: jaspTheme.font
-									color				: model.modelData !== undefined || isEnabled ? jaspTheme.black : jaspTheme.gray
+									color				: menuItem.itemEnabled ? jaspTheme.black : jaspTheme.gray
 									anchors
 									{
 										right			: parent.right
@@ -331,7 +332,7 @@ FocusScope
 									hoverEnabled	: true
 									anchors.fill	: parent
 									onClicked		: menu.props['functionCall'](index)
-									enabled			: model.modelData !== undefined || isEnabled
+									enabled			: menuItem.itemEnabled
 								}
 							}
 						}

--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -39,13 +39,11 @@ FocusScope
 			//flickableInteractive:	!ribbonModel.dataMode
 			onDoubleClicked:		__myRoot.doubleClicked()
 
-			function showCopyPasteMenu(fromItem, globalPos, rowIndex, columnIndex, header, rowheader)
+			function showPopupMenu(fromItem, globalPos, rowIndex, columnIndex, header, rowheader)
 			{
-				console.log("showCopyPasteMenu!")
-
 				var ctrlCmd = MACOS ? qsTr("Cmd") : qsTr("Ctrl");
 
-				var copyPasteMenuModel =
+				var menuModel =
 				[
 					{ text: qsTr("Select All"),	shortcut: qsTr("%1+A").arg(ctrlCmd),				func: function() { dataTableView.view.selectAll() },						icon: "menu-select-all"				},
 
@@ -55,6 +53,8 @@ FocusScope
 					{ text: qsTr("Copy"),			shortcut: qsTr("%1+C").arg(ctrlCmd),			func: function() { dataTableView.view.copy(false) },						icon: "menu-data-copy"				},
 					{ text: qsTr("Paste"),			shortcut: qsTr("%1+V").arg(ctrlCmd),			func: function() { dataTableView.view.paste(false) },						icon: "menu-data-paste"				},
 					{ text: qsTr("Clear cells"),	shortcut: qsTr("Del"),							func: function() { dataTableView.view.cellsClear(); },						icon: "menu-cells-clear"			},
+					{ text: qsTr("Undo: %1").arg(dataTableView.view.undoText()),	shortcut: qsTr("%1+Z").arg(ctrlCmd),		func: function() { dataTableView.view.undo() },	icon: "menu-undo", enabled: dataTableView.view.undoText() !== ""	},
+					{ text: qsTr("Redo: %1").arg(dataTableView.view.redoText()),	shortcut: qsTr("%1+Shift+Z").arg(ctrlCmd),	func: function() { dataTableView.view.redo() },	icon: "menu-redo", enabled: dataTableView.view.redoText() !== ""	},
 
 					{ text: "---" },
 
@@ -86,40 +86,46 @@ FocusScope
 						{ text: qsTr("Delete row"),													func: function() { dataTableView.view.rowsDelete();	},						icon: "menu-row-remove"				})
 				}
 
-				var copyPasteMenuText = []
-				var copyPasteMenuShortcuts = []
-				var copyPasteMenuFunctions = []
-				var copyPasteMenuIcons = []
+				var menuText = []
+				var menuShortcuts = []
+				var menuFunctions = []
+				var menuIcons = []
+				var menuEnabled = []
 
-				for (var i = 0; i < copyPasteMenuModel.length; i++)
+				for (var i = 0; i < menuModel.length; i++)
 				{
-					var menu = copyPasteMenuModel[i]
-					copyPasteMenuText.push(menu["text"])
+					var menu = menuModel[i]
+					menuText.push(menu["text"])
 					if (menu.hasOwnProperty("func"))
-						copyPasteMenuFunctions.push(menu["func"])
+						menuFunctions.push(menu["func"])
 					else
-						copyPasteMenuFunctions.push(function() {})
+						menuFunctions.push(function() {})
 					if (menu.hasOwnProperty("icon"))
-						copyPasteMenuIcons.push(jaspTheme.iconPath + menu["icon"] + ".svg")
+						menuIcons.push(jaspTheme.iconPath + menu["icon"] + ".svg")
 					else
-						copyPasteMenuIcons.push("")
+						menuIcons.push("")
 					if (menu.hasOwnProperty("shortcut"))
-						copyPasteMenuShortcuts.push(menu["shortcut"])
+						menuShortcuts.push(menu["shortcut"])
 					else
-						copyPasteMenuShortcuts.push("")
+						menuShortcuts.push("")
+					if (menu.hasOwnProperty("enabled"))
+						menuEnabled.push(menu["enabled"])
+					else
+						menuEnabled.push(true)
 				}
 
 				var props = {
 					"hasIcons": true,
-					"model":		copyPasteMenuText,
+					"model":		menuText,
 					"functionCall": function (index)
 					{
-						copyPasteMenuFunctions[index]();
+						menuFunctions[index]();
 
 						customMenu.hide()
 					},
-					"icons": copyPasteMenuIcons,
-					"shortcut": copyPasteMenuShortcuts
+					"icons": menuIcons,
+					"shortcut": menuShortcuts,
+					"enabled": menuEnabled
 				};
 
 				//customMenu.scrollOri.x	= __JASPDataViewRoot.contentX;
@@ -227,6 +233,27 @@ FocusScope
 							}
 							break;
 
+						case Qt.Key_A:
+							if(controlPressed)
+							{
+								theView.selectAll();
+								event.accepted = true;
+							}
+							break;
+
+						case Qt.Key_Z:
+							if(controlPressed)
+							{
+								if (shiftPressed)
+									theView.redo();
+								else
+									theView.undo();
+								event.accepted = true;
+							}
+							break;
+
+						case Qt.Key_Home:	mainWindowRoot.changeFocusToFileMenu(); break;
+
 						case Qt.Key_Up:		if(rowI > 0)										{ arrowPressed = true; arrowIndex   = Qt.point(colI, rowI - 1);		} break;
 						case Qt.Key_Down:	if(rowI	< dataTableView.view.rowCount()    - 1)		{ arrowPressed = true; arrowIndex   = Qt.point(colI, rowI + 1);		} break;
 						case Qt.Key_Left:	if(colI	> 0 && editItem.cursorPosition <= 0)		{ arrowPressed = true; arrowIndex   = Qt.point(colI - 1, rowI);		} break;
@@ -280,7 +307,7 @@ FocusScope
 							onPressed: (mouse) =>
 							{
 								if(mouse.buttons & Qt.RightButton)
-									dataTableView.showCopyPasteMenu(editItem, mapToGlobal(mouse.x, mouse.y), rowIndex, columnIndex);
+									dataTableView.showPopupMenu(editItem, mapToGlobal(mouse.x, mouse.y), rowIndex, columnIndex);
 							}
 						}
 					}
@@ -321,7 +348,7 @@ FocusScope
 								if(rightPressed)
 								{
 									dataTableView.view.clearEdit()
-									dataTableView.showCopyPasteMenu(itemHighlight, mapToGlobal(mouse.x, mouse.y), rowIndex, columnIndex);
+									dataTableView.showPopupMenu(itemHighlight, mapToGlobal(mouse.x, mouse.y), rowIndex, columnIndex);
 								}
 								else
 									dataTableView.view.edit(rowIndex, columnIndex)
@@ -448,7 +475,7 @@ FocusScope
 
 					function setColumnType(newColumnType)
 					{
-						dataSetModel.setColumnTypeFromQML(columnIndex, newColumnType)
+						dataTableView.view.setColumnType(columnIndex, newColumnType)
 					}
 
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
@@ -59,7 +59,7 @@ Item
 			else
 				hints.filterText += qsTr("Filter applied<br>")
 
-			filterModel.constructorJson = JSON.stringify(filterConstructor.returnFilterJSON())
+			filterModel.applyConstructorJson(JSON.stringify(filterConstructor.returnFilterJSON()))
 		}
 
 		if(!allCorrect)

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -47,7 +47,7 @@ FocusScope
 
 	function applyAndSendFilter(newFilter)
 	{
-		filterModel.rFilter = newFilter //Triggers send in FilterModel
+		filterModel.applyRFilter(newFilter) //Triggers send in FilterModel
 		absorbModelRFilter()
 	}
 
@@ -85,6 +85,22 @@ FocusScope
 			right:			parent.right
 			bottom:			parent.bottom
 			rightMargin:	Math.min(0, filterContainer.width - minWidthCollector.minWidth)
+		}
+
+		Keys.onPressed: (event) =>
+		{
+			var controlPressed	= Boolean(event.modifiers & Qt.ControlModifier)
+			var shiftPressed	= Boolean(event.modifiers & Qt.ShiftModifier  )
+
+			if (event.key === Qt.Key_Z && controlPressed)
+			{
+				if (shiftPressed)
+					filterModel.redo()
+				else
+					filterModel.undo()
+
+				event.accepted = true;
+			}
 		}
 
 		Item
@@ -310,6 +326,34 @@ FocusScope
 							font.family:			"Courier"
 							font.pixelSize:			baseFontSize * preferencesModel.uiScale
 							wrapMode:				TextArea.WrapAtWordBoundaryOrAnywhere
+
+							Keys.onPressed: (event) =>
+							{
+								var controlPressed	= Boolean(event.modifiers & Qt.ControlModifier)
+								var shiftPressed	= Boolean(event.modifiers & Qt.ShiftModifier  )
+
+								if (event.key === Qt.Key_Z && controlPressed)
+								{
+									if (shiftPressed)
+									{
+										if (!canRedo)
+										{
+											filterModel.redo()
+											event.accepted = true
+										}
+									}
+									else
+									{
+										if (!canUndo)
+										{
+											filterModel.undo()
+											event.accepted = true
+										}
+									}
+								}
+							}
+
+
 
 						}
 

--- a/Desktop/components/JASP/Widgets/JASPDataView.qml
+++ b/Desktop/components/JASP/Widgets/JASPDataView.qml
@@ -102,6 +102,14 @@ FocusScope
 					theView.selectAll();
 					event.accepted = true;
 				break;
+
+			case Qt.Key_Z:
+					if (shiftPressed)
+						theView.redo()
+					else
+						theView.undo()
+					event.accepted = true;
+				break;
 			}
 	}
 

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -114,7 +114,7 @@ Rectangle
 			var analysisTitle = customMenu.props['model'].getAnalysisTitle(index);
 			var analysisQML   = customMenu.props['model'].getAnalysisQML(index);
             
-            messages.log("showMyMenu() for " + ribbonButton.moduleName + " name " + analysisName + " title " + analysisTitle)
+			messages.log("showMyMenu() for " + ribbonButton.moduleName + " name " + analysisName + " title " + analysisTitle)
 
 			ribbonModel.analysisClicked(analysisName, analysisQML, analysisTitle, ribbonButton.moduleName)
 			customMenu.hide();
@@ -155,6 +155,7 @@ Rectangle
 		var props =
 		{
 			"model"					: ribbonButton.menu,
+
 			"functionCall"			: functionCall,
 			"hasIcons"				: ribbonButton.menu.hasIcons(),
 			"navigateFunc"			: navigateFunc,

--- a/Desktop/components/JASP/Widgets/VariablesWindow.qml
+++ b/Desktop/components/JASP/Widgets/VariablesWindow.qml
@@ -59,6 +59,24 @@ FocusScope
 			rightMargin:	Math.min(0, variablesContainer.width - minWidth)
 		}
 
+		Keys.onPressed: (event) =>
+		{
+			var controlPressed	= Boolean(event.modifiers & Qt.ControlModifier);
+			var shiftPressed	= Boolean(event.modifiers & Qt.ShiftModifier  );
+
+			if (event.key === Qt.Key_Z)
+			{
+				if(controlPressed)
+				{
+					if (shiftPressed)
+						labelModel.redo();
+					else
+						labelModel.undo();
+					event.accepted = true;
+				}
+			}
+		}
+
 		Rectangle
 		{
 			color:				jaspTheme.uiBackground
@@ -104,6 +122,7 @@ FocusScope
 				id:					columnNameVariablesWindow
 				value:				labelModel.columnName
 				onValueChanged:		if(labelModel.columnName !== value) labelModel.columnName = value
+				undoModel:			labelModel
 
 				anchors
 				{
@@ -120,6 +139,7 @@ FocusScope
 				label:				qsTr("Title: ");
 				value:				labelModel.columnTitle
 				onValueChanged:		if(labelModel.columnTitle !== value) labelModel.columnTitle = value
+				undoModel:			labelModel
 
 				anchors
 				{
@@ -144,9 +164,11 @@ FocusScope
 				control.padding:	3 * jaspTheme.uiScale
 
 				text:				labelModel.columnDescription
-				onTextChanged:		if(labelModel.columnDescription !== text) labelModel.columnDescription = text
+				onEditingFinished: 	if(labelModel.columnDescription !== text) labelModel.columnDescription = text
 				applyScriptInfo:	""
 				placeholderText:	"..."
+				undoModel:			labelModel
+				useTabAsSpaces:		false
 
 				property int maxHeight:	100 * jaspTheme.uiScale
 			}

--- a/Desktop/data/computedcolumnsmodel.h
+++ b/Desktop/data/computedcolumnsmodel.h
@@ -52,6 +52,9 @@ public:
 
 	Q_INVOKABLE bool				showAnalysisFormForColumn(const QString & columnName);
 
+	Q_INVOKABLE void				undo() { _undoStack->undo(); }
+	Q_INVOKABLE void				redo() { _undoStack->redo(); }
+
 	static		ComputedColumnsModel * singleton()		{ return _singleton; }
 
 
@@ -95,7 +98,10 @@ private slots:
 
 private:
 	static	ComputedColumnsModel	* _singleton;
-			Column					* _selectedColumn = nullptr;
+			Column					* _selectedColumn	= nullptr;
+
+			UndoStack				* _undoStack		= nullptr;
+
 
 };
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -274,7 +274,10 @@ QModelIndex DataSetPackage::indexForSubNode(DataSetBaseNode * node) const
 		case dataSetBaseNodeType::column:
 		{
 			Column * col = dynamic_cast<Column*>(node);
-			return createIndex(0, col->data()->columnIndex(col), dynamic_cast<void *>(col));
+			if (col)
+				return createIndex(0, col->data()->columnIndex(col), dynamic_cast<void *>(col));
+			else
+				return QModelIndex();
 		}
 
 		case dataSetBaseNodeType::label: //Doesnt really make sense to have this as the parent of a subnodemodel but whatever
@@ -282,7 +285,10 @@ QModelIndex DataSetPackage::indexForSubNode(DataSetBaseNode * node) const
 			Label	* lab = dynamic_cast<Label*>( node);
 			Column	* col = dynamic_cast<Column*>(node->parent());
 
-			return createIndex(col->labelIndex(lab), 0, dynamic_cast<void*>(lab));
+			if (col)
+				return createIndex(col->labelIndex(lab), 0, dynamic_cast<void*>(lab));
+			else
+				return QModelIndex();
 		}
 
 		case dataSetBaseNodeType::filter: //Doesnt really make sense to have this as the parent of a subnodemodel but whatever
@@ -1961,6 +1967,21 @@ void DataSetPackage::unicifyColumnNames()
 	}
 }
 
+Json::Value DataSetPackage::getColumn(const std::string& columnName) const
+{
+	Column		*	column	= _dataSet->column(columnName);
+	if (column)
+		return column->serialize();
+	else
+		return Json::nullValue;
+}
+
+void DataSetPackage::setColumn(const std::string& columnName, const Json::Value& col)
+{
+	Column		*	column	= _dataSet->column(columnName);
+	column->deserialize(col);
+}
+
 void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, QStringList newColNames)
 {
 	JASPTIMER_SCOPE(DataSetPackage::pasteSpreadsheet);
@@ -2291,9 +2312,9 @@ void DataSetPackage::resetModelOneCell()
 	setData(index(0,0), "", Qt::DisplayRole);
 
 	beginResetModel();
-	DataSetPackage::pkg()->setDataSetSize(1, 1);
-	DataSetPackage::pkg()->setColumnName(0, DataSetPackage::pkg()->freeNewColumnName(0), false);
-	DataSetPackage::pkg()->setColumnType(0, columnType::scale,	false);
+	setDataSetSize(1, 1);
+	setColumnName(0, freeNewColumnName(0), false);
+	setColumnType(0, columnType::scale,	false);
 	endResetModel();
 }
 

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -30,6 +30,7 @@
 #include "databaseinterface.h"
 #include "dataset.h"
 #include "datasetpackageenums.h"
+#include "undostack.h"
 
 class EngineSync;
 class DataSetPackageSubNodeModel;
@@ -234,6 +235,7 @@ public:
 
 				int							getColumnIndex(			const std::string	& name)			const	{ return !_dataSet ? -1 : _dataSet->getColumnIndex(name); }
 				int							getColumnIndex(			const QString		& name)			const	{ return getColumnIndex(name.toStdString()); }
+				Column*						getColumn(				const std::string	& name)					{ return _dataSet->column(name); }
 				enum columnType				getColumnType(			size_t columnIndex)					const;
 				std::string					getColumnName(			size_t columnIndex)					const;
 				intvec						getColumnDataInts(		size_t columnIndex);
@@ -250,8 +252,8 @@ public:
 				QStringList					getColumnValuesAsStringList(size_t columnIndex)				const;
 				QList<QVariant>				getColumnValuesAsDoubleList(size_t columnIndex)				const;
 				void						unicifyColumnNames();
-				Json::Value					getColumn(const std::string& columnName)					const;
-				void						setColumn(const std::string& columnName, const Json::Value& col);
+				Json::Value					serializeColumn(const std::string& columnName)					const;
+				void						deserializeColumn(const std::string& columnName, const Json::Value& col);
 
 				bool						setFilterData(const std::string & filter, const boolvec & filterResult);
 				void						resetFilterAllows(size_t columnIndex);
@@ -275,6 +277,8 @@ public:
 
 				bool manualEdits() const;
 				void setManualEdits(bool newManualEdits);
+
+				UndoStack*					undoStack() { return _undoStack; }
 
 signals:
 				void				datasetChanged(	QStringList				changedColumns,
@@ -376,6 +380,7 @@ private:
 							*	_labelsSubModel;
 	
 	QTimer						_databaseIntervalSyncher;
+	UndoStack				*	_undoStack					= nullptr;
 };
 
 #endif // FILEPACKAGE_H

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -250,6 +250,8 @@ public:
 				QStringList					getColumnValuesAsStringList(size_t columnIndex)				const;
 				QList<QVariant>				getColumnValuesAsDoubleList(size_t columnIndex)				const;
 				void						unicifyColumnNames();
+				Json::Value					getColumn(const std::string& columnName)					const;
+				void						setColumn(const std::string& columnName, const Json::Value& col);
 
 				bool						setFilterData(const std::string & filter, const boolvec & filterResult);
 				void						resetFilterAllows(size_t columnIndex);

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -1,9 +1,12 @@
 #include "expanddataproxymodel.h"
 #include "datasettablemodel.h"
+#include "log.h"
 
 ExpandDataProxyModel::ExpandDataProxyModel(QObject *parent)
 	: QObject{parent}
 {
+	_undoStack = new QUndoStack(this);
+	connect(_undoStack, &QUndoStack::indexChanged, this, &ExpandDataProxyModel::undoChanged) ;
 }
 
 int ExpandDataProxyModel::rowCount(bool includeVirtuals) const
@@ -40,6 +43,7 @@ QVariant ExpandDataProxyModel::data(int row, int col, int role) const
 		return DataSetPackage::getDataSetViewLines(col>0, row>0, true, true);
 	}
 	case int(dataPkgRoles::value):					return "";
+	case int(dataPkgRoles::columnType):				return int(columnType::scale);
 //	case int(dataPkgRoles::itemInputValue):			return "string"; ???
 	default:										return QVariant();
 	}
@@ -157,12 +161,34 @@ int ExpandDataProxyModel::getRole(const std::string &roleName) const
 		return it->second;
 }
 
+void ExpandDataProxyModel::undo()
+{
+	_undoStack->undo();
+}
+
+void ExpandDataProxyModel::redo()
+{
+	_undoStack->redo();
+}
+
+void ExpandDataProxyModel::columnDataTypeChanged(QString colName)
+{
+	// A column type has been changed: either it was explicitly set, and then it is already in the undoStack,
+	// or it is due a data change command, then this change must be added in the undoStack as child of this command.
+	// TODO
+}
+
 void ExpandDataProxyModel::removeRows(int start, int count)
 {
 	if (!_sourceModel)
 		return;
 
-	_sourceModel->removeRows(start, count);
+	if (count > 1)
+		_startMacro(QObject::tr("Removes %1 rows from %2").arg(count).arg(start + 1));
+
+	for (int i = 0; i < count; i++)
+		removeRow(start + i);
+	_endMacro();
 }
 
 void ExpandDataProxyModel::removeColumns(int start, int count)
@@ -170,7 +196,13 @@ void ExpandDataProxyModel::removeColumns(int start, int count)
 	if (!_sourceModel)
 		return;
 
-	_sourceModel->removeColumns(start, count);
+	if (count > 1)
+		_startMacro(QObject::tr("Removes %1 columns from %2").arg(count).arg(start + 1));
+
+	for (int i = 0; i < count; i++)
+		removeColumn(start + i);
+
+	_endMacro();
 }
 
 void ExpandDataProxyModel::removeRow(int row)
@@ -178,8 +210,8 @@ void ExpandDataProxyModel::removeRow(int row)
 	if (!_sourceModel)
 		return;
 
-	if (row >= 0 && row < _sourceModel->columnCount())
-		_sourceModel->removeRow(row);
+	if (row >= 0 && row < _sourceModel->rowCount())
+		_pushCommand(new RemoveRowCommand(this, row));
 }
 
 void ExpandDataProxyModel::removeColumn(int col)
@@ -188,7 +220,7 @@ void ExpandDataProxyModel::removeColumn(int col)
 		return;
 
 	if (col >= 0 && col < _sourceModel->columnCount())
-		_sourceModel->removeColumn(col);
+		_pushCommand(new RemoveColumnCommand(this, col));
 }
 
 void ExpandDataProxyModel::insertRow(int row)
@@ -196,56 +228,258 @@ void ExpandDataProxyModel::insertRow(int row)
 	if (!_sourceModel)
 		return;
 
-	_sourceModel->insertRow(row);
+	_pushCommand(new InsertRowCommand(this, row));
 }
 
-void ExpandDataProxyModel::insertColumn(int col)
+void ExpandDataProxyModel::insertColumn(int col, bool computed, bool R)
 {
 	if (!_sourceModel)
 		return;
 
-	_sourceModel->insertColumn(col);
+	_pushCommand(new InsertColumnCommand(this, col, computed, R));
 }
 
-QString ExpandDataProxyModel::insertColumnSpecial(int col, bool computed, bool R)
+void ExpandDataProxyModel::_pushCommand(UndoModelCommand *command)
 {
-	DataSetTableModel * dataSetTable = dynamic_cast<DataSetTableModel *>(_sourceModel);
+	if (!_parentCommand) // Push to the stack only when no macro is started: in this case the command is autmatically added to the _parentCommand
+		_undoStack->push(command);
+}
 
-	if (dataSetTable)
-		return dataSetTable->insertColumnSpecial(col, computed, R);
+void ExpandDataProxyModel::_startMacro(const QString& text)
+{
+	if (_parentCommand)
+		Log::log() << "Macro started though last one is not finished!" << std::endl;
+	_parentCommand = new UndoModelCommand(this);
+	if (!text.isEmpty())
+		_parentCommand->setText(text);
+}
 
-	return "";
+void ExpandDataProxyModel::_endMacro(UndoModelCommand* command)
+{
+	if (command)
+	{
+		if (_parentCommand)
+			_parentCommand->setText(command->text());
+		else
+			_undoStack->push(command); // Case when macro was not started
+	}
+	if (_parentCommand)
+		_undoStack->push(_parentCommand);
+
+	_parentCommand = nullptr;
 }
 
 void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 {
+	QUndoCommand* parentCommand = nullptr;
+
 	if (!_sourceModel || row < 0 || col < 0 || row >= rowCount() || col >= columnCount())
 		return;
 
+	if (col >= _sourceModel->columnCount() || row >= _sourceModel->rowCount())
+		_startMacro();
+
 	for (int colNr = _sourceModel->columnCount(); colNr <= col; colNr++)
-		insertColumnSpecial(colNr, false, false);
+		insertColumn(colNr, false, false);
 	for (int rowNr = _sourceModel->rowCount(); rowNr <= row; rowNr++)
 		insertRow(rowNr);
+
 }
 
-bool ExpandDataProxyModel::setData(int row, int col, const QVariant &value, int role)
+void ExpandDataProxyModel::setData(int row, int col, const QVariant &value, int role)
 {
 	if (!_sourceModel || row < 0 || col < 0)
-		return false;
+		return;
 
 	_expandIfNecessary(row, col);
-
-	return _sourceModel->setData(index(row, col), value, role);
+	_endMacro(new SetDataCommand(this, row, col, value, role));
 }
 
 void ExpandDataProxyModel::pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells, QStringList newColNames)
 {
-	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_sourceModel);
-
-	if (!dataSetTable || row < 0 || col < 0)
+	if (!_sourceModel || row < 0 || col < 0)
 		return;
 
-	_expandIfNecessary(row, col);
+	_expandIfNecessary(row + cells.size() > 0 ? cells[0].size() : 0, col + cells.size());
+	_endMacro(new PasteSpreadsheetCommand(this, row, col, cells, newColNames));
+}
 
-	dataSetTable->pasteSpreadsheet(row, col, cells, newColNames);
+int ExpandDataProxyModel::setColumnType(int columnIndex, int columnType)
+{
+	_pushCommand(new SetColumnTypeCommand(this, columnIndex, columnType));
+
+	return data(0, columnIndex, int(dataPkgRoles::columnType)).toInt();
+}
+
+SetDataCommand::SetDataCommand(ExpandDataProxyModel *proxyModel, int row, int col, const QVariant &value, int role)
+	: UndoModelCommand(proxyModel), _newValue(value), _row(row), _col(col), _role(role)
+{
+	setText(QObject::tr("Set value to %1 at row %2 column %3").arg(_newValue.toString()).arg(rowName(_row)).arg(columnName(_col)));
+}
+
+void SetDataCommand::undo()
+{
+	sourceModel()->setData(_proxyModel->index(_row, _col), _oldValue, _role);
+}
+
+void SetDataCommand::redo()
+{
+	_oldValue = _proxyModel->data(_row, _col);
+	sourceModel()->setData(_proxyModel->index(_row, _col), _newValue, _role);
+}
+
+InsertColumnCommand::InsertColumnCommand(ExpandDataProxyModel *proxyModel, int column, bool computed, bool R)
+	: UndoModelCommand(proxyModel), _col(column), _computed(computed), _R(R)
+{
+	setText(_computed ? QObject::tr("Insert computed column %1").arg(_col) : QObject::tr("Insert column %1").arg(columnName(_col)));
+}
+
+void InsertColumnCommand::undo()
+{
+	sourceModel()->removeColumn(_col);
+}
+
+void InsertColumnCommand::redo()
+{
+	DataSetTableModel * dataSetTable = dynamic_cast<DataSetTableModel *>(sourceModel());
+
+	if (dataSetTable)
+		dataSetTable->insertColumnSpecial(_col, _computed, _R);
+}
+
+InsertRowCommand::InsertRowCommand(ExpandDataProxyModel *proxyModel, int row)
+	: UndoModelCommand(proxyModel), _row(row)
+{
+	setText(QObject::tr("Insert row %1").arg(rowName(_row)));
+}
+
+void InsertRowCommand::undo()
+{
+	sourceModel()->removeRow(_row);
+}
+
+void InsertRowCommand::redo()
+{
+	sourceModel()->insertRow(_row);
+}
+
+RemoveColumnCommand::RemoveColumnCommand(ExpandDataProxyModel *proxyModel, int col)
+	: UndoModelCommand(proxyModel), _col(col)
+{
+	setText(QObject::tr("Remove column %1").arg(columnName(_col)));
+}
+
+void RemoveColumnCommand::undo()
+{
+	sourceModel()->insertColumn(_col);
+	DataSetTableModel * dataSetTable = dynamic_cast<DataSetTableModel *>(sourceModel());
+	if (dataSetTable)
+		DataSetPackage::pkg()->setColumn(dataSetTable->columnName(_col).toStdString(), _serializedColumn);
+}
+
+void RemoveColumnCommand::redo()
+{
+	DataSetTableModel * dataSetTable = dynamic_cast<DataSetTableModel *>(sourceModel());
+	if (dataSetTable) // Use its name to access a column instead of an index, since the name is sure to be the same but the the index
+		_serializedColumn = DataSetPackage::pkg()->getColumn(dataSetTable->columnName(_col).toStdString());
+	sourceModel()->removeColumn(_col);
+}
+
+RemoveRowCommand::RemoveRowCommand(ExpandDataProxyModel *proxyModel, int row)
+	: UndoModelCommand(proxyModel), _row(row)
+{
+	setText(QObject::tr("Remove row %1").arg(rowName(_row)));
+}
+
+void RemoveRowCommand::undo()
+{
+	sourceModel()->insertRow(_row);
+
+	for (int i = 0; i < sourceModel()->columnCount() && i < _values.count(); i++)
+		sourceModel()->setData(sourceModel()->index(_row, i), _values[i], 0);
+}
+
+void RemoveRowCommand::redo()
+{
+	_values.clear();
+	for (int i = 0; i < sourceModel()->columnCount(); i++)
+		_values.push_back(sourceModel()->data(sourceModel()->index(_row, i)));
+
+	sourceModel()->removeRow(_row);
+}
+
+PasteSpreadsheetCommand::PasteSpreadsheetCommand(ExpandDataProxyModel *proxyModel, int row, int col, const std::vector<std::vector<QString> > &cells, const QStringList &newColNames)
+	: UndoModelCommand(proxyModel), _row(row), _col(col), _newCells(cells), _newColNames(newColNames)
+{
+	setText(QObject::tr("Paste spreadsheet at row %1 column %2").arg(rowName(_row)).arg(columnName(_col)));
+}
+
+void PasteSpreadsheetCommand::undo()
+{
+	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_proxyModel->sourceModel());
+
+	if (dataSetTable)
+		dataSetTable->pasteSpreadsheet(_row, _col, _oldCells, _newColNames);
+}
+
+void PasteSpreadsheetCommand::redo()
+{
+	_oldCells.clear();
+	for (int c = 0; c < _newCells.size(); c++)
+	{
+		_oldCells.push_back(std::vector<QString>());
+		for (int r = 0; r < _newCells[c].size(); r++)
+			_oldCells[c].push_back(sourceModel()->data(sourceModel()->index(_row + r, _col + c)).toString());
+	}
+
+	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_proxyModel->sourceModel());
+
+	if (dataSetTable)
+		dataSetTable->pasteSpreadsheet(_row, _col, _newCells, _newColNames);
+}
+
+UndoModelCommand::UndoModelCommand(ExpandDataProxyModel *proxyModel)
+	: QUndoCommand{proxyModel->parentCommand()}, _proxyModel{proxyModel}
+{
+}
+
+QAbstractItemModel *UndoModelCommand::sourceModel() const
+{
+	return _proxyModel->sourceModel();
+}
+
+QString UndoModelCommand::columnName(int colIndex) const
+{
+	QString result = _proxyModel->headerData(colIndex, Qt::Orientation::Horizontal).toString();
+	if (result.isEmpty())
+		result = QString::number(colIndex + 1);
+
+	return result;
+}
+
+QString UndoModelCommand::rowName(int rowIndex) const
+{
+	QString result = _proxyModel->headerData(rowIndex, Qt::Orientation::Vertical).toString();
+	if (result.isEmpty())
+		result = QString::number(rowIndex + 1);
+
+	return result;
+}
+
+
+SetColumnTypeCommand::SetColumnTypeCommand(ExpandDataProxyModel *proxyModel, int col, int colType)
+	: UndoModelCommand(proxyModel),_col(col), _newColType(colType)
+{
+	setText(QObject::tr("Set type %1 to column %2").arg(columnTypeToQString(columnType(colType))).arg(columnName(col)));
+}
+
+void SetColumnTypeCommand::undo()
+{
+	sourceModel()->setData(_proxyModel->index(0, _col), _oldColType, int(dataPkgRoles::columnType));
+}
+
+void SetColumnTypeCommand::redo()
+{
+	_oldColType = _proxyModel->data(0, _col, int(dataPkgRoles::columnType)).toInt();
+	sourceModel()->setData(_proxyModel->index(0, _col), _newColType, int(dataPkgRoles::columnType));
 }

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -3,18 +3,134 @@
 
 #include <QAbstractItemModel>
 #include "utils.h"
+#include <QUndoCommand>
+#include <json/json.h>
 
-class DataSetView;
+class ExpandDataProxyModel;
+
+class UndoModelCommand : public QUndoCommand
+{
+public:
+	UndoModelCommand(ExpandDataProxyModel* proxyModel);
+
+	QAbstractItemModel* sourceModel()							const;
+	QString				columnName(int colIndex)				const;
+	QString				rowName(int rowIndex)					const;
+
+protected:
+	ExpandDataProxyModel*					_proxyModel = nullptr;
+};
+
+class SetDataCommand : public UndoModelCommand
+{
+public:
+	SetDataCommand(ExpandDataProxyModel *model, int row, int col, const QVariant &value, int role);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	QVariant				_oldValue,
+							_newValue;
+	int						_row,
+							_col,
+							_role;
+};
+
+class PasteSpreadsheetCommand : public UndoModelCommand
+{
+public:
+	PasteSpreadsheetCommand(ExpandDataProxyModel *model, int row, int col, const std::vector<std::vector<QString>>& cells, const QStringList& newColNames);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	std::vector<std::vector<QString>>	_newCells,
+										_oldCells;
+	QStringList							_newColNames;
+	int									_row,
+										_col;
+};
+
+class SetColumnTypeCommand : public UndoModelCommand
+{
+public:
+	SetColumnTypeCommand(ExpandDataProxyModel *model, int col, int colType);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int									_col,
+										_newColType,
+										_oldColType;
+};
+
+
+class InsertColumnCommand : public UndoModelCommand
+{
+public:
+	InsertColumnCommand(ExpandDataProxyModel *model, int col, bool computed, bool R);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_col;
+	bool					_computed,
+							_R;
+};
+
+class InsertRowCommand : public UndoModelCommand
+{
+public:
+	InsertRowCommand(ExpandDataProxyModel *model, int row);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_row;
+};
+
+class RemoveColumnCommand : public UndoModelCommand
+{
+public:
+	RemoveColumnCommand(ExpandDataProxyModel *model, int col);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_col;
+	Json::Value				_serializedColumn;
+};
+
+class RemoveRowCommand : public UndoModelCommand
+{
+public:
+	RemoveRowCommand(ExpandDataProxyModel *model, int row);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_row;
+	QVariantList			_values;
+};
 
 class ExpandDataProxyModel : public QObject
 {
+	Q_OBJECT
+
 public:
 	explicit ExpandDataProxyModel(QObject *parent);
 
 	int					rowCount(bool includeVirtuals = true)														const;
 	int					columnCount(bool includeVirtuals = true)													const;
 	QVariant			headerData(	int section, Qt::Orientation orientation, int role = Qt::DisplayRole )			const;
-	bool				setData(	int row, int col, const QVariant &value, int role);
+	void				setData(	int row, int col, const QVariant &value, int role);
 	Qt::ItemFlags		flags(int row, int column)																	const;
 	QModelIndex			index(int row, int column, const QModelIndex &parent = QModelIndex())						const;
 	QVariant			data(int row, int column, int role = Qt::DisplayRole)										const;
@@ -32,19 +148,33 @@ public:
 	void				removeRow(int row);
 	void				removeColumn(int col);
 	void				insertRow(int row);
-	void				insertColumn(int col);
-	QString				insertColumnSpecial(int col, bool computed, bool R);
+	void				insertColumn(int col, bool computed, bool R);
 	void				pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList());
+	int					setColumnType(int columnIndex, int columnType);
 
 	int					getRole(const std::string& roleName)														const;
+
+	void				undo();
+	void				redo();
+	QString				undoText()			{ return _undoStack->undoText(); }
+	QString				redoText()			{ return _undoStack->redoText(); }
+	QUndoCommand*		parentCommand()		{ return _parentCommand; }
+	void				columnDataTypeChanged(QString colName);
+
+signals:
+	void				undoChanged();
 
 protected:
 	void				_setRolenames();
 	void				_expandIfNecessary(int row, int col);
-
+	void				_pushCommand(UndoModelCommand* command);
+	void				_startMacro(const QString& text = QString());
+	void				_endMacro(UndoModelCommand* command = nullptr);
 
 	QAbstractItemModel*			_sourceModel			= nullptr;
 	bool						_expandDataSet			= false;
+	QUndoStack*					_undoStack				= nullptr;
+	UndoModelCommand*			_parentCommand			= nullptr;
 
 	strintmap					_roleNameToRole;
 

--- a/Desktop/data/filtermodel.cpp
+++ b/Desktop/data/filtermodel.cpp
@@ -5,6 +5,8 @@
 FilterModel::FilterModel(labelFilterGenerator * labelFilterGenerator)
 	: QObject(DataSetPackage::pkg()), _labelFilterGenerator(labelFilterGenerator)
 {
+	_undoStack = DataSetPackage::pkg()->undoStack();
+
 	reset();
 	connect(this,					&FilterModel::rFilterChanged,	this, &FilterModel::rescanRFilterForColumns	);
 	connect(DataSetPackage::pkg(),	&DataSetPackage::modelReset,	this, &FilterModel::dataSetPackageResetDone	);
@@ -77,6 +79,18 @@ void FilterModel::setFilterErrorMsg(	QString newFilterErrorMsg)
 		
 		emit filterErrorMsgChanged();
 	}
+}
+
+void FilterModel::applyConstructorJson(QString newConstructorJson)
+{
+	if (newConstructorJson != constructorJson())
+		_undoStack->pushCommand(new SetJsonFilterCommand(DataSetPackage::pkg(), this, newConstructorJson));
+}
+
+void FilterModel::applyRFilter(QString newRFilter)
+{
+	if (newRFilter != rFilter())
+		_undoStack->pushCommand(new SetRFilterCommand(DataSetPackage::pkg(), this, newRFilter));
 }
 
 void FilterModel::setConstructorJson(QString newconstructorJson)

--- a/Desktop/data/filtermodel.h
+++ b/Desktop/data/filtermodel.h
@@ -37,7 +37,7 @@ public:
 	bool	hasFilter()				const	{ return rFilter() != DEFAULT_FILTER || constructorJson() != DEFAULT_FILTER_JSON; }
 
 
-	Q_INVOKABLE void resetRFilter()				{ setRFilter(DEFAULT_FILTER); }
+	Q_INVOKABLE void resetRFilter()				{ applyRFilter(DEFAULT_FILTER); }
 	void		sendGeneratedAndRFilter();
 
 	void updateStatusBar();
@@ -52,6 +52,11 @@ public slots:
 	void setGeneratedFilter(QString newGeneratedFilter);
 	void setConstructorJson(QString newconstructorJson);
 	void setFilterErrorMsg(	QString newFilterErrorMsg);
+
+	void applyConstructorJson(	QString constructorJson);
+	void applyRFilter(			QString rFilter);
+	void undo() { _undoStack->undo(); }
+	void redo() { _undoStack->redo(); }
 
 	void processFilterResult(int requestId);
 	void processFilterErrorMsg(QString filterErrorMsg, int requestId);
@@ -97,6 +102,8 @@ private:
 								_columnsUsedInRFilter;
 
 	int							_lastSentRequestId		= 0;
+
+	UndoStack*					_undoStack				= nullptr;
 };
 
 #endif // FILTERMODEL_H

--- a/Desktop/data/labelmodel.h
+++ b/Desktop/data/labelmodel.h
@@ -4,6 +4,7 @@
 
 
 #include "datasettableproxy.h"
+#include "undostack.h"
 #include <QTimer>
 
 /// 
@@ -32,7 +33,7 @@ public:
 	QString		columnNameQ();
 	QString		columnTitle() const;
 	QString		columnDescription() const;
-	bool		setData(const QModelIndex & index, const QVariant & value,	int role = -1)						override;
+	bool		setData(const QModelIndex & index, const QVariant & value,	int role = Qt::EditRole)						override;
 	QVariant	data(	const QModelIndex & index,							int role = Qt::DisplayRole)	const	override;
 	QVariant	headerData(int section, Qt::Orientation orientation, int role)							const	override;
 
@@ -49,6 +50,8 @@ public:
 	Q_INVOKABLE void unselectAll();
 	Q_INVOKABLE bool setChecked(int rowIndex, bool checked);
 	Q_INVOKABLE void setLabel(int rowIndex, QString label);
+	Q_INVOKABLE void undo()				{ _undoStack->undo(); }
+	Q_INVOKABLE void redo()				{ _undoStack->redo(); }
 
 	boolvec			filterAllows(size_t col);
 	stringvec		labels(size_t col);
@@ -62,6 +65,7 @@ public:
 	void setColumnDescription(const QString & newColumnDescription);
 
 	bool showLabelEditor() const;
+	void setLabelMaxWidth();
 
 
 public slots:
@@ -97,15 +101,16 @@ signals:
 private:
 	std::vector<size_t> getSortedSelection()					const;
 	void				setValueMaxWidth();
-	void				setLabelMaxWidth();
 
 private:
-	bool				_visible		= false;
+	bool				_visible		= false,
+						_editing		= false;
 	double				_valueMaxWidth	= 10,
 						_labelMaxWidth	= 10,
 						_rowWidth		= 60;
 	std::set<QString>	_selected;
 	int					_lastSelected	= -1;
+	UndoStack*			_undoStack		= nullptr;
 };
 
 #endif // LABELMODEL_H

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -1,0 +1,493 @@
+#include "undostack.h"
+#include "log.h"
+#include "datasettablemodel.h"
+#include "labelmodel.h"
+#include "filtermodel.h"
+#include "computedcolumnsmodel.h"
+#include "utilities/qutils.h"
+
+UndoStack* UndoStack::_undoStack = nullptr;
+
+UndoStack::UndoStack(QObject* parent) : QUndoStack(parent)
+{
+	_undoStack = this;
+}
+
+void UndoStack::pushCommand(UndoModelCommand *command)
+{
+	if (!_parentCommand) // Push to the stack only when no macro is started: in this case the command is autmatically added to the _parentCommand
+		push(command);
+}
+
+void UndoStack::startMacro(const QString &text)
+{
+	if (_parentCommand)
+		Log::log() << "Macro started though last one is not finished!" << std::endl;
+	_parentCommand = new UndoModelCommand();
+	if (!text.isEmpty())
+		_parentCommand->setText(text);
+}
+
+void UndoStack::endMacro(UndoModelCommand *command)
+{
+	if (command)
+	{
+		if (_parentCommand)
+			_parentCommand->setText(command->text());
+		else
+			push(command); // Case when macro was not started
+	}
+	if (_parentCommand)
+		push(_parentCommand);
+
+	_parentCommand = nullptr;
+}
+
+
+SetDataCommand::SetDataCommand(QAbstractItemModel *model, int row, int col, const QVariant &value, int role)
+	: UndoModelCommand(model), _newValue{value}, _row{row}, _col{col}, _role{role}
+{
+	setText(QObject::tr("Set value to '%1' at row %2 column '%3'").arg(_newValue.toString()).arg(rowName(_row)).arg(columnName(_col)));
+}
+
+void SetDataCommand::undo()
+{
+	_model->setData(_model->index(_row, _col), _oldValue, _role);
+	if (_oldColType != _newColType)
+		_model->setData(_model->index(0, _col), _oldColType, int(dataPkgRoles::columnType));
+}
+
+void SetDataCommand::redo()
+{
+	_oldValue = _model->data(_model->index(_row, _col));
+	_oldColType = _model->data(_model->index(0, _col), int(dataPkgRoles::columnType)).toInt();
+
+	_model->setData(_model->index(_row, _col), _newValue, _role);
+
+	_newColType = _model->data(_model->index(0, _col), int(dataPkgRoles::columnType)).toInt();
+}
+
+InsertColumnCommand::InsertColumnCommand(QAbstractItemModel *model, int column, bool computed, bool R)
+	: UndoModelCommand(model), _col{column}, _computed{computed}, _R{R}
+{
+	setText(_computed ? QObject::tr("Insert computed column '%1'").arg(_col) : QObject::tr("Insert column '%1'").arg(columnName(_col)));
+}
+
+void InsertColumnCommand::undo()
+{
+	_model->removeColumn(_col);
+}
+
+void InsertColumnCommand::redo()
+{
+	DataSetTableModel * dataSetTable = dynamic_cast<DataSetTableModel *>(_model);
+
+	if (dataSetTable)
+		dataSetTable->insertColumnSpecial(_col, _computed, _R);
+}
+
+InsertRowCommand::InsertRowCommand(QAbstractItemModel *model, int row)
+	: UndoModelCommand(model), _row{row}
+{
+	setText(QObject::tr("Insert row %1").arg(rowName(_row)));
+}
+
+void InsertRowCommand::undo()
+{
+	_model->removeRow(_row);
+}
+
+void InsertRowCommand::redo()
+{
+	_model->insertRow(_row);
+}
+
+RemoveColumnCommand::RemoveColumnCommand(QAbstractItemModel *model, int col)
+	: UndoModelCommand(model), _col{col}
+{
+	setText(QObject::tr("Remove column '%1'").arg(columnName(_col)));
+}
+
+void RemoveColumnCommand::undo()
+{
+	_model->insertColumn(_col);
+	DataSetPackage::pkg()->deserializeColumn(columnName(_col).toStdString(), _serializedColumn);
+}
+
+void RemoveColumnCommand::redo()
+{
+	_serializedColumn = DataSetPackage::pkg()->serializeColumn(columnName(_col).toStdString());
+	_model->removeColumn(_col);
+}
+
+RemoveRowCommand::RemoveRowCommand(QAbstractItemModel *model, int row)
+	: UndoModelCommand(model), _row{row}
+{
+	setText(QObject::tr("Remove row %1").arg(rowName(_row)));
+}
+
+void RemoveRowCommand::undo()
+{
+	_model->insertRow(_row);
+
+	for (int i = 0; i < _model->columnCount() && i < _values.count(); i++)
+		_model->setData(_model->index(_row, i), _values[i], 0);
+}
+
+void RemoveRowCommand::redo()
+{
+	_values.clear();
+	for (int i = 0; i < _model->columnCount(); i++)
+		_values.push_back(_model->data(_model->index(_row, i)));
+
+	_model->removeRow(_row);
+}
+
+PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString> > &cells, const QStringList &newColNames)
+	: UndoModelCommand(model), _row{row}, _col{col}, _newCells{cells}, _newColNames{newColNames}
+{
+	setText(QObject::tr("Paste values at row %1 column '%2'").arg(rowName(_row)).arg(columnName(_col)));
+}
+
+void PasteSpreadsheetCommand::undo()
+{
+	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_model);
+
+	if (dataSetTable)
+		dataSetTable->pasteSpreadsheet(_row, _col, _oldCells, _newColNames);
+}
+
+void PasteSpreadsheetCommand::redo()
+{
+	_oldCells.clear();
+	for (int c = 0; c < _newCells.size(); c++)
+	{
+		_oldCells.push_back(std::vector<QString>());
+		for (int r = 0; r < _newCells[c].size(); r++)
+			_oldCells[c].push_back(_model->data(_model->index(_row + r, _col + c)).toString());
+	}
+
+	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_model);
+
+	if (dataSetTable)
+		dataSetTable->pasteSpreadsheet(_row, _col, _newCells, _newColNames);
+}
+
+
+SetColumnTypeCommand::SetColumnTypeCommand(QAbstractItemModel *model, int col, int colType)
+	: UndoModelCommand(model), _col{col}, _newColType{colType}
+{
+	setText(QObject::tr("Set type '%1' to column '%2'").arg(columnTypeToQString(columnType(colType))).arg(columnName(col)));
+}
+
+void SetColumnTypeCommand::undo()
+{
+	_model->setData(_model->index(0, _col), _oldColType, int(dataPkgRoles::columnType));
+}
+
+void SetColumnTypeCommand::redo()
+{
+	_oldColType = _model->data(_model->index(0, _col), int(dataPkgRoles::columnType)).toInt();
+	_model->setData(_model->index(0, _col), _newColType, int(dataPkgRoles::columnType));
+}
+
+SetColumnPropertyCommand::SetColumnPropertyCommand(QAbstractItemModel *model, QString newValue, ColumnProperty prop)
+	: UndoModelCommand(model), _prop(prop), _newValue{newValue}
+{
+	LabelModel* labelModel = qobject_cast<LabelModel*>(model);
+	if (labelModel)
+	{
+		_colId = labelModel->chosenColumn();
+
+		switch (_prop)
+		{
+		case ColumnProperty::Name:
+			_oldValue = labelModel->columnNameQ();
+			setText(QObject::tr("Change column name from '%1' to '%2'").arg(_oldValue).arg(_newValue));
+			break;
+		case ColumnProperty::Title:
+			_oldValue = labelModel->columnTitle();
+			setText(QObject::tr("Change column title from '%1' to '%2'").arg(_oldValue).arg(_newValue));
+			break;
+		case ColumnProperty::Description:
+			_oldValue = labelModel->columnDescription();
+			setText(QObject::tr("Change column description from '%1' to '%2'").arg(_oldValue).arg(_newValue));
+			break;
+		}
+	}
+	else
+	{
+		Log::log() << "Try to change the column name with the wrong model!" << std::endl;
+		setObsolete(true);
+	}
+}
+
+void SetColumnPropertyCommand::undo()
+{
+	switch (_prop)
+	{
+	case ColumnProperty::Name:
+		// In case that the command that deletes a column is undone, the id may change.
+		// As the column can be also recognize with its name, use it.
+		DataSetPackage::pkg()->setColumnName(DataSetPackage::pkg()->getColumnIndex(_newValue), fq(_oldValue));
+		break;
+	case ColumnProperty::Title:
+		DataSetPackage::pkg()->setColumnTitle(_colId, fq(_oldValue));
+		break;
+	case ColumnProperty::Description:
+		DataSetPackage::pkg()->setColumnDescription(_colId, fq(_oldValue));
+		break;
+	}
+}
+
+void SetColumnPropertyCommand::redo()
+{
+	switch (_prop)
+	{
+	case ColumnProperty::Name:
+		DataSetPackage::pkg()->setColumnName(DataSetPackage::pkg()->getColumnIndex(_oldValue), fq(_newValue));
+		break;
+	case ColumnProperty::Title:
+		DataSetPackage::pkg()->setColumnTitle(_colId, fq(_newValue));
+		break;
+	case ColumnProperty::Description:
+		DataSetPackage::pkg()->setColumnDescription(_colId, fq(_newValue));
+		break;
+	}
+
+}
+
+SetLabelCommand::SetLabelCommand(QAbstractItemModel *model, int labelIndex, QString newLabel)
+	: UndoModelCommand(model), _labelIndex{labelIndex}, _newLabel{newLabel}
+{	
+	_labelModel = qobject_cast<LabelModel*>(model);
+	if (_labelModel)
+	{
+		_colId = _labelModel->chosenColumn();
+		_oldLabel = _model->data(_model->index(_labelIndex, 0)).toString();
+		QString value = _model->data(_model->index(_labelIndex, 0), int(DataSetPackage::specialRoles::value)).toString();
+		setText(QObject::tr("Set label for value '%1' of column '%2' from '%3' to '%4'").arg(value).arg(_labelModel->columnNameQ()).arg(_oldLabel).arg(_newLabel));
+	}
+	else
+	{
+		Log::log() << "Try to set a label name with a wrong model!" << std::endl;
+		setObsolete(true);
+	}
+}
+
+void SetLabelCommand::undo()
+{
+	_labelModel->setChosenColumn(_colId);
+	_model->setData(_model->index(_labelIndex, 0), _oldLabel);
+	_labelModel->setLabelMaxWidth();
+}
+
+void SetLabelCommand::redo()
+{
+	_labelModel->setChosenColumn(_colId);
+	_model->setData(_model->index(_labelIndex, 0), _newLabel);
+	_labelModel->setLabelMaxWidth();
+}
+
+
+FilterLabelCommand::FilterLabelCommand(QAbstractItemModel *model, int labelIndex, bool checked)
+	: UndoModelCommand(model), _labelIndex{labelIndex}, _checked{checked}
+
+{
+	_labelModel = qobject_cast<LabelModel*>(model);
+	if (_labelModel)
+	{
+		_colId = _labelModel->chosenColumn();
+		QString label = _model->data(_model->index(_labelIndex, 0)).toString();
+		if (checked)
+			setText(QObject::tr("Filter rows having label '%1' in column '%2'").arg(label).arg(_labelModel->columnNameQ()));
+		else
+			setText(QObject::tr("Remove filter for rows having label '%1' in column '%2'").arg(label).arg(_labelModel->columnNameQ()));
+	}
+	else
+	{
+		Log::log() << "Try to set a label filter with a wrong model!" << std::endl;
+		setObsolete(true);
+	}
+}
+
+void FilterLabelCommand::undo()
+{
+	_labelModel->setChosenColumn(_colId);
+	_model->setData(_model->index(_labelIndex, 0), !_checked, int(DataSetPackage::specialRoles::filter));
+}
+
+void FilterLabelCommand::redo()
+{
+	_labelModel->setChosenColumn(_colId);
+	_model->setData(_model->index(_labelIndex, 0), _checked, int(DataSetPackage::specialRoles::filter));
+}
+
+MoveLabelCommand::MoveLabelCommand(QAbstractItemModel *model, const std::vector<size_t> &indexes, bool up)
+	: UndoModelCommand(model), _up{up}
+{
+	_labelModel = qobject_cast<LabelModel*>(model);
+	if (_labelModel)
+	{
+		_colId = _labelModel->chosenColumn();
+
+		QStringList allLabels = DataSetPackage::pkg()->getColumnLabelsAsStringList(_colId);
+		for (int i : indexes)
+		{
+			if (i < allLabels.count())
+				_labels.push_back(allLabels[i]);
+		}
+
+		if (_labels.size() == 1)
+		{
+			QString label = _labels[0];
+			if (_up)
+				setText(QObject::tr("Move up label '%1' of column '%2'").arg(label).arg(_labelModel->columnNameQ()));
+			else
+				setText(QObject::tr("Move down label '%1' of column '%2'").arg(label).arg(_labelModel->columnNameQ()));
+		}
+		else
+		{
+			if (_up)
+				setText(QObject::tr("Move up labels of column '%1'").arg(_labelModel->columnNameQ()));
+			else
+				setText(QObject::tr("Move down labels of column '%1'").arg(_labelModel->columnNameQ()));
+		}
+	}
+	else
+	{
+		Log::log() << "Try to move a label with a wrong model!" << std::endl;
+		setObsolete(true);
+	}
+}
+
+std::vector<size_t> MoveLabelCommand::_getIndexes()
+{
+	std::vector<size_t> indexes;
+	QStringList allLabels = DataSetPackage::pkg()->getColumnLabelsAsStringList(_colId);
+	for (const QString& label : _labels)
+	{
+		int i = allLabels.indexOf(label);
+		if (i >= 0)
+			indexes.push_back(i);
+	}
+
+	return indexes;
+}
+
+void MoveLabelCommand::_moveLabels(bool up)
+{
+	_labelModel->setChosenColumn(_colId);
+	std::vector<size_t> indexes = _getIndexes(); // The indexes must be recalculated each time
+	DataSetPackage::pkg()->labelMoveRows(_colId, indexes, up); //through DataSetPackage to make sure signals get sent
+}
+
+void MoveLabelCommand::undo()
+{
+	_moveLabels(!_up);
+}
+
+void MoveLabelCommand::redo()
+{
+	_moveLabels(_up);
+}
+
+ReverseLabelCommand::ReverseLabelCommand(QAbstractItemModel *model)
+	: UndoModelCommand(model)
+{
+	_labelModel = qobject_cast<LabelModel*>(model);
+	if (_labelModel)
+	{
+		_colId = _labelModel->chosenColumn();
+		setText(QObject::tr("Reverse labels of column '%2'").arg(_labelModel->columnNameQ()));
+	}
+	else
+	{
+		Log::log() << "Try to reverse a label with a wrong model!" << std::endl;
+		setObsolete(true);
+	}
+}
+
+void ReverseLabelCommand::undo()
+{
+	redo();
+}
+
+void ReverseLabelCommand::redo()
+{
+	_labelModel->setChosenColumn(_colId);
+	DataSetPackage::pkg()->labelReverse(_colId); //through DataSetPackage to make sure signals get sent
+}
+
+SetJsonFilterCommand::SetJsonFilterCommand(QAbstractItemModel *model, FilterModel* filterModel, const QString& newJsonValue)
+	: UndoModelCommand(model), _filterModel{filterModel}, _newJsonValue{newJsonValue}
+{
+	setText(QObject::tr("Change drag and drop filter"));
+}
+
+void SetJsonFilterCommand::undo()
+{
+	_filterModel->setConstructorJson(_oldJsonValue);
+}
+
+void SetJsonFilterCommand::redo()
+{
+	_oldJsonValue = _filterModel->constructorJson();
+	_filterModel->setConstructorJson(_newJsonValue);
+}
+
+SetRFilterCommand::SetRFilterCommand(QAbstractItemModel *model, FilterModel* filterModel, const QString& newRFilter)
+	: UndoModelCommand(model), _filterModel{filterModel}, _newRFilter{newRFilter}
+{
+	setText(QObject::tr("Change R filter"));
+}
+
+void SetRFilterCommand::undo()
+{
+	_filterModel->setRFilter(_oldRFilter);
+}
+
+void SetRFilterCommand::redo()
+{
+	_oldRFilter = _filterModel->rFilter();
+	_filterModel->setRFilter(_newRFilter);
+}
+
+CreateComputedColumnCommand::CreateComputedColumnCommand(QAbstractItemModel *model, const QString &name, int columnType, int computedColumnType)
+	: UndoModelCommand(model), _name{name}, _columnType{columnType}, _computedColumnType{computedColumnType}
+{
+	setText(QObject::tr("Create a computed column with name '%1").arg(name));
+}
+
+void CreateComputedColumnCommand::undo()
+{
+	DataSetPackage::pkg()->removeColumn(_name.toStdString());
+}
+
+void CreateComputedColumnCommand::redo()
+{
+	DataSetPackage::pkg()->createComputedColumn(fq(_name), columnType(_columnType), computedColumnType(_computedColumnType));
+}
+
+UndoModelCommand::UndoModelCommand(QAbstractItemModel *model)
+	: QUndoCommand(UndoStack::singleton()->parentCommand()), _model{model}
+{
+}
+
+QString UndoModelCommand::columnName(int colIndex) const
+{
+	QString result = _model->headerData(colIndex, Qt::Orientation::Horizontal).toString();
+	if (result.isEmpty())
+		result = QString::number(colIndex + 1);
+
+	return result;
+}
+
+QString UndoModelCommand::rowName(int rowIndex) const
+{
+	QString result = _model->headerData(rowIndex, Qt::Orientation::Vertical).toString();
+	if (result.isEmpty())
+		result = QString::number(rowIndex + 1);
+
+	return result;
+}

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -1,0 +1,268 @@
+#ifndef UNDOSTACK_H
+#define UNDOSTACK_H
+
+#include <QUndoStack>
+#include <QAbstractItemModel>
+#include <json/json.h>
+
+class LabelModel;
+class FilterModel;
+class ComputedColumnsModel;
+
+class UndoModelCommand : public QUndoCommand
+{
+public:
+	UndoModelCommand(QAbstractItemModel* model = nullptr);
+
+	QString				columnName(int colIndex)				const;
+	QString				rowName(int rowIndex)					const;
+
+protected:
+	QAbstractItemModel*	_model = nullptr;
+};
+
+class SetColumnPropertyCommand: public UndoModelCommand
+{
+public:
+	enum class ColumnProperty { Name, Title, Description };
+
+	SetColumnPropertyCommand(QAbstractItemModel *model, QString newValue, ColumnProperty prop);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	ColumnProperty			_prop	= ColumnProperty::Name;
+	int						_colId	= -1;
+	QString					_newValue,
+							_oldValue;
+};
+
+class SetLabelCommand: public UndoModelCommand
+{
+public:
+	SetLabelCommand(QAbstractItemModel *model, int labelIndex, QString newLabel);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	LabelModel*				_labelModel = nullptr;
+	int						_colId		= -1,
+							_labelIndex = -1;
+	QString					_newLabel,
+							_oldLabel;
+};
+
+class FilterLabelCommand: public UndoModelCommand
+{
+public:
+	FilterLabelCommand(QAbstractItemModel *model, int labelIndex, bool checked);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	LabelModel*				_labelModel = nullptr;
+	int						_colId		= -1,
+							_labelIndex = -1;
+	bool					_checked	= false;
+};
+
+class MoveLabelCommand: public UndoModelCommand
+{
+public:
+	MoveLabelCommand(QAbstractItemModel *model, const std::vector<size_t>& indexes, bool up);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	std::vector<size_t>		_getIndexes();
+	void					_moveLabels(bool up);
+
+	LabelModel*				_labelModel = nullptr;
+	int						_colId		= -1;
+	QStringList				_labels;
+	bool					_up			= false;
+};
+
+class ReverseLabelCommand: public UndoModelCommand
+{
+public:
+	ReverseLabelCommand(QAbstractItemModel *model);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	LabelModel*				_labelModel = nullptr;
+	int						_colId		= -1;
+};
+
+class SetJsonFilterCommand: public UndoModelCommand
+{
+public:
+	SetJsonFilterCommand(QAbstractItemModel *model, FilterModel* filterModel, const QString& newJsonValue);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	FilterModel*			_filterModel = nullptr;
+	QString					_oldJsonValue,
+							_newJsonValue;
+};
+
+class SetRFilterCommand: public UndoModelCommand
+{
+public:
+	SetRFilterCommand(QAbstractItemModel *model, FilterModel* filterModel, const QString& newRValue);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	FilterModel*			_filterModel = nullptr;
+	QString					_oldRFilter,
+							_newRFilter;
+};
+
+class CreateComputedColumnCommand: public UndoModelCommand
+{
+public:
+	CreateComputedColumnCommand(QAbstractItemModel *model, const QString& name, int columnType, int computedColumnType);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	QString					_name;
+	int						_columnType				= -1;
+	int						_computedColumnType		= -1;
+};
+
+class SetDataCommand : public UndoModelCommand
+{
+public:
+	SetDataCommand(QAbstractItemModel *model, int row, int col, const QVariant &value, int role);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	QVariant				_oldValue,
+							_newValue;
+	int						_row		= -1,
+							_col		= -1,
+							_role		= -1,
+							_newColType = -1,
+							_oldColType = -1;
+};
+
+class PasteSpreadsheetCommand : public UndoModelCommand
+{
+public:
+	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& cells, const QStringList& newColNames);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	std::vector<std::vector<QString>>	_newCells,
+										_oldCells;
+	QStringList							_newColNames;
+	int									_row = -1,
+										_col = -1;
+};
+
+class SetColumnTypeCommand : public UndoModelCommand
+{
+public:
+	SetColumnTypeCommand(QAbstractItemModel *model, int col, int colType);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int									_col		= -1,
+										_newColType = -1,
+										_oldColType = -1;
+};
+
+
+class InsertColumnCommand : public UndoModelCommand
+{
+public:
+	InsertColumnCommand(QAbstractItemModel *model, int col, bool computed, bool R);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_col		= -1;
+	bool					_computed	= false,
+							_R			= false;
+};
+
+class InsertRowCommand : public UndoModelCommand
+{
+public:
+	InsertRowCommand(QAbstractItemModel *model, int row);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_row = -1;
+};
+
+class RemoveColumnCommand : public UndoModelCommand
+{
+public:
+	RemoveColumnCommand(QAbstractItemModel *model, int col);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_col = -1;
+	Json::Value				_serializedColumn;
+};
+
+class RemoveRowCommand : public UndoModelCommand
+{
+public:
+	RemoveRowCommand(QAbstractItemModel *model, int row);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_row = -1;
+	QVariantList			_values;
+};
+
+
+class UndoStack : public QUndoStack
+{
+	Q_OBJECT
+public:
+	UndoStack(QObject* parent = nullptr);
+
+	static UndoStack*	singleton() { return _undoStack; }
+
+	void				pushCommand(UndoModelCommand* command);
+	void				startMacro(const QString& text = QString());
+	void				endMacro(UndoModelCommand* command = nullptr);
+	QUndoCommand*		parentCommand()		{ return _parentCommand; }
+
+private:
+
+	UndoModelCommand*			_parentCommand			= nullptr;
+
+	static UndoStack*			_undoStack;
+
+};
+
+#endif // UNDOSTACK_H

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -574,6 +574,9 @@ void MainWindow::loadQML()
 	connect(_ribbonModel, &RibbonModel::dataRemoveColumn,				DataSetView::lastInstancedDataSetView(),	&DataSetView::columnsDelete);
 	connect(_ribbonModel, &RibbonModel::dataRemoveRow,					DataSetView::lastInstancedDataSetView(),	&DataSetView::rowsDelete);
 	connect(_ribbonModel, &RibbonModel::cellsClear,						DataSetView::lastInstancedDataSetView(),	&DataSetView::cellsClear);
+	connect(_ribbonModel, &RibbonModel::dataUndo,						DataSetView::lastInstancedDataSetView(),	&DataSetView::undo);
+	connect(_ribbonModel, &RibbonModel::dataRedo,						DataSetView::lastInstancedDataSetView(),	&DataSetView::redo);
+	connect(_package,	&DataSetPackage::columnDataTypeChanged,			DataSetView::lastInstancedDataSetView(),	&DataSetView::columnDataTypeChanged);
 
 	connect(DataSetView::lastInstancedDataSetView(), &DataSetView::showComputedColumn,		this,			&MainWindow::showComputedColumn);
 	connect(DataSetView::lastInstancedDataSetView(), &DataSetView::selectionStartChanged,	_labelModel,	&LabelModel::changeSelectedColumn);

--- a/Desktop/modules/analysisentry.h
+++ b/Desktop/modules/analysisentry.h
@@ -69,6 +69,9 @@ public:
 
 	void			runSpecialFunc()		const { _specialFunc(); }
 
+	void			setMenu(const std::string& menu)	{ _menu = menu;			}
+	void			setEnabled(bool enabled)			{ _isEnabled = enabled;	}
+
 	static bool		requiresDataEntries(const AnalysisEntries & entries);
 
 private:

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -23,6 +23,7 @@
 #include "log.h"
 #include "data/datasetpackage.h"
 #include "jasptheme.h"
+#include "qquick/datasetview.h"
 
 using namespace Modules;
 
@@ -130,12 +131,22 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 		new AnalysisEntry([&](){ emit this->dataRemoveRow();			},					"delete-row",					fq(tr("Delete row")),			true,		"menu-row-remove"),
 		new AnalysisEntry([&](){ emit this->cellsClear();				},					"clear-cells",					fq(tr("Clear cells")),			true,		"menu-cells-clear")
 	});
+
+	_undoEntry = new AnalysisEntry([&](){ emit this->dataUndo();						},	"undo",							fq(tr("Undo")),					true,		"menu-undo");
+	_redoEntry = new AnalysisEntry([&](){ emit this->dataRedo();						},	"redo",							fq(tr("Redo")),					true,		"menu-redo");
+
+	_entriesUndo = new AnalysisEntries(
+	{
+		_undoEntry,
+		_redoEntry
+	});
 		
 	_analysesButton			= new RibbonButton(this, "Analyses",				fq(tr("Analyses")),					"JASP_logo_green.svg",		false, [&](){ emit finishCurrentEdit(); emit showStatistics(); },	fq(tr("Switch JASP to analyses mode")),				true);
 	_dataSwitchButton		= new RibbonButton(this, "Data",					fq(tr("Edit Data")),				"data-button.svg",			false, [&](){ emit showData(); },									fq(tr("Switch JASP to data editing mode")),			false);
 	_dataNewButton			= new RibbonButton(this, "Data-New",				fq(tr("New Data")),					"data-button-new.svg",		false, [&](){ emit genShowEmptyData();	 },							fq(tr("Open a workspace without data")),			true);
 	_insertButton			= new RibbonButton(this, "Data-Insert",				fq(tr("Insert")),					"data-button-insert.svg",	_entriesInsert,														fq(tr("Insert empty columns or rows")));
 	_removeButton			= new RibbonButton(this, "Data-Remove",				fq(tr("Remove")),					"data-button-erase.svg",	_entriesDelete,														fq(tr("Remove columns or rows")));
+	_undoButton				= new RibbonButton(this, "Data-Undo",				fq(tr("Undo/Redo")),				"data-button-undo-redo.svg", _entriesUndo,																	fq(tr("Undo/Redo changes")));
 	_synchroniseOnButton	= new RibbonButton(this, "Data-Synch-On",			fq(tr("Synchronisation")),			"data-button-sync-off.svg",	true, [&](){ emit setDataSynchronisation(true); },					fq(tr("Turn external data synchronisation on")),	false);
 	_synchroniseOffButton	= new RibbonButton(this, "Data-Synch-Off",			fq(tr("Synchronisation")),			"data-button-sync-on.svg",	true, [&](){ emit setDataSynchronisation(false); },					fq(tr("Turn external data synchronisation off")),	true);
 
@@ -143,7 +154,9 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	connect(this, &RibbonModel::dataLoadedChanged,		_dataNewButton,			[=](bool loaded){ _dataNewButton->setEnabled(	 !loaded); });
 	connect(this, &RibbonModel::dataLoadedChanged,		_insertButton,			&RibbonButton::setEnabled);
 	connect(this, &RibbonModel::dataLoadedChanged,		_removeButton,			&RibbonButton::setEnabled);
-	
+	connect(this, &RibbonModel::dataLoadedChanged,		_undoButton,					&RibbonButton::setEnabled);
+	connect(DataSetView::lastInstancedDataSetView(), &DataSetView::undoChanged, this,	&RibbonModel::setUndoRedoMenu);
+
 	connect(this, &RibbonModel::synchronisationChanged, _synchroniseOnButton,	[=](bool synching){ _synchroniseOnButton->setEnabled(!synching); });
 	connect(this, &RibbonModel::synchronisationChanged, _synchroniseOffButton,	[=](bool synching){ _synchroniseOffButton->setEnabled(synching); });
 
@@ -157,6 +170,7 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	addRibbonButtonModel(_synchroniseOffButton,		size_t(RowType::Data));
 	addRibbonButtonModel(_insertButton,				size_t(RowType::Data));
 	addRibbonButtonModel(_removeButton,				size_t(RowType::Data));
+	addRibbonButtonModel(_undoButton,				size_t(RowType::Data));
 }
 
 void RibbonModel::addSpecialRibbonButtonsLate()
@@ -287,7 +301,7 @@ void RibbonModel::analysisClicked(QString analysisFunction, QString analysisQML,
 {
 	RibbonButton * button = ribbonButtonModel(fq(module));
 	
-	if(button->isSpecial())		button->runSpecial(analysisTitle);
+	if(button->isSpecial())		button->runSpecial(analysisFunction);
 	else						emit analysisClickedSignal(analysisFunction, analysisQML, analysisTitle, module);
 }
 
@@ -402,6 +416,17 @@ void RibbonModel::ribbonButtonModelChanged(RibbonButton* model)
 	int row = ribbonButtonModelIndex(model);
 	if(row > -1)
 		emit dataChanged(index(row), index(row));
+}
+
+void RibbonModel::setUndoRedoMenu()
+{
+	DataSetView* view = DataSetView::lastInstancedDataSetView();
+	QString undoText = view->undoText(),
+			redoText = view->redoText();
+	_undoEntry->setEnabled(!undoText.isEmpty());
+	_redoEntry->setEnabled(!redoText.isEmpty());
+	_undoEntry->setMenu(fq(tr("Undo: %1").arg(undoText)));
+	_redoEntry->setMenu(fq(tr("Redo: %1").arg(redoText)));
 }
 
 /*void RibbonModel::moduleLoadingSucceeded(const QString & moduleName)

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -120,7 +120,8 @@ signals:
 				void setDataSynchronisation(bool);
 				void synchronisationChanged(bool);
 				void cellsClear();
-
+				void dataUndo();
+				void dataRedo();
 
 public slots:
 	void addRibbonButtonModelFromDynamicModule(Modules::DynamicModule * module);
@@ -135,6 +136,7 @@ private slots:
 	void dynamicModuleChanged(	Modules::DynamicModule * module);
 	void dynamicModuleReplaced(	Modules::DynamicModule * oldModule, Modules::DynamicModule * module);
 	void ribbonButtonModelChanged(RibbonButton* model);
+	void setUndoRedoMenu();
 
 private: // functions
 	void addRibbonButtonModel(RibbonButton* model, size_t row);
@@ -146,14 +148,20 @@ private: // fields
 	stringvec								_commonModulesToLoad;
 	size_t									_currentRow				= size_t(RowType::Analyses);
 	Modules::AnalysisEntries			*	_entriesInsert			= nullptr,
-										*	_entriesDelete			= nullptr;
+										*	_entriesDelete			= nullptr,
+										*	_entriesUndo			= nullptr;
 	RibbonButton						*	_analysesButton			= nullptr,
 										*	_dataSwitchButton		= nullptr,
 										*	_dataNewButton			= nullptr,
 										*	_insertButton			= nullptr,
 										*	_removeButton			= nullptr,
 										*	_synchroniseOnButton	= nullptr,
-										*	_synchroniseOffButton	= nullptr;
+										*	_synchroniseOffButton	= nullptr,
+										*	_undoButton				= nullptr;
+
+	Modules::AnalysisEntry				*	_undoEntry				= nullptr,
+										*	_redoEntry				= nullptr;
+
 	
 	static RibbonModel * _singleton;
 };

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -153,6 +153,9 @@ void DataSetView::modelDataChanged(const QModelIndex &topLeft, const QModelIndex
 			}
 	}
 
+	if (editing() && (topLeft == bottomRight)) // In case of Undo/Redo set the focus on the correspondig cell
+		positionEditItem(topLeft.row(), topLeft.column());
+
 
 	//The following else would be good but it doesnt seem to work on mac for some reason. It does work on linux though
 	/*else
@@ -184,6 +187,7 @@ void DataSetView::modelWasReset()
 {
 	//Log::log() << "void DataSetView::modelWasReset()" << std::endl;
 	_selectionModel = new QItemSelectionModel(_model->sourceModel(), this);
+
 	calculateCellSizes();
 }
 
@@ -536,6 +540,8 @@ void DataSetView::buildNewLinesAndCreateNewItems()
 
 	if(editing())
 		positionEditItem(_prevEditRow, _prevEditCol);
+	else
+		destroyEditItem();
 
 	JASPTIMER_STOP(DataSetView::buildNewLinesAndCreateNewItems);
 }

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -52,6 +52,8 @@ DataSetView::DataSetView(QQuickItem *parent)
 	connect(PreferencesModel::prefs(),	&PreferencesModel::interfaceFontChanged,		this, &DataSetView::resetItems,			Qt::QueuedConnection);
 
 	connect(DataSetPackage::pkg(),		&DataSetPackage::dataModeChanged,				this, &DataSetView::onDataModeChanged);
+	connect(_model,						&ExpandDataProxyModel::undoChanged,				this, &DataSetView::undoChanged);
+
 
 	setZ(10);
 
@@ -60,7 +62,6 @@ DataSetView::DataSetView(QQuickItem *parent)
 
 void DataSetView::setModel(QAbstractItemModel * model)
 {
-
 	_model->setSourceModel(model);
 
 	if (model)
@@ -1286,7 +1287,9 @@ QString DataSetView::columnInsertBefore(int col, bool computed, bool R)
 	if(col == -1)
 		col = _selectionStart.x() != -1 ? _selectionStart.x() : 0;
 
-	return _model->insertColumnSpecial(col, computed, R);
+	_model->insertColumn(col, computed, R);
+
+	return "";
 }
 
 QString DataSetView::columnInsertAfter(int col, bool computed, bool R)

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -163,6 +163,7 @@ signals:
 	void		selectionBudgesRight();
 
 	void		showComputedColumn(QString name);
+	void		undoChanged();
 	
 public slots:
 	void		calculateCellSizes()	{ calculateCellSizesAndClear(false); }
@@ -213,10 +214,16 @@ public slots:
 	void		rowsInserted(				const QModelIndex &parent, int first, int last);
 	void		rowsRemoved(				const QModelIndex &parent, int first, int last);
 
-	int			rowCount()		{ return _model->rowCount();	}
-	int			columnCount()	{ return _model->columnCount(); }
+	int			rowCount()								{ return _model->rowCount();	}
+	int			columnCount()							{ return _model->columnCount(); }
 
 	void		selectAll();
+	void		undo()									{ _model->undo(); }
+	void		redo()									{ _model->redo(); }
+	QString		undoText()								{ return _model->undoText(); }
+	QString		redoText()								{ return _model->redoText(); }
+
+	void		columnDataTypeChanged(QString colName)	{ _model->columnDataTypeChanged(colName); }
 
 	void		clearEdit();
 	void		edit(int row, int column);
@@ -225,7 +232,7 @@ public slots:
 	void		onDataModeChanged(bool dataMode);
 	void		commitLastEdit();
 
-	
+	int			setColumnType(int columnIndex, int newColumnType)	{ return _model->setColumnType(columnIndex, newColumnType); }
 protected:
 	void		_copy(bool includeHeader, bool clear);
 	void		calculateCellSizesAndClear(bool clearStorage);

--- a/Desktop/resources/icons/darkTheme/data-button-undo-redo.svg
+++ b/Desktop/resources/icons/darkTheme/data-button-undo-redo.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="35.457626"
+   height="15.440679"
+   viewBox="0 0 35.457626 15.440679"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="data-button-undo-redo.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="17.288136"
+     inkscape:cy="5.1864407"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="1885"
+     inkscape:window-y="223"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M 12.258475,15.440679 H 8.9152542 V 13.06519 h 3.3432208 c 1.843228,0 3.34322,-1.598704 3.34322,-3.5632334 0,-1.96453 -1.499992,-3.563234 -3.34322,-3.563234 H 5.5720338 v 3.563234 L 0,4.7509786 5.5720338,1.2e-7 V 3.5632336 h 6.6864412 c 3.072419,0 5.572034,2.664111 5.572034,5.938723 0,3.2746114 -2.499615,5.9387224 -5.572034,5.9387224 z"
+     id="path2"
+     style="stroke-width:1.15049;fill:#ffffff" />
+  <path
+     d="m 23.199152,15.440679 h 3.34322 V 13.06519 h -3.34322 c -1.843228,0 -3.34322,-1.598704 -3.34322,-3.5632335 0,-1.96453 1.499992,-3.563234 3.34322,-3.563234 h 6.686441 v 3.563234 L 35.457627,4.7509785 29.885593,0 v 3.5632335 h -6.686441 c -3.072419,0 -5.572034,2.664111 -5.572034,5.938723 0,3.2746115 2.499615,5.9387225 5.572034,5.9387225 z"
+     id="path2-9"
+     style="stroke-width:1.15049;fill:#ffffff" />
+</svg>

--- a/Desktop/resources/icons/darkTheme/menu-redo.svg
+++ b/Desktop/resources/icons/darkTheme/menu-redo.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg3874"
+   sodipodi:docname="menu-redo.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3878" />
+  <sodipodi:namedview
+     id="namedview3876"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12.101695"
+     inkscape:cy="12"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3874" />
+  <path
+     d="M 7.7224579,21.966102 H 12.152543 V 18.839635 H 7.7224579 c -2.4424537,0 -4.430085,-2.104112 -4.430085,-4.6897 0,-2.585588 1.9876313,-4.6897 4.430085,-4.6897 h 8.8601691 v 4.6897 L 23.966102,7.8970013 16.582627,1.6440678 V 6.3337679 H 7.7224579 c -4.0712481,0 -7.38347485,3.5063321 -7.38347485,7.8161671 0,4.309835 3.31222675,7.816167 7.38347485,7.816167 z"
+     id="path3872"
+     style="stroke-width:1.51935;fill:#ffffff" />
+</svg>

--- a/Desktop/resources/icons/darkTheme/menu-undo.svg
+++ b/Desktop/resources/icons/darkTheme/menu-undo.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="menu-undo.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12.20339"
+     inkscape:cy="12"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="1762"
+     inkscape:window-y="227"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="m 16.309322,21.864407 h -4.411016 v -3.04824 h 4.411016 c 2.431941,0 4.411017,-2.051465 4.411017,-4.57236 0,-2.520894 -1.979076,-4.57236 -4.411017,-4.57236 H 7.4872879 v 4.57236 L 0.13559321,8.1473278 7.4872879,2.0508474 v 4.5723599 h 8.8220341 c 4.053725,0 7.351695,3.4186007 7.351695,7.6205997 0,4.201999 -3.29797,7.6206 -7.351695,7.6206 z"
+     id="path2"
+     style="stroke-width:1.49698;fill:#ffffff" />
+</svg>

--- a/Desktop/resources/icons/lightTheme/data-button-undo-redo.svg
+++ b/Desktop/resources/icons/lightTheme/data-button-undo-redo.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="35.457626"
+   height="15.440679"
+   viewBox="0 0 35.457626 15.440679"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="data-button-undo-redo.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="17.186441"
+     inkscape:cy="5.1864407"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="1885"
+     inkscape:window-y="251"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M 12.258475,15.440679 H 8.9152542 V 13.06519 h 3.3432208 c 1.843228,0 3.34322,-1.598704 3.34322,-3.5632334 0,-1.96453 -1.499992,-3.563234 -3.34322,-3.563234 H 5.5720338 v 3.563234 L 0,4.7509786 5.5720338,1.2e-7 V 3.5632336 h 6.6864412 c 3.072419,0 5.572034,2.664111 5.572034,5.938723 0,3.2746114 -2.499615,5.9387224 -5.572034,5.9387224 z"
+     id="path2"
+     style="stroke-width:1.15049" />
+  <path
+     d="m 23.199152,15.440679 h 3.34322 V 13.06519 h -3.34322 c -1.843228,0 -3.34322,-1.598704 -3.34322,-3.5632335 0,-1.96453 1.499992,-3.563234 3.34322,-3.563234 h 6.686441 v 3.563234 L 35.457627,4.7509785 29.885593,0 v 3.5632335 h -6.686441 c -3.072419,0 -5.572034,2.664111 -5.572034,5.938723 0,3.2746115 2.499615,5.9387225 5.572034,5.9387225 z"
+     id="path2-9"
+     style="stroke-width:1.15049" />
+</svg>

--- a/Desktop/resources/icons/lightTheme/menu-redo.svg
+++ b/Desktop/resources/icons/lightTheme/menu-redo.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg3874"
+   sodipodi:docname="menu-redo.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3878" />
+  <sodipodi:namedview
+     id="namedview3876"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3874" />
+  <path
+     d="M 7.7224579,21.966102 H 12.152543 V 18.839635 H 7.7224579 c -2.4424537,0 -4.430085,-2.104112 -4.430085,-4.6897 0,-2.585588 1.9876313,-4.6897 4.430085,-4.6897 h 8.8601691 v 4.6897 L 23.966102,7.8970013 16.582627,1.6440678 V 6.3337679 H 7.7224579 c -4.0712481,0 -7.38347485,3.5063321 -7.38347485,7.8161671 0,4.309835 3.31222675,7.816167 7.38347485,7.816167 z"
+     id="path3872"
+     style="stroke-width:1.51935" />
+</svg>

--- a/Desktop/resources/icons/lightTheme/menu-undo.svg
+++ b/Desktop/resources/icons/lightTheme/menu-undo.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="menu-undo.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12.101695"
+     inkscape:cy="12"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="1700"
+     inkscape:window-y="566"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="m 16.309322,21.864407 h -4.411016 v -3.04824 h 4.411016 c 2.431941,0 4.411017,-2.051465 4.411017,-4.57236 0,-2.520894 -1.979076,-4.57236 -4.411017,-4.57236 H 7.4872879 v 4.57236 L 0.13559321,8.1473278 7.4872879,2.0508474 v 4.5723599 h 8.8220341 c 4.053725,0 7.351695,3.4186007 7.351695,7.6205997 0,4.201999 -3.29797,7.6206 -7.351695,7.6206 z"
+     id="path2"
+     style="stroke-width:1.49698" />
+</svg>


### PR DESCRIPTION
This adds Undo/Redo functionality for the Data Edit mode.
The Variables & Filter Windows have no undo/redo functions. This might be added later (the need to have undo/redo for these windows were not high since we did not receive any feature request for this). This would add also more complexity since the Variables Windows is accessible without Data Edit mode.
But for the Data Edit mode the need of a Undo/Redo is more compelling; the user may remove accidentally data.