### PR TITLE
Add copy/cut/paste with header

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -89,10 +89,11 @@ void Column::setName(const std::string &name)
 	if(_name == name)
 		return;
 
+	std::string orgName = _name;
 	_name = getUniqueName(name);
 
-	if(_title.empty() || _title == _name)
-		setTitle(name);
+	if(_title.empty() || _title == orgName)
+		setTitle(_name);
 
 	db().columnSetName(_id, _name);
 	incRevision();

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -2090,10 +2090,14 @@ void Column::deserialize(const Json::Value &json)
 	if (json.isNull())
 		return;
 
-	_name				= getUniqueName(json["name"].asString());
+	std::string name = json["name"].asString(),
+				title = json["title"].asString();
+
+	_name				= getUniqueName(name);
 	db().columnSetName(_id, _name);
 
-	_title				= json["title"].asString();
+	// If title was equal to name, then they should still stay the same if the name is changed to be unique.
+	_title				= name == title ? _name : title;
 	db().columnSetTitle(_id, _title);
 
 	_description		= json["description"].asString();

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -164,6 +164,7 @@ public:
 			const	stringset	 &	dependsOnColumns(bool refresh = true);
 			Json::Value				serialize()																const;
 			void					deserialize(const Json::Value& info);
+			std::string				getUniqueName(const std::string& name)									const;
 
 protected:
 			void					_checkForDependencyLoop(stringset foundNames, std::list<std::string> loopList);

--- a/Desktop/components/JASP/Widgets/JASPDataView.qml
+++ b/Desktop/components/JASP/Widgets/JASPDataView.qml
@@ -84,17 +84,17 @@ FocusScope
 			switch(event.key)
 			{
 			case Qt.Key_C:
-				theView.copy(shiftPressed);
+				theView.copy();
 				event.accepted = true;
 				break;
 
 			case Qt.Key_X:
-				theView.cut(shiftPressed);
+				theView.cut();
 				event.accepted = true;
 				break;
 
 			case Qt.Key_V:
-				theView.paste(shiftPressed);
+				theView.paste();
 				event.accepted = true;
 				break;
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1987,6 +1987,7 @@ void DataSetPackage::deserializeColumn(const std::string& columnName, const Json
 {
 	Column		*	column	= _dataSet->column(columnName);
 	column->deserialize(col);
+	emit datasetChanged({tq(columnName)}, {}, {}, false, false);
 }
 
 void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, QStringList newColNames, intvec coltypes)

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1960,23 +1960,6 @@ std::string DataSetPackage::freeNewColumnName(size_t startHere)
 	}
 }
 
-void DataSetPackage::unicifyColumnNames()
-{
-	for(int c=0; c<dataColumnCount(); c++)
-	{
-		std::string name = getColumnName(c);
-
-		for(int c1=c+1; c1<dataColumnCount(); c1++)
-			if(getColumnName(c1) == name)
-			{
-				std::string newName = name + "'";
-				while(!isColumnNameFree(newName))
-					newName = newName + "'";
-				setColumnName(c1, newName);
-			}
-	}
-}
-
 Json::Value DataSetPackage::serializeColumn(const std::string& columnName) const
 {
 	Column*	column	= _dataSet->column(columnName);
@@ -1990,7 +1973,7 @@ void DataSetPackage::deserializeColumn(const std::string& columnName, const Json
 	emit datasetChanged({tq(columnName)}, {}, {}, false, false);
 }
 
-void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, QStringList newColNames, intvec coltypes)
+void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, intvec coltypes)
 {
 	JASPTIMER_SCOPE(DataSetPackage::pasteSpreadsheet);
 
@@ -1999,7 +1982,6 @@ void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<
 	bool	rowCountChanged = int(row + rowMax) > dataRowCount()	,
 			colCountChanged = int(col + colMax) > dataColumnCount()	;
 
-	//beginResetModel();
 	beginSynchingData(false);
 	
 	if(colCountChanged || rowCountChanged)	
@@ -2027,30 +2009,15 @@ void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<
 			colVals[r + row] = cellVal == ColumnUtils::emptyValue ? "" : cellVal;
 		}
 
