### PR TITLE
Add a `ColorPalette` widget

### DIFF
--- a/Docs/development/guide-option-names.md
+++ b/Docs/development/guide-option-names.md
@@ -238,6 +238,7 @@ Notice that the options are nested within another option both in Qml and in the 
 - `max`: maximum
 - `min`: minimum
 - `*SavedToData`: Append this to options that are used to add columns to the data set. E.g., `predictionSavedToData`, `factorScoreSavedToData`, etc.
+- `colorPalette`: dropdown for specifying color palette options
 
 ### Specific to Bayesian analyses
 - `samplingMethod`: radiobutton for selecting type of MCMC sampling (e.g., `auto`, `manual`, `bas`, `mcmc`, etc.)

--- a/QMLComponents/components/JASP/Controls/ColorPalette.qml
+++ b/QMLComponents/components/JASP/Controls/ColorPalette.qml
@@ -1,0 +1,40 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+
+import QtQuick 2.8
+import JASP.Controls 1.0
+
+DropDown
+{
+	name: "colorPalette"
+	label: qsTr("Color palette")
+	indexDefaultValue: 0
+	values:
+	[
+		{ label: qsTr("Colorblind"),		value: "colorblind"		},
+		{ label: qsTr("Colorblind #2"),		value: "colorblind2"	},
+		{ label: qsTr("Colorblind #3"),		value: "colorblind3"	},
+		{ label: qsTr("Viridis"),			value: "viridis"		},
+		{ label: qsTr("ggplot2"),			value: "ggplot2"		},
+		{ label: qsTr("Gray"),				value: "gray"			},
+		{ label: qsTr("Blue"),				value: "blue"			},
+		{ label: qsTr("Sport teams: NBA"),	value: "nBA"			},
+		{ label: qsTr("Grand Budapest"),	value: "grandBudapest"	}
+	]
+}

--- a/QMLComponents/components/JASP/Controls/ColorPalette.qml
+++ b/QMLComponents/components/JASP/Controls/ColorPalette.qml
@@ -34,7 +34,7 @@ DropDown
 		{ label: qsTr("ggplot2"),			value: "ggplot2"		},
 		{ label: qsTr("Gray"),				value: "gray"			},
 		{ label: qsTr("Blue"),				value: "blue"			},
-		{ label: qsTr("Sport teams: NBA"),	value: "nBA"			},
+		{ label: qsTr("Sports teams: NBA"),	value: "sportsTeamsNBA"	},
 		{ label: qsTr("Grand Budapest"),	value: "grandBudapest"	}
 	]
 }

--- a/QMLComponents/components/JASP/Controls/qmldir
+++ b/QMLComponents/components/JASP/Controls/qmldir
@@ -12,6 +12,7 @@ CheckBox                            1.0 CheckBox.qml
 Chi2TestTableView                   1.0 Chi2TestTableView.qml
 CIField                             1.0 CIField.qml
 ColumnLayout                        1.0 ColumnLayout.qml
+ColorPalette                        1.0 ColorPalette.qml
 ComboBox                            1.0 ComboBox.qml
 ComponentsList                      1.0 ComponentsList.qml
 ComputedColumnField                 1.0 ComputedColumnField.qml


### PR DESCRIPTION
addresses part of: https://github.com/jasp-stats/INTERNAL-jasp/issues/602
and simplifies some other feature requests, such as:
https://github.com/jasp-stats/jasp-issues/issues/2122

(the last two palettes are included in the https://github.com/jasp-stats/jaspGraphs/pull/91)