### PR TITLE
Fixed width column and operatorlists

### DIFF
--- a/Desktop/components/JASP/Widgets/FilterConstructor/ColumnDrag.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ColumnDrag.qml
@@ -6,6 +6,8 @@ DragGeneric {
 
 	shownChild: showMe
 	dragKeys: showMe.dragKeys
+    
+    property alias maxSize: showMe.maxSize
 
 	JASPColumn
 	{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
@@ -142,6 +142,7 @@ FocusScope
 			anchors.top:	parent.top
 			anchors.left:	columnsLeftScrollBar.right
 			anchors.bottom:	parent.bottom
+            width:          maxWidth
 		}
 	}
 
@@ -153,13 +154,8 @@ FocusScope
 		anchors.left: columnList.right
 		anchors.right: funcVarLists.left
 		anchors.bottom: parent.bottom
-		//border.width: 1
-		//border.color: "grey"
 
 		z: -1
-		//clip: true
-
-
 
 		Rectangle
 		{
@@ -355,8 +351,6 @@ FocusScope
 				margins:		2 * preferencesModel.uiScale
 				bottomMargin:	filterConstructor.extraSpaceUnderColumns + filterConstructor.blockDim
 			}
-
-			width:	80 * preferencesModel.uiScale //for init or something?
 		}
 	}
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
@@ -4,29 +4,21 @@ import QtQuick 2.0
 ListView
 {
 	id:						listOfStuff
-	width:					0
+    implicitWidth:          130 * jaspTheme.uiScale
 	spacing:				4
 	maximumFlickVelocity:	jaspTheme.maximumFlickVelocity
 	boundsBehavior:			Flickable.StopAtBounds
 
 
 	property string	__debugName:	"ElementView"
-	property real	maxWidth:		300 * preferencesModel.uiScale
+	property real	maxWidth:		180 * preferencesModel.uiScale
 	property real	widthMargin:	10
-
-	property int	_recalculateWidth: 0 //To trigger a recalculation of the width from the delegates
-
-	onMaxWidthChanged:
-	{
-		listOfStuff.width = 0;
-		_recalculateWidth++;
-	}
 
 	delegate: MouseArea
 	{
 
-		width:  orientation === ListView.Horizontal ? elementLoader.width	: ListView.view.width
-		height: orientation === ListView.Horizontal ? ListView.view.height	: elementLoader.height
+		implicitWidth:  orientation === ListView.Horizontal ? elementLoader.item.width	: ListView.view.width
+		implicitHeight: orientation === ListView.Horizontal ? ListView.view.height	: elementLoader.item.height
 
 		z: 5
 
@@ -101,24 +93,6 @@ ListView
 															 separatorComp :
 															 defaultComp
 
-			function calcWidth()
-			{
-				if(listOfStuff.orientation !== ListView.Horizontal && listOfStuff.width < width + listOfStuff.widthMargin)
-					listOfStuff.width = width + listOfStuff.widthMargin
-
-			}
-
-			property int _recalculateWidth: 0
-
-			onLoaded:
-			{
-				_recalculateWidth = Qt.binding(function() { return listOfStuff._recalculateWidth; } )
-
-				calcWidth()
-			}
-
-			on_RecalculateWidthChanged: calcWidth()
-			onWidthChanged: calcWidth()
 		}
 
 		onDoubleClicked: alternativeDropFunctionDef()
@@ -130,7 +104,7 @@ ListView
 		Component { id: stringComp;			StringDrag				{ toolTipText: listToolTip; text: listText;										alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: separatorComp;		Item					{ height: filterConstructor.blockDim; width: listWidth - listOfStuff.widthMargin; Rectangle { height: 1; color: jaspTheme.black; width: parent.width ; anchors.centerIn: parent }  } }
 		Component { id: defaultComp;		Text					{ text: "Something wrong!"; color: jaspTheme.red }  }
-		Component {	id: columnComp;			ColumnDrag				{ toolTipText: listToolTip; columnName: listColName; columnIcon: listColIcon;		alternativeDropFunction: alternativeDropFunctionDef } }
+        Component {	id: columnComp;			ColumnDrag				{ toolTipText: listToolTip; columnName: listColName; columnIcon: listColIcon;		alternativeDropFunction: alternativeDropFunctionDef; maxSize: listOfStuff.maxWidth } }
 	}
 
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
@@ -1,6 +1,6 @@
-import JASP.Controls 1.0
-import QtQuick.Controls 2.2
-import QtQuick 2.9
+import JASP.Controls
+import QtQuick.Controls
+import QtQuick
 
 
 Item
@@ -163,6 +163,7 @@ Item
 				anchors.top:	parent.top
 				anchors.left:	columnsLeftScrollBar.right
 				anchors.bottom:	parent.bottom
+                width:          maxWidth
 			}
 		}
 
@@ -326,7 +327,7 @@ Item
 					bottomMargin:	filterConstructor.extraSpaceUnderColumns + filterConstructor.blockDim
 				}
 
-				width:	80 * preferencesModel.uiScale //for init or something?
+				//width:	80 * preferencesModel.uiScale //for init or something?
 			}
 		}
 	}

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -10,7 +10,8 @@ Item
 
 	property real	maxSize:		baseFontSize * 10 * preferencesModel.uiScale
 					height:			filterConstructor.blockDim
-					width:			colIcon.width + colName.width
+					implicitWidth:	colIcon.width + colName.width
+                    width:          implicitWidth
 	property bool	isNumerical:	columnIcon.indexOf("scale") >= 0
 	property bool	isOrdinal:		columnIcon.indexOf("ordinal") >= 0
 
@@ -53,7 +54,7 @@ Item
 			bottom:		parent.bottom
 		}
 
-		width:			Math.min(columnNameMeasure.width + 10, jaspColumnRoot.maxSize)
+        width:          Math.min(columnNameMeasure.width + 10, jaspColumnRoot.maxSize - colIcon.width)
 		font.pixelSize: baseFontSize * preferencesModel.uiScale
 		color:			jaspTheme.textEnabled
 		leftPadding:	2


### PR DESCRIPTION
so Qt 6.5.2 breaks the automatic (though hacky) determining of width for the lists left and right of the filterconstructor and computedcolumnconstructor

Couldnt figure out why so now I just decided to set a static width so we can at least see the entries

