### PR TITLE
Bugfix: Fix cell show blank after remove label

### DIFF
--- a/Desktop/components/JASP/Widgets/VariablesWindow.qml
+++ b/Desktop/components/JASP/Widgets/VariablesWindow.qml
@@ -554,6 +554,7 @@ FocusScope
 
 											Text
 											{
+												id	 :					cellValue
 												color:					jaspTheme.grayDarker
 												text:					itemValue
 												elide:					Text.ElideMiddle
@@ -593,11 +594,12 @@ FocusScope
 												verticalAlignment:	Text.AlignVCenter
 
 												property int chosenColumnWas: -1
+												property string lableText: text ? text : cellValue.text // Set value as label if label text is empty.
 
 												onEditingFinished:
 												{
 													if(chosenColumnWas === columnModel.chosenColumn && rowIndex >= 0)
-														columnModel.setLabel(rowIndex, text)
+														columnModel.setLabel(rowIndex, lableText)
 												}
 
 												onActiveFocusChanged:


### PR DESCRIPTION
Fix https://github.com/jasp-stats/jasp-issues/issues/1655

Showing empty content is not a good idea especially for table and plot results. so let's just set value as label while label is empty.