### PR TITLE
Synchronise the Variable Window with the selected column

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1409,7 +1409,7 @@ strintmap Column::labelsSyncStrings(const stringvec &new_values, const strstrmap
 
 		maxLabelKey = std::max(labelValue, maxLabelKey); //to be used in labelsResetValues
 
-		if(mapValuesToAdd.count(labelText))	//Found it!
+		if(mapValuesToAdd.contains(labelText))
 		{
 			result[labelText] = mapValuesToAdd[labelText];
 			mapValuesToAdd.erase(labelText);

--- a/Desktop/data/labelmodel.cpp
+++ b/Desktop/data/labelmodel.cpp
@@ -308,6 +308,12 @@ void LabelModel::refresh()
 	setLabelMaxWidth();
 }
 
+void LabelModel::changeSelectedColumn(QPoint selectionStart)
+{
+	if (selectionStart.x() != chosenColumn())
+		setChosenColumn(selectionStart.x());
+}
+
 void LabelModel::removeAllSelected()
 {
 	QMap<QString, size_t> mapValueToRow;

--- a/Desktop/data/labelmodel.h
+++ b/Desktop/data/labelmodel.h
@@ -22,7 +22,7 @@ class LabelModel : public DataSetTableProxy
 	Q_PROPERTY(double	rowWidth			READ rowWidth			WRITE setRowWidth			NOTIFY rowWidthChanged			)
 	Q_PROPERTY(double	valueMaxWidth		READ valueMaxWidth									NOTIFY valueMaxWidthChanged		)
 	Q_PROPERTY(double	labelMaxWidth		READ labelMaxWidth									NOTIFY labelMaxWidthChanged		)
-	Q_PROPERTY(bool		showLabelEditor	READ showLabelEditor								NOTIFY showLabelEditorChanged	)
+	Q_PROPERTY(bool		showLabelEditor		READ showLabelEditor								NOTIFY showLabelEditorChanged	)
 
 public:
 				LabelModel();
@@ -75,6 +75,7 @@ public slots:
 	void setRowWidth(double len);
 	void onChosenColumnChanged();
 	void refresh();
+	void changeSelectedColumn(QPoint selectionStart);
 
 signals:
 	void visibleChanged(bool visible);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -574,7 +574,8 @@ void MainWindow::loadQML()
 	connect(_ribbonModel, &RibbonModel::dataRemoveColumn,				DataSetView::lastInstancedDataSetView(),	&DataSetView::columnsDelete);
 	connect(_ribbonModel, &RibbonModel::dataRemoveRow,					DataSetView::lastInstancedDataSetView(),	&DataSetView::rowsDelete);
 
-	connect(DataSetView::lastInstancedDataSetView(), &DataSetView::showComputedColumn,		this,	&MainWindow::showComputedColumn);
+	connect(DataSetView::lastInstancedDataSetView(), &DataSetView::showComputedColumn,		this,			&MainWindow::showComputedColumn);
+	connect(DataSetView::lastInstancedDataSetView(), &DataSetView::selectionStartChanged,	_labelModel,	&LabelModel::changeSelectedColumn);
 
 	Log::log() << "QML Initialized!"  << std::endl;
 


### PR DESCRIPTION
When the Variable Window is open, it would be user friendly to synchronise it with the selected column in the the Data view

