### PR TITLE
Unchecked all labels should be forbidden

### DIFF
--- a/Desktop/data/columnModel.cpp
+++ b/Desktop/data/columnModel.cpp
@@ -427,7 +427,7 @@ bool ColumnModel::setChecked(int rowIndex, bool checked)
 	_undoStack->pushCommand(new FilterLabelCommand(this, rowIndex, checked));
 	_editing = false;
 
-	return data(index(rowIndex, 0), int(DataSetPackage::specialRoles::filter)).toBool();
+	return data(index(rowIndex, 0), int(DataSetPackage::specialRoles::filter)).toBool() == checked;
 }
 
 void ColumnModel::setLabel(int rowIndex, QString label)


### PR DESCRIPTION
When all but one labels are unchecked, the last not-unchecked label cannot be unchecked, because all the data would be filtered. In fact the internal label is not unchecked,  but the view let see all labels unchecked.

