### PR TITLE
Some changes in the GUI

### DIFF
--- a/Desktop/components/JASP/Widgets/CustomMenu.qml
+++ b/Desktop/components/JASP/Widgets/CustomMenu.qml
@@ -73,7 +73,7 @@ FocusScope
 		case Qt.Key_Space:
 			if (currentIndex > -1)
 			{
-				menu.props['functionCall'](currentIndex)
+				callMenuAction(currentIndex)
 				menu.currentIndex = -1;
 			}
 			closeMenu();
@@ -161,6 +161,13 @@ FocusScope
 				menu.sourceItem.myMenuOpen = false;
 		}
 		menu.hide();
+	}
+
+	function callMenuAction(index)
+	{
+		if (menu.sourceItem !== null)
+			menu.sourceItem.forceActiveFocus()
+		menu.props['functionCall'](index)
 	}
 
 	Rectangle
@@ -331,7 +338,7 @@ FocusScope
 									id				: mouseArea
 									hoverEnabled	: true
 									anchors.fill	: parent
-									onClicked		: menu.props['functionCall'](index)
+									onClicked		: callMenuAction(index)
 									enabled			: menuItem.itemEnabled
 								}
 							}

--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -711,7 +711,7 @@ FocusScope
 												+ "<br><br>"
 												+ (!columnModel.visible	? qsTr("Doubleclick here to change variable settings")
 																		: (columnModel.chosenColumn === columnIndex ? qsTr("Doubleclick here to close variable window")
-																													: qsTr("Doubleclick here to change selected variable")
+																													: qsTr("Click here to change selected variable")
 																		  )
 												  )
 											  )

--- a/Desktop/modules/ribbonbutton.cpp
+++ b/Desktop/modules/ribbonbutton.cpp
@@ -167,6 +167,7 @@ void RibbonButton::bindYourself()
 	connect(this,								&RibbonButton::requiresDataChanged,		this, &RibbonButton::somePropertyChanged);
 	connect(this,								&RibbonButton::activeChanged,			this, &RibbonButton::somePropertyChanged);
 
+	setActiveDefault();
 	connect(this,								&RibbonButton::enabledChanged,			[=]() { setActiveDefault(); });
 	connect(this,								&RibbonButton::dataLoadedChanged,		[=]() { setActiveDefault(); });
 	connect(this,								&RibbonButton::requiresDataChanged,		[=]() { setActiveDefault(); });

--- a/Desktop/modules/ribbonbutton.cpp
+++ b/Desktop/modules/ribbonbutton.cpp
@@ -167,9 +167,9 @@ void RibbonButton::bindYourself()
 	connect(this,								&RibbonButton::requiresDataChanged,		this, &RibbonButton::somePropertyChanged);
 	connect(this,								&RibbonButton::activeChanged,			this, &RibbonButton::somePropertyChanged);
 
-	connect(this,								&RibbonButton::enabledChanged,			this, &RibbonButton::activeChanged		);
-	connect(this,								&RibbonButton::dataLoadedChanged,		this, &RibbonButton::activeChanged		);
-	connect(this,								&RibbonButton::requiresDataChanged,		this, &RibbonButton::activeChanged		);
+	connect(this,								&RibbonButton::enabledChanged,			[=]() { setActiveDefault(); });
+	connect(this,								&RibbonButton::dataLoadedChanged,		[=]() { setActiveDefault(); });
+	connect(this,								&RibbonButton::requiresDataChanged,		[=]() { setActiveDefault(); });
 
 	connect(DynamicModules::dynMods(),	&DynamicModules::dataLoadedChanged,	this, &RibbonButton::dataLoadedChanged	);
 }
@@ -218,6 +218,20 @@ void RibbonButton::setEnabled(bool enabled)
 
 		emit DynamicModules::dynMods()->moduleEnabledChanged(nameQ(), enabled);
 	}
+}
+
+void RibbonButton::setActiveDefault()
+{
+	setActive(enabled() && (!requiresData() || dataLoaded()));
+}
+
+void RibbonButton::setActive(bool active)
+{
+	if (_active == active)
+		return;
+
+	_active = active;
+	emit activeChanged();
 }
 
 void RibbonButton::setIsCommon(bool isCommon)

--- a/Desktop/modules/ribbonbutton.h
+++ b/Desktop/modules/ribbonbutton.h
@@ -44,7 +44,7 @@ class RibbonButton : public QObject
 	Q_PROPERTY(QString	iconSource		READ iconSource			WRITE setIconSource			NOTIFY iconSourceChanged	)
 	Q_PROPERTY(QVariant	menu			READ menu											NOTIFY analysisMenuChanged	)
 	Q_PROPERTY(bool		dataLoaded		READ dataLoaded										NOTIFY dataLoadedChanged	)
