### PR TITLE
Adjusting CMake scripts to build on Linux distros that use Debian-flavored multiarch directory names

### DIFF
--- a/Tools/CMake/Libraries.cmake
+++ b/Tools/CMake/Libraries.cmake
@@ -179,7 +179,9 @@ if(LINUX)
     set(LIBREADSTAT_LIBRARY_DIRS /app/lib)
   else()
     set(LIBREADSTAT_INCLUDE_DIRS /usr/local/include /usr/include)
-    set(LIBREADSTAT_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu)
+    # The last two library paths handle the two most common multiarch cases.
+    # Other multiarch-compliant paths may come up but should be rare.
+    set(LIBREADSTAT_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
   endif()
 
   message(CHECK_START "Looking for libreadstat.so")

--- a/Tools/CMake/Libraries.cmake
+++ b/Tools/CMake/Libraries.cmake
@@ -179,7 +179,7 @@ if(LINUX)
     set(LIBREADSTAT_LIBRARY_DIRS /app/lib)
   else()
     set(LIBREADSTAT_INCLUDE_DIRS /usr/local/include /usr/include)
-    set(LIBREADSTAT_LIBRARY_DIRS /usr/local/lib /usr/lib)
+    set(LIBREADSTAT_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu)
   endif()
 
   message(CHECK_START "Looking for libreadstat.so")

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -84,32 +84,27 @@ if(("jaspMetaAnalysis" IN_LIST JASP_EXTRA_MODULES) OR ("jaspJags" IN_LIST
                                                        JASP_EXTRA_MODULES))
   if(LINUX)
 
- #   if(LINUX_LOCAL_BUILD)
- #     set(jags_HOME /usr/local)
- #   endif()
+    if(LINUX_LOCAL_BUILD)
+      set(jags_HOME /usr/local)
+    endif()
 
- #   if(FLATPAK_USED)
- #     set(jags_HOME /app)
- #   endif()
+    if(FLATPAK_USED)
+      set(jags_HOME /app)
+    endif()
 
- #   message(CHECK_START "Looking for libjags.so")
- #
- #   execute_process(
- #      COMMAND_ECHO STDOUT
- #     #ERROR_QUIET OUTPUT_QUIET
- #     COMMAND pkg-config --)
- #
- #   find_file(LIBJAGS libjags.so HINTS ${jags_HOME}/lib REQUIRED)
- #   if(EXISTS ${LIBJAGS})
- #     message(CHECK_PASS "found")
- #     message(STATUS "  ${LIBJAGS}")
- #   else()
- #     message(CHECK_FAIL "not found")
- #     message(
- #       FATAL_ERROR
- #         "JAGS is required for building on Linux, please follow the build instruction before you continue."
- #     )
- #   endif()
+    message(CHECK_START "Looking for libjags.so")
+
+    find_file(LIBJAGS libjags.so HINTS ${jags_HOME}/lib)
+    if(EXISTS ${LIBJAGS})
+      message(CHECK_PASS "found")
+      message(STATUS "  ${LIBJAGS}")
+    else()
+      message(CHECK_FAIL "not found")
+      message(
+        WARNING
+          "JAGS is required for building on Linux but wasnt found, perhaps JASP builds, otherwise follow the build instruction before you continue."
+      )
+    endif()
 
   else()
     # On macOS and Windows jags will live inside R.framework/ or R/

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -56,7 +56,7 @@ if(NOT JASP_TEST_BUILD)
 		"jaspSummaryStatistics"
 		"jaspTimeSeries"
 		"jaspVisualModeling"
-    )
+        )
 else() #it IS a test build
 	set(JASP_COMMON_MODULES
 		"jaspDescriptives"
@@ -84,26 +84,32 @@ if(("jaspMetaAnalysis" IN_LIST JASP_EXTRA_MODULES) OR ("jaspJags" IN_LIST
                                                        JASP_EXTRA_MODULES))
   if(LINUX)
 
-    if(LINUX_LOCAL_BUILD)
-      set(jags_HOME /usr/local)
-    endif()
+ #   if(LINUX_LOCAL_BUILD)
+ #     set(jags_HOME /usr/local)
+ #   endif()
 
-    if(FLATPAK_USED)
-      set(jags_HOME /app)
-    endif()
+ #   if(FLATPAK_USED)
+ #     set(jags_HOME /app)
+ #   endif()
 
-    message(CHECK_START "Looking for libjags.so")
-    find_file(LIBJAGS libjags.so HINTS ${jags_HOME}/lib REQUIRED)
-    if(EXISTS ${LIBJAGS})
-      message(CHECK_PASS "found")
-      message(STATUS "  ${LIBJAGS}")
-    else()
-      message(CHECK_FAIL "not found")
-      message(
-        FATAL_ERROR
-          "JAGS is required for building on Windows, please follow the build instruction before you continue."
-      )
-    endif()
+ #   message(CHECK_START "Looking for libjags.so")
+ #
+ #   execute_process(
+ #      COMMAND_ECHO STDOUT
+ #     #ERROR_QUIET OUTPUT_QUIET
+ #     COMMAND pkg-config --)
+ #
+ #   find_file(LIBJAGS libjags.so HINTS ${jags_HOME}/lib REQUIRED)
+ #   if(EXISTS ${LIBJAGS})
+ #     message(CHECK_PASS "found")
+ #     message(STATUS "  ${LIBJAGS}")
+ #   else()
+ #     message(CHECK_FAIL "not found")
+ #     message(
+ #       FATAL_ERROR
+ #         "JAGS is required for building on Linux, please follow the build instruction before you continue."
+ #     )
+ #   endif()
 
   else()
     # On macOS and Windows jags will live inside R.framework/ or R/

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -755,12 +755,18 @@ elseif(LINUX)
 
     set(R_HOME_PATH $ENV{R_HOME})
 
-    if(R_HOME_PATH STREQUAL "")
+    if("${R_HOME_PATH}" STREQUAL "")
 
-      message(CHECK_FAIL "unsuccessful")
-      message(
-        FATAL_ERROR
-          "R is not installed in your system. Please install R and try again.")
+        if(NOT EXISTS "/usr/lib/R/bin/R")
+          message(CHECK_FAIL "unsuccessful.")
+          message(FATAL_ERROR "R is not installed in your system. Please install R and try again, or set R_HOME properly.")
+        else()
+            set($ENV{R_HOME} /usr/lib/R)
+            set(R_HOME_PATH /usr/lib/R)
+
+            message(CHECK_PASS "successful")
+            message(STATUS "R_HOME is ${R_HOME_PATH}")
+        endif()
 
     else()
 


### PR DESCRIPTION
This PR comprises the tweaks I made with @JorisGoosen on 2023-11-01 to fix some issues that precluded building JASP on Linux systems that use the Debian-flavored multiarch directory names. Most of the changes occur in Tools/CMake/Modules.cmake.

With these changes, I can build JASP on my Debian AMD64 system. The tweaks should also support ARM64 systems, but this hasn't been tested. Other architectures will probably still break the build process.