-		std::string colName = getColumnName(dataCol),
-					newName = newColNames.size() > c && newColNames[c] != "" ? fq(newColNames[c]) : colName == "" ? freeNewColumnName(dataCol) : colName;
-		
-		initColumnWithStrings(dataCol, newName, colVals, "", desiredType);
+		std::string colName = getColumnName(dataCol);
+		initColumnWithStrings(dataCol, colName, colVals, "", desiredType);
 
-		if(newName != "")
-			changed.push_back(newName);
+		changed.push_back(colName);
 
 	}
 
 	strstrmap		changeNameColumns;
-	if(newColNames.size() > 0)
-	{
-		unicifyColumnNames();
-
-		stringvec colNamesNew = getColumnNames();
-
-		for(size_t i=0; i<colNames.size() && i < colNamesNew.size(); i++)
-			if(colNames[i] != colNamesNew[i])
-				changeNameColumns[colNames[i]] = colNamesNew[i];
-	}
-	
-
-	stringvec				missingColumns;
+	stringvec		missingColumns;
 
 	endSynchingData(changed, missingColumns, changeNameColumns, rowCountChanged, colCountChanged, false);
 	setManualEdits(true); //set manual edits here so external synching is turned off, endSynchingData also just reset it, so thats why it is way down here

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -199,7 +199,7 @@ public:
 				void						initColumnWithStrings(			QVariant			colId,		const std::string & newName, const stringvec	& values,	const std::string & title = "", columnType desiredType = columnType::unknown);
 				void						initializeComputedColumns();
 				
-				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList(), intvec colTypes = intvec());
+				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & cells, intvec colTypes = intvec());
 
 				void						storeInEmptyValues(		const std::string	& columnName, const intstrmap & emptyValues);
 
@@ -255,7 +255,6 @@ public:
 				QStringList					getColumnLabelsAsStringList(const std::string & columnName)	const;
 				QStringList					getColumnLabelsAsStringList(size_t columnIndex)				const;
 				QList<QVariant>				getColumnValuesAsDoubleList(size_t columnIndex)				const;
-				void						unicifyColumnNames();
 				Json::Value					serializeColumn(const std::string& columnName)					const;
 				void						deserializeColumn(const std::string& columnName, const Json::Value& col);
 

--- a/Desktop/data/datasettablemodel.cpp
+++ b/Desktop/data/datasettablemodel.cpp
@@ -80,10 +80,10 @@ int DataSetTableModel::setColumnTypeFromQML(int columnIndex, int newColumnType)
 	return data(index(0, columnIndex), int(DataSetPackage::specialRoles::columnType)).toInt();
 }
 
-void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & cells, QStringList newColNames, std::vector<int> colTypes)
+void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & cells, std::vector<int> colTypes)
 {
 	QModelIndex idx = mapToSource(index(row, col));
-	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), cells, newColNames, colTypes);
+	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), cells, colTypes);
 }
 
 QString DataSetTableModel::insertColumnSpecial(int column, bool computed, bool R)

--- a/Desktop/data/datasettablemodel.h
+++ b/Desktop/data/datasettablemodel.h
@@ -49,7 +49,7 @@ public:
 
 	bool					synchingData()							const				{ return DataSetPackage::pkg()->synchingData();										}
 
-	void					pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList(), std::vector<int> colTypes = std::vector<int>());
+	void					pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, std::vector<int> colTypes = std::vector<int>());
 
 	bool					showInactive()							const				{ return _showInactive;	}
 

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -227,13 +227,13 @@ void ExpandDataProxyModel::setData(int row, int col, const QVariant &value, int 
 	_undoStack->endMacro(new SetDataCommand(_sourceModel, row, col, value, role));
 }
 
-void ExpandDataProxyModel::pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells, QStringList newColNames)
+void ExpandDataProxyModel::pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells)
 {
 	if (!_sourceModel || row < 0 || col < 0 || cells.size() == 0 || cells[0].size() == 0)
 		return;
 
 	_expandIfNecessary(row + cells[0].size() - 1, col + cells.size() - 1);
-	_undoStack->endMacro(new PasteSpreadsheetCommand(_sourceModel, row, col, cells, newColNames));
+	_undoStack->endMacro(new PasteSpreadsheetCommand(_sourceModel, row, col, cells));
 }
 
 int ExpandDataProxyModel::setColumnType(int columnIndex, int columnType)

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -242,3 +242,25 @@ int ExpandDataProxyModel::setColumnType(int columnIndex, int columnType)
 
 	return data(0, columnIndex, int(dataPkgRoles::columnType)).toInt();
 }
