### PR TITLE
Save should not always call Save As.

### DIFF
--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -85,6 +85,7 @@ Window
 
 		Shortcut { onActivated: mainWindow.showEnginesWindow();					sequences: ["Ctrl+Alt+Shift+E"];								context: Qt.ApplicationShortcut; }
 		Shortcut { onActivated: mainWindow.saveKeyPressed();					sequences: ["Ctrl+S", Qt.Key_Save];								context: Qt.ApplicationShortcut; }
+		Shortcut { onActivated: mainWindow.saveAsKeyPressed();					sequences: ["Ctrl+Shift+S", Qt.Key_SaveAs];						context: Qt.ApplicationShortcut; }
 		Shortcut { onActivated: { ribbon.showFileMenuPressed(); mainWindow.openKeyPressed();}
 																				sequences: ["Ctrl+O"];											context: Qt.ApplicationShortcut; }
 		//This is now redo! Shortcut { onActivated: mainWindow.syncKeyPressed();					sequences: ["Ctrl+Y", Qt.Key_Reload];							context: Qt.ApplicationShortcut; }

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -2478,7 +2478,7 @@ void DataSetPackage::setEmptyValues(Json::Value &emptyValues)
 	_dataSet->setEmptyValuesJson(emptyValues);
 }
 
-bool DataSetPackage::jaspFileReadOnly() const
+bool DataSetPackage::currentFileIsExample() const
 {
 	return currentFile().startsWith(AppDirs::examples());
 }

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -2478,12 +2478,20 @@ void DataSetPackage::setEmptyValues(Json::Value &emptyValues)
 	_dataSet->setEmptyValuesJson(emptyValues);
 }
 
+bool DataSetPackage::jaspFileReadOnly() const
+{
+	return currentFile().startsWith(AppDirs::examples());
+}
+
 void DataSetPackage::setDataFilePath(std::string filePath)				
