### PR TITLE
Fix for LaTeX showing in darktheme mode

### DIFF
--- a/Desktop/html/css/darkTheme-jasp.css
+++ b/Desktop/html/css/darkTheme-jasp.css
@@ -191,8 +191,10 @@ div.jasp-image-image.no-data.error {
 
 /* not use color invert for img in annotations */
 .ql-editor p img,
-iframe.ql-video:not(:fullscreen) {
-    filter:  invert(1) !important;
+iframe.ql-video:not(:fullscreen),
+.ql-editor mjx-container svg,
+mjx-container {
+    filter:  invert(1);
 }
 
 


### PR DESCRIPTION
After img and video embed merged, the LaTeX showing in darktheme needs a new fix.