### PR TITLE
Add undo for Computed column

### DIFF
--- a/Desktop/data/columnsmodel.h
+++ b/Desktop/data/columnsmodel.h
@@ -44,6 +44,8 @@ signals:
 	void labelsReordered(	QString					columnName);
 
 private:
+	QVariant				_getLabels(int colId) const;
+
 	DataSetTableModel		* _tableModel	= nullptr;
 	static ColumnsModel		* _singleton;
 };

--- a/Desktop/data/computedcolumnsmodel.cpp
+++ b/Desktop/data/computedcolumnsmodel.cpp
@@ -136,8 +136,7 @@ void ComputedColumnsModel::emitSendComputeCode(const QString & columnName, const
 
 void ComputedColumnsModel::sendCode(const QString & code, const QString & json)
 {
-	setComputeColumnJson(json);
-	sendCode(code);
+	_undoStack->push(new SetComputedColumnCodeCommand(DataSetPackage::pkg(), _selectedColumn->name(), code, json));
 }
 
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -505,9 +505,8 @@ QVariant DataSetPackage::data(const QModelIndex &index, int role) const
 		case Qt::DisplayRole:						[[fallthrough]];
 		case int(specialRoles::label):				return tq((*column)[index.row()]);
 		case int(specialRoles::description):		return tq(column->description());
-		case int(specialRoles::labelsStrList):		return getColumnLabelsAsStringList(column->name(), true);
+		case int(specialRoles::labelsStrList):		return getColumnLabelsAsStringList(column->name());
 		case int(specialRoles::valuesDblList):		return getColumnValuesAsDoubleList(getColumnIndex(column->name()));
-		case int(specialRoles::valuesStrList):		return getColumnValuesAsStringList(getColumnIndex(column->name()));
 		case int(specialRoles::inEasyFilter):		return isColumnUsedInEasyFilter(column->name());
 		case int(specialRoles::value):				return tq(column->getValue(index.row()));
 		case int(specialRoles::name):				return tq(column->name());
@@ -547,9 +546,8 @@ QVariant DataSetPackage::data(const QModelIndex &index, int role) const
 		case int(specialRoles::filter):				return labels[index.row()]->filterAllows();
 		case int(specialRoles::value):				return tq(labels[index.row()]->originalValueAsString(true));
 		case int(specialRoles::description):		return tq(labels[index.row()]->description());
-		case int(specialRoles::labelsStrList):		return getColumnLabelsAsStringList(column->name(), true);
+		case int(specialRoles::labelsStrList):		return getColumnLabelsAsStringList(column->name());
 		case int(specialRoles::valuesDblList):		return getColumnValuesAsDoubleList(getColumnIndex(column->name()));
-		case int(specialRoles::valuesStrList):		return getColumnValuesAsStringList(getColumnIndex(column->name()));
 		case int(specialRoles::lines):				return getDataSetViewLines(index.row() == 0, index.column() == 0, true, true);
 		case Qt::DisplayRole:
 		case int(specialRoles::label):				return tq(labels[index.row()]->label());
@@ -1840,52 +1838,21 @@ std::string DataSetPackage::getColumnName(size_t columnIndex) const
 	return _dataSet && _dataSet->column(columnIndex) ? _dataSet->column(columnIndex)->name() : "";
 }
 
-QStringList DataSetPackage::getColumnLabelsAsStringList(const std::string & columnName, bool dropUnused)	const
+QStringList DataSetPackage::getColumnLabelsAsStringList(const std::string & columnName)	const
 {
 	int colIndex = getColumnIndex(columnName);
 
-	if(colIndex > -1)	return getColumnLabelsAsStringList(colIndex, dropUnused);
+	if(colIndex > -1)	return getColumnLabelsAsStringList(colIndex);
 	else				return QStringList();;
 }
 
-QStringList DataSetPackage::getColumnLabelsAsStringList(size_t columnIndex, bool dropUnused)	const
+QStringList DataSetPackage::getColumnLabelsAsStringList(size_t columnIndex)	const
 {
 	QStringList list;
 	if(columnIndex < 0 || columnIndex >= dataColumnCount()) return list;
 
 	for (const Label * label : _dataSet->columns()[columnIndex]->labels())
 		list.append(tq(label->label()));
-
-	if(dropUnused)
-	{
-		QStringList notUsedLabels = list;
-		int max = rowCount();
-
-		for (int i = 0; i < max; i++)
-		{
-			QString value = data(index(i, columnIndex)).toString();
-			notUsedLabels.removeAll(value);
-			if (notUsedLabels.count() == 0) break;
-		}
-
-		// The order of the labels must be kept.
-		for (const QString& notUsedLabel : notUsedLabels)
-			list.removeAll(notUsedLabel);
-	}
-
-	return list;
-}
-
-QStringList DataSetPackage::getColumnValuesAsStringList(size_t columnIndex)	const
-{
-	QStringList list;
-	if(columnIndex < 0 || columnIndex >= dataColumnCount()) return list;
-
-	size_t rows = rowCount();
-	Column * col = _dataSet->columns()[columnIndex];
-
-	for(size_t i = 0; i < rows; i++)
-		list.append(QString::number(col->labels()[i]->value()));
 
 	return list;
 }

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -247,9 +247,8 @@ public:
 				void						setColumnDataInts(		size_t columnIndex, const intvec		& ints);
 				void						setColumnDataDbls(		size_t columnIndex, const doublevec		& dbls);
 				size_t						getMaximumColumnWidthInCharacters(int columnIndex)			const;
