### PR TITLE
Beter handling of Selection. mouse click and right-click behaviour on the Data view

### DIFF
--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -414,7 +414,7 @@ FocusScope
 						onClicked: 			(mouseEvent)=>
 											{
 												if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
-													dataTableView.view.rowSelect(rowIndex, mouseEvent.modifiers & Qt.ShiftModifier );
+													dataTableView.view.rowSelect(rowIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton);
 												if(mouseEvent.button === Qt.RightButton)
 													dataTableView.showCopyPasteMenu(parent, mapToGlobal(mouseEvent.x, mouseEvent.y), rowIndex, -1, true, true);
 											}
@@ -633,7 +633,7 @@ FocusScope
 								if(ribbonModel.dataMode)
 								{
 									if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
-									   dataTableView.view.columnSelect(columnIndex, mouseEvent.modifiers & Qt.ShiftModifier);
+									   dataTableView.view.columnSelect(columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton);
 									if(mouseEvent.button === Qt.RightButton)
 									   dataTableView.showCopyPasteMenu(parent, mapToGlobal(mouseEvent.x, mouseEvent.y), -1, columnIndex, true, false);
 								}

--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -43,8 +43,6 @@ FocusScope
 			{
 				console.log("showCopyPasteMenu!")
 
-				view.contextMenuClickedAtIndex(rowIndex, columnIndex);
-
 				var ctrlCmd = MACOS ? qsTr("Cmd") : qsTr("Ctrl");
 
 				var copyPasteMenuModel =
@@ -67,23 +65,25 @@ FocusScope
 
 				if(!header || !rowheader)
 				{
-					copyPasteMenuModel.push({ text: "---" },
+					copyPasteMenuModel.push({ text: "---" });
+					if (!header)
+						copyPasteMenuModel.push({ text: qsTr("Select column"),						func: function() { dataTableView.view.columnSelect(			columnIndex) },	icon: "menu-column-select"			})
+					copyPasteMenuModel.push(
+						{ text: qsTr("Insert column before"),										func: function() { dataTableView.view.columnInsertBefore(	columnIndex) },	icon: "menu-column-insert-before"	},
+						{ text: qsTr("Insert column after"),										func: function() { dataTableView.view.columnInsertAfter(	columnIndex) },	icon: "menu-column-insert-after"	},
+						{ text: qsTr("Delete column"),												func: function() { dataTableView.view.columnsDelete() },					icon: "menu-column-remove"			})
 
-					{ text: qsTr("Select column"),													func: function() { dataTableView.view.columnSelect(			columnIndex) },	icon: "menu-column-select"			},
-					{ text: qsTr("Insert column before"),											func: function() { dataTableView.view.columnInsertBefore(	columnIndex) },	icon: "menu-column-insert-before"	},
-					{ text: qsTr("Insert column after"),											func: function() { dataTableView.view.columnInsertAfter(	columnIndex) },	icon: "menu-column-insert-after"	},
-					{ text: qsTr("Delete column"),													func: function() { dataTableView.view.columnsDelete() },					icon: "menu-column-remove"			})
-					
 				 }
-				
+
 				if(!header || rowheader)
 				{
-					copyPasteMenuModel.push({ text: "---" },
-
-					{ text: qsTr("Select row"),														func: function() { dataTableView.view.rowSelect(			rowIndex) },	icon: "menu-row-select"				},
-					{ text: qsTr("Insert row before"),												func: function() { dataTableView.view.rowInsertBefore(		rowIndex) },	icon: "menu-row-insert-before"		},
-					{ text: qsTr("Insert row after"),												func: function() { dataTableView.view.rowInsertAfter(		rowIndex) },	icon: "menu-row-insert-after"		},
-					{ text: qsTr("Delete row"),														func: function() { dataTableView.view.rowsDelete(			rowIndex); },	icon: "menu-row-remove"				})
+					copyPasteMenuModel.push({ text: "---" })
+					if (!header)
+						copyPasteMenuModel.push({ text: qsTr("Select row"),							func: function() { dataTableView.view.rowSelect(			rowIndex) },	icon: "menu-row-select"				})
+					copyPasteMenuModel.push(
+						{ text: qsTr("Insert row before"),											func: function() { dataTableView.view.rowInsertBefore(		rowIndex) },	icon: "menu-row-insert-before"		},
+						{ text: qsTr("Insert row after"),											func: function() { dataTableView.view.rowInsertAfter(		rowIndex) },	icon: "menu-row-insert-after"		},
+						{ text: qsTr("Delete row"),													func: function() { dataTableView.view.rowsDelete();	},						icon: "menu-row-remove"				})
 				}
 
 				var copyPasteMenuText = []
@@ -243,10 +243,9 @@ FocusScope
 							if(!shiftPressed)
 								dataTableView.view.selectionStart	= arrowIndex;
 							else
-							{
 								dataTableView.view.selectionEnd  = arrowIndex;
-								dataTableView.view.edit(arrowIndex.y, arrowIndex.x);
-							}
+
+							dataTableView.view.edit(arrowIndex.y, arrowIndex.x);
 
 							event.accepted = true;
 						}
