### PR TITLE
Filter settings should be removed after closing the workspace

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -137,6 +137,8 @@ void DataSetPackage::reset(bool newDataSet)
 	_dataMode					= false;
 	_manualEdits				= false;
 
+	_columnNameUsedInEasyFilter.clear();
+
 	setLoaded(false);
 	setModified(false);
 	setSynchingExternally(false); //Default is off, AsyncLoader::loadPackage(...) will turn it on for non-jasp

--- a/Desktop/data/filtermodel.cpp
+++ b/Desktop/data/filtermodel.cpp
@@ -124,7 +124,7 @@ void FilterModel::setConstructorR(QString newConstructorR)
 			DataSetPackage::filter()->setConstructorR(fq(newConstructorR));
 
 		emit constructorRChanged();
-		emit updateGeneratedFilterWithR(newConstructorR);
+		setGeneratedFilter(tq(_labelFilterGenerator->generateFilter()));
 	}
 }
 void FilterModel::setGeneratedFilter(QString newGeneratedFilter)

--- a/Desktop/data/filtermodel.h
+++ b/Desktop/data/filtermodel.h
@@ -79,7 +79,6 @@ signals:
 	void constructorJsonChanged();
 
 	void updateColumnsUsedInConstructedFilter(std::set<std::string> columnNames);
-	void updateGeneratedFilterWithR(QString constructorR);
 
 	void refreshAllAnalyses();
 	void filterUpdated();

--- a/Desktop/data/labelfiltergenerator.cpp
+++ b/Desktop/data/labelfiltergenerator.cpp
@@ -18,13 +18,15 @@ std::string labelFilterGenerator::generateFilter()
 			neededFilters++;
 
 	std::stringstream newGeneratedFilter;
+	Filter* filter = DataSetPackage::pkg()->filter();
+	std::string filterRScript = filter ? filter->constructorR() : "";
 
 	newGeneratedFilter << "generatedFilter <- ";
 
 	if(neededFilters == 0)
 	{
-		if(easyFilterConstructorRScript == "")	return DEFAULT_FILTER_GEN;
-		else									newGeneratedFilter << "("<< easyFilterConstructorRScript <<")";
+		if(filterRScript == "")	return DEFAULT_FILTER_GEN;
+		else					newGeneratedFilter << "("<< filterRScript <<")";
 	}
 	else
 	{
@@ -44,8 +46,8 @@ std::string labelFilterGenerator::generateFilter()
 		if(moreThanOne)
 			newGeneratedFilter << ")";
 
-		if(easyFilterConstructorRScript != "")
-				newGeneratedFilter << " & \n("<<easyFilterConstructorRScript<<")";
+		if(filterRScript != "")
+				newGeneratedFilter << " & \n("<<filterRScript<<")";
 	}
 
 	return newGeneratedFilter.str();
@@ -84,13 +86,4 @@ std::string	labelFilterGenerator::generateLabelFilter(size_t col)
 	out << ")";
 
 	return out.str();
-}
-
-void labelFilterGenerator::easyFilterConstructorRCodeChanged(QString newRScript)
-{
-	if(easyFilterConstructorRScript != newRScript.toStdString())
-	{
-		easyFilterConstructorRScript = newRScript.toStdString();
-		emit setGeneratedFilter(QString::fromStdString(generateFilter()));
-	}
 }

--- a/Desktop/data/labelfiltergenerator.h
+++ b/Desktop/data/labelfiltergenerator.h
@@ -20,14 +20,10 @@ public:
 
 public slots:
 	void labelFilterChanged();
-	void easyFilterConstructorRCodeChanged(QString newRScript);
 
 private:
 	///Generates sub-filter for specified column
-	std::string	generateLabelFilter(size_t col);
-
-	std::string easyFilterConstructorRScript = "";
-	
+	std::string	generateLabelFilter(size_t col);	
 	
 	ColumnModel * _columnModel = nullptr;
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -450,7 +450,6 @@ void MainWindow::makeConnections()
 	connect(_filterModel,			&FilterModel::updateColumnsUsedInConstructedFilter, _package,				&DataSetPackage::setColumnsUsedInEasyFilter					);
 	connect(_filterModel,			&FilterModel::filterUpdated,						_package,				&DataSetPackage::refresh									);
 	connect(_filterModel,			&FilterModel::sendFilter,							_engineSync,			&EngineSync::sendFilter										);
-	connect(_filterModel,			&FilterModel::updateGeneratedFilterWithR,			_labelFilterGenerator,	&labelFilterGenerator::easyFilterConstructorRCodeChanged	);
 
 	connect(_labelFilterGenerator,	&labelFilterGenerator::setGeneratedFilter,			_filterModel,			&FilterModel::setGeneratedFilter,							Qt::QueuedConnection);
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/2344

2 issues:

- the labelFilterGenerator keeps a copy of the R constructed filter string: this is unnecessary, it can use directly this string from the Filter object
- the _columnNameUsedInEasyFilter map in DataSetPackage must be cleared when it is reset.
- 