-	Q_PROPERTY(bool		active			READ active											NOTIFY activeChanged		)
+	Q_PROPERTY(bool		active			READ active				WRITE setActive				NOTIFY activeChanged		)
 	Q_PROPERTY(QString	toolTip			READ toolTip			WRITE setToolTip			NOTIFY toolTipChanged		)
 	Q_PROPERTY(bool		special			READ isSpecial										NOTIFY isSpecialChanged		)
 	Q_PROPERTY(bool		ready			READ ready				WRITE setReady				NOTIFY readyChanged			)
@@ -74,7 +74,7 @@ public:
 	QVariant					menu()														const			{ return QVariant::fromValue(_menuModel);					}
 	stringvec					getAllEntries()												const;
 	bool						dataLoaded()												const			{ return Modules::DynamicModules::dynMods() &&  Modules::DynamicModules::dynMods()->dataLoaded();	}
-	bool						active()													const			{ return _enabled && (!requiresData() || dataLoaded());		}
+	bool						active()													const			{ return _active;											}
 	QString						toolTip()													const			{ return _toolTip;											}
 	bool						isBundled()													const			{ return _module && _module->isBundled();					}
 	QString						version()													const			{ return !_module ? "?" : _module->versionQ();				}
@@ -103,6 +103,7 @@ public slots:
 	void setReady(bool ready);
 	void setError(bool error);
 	void setRemember(bool remember);
+	void setActive(bool active);
 
 
 	void runSpecial(QString func);;
@@ -129,6 +130,7 @@ signals:
 
 private:
 	void bindYourself();
+	void setActiveDefault();
 
 
 private:
@@ -137,6 +139,7 @@ private:
 									_isDynamicModule	= true,
 									_isCommonModule		= false,
 									_enabled			= false,
+									_active				= false,
 									_ready				= false,
 									_error				= false,
 									_remember			= true,

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -150,8 +150,8 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	_synchroniseOnButton	= new RibbonButton(this, "Data-Synch-On",			fq(tr("Synchronisation")),			"data-button-sync-off.svg",	true, [&](){ emit setDataSynchronisation(true); },					fq(tr("Turn external data synchronisation on")),	false);
 	_synchroniseOffButton	= new RibbonButton(this, "Data-Synch-Off",			fq(tr("Synchronisation")),			"data-button-sync-on.svg",	true, [&](){ emit setDataSynchronisation(false); },					fq(tr("Turn external data synchronisation off")),	true);
 
-	_undoButton				= new RibbonButton(this, "Data-Undo",				fq(tr("Undo")),						"menu-undo.svg",			true,  [&](){ emit dataUndo(); },									fq(tr("Undo changes, %1+Z").arg(getShortCutKey())),					false);
-	_redoButton				= new RibbonButton(this, "Data-Redo",				fq(tr("Redo")),						"menu-redo.svg",			true,  [&](){ emit dataRedo(); },									fq(tr("Redo changes, %1+shift+Z or %1+Y").arg(getShortCutKey())),	false);
+	_undoButton				= new RibbonButton(this, "Data-Undo",				fq(tr("Undo")),						"menu-undo.svg",			true,  [&](){ emit dataUndo(); },									fq(tr("Undo changes, %1+Z").arg(getShortCutKey())),					true);
+	_redoButton				= new RibbonButton(this, "Data-Redo",				fq(tr("Redo")),						"menu-redo.svg",			true,  [&](){ emit dataRedo(); },									fq(tr("Redo changes, %1+shift+Z or %1+Y").arg(getShortCutKey())),	true);
 
 	connect(this, &RibbonModel::dataLoadedChanged,		_dataSwitchButton,		&RibbonButton::setEnabled);
 	connect(this, &RibbonModel::dataLoadedChanged,		_dataNewButton,			[=](bool loaded){ _dataNewButton->setEnabled(	 !loaded); });
@@ -169,8 +169,8 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 			QString undoText = view->undoText(),
 					redoText = view->redoText();
 
-			_undoButton->setEnabled(!undoText.isEmpty());
-			_redoButton->setEnabled(!redoText.isEmpty());
+			_undoButton->setActive(!undoText.isEmpty());
+			_redoButton->setActive(!redoText.isEmpty());
 
 			_undoButton->setToolTip(tr("Undo %2 (%1+Z)")				.arg(getShortCutKey()).arg(undoText));
 			_redoButton->setToolTip(tr("Redo %2 (%1+shift+Z or %1+Y)")	.arg(getShortCutKey()).arg(redoText));


### PR DESCRIPTION
- After selecting a menu in the custom menu (popup menu), the source item of the popup should get back the focus (behalve if the action of the menu sets the focus). 
- Undo/Redo ribbon menu should be set enabled/disabled in place of visible/invisible 
- Change tooltip: when variable settings window is open, only a click (not a doubleclick) on another variable header changes the selected variable.

