### PR TITLE
Reset labels on type switch to scalar

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -905,6 +905,7 @@ bool Column::setAsScale(const doublevec & values)
 	}
 
 	setType(columnType::scale);
+	labelsClear(); //delete now unused labels so they can not be erroneously reused when returning to non-scalar type
 	if(!_data->writeBatchedToDB())
 		db().columnSetValues(_id, _dbls);
 	incRevision();


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/jasp-test-release/issues/2354

This also fixes the column getting weird Labels when going: scalar -> NominalT -> scalar -> Nominal