### PR TITLE
Tweaks for parse exported html

### DIFF
--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -548,38 +548,25 @@ $(document).ready(function () {
 	$("body").on("click", window.unselectByClickingBody)
 })
 
-var wrapHTML = function (html, exportParams, doctype = false) {
-	var completehtml = ""
-	if(doctype)
-		completehtml = "<!DOCTYPE HTML>\n"
-	completehtml += "<html>\n"
-	completehtml += "	<head>\n"
-	completehtml += "		<meta http-equiv='Content-Type' content='text/html; charset=utf-8' />\n"
-	completehtml += "		<title>JASP</title>"
-	completehtml += "		<style>"
-	completehtml += "			p {margin-top:1em; margin-bottom:1em;}"
-	if (exportParams.isFormatted())
-		completehtml += "			body {font-family: sans-serif;}"
-	completehtml += "		</style>"
-	completehtml += "	</head>\n"
+var wrapHTML = function (htmlStrings, exportParams, doctype = false) {
 
-	var styles = JASPWidgets.Exporter.getStyles($("body"), ["display", "padding", "margin"]);
-	completehtml += "	<body " + styles + ">\n";
-	
-	//const htmlObj = $.parseHTML(html);
-	//	$(htmlObj).find('mjx-assistive-mml math').remove();
-	//const result = $(htmlObj).prop('outerHTML');
+    let result = ""
+    let html = new DOMParser().parseFromString(htmlStrings, 'text/html'); // here to parse as `xml` or `application/xhtml+xml`
 
-	//Dont convert to DOM because it replace <img.../> with <img...> which breaks unitTest(Recursive)
-	const mjxAssistReg = /\<mjx-assistive-mml.+?\<\/mjx-assistive-mml\>/g;
-	html = html.replace(mjxAssistReg, "");
+    $(html).find('head').prepend(`<title>JASP</title>`)
+                        .prepend(`<style>p {margin-top:1em; margin-bottom:1em;}
+                                ${exportParams.isFormatted() ? `body {font-family: sans-serif;}` : `body {display: block; font-family: sans-serif; padding: 0px; margin: 0px;}`}
+                                </style>`);
 
-	completehtml += html
+    $(html).find('mjx-assistive-mml').remove(); // remove mathml stuff from export
 
-	completehtml += "	</body>\n"
-	completehtml += "</html>";
-	return completehtml;
-};
+    result = new XMLSerializer().serializeToString(html);
+
+    if(doctype)
+        result = "<!DOCTYPE HTML>\n" + result;
+
+    return result;
+}
 
 var pushHTMLToClipboard = function (exportContent, exportParams) {
 


### PR DESCRIPTION
However I still think this is unlikely to solve the inconsistency of comparing .jasp files, since the difference is subtle and the original difference was in the old jasp file,unless we refreshing old .jasp file and use the new file as a benchmark or just using JSON comparing.

This PR contains two equivalent commits
1. Parsing strings into html by jquery will lose end end tag slash?
2. The browser natively parses it as html, or it can be set to xml/xhtml (but it currently has parsing errors: some tags need to be escaped).