### PR TITLE
Fix MatrixModels build fail due to conflicting Matrix versions for local linux builds

### DIFF
--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -53,3 +53,9 @@ if (Sys.info()["sysname"] == "Darwin") {
   source('@MODULES_BINARY_PATH@/symlinkTools.R')
   convertAbsoluteSymlinksToRelative('@R_LIBRARY_PATH@', '@MODULES_RENV_CACHE_PATH@')
 }
+
+#This is necessary because of conflicts with Matrix dep of base R lib.
+#Can be removed when a new version of R updates its Matrix
+if (@IS_LINUX_LOCAL_BUILD@) {
+	renv::install("Matrix", type="source")
+}


### PR DESCRIPTION
R 4.3.1 still has the ancient Matrix version.
