### PR TITLE
Column type switch can lead to crash

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1658,6 +1658,7 @@ bool Column::setStringValueToRowIfItFits(size_t row, const std::string & value, 
 						if(_labels[i] == oldLabel)
 						{
 							_labels.erase(_labels.begin() + i);
+							oldLabel->dbDelete();
 							break;
 						}
 
@@ -1707,11 +1708,8 @@ bool Column::setStringValueToRowIfItFits(size_t row, const std::string & value, 
 						}
 					}
 
-					if(oldLabel)
-					{
-						oldLabel->dbDelete();
-						delete oldLabel;
-					}
+					delete oldLabel;
+
 					_resetLabelValueMap();
 					_dbUpdateLabelOrder();
 				}

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1420,7 +1420,6 @@ strintmap Column::labelsSyncStrings(const stringvec &new_values, const strstrmap
 	stringset	valuesToAdd;
 	intset		valuesToRemove;
 	strintmap	result;
-	int			maxLabelKey = 0;
 
 	for (const std::string& v : new_values)
 		valuesToAdd.insert(v);
@@ -1430,8 +1429,6 @@ strintmap Column::labelsSyncStrings(const stringvec &new_values, const strstrmap
 	{
 		std::string labelText	= label->originalValueAsString();
 		int labelValue			= label->value();
-
-		maxLabelKey = std::max(labelValue, maxLabelKey); //to be used in labelsResetValues
 
 		auto it = valuesToAdd.find(labelText);
 		if (it != valuesToAdd.end())
@@ -1449,11 +1446,11 @@ strintmap Column::labelsSyncStrings(const stringvec &new_values, const strstrmap
 	if (valuesToRemove.size() > 0)
 	{
 		labelsRemoveValues(valuesToRemove);
-		result = labelsResetValues(maxLabelKey);
+		//result = labelsResetValues(maxLabelKey);
 	}
 
 	for (const std::string & newLabel : valuesToAdd)
-		result[newLabel] = labelsAdd(++maxLabelKey, newLabel, true, "", newLabel);
+		result[newLabel] = labelsAdd(newLabel);
 
 	//Now all thats left is to use the new_labels mapping. As far as I can see during this refactor it is only used when importing from ReadStat
 	//And there we can have string-value and string-label in the same datafile that can be different.

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -179,6 +179,7 @@ protected:
 			bool					_resetEmptyValuesForScale(		intstrmap & emptyValuesMap);
 			bool					_resetEmptyValuesForNominalText(intstrmap & emptyValuesMap, bool tryToConvert = true);
 			
+			void					_resetLabelValueMap();
 
 private:
 			DataSet		*			_data				= nullptr;


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2362

The crash was due to the fact that _labelByValueMap was not updated when a label was changed. Also this PR adds the automatic switch to from nominalText to nominal if all values becomes integer. This is needed because if a user adds accidentally a string value to a nominal (or ordinal) column, the column is automatically changed to nominalText. If the user removes the wrong value, the column stays to nominalText, and the user has no way to change it back to nominal. JASP should detect this scenario and change the column to the tight type.

