### PR TITLE
Make remove columns/rows quicker

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1265,6 +1265,8 @@ int Column::labelsAdd(int value, const std::string & display, bool filterAllows,
 
 void Column::labelsRemoveValues(std::set<int> valuesToRemove)
 {
+	if (valuesToRemove.empty()) return;
+
 	JASPTIMER_SCOPE(Column::labelsRemoveValues);
 
 	_labels.erase(

--- a/Desktop/data/computedcolumnsmodel.cpp
+++ b/Desktop/data/computedcolumnsmodel.cpp
@@ -304,7 +304,7 @@ void ComputedColumnsModel::removeColumn()
 		return;
 
 	// TODO pass RemoveColumnCommand aab
-	_undoStack->pushCommand(new RemoveColumnCommand(DataSetPackage::pkg(), _selectedColumn->id()));
+	_undoStack->pushCommand(new RemoveColumnsCommand(DataSetPackage::pkg(), _selectedColumn->id(), 1));
 
 	DataSetPackage::pkg()->requestComputedColumnDestruction(_selectedColumn->name());
 	setComputeColumnNameSelected("");

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -196,10 +196,10 @@ public:
 				intstrmap					initColumnAsNominalText(		size_t				colNo,		const std::string & newName, const stringvec	& values,	const strstrmap & labels = strstrmap(), const std::string & title = "");
 				intstrmap					initColumnAsNominalText(		const std::string & colName,	const std::string & newName, const stringvec	& values,	const strstrmap & labels = strstrmap(), const std::string & title = "")	{ return initColumnAsNominalText(_dataSet->getColumnIndex(colName), newName, values, labels, title); }
 				intstrmap					initColumnAsNominalText(		QVariant			colID,		const std::string & newName, const stringvec	& values,	const strstrmap & labels = strstrmap(), const std::string & title = "");
-				void						initColumnWithStrings(			QVariant			colId,		const std::string & newName, const stringvec	& values, const std::string & title = "");
+				void						initColumnWithStrings(			QVariant			colId,		const std::string & newName, const stringvec	& values,	const std::string & title = "", columnType desiredType = columnType::unknown);
 				void						initializeComputedColumns();
 				
-				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList());
+				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList(), intvec colTypes = intvec());
 
 				void						storeInEmptyValues(		const std::string	& columnName, const intstrmap & emptyValues);
 
@@ -341,7 +341,6 @@ private:
 				bool				setAllowFilterOnLabel(const QModelIndex & index, bool newAllowValue);
 				bool				setDescriptionOnLabel(const QModelIndex & index, const QString & newDescription);
 				QModelIndex			lastCurrentCell();
-				void				resetModelOneCell();
 
 
 private:

--- a/Desktop/data/datasettablemodel.cpp
+++ b/Desktop/data/datasettablemodel.cpp
@@ -80,10 +80,10 @@ int DataSetTableModel::setColumnTypeFromQML(int columnIndex, int newColumnType)
 	return data(index(0, columnIndex), int(DataSetPackage::specialRoles::columnType)).toInt();
 }
 
-void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & cells, QStringList newColNames)
+void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & cells, QStringList newColNames, std::vector<int> colTypes)
 {
 	QModelIndex idx = mapToSource(index(row, col));
-	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), cells, newColNames);
+	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), cells, newColNames, colTypes);
 }
 
 QString DataSetTableModel::insertColumnSpecial(int column, bool computed, bool R)

--- a/Desktop/data/datasettablemodel.h
+++ b/Desktop/data/datasettablemodel.h
@@ -49,7 +49,7 @@ public:
 
 	bool					synchingData()							const				{ return DataSetPackage::pkg()->synchingData();										}
 
