### PR TITLE
Fix data paste crash from some editors (#5274)

### DIFF
--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1232,10 +1232,8 @@ void DataSetView::paste(QPoint where)
 		size_t row = 0, col = 0;
 		for(const QString & rowStr : clipboard->text().split("\n"))
 		{
-			if(!rowStr.contains("\t")) //some editors might throw an empty line onto the end of the clipboard. Should at least have one value on the row
-				continue;
-
 			col = 0;
+			if (rowStr.isEmpty()) continue; // Some editors might throw an empty line onto the end of the clipboard. Should at least have one value on the row
 			for(const QString & cellStr : rowStr.split("\t"))
 			{
 				if(newData.size()		<= col) newData.	 resize(col+1);
@@ -1246,6 +1244,8 @@ void DataSetView::paste(QPoint where)
 			}
 			row++;
 		}
+		for(auto& column : newData)
+			column.resize(row); // Make sure that all columns have the same number of rows
 
 		Log::log() << "DataSetView about to paste data (" << col << " columns and " << row << " rows) at row: " << topLeft.y() << " and col: " << topLeft.x() << std::endl;
 

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1225,13 +1225,16 @@ void DataSetView::paste(QPoint where)
 		QPoint topLeft = isCell(where) ? where : selectionTopLeft();
 
 		QClipboard * clipboard = QGuiApplication::clipboard();
-		Log::log() << "Clipboard: " << clipboard->text();
+		//Log::log() << "Clipboard: " << clipboard->text(); //We should not log clipboard for privacy/data anonimity reasons
 
 		std::vector<std::vector<QString>> newData;
 
 		size_t row = 0, col = 0;
 		for(const QString & rowStr : clipboard->text().split("\n"))
 		{
+			if(!rowStr.contains("\t")) //some editors might throw an empty line onto the end of the clipboard. Should at least have one value on the row
+				continue;
+
 			col = 0;
 			for(const QString & cellStr : rowStr.split("\t"))
 			{


### PR DESCRIPTION
Fixes weird behavior and crashes upon pasting from other spreadsheet editors.

We could also merge this into stable and hotfix?

Should fix:
https://github.com/jasp-stats/jasp-issues/issues/2324