### PR TITLE
Fixes for R-console ribbonbutton

### DIFF
--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -164,7 +164,7 @@ Rectangle
 
 		customMenu.toggle(ribbonButton, props, 0, ribbonButton.height);
 
-		myMenuOpen = Qt.binding(function() { return customMenu.visible && customMenu.sourceItem === ribbonButton; });
+		myMenuOpen = Qt.binding(function() { return customMenu.visible && customMenu.sourceItem == ribbonButton; });
 
 	}
 

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -170,17 +170,30 @@ Rectangle
 
 	Rectangle
 	{
-		id		: borderLeft
-		color   : myMenuOpen  ? jaspTheme.grayDarker  : jaspTheme.gray
-		width   : separator ? 2 * jaspTheme.uiScale : showPressed ? 1 : 0
-		radius	: separator ? width : 0
-		height	: separator ? parent.height * 0.6 : parent.height
+		id:			separatorLine
+		visible:	separator
+		color:		jaspTheme.gray
+		width:		2 * jaspTheme.uiScale
+		radius:		width
+		height:		parent.height * 0.6
 		anchors
 		{
-			left:				separator ? undefined				: parent.left
-			horizontalCenter:	separator ? parent.horizontalCenter	: undefined
+			horizontalCenter:	parent.horizontalCenter
 			top:				parent.top
-			topMargin:			separator ? parent.height * 0.2		: 0
+			topMargin:			parent.height * 0.2
+		}
+	}
+
+	Rectangle
+	{
+		id		: borderLeft
+		color   : myMenuOpen  ? jaspTheme.grayDarker  : jaspTheme.gray
+		width   : showPressed ? 1 : 0
+		anchors
+		{
+			left:				parent.left
+			top:				parent.top
+			bottom:				parent.bottom
 		}
 	}
 

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -199,7 +199,7 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 
 void RibbonModel::addSpecialRibbonButtonsLate()
 {
-	addRibbonButtonModel(new RibbonButton(this, "R", fq(tr("R console")), "Rlogo.svg", false, [&](){ emit showRCommander(); }, fq(tr("Execute R code in a console"))), size_t(RowType::Analyses));
+	addRibbonButtonModel(new RibbonButton(this, "R", fq(tr("R console")), "Rlogo.svg", false, [&](){ emit showRCommander(); }, fq(tr("Execute R code in a console")), false, true), size_t(RowType::Analyses));
 }
 
 void RibbonModel::dynamicModuleChanged(Modules::DynamicModule * dynMod)


### PR DESCRIPTION
This fixes https://github.com/jasp-stats/jasp-test-release/issues/2358
by not reusing the left-border but just add a separatorrectangle

also it makes the R console button show up in the modulesmenu again and stays disabled/enabled across jasp-restarts as desired.