### PR TITLE
editImg, saveImg and rewriteImgs should always have their module load…

### DIFF
--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -113,10 +113,9 @@ public:
 			AnalysisForm	*	form()				const				{ return _analysisForm;						}
 			bool				hasForm()			const				{ return _analysisForm;						}
 			bool				isDuplicate()		const	override	{ return _isDuplicate;						}
-			bool				utilityRunAllowed() const				{ return  isSaveImg() || isEditImg() || isRewriteImgs();							}
-			bool				shouldRun()								{ return !isWaitingForModule() && ( utilityRunAllowed() || isEmpty() ) && form();	}
-			bool				beingTranslated()                        { return _beingTranslated; };
-			void				setBeingTranslated(bool value)           { _beingTranslated = value; };
+			bool				shouldRun()								{ return !isWaitingForModule() && ( isSaveImg() || isEditImg() || isRewriteImgs() || isEmpty() ) && form();	}
+			bool				beingTranslated()						{ return _beingTranslated; };
+			void				setBeingTranslated(bool value)			{ _beingTranslated = value; };
 	const	Json::Value		&	resultsMeta()		const	override	{ return _resultsMeta;						}
 			void				setTitle(const std::string& title)	override;
 			void				run()						override;

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -1072,10 +1072,7 @@ bool EngineRepresentation::willProcessAnalysis(Analysis * analysis)
 	if(_stopRequested || !channel() || !analysis || !idle() || !analysis->shouldRun())
 		return false;
 
-	const std::string modName = analysis->dynamicModule()->name();
-
-	return	(	runsAnalysis()					&& _dynModName == modName && _moduleLoaded)
-			|| (analysis->utilityRunAllowed()	&& runsUtility()		 );
+	return runsAnalysis() && _dynModName == analysis->dynamicModule()->name() && _moduleLoaded;
 }
 
 void canIRegisterModule(const std::string & name);


### PR DESCRIPTION
This fixes https://github.com/jasp-stats/jasp-test-release/issues/2347 by avoiding a warning that breaks loading the state