### PR TITLE
Feat: Add video iframe support in annotation

### DIFF
--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -309,7 +309,7 @@ Item
 				else
 				{
 					request.reject();
-					console.log("Navigation requeste rejected:", requestedURL.hostname)
+					console.log("Navigation requested rejected:", requestedURL.hostname)
 				}
 			}
 

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -268,7 +268,7 @@ Item
 					} 
 					else if (pattern.indexOf('*') !== -1)
 					{
-						const regex = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
+						var regex = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
 						if (regex.test(hostname))
 						{
 							return true;

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -270,9 +270,12 @@ Item
 			onFullScreenRequested: function(request) 
 			{
 				request.accept()
-				analysesModel.visible = false
-				minimizeDataPanel()
-				mainWindowRoot.toggleFullScreen()
+
+				if(request.toggleOn)
+				{
+					analysesModel.visible = false
+					minimizeDataPanel()
+				}
 			}
 
 			onNavigationRequested: (request)=>

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -299,6 +299,8 @@ Item
 				{
 					request.reject();
 					console.log("Navigation requeste rejected:", requestedURL.hostname)
+
+					messages.showWarningQML(qsTr("Video link not accepted"), qsTr("JASP only allows the following videoservices: \n\n%1\n\nContact the JASP team to request adding another videoservice to the list.".arg(urlWhitelist.join(", "))));
 				}
 			}
 

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -255,14 +255,25 @@ Item
 				}
 			}
 
-			property var urlWhitelist : ['www.youtube.com', 'www.youtu.be', 'player.vimeo.com', 'www.bilibili.com', 'v.qq.com'];
+			property var urlWhitelist : ['www.youtube.com', 'www.youtu.be', '*.vimeo.com', '*.vimeocdn.com', '*.akamaized.net', '*.bilibili.com', '*.hdslb.com', '*.qq.com', '*.smtcdns.com'];
 
-			function isURLInWhitelist(hostname) 
+			function isURLInWhitelist(hostname)
 			{
-				for (var i = 0; i < urlWhitelist.length; i++) 
+				for (var i = 0; i < urlWhitelist.length; i++)
 				{
-					if (hostname === urlWhitelist[i]) 
+					var pattern = urlWhitelist[i];
+					if (pattern === hostname)
+					{
 						return true;
+					} 
+					else if (pattern.indexOf('*') !== -1)
+					{
+						const regex = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
+						if (regex.test(hostname))
+						{
+							return true;
+						}
+					}
 				}
 				return false;
 			}
@@ -299,8 +310,6 @@ Item
 				{
 					request.reject();
 					console.log("Navigation requeste rejected:", requestedURL.hostname)
-
-					messages.showWarningQML(qsTr("Video link not accepted"), qsTr("JASP only allows the following videoservices: \n\n%1\n\nContact the JASP team to request adding another videoservice to the list.".arg(urlWhitelist.join(", "))));
 				}
 			}
 
@@ -308,6 +317,7 @@ Item
 			{
 				resultsJsInterface.resultsLoaded = loadRequest.status === WebEngineView.LoadSucceededStatus;
 				setTranslatedResultsString();
+				runJavaScript(`window.sendUrlWhitelist(${JSON.stringify(urlWhitelist)})`); //sent urlWhitelist to js side
 			}
 
 
@@ -351,7 +361,9 @@ Item
 				"Background Color" : qsTr("Background Color"),  "Subscript" : qsTr("Subscript"), 	 "Superscript"  : qsTr("Superscript"),  "Blockquote"    : qsTr("Blockquote"), 		"Add Indent" : qsTr("Add Indent"),
 				"Remove Indent"   : qsTr("Remove Indent"), 	    "Font Size" : qsTr("Font Size"), "Clear Formatting" : qsTr("Clear Formatting"),			"Click here to add text" : qsTr("Click here to add text"),
 				"Copied to clipboard" : qsTr("Copied to clipboard"), "Citations copied to clipboard" : qsTr("Citations copied to clipboard"), 	"LaTeX code copied to clipboard" : qsTr("LaTeX code copied to clipboard"),
