### PR TITLE
JASP cooperative window

### DIFF
--- a/Desktop/components/JASP/Widgets/ContactWindow.qml
+++ b/Desktop/components/JASP/Widgets/ContactWindow.qml
@@ -18,17 +18,26 @@ WavyWindow
 		id:				contactText
 		textFormat:		Text.RichText
 		text:
-"For <a href=\"https://github.com/jasp-stats/jasp-issues/issues/new?assignees=&labels=Feature+Request&projects=&template=feature-request.yml&title=%5BFeature+Request%5D%3A+\">feature requests</a> and <a href=\"https://github.com/jasp-stats/jasp-issues/issues/new?assignees=&labels=Bug&projects=&template=bug-report.yml&title=%5BBug%5D%3A+\">bug reports</a>: please post an issue on our GitHub page, <a href=\"https://jasp-stats.org/2018/03/29/request-feature-report-bug-jasp/\">as explained here.</a>
+qsTr("For <a href=\"%1\">feature requests</a> and <a href=\"%2\">bug reports</a>: please post an issue on our GitHub page, <a href=\"%3\">as explained here.</a>
 This will bring you in direct contact with the JASP software developers.
 
-For statistical questions: please post an issue <a href=\"https://forum.cogsci.nl/index.php?p=/categories/jasp-bayesfactor\">on the JASP Forum.</a>
+For statistical questions: please post an issue <a href=\"%4\">on the JASP Forum.</a>
 
-For information on the JASP Cooperative: please read <a href=\"https://jasp-stats.org/cooperative/\">the information on the JASP website</a>
+For information on the JASP Cooperative: please read <a href=\"%5\">the information on the JASP website</a>
 
-For suggesting we add your institution to the <a href=\"https://jasp-stats.org/world-map/\">JASP World Map</a> please send an email to <a href=\"mailto:communications@jasp-stats.org\">communications@jasp-stats.org</a>.
+For suggesting we add your institution to the <a href=\"%6\">JASP World Map</a> please send an email to <a href=\"%7\">communications@jasp-stats.org</a>.
 
-For individual donations: please visit <a href=\"https://jasp-stats.org/donate/\">the JASP website</a>.
-".replace(/&/g, "&amp;").replace(/, /g, ",&nbsp;").replace(/\n/g, "<br>")
+For individual donations: please visit <a href=\"%8\">the JASP website</a>.
+")
+.arg("https://github.com/jasp-stats/jasp-issues/issues/new?assignees=&labels=Feature+Request&projects=&template=feature-request.yml&title=%5BFeature+Request%5D%3A+")
+.arg("https://github.com/jasp-stats/jasp-issues/issues/new?assignees=&labels=Bug&projects=&template=bug-report.yml&title=%5BBug%5D%3A+")
+.arg("https://jasp-stats.org/2018/03/29/request-feature-report-bug-jasp/")
+.arg("https://forum.cogsci.nl/index.php?p=/categories/jasp-bayesfactor")
+.arg(mainWindow.coopUrl)
+.arg("https://jasp-stats.org/world-map/")
+.arg("mailto:communications@jasp-stats.org")
+.arg("https://jasp-stats.org/donate/")
+.replace(/&/g, "&amp;").replace(/, /g, ",&nbsp;").replace(/\n/g, "<br>")
 		color:			jaspTheme.textEnabled
 		leftPadding:	0
 		topPadding:		0

--- a/Desktop/components/JASP/Widgets/CooperativeWindow.qml
+++ b/Desktop/components/JASP/Widgets/CooperativeWindow.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import JASP.Widgets
+import JASP.Controls
+import QtQuick.Controls as QC
+
+WavyWindow
+{
+	id:				cooperativeWindow
+
+	visible:				mainWindow.cooperativeVisible
+	onVisibleChanged:		mainWindow.cooperativeVisible = visible
+	onCloseModel:			{ mainWindow.cooperativeVisible = false }
+
+	title:					qsTr("JASP Cooperative")
+
+	QC.TextArea
+	{
+		id:				cooperativeText
+		textFormat:		Text.RichText
+		text:
+			qsTr("<h3>Cooperative</h3>
+The institutions of higher learning that participate in the JASP Cooperative jointly support the maintenance and further development of JASP, therefore providing an invaluable educational service to their own students and to those of other institutions worldwide.
+
+If your institution is not yet part of the cooperative, you can <a href=\"%2\">suggest that they join</a>.
+
+<i>Educator Institutions:</i>
+%1").arg(
+	mainWindow.coopEducators
+).arg(
+	mainWindow.coopHowToSupport
+).replace(/&/g, "&amp;").replace(/, /g, ",&nbsp;").replace(/\n/g, "<br>")
+		color:			jaspTheme.textEnabled
+		leftPadding:	0
+		topPadding:		0
+		bottomPadding:	0
+		wrapMode:		TextEdit.Wrap
+		font.family:	jaspTheme.font
+		font.pixelSize:	16 * jaspTheme.uiScale
+		width:			parent.width * 0.8
+
+		selectByMouse:	true
+		readOnly:		true
+
+		onPressed:		(event)=>{ if (event.button === Qt.RightButton)	contextMenu.popup()  }
+
+		QC.Menu
+		{
+			id:		contextMenu
+			width:	120
+
+			QC.Action { text: qsTr("Select All");		onTriggered: cooperativeText.selectAll();	}
+			QC.Action { text: qsTr("Copy Selection");	onTriggered: cooperativeText.copy();		}
+		}
+
+		onLinkActivated:	(link)=>{ Qt.openUrlExternally(link) }
+
+		MouseArea
+		{
+			id:					cursorShower
+			acceptedButtons:	Qt.NoButton
+			hoverEnabled:		true
+			anchors.fill:		parent
+
+			cursorShape:		!containsMouse || cooperativeText.linkAt(mouseX, mouseY) === "" ? Qt.ArrowCursor : Qt.PointingHandCursor
+		}
+	}
+
+}
+

--- a/Desktop/components/JASP/Widgets/Supporters.qml
+++ b/Desktop/components/JASP/Widgets/Supporters.qml
@@ -49,14 +49,7 @@ Item
 
 			Repeater
 			{
-				model:
-				[
-					"Tilburg University",
-					"KU Leuven",
-					"Nyenrode Business University",
-					"M&S / Faculty of Social Sciences / Utrecht University",
-					"University of Amsterdam"
-				]
+				model:	mainWindow.coopThankYou
 
 				Text
 				{
@@ -98,7 +91,7 @@ Item
 		cursorShape:			Qt.PointingHandCursor
 		acceptedButtons:		Qt.LeftButton
 		anchors.fill:			parent
-		onClicked:				Qt.openUrlExternally("https://jasp-stats.org/how-to-support/")
+		onClicked:				Qt.openUrlExternally(mainWindow.coopHowToSupport)
 		z:						-8
 	}
 }

--- a/Desktop/cooperativedefs.h
+++ b/Desktop/cooperativedefs.h
@@ -1,0 +1,54 @@
+#ifndef COOPERATIVEDEFS_H
+#define COOPERATIVEDEFS_H
+
+#include "QStringList"
+
+namespace Coop
+{
+
+const QStringList & welcomepageThankYous()
+{
+	// Want to thank an institution on the welcomepage?
+	// Just add an entry in the list below:
+	static QStringList list =
+	{
+		"University of Amsterdam",
+		"M&S / Faculty of Social Sciences / Utrecht University",
+		"Nyenrode Business University",
+		"KU Leuven",
+		"Tilburg University",
+	};
+
+	return list;
+}
+
+const QStringList & educatorsTier()
+{
+	// Want to add an institution to the educators tier in the cooperative window?
+	// Just add an entry in the list below:
+	static QStringList list =
+	{
+		"University of Amsterdam",
+		"Utrecht University",
+		"Nyenrode Business University",
+		"KU Leuven",
+		"Tilburg University",
+	};
+
+	return list;
+}
+
+const QString & howToSupport()
+{
+	static QString howTo = "https://jasp-stats.org/how-to-support/";
+	return howTo;
+}
+
+const QString & cooperativeUrl()
+{
+	static QString coop = "https://jasp-stats.org/cooperative/";
+	return coop;
+}
+
+}
+#endif // COOPERATIVEDEFS_H

--- a/Desktop/cooperativedefs.h
+++ b/Desktop/cooperativedefs.h
@@ -6,7 +6,7 @@
 namespace Coop
 {
 
-const QStringList & welcomepageThankYous()
+const QStringList & educatorsTier()
 {
 	// Want to thank an institution on the welcomepage?
 	// Just add an entry in the list below:
@@ -22,31 +22,15 @@ const QStringList & welcomepageThankYous()
 	return list;
 }
 
-const QStringList & educatorsTier()
-{
-	// Want to add an institution to the educators tier in the cooperative window?
-	// Just add an entry in the list below:
-	static QStringList list =
-	{
-		"University of Amsterdam",
-		"Utrecht University",
-		"Nyenrode Business University",
-		"KU Leuven",
-		"Tilburg University",
-	};
-
-	return list;
-}
-
 const QString & howToSupport()
 {
-	static QString howTo = "https://jasp-stats.org/how-to-support/";
+	static QString howTo = "https://jasp-stats.org/cooperative-how-to-join/";
 	return howTo;
 }
 
 const QString & cooperativeUrl()
 {
-	static QString coop = "https://jasp-stats.org/cooperative/";
+	static QString coop = "https://jasp-stats.org/cooperative-vision-and-goals/";
 	return coop;
 }
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -89,6 +89,8 @@
 #include "boost/iostreams/stream.hpp"
 #include <boost/iostreams/device/null.hpp>
 
+#include "cooperativedefs.h"
+
 using namespace std;
 using namespace Modules;
 
@@ -255,6 +257,39 @@ QString MainWindow::windowTitle() const
 	return _package->windowTitle();
 }
 
+const QStringList & MainWindow::coopThankYou() const
+{
+	return Coop::welcomepageThankYous();
+}
+
+const QString & MainWindow::coopEducators() const
+{
+	//Little magic trick ;)
+	static QString educators = []()->QString
+	{
+		QStringList tmp = Coop::educatorsTier();
+
+		if(tmp.size() == 0)
+			return "Something is wrong with Coop::educatorsTier()";
+
+		tmp[tmp.size()-1].prepend(tr("and "));
+
+		return tmp.join(", ");
+	}();
+
+	return educators;
+}
+
+const QString & MainWindow::coopHowToSupport() const
+{
+	return Coop::howToSupport();
+}
+
+const QString & MainWindow::coopUrl() const
+{
+	return Coop::cooperativeUrl();
+}
+
 bool MainWindow::checkDoSync()
 {
 	//Only do this if we are *not* running in reporting mode. 
@@ -378,6 +413,7 @@ void MainWindow::makeConnections()
 	connect(_fileMenu,				&FileMenu::dataSetIORequest,						this,					&MainWindow::dataSetIORequestHandler						);
 	connect(_fileMenu,				&FileMenu::showAbout,								this,					&MainWindow::showAbout										);
 	connect(_fileMenu,				&FileMenu::showContact,								this,					&MainWindow::showContact									);
+	connect(_fileMenu,				&FileMenu::showCooperative,							this,					&MainWindow::showCooperative								);
 
 	connect(_odm,					&OnlineDataManager::progress,						this,					&MainWindow::setProgressStatus,								Qt::QueuedConnection);
 
@@ -569,10 +605,11 @@ void MainWindow::loadQML()
 
 
 
-	Log::log() << "Loading HelpWindow"  << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/HelpWindow.qml"));
-	Log::log() << "Loading AboutWindow" << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/AboutWindow.qml"));
-	Log::log() << "Loading ContactWindow" << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/ContactWindow.qml"));
-	Log::log() << "Loading MainWindow"  << std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/MainWindow.qml"));
+	Log::log() << "Loading HelpWindow"			<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/HelpWindow.qml"));
+	Log::log() << "Loading AboutWindow"			<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/AboutWindow.qml"));
+	Log::log() << "Loading ContactWindow"		<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/ContactWindow.qml"));
+	Log::log() << "Loading CooperativeWindow"	<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/CooperativeWindow.qml"));
+	Log::log() << "Loading MainWindow"			<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/MainWindow.qml"));
 
 	
 	//To make sure we connect to the "main datasetview":
@@ -1650,8 +1687,10 @@ void MainWindow::showContact()
 	setContactVisible(true);
 }
 
-
-
+void MainWindow::showCooperative()
+{
+	setCooperativeVisible(true);
+}
 
 void MainWindow::startDataEditorEventCompleted(FileEvent* event)
 {
@@ -2008,4 +2047,17 @@ void MainWindow::setContactVisible(bool newContactVisible)
 		return;
 	_contactVisible = newContactVisible;
 	emit contactVisibleChanged();
+}
+
+bool MainWindow::cooperativeVisible() const
+{
+	return _cooperativeVisible;
+}
+
+void MainWindow::setCooperativeVisible(bool newCooperativeVisible)
+{
+	if (_cooperativeVisible == newCooperativeVisible)
+		return;
+	_cooperativeVisible = newCooperativeVisible;
+	emit cooperativeVisibleChanged();
 }

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -259,7 +259,7 @@ QString MainWindow::windowTitle() const
 
 const QStringList & MainWindow::coopThankYou() const
 {
-	return Coop::welcomepageThankYous();
+	return Coop::educatorsTier();
 }
 
 const QString & MainWindow::coopEducators() const

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -71,43 +71,51 @@ using Modules::Upgrader;
 class MainWindow : public QObject
 {
 	Q_OBJECT
-	Q_PROPERTY(bool		progressBarVisible	READ progressBarVisible		WRITE setProgressBarVisible		NOTIFY progressBarVisibleChanged	)
-	Q_PROPERTY(int		progressBarProgress	READ progressBarProgress	WRITE setProgressBarProgress	NOTIFY progressBarProgressChanged	)
-	Q_PROPERTY(QString	progressBarStatus	READ progressBarStatus		WRITE setProgressBarStatus		NOTIFY progressBarStatusChanged		)
-	Q_PROPERTY(QString	windowTitle			READ windowTitle											NOTIFY windowTitleChanged			)
-	Q_PROPERTY(int		screenPPI			READ screenPPI				WRITE setScreenPPI				NOTIFY screenPPIChanged				)
-	Q_PROPERTY(bool		dataAvailable		READ dataAvailable											NOTIFY dataAvailableChanged			)
-	Q_PROPERTY(bool		analysesAvailable	READ analysesAvailable										NOTIFY analysesAvailableChanged		)
-	Q_PROPERTY(bool		welcomePageVisible	READ welcomePageVisible		WRITE setWelcomePageVisible		NOTIFY welcomePageVisibleChanged	)
-	Q_PROPERTY(QString	downloadNewJASPUrl	READ downloadNewJASPUrl		WRITE setDownloadNewJASPUrl		NOTIFY downloadNewJASPUrlChanged	)
-	Q_PROPERTY(bool		contactVisible		READ contactVisible			WRITE setContactVisible			NOTIFY contactVisibleChanged		)
+	Q_PROPERTY(bool			progressBarVisible	READ progressBarVisible		WRITE setProgressBarVisible		NOTIFY progressBarVisibleChanged	)
+	Q_PROPERTY(int			progressBarProgress	READ progressBarProgress	WRITE setProgressBarProgress	NOTIFY progressBarProgressChanged	)
+	Q_PROPERTY(QString		progressBarStatus	READ progressBarStatus		WRITE setProgressBarStatus		NOTIFY progressBarStatusChanged		)
+	Q_PROPERTY(QString		windowTitle			READ windowTitle											NOTIFY windowTitleChanged			)
+	Q_PROPERTY(int			screenPPI			READ screenPPI				WRITE setScreenPPI				NOTIFY screenPPIChanged				)
+	Q_PROPERTY(bool			dataAvailable		READ dataAvailable											NOTIFY dataAvailableChanged			)
+	Q_PROPERTY(bool			analysesAvailable	READ analysesAvailable										NOTIFY analysesAvailableChanged		)
+	Q_PROPERTY(bool			welcomePageVisible	READ welcomePageVisible		WRITE setWelcomePageVisible		NOTIFY welcomePageVisibleChanged	)
+	Q_PROPERTY(QString		downloadNewJASPUrl	READ downloadNewJASPUrl		WRITE setDownloadNewJASPUrl		NOTIFY downloadNewJASPUrlChanged	)
+	Q_PROPERTY(bool			contactVisible		READ contactVisible			WRITE setContactVisible			NOTIFY contactVisibleChanged		)
+	Q_PROPERTY(bool			cooperativeVisible	READ cooperativeVisible		WRITE setCooperativeVisible		NOTIFY cooperativeVisibleChanged	)
+	Q_PROPERTY(QStringList	coopThankYou		READ coopThankYou											CONSTANT)
+	Q_PROPERTY(QString		coopEducators		READ coopEducators											CONSTANT)
+	Q_PROPERTY(QString		coopHowToSupport	READ coopHowToSupport										CONSTANT)
+	Q_PROPERTY(QString		coopUrl				READ coopUrl												CONSTANT)
 
 
 	friend class FileMenu;
 public:
 	explicit MainWindow(QApplication *application);
-	void open(QString filepath);
-	void open(const Json::Value & dbJson);
-	void testLoadedJaspFile(int timeOut, bool save);
-	void reportHere(QString dir);
-
-	~MainWindow() override;
-
-	bool	progressBarVisible()	const	{ return _progressBarVisible;	}
-	int		progressBarProgress()	const	{ return _progressBarProgress;	}
-	QString	progressBarStatus()		const	{ return _progressBarStatus;	}
-	QString	windowTitle()			const;
-	int		screenPPI()				const	{ return _screenPPI;			}
-	bool	dataAvailable()			const	{ return _dataAvailable;		}
-	bool	analysesAvailable()		const	{ return _analysesAvailable;	}
-	bool	welcomePageVisible()	const	{ return _welcomePageVisible;	}
-	bool	checkAutomaticSync()	const	{ return _checkAutomaticSync;	}
-	QString downloadNewJASPUrl()	const	{ return _downloadNewJASPUrl;	}
+			~MainWindow() override;
 
 	static MainWindow * singleton() { return _singleton; }
 
-	bool contactVisible() const;
-	void setContactVisible(bool newContactVisible);
+	void				open(QString filepath);
+	void				open(const Json::Value & dbJson);
+	void				testLoadedJaspFile(int timeOut, bool save);
+	void				reportHere(QString dir);
+
+	bool				progressBarVisible()	const	{ return _progressBarVisible;	}
+	int					progressBarProgress()	const	{ return _progressBarProgress;	}
+	const QString &		progressBarStatus()		const	{ return _progressBarStatus;	}
+	QString				windowTitle()			const;
+	int					screenPPI()				const	{ return _screenPPI;			}
+	bool				dataAvailable()			const	{ return _dataAvailable;		}
+	bool				analysesAvailable()		const	{ return _analysesAvailable;	}
+	bool				welcomePageVisible()	const	{ return _welcomePageVisible;	}
+	bool				checkAutomaticSync()	const	{ return _checkAutomaticSync;	}
+	bool				contactVisible()		const;
+	bool				cooperativeVisible()	const;
+	QString				downloadNewJASPUrl()	const	{ return _downloadNewJASPUrl;	}
+	const QStringList & coopThankYou()			const;
+	const QString &		coopEducators()			const;
+	const QString &		coopHowToSupport()		const;
+	const QString &		coopUrl()				const;
 
 public slots:
 	void setImageBackgroundHandler(QString value);
@@ -119,6 +127,8 @@ public slots:
 	void setAnalysesAvailable(bool analysesAvailable);
 	void setDataAvailable(bool dataAvailable);
 	void setScreenPPI(int screenPPI);
+	void setContactVisible(bool newContactVisible);
+	void setCooperativeVisible(bool newCooperativeVisible);
 
 	void showRCommander();
 
@@ -128,6 +138,7 @@ public slots:
 
 	void showAbout();
 	void showContact();
+	void showCooperative();
 
 	void saveKeyPressed();
 	void saveAsKeyPressed();
@@ -219,6 +230,8 @@ signals:
 	void showComputedColumn(		QString		columnName);
 
 	void contactVisibleChanged();
+
+	void cooperativeVisibleChanged();
 
 private slots:
 	void resultsPageLoaded();
@@ -320,7 +333,8 @@ private:
 									_savingForClose			= false,
 									_welcomePageVisible		= true,
 									_checkAutomaticSync		= false,
-									_contactVisible			= false;
+									_contactVisible			= false,
+									_cooperativeVisible		= false;
 									
 	QFont							_defaultFont;
 };

--- a/Desktop/widgets/filemenu/actionbuttons.cpp
+++ b/Desktop/widgets/filemenu/actionbuttons.cpp
@@ -30,6 +30,7 @@ void ActionButtons::loadButtonData(std::vector<ActionButtons::DataRow> &data)
 		{FileOperation::Close,			tr("Close"),			false,	{}																																				},
 		{FileOperation::Preferences,	tr("Preferences"),		true,	{ResourceButtons::PrefsData, ResourceButtons::PrefsResults, ResourceButtons::PrefsUI, ResourceButtons::PrefsAdvanced}							},
 		{FileOperation::Contact,		tr("Contact"),			true,	{}																																				},
+		{FileOperation::Cooperative,	tr("Cooperative"),		true,	{}																																				},
 		{FileOperation::About,			tr("About"),			true,	{}																																				}
 	  };
 }