@@ -278,9 +277,11 @@ FocusScope
 							anchors.fill:		parent
 							acceptedButtons:	Qt.RightButton
 
-							onPressed:
+							onPressed: (mouse) =>
+							{
 								if(mouse.buttons & Qt.RightButton)
 									dataTableView.showCopyPasteMenu(editItem, mapToGlobal(mouse.x, mouse.y), rowIndex, columnIndex);
+							}
 						}
 					}
 				}
@@ -293,37 +294,45 @@ FocusScope
 					color:				itemActive ? jaspTheme.textEnabled : jaspTheme.textDisabled
 					font:				jaspTheme.font
 					verticalAlignment:	Text.AlignVCenter
-					
+
 					MouseArea
 					{
 						z:					1234
 						hoverEnabled:		true
 						anchors.fill:		itemHighlight
 						acceptedButtons:	Qt.LeftButton | Qt.RightButton
-						
-						onPressed:	(mouse) => 
-						{		
+
+						onPressed:	(mouse) =>
+						{
 							if(ribbonModel.dataMode)
 							{
-								var shiftPressed = Boolean(mouse.modifiers & Qt.ShiftModifier);
+								var shiftPressed = Boolean(mouse.modifiers & Qt.ShiftModifier)
+								var rightPressed = Boolean(mouse.buttons & Qt.RightButton)
+								var isSelected = dataTableView.view.isSelected(rowIndex, columnIndex)
 
-								if(Boolean(mouse.buttons & Qt.RightButton))
+								if(!shiftPressed)
 								{
-									forceActiveFocus();
+									if (!rightPressed || !isSelected)
+										dataTableView.view.selectionStart = Qt.point(columnIndex, rowIndex)
+								}
+								else
+									dataTableView.view.selectionEnd = Qt.point(columnIndex, rowIndex);
+
+								if(rightPressed)
+								{
+									dataTableView.view.clearEdit()
 									dataTableView.showCopyPasteMenu(itemHighlight, mapToGlobal(mouse.x, mouse.y), rowIndex, columnIndex);
 								}
 								else
-								{
-									if(!shiftPressed)	dataTableView.view.selectionStart   = Qt.point(columnIndex, rowIndex);
-									else				dataTableView.view.selectionEnd		= Qt.point(columnIndex, rowIndex);
-								}
+									dataTableView.view.edit(rowIndex, columnIndex)
+
 							}
 							else if (labelModel.visible)
 							{
 								labelModel.chosenColumn = columnIndex
 							}
 						}
-											
+
 						onPositionChanged:	(mouse) =>
 						{
 							if(ribbonModel.dataMode && Boolean(mouse.modifiers & Qt.ShiftModifier))
@@ -334,12 +343,12 @@ FocusScope
 						}
 
 					}
-					
+
 					Rectangle
 					{
 						id:				itemHighlight
 						visible:		ribbonModel.dataMode && (dataTableView.selection && dataTableView.selection.hasSelection && dataTableView.view.isSelected(rowIndex, columnIndex))
-						
+
 						color:			jaspTheme.itemHighlight
 						opacity:		1.0
 						z:				-1
@@ -404,9 +413,9 @@ FocusScope
 						acceptedButtons:	Qt.LeftButton | Qt.RightButton
 						onClicked: 			(mouseEvent)=>
 											{
-												if(mouseEvent.button === Qt.LeftButton)
+												if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
 													dataTableView.view.rowSelect(rowIndex, mouseEvent.modifiers & Qt.ShiftModifier );
-												else if(mouseEvent.button === Qt.RightButton)
+												if(mouseEvent.button === Qt.RightButton)
 													dataTableView.showCopyPasteMenu(parent, mapToGlobal(mouseEvent.x, mouseEvent.y), rowIndex, -1, true, true);
 											}
 					}
@@ -623,9 +632,9 @@ FocusScope
 
 								if(ribbonModel.dataMode)
 								{
-									if(mouseEvent.button === Qt.LeftButton)
+									if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
 									   dataTableView.view.columnSelect(columnIndex, mouseEvent.modifiers & Qt.ShiftModifier);
-									else if(mouseEvent.button === Qt.RightButton)
+									if(mouseEvent.button === Qt.RightButton)
 									   dataTableView.showCopyPasteMenu(parent, mapToGlobal(mouseEvent.x, mouseEvent.y), -1, columnIndex, true, false);
 								}
 							}

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -568,7 +568,7 @@ void MainWindow::loadQML()
 	connect(_ribbonModel, &RibbonModel::dataInsertComputedColumnAfter,	DataSetView::lastInstancedDataSetView(),	&DataSetView::columnComputedInsertAfter);
 	connect(_ribbonModel, &RibbonModel::dataInsertColumnBefore,			DataSetView::lastInstancedDataSetView(),	&DataSetView::columnInsertBefore);
 	connect(_ribbonModel, &RibbonModel::dataInsertColumnAfter,			DataSetView::lastInstancedDataSetView(),	&DataSetView::columnInsertAfter);