-	void					pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList());
+	void					pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList(), std::vector<int> colTypes = std::vector<int>());
 
 	bool					showInactive()							const				{ return _showInactive;	}
 

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -76,6 +76,8 @@ QVariant ExpandDataProxyModel::headerData(int section, Qt::Orientation orientati
 	{
 		if (section < _sourceModel->rowCount())
 			return _sourceModel->headerData(section, orientation, role);
+		else if (section == 0 && role == int(dataPkgRoles::maxRowHeaderString))
+			return "XXXX";
 		else
 			return  DataSetPackage::pkg()->dataRowCount() + (section - _sourceModel->rowCount()) + 1;
 	}
@@ -163,34 +165,24 @@ int ExpandDataProxyModel::getRole(const std::string &roleName) const
 
 void ExpandDataProxyModel::removeRows(int start, int count)
 {
-	if (!_sourceModel)
+	if (!_sourceModel || count <= 0 || start < 0 || start >= _sourceModel->rowCount())
 		return;
 
-	if (count > 1)
-		_undoStack->startMacro(QObject::tr("Removes %1 rows from %2").arg(count).arg(start + 1));
+	if (start + count >= _sourceModel->rowCount())
+		count = _sourceModel->rowCount() - start;
 
-	for (int i = 0; i < count; i++)
-		if (start < _sourceModel->rowCount())
-			removeRow(start);
-
-	if (count > 1)
-		_undoStack->endMacro();
+	_undoStack->pushCommand(new RemoveRowsCommand(_sourceModel, start, count));
 }
 
 void ExpandDataProxyModel::removeColumns(int start, int count)
 {
-	if (!_sourceModel)
+	if (!_sourceModel || count <= 0 || start < 0 || start >= _sourceModel->columnCount())
 		return;
 
-	if (count > 1)
-		_undoStack->startMacro(QObject::tr("Removes %1 columns from %2").arg(count).arg(start + 1));
+	if (start + count >= _sourceModel->columnCount())
+		count = _sourceModel->columnCount() - start;
 
-	for (int i = 0; i < count; i++)
-		if (start < _sourceModel->columnCount())
-			removeColumn(start);
-
-	if (count > 1)
-		_undoStack->endMacro();
+	_undoStack->pushCommand(new RemoveColumnsCommand(_sourceModel, start, count));
 }
 
 void ExpandDataProxyModel::removeRow(int row)

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -185,24 +185,6 @@ void ExpandDataProxyModel::removeColumns(int start, int count)
 	_undoStack->pushCommand(new RemoveColumnsCommand(_sourceModel, start, count));
 }
 
-void ExpandDataProxyModel::removeRow(int row)
-{
-	if (!_sourceModel)
-		return;
-
-	if (row >= 0 && row < _sourceModel->rowCount())
-		_undoStack->pushCommand(new RemoveRowCommand(_sourceModel, row));
-}
-
-void ExpandDataProxyModel::removeColumn(int col)
-{
-	if (!_sourceModel)
-		return;
-
-	if (col >= 0 && col < _sourceModel->columnCount())
-		_undoStack->pushCommand(new RemoveColumnCommand(_sourceModel, col));
-}
-
 void ExpandDataProxyModel::insertRow(int row)
 {
 	if (!_sourceModel)

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -30,8 +30,6 @@ public:
 
 	void				removeRows(int start, int count);
 	void				removeColumns(int start, int count);
-	void				removeRow(int row);
-	void				removeColumn(int col);
 	void				insertRow(int row);
 	void				insertColumn(int col, bool computed, bool R);
 	void				pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList());

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -109,7 +109,10 @@ void InsertRowCommand::redo()
 RemoveColumnsCommand::RemoveColumnsCommand(QAbstractItemModel *model, int start, int count)
 	: UndoModelCommand(model), _start{start}, _count{count}
 {
-	setText(QObject::tr("Remove %1 columns from '%2'").arg(_count).arg(columnName(_start)));
+	if (count == 1)
+		setText(QObject::tr("Remove column '%1'").arg(columnName(_start)));
+	else
+		setText(QObject::tr("Remove %1 columns from '%2'").arg(_count).arg(columnName(_start)));
 }
 
 void RemoveColumnsCommand::undo()
@@ -128,29 +131,13 @@ void RemoveColumnsCommand::redo()
 	_model->removeColumns(_start, _count);
 }
 
