### PR TITLE
Add dataSetInfo properties

### DIFF
--- a/Desktop/data/columnsmodel.h
+++ b/Desktop/data/columnsmodel.h
@@ -32,6 +32,7 @@ public:
 
 	QVariant					provideInfo(VariableInfo::InfoType info, const QString& colName = "", int row = 0)	const	override;
 	QAbstractItemModel		*	providerModel()																				override	{ return this;	}
+	QQmlContext				*	providerQMLContext()																const	override;
 	static ColumnsModel		*	singleton()	{ return _singleton; }
 
 public slots:

--- a/QMLComponents/variableinfo.cpp
+++ b/QMLComponents/variableinfo.cpp
@@ -1,5 +1,7 @@
 #include "variableinfo.h"
 #include "jasptheme.h"
+#include "QQmlContext"
+#include "QTimer"
 
 VariableInfo* VariableInfo::_singleton = nullptr;
 
@@ -7,7 +9,16 @@ VariableInfo::VariableInfo(VariableInfoProvider* providerInfo) :
 	QObject(providerInfo->providerModel()), _provider(providerInfo)
 {
 	if (_singleton == nullptr)
+	{
 		_singleton = this;
+		QTimer::singleShot(0, [&]() { _setDataSetInfoInContext(); });
+	}
+}
+
+void VariableInfo::_setDataSetInfoInContext()
+{
+	QQmlContext* context = _provider->providerQMLContext();
+	context->setContextProperty("dataSetInfo", this);
 }
 
 VariableInfo *VariableInfo::info()
@@ -50,4 +61,14 @@ QString VariableInfo::getIconFile(columnType colType, VariableInfo::IconType typ
 	}
 
 	return ""; //We are never getting here but GCC isn't convinced
+}
+
+int VariableInfo::rowCount()
+{
+	return _provider ? _provider->provideInfo(VariableInfo::DataSetRowCount).toInt() : 0;
+}
+
+bool VariableInfo::dataAvailable()
+{
+	return _provider ? _provider->provideInfo(VariableInfo::DataAvailable).toBool() : false;
 }

--- a/QMLComponents/variableinfo.h
+++ b/QMLComponents/variableinfo.h
@@ -22,6 +22,7 @@
 #include <QVariant>
 #include <QIcon>
 #include <QAbstractItemModel>
+#include <QQmlContext>
 #include "columntype.h"
 
 class VariableInfoProvider;
@@ -36,16 +37,22 @@ class VariableInfo : public QObject
 {
 	Q_OBJECT
 public:
-	enum InfoType { VariableType, VariableTypeName, VariableTypeIcon, VariableTypeDisabledIcon, VariableTypeInactiveIcon, VariableNames, DataSetRowCount, Labels, DoubleValues, NameRole, DataSetValue, MaxWidth, SignalsBlocked };
+	enum InfoType { VariableType, VariableTypeName, VariableTypeIcon, VariableTypeDisabledIcon, VariableTypeInactiveIcon, VariableNames, DataSetRowCount, Labels, DoubleValues, NameRole, DataSetValue, MaxWidth, SignalsBlocked, DataAvailable };
 	enum IconType { DefaultIconType, DisabledIconType, InactiveIconType };
 
 public:
 	VariableInfo(VariableInfoProvider* provider);
 
+	Q_PROPERTY(int	rowCount		READ rowCount		NOTIFY rowCountChanged		)
+	Q_PROPERTY(bool	dataAvailable	READ dataAvailable	NOTIFY dataAvailableChanged	)
+
 	static VariableInfo*		info();
 	static QString				getIconFile(columnType colType, IconType type);
 
 	VariableInfoProvider*		provider()	{ return _provider; }
+
+	int rowCount();
+	bool dataAvailable();
 
 signals:
 	void namesChanged(QMap<QString, QString> changedNames);
@@ -53,8 +60,12 @@ signals:
 	void columnTypeChanged(QString colName);
 	void labelsChanged(QString columnName, QMap<QString, QString> changedLabels);
 	void labelsReordered(QString columnName);
+	void rowCountChanged();
+	void dataAvailableChanged();
 
-private:
+private:	
+	void _setDataSetInfoInContext();
+
 	VariableInfoProvider *	_provider	= nullptr;
 
 	static VariableInfo *_singleton;
@@ -65,6 +76,7 @@ class VariableInfoProvider
 public:
 	virtual QVariant				provideInfo(VariableInfo::InfoType info, const QString& name = "", int row = 0)	const	= 0;
 	virtual QAbstractItemModel*		providerModel()																			{ return nullptr;			}
+	virtual QQmlContext*			providerQMLContext()															const	= 0;
 };
 
 class VariableInfoConsumer


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2413

The QML files use dataSetModel.rowCount() and mainWindow.dataAvailiable. There are 2 problems with this: 

- First, QML analysis files should not use objects that are not defined outside the QMLComponents library (which will become a submodule), since these QML files will be used outside JASP (in R Studio).
- Second, dataSetModel.rowCount()  is a function, not a property, so it cannot signal its changes. So it should be made as a property.

For this, an object dataSetInfo is made available in the root context with 2 properties dataAvailable & rowCount. The provider (here the ColumnsModel) has to take care that the signals are well propagated.

When this PR is merged, the QML files will have to be updated.