-	connect(_ribbonModel, &RibbonModel::finishCurrentEdit,				DataSetView::lastInstancedDataSetView(),	&DataSetView::finishCurrentEdit);
+	connect(_ribbonModel, &RibbonModel::finishCurrentEdit,				DataSetView::lastInstancedDataSetView(),	&DataSetView::commitLastEdit);
 	connect(_ribbonModel, &RibbonModel::dataInsertRowBefore,			DataSetView::lastInstancedDataSetView(),	&DataSetView::rowInsertBefore);
 	connect(_ribbonModel, &RibbonModel::dataInsertRowAfter,				DataSetView::lastInstancedDataSetView(),	&DataSetView::rowInsertAfter);
 	connect(_ribbonModel, &RibbonModel::dataRemoveColumn,				DataSetView::lastInstancedDataSetView(),	&DataSetView::columnsDelete);

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -126,8 +126,8 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	
 	_entriesDelete = new AnalysisEntries(
 	{
-		new AnalysisEntry([&](){ emit this->dataRemoveColumn(-1);			},				"delete-column",				fq(tr("Delete column")),		true,		"menu-column-remove"),
-		new AnalysisEntry([&](){ emit this->dataRemoveRow(-1);				},				"delete-row",					fq(tr("Delete row")),			true,		"menu-row-remove"),
+		new AnalysisEntry([&](){ emit this->dataRemoveColumn();			},					"delete-column",				fq(tr("Delete column")),		true,		"menu-column-remove"),
+		new AnalysisEntry([&](){ emit this->dataRemoveRow();			},					"delete-row",					fq(tr("Delete row")),			true,		"menu-row-remove"),
 		new AnalysisEntry([&](){ emit this->cellsClear();				},					"clear-cells",					fq(tr("Clear cells")),			true,		"menu-cells-clear")
 	});
 		

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -115,8 +115,8 @@ signals:
 				void dataInsertColumnAfter(int,bool,bool);
 				void dataInsertRowBefore(int);
 				void dataInsertRowAfter(int);