-				QStringList					getColumnLabelsAsStringList(const std::string & columnName,	bool dropUnused = false)	const;
-				QStringList					getColumnLabelsAsStringList(size_t columnIndex,				bool dropUnused = false)	const;
-				QStringList					getColumnValuesAsStringList(size_t columnIndex)				const;
+				QStringList					getColumnLabelsAsStringList(const std::string & columnName)	const;
+				QStringList					getColumnLabelsAsStringList(size_t columnIndex)				const;
 				QList<QVariant>				getColumnValuesAsDoubleList(size_t columnIndex)				const;
 				void						unicifyColumnNames();
 				Json::Value					serializeColumn(const std::string& columnName)					const;

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -469,6 +469,31 @@ void CreateComputedColumnCommand::redo()
 	DataSetPackage::pkg()->createComputedColumn(fq(_name), columnType(_columnType), computedColumnType(_computedColumnType));
 }
 
+SetComputedColumnCodeCommand::SetComputedColumnCodeCommand(QAbstractItemModel *model, const std::string& name, const QString& rCode, const QString& jsonCode)
+	: UndoModelCommand(model), _name{name}, _newRCode{rCode}, _newJsonCode{jsonCode}
+{
+	_computedColumnModel = ComputedColumnsModel::singleton();
+	setText(QObject::tr("Set code to computed column with name '%1").arg(tq(name)));
+}
+
+void SetComputedColumnCodeCommand::undo()
+{
+	_computedColumnModel->selectColumn(DataSetPackage::pkg()->getColumn(_name));
+	_computedColumnModel->setComputeColumnJson(_oldJsonCode);
+	_computedColumnModel->sendCode(_oldRCode);
+}
+
+void SetComputedColumnCodeCommand::redo()
+{
+	_computedColumnModel->selectColumn(DataSetPackage::pkg()->getColumn(_name));
+	_oldJsonCode = _computedColumnModel->computeColumnJson();
+	_oldRCode = _computedColumnModel->computeColumnRCode();
+
+	_computedColumnModel->setComputeColumnJson(_newJsonCode);
+	_computedColumnModel->sendCode(_newRCode);
+}
+
+
 UndoModelCommand::UndoModelCommand(QAbstractItemModel *model)
 	: QUndoCommand(UndoStack::singleton()->parentCommand()), _model{model}
 {

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -142,6 +142,23 @@ private:
 	int						_computedColumnType		= -1;
 };
 
+class SetComputedColumnCodeCommand: public UndoModelCommand
+{
+public:
+	SetComputedColumnCodeCommand(QAbstractItemModel *model, const std::string& name, const QString& rCode, const QString& jsonCode);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	ComputedColumnsModel*	_computedColumnModel = nullptr;
+	std::string				_name;
+	QString					_oldRCode,
+							_newRCode,
+							_oldJsonCode,
+							_newJsonCode;
+};
+
 class SetDataCommand : public UndoModelCommand
 {
 public:

--- a/QMLComponents/controls/sourceitem.cpp
+++ b/QMLComponents/controls/sourceitem.cpp
@@ -106,6 +106,14 @@ void SourceItem::connectModels()
 		connect(_nativeModel, &QAbstractItemModel::rowsMoved,			this, &SourceItem::_resetModel);
 		connect(_nativeModel, &QAbstractItemModel::modelReset,			this, &SourceItem::_resetModel);
 	}
+	if (_listControl->useSourceLevels() && _nativeModel != infoProviderModel())
+	{
+		QAbstractItemModel* providerModel = infoProviderModel(); // When the levels/labels of the source is used, then any change of the provider model must also be signalled
+		connect(providerModel, &QAbstractItemModel::rowsInserted,		this, &SourceItem::_resetModel);
+		connect(providerModel, &QAbstractItemModel::rowsRemoved,		this, &SourceItem::_resetModel);
+		connect(providerModel, &QAbstractItemModel::rowsMoved,			this, &SourceItem::_resetModel);
+		connect(providerModel, &QAbstractItemModel::modelReset,			this, &SourceItem::_resetModel);
+	}
 
 	if (_isVariableInfoModel)
 	{

--- a/QMLComponents/variableinfo.h
+++ b/QMLComponents/variableinfo.h
@@ -36,7 +36,7 @@ class VariableInfo : public QObject
 {
 	Q_OBJECT
 public:
-	enum InfoType { VariableType, VariableTypeName, VariableTypeIcon, VariableTypeDisabledIcon, VariableTypeInactiveIcon, VariableNames, RowCount, Labels, StringValues, DoubleValues, NameRole, Value, MaxWidth, SignalsBlocked };
+	enum InfoType { VariableType, VariableTypeName, VariableTypeIcon, VariableTypeDisabledIcon, VariableTypeInactiveIcon, VariableNames, RowCount, Labels, DoubleValues, NameRole, Value, MaxWidth, SignalsBlocked };
 	enum IconType { DefaultIconType, DisabledIconType, InactiveIconType };
 
 public:


### PR DESCRIPTION
Fix also problems with labels & filters:
. VariablesList of TableView using levels of a variable as source, did not get the right values. . If filter is changed, the model of this control must be reset.

