### PR TITLE
When synchronization is on, add menu to be able to start external spreadsheet editor

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -812,7 +812,7 @@ bool DataSetPackage::setData(const QModelIndex &index, const QVariant &value, in
 				
 				stringvec changedCols = {column->name()};
 				endSynchingDataChangedColumns(changedCols, false, false);
-				setManualEdits(true);
+				//setManualEdits(true); // A label change is not a data change, so don't set manual edit: this would unset synchronisation if it was on.
 				return true;
 			}
 			break;

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -54,7 +54,7 @@ class DataSetPackage : public QAbstractItemModel //Not QAbstractTableModel becau
 	Q_PROPERTY(QString		currentFile				READ currentFile			WRITE setCurrentFile		NOTIFY currentFileChanged			)
 	Q_PROPERTY(bool			dataMode				READ dataMode											NOTIFY dataModeChanged				)
 	Q_PROPERTY(bool			synchingExternally		READ synchingExternally		WRITE setSynchingExternally NOTIFY synchingExternallyChanged	) //might have to be moved to dataset when we have multiple datasets, alse CurrentDataFile in FileMenu will need to be looked at...
-	Q_PROPERTY(bool			manualEdits				READ manualEdits			WRITE setManualEdits		NOTIFY manualEditsChanged			)
+	Q_PROPERTY(bool			manualEdits				READ manualEdits			WRITE setManualEdits		NOTIFY manualEditsChanged			) ///< Did the user change something in the data in such a way that external synching should be disabled if enabled?
 
 	typedef DataSetPackageSubNodeModel							SubNodeModel;
 

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -142,6 +142,11 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 		new AnalysisEntry([&](){ emit this->cellsClear();				},					"clear-cells",					fq(tr("Clear cells")),			true,		"menu-cells-clear")
 	});
 
+	_entriesSynchronisationOn = new AnalysisEntries(
+	{
+		new AnalysisEntry([&]() { MainWindow::singleton()->startDataEditorHandler(); },		"open-datafile",				fq(tr("Open datafile with default spreadsheed editor")),	true, ""),
+		new AnalysisEntry([&]() { emit setDataSynchronisation(false);	},					"stop-externaledit",			fq(tr("Turn external data synchronisation off")),			true, "")
+	});
 
 	_analysesButton			= new RibbonButton(this, "Analyses",				fq(tr("Analyses")),					"JASP_logo_green.svg",		false, [&](){ emit finishCurrentEdit(); emit showStatistics(); },	fq(tr("Switch JASP to analyses mode")),				true);
 	_dataSwitchButton		= new RibbonButton(this, "Data",					fq(tr("Edit Data")),				"data-button.svg",			false, [&](){ emit showData(); },									fq(tr("Switch JASP to data editing mode")),			false, false, false);
@@ -149,7 +154,7 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	_insertButton			= new RibbonButton(this, "Data-Insert",				fq(tr("Insert")),					"data-button-insert.svg",	_entriesInsert,														fq(tr("Insert empty columns or rows")));
 	_removeButton			= new RibbonButton(this, "Data-Remove",				fq(tr("Remove")),					"data-button-erase.svg",	_entriesDelete,														fq(tr("Remove columns or rows")));
 	_synchroniseOnButton	= new RibbonButton(this, "Data-Synch-On",			fq(tr("Synchronisation")),			"data-button-sync-off.svg",	true, [&](){ emit setDataSynchronisation(true); },					fq(tr("Turn external data synchronisation on")),	false);
-	_synchroniseOffButton	= new RibbonButton(this, "Data-Synch-Off",			fq(tr("Synchronisation")),			"data-button-sync-on.svg",	true, [&](){ emit setDataSynchronisation(false); },					fq(tr("Turn external data synchronisation off")),	true);
+	_synchroniseOffButton	= new RibbonButton(this, "Data-Synch-Off",			fq(tr("Synchronisation")),			"data-button-sync-on.svg",	_entriesSynchronisationOn,											fq(tr("Turn external data synchronisation off")),	true);
 
 	_undoButton				= new RibbonButton(this, "Data-Undo",				fq(tr("Undo")),						"menu-undo.svg",			true,  [&](){ emit dataUndo(); },									fq(tr("Undo changes, %1+Z").arg(getShortCutKey())),					true, false, false);
 	_redoButton				= new RibbonButton(this, "Data-Redo",				fq(tr("Redo")),						"menu-redo.svg",			true,  [&](){ emit dataRedo(); },									fq(tr("Redo changes, %1+shift+Z or %1+Y").arg(getShortCutKey())),	true, false, false);

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -142,7 +142,7 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 		new AnalysisEntry([&](){ emit this->cellsClear();				},					"clear-cells",					fq(tr("Clear cells")),			true,		"menu-cells-clear")
 	});
 