-
-RemoveColumnCommand::RemoveColumnCommand(QAbstractItemModel *model, int col)
-	: UndoModelCommand(model), _col{col}
-{
-	setText(QObject::tr("Remove column '%1'").arg(columnName(_col)));
-}
-
-void RemoveColumnCommand::undo()
-{
-	_model->insertColumn(_col);
-	DataSetPackage::pkg()->deserializeColumn(columnName(_col).toStdString(), _serializedColumn);
-}
-
-void RemoveColumnCommand::redo()
-{
-	_serializedColumn = DataSetPackage::pkg()->serializeColumn(columnName(_col).toStdString());
-	_model->removeColumn(_col);
-}
-
 RemoveRowsCommand::RemoveRowsCommand(QAbstractItemModel *model, int start, int count)
 	: UndoModelCommand(model), _start{start}, _count{count}
 {
-	setText(QObject::tr("Remove rows %1 to %2").arg(rowName(_start), rowName(_start + count)));
+	if (count == 1)
+		setText(QObject::tr("Remove row %1").arg(rowName(_start)));
+	else
+		setText(QObject::tr("Remove rows %1 to %2").arg(rowName(_start), rowName(_start + count)));
 }
 
 void RemoveRowsCommand::undo()
@@ -183,31 +170,6 @@ void RemoveRowsCommand::redo()
 	}
 
 	_model->removeRows(_start, _count);
-}
-
-
-
-RemoveRowCommand::RemoveRowCommand(QAbstractItemModel *model, int row)
-	: UndoModelCommand(model), _row{row}
-{
-	setText(QObject::tr("Remove row %1").arg(rowName(_row)));
-}
-
-void RemoveRowCommand::undo()
-{
-	_model->insertRow(_row);
-
-	for (int i = 0; i < _model->columnCount() && i < _values.count(); i++)
-		_model->setData(_model->index(_row, i), _values[i], 0);
-}
-
-void RemoveRowCommand::redo()
-{
-	_values.clear();
-	for (int i = 0; i < _model->columnCount(); i++)
-		_values.push_back(_model->data(_model->index(_row, i)));
-
-	_model->removeRow(_row);
 }
 
 PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString> > &cells, const QStringList &newColNames)

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -247,6 +247,36 @@ private:
 	Json::Value				_serializedColumn;
 };
 
+class RemoveColumnsCommand : public UndoModelCommand
+{
+public:
+	RemoveColumnsCommand(QAbstractItemModel *model, int start, int count);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int							_start = -1,
+								_count = 0;
+	std::vector<Json::Value>	_serializedColumns;
+};
+
+
+class RemoveRowsCommand : public UndoModelCommand
+{
+public:
+	RemoveRowsCommand(QAbstractItemModel *model, int start, int count);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int									_start = -1,
+										_count = 0;
+	std::vector<std::vector<QString>>	_values;
+	std::vector<int>					_colTypes;
+};
+
 class RemoveRowCommand : public UndoModelCommand
 {
 public:

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -234,19 +234,6 @@ private:
 	int						_row = -1;
 };
 
-class RemoveColumnCommand : public UndoModelCommand
-{
-public:
-	RemoveColumnCommand(QAbstractItemModel *model, int col);
-
-	void undo()					override;
-	void redo()					override;
-
-private:
-	int						_col = -1;
-	Json::Value				_serializedColumn;
-};
-
 class RemoveColumnsCommand : public UndoModelCommand
 {
 public:
@@ -276,20 +263,6 @@ private:
 	std::vector<std::vector<QString>>	_values;
 	std::vector<int>					_colTypes;
 };
-
-class RemoveRowCommand : public UndoModelCommand
-{
-public:
-	RemoveRowCommand(QAbstractItemModel *model, int row);
-
-	void undo()					override;
-	void redo()					override;
-
-private:
-	int						_row = -1;
-	QVariantList			_values;
-};
-
 
 class UndoStack : public QUndoStack
 {


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2374
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2376

Thanks to the expanded model, it is not necessary anymore to add a unique cell when there is no column or row anymore.
When removing all rows, the columns should not be removed anyway
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2373