### PR TITLE
Add Contact and Supporters

### DIFF
--- a/Desktop/components/JASP/Widgets/AboutWindow.qml
+++ b/Desktop/components/JASP/Widgets/AboutWindow.qml
@@ -7,10 +7,6 @@ WavyWindow
 {
 	id:				aboutWindow
 
-   
-	property string labelcolor:			"#F99800"
-	property string closebuttoncolor:	"#50B0E3"
-
 	visible:				aboutModel.visible
 	onVisibleChanged:		aboutModel.visible = visible
 	onCloseModel:			{ aboutModel.visible = false }

--- a/Desktop/components/JASP/Widgets/AboutWindow.qml
+++ b/Desktop/components/JASP/Widgets/AboutWindow.qml
@@ -1,281 +1,162 @@
-import QtQuick 2.11
-import QtQuick.Window 2.11
-import QtQuick.Controls 2.5
-import QtWebEngine 1.7
-import JASP.Widgets 1.0
-import JASP.Controls 1.0 as JC
+import QtQuick
+import JASP.Widgets
+import JASP.Controls
+import QtQuick.Controls as QC
 
-
-Window
+WavyWindow
 {
 	id:				aboutWindow
 
-	width:			850 * preferencesModel.uiScale
-	height:			550 * preferencesModel.uiScale
-    
-	minimumWidth:	850 
-	minimumHeight:	550 
-
-	// maximumWidth:	850 
-    // maximumHeight:	550
    
 	property string labelcolor:			"#F99800"
 	property string closebuttoncolor:	"#50B0E3"
 
 	visible:				aboutModel.visible
 	onVisibleChanged:		aboutModel.visible = visible
+	onCloseModel:			{ aboutModel.visible = false }
+
 	title:					qsTr("About JASP")
 
-	color:			jaspTheme.white
 
-	Shortcut { onActivated: aboutModel.visible = false;	sequences: ["Ctrl+Q", "Ctrl+W", Qt.Key_Close]; }
+	property int labelwidth:	10 + Math.max(	jaspVersionLabel.implicitWidth,
+												buildDateLabel	.implicitWidth,
+												sourceLabel		.implicitWidth,
+												downloadLabel	.implicitWidth,
+												citationLabel	.implicitWidth)
 
-	Connections
+	Text { text: aboutModel.copyrightMessage; color: jaspTheme.textEnabled	}
+
+	Row
 	{
-		target:			mainWindow
-		function onCloseWindows() { aboutModel.visible = false; }
+		Label { text: "<b>" + qsTr("Version:") + "</b>";		color: labelcolor; width: aboutWindow.labelwidth; id: jaspVersionLabel }
+		Text	 { text: aboutModel.version;	color: jaspTheme.textEnabled											}
 	}
 
-
-	Image
+	Row
 	{
-		id:				topWave
-		anchors.top:	parent.top
-		anchors.left:	parent.left
-		anchors.right:	parent.right
-		height:			parent.height/4
-
-		source:		jaspTheme.iconPath + "jasp-wave-down-blue-120.svg"
+		Label { text: "<b>" + qsTr("Built on:") + "</b>";		color: labelcolor; width: aboutWindow.labelwidth; id: buildDateLabel	}
+		Text	 { text: aboutModel.buildDate;	color: jaspTheme.textEnabled											}
 	}
 
-	Item
+	Row
 	{
-		id:				jaspLogo
-
-		width:			parent.height / 3
-		height:			parent.height / 5.5
-		anchors
+		Label { text: "<b>" + qsTr("Source:") + "</b>";		color: labelcolor; width: aboutWindow.labelwidth; id: sourceLabel		}
+		Text
 		{
-			left:		parent.left
-			leftMargin: 50 * preferencesModel.uiScale
-			top:		aboutInfoBox.top
-			topMargin:	25 * preferencesModel.uiScale
-		}
+			text:		"<u>" + qsTr("Access the sources here") + "</u>"
+			color:		jaspTheme.blue
 
-		Image
-		{
-			anchors.fill:		parent
-			fillMode:			Image.PreserveAspectFit
-			source:				jaspTheme.iconPath + "jasp-logo-black.svg"
-			sourceSize.width:	width  * 2
-			sourceSize.height:	height * 2
-			mipmap:				true
+			MouseArea
+			{
+				id:				mouseAreaSources
+				anchors.fill:	parent
+				onClicked:		Qt.openUrlExternally(aboutModel.commitUrl)
+				cursorShape:	Qt.PointingHandCursor
+			}
 		}
 	}
 
-	Rectangle
+	Row
 	{
-		id:							aboutInfoBox
-		property int labelwidth:	Math.max(jaspVersionLabel.implicitWidth,
-										  buildDateLabel.implicitWidth,
-										  sourceLabel.implicitWidth,
-										  downloadLabel.implicitWidth,
-										  citationLabel.implicitWidth) + 10
-
-		anchors
+		Label { text: "<b>" + qsTr("Download:") + "</b>";		color:	labelcolor; width: aboutWindow.labelwidth; id:	downloadLabel	}
+		Text
 		{
-			top:			topWave.bottom
-			left:			jaspLogo.right
-			right:			parent.right
-			leftMargin:		25
-			rightMargin:	15
+			text:			"<u>" + aboutModel.downloadUrl + "</u>"
+			color:			jaspTheme.blue
+
+			MouseArea
+			{
+				id:				mouseAreaDownload
+				anchors.fill:	parent
+				onClicked:		Qt.openUrlExternally(aboutModel.downloadUrl)
+				cursorShape:	Qt.PointingHandCursor
+
+			}
 		}
-		height:			contentInfo.height
-		color:			jaspTheme.white
+	}
+
+	Row
+	{
+		width:				parent.width
+
+		Label
+		{
+			id:				citationLabel
+			width:			aboutWindow.labelwidth
+			text:			"<b>" + qsTr("Citation:") + "</b>"
+			color:			labelcolor
+		}
 
 		Column
 		{
-			id: contentInfo
-			anchors.left:	parent.left
-			anchors.top:	parent.top
-			anchors.right:	parent.right
-			spacing:		5 * preferencesModel.uiScale
+			width:			Math.min(parent.width - aboutWindow.labelwidth, 450 * jaspTheme.uiScale)
 
-			JC.Text { text: aboutModel.copyrightMessage; color: jaspTheme.textEnabled	}
-
-			Row
+			QC.TextArea
 			{
-				JC.Label { text: "<b>" + qsTr("Version:") + "</b>";		color: labelcolor; width: aboutInfoBox.labelwidth; id: jaspVersionLabel }
-				JC.Text	 { text: aboutModel.version;	color: jaspTheme.textEnabled											}
-			}
-
-			Row
-			{
-				JC.Label { text: "<b>" + qsTr("Built on:") + "</b>";		color: labelcolor; width: aboutInfoBox.labelwidth; id: buildDateLabel	}
-				JC.Text	 { text: aboutModel.buildDate;	color: jaspTheme.textEnabled											}
-			}
-
-			Row
-			{
-				JC.Label { text: "<b>" + qsTr("Source:") + "</b>";		color: labelcolor; width: aboutInfoBox.labelwidth; id: sourceLabel		}
-				JC.Text
-				{
-					text:		"<u>" + qsTr("Access the sources here") + "</u>"
-					color:		jaspTheme.blue
-
-					MouseArea
-					{
-						id:				mouseAreaSources
-						anchors.fill:	parent
-						onClicked:		Qt.openUrlExternally(aboutModel.commitUrl)
-						cursorShape:	Qt.PointingHandCursor
-					}
-				}
-			}
-
-			Row
-			{
-				JC.Label { text: "<b>" + qsTr("Download:") + "</b>";		color:	labelcolor; width: aboutInfoBox.labelwidth; id:	downloadLabel	}
-				JC.Text
-				{
-					text:			"<u>" + aboutModel.downloadUrl + "</u>"
-					color:			jaspTheme.blue
-
-					MouseArea
-					{
-						id:				mouseAreaDownload
-						anchors.fill:	parent
-						onClicked:		Qt.openUrlExternally(aboutModel.downloadUrl)
-						cursorShape:	Qt.PointingHandCursor
-
-					}
-				}
-			}
-
-			Row
-			{
-				JC.Label
-				{
-					id:				citationLabel
-					width:			aboutInfoBox.labelwidth
-					text:			"<b>" + qsTr("Citation:") + "</b>"
-					color:			labelcolor
-				}
-
-				Column
-				{
-					TextArea
-					{
-						id:				citationText
-						textFormat:		Text.StyledText
-						text:			aboutModel.citation
-						color:			jaspTheme.textEnabled
-						leftPadding:	0
-						topPadding:		0
-						bottomPadding:	0
-						width:			aboutInfoBox.width - aboutInfoBox.labelwidth
-						wrapMode:		TextEdit.WordWrap
-						font:			jaspTheme.font
-
-						selectByMouse:	true
-						readOnly:		true
-
-						onPressed:		if (event.button === Qt.RightButton)	contextMenu.popup()
-
-						Menu
-						{
-							id:		contextMenu
-							width:	120
-
-							Action { text: qsTr("Select All");		onTriggered: citationText.selectAll();	}
-							Action { text: qsTr("Copy Selection");	onTriggered: citationText.copy();		} //citationText.deselect(); is not really necessary right?
-						}
-					}
-
-					JC.Text
-					{
-						text:			"<u>" + qsTr("BibTeX") + "</u>"
-						color:			jaspTheme.blue
-
-						MouseArea
-						{
-							id:				mouseAreaBibTex
-							anchors.fill:	parent
-							onClicked:		Qt.openUrlExternally(aboutModel.citationUrl)
-							cursorShape:	Qt.PointingHandCursor
-						}
-					}
-				}
-			}
-
-			JC.Text
-			{
-				id:				warrantyText
-				text:			aboutModel.warranty
+				id:				citationText
 				textFormat:		Text.StyledText
-				opacity:		0.5
+				text:			aboutModel.citation
 				color:			jaspTheme.textEnabled
+				leftPadding:	0
+				topPadding:		0
+				bottomPadding:	0
+				wrapMode:		TextEdit.Wrap
+				font:			jaspTheme.fontCode
+				width:			parent.width
+
+				selectByMouse:	true
+				readOnly:		true
+
+				onPressed:		(event)=>{ if (event.button === Qt.RightButton)	contextMenu.popup() }
+
+				QC.Menu
+				{
+					id:		contextMenu
+					width:	120
+
+					QC.Action { text: qsTr("Select All");		onTriggered: citationText.selectAll();	}
+					QC.Action { text: qsTr("Copy Selection");	onTriggered: citationText.copy();		} //citationText.deselect(); is not really necessary right?
+				}
 			}
 
-			JC.Text
+			Text
 			{
-				id:				openSourceText
-				text:			"<u>" + qsTr("Open Source Components") + "</u>"
+				text:			"<u>" + qsTr("BibTeX") + "</u>"
 				color:			jaspTheme.blue
 
 				MouseArea
 				{
-					id:				mouseAreaOpenSource
+					id:				mouseAreaBibTex
 					anchors.fill:	parent
-					onClicked:		Qt.openUrlExternally(aboutModel.openSourceUrl)
+					onClicked:		Qt.openUrlExternally(aboutModel.citationUrl)
 					cursorShape:	Qt.PointingHandCursor
 				}
 			}
 		}
 	}
 
-	Rectangle
+	Text
 	{
-		id:				closeButton
-		x:				aboutWindow.width / 2 - parent.x -width / 2
-		anchors.top:	aboutInfoBox.bottom
-		anchors.topMargin: 10 * preferencesModel.uiScale
-		color:			closebuttoncolor
-		radius:			5 * preferencesModel.uiScale
-		height:			25 * preferencesModel.uiScale
-		width:			75 * preferencesModel.uiScale
+		id:				warrantyText
+		text:			aboutModel.warranty
+		textFormat:		Text.StyledText
+		opacity:		0.5
+		color:			jaspTheme.textEnabled
+	}
 
-		JC.Text
-		{
-			anchors.centerIn:		parent
-			text:					qsTr("Close")
-			color:					jaspTheme.white
-			horizontalAlignment:	Text.AlignHCenter
-			verticalAlignment:		Text.AlignVCenter
-		}
+	Text
+	{
+		id:				openSourceText
+		text:			"<u>" + qsTr("Open Source Components") + "</u>"
+		color:			jaspTheme.blue
 
 		MouseArea
 		{
-			onClicked:				{aboutModel.visible = false; aboutWindow.close()}
-			anchors.fill:			parent
-			cursorShape:			Qt.PointingHandCursor
-			focus:					true
-			Keys.onEnterPressed:	{aboutModel.visible = false; aboutWindow.close()}
-			Keys.onReturnPressed: (event)=>	{aboutModel.visible = false; aboutWindow.close()}
-			Keys.onEscapePressed:	{aboutModel.visible = false; aboutWindow.close()}
+			id:				mouseAreaOpenSource
+			anchors.fill:	parent
+			onClicked:		Qt.openUrlExternally(aboutModel.openSourceUrl)
+			cursorShape:	Qt.PointingHandCursor
 		}
-	}
-
-	Image
-	{
-		id:					bottomWave
-		z:					-1
-
-		anchors.bottom:		parent.bottom
-		anchors.left:		parent.left
-		anchors.right:		parent.right
-		height:				parent.height/4
-		source:				jaspTheme.iconPath + "jasp-wave-up-green-120.svg"
 	}
 }
 

--- a/Desktop/components/JASP/Widgets/ContactWindow.qml
+++ b/Desktop/components/JASP/Widgets/ContactWindow.qml
@@ -1,0 +1,73 @@
+import QtQuick
+import JASP.Widgets
+import JASP.Controls
+import QtQuick.Controls as QC
+
+WavyWindow
+{
+	id:				contactWindow
+
+   
+	property string labelcolor:			"#F99800"
+	property string closebuttoncolor:	"#50B0E3"
+
+	visible:				mainWindow.contactVisible
+	onVisibleChanged:		mainWindow.contactVisible = visible
+	onCloseModel:			{ mainWindow.contactVisible = false }
+
+	title:					qsTr("Contact JASP")
+
+	QC.TextArea
+	{
+		id:				contactText
+		textFormat:		Text.RichText
+		text:
+"For <a href=\"https://github.com/jasp-stats/jasp-issues/issues/new?assignees=&labels=Feature+Request&projects=&template=feature-request.yml&title=%5BFeature+Request%5D%3A+\">feature requests</a> and <a href=\"https://github.com/jasp-stats/jasp-issues/issues/new?assignees=&labels=Bug&projects=&template=bug-report.yml&title=%5BBug%5D%3A+\">bug reports</a>: please post an issue on our GitHub page, <a href=\"https://jasp-stats.org/2018/03/29/request-feature-report-bug-jasp/\">as explained here.</a>
+This will bring you in direct contact with the JASP software developers.
+
+For statistical questions: please post an issue <a href=\"https://forum.cogsci.nl/index.php?p=/categories/jasp-bayesfactor\">on the JASP Forum.</a>
+
+For information on the JASP Cooperative: please read <a href=\"https://jasp-stats.org/cooperative/\">the information on the JASP website</a>
+
+For suggesting we add your institution to the <a href=\"https://jasp-stats.org/world-map/\">JASP World Map</a> please send an email to <a href=\"mailto:communications@jasp-stats.org\">communications@jasp-stats.org</a>.
+
+For individual donations: please visit <a href=\"https://jasp-stats.org/donate/\">the JASP website</a>.
+".replace(/&/g, "&amp;").replace(/, /g, ",&nbsp;").replace(/\n/g, "<br>")
+		color:			jaspTheme.textEnabled
+		leftPadding:	0
+		topPadding:		0
+		bottomPadding:	0
+		wrapMode:		TextEdit.Wrap
+		font.family:	jaspTheme.font
+		font.pixelSize:	16 * jaspTheme.uiScale
+		width:			parent.width
+
+		selectByMouse:	true
+		readOnly:		true
+
+		onPressed:		(event)=>{ if (event.button === Qt.RightButton)	contextMenu.popup()  }
+
+		QC.Menu
+		{
+			id:		contextMenu
+			width:	120
+
+			QC.Action { text: qsTr("Select All");		onTriggered: contactText.selectAll();	}
+			QC.Action { text: qsTr("Copy Selection");	onTriggered: contactText.copy();		}
+		}
+
+		onLinkActivated:	(link)=>{ Qt.openUrlExternally(link) }
+
+		MouseArea
+		{
+			id:					cursorShower
+			acceptedButtons:	Qt.NoButton
+			hoverEnabled:		true
+			anchors.fill:		parent
+
+			cursorShape:		!containsMouse || contactText.linkAt(mouseX, mouseY) === "" ? Qt.ArrowCursor : Qt.PointingHandCursor
+		}
+	}
+
+}
+

--- a/Desktop/components/JASP/Widgets/ContactWindow.qml
+++ b/Desktop/components/JASP/Widgets/ContactWindow.qml
@@ -7,10 +7,6 @@ WavyWindow
 {
 	id:				contactWindow
 
-   
-	property string labelcolor:			"#F99800"
-	property string closebuttoncolor:	"#50B0E3"
-
 	visible:				mainWindow.contactVisible
 	onVisibleChanged:		mainWindow.contactVisible = visible
 	onCloseModel:			{ mainWindow.contactVisible = false }

--- a/Desktop/components/JASP/Widgets/Supporters.qml
+++ b/Desktop/components/JASP/Widgets/Supporters.qml
@@ -1,0 +1,102 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import JASP.Widgets
+
+
+Item
+{
+	height:							supportColumn.height
+	property int fontPixelSize:		14
+
+	ColumnLayout
+	{
+		id:							supportColumn
+		spacing:					welcomeRoot.scaler * 20
+		anchors.left:				parent.left
+		anchors.right:				parent.right
+
+		Text
+		{
+			text:					qsTr("JASP is supported by the following institutions:").replace(/, /g, ",&nbsp;").replace(/\n\n/g, "<br><br>")
+			font.family:			jaspTheme.font
+			font.weight:			Font.Normal
+			font.pixelSize:         fontPixelSize * welcomeRoot.scaler
+			color:					jaspTheme.white
+			wrapMode:				TextEdit.Wrap
+			renderType:				Text.QtRendering
+			textFormat:				Text.StyledText
+			horizontalAlignment:	Text.AlignHCenter
+			Layout.fillWidth:		true
+		}
+
+		SwipeView
+		{
+			id:						swipeSupporters
+			orientation:			Qt.Vertical
+			Layout.fillWidth:		true
+			clip:					true
+			currentIndex:			Math.floor(Math.random() * count)
+			wheelEnabled:			true
+
+			Timer
+			{
+				interval:			5000
+				repeat:				true
+				running:			true
+				onTriggered:		{ swipeSupporters.setCurrentIndex((swipeSupporters.currentIndex + 1) % swipeSupporters.count) }
+			}
+
+			Repeater
+			{
+				model:
+				[
+					"Tilburg University",
+					"KU Leuven",
+					"Nyenrode Business University",
+					"M&S / Faculty of Social Sciences / Utrecht University",
+					"University of Amsterdam"
+				]
+
+				Text
+				{
+					text:					String(modelData).replace(/&/g, "&amp;").replace(/, /g, ",&nbsp;").replace(/\n/g, "<br>")
+					font.family:			jaspTheme.font
+					font.weight:			Font.Bold
+					font.pixelSize:         (4 + fontPixelSize) * welcomeRoot.scaler
+					color:					jaspTheme.white
+					wrapMode:				TextEdit.Wrap
+					renderType:				Text.QtRendering
+					textFormat:				Text.StyledText
+					horizontalAlignment:	Text.AlignHCenter
+
+					width:					swipeSupporters.width
+				}
+			}
+
+
+		}
+
+		Text
+		{
+			text:					qsTr("Suggest your institution joins the JASP Cooperative").replace(/, /g, ",&nbsp;").replace(/\n\n/g, "<br><br>")
+			font.family:			jaspTheme.font
+			font.weight:			Font.Normal
+			font.pixelSize:         fontPixelSize * welcomeRoot.scaler
+			font.underline:			true
+			color:					jaspTheme.white
+			wrapMode:				TextEdit.Wrap
+			renderType:				Text.QtRendering
+			textFormat:				Text.StyledText
+			horizontalAlignment:	Text.AlignHCenter
+			Layout.fillWidth:		true
+		}
+	}
+
+	MouseArea
+	{
+		cursorShape:			Qt.PointingHandCursor
+		acceptedButtons:		Qt.NoButton
+		anchors.fill:			parent
+	}
+}

--- a/Desktop/components/JASP/Widgets/Supporters.qml
+++ b/Desktop/components/JASP/Widgets/Supporters.qml
@@ -96,7 +96,9 @@ Item
 	MouseArea
 	{
 		cursorShape:			Qt.PointingHandCursor
-		acceptedButtons:		Qt.NoButton
+		acceptedButtons:		Qt.LeftButton
 		anchors.fill:			parent
+		onClicked:				Qt.openUrlExternally("https://jasp-stats.org/how-to-support/")
+		z:						-8
 	}
 }

--- a/Desktop/components/JASP/Widgets/WavyWindow.qml
+++ b/Desktop/components/JASP/Widgets/WavyWindow.qml
@@ -1,0 +1,145 @@
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+//import QtWebEngine
+import JASP.Widgets
+import JASP.Controls as JC
+
+
+Window
+{
+	id:				aboutWindow
+
+	width:			1000 * preferencesModel.uiScale
+	height:			550 * preferencesModel.uiScale
+
+	minimumWidth:	850
+	minimumHeight:	550
+
+	default property alias	content:			contentInfo.children
+			property string labelcolor:			"#F99800"
+			property string closebuttoncolor:	"#50B0E3"
+
+	visible:				false
+	title:					qsTr("About JASP")
+
+	color:			jaspTheme.white
+
+	signal closeModel();
+
+	Shortcut { onActivated: closeModel();	sequences: ["Ctrl+Q", "Ctrl+W", Qt.Key_Close]; }
+
+	Connections
+	{
+		target:			mainWindow
+		function onCloseWindows() { closeModel(); }
+	}
+
+	Image
+	{
+		id:				topWave
+		anchors.top:	parent.top
+		anchors.left:	parent.left
+		anchors.right:	parent.right
+		height:			parent.height/4
+
+		source:		jaspTheme.iconPath + "jasp-wave-down-blue-120.svg"
+	}
+
+	Item
+	{
+		id:				jaspLogo
+
+		width:			parent.height / 3
+		height:			parent.height / 5.5
+		anchors
+		{
+			left:		parent.left
+			leftMargin: 50 * preferencesModel.uiScale
+			top:		aboutInfoBox.top
+			topMargin:	25 * preferencesModel.uiScale
+		}
+
+		Image
+		{
+			anchors.fill:		parent
+			fillMode:			Image.PreserveAspectFit
+			source:				jaspTheme.iconPath + "jasp-logo-black.svg"
+			sourceSize.width:	width  * 2
+			sourceSize.height:	height * 2
+			mipmap:				true
+		}
+	}
+
+	Rectangle
+	{
+		id:							aboutInfoBox
+
+		anchors
+		{
+			top:			topWave.bottom
+			left:			jaspLogo.right
+			right:			parent.right
+			leftMargin:		25
+			rightMargin:	15
+		}
+		height:			contentInfo.height
+		color:			jaspTheme.white
+
+		Column
+		{
+			id:				contentInfo
+			anchors.left:	parent.left
+			anchors.top:	parent.top
+			anchors.right:	parent.right
+			spacing:		5 * preferencesModel.uiScale
+
+			//This is where the subitems go!
+		}
+	}
+
+	Rectangle
+	{
+		id:					closeButton
+		x:					aboutWindow.width / 2 - parent.x -width / 2
+		anchors.top:		aboutInfoBox.bottom
+		anchors.topMargin:	10 * preferencesModel.uiScale
+		color:				closebuttoncolor
+		radius:				5 * preferencesModel.uiScale
+		height:				25 * preferencesModel.uiScale
+		width:				75 * preferencesModel.uiScale
+
+		JC.Text
+		{
+			anchors.centerIn:		parent
+			text:					qsTr("Close")
+			color:					jaspTheme.white
+			horizontalAlignment:	Text.AlignHCenter
+			verticalAlignment:		Text.AlignVCenter
+		}
+
+		MouseArea
+		{
+			onClicked:				(event) => { closeModel() }
+			anchors.fill:			parent
+			cursorShape:			Qt.PointingHandCursor
+			focus:					true
+			Keys.onEnterPressed:	(event) => { closeModel() }
+			Keys.onReturnPressed:	(event) => { closeModel() }
+			Keys.onEscapePressed:	(event) => { closeModel() }
+		}
+	}
+
+	Image
+	{
+		id:					bottomWave
+		z:					-1
+
+		anchors.bottom:		parent.bottom
+		anchors.left:		parent.left
+		anchors.right:		parent.right
+		height:				parent.height/4
+		source:				jaspTheme.iconPath + "jasp-wave-up-green-120.svg"
+	}
+}
+

--- a/Desktop/components/JASP/Widgets/WelcomePage.qml
+++ b/Desktop/components/JASP/Widgets/WelcomePage.qml
@@ -16,11 +16,10 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-import QtQuick			2.11
-import QtQuick.Controls 2.4
-import QtQuick.Layouts	1.3
-
-import JASP.Widgets		1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import JASP.Widgets
 
 FocusScope
 {
@@ -271,7 +270,7 @@ FocusScope
 				anchors
 				{
 					top:					openADataFile.bottom
-					topMargin:				(openADataFile.height * 2.5) - (height / 2)
+					topMargin:				(openADataFile.height * 2) - (height / 2)
 					horizontalCenter:		openADataFile.horizontalCenter
 				}
 
@@ -303,27 +302,14 @@ FocusScope
 
 			property int widthOverflowers:	width * 0.9
 
-			Text
+			Supporters
 			{
-				id:						keepInMindBeta
-				text:					qsTr("Please keep in mind that this is a preview release and a number of features are still missing.\n\nIf JASP doesn’t do all you want today, then check back tomorrow: JASP is being developed at break-neck speed!").replace(/, /g, ",&nbsp;").replace(/\n\n/g, "<br><br>")
-				font.family:			jaspTheme.font
-				font.pixelSize:			12 * welcomeRoot.scaler
-				font.weight:			Font.Normal
-				color:					jaspTheme.white
 				width:					parent.widthOverflowers
-				wrapMode:				TextEdit.Wrap
-				renderType:				Text.QtRendering
-				textFormat:				Text.StyledText
-//				readOnly:				true
-//				selectByKeyboard:		false
-//				selectByMouse:			false
-				horizontalAlignment:	Text.AlignHCenter
 
 				anchors
 				{
 					bottom:				parent.bottom
-					bottomMargin:		-20
+					bottomMargin:		-15
 					horizontalCenter:	parent.horizontalCenter
 				}
 			}

--- a/Desktop/components/JASP/Widgets/qmldir
+++ b/Desktop/components/JASP/Widgets/qmldir
@@ -36,3 +36,5 @@ ErrorMessage				1.0 ErrorMessage.qml
 EnginesWindow				1.0 EnginesWindow.qml
 ResizeDataDialog			1.0	ResizeDataDialog.qml
 RenameColumnDialog			1.0	RenameColumnDialog.qml
+WavyWindow                  1.0 WavyWindow.qml
+Supporters                  1.0 Supporters.qml

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -376,7 +376,8 @@ void MainWindow::makeConnections()
 
 	connect(_fileMenu,				&FileMenu::exportSelected,							_resultsJsInterface,	&ResultsJsInterface::exportSelected							);
 	connect(_fileMenu,				&FileMenu::dataSetIORequest,						this,					&MainWindow::dataSetIORequestHandler						);
-	connect(_fileMenu,				&FileMenu::showAbout,								this,					&MainWindow::showAbout										);	
+	connect(_fileMenu,				&FileMenu::showAbout,								this,					&MainWindow::showAbout										);
+	connect(_fileMenu,				&FileMenu::showContact,								this,					&MainWindow::showContact									);
 
 	connect(_odm,					&OnlineDataManager::progress,						this,					&MainWindow::setProgressStatus,								Qt::QueuedConnection);
 
@@ -570,6 +571,7 @@ void MainWindow::loadQML()
 
 	Log::log() << "Loading HelpWindow"  << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/HelpWindow.qml"));
 	Log::log() << "Loading AboutWindow" << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/AboutWindow.qml"));
+	Log::log() << "Loading ContactWindow" << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/ContactWindow.qml"));
 	Log::log() << "Loading MainWindow"  << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/MainWindow.qml"));
 
 	
@@ -1633,6 +1635,13 @@ void MainWindow::showAbout()
 	_aboutModel->setVisible(true);
 }
 
+void MainWindow::showContact()
+{
+	setContactVisible(true);
+}
+
+
+
 
 void MainWindow::startDataEditorEventCompleted(FileEvent* event)
 {
@@ -1976,4 +1985,17 @@ QString MainWindow::versionString()
 		+	" (" + QString::fromStdString(AppInfo::getArchLabel()) + ")"
 #endif
 			;
+}
+
+bool MainWindow::contactVisible() const
+{
+	return _contactVisible;
+}
+
+void MainWindow::setContactVisible(bool newContactVisible)
+{
+	if (_contactVisible == newContactVisible)
+		return;
+	_contactVisible = newContactVisible;
+	emit contactVisibleChanged();
 }

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -80,6 +80,7 @@ class MainWindow : public QObject
 	Q_PROPERTY(bool		analysesAvailable	READ analysesAvailable										NOTIFY analysesAvailableChanged		)
 	Q_PROPERTY(bool		welcomePageVisible	READ welcomePageVisible		WRITE setWelcomePageVisible		NOTIFY welcomePageVisibleChanged	)
 	Q_PROPERTY(QString	downloadNewJASPUrl	READ downloadNewJASPUrl		WRITE setDownloadNewJASPUrl		NOTIFY downloadNewJASPUrlChanged	)
+	Q_PROPERTY(bool		contactVisible		READ contactVisible			WRITE setContactVisible			NOTIFY contactVisibleChanged		)
 
 
 	friend class FileMenu;
@@ -105,6 +106,9 @@ public:
 
 	static MainWindow * singleton() { return _singleton; }
 
+	bool contactVisible() const;
+	void setContactVisible(bool newContactVisible);
+
 public slots:
 	void setImageBackgroundHandler(QString value);
 	void plotPPIChangedHandler(int ppi, bool wasUserAction);
@@ -123,6 +127,7 @@ public slots:
 	void clearModulesFoldersUser();
 
 	void showAbout();
+	void showContact();
 
 	void saveKeyPressed();
 	void saveAsKeyPressed();
@@ -210,6 +215,8 @@ signals:
 	void hideDataPanel();
 	void exitSignal(				int			returnCode = 0) const;
 	void showComputedColumn(		QString		columnName);
+
+	void contactVisibleChanged();
 
 private slots:
 	void resultsPageLoaded();
@@ -310,7 +317,8 @@ private:
 									_analysesAvailable		= false,
 									_savingForClose			= false,
 									_welcomePageVisible		= true,
-									_checkAutomaticSync		= false;
+									_checkAutomaticSync		= false,
+									_contactVisible			= false;
 									
 	QFont							_defaultFont;
 };

