### PR TITLE
this keeps the column in existence after you destroy the analysis

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -100,7 +100,8 @@ Analysis::~Analysis()
 
 	if(DataSetPackage::pkg() && DataSetPackage::pkg()->hasDataSet())
 		for(const std::string & col : computedColumns())
-			emit requestComputedColumnDestruction(col);
+			if(!DataSetPackage::pkg()->isColumnAnalysisNotComputed(col))
+				emit requestComputedColumnDestruction(col);
 }
 
 bool Analysis::checkAnalysisEntry()

--- a/Desktop/data/computedcolumnsmodel.cpp
+++ b/Desktop/data/computedcolumnsmodel.cpp
@@ -432,7 +432,7 @@ void ComputedColumnsModel::analysisRemoved(Analysis * analysis)
 	std::set<std::string> colsToRemove;
 
 	for(Column * col : computedColumns())
-		if(col->analysisId() == analysis->id())
+		if(col->analysisId() == analysis->id() && col->codeType() != computedColumnType::analysisNotComputed)
 			colsToRemove.insert(col->name());
 
 	for(const std::string & col : colsToRemove)


### PR DESCRIPTION
fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2424 (column dissappears when distributions analysis is removed)
 