-	_entriesSynchronisationOn = new AnalysisEntries(
+	_entriesSynchOn = new AnalysisEntries(
 	{
 		new AnalysisEntry([&]() { MainWindow::singleton()->startDataEditorHandler(); },		"open-datafile",				fq(tr("Open datafile with default spreadsheet editor")),	true, ""),
 		new AnalysisEntry([&]() { emit setDataSynchronisation(false);	},					"stop-externaledit",			fq(tr("Turn external data synchronisation off")),			true, "")
@@ -154,7 +154,7 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	_insertButton			= new RibbonButton(this, "Data-Insert",				fq(tr("Insert")),					"data-button-insert.svg",	_entriesInsert,														fq(tr("Insert empty columns or rows")));
 	_removeButton			= new RibbonButton(this, "Data-Remove",				fq(tr("Remove")),					"data-button-erase.svg",	_entriesDelete,														fq(tr("Remove columns or rows")));
 	_synchroniseOnButton	= new RibbonButton(this, "Data-Synch-On",			fq(tr("Synchronisation")),			"data-button-sync-off.svg",	true, [&](){ emit setDataSynchronisation(true); },					fq(tr("Turn external data synchronisation on")),	false);
-	_synchroniseOffButton	= new RibbonButton(this, "Data-Synch-Off",			fq(tr("Synchronisation")),			"data-button-sync-on.svg",	_entriesSynchronisationOn,											fq(tr("Turn external data synchronisation off")),	true);
+	_synchroniseOffButton	= new RibbonButton(this, "Data-Synch-Off",			fq(tr("Synchronisation")),			"data-button-sync-on.svg",	_entriesSynchOn,													fq(tr("Turn external data synchronisation off")),	true);
 
 	_undoButton				= new RibbonButton(this, "Data-Undo",				fq(tr("Undo")),						"menu-undo.svg",			true,  [&](){ emit dataUndo(); },									fq(tr("Undo changes, %1+Z").arg(getShortCutKey())),					true, false, false);
 	_redoButton				= new RibbonButton(this, "Data-Redo",				fq(tr("Redo")),						"menu-redo.svg",			true,  [&](){ emit dataRedo(); },									fq(tr("Redo changes, %1+shift+Z or %1+Y").arg(getShortCutKey())),	true, false, false);

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -144,7 +144,7 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 
 	_entriesSynchronisationOn = new AnalysisEntries(
 	{
-		new AnalysisEntry([&]() { MainWindow::singleton()->startDataEditorHandler(); },		"open-datafile",				fq(tr("Open datafile with default spreadsheed editor")),	true, ""),
+		new AnalysisEntry([&]() { MainWindow::singleton()->startDataEditorHandler(); },		"open-datafile",				fq(tr("Open datafile with default spreadsheet editor")),	true, ""),
 		new AnalysisEntry([&]() { emit setDataSynchronisation(false);	},					"stop-externaledit",			fq(tr("Turn external data synchronisation off")),			true, "")
 	});
 

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -146,7 +146,8 @@ private: // fields
 	stringvec								_commonModulesToLoad;
 	size_t									_currentRow				= size_t(RowType::Analyses);
 	Modules::AnalysisEntries			*	_entriesInsert			= nullptr,
-										*	_entriesDelete			= nullptr;
+										*	_entriesDelete			= nullptr,
+										*	_entriesSynchronisationOn = nullptr;
 	RibbonButton						*	_analysesButton			= nullptr,
 										*	_dataSwitchButton		= nullptr,
 										*	_dataNewButton			= nullptr,

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -147,7 +147,7 @@ private: // fields
 	size_t									_currentRow				= size_t(RowType::Analyses);
 	Modules::AnalysisEntries			*	_entriesInsert			= nullptr,
 										*	_entriesDelete			= nullptr,
-										*	_entriesSynchronisationOn = nullptr;
+										*	_entriesSynchOn			= nullptr;
 	RibbonButton						*	_analysesButton			= nullptr,
 										*	_dataSwitchButton		= nullptr,
 										*	_dataNewButton			= nullptr,


### PR DESCRIPTION
When you open a datafile or a JASP file that is synchronized with a data file, in Data Edit mode, it is not possible to start directly the external spreadsheet editor: you have first to switch it off, and then switch it on again. This is not quite intuitive. So add a menu in the Synchronzation ribbon button, so to let the user have the possibility to start directly the spreadsheet editor.