-{ 
+{
 	if(!_dataSet || _dataSet->dataFilePath() == filePath)
-		return;
+		return;	
 
 	_dataSet->setDataFilePath(filePath);
+	if (tq(filePath).startsWith(AppDirs::examples()))
+		setDataFileReadOnly(true);
+
 	emit synchingExternallyChanged(synchingExternally());
 }
 

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -160,7 +160,7 @@ public:
 
 				// The data file might be read-only if it comes from the examples or read from an external database
 				bool				dataFileReadOnly()					const	{ return _dataFileReadOnly;						     }
-				bool				jaspFileReadOnly()					const;
+				bool				currentFileIsExample()					const;
 				uint				dataFileTimestamp()					const	{ return _dataFileTimestamp;					      }
 				bool				isDatabaseSynching()				const	{ return _databaseIntervalSyncher.isActive();	}
 				bool				filterShouldRunInit()				const	{ return _filterShouldRunInit;							}

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -158,7 +158,9 @@ public:
 		const	Version			&	archiveVersion()					const	{ return _archiveVersion;						   }
 				Json::Value			emptyValuesJson()					const	{ return _dataSet->emptyValuesJson(); 				}
 
+				// The data file might be read-only if it comes from the examples or read from an external database
 				bool				dataFileReadOnly()					const	{ return _dataFileReadOnly;						     }
+				bool				jaspFileReadOnly()					const;
 				uint				dataFileTimestamp()					const	{ return _dataFileTimestamp;					      }
 				bool				isDatabaseSynching()				const	{ return _databaseIntervalSyncher.isActive();	}
 				bool				filterShouldRunInit()				const	{ return _filterShouldRunInit;							}

--- a/Desktop/data/exporters/jaspexporter.cpp
+++ b/Desktop/data/exporters/jaspexporter.cpp
@@ -63,6 +63,9 @@ void JASPExporter::saveDataSet(const std::string &path, std::function<void(int)>
 		throw std::runtime_error("File could not be closed.");
 
 	archive_write_free(a);
+
+	//Make sure it is now always considered "loading" in DataSetPackage
+	DataSetPackage::pkg()->setLoaded(true);
 }
 
 void JASPExporter::saveManifest(archive * a)

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -838,7 +838,7 @@ void MainWindow::saveKeyPressed()
 
 void MainWindow::saveAsKeyPressed()
 {
-	if (_package->hasDataSet()) _fileMenu->saveAs();
+	if (_package->isLoaded()) _fileMenu->saveAs();
 }
 
 void MainWindow::openKeyPressed()
@@ -1495,22 +1495,23 @@ void MainWindow::analysisChangedDownstreamHandler(int id, QString options)
 bool MainWindow::startDataEditorHandler()
 {
 	setCheckAutomaticSync(false);
-	QString path = QString::fromStdString(_package->dataFilePath());
+	QString dataFilePath = QString::fromStdString(_package->dataFilePath());
+
 	if (
-			(path.isEmpty() || _package->manualEdits())
-			|| path.startsWith("http")
-			|| !QFileInfo::exists(path)
-			|| Utils::getFileSize(path.toStdString()) == 0
+			(dataFilePath.isEmpty() || _package->manualEdits())
+			|| dataFilePath.startsWith("http")
+			|| !QFileInfo::exists(dataFilePath)
+			|| Utils::getFileSize(dataFilePath.toStdString()) == 0
 			|| _package->dataFileReadOnly()
 	)
 	{
 		QString									message = tr("JASP was started without associated data file (csv, sav or ods file). But to edit the data, JASP starts a spreadsheet editor based on this file and synchronize the data when the file is saved. Does this data file exist already, or do you want to generate it?");
-		if (path.startsWith("http"))			message = tr("JASP was started with an online data file (csv, sav or ods file). But to edit the data, JASP needs this file on your computer. Does this data file also exist on your computer, or do you want to generate it?");
+		if (dataFilePath.startsWith("http"))	message = tr("JASP was started with an online data file (csv, sav or ods file). But to edit the data, JASP needs this file on your computer. Does this data file also exist on your computer, or do you want to generate it?");
 		else if (_package->dataFileReadOnly())	message = tr("JASP was started with a read-only data file (probably from the examples). But to edit the data, JASP needs to write to the data file. Does the same file also exist on your computer, or do you want to generate it?");
 
 		MessageForwarder::DialogResponse choice;
 
-		const bool manualEditsMode = _package->manualEdits() && !path.isEmpty() && !_package->dataFileReadOnly();
+		const bool manualEditsMode = _package->manualEdits() && !dataFilePath.isEmpty() && !_package->dataFileReadOnly();
 
 		if (manualEditsMode)
 		{
@@ -1547,17 +1548,17 @@ bool MainWindow::startDataEditorHandler()
 				name = name.replace('#', '_');
 			}
 
-			QFileInfo pkgFile(_package->currentFile());
-			if (pkgFile.dir().exists() && !pkgFile.absolutePath().startsWith(AppDirs::examples()) && !_package->dataFileReadOnly()) //If the file was opened from a directory that exists and is not examples we use that as basis to open a csv
+			QFileInfo pkgFile(_package->currentFile()); // dataFilePath might be empty, so take the current file (the file from which the workspace is loaded, that is a jasp or a data file)
+			if (pkgFile.dir().exists() && !pkgFile.absolutePath().startsWith(AppDirs::examples())) //If the file was opened from a directory that exists and is not examples we use that as basis to open a csv
 				name = pkgFile.dir().absoluteFilePath(_package->name().replace('#', '_') + ".csv");
 
-			path = MessageForwarder::browseSaveFile(caption, name, filter);
+			dataFilePath = MessageForwarder::browseSaveFile(caption, name, filter);
 
-			if (path == "")
+			if (dataFilePath == "")
 				return false;
 
-			if (!path.endsWith(".csv", Qt::CaseInsensitive))
-				path.append(".csv");
+			if (!dataFilePath.endsWith(".csv", Qt::CaseInsensitive))
+				dataFilePath.append(".csv");
 
 			event = new FileEvent(this, FileEvent::FileGenerateData);
 			break;
@@ -1572,8 +1573,8 @@ bool MainWindow::startDataEditorHandler()
 				QString caption = "Find Data File";
 				QString filter = "Data File (*.csv *.txt *.tsv *.sav *.ods)";
 
-				path = MessageForwarder::browseOpenFile(caption, "", filter);
-				if (path == "")
+				dataFilePath = MessageForwarder::browseOpenFile(caption, "", filter);
+				if (dataFilePath == "")
 					return false;
 
 				event = new FileEvent(this, FileEvent::FileSyncData);
@@ -1588,18 +1589,18 @@ bool MainWindow::startDataEditorHandler()
 		{
 			connect(event, &FileEvent::completed, this,			&MainWindow::startDataEditorEventCompleted);
 			connect(event, &FileEvent::completed, _fileMenu,	&FileMenu::setSyncFile);
-			event->setPath(path);
+			event->setPath(dataFilePath);
 			_loader->io(event);
 			showProgress();
 		}
 		else
 		{
-			startDataEditor(path);
+			startDataEditor(dataFilePath);
 			_package->setSynchingExternally(true);
 		}
 	}
 	else
-		startDataEditor(path);
+		startDataEditor(dataFilePath);
 
 	return true;
 }

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -836,6 +836,11 @@ void MainWindow::saveKeyPressed()
 	if (_package->isModified()) _fileMenu->save();
 }
 