--- a/Desktop/widgets/filemenu/actionbuttons.cpp
+++ b/Desktop/widgets/filemenu/actionbuttons.cpp
@@ -26,9 +26,10 @@ void ActionButtons::loadButtonData(std::vector<ActionButtons::DataRow> &data)
 		{FileOperation::SaveAs,			tr("Save As"),			false,	{ResourceButtons::Computer, ResourceButtons::OSF }																								},
 		{FileOperation::ExportResults,	tr("Export Results"),	false,	{ResourceButtons::Computer, ResourceButtons::OSF }																								},
 		{FileOperation::ExportData,		tr("Export Data"),		false,	{ResourceButtons::Computer, ResourceButtons::OSF }																								},
-		{FileOperation::SyncData,		tr("Sync Data"),		false,	{ResourceButtons::Computer, ResourceButtons::OSF, ResourceButtons::Database, ResourceButtons::CurrentFile}																	},
+		{FileOperation::SyncData,		tr("Sync Data"),		false,	{ResourceButtons::Computer, ResourceButtons::OSF, ResourceButtons::Database, ResourceButtons::CurrentFile}										},
 		{FileOperation::Close,			tr("Close"),			false,	{}																																				},
 		{FileOperation::Preferences,	tr("Preferences"),		true,	{ResourceButtons::PrefsData, ResourceButtons::PrefsResults, ResourceButtons::PrefsUI, ResourceButtons::PrefsAdvanced}							},