--- a/Desktop/widgets/filemenu/actionbuttons.h
+++ b/Desktop/widgets/filemenu/actionbuttons.h
@@ -12,7 +12,7 @@ class ActionButtons : public QAbstractListModel
 	Q_PROPERTY(FileOperation selectedAction READ selectedAction WRITE setSelectedAction NOTIFY selectedActionChanged)
 
 public:
-	enum FileOperation {None = 0, Open, Save, SaveAs, ExportResults, ExportData, SyncData, Close, Preferences, Contact, About};
+	enum FileOperation {None = 0, Open, Save, SaveAs, ExportResults, ExportData, SyncData, Close, Preferences, Contact, Cooperative, About};
 	Q_ENUM(FileOperation)
 
 	struct DataRow { FileOperation operation; QString name; bool enabled; std::set<ResourceButtons::ButtonType> resourceButtons; };

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -55,6 +55,7 @@ FileMenu::FileMenu(QObject *parent) : QObject(parent)
 	_actionButtons->setEnabled(ActionButtons::Close,			false);
 	_actionButtons->setEnabled(ActionButtons::Preferences,		true);
 	_actionButtons->setEnabled(ActionButtons::Contact,			true);
+	_actionButtons->setEnabled(ActionButtons::Cooperative,		true);
 	_actionButtons->setEnabled(ActionButtons::About,			true);
 
 	setResourceButtonsVisibleFor(_fileoperation);
@@ -416,6 +417,12 @@ void FileMenu::actionButtonClicked(const ActionButtons::FileOperation action)
 	case ActionButtons::FileOperation::Contact:
 		setVisible(false);
 		showContactRequest();
+		break;
+
+
+	case ActionButtons::FileOperation::Cooperative:
+		setVisible(false);
+		showCooperative();
 		break;
 
 	default:

--- a/Desktop/widgets/filemenu/filemenu.h
+++ b/Desktop/widgets/filemenu/filemenu.h
@@ -111,6 +111,7 @@ signals:
 	void dummyChangedNotifier();
 	void showAbout();
 	void showContact();
+	void showCooperative();
 	void modeChanged(FileEvent::FileMode mode);
 
 public slots:


### PR DESCRIPTION
made the texts translatable
split off the url from the texts to mke sure translators cant mess up the urls
adds the extr button to the hamburgermenu "Cooperative" as well

The defines for the supporters on the welcomepage and the educators tier of the cooperative
have been placed conveniently in Desktop/cooperativedefs.h
so even non-technical contributors can update them easily
if we add other tiers later on they can be placed there in a similar manner