### PR TITLE
Edit/New data Ribbon should be enabled at the right moment

### DIFF
--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -691,14 +691,11 @@ FocusScope
 								createComputeDialog.open()
 							else
 							{
-								if(ribbonModel.dataMode)
-								{
-									if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
-									   dataTableView.view.columnSelect(columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton);
+								if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
+								   dataTableView.view.columnSelect(columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton);
 
-									if(mouseEvent.button === Qt.RightButton)
-									   dataTableView.showPopupMenu(parent, mapToGlobal(mouseEvent.x, mouseEvent.y), -1, columnIndex, true, false);
-								}
+								if(ribbonModel.dataMode && mouseEvent.button === Qt.RightButton)
+									dataTableView.showPopupMenu(parent, mapToGlobal(mouseEvent.x, mouseEvent.y), -1, columnIndex, true, false);
 							}
 						}
 					}

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1268,7 +1268,7 @@ void MainWindow::populateUIfromDataSet()
 
 	bool hasAnalyses = _analyses->count() > 0;
 
-	setDataAvailable((_package->rowCount() > 0 || _package->columnCount() > 0));
+	setDataAvailable(_package->dataSet() && (_package->dataSet()->rowCount() > 0 && _package->dataSet()->columnCount() > 0));
 
 	hideProgress();
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -287,6 +287,8 @@ void MainWindow::makeConnections()
 	connect(this,					&MainWindow::editImageCancelled,					_resultsJsInterface,	&ResultsJsInterface::cancelImageEdit						);
 	connect(this,					&MainWindow::dataAvailableChanged,					_dynamicModules,		&DynamicModules::setDataLoaded								);
 	connect(this,					&MainWindow::dataAvailableChanged,					_ribbonModel,			&RibbonModel::dataLoadedChanged								);
+	connect(this,					&MainWindow::dataAvailableChanged,					this,					&MainWindow::checkEmptyWorkspace							);
+	connect(this,					&MainWindow::analysesAvailableChanged,				this,					&MainWindow::checkEmptyWorkspace							);
 	connect(this,					&MainWindow::showComputedColumn,					_columnModel,			&ColumnModel::openComputedColumn							);
 
 
@@ -881,6 +883,12 @@ void MainWindow::refreshPlotsHandler(bool askUserForRefresh)
 		_analyses->refreshAllAnalyses();
 }
 