+		{FileOperation::Contact,		tr("Contact"),			true,	{}																																				},
 		{FileOperation::About,			tr("About"),			true,	{}																																				}
 	  };
 }

--- a/Desktop/widgets/filemenu/actionbuttons.h
+++ b/Desktop/widgets/filemenu/actionbuttons.h
@@ -12,7 +12,7 @@ class ActionButtons : public QAbstractListModel
 	Q_PROPERTY(FileOperation selectedAction READ selectedAction WRITE setSelectedAction NOTIFY selectedActionChanged)
 
 public:
-	enum FileOperation {None = 0, Open, Save, SaveAs, ExportResults, ExportData, SyncData, Close, Preferences, About};
+	enum FileOperation {None = 0, Open, Save, SaveAs, ExportResults, ExportData, SyncData, Close, Preferences, Contact, About};
 	Q_ENUM(FileOperation)
 
 	struct DataRow { FileOperation operation; QString name; bool enabled; std::set<ResourceButtons::ButtonType> resourceButtons; };

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -54,6 +54,7 @@ FileMenu::FileMenu(QObject *parent) : QObject(parent)
 	_actionButtons->setEnabled(ActionButtons::SyncData,			false);
 	_actionButtons->setEnabled(ActionButtons::Close,			false);
 	_actionButtons->setEnabled(ActionButtons::Preferences,		true);