+void MainWindow::saveAsKeyPressed()
+{
+	if (_package->hasDataSet()) _fileMenu->saveAs();
+}
+
 void MainWindow::openKeyPressed()
 {
 	_fileMenu->showFileOpenMenu();

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -125,6 +125,7 @@ public slots:
 	void showAbout();
 
 	void saveKeyPressed();
+	void saveAsKeyPressed();
 	void openKeyPressed();
 	void syncKeyPressed();
 	void refreshKeyPressed();

--- a/Desktop/widgets/filemenu/datalibrarylistmodel.cpp
+++ b/Desktop/widgets/filemenu/datalibrarylistmodel.cpp
@@ -52,7 +52,7 @@ void DataLibraryListModel::openFile(const QString &path)
 {
 	FileEvent *event = new FileEvent(this->parent(), FileEvent::FileOpen);
 	event->setPath(path);
-	event->setReadOnly();
+	event->setReadOnly(); // A file from the Data Library should be read only, also csv file so that its path is not added in the recent list
 
 	emit openFileEvent(event);
 	

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -110,20 +110,14 @@ FileEvent *FileMenu::open(const Json::Value & dbJson)
 
 FileEvent *FileMenu::saveAs()
 {
-	FileEvent *event = _computer->browseSave();
-
-	if (!event->isCompleted())
-		// If the JASP file is saved on the computer, it should not be read only anymore (if it was)
-		DataSetPackage::pkg()->setDataFileReadOnly(false);
-
-	return event;
+	return _computer->browseSave();
 }
 
 FileEvent *FileMenu::save()
 {
 	FileEvent *event = nullptr;
 
-	if (_currentFileType != Utils::FileType::jasp || DataSetPackage::pkg()->dataFileReadOnly())
+	if (_currentFileType != Utils::FileType::jasp || DataSetPackage::pkg()->jaspFileReadOnly())
 	{
 		event = saveAs();
 		if (event->isCompleted())
@@ -407,7 +401,7 @@ void FileMenu::actionButtonClicked(const ActionButtons::FileOperation action)
 	case ActionButtons::FileOperation::SyncData:			setMode(FileEvent::FileSyncData);		break;
 	case ActionButtons::FileOperation::Close:				close();								break;
 	case ActionButtons::FileOperation::Save:
-		if (getCurrentFileType() == Utils::FileType::jasp && ! DataSetPackage::pkg()->dataFileReadOnly())
+		if (getCurrentFileType() == Utils::FileType::jasp && ! DataSetPackage::pkg()->jaspFileReadOnly())
 			save();
 		else
 			setMode(FileEvent::FileSave);			

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -108,13 +108,24 @@ FileEvent *FileMenu::open(const Json::Value & dbJson)
 	return event;
 }
 
+FileEvent *FileMenu::saveAs()
+{
+	FileEvent *event = _computer->browseSave();
+
+	if (!event->isCompleted())
+		// If the JASP file is saved on the computer, it should not be read only anymore (if it was)
+		DataSetPackage::pkg()->setDataFileReadOnly(false);
+
+	return event;
+}
+
 FileEvent *FileMenu::save()
 {
 	FileEvent *event = nullptr;
 
 	if (_currentFileType != Utils::FileType::jasp || DataSetPackage::pkg()->dataFileReadOnly())
 	{
-		event = _computer->browseSave();
+		event = saveAs();
 		if (event->isCompleted())
 			return event;
 	}

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -117,7 +117,7 @@ FileEvent *FileMenu::save()
 {
 	FileEvent *event = nullptr;
 
-	if (_currentFileType != Utils::FileType::jasp || DataSetPackage::pkg()->jaspFileReadOnly())
+	if (_currentFileType != Utils::FileType::jasp || DataSetPackage::pkg()->currentFileIsExample())
 	{
 		event = saveAs();
 		if (event->isCompleted())
@@ -401,7 +401,7 @@ void FileMenu::actionButtonClicked(const ActionButtons::FileOperation action)
 	case ActionButtons::FileOperation::SyncData:			setMode(FileEvent::FileSyncData);		break;
 	case ActionButtons::FileOperation::Close:				close();								break;
 	case ActionButtons::FileOperation::Save:
-		if (getCurrentFileType() == Utils::FileType::jasp && ! DataSetPackage::pkg()->jaspFileReadOnly())
+		if (getCurrentFileType() == Utils::FileType::jasp && ! DataSetPackage::pkg()->currentFileIsExample())
 			save();
 		else
 			setMode(FileEvent::FileSave);			

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -307,7 +307,7 @@ void FileMenu::dataSetIOCompleted(FileEvent *event)
 		{
 		case FileEvent::FileOpen:
 		case FileEvent::FileSave:
-			enableButtonsForOpenedWorkspace(event->type() == Utils::FileType::jasp || event->operation() == FileEvent::FileSave);
+			enableButtonsForOpenedWorkspace((!event->isReadOnly() && event->type() == Utils::FileType::jasp) || event->operation() == FileEvent::FileSave);
 			break;
 
 		case FileEvent::FileClose:

--- a/Desktop/widgets/filemenu/filemenu.h
+++ b/Desktop/widgets/filemenu/filemenu.h
@@ -74,6 +74,7 @@ public:
 	FileEvent *	open(const QString &filepath);
 	FileEvent * open(const Json::Value & databaseInfo);
 	FileEvent *	save();
+	FileEvent *	saveAs();
 	void		sync();
 
 	void			setCurrentDataFile(const QString		& path);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2383

A JASP file from the Data Library should be read-only, but once it is saved with another name on the PC (Save As), the file should not be read-only anymore

Add CTRL-SHIFT-S shortcut to call Save As.