-				"Introduction:"		: qsTr("Introduction:"),  "Conclusion:" : qsTr("Conclusion:"), "Image" : qsTr("Image"), "Embed web video" : qsTr("Embed web video")
+				"Introduction:"		: qsTr("Introduction:"),  "Conclusion:" : qsTr("Conclusion:"), "Image" : qsTr("Image"), "Embed web video" : qsTr("Embed web video"), "Unsupported video services" : qsTr("Unsupported video services"), 
+				"JASP only allows the following videoservices:" : qsTr("JASP only allows the following videoservices:"), "Contact the JASP team to request adding another videoservice to the list." : qsTr("Contact the JASP team to request adding another videoservice to the list.")
+
 			}
 
 			function setTranslatedResultsString()

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -255,15 +255,47 @@ Item
 				}
 			}
 
+			property var urlWhitelist : ['www.youtube.com', 'www.youtu.be', 'player.vimeo.com', 'www.bilibili.com', 'v.qq.com'];
+
+			function isURLInWhitelist(hostname) 
+			{
+				for (var i = 0; i < urlWhitelist.length; i++) 
+				{
+					if (hostname === urlWhitelist[i]) 
+						return true;
+				}
+				return false;
+			}
+
+			onFullScreenRequested: function(request) 
+			{
+				request.accept()
+				analysesModel.visible = false
+				mainWindowRoot.toggleFullScreen()
+			}
+
 			onNavigationRequested: (request)=>
 			{
+				var requestedURL = new URL(request.url);
+
 				if(request.navigationType === WebEngineNavigationRequest.ReloadNavigation || request.url == resultsJsInterface.resultsPageUrl)
 					request.accept()
 				else
 				{
 					if(request.navigationType === WebEngineNavigationRequest.LinkClickedNavigation)
-						Qt.openUrlExternally(request.url);
-					request.reject();
+					{
+                        Qt.openUrlExternally(request.url);
+					}
+  					else if(isURLInWhitelist(requestedURL.hostname))
+					{
+						request.accept();
+						console.log("Navigation requeste accepted:", requestedURL.hostname)
+					}
+					else
+					{
+						request.reject();
+						console.log("Navigation requeste rejected:", requestedURL.hostname)
+					}
 				}
 			}
 
@@ -314,7 +346,7 @@ Item
 				"Background Color" : qsTr("Background Color"),  "Subscript" : qsTr("Subscript"), 	 "Superscript"  : qsTr("Superscript"),  "Blockquote"    : qsTr("Blockquote"), 		"Add Indent" : qsTr("Add Indent"),
 				"Remove Indent"   : qsTr("Remove Indent"), 	    "Font Size" : qsTr("Font Size"), "Clear Formatting" : qsTr("Clear Formatting"),			"Click here to add text" : qsTr("Click here to add text"),
 				"Copied to clipboard" : qsTr("Copied to clipboard"), "Citations copied to clipboard" : qsTr("Citations copied to clipboard"), 	"LaTeX code copied to clipboard" : qsTr("LaTeX code copied to clipboard"),
-				"Introduction:"		: qsTr("Introduction:"),  "Conclusion:" : qsTr("Conclusion:"), "Image" : qsTr("Image")
+				"Introduction:"		: qsTr("Introduction:"),  "Conclusion:" : qsTr("Conclusion:"), "Image" : qsTr("Image"), "Embed web video" : qsTr("Embed web video")
 			}
 
 			function setTranslatedResultsString()

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -271,6 +271,7 @@ Item
 			{
 				request.accept()
 				analysesModel.visible = false
+				minimizeDataPanel()
 				mainWindowRoot.toggleFullScreen()
 			}
 
@@ -279,23 +280,22 @@ Item
 				var requestedURL = new URL(request.url);
 
 				if(request.navigationType === WebEngineNavigationRequest.ReloadNavigation || request.url == resultsJsInterface.resultsPageUrl)
+				{
 					request.accept()
+				}
+				else if(request.navigationType === WebEngineNavigationRequest.LinkClickedNavigation)
+				{
+					Qt.openUrlExternally(request.url);
+				}
+				else if(isURLInWhitelist(requestedURL.hostname))
+				{
+					request.accept();
+					console.log("Navigation requeste accepted:", requestedURL.hostname)
+				}
 				else
 				{
-					if(request.navigationType === WebEngineNavigationRequest.LinkClickedNavigation)
-					{
-                        Qt.openUrlExternally(request.url);
-					}
-  					else if(isURLInWhitelist(requestedURL.hostname))
-					{
-						request.accept();
-						console.log("Navigation requeste accepted:", requestedURL.hostname)
-					}
-					else
-					{
-						request.reject();
-						console.log("Navigation requeste rejected:", requestedURL.hostname)
-					}
+					request.reject();
+					console.log("Navigation requeste rejected:", requestedURL.hostname)
 				}
 			}
 

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -255,7 +255,7 @@ Item
 				}
 			}
 
