### PR TITLE
Make js/html interface translatable

### DIFF
--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -304,10 +304,27 @@ Item
 			property string resultsString:	qsTr("Results")
 			onResultsStringChanged:			setTranslatedResultsString();
 
+			// Defined the elements that need to be translated in the html/js interface
+			// where use i18n(...) to return  translations
+			property var i18nObject: 
+			{
+				"Bold"			   : qsTr("Bold"), 			       "Italic" : qsTr("Italic"),   	"Underline"    : qsTr("Underline"),    "Link"           : qsTr("Link"),           "Formula"      : qsTr("Formula"),
+				"Code Block"	   : qsTr("Code Block"),  		   "Header" : qsTr("Header"),   	"Ordered List" : qsTr("Ordered List"), "Unordered List" : qsTr("Unordered List"), "Color Picker" : qsTr("Color Picker"), 
+				"Background Color" : qsTr("Background Color"),  "Subscript" : qsTr("Subscript"), 	 "Superscript"  : qsTr("Superscript"),  "Blockquote"    : qsTr("Blockquote"), 		"Add Indent" : qsTr("Add Indent"),
+				"Remove Indent"   : qsTr("Remove Indent"), 	    "Font Size" : qsTr("Font Size"), "Clear Formatting" : qsTr("Clear Formatting"),			"Click here to add text" : qsTr("Click here to add text"),
+				"Copied to clipboard" : qsTr("Copied to clipboard"), "Citations copied to clipboard" : qsTr("Citations copied to clipboard"), 	"LaTeX code copied to clipboard" : qsTr("LaTeX code copied to clipboard")
+			}
+
 			function setTranslatedResultsString()
 			{
 				if(resultsJsInterface.resultsLoaded)
+				{
 					runJavaScript("window.setAnalysesTitle(\"" + resultsString + "\");");
+
+					// To parse the QML i18n object to js object
+					// will also make the js i18n follow changes of JASP GUI language
+					runJavaScript(`window.setI18nStrings(${JSON.stringify(i18nObject)})`) 
+				}
 			}
 
 			QtObject

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -1,5 +1,26 @@
 var JASPWidgets = {};
 