-				void dataRemoveColumn(int);
-				void dataRemoveRow(int);
+				void dataRemoveColumn();
+				void dataRemoveRow();
 				void setDataSynchronisation(bool);
 				void synchronisationChanged(bool);
 				void cellsClear();

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -192,13 +192,13 @@ public slots:
 	void		copy(	bool includeHeader = false) { _copy(includeHeader, false); }
 	void		paste(	bool includeHeader = false);
 
-	void		columnSelect(				int col = -1,	bool shiftPressed = false);
-	QString		columnInsertBefore(			int col = -1, bool computed = false, bool R = false);
-	QString		columnInsertAfter(			int col = -1, bool computed = false, bool R = false);
+	void		columnSelect(				int col,		bool shiftPressed = false, bool rightClicked = false);
+	QString		columnInsertBefore(			int col = -1,	bool computed = false, bool R = false);
+	QString		columnInsertAfter(			int col = -1,	bool computed = false, bool R = false);
 	void		columnComputedInsertAfter(	int col = -1,	bool R=true);
 	void		columnComputedInsertBefore(	int col = -1,	bool R=true);
 	void		columnsDelete();
-	void		rowSelect(					int row = -1,	bool shiftPressed = false);
+	void		rowSelect(					int row,		bool shiftPressed = false, bool rightClicked = false);
 	void		rowInsertBefore(			int row = -1);
 	void		rowInsertAfter(				int row = -1);
 	void		rowsDelete();

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -180,7 +180,7 @@ public slots:
 	void		modelWasReset();
 	void		setExtraColumnX();
 	
-	void		setSelectionStart(	QPoint selectionStart	);
+	void		setSelectionStart(	QPoint selectionStart);
 	void		setSelectionEnd(	QPoint selectionEnd	);
 	bool		isSelected(int row, int col);
 	void		pollSelectScroll(	int row, int column);
@@ -197,11 +197,11 @@ public slots:
 	QString		columnInsertAfter(			int col = -1, bool computed = false, bool R = false);
 	void		columnComputedInsertAfter(	int col = -1,	bool R=true);
 	void		columnComputedInsertBefore(	int col = -1,	bool R=true);
-	void		columnsDelete(				int col = -1);
+	void		columnsDelete();
 	void		rowSelect(					int row = -1,	bool shiftPressed = false);
 	void		rowInsertBefore(			int row = -1);
 	void		rowInsertAfter(				int row = -1);
-	void		rowsDelete(					int row = -1);
+	void		rowsDelete();
 	void		cellsClear();
 
 	void		columnsAboutToBeInserted(	const QModelIndex &parent, int first, int last);
@@ -218,12 +218,12 @@ public slots:
 
 	void		selectAll();
 
+	void		clearEdit();
 	void		edit(int row, int column);
 	void		destroyEditItem(bool restoreItem=true);
 	void		commitEdit(				int row, int column, QVariant editedValue);
 	void		onDataModeChanged(bool dataMode);
-	void		contextMenuClickedAtIndex(int row, int column);
-	void		finishCurrentEdit();
+	void		commitLastEdit();
 
 	
 protected:


### PR DESCRIPTION
In the DataView, different issues have been solved: 

- Select a cell, right click on another cell: the selected cell should be unselected, and the pop-up menu should appear on the new cell.
- Select multiple cells (by using shift):
  - right-click on one of these cells: the selected cells should stay selected, and the pop-uo menu should appear.
  - right-click on an unselected cell: the selected cells are unselected, the new cell is selected, and the pop-up menu should appear.
  - A simple click (on a selected cell or not): the other cells are unselected , the current cell is selected, and this cell gets the focus..
- Click on a row header: the whole row should be selected.
  - Click on one cell (selected or not): the row is unselected, only the current cell is selected and has the focus.
  - Right-click on a selected cell: the row stays selected, and a pop-up menu appears on the clicked cell.
  - Right-click on a unselected cell, the row is unselected and a pop-up menu appears on the clicked cell. 
- Click on a row header and shift-click on another row header: all the rows between the 2 rows should be selected. Same behaviour as with only one row selected. If delete row is selected from the pop-up menu or from the ribbon menu: all the selected rows should be removed. 
- Same behaviour with column header

