### PR TITLE
Bugfix: handle wide table and Rsyntax printing

### DIFF
--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -584,6 +584,10 @@ pre {
     border-style: ridge;
 }
 
+.jasp-rsyntax-container pre {
+    white-space: pre-wrap;
+}
+
 /*.jasp-indent {
 	margin-left: .5em ;
 	padding-left: 0.8em ;

--- a/Desktop/html/css/printing.css
+++ b/Desktop/html/css/printing.css
@@ -1,24 +1,27 @@
 @media only print
 {
-    #results {  display: block;  }
+    #results    {  display: block;  }
 
     .jasp-toolbar h1, .jasp-toolbar h2, .jasp-toolbar h3, .jasp-toolbar h4, .jasp-toolbar h5, .jasp-toolbar h6, .jasp-toolbar div , .jasp-toolbar span
-	                                { display:				block !important;	}
-	.toolbar-button					{ display:				none  !important;	visibility: hidden; }
-	.jasp-menu						{ display:				none  !important;	visibility: hidden; }
-	.jasp-menu-selected				{ display:				none  !important;	visibility: hidden; }
-	.jaspReportTop					{ display:				none  !important;	visibility: hidden; }
-	body							{ float:				none  !important;	}
+	                                    { display:	block !important;  }
+	.toolbar-button			    { display:	none  !important;  visibility: hidden; }
+	.jasp-menu			    { display:	none  !important;  visibility: hidden; }
+	.jasp-menu-selected		    { display:	none  !important;  visibility: hidden; }
+	.jaspReportTop			    { display:	none  !important;  visibility: hidden; }
+	body				    { float:	none  !important;  }
 
-    .jasp-toolbar					{ page-break-after:		avoid;	}
-	.jasp-analysis					{ page-break-after:		always; }
-	.jasp-collection				{ page-break-inside:	avoid;	}
-	.hidden-collection				{ page-break-inside:	auto;	}
-	.object-body					{ page-break-inside:	auto;	}
-	.object-body .hidden-collection	{ page-break-inside:	auto;	}
-	.jasp-image						{ page-break-inside:	avoid;	}
-	.jasp-notes						{ page-break-inside:	avoid;	}
-	.jasp-table-primitive			{ page-break-inside:	avoid;	}
+    .jasp-toolbar			    { page-break-after:	avoid;	}
+	.jasp-analysis			    { page-break-after:	always; }
+	.jasp-collection		    { page-break-inside:	avoid;	}
+	.hidden-collection		    { page-break-inside:	auto;	}
+	.object-body			    { page-break-inside:	auto;	}
+	.object-body .hidden-collection	    { page-break-inside:	auto;	}
+	.jasp-image			    { page-break-inside:	avoid;	}
+	.jasp-notes			    { page-break-inside:	avoid;	}
+	.jasp-table-primitive		    { page-break-inside:	avoid;	}
+
+    table                                   { table-layout:fixed !important;  width: 90em !important; }
+    table td                                { white-space: pre-wrap !important; word-wrap: break-all !important; }
 }
 
 @page { margin:		1cm; }

--- a/Desktop/html/css/printing.css
+++ b/Desktop/html/css/printing.css
@@ -4,24 +4,27 @@
 
     .jasp-toolbar h1, .jasp-toolbar h2, .jasp-toolbar h3, .jasp-toolbar h4, .jasp-toolbar h5, .jasp-toolbar h6, .jasp-toolbar div , .jasp-toolbar span
 	                                    { display:	block !important;  }
-	.toolbar-button			    { display:	none  !important;  visibility: hidden; }
-	.jasp-menu			    { display:	none  !important;  visibility: hidden; }
-	.jasp-menu-selected		    { display:	none  !important;  visibility: hidden; }
-	.jaspReportTop			    { display:	none  !important;  visibility: hidden; }
-	body				    { float:	none  !important;  }
+	.toolbar-button			    		{ display:	none  !important;  visibility: hidden; }
+	.jasp-menu			    			{ display:	none  !important;  visibility: hidden; }
+	.jasp-menu-selected		    		{ display:	none  !important;  visibility: hidden; }
+	.jaspReportTop			    		{ display:	none  !important;  visibility: hidden; }
+	body				   				{ float:	none  !important;  }
 
-    .jasp-toolbar			    { page-break-after:	avoid;	}
-	.jasp-analysis			    { page-break-after:	always; }
-	.jasp-collection		    { page-break-inside:	avoid;	}
-	.hidden-collection		    { page-break-inside:	auto;	}
-	.object-body			    { page-break-inside:	auto;	}
+    .jasp-toolbar			    		{ page-break-after:	avoid;	}
+	.jasp-analysis			    		{ page-break-after:	always; }
+	.jasp-collection		    		{ page-break-inside:	avoid;	}
+	.hidden-collection		    		{ page-break-inside:	auto;	}
+	.object-body			    		{ page-break-inside:	auto;	}
 	.object-body .hidden-collection	    { page-break-inside:	auto;	}
-	.jasp-image			    { page-break-inside:	avoid;	}
-	.jasp-notes			    { page-break-inside:	avoid;	}
-	.jasp-table-primitive		    { page-break-inside:	avoid;	}
+	.jasp-image			    			{ page-break-inside:	avoid;	}
+	.jasp-notes			    			{ page-break-inside:	avoid;	}
 
-    table                                   { table-layout:fixed !important;  width: 90em !important; }
-    table td                                { white-space: pre-wrap !important; word-wrap: break-all !important; }
+	.jasp-table-primitive		   		{ page-break-inside:	avoid;	}
+    .jasp-table table               	{ table-layout:fixed !important;  width: 90em !important; }
+    .jasp-table table td            	{ white-space: pre-wrap !important; word-wrap: break-all !important; }
+
+	.jasp-rsyntax-container 			{ max-width: 90em !important; }
+
 }
 
 @page { margin:		1cm; }

--- a/Desktop/html/css/printing.css
+++ b/Desktop/html/css/printing.css
@@ -20,10 +20,10 @@
 	.jasp-notes			    			{ page-break-inside:	avoid;	}
 
 	.jasp-table-primitive		   		{ page-break-inside:	avoid;	}
-    .jasp-table table               	{ table-layout:fixed !important;  width: 90em !important; }
+    .jasp-table table               	{ table-layout:fixed !important;  width: 20cm !important; }
     .jasp-table table td            	{ white-space: pre-wrap !important; word-wrap: break-all !important; }
 
-	.jasp-rsyntax-container 			{ max-width: 90em !important; }
+	.jasp-rsyntax-container 			{ max-width: 20cm !important; }
 
 }
 


### PR DESCRIPTION
The default output of Qt PDF printing conforms to the standard size of A4 paper. Anything outside this range will be cut off.

- Not a perfect solution, but for now it can handle with wide tables of about <30 columns.Wider tables will overlap rather than be cut off, I believe overlaps are more easily visible to users as incomplete, so this works for users processing tables manually .
- Wide Rsyntax is also can wrap in PDF

Fix https://github.com/jasp-stats/INTERNAL-jasp/issues/2341
Related https://github.com/jasp-stats/INTERNAL-jasp/issues/1715