+var i18nStrs = null;
+// The global translation function needs to be loaded before all other .js files.
+window.setI18nStrings = function (i18nObject) {
+        i18nStrs = i18nObject
+        return i18nStrs
+}
+
+// Use i18n(...) to call strings to be translated then update them in MainPage.qml
+function i18n(str) {
+	if (typeof str === "string" && str instanceof String) {
+		console.log("i18n can only be used for literal strings")
+	} else {
+		let findI18nStr = i18nStrs[str] !== null && i18nStrs[str] !== undefined;
+		if (findI18nStr) {
+			return i18nStrs[str];
+		} else {
+			return str;
+		}
+	}
+}
+
 if(insideJASP)
 {
 	var Parchment = Quill.import('parchment');
@@ -385,7 +406,7 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 
 	initialize: function () {
 
-		this.ghostTextDefault = 'Click here to add text';
+		this.ghostTextDefault = i18n('Click here to add text');
 
 		this.editing = false;
 
@@ -556,33 +577,33 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 		//     Instead, we will use the browser standard "title" attribute as
 		//     mentioned here: https://github.com/quilljs/quill/issues/1271#issuecomment-597928093
 
-		this.$quillToolbar.querySelector('button.ql-bold').setAttribute('title', 'Bold');
-		this.$quillToolbar.querySelector('button.ql-italic').setAttribute('title', 'Italic');
-		this.$quillToolbar.querySelector('button.ql-underline').setAttribute('title', 'Underline');
-		this.$quillToolbar.querySelector('button.ql-link').setAttribute('title', 'Link');
+		this.$quillToolbar.querySelector('button.ql-bold').setAttribute('title', i18n('Bold'));
+		this.$quillToolbar.querySelector('button.ql-italic').setAttribute('title', i18n('Italic'));
+		this.$quillToolbar.querySelector('button.ql-underline').setAttribute('title', i18n('Underline'));
+		this.$quillToolbar.querySelector('button.ql-link').setAttribute('title', i18n('Link'));
 
-		this.$quillToolbar.querySelector('button.ql-formula').setAttribute('title', 'Formula');
-		this.$quillToolbar.querySelector('button.ql-code-block').setAttribute('title', 'Code Block');
+		this.$quillToolbar.querySelector('button.ql-formula').setAttribute('title', i18n('Formula'));
+		this.$quillToolbar.querySelector('button.ql-code-block').setAttribute('title', i18n('Code Block'));
 
-		this.$quillToolbar.querySelector('.ql-header.ql-picker').setAttribute('title', 'Header');
+		this.$quillToolbar.querySelector('.ql-header.ql-picker').setAttribute('title', i18n('Header'));
 		let lists = this.$quillToolbar.querySelectorAll('button.ql-list')
-		lists[0].setAttribute('title', 'Ordered List')
-		lists[1].setAttribute('title', 'Unordered List')
+		lists[0].setAttribute('title', i18n('Ordered List'))
+		lists[1].setAttribute('title', i18n('Unordered List'))
 
-		this.$quillToolbar.querySelector('.ql-color.ql-picker.ql-color-picker').setAttribute('title', 'Color Picker');
-		this.$quillToolbar.querySelector('.ql-background.ql-picker.ql-color-picker').setAttribute('title', 'Background Color');
+		this.$quillToolbar.querySelector('.ql-color.ql-picker.ql-color-picker').setAttribute('title', i18n('Color Picker'));
+		this.$quillToolbar.querySelector('.ql-background.ql-picker.ql-color-picker').setAttribute('title', i18n('Background Color'));
 
 		let scripts = this.$quillToolbar.querySelectorAll('button.ql-script')
-		scripts[0].setAttribute('title', 'Subscript')
-		scripts[1].setAttribute('title', 'Superscript')
+		scripts[0].setAttribute('title', i18n('Subscript'))
+		scripts[1].setAttribute('title', i18n('Superscript'))
 
-		this.$quillToolbar.querySelector('button.ql-blockquote').setAttribute('title', 'Blockquote');
+		this.$quillToolbar.querySelector('button.ql-blockquote').setAttribute('title', i18n('Blockquote'));
 		let indents = this.$quillToolbar.querySelectorAll('button.ql-indent')
-		indents[0].setAttribute('title', 'Add Indent')
-		indents[1].setAttribute('title', 'Remove Indent')
+		indents[0].setAttribute('title', i18n('Add Indent'))
+		indents[1].setAttribute('title', i18n('Remove Indent'))
 
-		this.$quillToolbar.querySelector('.ql-size.ql-picker').setAttribute('title', 'Font Size');
-		this.$quillToolbar.querySelector('button.ql-clean').setAttribute('title', 'Clear Formatting');
+		this.$quillToolbar.querySelector('.ql-size.ql-picker').setAttribute('title', i18n('Font Size'));
+		this.$quillToolbar.querySelector('button.ql-clean').setAttribute('title', i18n('Clear Formatting'));
 
 		// Customized quill editor syntax to fix code-block
   		// FIXME: Fix css styles on export html when refactoring

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -9,15 +9,15 @@ window.setI18nStrings = function (i18nObject) {
 
 // Use i18n(...) to call strings to be translated then update them in MainPage.qml
 function i18n(str) {
-	if (typeof str === "string" && str instanceof String) {
-		console.log("i18n can only be used for literal strings")
-	} else {
-		let findI18nStr = i18nStrs[str] !== null && i18nStrs[str] !== undefined;
-		if (findI18nStr) {
+	if (typeof str === "string") {
+		if (i18nStrs.hasOwnProperty(str)) {
 			return i18nStrs[str];
 		} else {
 			return str;
 		}
+    } else {
+		console.error("i18n can only be used for strings")
+		return str;
 	}
 }
 

--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -129,7 +129,7 @@ $(document).ready(function () {
 
 	window.copyMenuClicked = function () {
 		if (window.menuObject.copyMenuClicked && window.menuObject.copyMenuClicked())
-			window.menuObject.toolbar.displayMessage("Copied to clipboard");
+			window.menuObject.toolbar.displayMessage(i18n("Copied to clipboard"));
 
 		setSelection(false);
 		window.menuObject = null;
@@ -151,8 +151,8 @@ $(document).ready(function () {
 	window.showDependenciesClicked	= function () { window.menuObjectFunctionCaller( window.menuObject.showDependenciesClicked	.bind(window.menuObject) ); }
 	window.duplicateMenuClicked		= function () { window.menuObjectFunctionCaller( window.menuObject.duplicateMenuClicked		.bind(window.menuObject) ); }
 	window.removeMenuClicked		= function () { window.menuObjectFunctionCaller( window.menuObject.removeMenuClicked		.bind(window.menuObject) ); }
-	window.citeMenuClicked			= function () { window.menuObjectFunctionCaller( window.menuObject.citeMenuClicked			.bind(window.menuObject),	"Citations copied to clipboard"	); }
-	window.latexCodeMenuClicked		= function () { window.menuObjectFunctionCaller( window.menuObject.latexCodeMenuClicked		.bind(window.menuObject),	"LaTeX code copied to clipboard"); }
+	window.citeMenuClicked			= function () { window.menuObjectFunctionCaller( window.menuObject.citeMenuClicked			.bind(window.menuObject),	i18n("Citations copied to clipboard")	); }
+	window.latexCodeMenuClicked		= function () { window.menuObjectFunctionCaller( window.menuObject.latexCodeMenuClicked		.bind(window.menuObject),	i18n("LaTeX code copied to clipboard")  ); }
 
 	window.notesMenuClicked = function (noteType, visibility) {
 		if (window.menuObject.notesMenuClicked && window.menuObject.notesMenuClicked(noteType, visibility))


### PR DESCRIPTION
Fix https://github.com/jasp-stats/jasp-issues/issues/1474

Inspired by joris' comment [here](https://github.com/jasp-stats/jasp-issues/issues/1474#issuecomment-957304957), reused the `qsTr() ` to translate the string, I don't know if it's messy, but it works.😜

a test case [here ](https://github.com/shun2wang/jasp-desktop/commit/4b74ebe75ecc44b3b122e8fa7c76f461738df2d6) you can patch the `.qm` files and have a look in jaspNote "Bold" option.