### PR TITLE
Be robuster when reading JASP file

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1655,7 +1655,11 @@ void DataSetPackage::columnLabelsFromJsonForJASPFile(Json::Value xData, Json::Va
 			else
 				Log::log() << "Cannot find key " << key << std::flush;
 
-			_dataSet->columns()[columnIndex]->labelByValue(key)->setOriginalValue(val);
+			Label* label = _dataSet->columns()[columnIndex]->labelByValue(key);
+			if (label)
+				label->setOriginalValue(val);
+			else
+				Log::log() << "Cannot find label for key " << key << std::endl;
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2338

In the Viagra JASP file, there was a reference to 'orgStringValues' with values that do not correspond to any labels... Just skip it.