+void MainWindow::checkEmptyWorkspace()
+{
+	if (!analysesAvailable() && !dataAvailable())
+		_fileMenu->close();
+}
+
 void MainWindow::analysisResultsChangedHandler(Analysis *analysis)
 {
 	static bool showInstructions = true;
@@ -1060,7 +1068,7 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 	}
 	else if (event->operation() == FileEvent::FileClose)
 	{
-		if (_package->isModified())
+		if (_package->isModified() && (dataAvailable() || analysesAvailable()))
 		{
 			QString title = windowTitle();
 			title.chop(1);

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -186,6 +186,7 @@ private:
 	void _openDbJson();
 	void connectFileEventCompleted(FileEvent * event);
 	void refreshPlotsHandler(bool askUserForRefresh = true);
+	void checkEmptyWorkspace();
 
 signals:
 	void saveJaspFile();

--- a/Desktop/modules/ribbonbutton.cpp
+++ b/Desktop/modules/ribbonbutton.cpp
@@ -49,8 +49,8 @@ RibbonButton::RibbonButton(QObject *parent, DynamicModule * module)  : QObject(p
 	bindYourself();
 }
 
-RibbonButton::RibbonButton(QObject *parent,	std::string name, std::string title, std::string icon, bool requiresData, std::function<void ()> justThisFunction, std::string toolTip, bool enabled, bool remember)
-	: QObject(parent), _enabled(enabled), _remember(remember), _special(true), _module(nullptr), _specialButtonFunc(justThisFunction)
+RibbonButton::RibbonButton(QObject *parent,	std::string name, std::string title, std::string icon, bool requiresData, std::function<void ()> justThisFunction, std::string toolTip, bool enabled, bool remember, bool defaultActiveBinding)
+	: QObject(parent), _enabled(enabled), _defaultActiveBinding(defaultActiveBinding), _remember(remember), _special(true), _module(nullptr), _specialButtonFunc(justThisFunction)
 {
 	_menuModel = new MenuModel(this);
 
@@ -64,8 +64,8 @@ RibbonButton::RibbonButton(QObject *parent,	std::string name, std::string title,
 	bindYourself();
 }
 
-RibbonButton::RibbonButton(QObject *parent, std::string name,	std::string title, std::string icon, Modules::AnalysisEntries * funcEntries, std::string toolTip, bool enabled, bool remember)
-	: QObject(parent), _enabled(enabled), _remember(remember), _special(true), _module(nullptr)
+RibbonButton::RibbonButton(QObject *parent, std::string name,	std::string title, std::string icon, Modules::AnalysisEntries * funcEntries, std::string toolTip, bool enabled, bool remember, bool defaultActiveBinding)
+	: QObject(parent), _enabled(enabled), _defaultActiveBinding(defaultActiveBinding), _remember(remember), _special(true), _module(nullptr)
 {
 	_menuModel = new MenuModel(this, funcEntries);
 
@@ -167,10 +167,13 @@ void RibbonButton::bindYourself()
 	connect(this,								&RibbonButton::requiresDataChanged,		this, &RibbonButton::somePropertyChanged);
 	connect(this,								&RibbonButton::activeChanged,			this, &RibbonButton::somePropertyChanged);
 
-	setActiveDefault();
-	connect(this,								&RibbonButton::enabledChanged,			[=]() { setActiveDefault(); });
-	connect(this,								&RibbonButton::dataLoadedChanged,		[=]() { setActiveDefault(); });
-	connect(this,								&RibbonButton::requiresDataChanged,		[=]() { setActiveDefault(); });
+	if (_defaultActiveBinding)
+	{
+		setActiveDefault();
+		connect(this,								&RibbonButton::enabledChanged,			[=]() { setActiveDefault(); });
+		connect(this,								&RibbonButton::dataLoadedChanged,		[=]() { setActiveDefault(); });
+		connect(this,								&RibbonButton::requiresDataChanged,		[=]() { setActiveDefault(); });
+	}
 
 	connect(DynamicModules::dynMods(),	&DynamicModules::dataLoadedChanged,	this, &RibbonButton::dataLoadedChanged	);
 }

--- a/Desktop/modules/ribbonbutton.h
+++ b/Desktop/modules/ribbonbutton.h
@@ -56,8 +56,8 @@ public:
 
 	RibbonButton(QObject *parent);
 	RibbonButton(QObject *parent, Modules::DynamicModule * module);
-	RibbonButton(QObject *parent, std::string name,	std::string title, std::string icon, bool requiresData, std::function<void()> justThisFunction, std::string toolTip = "", bool enabled = true, bool remember = false);
-	RibbonButton(QObject *parent, std::string name,	std::string title, std::string icon, Modules::AnalysisEntries * funcEntries, std::string toolTip = "", bool enabled = true, bool remember = false);
+	RibbonButton(QObject *parent, std::string name,	std::string title, std::string icon, bool requiresData, std::function<void()> justThisFunction, std::string toolTip = "", bool enabled = true, bool remember = false, bool defaultActiveBinding = true);
+	RibbonButton(QObject *parent, std::string name,	std::string title, std::string icon, Modules::AnalysisEntries * funcEntries, std::string toolTip = "", bool enabled = true, bool remember = false, bool defaultActiveBinding = true);
 	~RibbonButton();
 
 
@@ -140,6 +140,7 @@ private:
 									_isCommonModule		= false,
 									_enabled			= false,
 									_active				= false,
+									_defaultActiveBinding = true,
 									_ready				= false,
 									_error				= false,
 									_remember			= true,

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -158,7 +158,13 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	connect(this, &RibbonModel::dataLoadedChanged,							_dataSwitchButton,	[=](bool loaded)			{ _dataSwitchButton	->setEnabled(loaded);				});
 	connect(this, &RibbonModel::dataLoadedChanged,							_dataNewButton,		[=](bool loaded)			{ _dataNewButton	->setEnabled(!loaded);				});
 	connect(MainWindow::singleton(), &MainWindow::dataAvailableChanged,		_dataSwitchButton,	[=](bool dataAvailable)		{ _dataSwitchButton	->setActive(dataAvailable);			});
-	connect(MainWindow::singleton(), &MainWindow::analysesAvailableChanged, _dataNewButton,		[=](bool analysesAvailable)	{ _dataNewButton	->setActive(!analysesAvailable); _dataNewButton->setTitle(analysesAvailable ? fq(tr("No Data")) : fq(tr("New Data")));	});
+
+	connect(MainWindow::singleton(), &MainWindow::analysesAvailableChanged, _dataNewButton,		[=](bool analysesAvailable)
+	{
+		_dataNewButton	->setActive(	!analysesAvailable);
+		_dataNewButton	->setTitle(		 analysesAvailable ? fq(tr("No Data"))	: fq(tr("New Data"))	);
+		_dataNewButton	->setIconSource( analysesAvailable ? "data-button.svg"	: "data-button-new.svg"	);
+	});
 
 	connect(this, &RibbonModel::dataLoadedChanged,		_insertButton,			&RibbonButton::setEnabled);
 	connect(this, &RibbonModel::dataLoadedChanged,		_removeButton,			&RibbonButton::setEnabled);

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -158,7 +158,7 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	connect(this, &RibbonModel::dataLoadedChanged,							_dataSwitchButton,	[=](bool loaded)			{ _dataSwitchButton	->setEnabled(loaded);				});
 	connect(this, &RibbonModel::dataLoadedChanged,							_dataNewButton,		[=](bool loaded)			{ _dataNewButton	->setEnabled(!loaded);				});
 	connect(MainWindow::singleton(), &MainWindow::dataAvailableChanged,		_dataSwitchButton,	[=](bool dataAvailable)		{ _dataSwitchButton	->setActive(dataAvailable);			});
-	connect(MainWindow::singleton(), &MainWindow::analysesAvailableChanged, _dataNewButton,		[=](bool analysesAvailable)	{ _dataNewButton	->setActive(!analysesAvailable);	});
+	connect(MainWindow::singleton(), &MainWindow::analysesAvailableChanged, _dataNewButton,		[=](bool analysesAvailable)	{ _dataNewButton	->setActive(!analysesAvailable); _dataNewButton->setTitle(analysesAvailable ? fq(tr("No Data")) : fq(tr("New Data")));	});
 
 	connect(this, &RibbonModel::dataLoadedChanged,		_insertButton,			&RibbonButton::setEnabled);
 	connect(this, &RibbonModel::dataLoadedChanged,		_removeButton,			&RibbonButton::setEnabled);

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -24,6 +24,7 @@
 #include "data/datasetpackage.h"
 #include "jasptheme.h"
 #include "qquick/datasetview.h"
+#include "mainwindow.h"
 
 using namespace Modules;
 
@@ -143,18 +144,22 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 
 
 	_analysesButton			= new RibbonButton(this, "Analyses",				fq(tr("Analyses")),					"JASP_logo_green.svg",		false, [&](){ emit finishCurrentEdit(); emit showStatistics(); },	fq(tr("Switch JASP to analyses mode")),				true);
-	_dataSwitchButton		= new RibbonButton(this, "Data",					fq(tr("Edit Data")),				"data-button.svg",			false, [&](){ emit showData(); },									fq(tr("Switch JASP to data editing mode")),			false);
-	_dataNewButton			= new RibbonButton(this, "Data-New",				fq(tr("New Data")),					"data-button-new.svg",		false, [&](){ emit genShowEmptyData();	 },							fq(tr("Open a workspace without data")),			true);
+	_dataSwitchButton		= new RibbonButton(this, "Data",					fq(tr("Edit Data")),				"data-button.svg",			false, [&](){ emit showData(); },									fq(tr("Switch JASP to data editing mode")),			false, false, false);
+	_dataNewButton			= new RibbonButton(this, "Data-New",				fq(tr("New Data")),					"data-button-new.svg",		false, [&](){ emit genShowEmptyData();	 },							fq(tr("Open a workspace without data")),			true, false, false);
 	_insertButton			= new RibbonButton(this, "Data-Insert",				fq(tr("Insert")),					"data-button-insert.svg",	_entriesInsert,														fq(tr("Insert empty columns or rows")));
 	_removeButton			= new RibbonButton(this, "Data-Remove",				fq(tr("Remove")),					"data-button-erase.svg",	_entriesDelete,														fq(tr("Remove columns or rows")));
 	_synchroniseOnButton	= new RibbonButton(this, "Data-Synch-On",			fq(tr("Synchronisation")),			"data-button-sync-off.svg",	true, [&](){ emit setDataSynchronisation(true); },					fq(tr("Turn external data synchronisation on")),	false);
 	_synchroniseOffButton	= new RibbonButton(this, "Data-Synch-Off",			fq(tr("Synchronisation")),			"data-button-sync-on.svg",	true, [&](){ emit setDataSynchronisation(false); },					fq(tr("Turn external data synchronisation off")),	true);
 
-	_undoButton				= new RibbonButton(this, "Data-Undo",				fq(tr("Undo")),						"menu-undo.svg",			true,  [&](){ emit dataUndo(); },									fq(tr("Undo changes, %1+Z").arg(getShortCutKey())),					true);
-	_redoButton				= new RibbonButton(this, "Data-Redo",				fq(tr("Redo")),						"menu-redo.svg",			true,  [&](){ emit dataRedo(); },									fq(tr("Redo changes, %1+shift+Z or %1+Y").arg(getShortCutKey())),	true);
+	_undoButton				= new RibbonButton(this, "Data-Undo",				fq(tr("Undo")),						"menu-undo.svg",			true,  [&](){ emit dataUndo(); },									fq(tr("Undo changes, %1+Z").arg(getShortCutKey())),					true, false, false);
+	_redoButton				= new RibbonButton(this, "Data-Redo",				fq(tr("Redo")),						"menu-redo.svg",			true,  [&](){ emit dataRedo(); },									fq(tr("Redo changes, %1+shift+Z or %1+Y").arg(getShortCutKey())),	true, false, false);
 
-	connect(this, &RibbonModel::dataLoadedChanged,		_dataSwitchButton,		[=](bool loaded){ _dataSwitchButton->setEnabled(loaded); _dataSwitchButton->setActive(DataSetPackage::pkg()->hasDataSet() && DataSetPackage::pkg()->dataSet()->columnCount() > 0); });
-	connect(this, &RibbonModel::dataLoadedChanged,		_dataNewButton,			[=](bool loaded){ _dataNewButton->setEnabled(	 !loaded); });
+	_dataNewButton->setActive(true);
+	connect(this, &RibbonModel::dataLoadedChanged,							_dataSwitchButton,	[=](bool loaded)			{ _dataSwitchButton	->setEnabled(loaded);				});
+	connect(this, &RibbonModel::dataLoadedChanged,							_dataNewButton,		[=](bool loaded)			{ _dataNewButton	->setEnabled(!loaded);				});
+	connect(MainWindow::singleton(), &MainWindow::dataAvailableChanged,		_dataSwitchButton,	[=](bool dataAvailable)		{ _dataSwitchButton	->setActive(dataAvailable);			});
+	connect(MainWindow::singleton(), &MainWindow::analysesAvailableChanged, _dataNewButton,		[=](bool analysesAvailable)	{ _dataNewButton	->setActive(!analysesAvailable);	});
+
 	connect(this, &RibbonModel::dataLoadedChanged,		_insertButton,			&RibbonButton::setEnabled);
 	connect(this, &RibbonModel::dataLoadedChanged,		_removeButton,			&RibbonButton::setEnabled);
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2361

If there is no data, the New Data icon should be enabled, but if an analysis that does not require data (like a distribution) is added, then the New Data should be disabled. If you remove the analysis, the New Data should be enabled. If you open a JASP file that has no data, the New Data icon should be disabled.