+
+void ExpandDataProxyModel::copyColumns(int startCol, const std::vector<Json::Value>& copiedColumns)
+{
+	if (!_sourceModel || startCol < 0 || copiedColumns.size() == 0 || startCol == copiedColumns[0])
+		return;
+
+	_expandIfNecessary(0, startCol + copiedColumns.size() - 1);
+	_undoStack->endMacro(new CopyColumnsCommand(_sourceModel, startCol, copiedColumns));
+}
+
+Json::Value ExpandDataProxyModel::serializedColumn(int col)
+{
+	Json::Value result;
+	if (col < _sourceModel->columnCount())
+	{
+		QString colName = _sourceModel->headerData(col, Qt::Orientation::Horizontal).toString();
+		if (!colName.isEmpty())
+			result = DataSetPackage::pkg()->serializeColumn(colName.toStdString());
+	}
+
+	return result;
+}

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -34,6 +34,8 @@ public:
 	void				insertColumn(int col, bool computed, bool R);
 	void				pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList());
 	int					setColumnType(int columnIndex, int columnType);
+	void				copyColumns(int startCol, const std::vector<Json::Value>& copiedColumns);
+	Json::Value			serializedColumn(int col);
 
 	int					getRole(const std::string& roleName)														const;
 

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -32,7 +32,7 @@ public:
 	void				removeColumns(int start, int count);
 	void				insertRow(int row);
 	void				insertColumn(int col, bool computed, bool R);
-	void				pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells, QStringList newColNames = QStringList());
+	void				pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells);
 	int					setColumnType(int columnIndex, int columnType);
 	void				copyColumns(int startCol, const std::vector<Json::Value>& copiedColumns);
 	Json::Value			serializedColumn(int col);

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -149,7 +149,7 @@ void RemoveRowsCommand::undo()
 	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_model);
 
 	if (dataSetTable)
-		dataSetTable->pasteSpreadsheet(_start, 0, _values, QStringList(), _colTypes);
+		dataSetTable->pasteSpreadsheet(_start, 0, _values, _colTypes);
 	else
 	{
 		for (int i = 0; i < _model->columnCount() && i < _values.size(); i++)
@@ -176,8 +176,8 @@ void RemoveRowsCommand::redo()
 	_model->removeRows(_start, _count);
 }
 
-PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString> > &cells, const QStringList &newColNames)
-	: UndoModelCommand(model), _row{row}, _col{col}, _newCells{cells}, _newColNames{newColNames}
+PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString> > &cells)
+	: UndoModelCommand(model), _row{row}, _col{col}, _newCells{cells}
 {
 	setText(QObject::tr("Paste values at row %1 column '%2'").arg(rowName(_row)).arg(columnName(_col)));
 }
@@ -187,7 +187,7 @@ void PasteSpreadsheetCommand::undo()
 	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_model);
 
 	if (dataSetTable)
-		dataSetTable->pasteSpreadsheet(_row, _col, _oldCells, _newColNames);
+		dataSetTable->pasteSpreadsheet(_row, _col, _oldCells);
 }
 
 void PasteSpreadsheetCommand::redo()
@@ -203,7 +203,7 @@ void PasteSpreadsheetCommand::redo()
 	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_model);
 
 	if (dataSetTable)
-		dataSetTable->pasteSpreadsheet(_row, _col, _newCells, _newColNames);
+		dataSetTable->pasteSpreadsheet(_row, _col, _newCells);
 }
 
 

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -264,6 +264,21 @@ private:
 	std::vector<int>					_colTypes;
 };
 
