### PR TITLE
[After 0.17.3] fix install-jaspBase.R.in for `renv` 1.0.0

### DIFF
--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -37,7 +37,7 @@ if (md5SumsChanged(modulePkg, moduleLibrary)) {
 
   renv::hydrate(library = moduleLibrary, project = modulePkg, sources=moduleLibrary)
   options(renv.config.install.verbose = TRUE)
-  renv::install(project = modulePkg, library = moduleLibrary, prompt = prompt)
+  renv::install(package = modulePkg, project = modulePkg, library = moduleLibrary, prompt = prompt)
 
   correctlyInstalled <- installModulePkg(modulePkg, moduleLibrary, prompt, cacheAble=TRUE) 
 


### PR DESCRIPTION
Requires https://github.com/jasp-stats/jaspBase/pull/130

It could be that we also need to add this patch

```diff
diff --git a/Modules/install-module.R.in b/Modules/install-module.R.in
index 9837b7554..e11882e80 100644
--- a/Modules/install-module.R.in
+++ b/Modules/install-module.R.in
@@ -37,6 +37,7 @@ result <- jaspBase::installJaspModule("@MODULES_SOURCE_PATH@/@MODULE@",
        repos="@R_REPOSITORY@", 
        moduleLibrary="@MODULES_BINARY_PATH@/@MODULE@", 
        onlyModPkg=FALSE,
+        libPathsToUse = "@R_LIBRARY_PATH@",
        frameworkLibrary="@R_LIBRARY_PATH@")
```

but you'll notice when you try it in JASP :slightly_smiling_face: 