+	_actionButtons->setEnabled(ActionButtons::Contact,			true);
 	_actionButtons->setEnabled(ActionButtons::About,			true);
 
 	setResourceButtonsVisibleFor(_fileoperation);
@@ -411,6 +412,12 @@ void FileMenu::actionButtonClicked(const ActionButtons::FileOperation action)
 		setVisible(false);
 		showAboutRequest();
 		break;
+
+	case ActionButtons::FileOperation::Contact:
+		setVisible(false);
+		showContactRequest();
+		break;
+
 	default:
 		break;
 	}
@@ -425,6 +432,11 @@ void FileMenu::resourceButtonClicked(const int buttonType)
 void FileMenu::showAboutRequest()
 {
 	emit showAbout();
+}
+
+void FileMenu::showContactRequest()
+{
+	emit showContact();
 }
 
 void FileMenu::setSyncRequest(const QString& path, bool waitForExistence)

--- a/Desktop/widgets/filemenu/filemenu.h
+++ b/Desktop/widgets/filemenu/filemenu.h
@@ -110,6 +110,7 @@ signals:
 	void visibleChanged(bool visible);
 	void dummyChangedNotifier();
 	void showAbout();
+	void showContact();
 	void modeChanged(FileEvent::FileMode mode);
 
 public slots:
@@ -124,6 +125,7 @@ public slots:
 	void showFileOpenMenu();
 	void resourceButtonClicked(const int buttonType);
 	void showAboutRequest();
+	void showContactRequest();
 	void dataColumnAdded(QString columnName);
 	void analysesExportResults();
 	void refresh();


### PR DESCRIPTION
Implements https://github.com/jasp-stats/INTERNAL-jasp/issues/2380

- add supporters to welcomepage
- make sure supporters dont collide with new version button
- Add contact window

<img width="1970" alt="image" src="https://github.com/jasp-stats/jasp-desktop/assets/29062713/2ef5afc3-6ef6-4baa-8855-2498107ae9b5">

Looks good like this @EJWagenmakers  @JohnnyDoorn  ?