### PR TITLE
Make sure upgrade to conan2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ cmake-build-*
 # Xcode project
 xcode-project/
 
+# Conan
+CMakeUserPresets.json
+
 
 # Temporary 
 Frameworks/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,21 @@ if(APPLE)
 	set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0 CACHE STRING "Minimum macOS version the build will be able to run on" FORCE)
     set(CONAN_ARCH "armv8")
   else()
-	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version the build will be able to run on" FORCE)
+	set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0 CACHE STRING "Minimum macOS version the build will be able to run on" FORCE)
     set(CONAN_ARCH "x86_64")
   endif()
+  
+  
+  if("${CMAKE_OSX_SYSROOT}" STREQUAL "macosx")
+	  execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
+		OUTPUT_VARIABLE SDKROOT
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	set(CMAKE_OSX_SYSROOT ${SDKROOT})
+	message(STATUS "Got CMAKE_OSX_SYSROOT from xcrun as '${SDKROOT}'")
+  else()
+	message(STATUS "CMAKE_OSX_SYSROOT='${CMAKE_OSX_SYSROOT}'")
+  endif()
+ 
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(APPLE)
   endif()
   
   
-  if("${CMAKE_OSX_SYSROOT}" STREQUAL "macosx")
+  if("${CMAKE_OSX_SYSROOT}" STREQUAL "macosx" OR "${CMAKE_OSX_SYSROOT}" STREQUAL "")
 	  execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
 		OUTPUT_VARIABLE SDKROOT
 		OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/Docs/development/jasp-build-guide-windows.md
+++ b/Docs/development/jasp-build-guide-windows.md
@@ -103,11 +103,11 @@ You can download Conan from their [GitHub Release page](https://github.com/conan
 After installing Conan, you should make sure that Conan is configured correctly. Open the Windows Terminal, or the Command Prompt, and run the following commands:
 
 ```bash
-conan profile new default --detect
-conan profile show default
+conan profile detect --name default
+conan profile show
 ```
 
-You should see something like this. CMake later uses this template to modify some of its parameters and download and prepare the dependencies accordingly. For instance, if you are building a Debug version of JASP, CMake will change this profile to account for that.
+You should see something like below, you can edit the `default` file in `path\to\user\username\.conan2\profiles` by notepad. CMake later uses this template to modify some of its parameters and download and prepare the dependencies accordingly. For instance, if you are building a Debug version of JASP, CMake will change this profile to account for that.
 
 ```
 [settings]
@@ -120,8 +120,9 @@ compiler.version=16
 build_type=Debug
 [options]
 [conf]
-[build_requires]
-[env]
+tools.microsoft.msbuild:vs_version=17
+tools.cmake.cmaketoolchain:generator=Ninja
+[tool_requires]
 ```
 
 > 💡 Although CMake and Qt Creator will run Conan process for you, if it's your very first time configuring JASP, and you ran into any problem, you can run the Conan command manually. If things go wrong, CMake configuration will stop and tells you what you should do to resolve the Conan issue. 

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -22,14 +22,7 @@ if(USE_CONAN)
   set(CONAN_FILE_PATH ${CMAKE_SOURCE_DIR})
 
   message(STATUS "  ${CMAKE_BUILD_TYPE}")
-
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CONAN_COMPILER_RUNTIME "MDd")
-  elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(CONAN_COMPILER_RUNTIME "MD")
-  else()
-    set(CONAN_COMPILER_RUNTIME "MDd")
-  endif()
+  set(CONAN_COMPILER_RUNTIME "dynamic")
 
   if(WIN32)
 
@@ -39,8 +32,9 @@ if(USE_CONAN)
       COMMAND_ECHO STDOUT
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       COMMAND
-        conan install ${CONAN_FILE_PATH} -s build_type=${CMAKE_BUILD_TYPE} -s
-        compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing)
+      conan install ${CONAN_FILE_PATH} --output-folder=${CMAKE_BINARY_DIR}/conan_build
+      -s build_type=${CMAKE_BUILD_TYPE}
+      -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing)
 
   elseif(APPLE)
 
@@ -68,7 +62,7 @@ if(USE_CONAN)
 
   endif()
 
-  if(EXISTS ${CMAKE_BINARY_DIR}/conan_paths.cmake)
+  if(EXISTS ${CMAKE_BINARY_DIR}/conan_build/conanbuild.bat)
     message(CHECK_PASS "successful")
   else()
     message(CHECK_FAIL "unsuccessful")
@@ -78,7 +72,8 @@ if(USE_CONAN)
     )
   endif()
 
-  include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
+  include(${CMAKE_BINARY_DIR}/conan_build/conan_toolchain.cmake)
+
 endif()
 
 list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -23,6 +23,7 @@ if(USE_CONAN)
 
   message(STATUS "  ${CMAKE_BUILD_TYPE}")
   set(CONAN_COMPILER_RUNTIME "dynamic")
