### PR TITLE
make filter responsive by switching to dataMode on changes

### DIFF
--- a/CommonData/filter.cpp
+++ b/CommonData/filter.cpp
@@ -14,6 +14,8 @@ void Filter::dbCreate()
 
 void Filter::dbUpdate()
 {
+	JASPTIMER_SCOPE(Filter::dbUpdate);
+
 	assert(_id != -1);
 
 	db().transactionWriteBegin();

--- a/CommonData/label.cpp
+++ b/CommonData/label.cpp
@@ -45,6 +45,8 @@ void Label::dbDelete()
 
 void Label::dbCreate()
 {
+	JASPTIMER_SCOPE(Label::dbCreate);
+
 	if(_column->batchedLabel())
 		return;
 		
@@ -74,6 +76,8 @@ void Label::dbLoad(int labelId)
 
 void Label::dbUpdate()
 {
+	JASPTIMER_SCOPE(Label::dbUpdate);
+
 	if(_column->batchedLabel())
 		return;
 	
@@ -146,6 +150,8 @@ void Label::setDescription(const std::string &description)
 
 void Label::setFilterAllows(bool allowFilter)
 {
+	JASPTIMER_SCOPE(Label::setFilterAllows);
+
 	if(_filterAllows != allowFilter)
 	{
 		_filterAllows = allowFilter;

--- a/Desktop/data/columnModel.cpp
+++ b/Desktop/data/columnModel.cpp
@@ -204,6 +204,8 @@ QVariant ColumnModel::data(	const QModelIndex & index, int role) const
 
 void ColumnModel::filteredOutChangedHandler(int c)
 {
+	JASPTIMER_SCOPE(ColumnModel::filteredOutChangedHandler);
+
 	if(c == chosenColumn())
 		emit filteredOutChanged();
 }
@@ -406,6 +408,8 @@ void ColumnModel::unselectAll()
 
 bool ColumnModel::setChecked(int rowIndex, bool checked)
 {
+	JASPTIMER_SCOPE(ColumnModel::setChecked);
+
 	_editing = true;
 	_undoStack->pushCommand(new FilterLabelCommand(this, rowIndex, checked));
 	_editing = false;

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -871,6 +871,8 @@ bool DataSetPackage::setDescriptionOnLabel(const QModelIndex & index, const QStr
 
 bool DataSetPackage::setAllowFilterOnLabel(const QModelIndex & index, bool newAllowValue)
 {
+	JASPTIMER_SCOPE(DataSetPackage::setAllowFilterOnLabel);
+
 	Label  * label  = dynamic_cast<Label*>(indexPointerToNode(index));
 	Column * column = dynamic_cast<Column*>(label->parent());
 	
@@ -909,7 +911,7 @@ bool DataSetPackage::setAllowFilterOnLabel(const QModelIndex & index, bool newAl
 		labels[row]->setFilterAllows(newAllowValue);
 
 		if(before != column->hasFilter())
-			notifyColumnFilterStatusChanged(col);
+			notifyColumnFilterStatusChanged(col); //basically resetModel now
 
 		emit labelFilterChanged();
 		QModelIndex columnParentNode = indexForSubNode(column);
@@ -1049,6 +1051,8 @@ bool DataSetPackage::isColumnUsedInEasyFilter(const std::string & colName) const
 
 void DataSetPackage::notifyColumnFilterStatusChanged(int columnIndex)
 {
+	JASPTIMER_SCOPE(DataSetPackage::notifyColumnFilterStatusChanged);
+
 	emit columnsFilteredCountChanged();
 	//emit headerDataChanged(Qt::Horizontal, columnIndex, columnIndex); //this keeps crashing jasp and i dont know why
 	beginResetModel();

--- a/Desktop/data/filtermodel.cpp
+++ b/Desktop/data/filtermodel.cpp
@@ -129,6 +129,8 @@ void FilterModel::setConstructorR(QString newConstructorR)
 }
 void FilterModel::setGeneratedFilter(QString newGeneratedFilter)
 {
+	JASPTIMER_SCOPE(FilterModel::setGeneratedFilter);
+
 	_setGeneratedFilter(newGeneratedFilter);
 	// After this commit https://github.com/jasp-stats/jasp-desktop/commit/65f007cba2ff8986fc3ad86ac4b1a00fa706769b  the filter was not executed.
 	// If a model reset is called just before, this will set the generatedFilter to the right value, and _setGeneratedFilter will returns false
@@ -138,12 +140,14 @@ void FilterModel::setGeneratedFilter(QString newGeneratedFilter)
 
 bool FilterModel::_setGeneratedFilter(const QString& newGeneratedFilter)
 {
+	JASPTIMER_SCOPE(FilterModel::_setGeneratedFilter);
+
 	if (newGeneratedFilter != generatedFilter())
 	{
 		if(DataSetPackage::filter())
 			DataSetPackage::filter()->setGeneratedFilter(fq(newGeneratedFilter));
 
-		emit generatedFilterChanged();
+		emit generatedFilterChanged(); //does nothing?
 		return true;
 	}
 
@@ -177,6 +181,8 @@ void FilterModel::processFilterErrorMsg(QString filterErrorMsg, int requestId)
 
 void FilterModel::sendGeneratedAndRFilter()
 {
+	JASPTIMER_SCOPE(FilterModel::sendGeneratedAndRFilter);
+
 	setFilterErrorMsg("");
 	_lastSentRequestId = emit sendFilter(generatedFilter(), rFilter());
 }

--- a/Desktop/data/labelfiltergenerator.cpp
+++ b/Desktop/data/labelfiltergenerator.cpp
@@ -9,6 +9,8 @@ labelFilterGenerator::labelFilterGenerator(ColumnModel *columnModel, QObject *pa
 
 std::string labelFilterGenerator::generateFilter()
 {
+	JASPTIMER_SCOPE(labelFilterGenerator::generateFilter);
+
 	int neededFilters = 0;
 	
 	for(size_t col=0; col<_columnModel->dataColumnCount(); col++)
@@ -51,11 +53,14 @@ std::string labelFilterGenerator::generateFilter()
 
 void labelFilterGenerator::labelFilterChanged()
 {
+	JASPTIMER_SCOPE(labelFilterGenerator::labelFilterChanged);
 	emit setGeneratedFilter(QString::fromStdString(generateFilter()));
 }
 
 std::string	labelFilterGenerator::generateLabelFilter(size_t col)
 {
+	JASPTIMER_SCOPE(labelFilterGenerator::generateLabelFilter);
+
 	std::string columnName = _columnModel->columnName(col);
 	std::stringstream out;
 	int pos = 0, neg = 0;

--- a/Desktop/engine/enginesync.h
+++ b/Desktop/engine/enginesync.h
@@ -171,8 +171,7 @@ private:
 private:
 	static EngineSync				*	_singleton;
 	RFilterStore					*	_waitingFilter					= nullptr;
-	bool								_filterRunning					= false,
-										_stopProcessing					= false,
+	bool								_stopProcessing					= false,
 										_dataMode						= false;
 	int									_filterCurrentRequestID			= 0;
 	std::string							_memoryName,


### PR DESCRIPTION
fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2145 and https://github.com/jasp-stats/jasp-issues/issues/1644 Also adds a few profiling timers

Im fairly sure this shouldnt add any problems as the only difference between this and the current nightly is that filters wont ever be ran in "Analyses" mode but will just switch to data mode. This alredy worked fine and apparently obviates the gui becoming unresponsive by not hving to pause/resume the engines repeatedly.