### PR TITLE
Dont switch to data editing mode on filterrun, as this gives silly behaviour

### DIFF
--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -52,7 +52,7 @@ EngineSync::EngineSync(QObject *parent)
 	_singleton = this;
 	
 	_filterRunningResetTimer = new QTimer(this);
-	_filterRunningResetTimer->setInterval(2000);
+	_filterRunningResetTimer->setInterval(1000);
 	_filterRunningResetTimer->setSingleShot(true);
 	
 	connect(_filterRunningResetTimer, &QTimer::timeout, this, [&](){ _filterRunning = false; });

--- a/Desktop/engine/enginesync.h
+++ b/Desktop/engine/enginesync.h
@@ -170,9 +170,11 @@ private:
 
 private:
 	static EngineSync				*	_singleton;
+	QTimer							*	_filterRunningResetTimer		= nullptr;
 	RFilterStore					*	_waitingFilter					= nullptr;
 	bool								_stopProcessing					= false,
-										_dataMode						= false;
+										_dataMode						= false,
+										_filterRunning					= false;
 	int									_filterCurrentRequestID			= 0;
 	std::string							_memoryName,
 										_engineInfo;


### PR DESCRIPTION
now a timer is started after a filter is ran, 2s delay before it allows analyses etc to run this should also fix https://github.com/jasp-stats/INTERNAL-jasp/issues/2145 and reverts some of https://github.com/jasp-stats/jasp-desktop/commit/80c5077268c90524a403b1b33101c7bf8ab0ad32

