### PR TITLE
Fix to JS interface i18n

### DIFF
--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -1,22 +1,23 @@
 var JASPWidgets = {};
 
-var i18nStrs = null;
+var i18nStrsObj = {};
 // The global translation function needs to be loaded before all other .js files.
 window.setI18nStrings = function (i18nObject) {
-        i18nStrs = i18nObject
-        return i18nStrs
+		i18nStrsObj = i18nObject
+		return i18nStrsObj
 }
 
 // Use i18n(...) to call strings to be translated then update them in MainPage.qml
 function i18n(str) {
 	if (typeof str === "string") {
-		if (i18nStrs.hasOwnProperty(str)) {
-			return i18nStrs[str];
+		let findI18nStr = i18nStrsObj[str] !== null && i18nStrsObj[str] !== undefined;
+		if (findI18nStr) {
+			return i18nStrsObj[str];
 		} else {
 			return str;
 		}
-    } else {
-		console.error("i18n can only be used for strings")
+	} else {
+		console.error("i18n can only be used for literal strings")
 		return str;
 	}
 }


### PR DESCRIPTION
@boutinb  I'm sorry i have to do a small revert to my first commit in the https://github.com/jasp-stats/jasp-desktop/pull/5130, since the last commit didn't address the case of judging null and this doesn't work on new daily builds. But testing before the last commit did work on my PC (I suspect I was caught by browser devtools memory cache), so make a test on your machine before merging this:-)

Now in my PC looks :

in Chinese
![image](https://github.com/jasp-stats/jasp-desktop/assets/10348402/d4e0c854-c174-4198-9f05-7f5e5151c5bd)

in France:
![image](https://github.com/jasp-stats/jasp-desktop/assets/10348402/5a1a7066-a519-415f-9414-b38933776dba)
