### PR TITLE
Fix long-name filed width under multiple languages

### DIFF
--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -536,7 +536,7 @@ void SetRFilterCommand::redo()
 CreateComputedColumnCommand::CreateComputedColumnCommand(QAbstractItemModel *model, const QString &name, int columnType, int computedColumnType)
 	: UndoModelCommand(model), _name{name}, _columnType{columnType}, _computedColumnType{computedColumnType}
 {
-	setText(QObject::tr("Create a computed column with name '%1").arg(name));
+	setText(QObject::tr("Create a computed column with name '%1'").arg(name));
 }
 
 void CreateComputedColumnCommand::undo()
@@ -553,7 +553,7 @@ SetComputedColumnCodeCommand::SetComputedColumnCodeCommand(QAbstractItemModel *m
 	: UndoModelCommand(model), _name{name}, _newRCode{rCode}, _newJsonCode{jsonCode}
 {
 	_computedColumnModel = ComputedColumnsModel::singleton();
-	setText(QObject::tr("Set code to computed column with name '%1").arg(tq(name)));
+	setText(QObject::tr("Set code to computed column with name '%1'").arg(tq(name)));
 }
 
 void SetComputedColumnCodeCommand::undo()

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -631,9 +631,9 @@ SetUseCustomEmptyValuesCommand::SetUseCustomEmptyValuesCommand(QAbstractItemMode
 		std::string colName = col->name();
 
 		if (_useCustom)
-			setText(QObject::tr("Use custom empty values for column '%1").arg(tq(colName)));
+			setText(QObject::tr("Use custom empty values for column '%1'").arg(tq(colName)));
 		else
-			setText(QObject::tr("Use default empty values for column '%1").arg(tq(colName)));
+			setText(QObject::tr("Use default empty values for column '%1'").arg(tq(colName)));
 	}
 	else
 		setObsolete(true);
@@ -663,7 +663,7 @@ SetCustomEmptyValuesCommand::SetCustomEmptyValuesCommand(QAbstractItemModel *mod
 		for (const QString& val : customEmptyValues)
 			_newCustomEmptyValues.insert(fq(val));
 
-		setText(QObject::tr("Set empty values for column '%1").arg(tq(colName)));
+		setText(QObject::tr("Set empty values for column '%1'").arg(tq(colName)));
 	}
 	else
 		setObsolete(true);

--- a/Desktop/po/jaspDesktop-de.po
+++ b/Desktop/po/jaspDesktop-de.po
@@ -4513,13 +4513,13 @@ msgstr "R-Filter ändern"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
-msgstr "Berechnete Spalte erstellen mit Namen '%1"
+msgid "Create a computed column with name '%1'"
+msgstr "Berechnete Spalte erstellen mit Namen '%1'"
 
 #, fuzzy, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
-msgstr "Code setzen auf berechnete Spalte mit Namen '%1"
+msgid "Set code to computed column with name '%1'"
+msgstr "Code setzen auf berechnete Spalte mit Namen '%1'"
 
 msgctxt "MainWindow|"
 msgid ""
@@ -5064,17 +5064,17 @@ msgstr "Arbeitsbereichsbeschreibung ändern von '%1' auf '%2'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
-msgstr "Benutzerdefinierte leere Werte für Spalte '%1"
+msgid "Use custom empty values for column '%1'"
+msgstr "Benutzerdefinierte leere Werte für Spalte '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
-msgstr "Standardmäßige leere Werte für Spalte '%1"
+msgid "Use default empty values for column '%1'"
+msgstr "Standardmäßige leere Werte für Spalte '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr "Leere Werte für Spalte '%1 einstellen"
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-eo.po
+++ b/Desktop/po/jaspDesktop-eo.po
@@ -4151,12 +4151,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -4655,17 +4655,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-es.po
+++ b/Desktop/po/jaspDesktop-es.po
@@ -4521,13 +4521,13 @@ msgstr "Cambiar el filtro de R"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
-msgstr "Crear una columna calculada de nombre '%1"
+msgid "Create a computed column with name '%1'"
+msgstr "Crear una columna calculada de nombre '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
-msgstr "Establecer el código de la columna calculada de nombre '%1"
+msgid "Set code to computed column with name '%1'"
+msgstr "Establecer el código de la columna calculada de nombre '%1'"
 
 msgctxt "MainWindow|"
 msgid ""
@@ -5068,18 +5068,18 @@ msgstr "Cambiar la descripción del área de trabajo de '%1' a '%2'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
-msgstr "Usar los valores vacíos habituales para la columna '%1"
+msgid "Use custom empty values for column '%1'"
+msgstr "Usar los valores vacíos habituales para la columna '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
-msgstr "Usar los valores vacíos predeterminados para la columna '%1"
+msgid "Use default empty values for column '%1'"
+msgstr "Usar los valores vacíos predeterminados para la columna '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
-msgstr "Fijar los valores vacíos para la columna '%1"
+msgid "Set empty values for column '%1'"
+msgstr "Fijar los valores vacíos para la columna '%1'"
 
 msgctxt "QObject|"
 msgid "Set workspace empty values"

--- a/Desktop/po/jaspDesktop-fr.po
+++ b/Desktop/po/jaspDesktop-fr.po
@@ -4548,12 +4548,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -5073,17 +5073,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-gl.po
+++ b/Desktop/po/jaspDesktop-gl.po
@@ -4501,13 +4501,13 @@ msgstr "Trocar o filtro de R"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
-msgstr "Crear unha columna calculada de nome '%1"
+msgid "Create a computed column with name '%1'"
+msgstr "Crear unha columna calculada de nome '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
-msgstr "Establecer o código da columna calculada de nome '%1"
+msgid "Set code to computed column with name '%1'"
+msgstr "Establecer o código da columna calculada de nome '%1'"
 
 msgctxt "MainWindow|"
 msgid ""
@@ -5046,18 +5046,18 @@ msgstr "Trocar a descrición da área de traballo de '%1' a '%2'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
-msgstr "Usar os valores baleiros habituais para a columna '%1"
+msgid "Use custom empty values for column '%1'"
+msgstr "Usar os valores baleiros habituais para a columna '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
-msgstr "Usar os valores baleiros predeterminados para a columna '%1"
+msgid "Use default empty values for column '%1'"
+msgstr "Usar os valores baleiros predeterminados para a columna '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
-msgstr "Fixar os valores baleiros para a columna '%1"
+msgid "Set empty values for column '%1'"
+msgstr "Fixar os valores baleiros para a columna '%1'"
 
 msgctxt "QObject|"
 msgid "Set workspace empty values"

--- a/Desktop/po/jaspDesktop-id.po
+++ b/Desktop/po/jaspDesktop-id.po
@@ -4222,12 +4222,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -4729,17 +4729,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-ja.po
+++ b/Desktop/po/jaspDesktop-ja.po
@@ -4406,12 +4406,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -4923,17 +4923,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-nl.po
+++ b/Desktop/po/jaspDesktop-nl.po
@@ -4486,12 +4486,12 @@ msgstr "R-Filter aanpassen"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr "Creëer een berekende kolom met naam '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr "Zet code voor berekende kolom met naam '%1'"
 
 msgctxt "MainWindow|"
@@ -5007,17 +5007,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-pl.po
+++ b/Desktop/po/jaspDesktop-pl.po
@@ -4481,12 +4481,12 @@ msgstr "Zmień filtr R"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr "Stwórz kolumnę wyliczoną z nazwą '%1'"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr "Wprowadź kod do kolumny wyliczonej o nazwie '%1'"
 
 msgctxt "MainWindow|"
@@ -5042,17 +5042,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-pt.po
+++ b/Desktop/po/jaspDesktop-pt.po
@@ -4439,12 +4439,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -4957,17 +4957,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-ru.po
+++ b/Desktop/po/jaspDesktop-ru.po
@@ -4485,12 +4485,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -5004,17 +5004,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-tr.po
+++ b/Desktop/po/jaspDesktop-tr.po
@@ -4172,12 +4172,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -4675,17 +4675,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-zh_Hans.po
+++ b/Desktop/po/jaspDesktop-zh_Hans.po
@@ -4308,12 +4308,12 @@ msgstr "更改 R 筛选器"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr "创建名为 “%1” 的计算列"
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr "将代码设置为名为 “%1” 的计算列"
 
 msgctxt "MainWindow|"
@@ -4846,17 +4846,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop-zh_Hant.po
+++ b/Desktop/po/jaspDesktop-zh_Hant.po
@@ -4297,12 +4297,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -4815,17 +4815,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"

--- a/Desktop/po/jaspDesktop.pot
+++ b/Desktop/po/jaspDesktop.pot
@@ -4124,12 +4124,12 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Create a computed column with name '%1"
+msgid "Create a computed column with name '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set code to computed column with name '%1"
+msgid "Set code to computed column with name '%1'"
 msgstr ""
 
 msgctxt "MainWindow|"
@@ -4626,17 +4626,17 @@ msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use custom empty values for column '%1"
+msgid "Use custom empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Use default empty values for column '%1"
+msgid "Use default empty values for column '%1'"
 msgstr ""
 
 #, qt-format
 msgctxt "QObject|"
-msgid "Set empty values for column '%1"
+msgid "Set empty values for column '%1'"
 msgstr ""
 
 msgctxt "QObject|"


### PR DESCRIPTION
Variable window variable long-name filed width should adapt to translated label text width. for test: change to Chinese language and see new design of variable window close button.
also small style changes of translation strings.

Before:
_the close button is nearly blocked and filed not same wide._
![图片](https://github.com/jasp-stats/jasp-desktop/assets/10348402/755d6016-3f95-48ba-813a-38d46b613752)


After:
![图片](https://github.com/jasp-stats/jasp-desktop/assets/10348402/bb8bd3d3-fbf1-44bb-b6e5-6de6f8111154)