+  set(CONAN_RESULT_FILE "conanbuild.bat") #for windows
 
   if(WIN32)
 
@@ -38,6 +39,8 @@ if(USE_CONAN)
 
   elseif(APPLE)
 
+    set(CONAN_RESULT_FILE "conanbuild.sh")
+
     if(CROSS_COMPILING)
 
       execute_process(
@@ -45,8 +48,8 @@ if(USE_CONAN)
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMAND
           conan install ${CONAN_FILE_PATH} -s build_type=${CMAKE_BUILD_TYPE} -s
-          os.version=${CMAKE_OSX_DEPLOYMENT_TARGET} -s os.sdk=macosx -s
-          arch=${CONAN_ARCH} -s arch_build=${CONAN_ARCH} --build=missing)
+          os.version=${CMAKE_OSX_DEPLOYMENT_TARGET} -s
+          arch=${CONAN_ARCH} -s arch_build=${CONAN_ARCH} --build=missing -of ${CMAKE_BINARY_DIR}/conan_build)
 
     else()
 
@@ -55,14 +58,14 @@ if(USE_CONAN)
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMAND
           conan install ${CONAN_FILE_PATH} -s build_type=${CMAKE_BUILD_TYPE} -s
-          os.version=${CMAKE_OSX_DEPLOYMENT_TARGET} -s os.sdk=macosx
-          --build=missing)
+          os.version=${CMAKE_OSX_DEPLOYMENT_TARGET}
+          --build=missing -of ${CMAKE_BINARY_DIR}/conan_build)
 
     endif()
 
   endif()
 
-  if(EXISTS ${CMAKE_BINARY_DIR}/conan_build/conanbuild.bat)
+  if(EXISTS ${CMAKE_BINARY_DIR}/conan_build/${CONAN_RESULT_FILE})
     message(CHECK_PASS "successful")
   else()
     message(CHECK_FAIL "unsuccessful")

--- a/Tools/CMake/Install.cmake
+++ b/Tools/CMake/Install.cmake
@@ -150,7 +150,7 @@ if(APPLE)
   # See here: https://bugreports.qt.io/browse/QTBUG-100686
   #
   # Feel free to remove it when the bug is fixed
