### PR TITLE
this regex removes the superfluous mjx-assistive-mml element without dom-parsing

### DIFF
--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -566,10 +566,15 @@ var wrapHTML = function (html, exportParams, doctype = false) {
 	var styles = JASPWidgets.Exporter.getStyles($("body"), ["display", "padding", "margin"]);
 	completehtml += "	<body " + styles + ">\n";
 	
-	const htmlObj = $.parseHTML(html);
-		$(htmlObj).find('mjx-assistive-mml math').remove();
-	const result = $(htmlObj).prop('outerHTML');
-	completehtml += result
+	//const htmlObj = $.parseHTML(html);
+	//	$(htmlObj).find('mjx-assistive-mml math').remove();
+	//const result = $(htmlObj).prop('outerHTML');
+
+	//Dont convert to DOM because it replace <img.../> with <img...> which breaks unitTest(Recursive)
+	const mjxAssistReg = /\<mjx-assistive-mml.+?\<\/mjx-assistive-mml\>/g;
+	html = html.replace(mjxAssistReg, "");
+
+	completehtml += html
 
 	completehtml += "	</body>\n"
 	completehtml += "</html>";

--- a/Desktop/html/js/table.js
+++ b/Desktop/html/js/table.js
@@ -801,10 +801,10 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 
 			style = JASPWidgets.Exporter.getTableContentStyles($elObj, exportParams);
 
-			if ($elObj.prop("rowspan") && $elObj.prop("rowspan") != 1)
+			/*if ($elObj.prop("rowspan") && $elObj.prop("rowspan") != 1)
 				attrs += 'rowspan="' + $elObj.prop("rowspan") + '" '
 			if ($elObj.prop("colspan") && $elObj.prop("colspan") != 1)
-				attrs += 'colspan="' + $elObj.prop("colspan") + '" '
+				attrs += 'colspan="' + $elObj.prop("colspan") + '" '*/
 		}
 		else if (tag === "table") {
 			style = JASPWidgets.Exporter.getTableStyles($elObj, exportParams);

--- a/Desktop/html/js/table.js
+++ b/Desktop/html/js/table.js
@@ -798,13 +798,7 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 		var tag = $elObj.prop("tagName").toLowerCase()
 
 		if (tag === "td" || tag === "th") {
-
 			style = JASPWidgets.Exporter.getTableContentStyles($elObj, exportParams);
-
-			/*if ($elObj.prop("rowspan") && $elObj.prop("rowspan") != 1)
-				attrs += 'rowspan="' + $elObj.prop("rowspan") + '" '
-			if ($elObj.prop("colspan") && $elObj.prop("colspan") != 1)
-				attrs += 'colspan="' + $elObj.prop("colspan") + '" '*/
 		}
 		else if (tag === "table") {
 			style = JASPWidgets.Exporter.getTableStyles($elObj, exportParams);

--- a/Desktop/results/resultsjsinterface.h
+++ b/Desktop/results/resultsjsinterface.h
@@ -87,7 +87,7 @@ signals:
 	Q_INVOKABLE void removeAllAnalyses();
 	Q_INVOKABLE void pdfPrintingFinished(	QString pdfPath);
 	Q_INVOKABLE void exportToPDF(			QString pdfPath);
-	void prepForExport();
+				void prepForExport();
 	Q_INVOKABLE void exportPrepFinished();
 	Q_INVOKABLE void showRSyntaxInResults(	bool show);
 

--- a/Desktop/resultstesting/compareresults.cpp
+++ b/Desktop/resultstesting/compareresults.cpp
@@ -27,12 +27,12 @@ void compareResults::sanitizeHtml(QString & result)
 
 	std::vector<std::pair<QString, QString>> replacers (
 		{
-			std::make_pair("&nbsp;",	" "),
-			std::make_pair("&tau;",		"tau"),
-			std::make_pair("<br>",		"\n"),
-			std::make_pair("\"Segoe UI\"", ""), //Why are we replacing these fonts anyway?
-			std::make_pair("\"Helvetica Neue\"", ""),
-			std::make_pair("\"Lucida Grande\"", "")
+			std::make_pair("&nbsp;",						" "),
+			std::make_pair("&tau;",							"tau"),
+			std::make_pair("<br>",							"\n"),
+			std::make_pair("&qout;Segoe UI&qout;",			""), //Why are we replacing these fonts anyway?
+			std::make_pair("&qout;Helvetica Neue&qout;",	""),
+			std::make_pair("&qout;Lucida Grande&qout;",		"")
 		});
 
 	for(auto & p : replacers)
@@ -265,13 +265,13 @@ result compareResults::convertXmltoResultStruct(const QString &  resultXml)
 			//ignore
 			break;
 		}
-	}
-
-	if(xml.hasError())
-	{
-		std::cerr << "xml hadError: " << xml.errorString().toStdString() << "!" << std::endl;
-		//const char * xmlDivider = "<---------------------------------------------------------------------------------------------------------------------------------------------------------------------->\n";
-		//std::cerr << "broken XML:\n" << xmlDivider << resultXml.toStdString() << xmlDivider << std::endl;
+		
+		if(xml.hasError())
+		{
+			std::cerr << "xml hadError at (line=" << xml.lineNumber() << ", col=" << xml.columnNumber() << ", slice=" << resultXml.sliced(xml.characterOffset(), std::min(10, int(resultXml.size() - xml.characterOffset()))) << ") : " << xml.errorString().toStdString() << "!" << std::endl;
+			//const char * xmlDivider = "<---------------------------------------------------------------------------------------------------------------------------------------------------------------------->\n";
+			//std::cerr << "broken XML:\n" << xmlDivider << resultXml.toStdString() << xmlDivider << std::endl;
+		}
 	}
 
 	return res;
@@ -297,15 +297,18 @@ bool compareResults::compare(const QString & resultOld, const QString & resultNe
 	out << "hallo";
 	out << "Old result:\n" << resultOld << "\n";
 	out << "Old result conversion:" << "\n"; */
+	
 	result oldRes = convertXmltoResultStruct(resultOld);
 	std::cout << "\nConverted to:\n" << oldRes.toString() << "" << std::endl;
+	//out << "\nConverted to:\n" << tq(oldRes.toString()) << "\n\n----------------------\n\n";
 
 	std::cout << "New result conversion:" << std::endl;
 	//out << "New result\n" << resultNew << "\n" << "\n";
 	//out << "New result conversion:" << "\n";
 	result newRes = convertXmltoResultStruct(resultNew);
 	std::cout << "\nConverted to:\n" << newRes.toString() << "" << std::endl;
-	//file.close():
+	//out << "\nConverted to:\n" << tq(newRes.toString()) << "\n";
+	//file.close();
 
 	succes = oldRes == newRes;
 


### PR DESCRIPTION

Fixes --unitTest and --unitTestRecursive

would be good to resave the data library after this btw