+class CopyColumnsCommand : public UndoModelCommand
+{
+public:
+	CopyColumnsCommand(QAbstractItemModel* model, int startCol, const std::vector<Json::Value>& copiedColumns);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int							_startCol = -1;
+	std::vector<Json::Value>	_copiedColumns,
+								_originalColumns;
+
+};
+
 class UndoStack : public QUndoStack
 {
 	Q_OBJECT

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -180,7 +180,7 @@ private:
 class PasteSpreadsheetCommand : public UndoModelCommand
 {
 public:
-	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& cells, const QStringList& newColNames);
+	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& cells);
 
 	void undo()					override;
 	void redo()					override;
@@ -188,7 +188,6 @@ public:
 private:
 	std::vector<std::vector<QString>>	_newCells,
 										_oldCells;
-	QStringList							_newColNames;
 	int									_row = -1,
 										_col = -1;
 };

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -38,6 +38,7 @@ struct ItemContextualized
 class DataSetView : public QQuickItem
 {
 	Q_OBJECT
+
 	Q_PROPERTY( QAbstractItemModel	*	model					READ model					WRITE setModel					NOTIFY modelChanged					)
 	Q_PROPERTY( int						itemHorizontalPadding	READ itemHorizontalPadding	WRITE setItemHorizontalPadding	NOTIFY itemHorizontalPaddingChanged )
 	Q_PROPERTY( int						itemVerticalPadding		READ itemVerticalPadding	WRITE setItemVerticalPadding	NOTIFY itemVerticalPaddingChanged	)
@@ -188,10 +189,17 @@ public slots:
 	void		setEditing(bool shiftSelectActive);
 	bool		relaxForSelectScroll();
 
+	bool		isVirtual		(const QPoint& point);
+	bool		isColumnHeader	(const QPoint& p) { return p.x() >= 0	&& p.y() == -1; }
+	bool		isRowHeader		(const QPoint& p) { return p.x() == -1	&& p.y() >= 0;	}
+	bool		isCell			(const QPoint& p) { return p.x() >= 0	&& p.y() >= 0;	}
 
-	void		cut(	bool includeHeader = false) { _copy(includeHeader, true);  }
-	void		copy(	bool includeHeader = false) { _copy(includeHeader, false); }
-	void		paste(	bool includeHeader = false, QPoint where = QPoint());
+
+
+
+	void		cut(	QPoint where = QPoint(-1,-1)) { _copy(where, true);  }
+	void		copy(	QPoint where = QPoint(-1,-1)) { _copy(where, false); }
+	void		paste(	QPoint where = QPoint(-1,-1));
 
 	void		columnSelect(				int col,		bool shiftPressed = false, bool rightClicked = false);
 	QString		columnInsertBefore(			int col = -1,	bool computed = false, bool R = false);
@@ -232,7 +240,7 @@ public slots:
 
 	int			setColumnType(int columnIndex, int newColumnType)	{ return _model->setColumnType(columnIndex, newColumnType); }
 protected:
-	void		_copy(bool includeHeader, bool clear);
+	void		_copy(QPoint where, bool clear);
 	void		calculateCellSizesAndClear(bool clearStorage);
 	void		determineCurrentViewPortIndices();
 	void		storeOutOfViewItems();

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -191,7 +191,7 @@ public slots:
 
 	void		cut(	bool includeHeader = false) { _copy(includeHeader, true);  }
 	void		copy(	bool includeHeader = false) { _copy(includeHeader, false); }
-	void		paste(	bool includeHeader = false);
+	void		paste(	bool includeHeader = false, QPoint where = QPoint());
 
 	void		columnSelect(				int col,		bool shiftPressed = false, bool rightClicked = false);
 	QString		columnInsertBefore(			int col = -1,	bool computed = false, bool R = false);
@@ -326,6 +326,7 @@ protected:
 	long		_selectScrollMs			= 0;
 	QPoint		_selectionStart			= QPoint(-1, -1),
 				_selectionEnd			= QPoint(-1, -1);
+	std::vector<Json::Value> _copiedColumns;
 
 
 };


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2375

If a copy is done from the column header, the column name is also copied in the clipboard, so that if the user paste it in Excel, then the whole column with its name is copied. 
If a paste is done in a cell in JASP, then the clipboard is copied. 
If a paste is done in a column header, then if the copy was done form a column header, then the whole column (with name, labels, description...) is copied. 
If a cut is done in a column header, the whole column is removed.

Moreover it ensures now that the name of a column is unique.

