### PR TITLE
ENH: Data edtior Enter/Return key jump to next row

### DIFF
--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -309,6 +309,9 @@ FocusScope
 						case Qt.Key_Backtab: if(colI > 0)										{ arrowPressed = true; arrowIndex = Qt.point(colI - 1, rowI);	shiftPressed = false; } break;
 						case Qt.Key_Tab:	 if(colI < dataTableView.view.columnCount() - 1)	{ arrowPressed = true; arrowIndex = Qt.point(colI + 1, rowI);		} break;
 
+						case Qt.Key_Return:
+						case Qt.Key_Enter:	if(rowI	< dataTableView.view.rowCount()    - 1)		{ arrowPressed = true; arrowIndex   = Qt.point(colI, rowI + 1);		} break;
+
 
 						}
 


### PR DESCRIPTION
Enabled <kbd>Enter</kbd> / <kbd>Return</kbd> key to switch to next line in data editor, consistent with user experience on all spreadsheet editors(such MS-excel and LibreOffice).

