### PR TITLE
Bugfix: remove legacy analysis result in clipboard

### DIFF
--- a/Desktop/html/js/analyses.js
+++ b/Desktop/html/js/analyses.js
@@ -110,10 +110,11 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 				this.views = _.without(this.analyses, analysis);
 
 				analysesVar.setBottomSpacerHeight();
+
+				analysis.$el.addClass("removed"); 
+				analysis.$el.remove(); 
 			});
 		});
-
-		
 	},
 
 	removeAnalysisId: function (analysisId) {

--- a/Desktop/html/js/analyses.js
+++ b/Desktop/html/js/analyses.js
@@ -110,7 +110,8 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 				this.views = _.without(this.analyses, analysis);
 
 				analysesVar.setBottomSpacerHeight();
-
+				// just add classNmae then will not be collected in exports from jaspWidgets.js,
+				// then removed element from the DOM.
 				analysis.$el.addClass("removed"); 
 				analysis.$el.remove(); 
 			});

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -175,8 +175,10 @@ JASPWidgets.Exporter = {
 			var viewList = [];
 			for (var i = 0; i < exportObj.views.length; i++) {
 				var view = exportObj.views[i];
-				if (exportParams.includeNotes || view.$el.hasClass('jasp-notes') === false)
-					viewList.push(view);
+				if (exportParams.includeNotes || view.$el.hasClass('jasp-notes') === false) {
+					if (view.$el.hasClass('removed') === false)
+						viewList.push(view);
+				}
 			}
 
 			if (viewList.length === 0)
@@ -203,7 +205,7 @@ JASPWidgets.Exporter = {
 		var self = parent;
 		var index = i;
 		var callback = completedCallback;
-		var trackerView = view;
+
 		var cc = function (exParams, exContent) {
 			self.buffer[index] = exContent;
 			self.exportCounter -= 1;
@@ -211,8 +213,8 @@ JASPWidgets.Exporter = {
 				var completeText = "";
 				var raw = null;
 				if (!exportParams.error) {
-					completeText = "<div " + self.getStyleAttr() + ">\n";
-					completeText += '<div style="display:inline-block; ' + innerStyle + '">\n';
+					completeText = `<div class="${self.className}" ${self.getStyleAttr()} >\n`;
+					completeText += `<div style="display:inline-block; ${innerStyle}">\n`;
 					if (!self.disableTitleExport && self.toolbar !== undefined) {
 						completeText += JASPWidgets.Exporter.getTitleHtml(self.toolbar, exportParams)
 					}

--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -352,7 +352,7 @@ $(document).ready(function () {
 			hideInstructions()
 	}
 
-	window.remove = function (id) {
+	window.removeAnalysisTrigger = function (id) {
 
 		window.unselect()
 

--- a/Desktop/results/resultsjsinterface.cpp
+++ b/Desktop/results/resultsjsinterface.cpp
@@ -319,7 +319,7 @@ void ResultsJsInterface::unselect()
 
 void ResultsJsInterface::removeAnalysis(Analysis *analysis)
 {
-	runJavaScript("window.remove(" + QString::number(analysis->id()) + ")");
+	runJavaScript("window.removeAnalysisTrigger(" + QString::number(analysis->id()) + ")");
 }
 
 void ResultsJsInterface::removeAnalyses()


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1301 and https://github.com/jasp-stats/jasp-issues/issues/2194

It's because we just set 'removed'  analysis view invisible but not really removed. then it was got in exporter.