-			property var urlWhitelist : ['www.youtube.com', 'www.youtu.be', '*.vimeo.com', '*.vimeocdn.com', '*.akamaized.net', '*.bilibili.com', '*.hdslb.com', '*.qq.com', '*.smtcdns.com'];
+			property var urlWhitelist : ['www.youtube.com', 'www.youtu.be'] //'*.vimeo.com', '*.vimeocdn.com', '*.akamaized.net', '*.bilibili.com', '*.hdslb.com', '*.qq.com', '*.smtcdns.com'];
 
 			function isURLInWhitelist(hostname)
 			{

--- a/Desktop/html/css/darkTheme-jasp.css
+++ b/Desktop/html/css/darkTheme-jasp.css
@@ -190,8 +190,9 @@ div.jasp-image-image.no-data.error {
 
 
 /* not use color invert for img in annotations */
-.jasp-notes .ql-editor p img {
-  filter:  invert(1);
+.ql-editor p img,
+iframe.ql-video:not(:fullscreen) {
+    filter:  invert(1) !important;
 }
 
 

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -597,6 +597,14 @@ pre {
   font-family: monospace, monospace;
 }
 
+/* quill editor of jasp annotations styles */
+
+iframe.ql-video {
+	width: 100%;
+	padding: 15px;
+	min-height: 360px;
+  }
+
 /* The following code convinces webengine to have scrollbars that look sorta like JASPScrollBar */
 /* width */
 ::-webkit-scrollbar {

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -22,28 +22,106 @@ function i18n(str) {
 	}
 }
 
-if(insideJASP)
-{
+var videoUrlList = [];
+
+window.sendUrlWhitelist = function (RequestedURL) {
+	videoUrlList = RequestedURL; // to get from MainPage.qml
+}
+
+function isURLInWhitelist(hostname) {
+	for (var i = 0; i < videoUrlList.length; i++) {
+		var pattern = videoUrlList[i];
+		if (pattern === hostname) {
+			return true;
+		} else if (pattern.indexOf('*') !== -1) {
+			const regex = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
+			if (regex.test(hostname)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+if (insideJASP) {
 	var Parchment = Quill.import('parchment');
 
 	var LineBreakClass = new Parchment.Attributor.Class('linebreak', 'linebreak', {
-	scope: Parchment.Scope.BLOCK
+		scope: Parchment.Scope.BLOCK
 	});
 
 	Quill.register('modules/blotFormatter', QuillBlotFormatter.default);
 
 	Quill.register('formats/linebreak', LineBreakClass);
-	
+
 	// See https://github.com/quilljs/quill/issues/262
 	var Link = Quill.import('formats/link');
-	Link.sanitize = function(url) {
-        // Check if the url contains the protocol, otherwise add it automatically
-        var checkUrl = url.match(/^(http|https):\/\//i); 
-        if (!checkUrl) {
-            url = "https://" + url;
-          }
-        return url;
+	Link.sanitize = function (url) {
+		// Check if the url contains the protocol, otherwise add it automatically
+		var checkUrl = url.match(/^(http|https):\/\//i);
+		if (!checkUrl) {
+			url = "https://" + url;
+		}
+		return url;
 	}
+
+	function customVideoUrl(url) {
+		if (!/^(http|https):\/\//i.test(url)) {
+			url = 'https://' + url;
+		} else if (/^(http):\/\//i.test(url)) {
+			url = url.replace(/^http:/i, 'https:');
+		}
+		let matchs = url.match(/^(?:(https?):\/\/)?(?:(?:www|m)\.)?youtube\.com\/watch.*v=([a-zA-Z0-9_-]+)/) ||
+			url.match(/^(?:(https?):\/\/)?(?:(?:www|m)\.)?youtu\.be\/([a-zA-Z0-9_-]+)/) ||
+			url.match(/^.*(youtu.be\/|v\/|e\/|u\/\w+\/|embed\/|v=)([^#\&\?]*).*/);
+		if (matchs && matchs[2].length === 11) {
+			return ('https') + '://www.youtube.com/embed/' + matchs[2] + '?showinfo=0';
+		}
+		if (matchs = url.match(/^(?:(https?):\/\/)?(?:www\.)?vimeo\.com\/(\d+)/)) {
+			return (match[1] || 'https') + '://player.vimeo.com/video/' + matchs[2] + '/';
+		}
+		if (matchs = url.match(/(?:www\.|\/\/)bilibili\.com\/video\/(\w+)/)) {
+			return 'https://player.bilibili.com/player.html?bvid=' + matchs[1]
+
+		}
+		if (matchs = url.match(/\/\/v\.qq\.com\/x\/cover\/.*\/([^\/]+)\.html\??.*/)) {
+			return 'https://v.qq.com/txp/iframe/player.html?vid=' + matchs[1]
+		}
+		
+		return url
+	}
+
+	const BlockEmbed = Quill.import("blots/block/embed");
+
+	class EmbendVideo extends BlockEmbed {
+		static create(value) {
+			value = customVideoUrl(value)
+			let node = super.create(value);
+			let div = document.createElement('div');
+				div.setAttribute("title", i18n("Unsupported video services"));
+			$(div).append(`${i18n('JASP only allows the following videoservices:')}<br><br> <i>"Youtube, Vimeo, Bilibili, Tencent-Video"</i> <br><br>${i18n('Contact the JASP team to request adding another videoservice to the list.')}`)	
+			node.setAttribute('frameborder', '0');
+			node.setAttribute('allowfullscreen', true);
+			node.setAttribute('src', value);
+			if (!isURLInWhitelist((new URL(value).hostname)))
+				node.innerHTML = $(div).dialog({ // give a warnning for unsupported urls and then remove from node.
+					modal: true, buttons: {
+						Ok: function () {
+							$(node).remove();
+							$(this).dialog("close");
+						}
+					}
+				})
+			return node;
+		}
+	}
+
+	EmbendVideo.blotName = 'video';
+	EmbendVideo.className = 'ql-video';
+	EmbendVideo.tagName = 'IFRAME';
+
+	Quill.register(EmbendVideo);
+
 }
 
 JASPWidgets.Encodings = {

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -499,7 +499,7 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 		this.$el.append("<div id=\"editor\"></div>");
 
 		var toolbarOptions = [
-			['bold', 'italic', 'underline', 'link'], ['formula', 'code-block', 'image'],
+			['bold', 'italic', 'underline', 'link'], ['formula', 'code-block', 'image', 'video'],
 			// [{ 'size': ['small', false, 'large', 'huge'] }],
 			[{ 'header': [1, 2, 3, 4, false] }, { 'list': 'ordered'}, { 'list': 'bullet' }],
 			[{ 'color': [] }, { 'background': [] }],
@@ -592,6 +592,7 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 		this.$quillToolbar.querySelector('button.ql-formula').setAttribute('title', i18n('Formula'));
 		this.$quillToolbar.querySelector('button.ql-code-block').setAttribute('title', i18n('Code Block'));
 		this.$quillToolbar.querySelector('button.ql-image').setAttribute('title', i18n('Image'));
+		this.$quillToolbar.querySelector('button.ql-video').setAttribute('title', i18n('Embed web video'));
 
 		this.$quillToolbar.querySelector('.ql-header.ql-picker').setAttribute('title', i18n('Header'));
 		let lists = this.$quillToolbar.querySelectorAll('button.ql-list')

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -77,16 +77,17 @@ if (insideJASP) {
 		if (matchs && matchs[2].length === 11) {
 			return ('https') + '://www.youtube.com/embed/' + matchs[2] + '?showinfo=0';
 		}
-		if (matchs = url.match(/^(?:(https?):\/\/)?(?:www\.)?vimeo\.com\/(\d+)/)) {
-			return (match[1] || 'https') + '://player.vimeo.com/video/' + matchs[2] + '/';
-		}
-		if (matchs = url.match(/(?:www\.|\/\/)bilibili\.com\/video\/(\w+)/)) {
-			return 'https://player.bilibili.com/player.html?bvid=' + matchs[1]
+		// enable it once h.264 encoding is available on qtwebengine
+		// if (matchs = url.match(/^(?:(https?):\/\/)?(?:www\.)?vimeo\.com\/(\d+)/)) {
+		// 	return (match[1] || 'https') + '://player.vimeo.com/video/' + matchs[2] + '/';
+		// }
+		// if (matchs = url.match(/(?:www\.|\/\/)bilibili\.com\/video\/(\w+)/)) {
+		// 	return 'https://player.bilibili.com/player.html?bvid=' + matchs[1]
 
-		}
-		if (matchs = url.match(/\/\/v\.qq\.com\/x\/cover\/.*\/([^\/]+)\.html\??.*/)) {
-			return 'https://v.qq.com/txp/iframe/player.html?vid=' + matchs[1]
-		}
+		// }
+		// if (matchs = url.match(/\/\/v\.qq\.com\/x\/cover\/.*\/([^\/]+)\.html\??.*/)) {
+		// 	return 'https://v.qq.com/txp/iframe/player.html?vid=' + matchs[1]
+		// }
 		
 		return url
 	}
@@ -99,7 +100,7 @@ if (insideJASP) {
 			let node = super.create(value);
 			let div = document.createElement('div');
 				div.setAttribute("title", i18n("Unsupported video services"));
-			$(div).append(`${i18n('JASP only allows the following videoservices:')}<br><br> <i>"Youtube, Vimeo, Bilibili, Tencent-Video"</i> <br><br>${i18n('Contact the JASP team to request adding another videoservice to the list.')}`)	
+			$(div).append(`${i18n('JASP only allows the following videoservices:')}<br><br> <i>"Youtube video"</i> <br><br>${i18n('Contact the JASP team to request adding another videoservice to the list.')}`)	
 			node.setAttribute('frameborder', '0');
 			node.setAttribute('allowfullscreen', true);
 			node.setAttribute('src', value);

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -29,8 +29,8 @@ window.sendUrlWhitelist = function (RequestedURL) {
 }
 
 function isURLInWhitelist(hostname) {
-	for (var i = 0; i < videoUrlList.length; i++) {
-		var pattern = videoUrlList[i];
+	for (let i = 0; i < videoUrlList.length; i++) {
+		let pattern = videoUrlList[i];
 		if (pattern === hostname) {
 			return true;
 		} else if (pattern.indexOf('*') !== -1) {
@@ -71,6 +71,7 @@ if (insideJASP) {
 		} else if (/^(http):\/\//i.test(url)) {
 			url = url.replace(/^http:/i, 'https:');
 		}
+		
 		let matchs = url.match(/^(?:(https?):\/\/)?(?:(?:www|m)\.)?youtube\.com\/watch.*v=([a-zA-Z0-9_-]+)/) ||
 			url.match(/^(?:(https?):\/\/)?(?:(?:www|m)\.)?youtu\.be\/([a-zA-Z0-9_-]+)/) ||
 			url.match(/^.*(youtu.be\/|v\/|e\/|u\/\w+\/|embed\/|v=)([^#\&\?]*).*/);
@@ -104,7 +105,7 @@ if (insideJASP) {
 			node.setAttribute('frameborder', '0');
 			node.setAttribute('allowfullscreen', true);
 			node.setAttribute('src', value);
-			if (!isURLInWhitelist((new URL(value).hostname)))
+			if (!isURLInWhitelist((new URL(value).hostname))) {
 				node.innerHTML = $(div).dialog({ // give a warnning for unsupported urls and then remove from node.
 					modal: true, buttons: {
 						Ok: function () {
@@ -113,7 +114,12 @@ if (insideJASP) {
 						}
 					}
 				})
+			}
 			return node;
+		}
+		
+		static value(node){
+			return node.getAttribute('src');
 		}
 	}
 
@@ -121,7 +127,7 @@ if (insideJASP) {
 	EmbendVideo.className = 'ql-video';
 	EmbendVideo.tagName = 'IFRAME';
 
-	Quill.register(EmbendVideo);
+	Quill.register(EmbendVideo, true);
 
 }
 


### PR DESCRIPTION
Close https://github.com/jasp-stats/INTERNAL-jasp/issues/2402

Let's evaluate the security of doing this together: the current approach is a domain whitelist mechanism, and we can also choose the URL entered by the user on the js side (I plan to do this but not now) to prevent XSS attacks when it becomes a web program in the future. any other security issues that should be more special attention?