-  install(FILES ${_LIB_BROTLICOMMON} DESTINATION ${JASP_INSTALL_FRAMEWORKDIR})
+  #install(FILES ${_LIB_BROTLICOMMON} DESTINATION ${JASP_INSTALL_FRAMEWORKDIR})
 
   install(
     DIRECTORY ${MODULES_BINARY_PATH}/

--- a/Tools/CMake/Libraries.cmake
+++ b/Tools/CMake/Libraries.cmake
@@ -208,24 +208,6 @@ if(APPLE)
 
   find_package(Brotli 1.0.9 REQUIRED)
 
- # set(_LIB_BROTLICOMMON
- #     ${Brotli_LIB_DIRS}/libbrotlicommon.1.0.9.dylib
- # )
-
- # if(EXISTS "${_LIB_BROTLICOMMON}")
- #   message(CHECK_PASS "found")
- #   message(STATUS "  Copying the 'libbrotlicommon' to the local build folder")
- #   execute_process(
- #     WORKING_DIRECTORY ${Brotli_LIB_DIRS}
- #     COMMAND ${CMAKE_COMMAND} -E copy ${_LIB_BROTLICOMMON}
- #             ${CMAKE_BINARY_DIR}/libbrotlicommon.1.dylib)
- #   set(_LIB_BROTLICOMMON ${CMAKE_BINARY_DIR}/libbrotlicommon.1.dylib)
- #   message(STATUS "  ${_LIB_BROTLICOMMON}")
- # else()
- #   message(CHECK_FAIL "not found")
- #   message(FATAL_ERROR "libbrotli is required for creating the DMG file. ")
- # endif()
-
 endif()
 
 if(WIN32)

--- a/Tools/CMake/Libraries.cmake
+++ b/Tools/CMake/Libraries.cmake
@@ -208,23 +208,23 @@ if(APPLE)
 
   find_package(Brotli 1.0.9 REQUIRED)
 
-  set(_LIB_BROTLICOMMON
-      ${Brotli_LIB_DIRS}/libbrotlicommon.1.0.9.dylib
-  )
+ # set(_LIB_BROTLICOMMON
+ #     ${Brotli_LIB_DIRS}/libbrotlicommon.1.0.9.dylib
+ # )
 
-  if(EXISTS "${_LIB_BROTLICOMMON}")
-    message(CHECK_PASS "found")
-    message(STATUS "  Copying the 'libbrotlicommon' to the local build folder")
-    execute_process(
-      WORKING_DIRECTORY ${Brotli_LIB_DIRS}
-      COMMAND ${CMAKE_COMMAND} -E copy ${_LIB_BROTLICOMMON}
-              ${CMAKE_BINARY_DIR}/libbrotlicommon.1.dylib)
-    set(_LIB_BROTLICOMMON ${CMAKE_BINARY_DIR}/libbrotlicommon.1.dylib)
-    message(STATUS "  ${_LIB_BROTLICOMMON}")
-  else()
-    message(CHECK_FAIL "not found")
-    message(FATAL_ERROR "libbrotli is required for creating the DMG file. ")
-  endif()
+ # if(EXISTS "${_LIB_BROTLICOMMON}")
+ #   message(CHECK_PASS "found")
+ #   message(STATUS "  Copying the 'libbrotlicommon' to the local build folder")
+ #   execute_process(
+ #     WORKING_DIRECTORY ${Brotli_LIB_DIRS}
+ #     COMMAND ${CMAKE_COMMAND} -E copy ${_LIB_BROTLICOMMON}
+ #             ${CMAKE_BINARY_DIR}/libbrotlicommon.1.dylib)
+ #   set(_LIB_BROTLICOMMON ${CMAKE_BINARY_DIR}/libbrotlicommon.1.dylib)
+ #   message(STATUS "  ${_LIB_BROTLICOMMON}")
+ # else()
+ #   message(CHECK_FAIL "not found")
+ #   message(FATAL_ERROR "libbrotli is required for creating the DMG file. ")
+ # endif()
 
 endif()
 

--- a/Tools/CMake/Programs.cmake
+++ b/Tools/CMake/Programs.cmake
@@ -146,6 +146,12 @@ if(WIN32)
     message(CHECK_PASS "found")
     message(STATUS "  ${RTOOLS_PATH}")
 
+    message(CHECK_START "Looking for Rtools42 legacy")
+    if(DEFINED RTOOLS42_HOME)
+        unset(RTOOLS42_HOME)
+    endif()
+
+
   else()
 
     # @todo, apparently, Rtool42 registers an environment variable called

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -33,7 +33,8 @@
 #       a CMake module. I leave this for later cleanup
 #
 
-set(R_BINARY_REPOSITORY "https://static.jasp-stats.org/development")
+set(R_BINARY_REPOSITORY "https://cran.r-project.org/bin/macosx/big-sur-arm64/base/")
+
 set(AVAILABLE_R_VERSIONS
     "R-4.1.2"
     "R-4.1.2-arm64"
@@ -50,7 +51,7 @@ set(AVAILABLE_R_VERSIONS
     "R-4.3.0"
     "R-4.3.0-arm64"
     "R-4.3.0-win"
-	"R-4.3.1"
+    "R-4.3.1"
     "R-4.3.1-arm64"
     "R-4.3.1-win"
 )

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -33,7 +33,7 @@
 #       a CMake module. I leave this for later cleanup
 #
 
-set(R_BINARY_REPOSITORY "https://cran.r-project.org/bin/macosx/big-sur-arm64/base/")
+set(R_BINARY_REPOSITORY "https://static.jasp-stats.org/development/")
 
 set(AVAILABLE_R_VERSIONS
     "R-4.1.2"

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -9,8 +9,8 @@
 [requires]
 boost/[>=1.82.0 <2.0.0]
 libiconv/1.17
+zlib/1.3
 libarchive/3.6.2
-zlib/1.2.13
 zstd/1.5.2
 jsoncpp/1.9.5
 openssl/3.0.10
@@ -25,4 +25,4 @@ CMakeDeps
 CMakeToolchain
 
 [options]
-brotli:shared=True
+brotli/:shared=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -8,12 +8,12 @@
 
 [requires]
 boost/[>=1.82.0 <2.0.0]
-libiconv/1.16
-libarchive/3.5.2
-zlib/1.2.11
+libiconv/1.17
+libarchive/3.6.2
+zlib/1.2.13
 zstd/1.5.2
 jsoncpp/1.9.5
-openssl/1.1.1m
+openssl/3.0.10
 bison/3.7.6
 brotli/1.0.9
 sqlite3/3.38.5
@@ -21,8 +21,8 @@ gmp/6.3.0
 mpfr/4.2.1
 
 [generators]
-cmake_paths
-cmake_find_package
+CMakeDeps
+CMakeToolchain
 
 [options]
 brotli:shared=True

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -8,7 +8,6 @@
 
 [requires]
 boost/[>=1.82.0 <2.0.0]
-libiconv/1.17
 zlib/1.3
 libarchive/3.6.2
 zstd/1.5.2


### PR DESCRIPTION
My conan was upgrade to 2.0 version but not really work so let's make sure it. the benefit of version 2.0 is that we can greatly reduce build configuration time on local builds without configuring dependencies again.

Using `pip install --upgrade conan` to upgrade local conan version to 2.0.x, and then using `conan version` to check install status.
maybe not wise but have to bump some pkg version to resolve conflict on conan center.

- Windows:

Visual Studio on my local is VS2022(i.e. VS17 193）in docs:
```
compiler.version=193
tools.microsoft.msbuild:vs_version = 17
```

- Linux:

N/A

- macOS:

I'm not on mac so cannot check it, anyone on mac can help.