### PR TITLE
Feat: allow dollar sign as delimiters in help docs

### DIFF
--- a/Docs/development/jasp-adding-module.md
+++ b/Docs/development/jasp-adding-module.md
@@ -162,7 +162,7 @@ The help folder is where you place the documentation for your module. You should
 - **Image**:To be able to refer to another helpfile or an image in your module's  helpfile or in the `info` field of the = options in QML you can use a special string.
 This string is `%HELP_FOLDER%` and when loaded it will be replaced with the path to the `help`-folder of your module.
 So suppose you have an image in `module/help/img/picture.png`, to link to it you would put `"%HELP_FOLDER%/img/picture.png"` in your markdown.
-- **Math**:If you want to add math expressions to help documentation, use TeX/LaTeX code into `\\\\(...\\\\)` for inline style or `\\\\[...\\\\]` for block style math expressions, note that you may need to escape characters such `\\\\(\\alpha+\\beta\\\\)` to get $\alpha+\beta$.
+- **Math**:If you want to add math expressions to help documentation, use TeX/LaTeX code into `\\\\(...\\\\)` or `$...$` for inline style, and use `\\\\[...\\\\]` or `$$...$$` for block style math expressions, note that you may need to escape characters such `$\\alpha+\\beta$` to get $\alpha+\beta$.
 - **R Code**:Suppose want to display example R code block or highlighting in the help documentation, you can use ` ```r ``` ` with your R code.
 
 #### Package Metadata

--- a/Resources/Help/index.html
+++ b/Resources/Help/index.html
@@ -1,46 +1,59 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-  <link rel="stylesheet" href="lightTheme.css"                           type="text/css" id="style"/>
-  <link rel="stylesheet" href="qrc:/html/css/highlight-default.min.css"  type="text/css" id="style"/>
+  <link rel="stylesheet" href="lightTheme.css" type="text/css" id="style" />
+  <link rel="stylesheet" href="qrc:/html/css/highlight-default.min.css" type="text/css" id="style" />
 
   <script src="marked.js" type="text/javascript"></script>
-  <script src="qrc:/html/js/mathjax-tex-svg-full.js" type="text/javascript"></script>
   <script src="qrc:/html/js/highlight.min.js" type="text/javascript"></script>
   <script src="qrc:/html/js/highlight-r.min.js" type="text/javascript"></script>
   <script src="marked-hljs-ext.js" type="text/javascript"></script>
+
+  <script>
+    // Mathjax needs to be pre-configured before loading,custom config to allow dollar sign as delimiter.
+    MathJax = {
+      tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']]
+      }
+    };
+  </script>
+
+  <script src="qrc:/html/js/mathjax-tex-svg-full.js" type="text/javascript"></script>
 
   <title>JASP Help</title>
 
   <script>
     const markedHighlightOptions = {
-    langPrefix: 'hljs language-',
-    highlight(code, lang) {
+      langPrefix: 'hljs language-',
+      highlight(code, lang) {
         const language = hljs.getLanguage(lang) ? lang : 'plaintext';
         return hljs.highlight(code, { language }).value;
       }
     }
-  marked.use(markedHighlight(markedHighlightOptions));
+    marked.use(markedHighlight(markedHighlightOptions));
   </script>
 
-	<script type="text/javascript">
-    window.render = function(content) { 
-      document.body.innerHTML = marked.parse(content); 
+  <script type="text/javascript">
+    window.render = function (content) {
+      document.body.innerHTML = marked.parse(content);
       MathJax.typesetPromise();
-      window.scrollTo(0, 0); 
+      window.scrollTo(0, 0);
     }
-    window.renderHtml = function(content)   { 
-      document.body.innerHTML = content;  
-      window.scrollTo(0, 0); 
+    window.renderHtml = function (content) {
+      document.body.innerHTML = content;
+      window.scrollTo(0, 0);
     }
-    window.setTheme   = function(themeName) { 
-      document.getElementById("style").setAttribute("href", themeName + ".css");  
+    window.setTheme = function (themeName) {
+      document.getElementById("style").setAttribute("href", themeName + ".css");
     }
-    window.setFont    = function(fontName)  {
+    window.setFont = function (fontName) {
       document.getElementsByTagName("body")[0].style["font-family"] = fontName;
     }
-	</script>
+  </script>
 </head>
+
 <body>
 </body>
+
 </html>


### PR DESCRIPTION
It just allows people to use dollar signs as delimiters for math in help files to keep some Markdown habits, we specifically using `\\(...\\)` or `\\[...\\]` as delimiters inside jaspHtml, so this won't affect that.