### PR TITLE
Beter handling of allowed types

### DIFF
--- a/QMLComponents/components/JASP/Controls/AssignButton.qml
+++ b/QMLComponents/components/JASP/Controls/AssignButton.qml
@@ -61,23 +61,7 @@ Button
 	function setIconToLeft()	{ if (rightSource.activeFocus)	leftToRight = false; setState(); }
 	function setState()
 	{
-		var isEnabled = sourceM.enabled && targetM.enabled && sourceM.model && sourceM.model.selectedItems().length > 0;
-		if (isEnabled)
-		{
-			if (targetM.allowedColumns.length > 0)
-			{
-				isEnabled = false;
-				var sourceSelectedItemsTypes = sourceM.model.selectedItemsTypes()
-				for (var i = 0; i < sourceSelectedItemsTypes.length; i++)
-				{
-					var itemType = sourceSelectedItemsTypes[i];
-					if (targetM.allowedColumns.includes(itemType))
-						isEnabled = true;
-				}
-			}
-		}
-		
-		enabled = isEnabled
+		enabled = sourceM.enabled && targetM.enabled && sourceM.model && sourceM.model.selectedItems().length > 0 && targetM.areTypesAllowed(sourceM.model.selectedItemsTypes());
 	}
 
 

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -78,26 +78,7 @@ VariablesListBase
 
 	function setEnabledState(source, dragging)
 	{
-		var result = !dragging;
-		if (dragging)
-		{
-			if (source.model.selectedItems().length > 0)
-			{
-				if (variablesList.allowedColumns.length > 0)
-				{
-					result = false;
-					var sourceSelectedItemsTypes = source.model.selectedItemsTypes()
-					for (var i = 0; i < sourceSelectedItemsTypes.length; i++)
-					{
-						var itemType = sourceSelectedItemsTypes[i];
-						if (variablesList.allowedColumns.includes(itemType))
-							result = true;
-					}
-				}
-				else
-					result = true;
-			}
-		}
+		var result = !dragging || areTypesAllowed(source.model.selectedItemsTypes());
 
 		// Do not use variablesList.enabled: this may break the binding if the developer used it in his QML form.
 		itemRectangle.enabled = result
@@ -445,7 +426,7 @@ VariablesListBase
 				property string columnType:			isVariable && (typeof model.columnType !== "undefined") ? model.columnType : ""
 				property var extraItem:				model.rowComponent
 
-				enabled: variablesList.listViewType != JASP.AvailableVariables || !columnType || variablesList.allowedColumns.length == 0 || (variablesList.allowedColumns.indexOf(columnType) >= 0)
+				enabled: variablesList.listViewType != JASP.AvailableVariables || !columnType || variablesList.areTypesAllowed([columnType])
 				
 				function setRelative(draggedRect)
 				{

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -241,6 +241,18 @@ QString JASPListControl::getSourceType(QString name)
 	return model() ? model()->getItemType(name) : "";
 }
 
+bool JASPListControl::areTypesAllowed(QStringList types)
+{
+	bool result = true;
+
+	if (!_variableTypesAllowed.empty())
+		for (const QString& type : types)
+			if (!_variableTypesAllowed.contains(columnTypeFromQString(type)))
+				result = false;
+
+	return result;
+}
+
 int JASPListControl::count()
 {
 	return model() ? model()->rowCount() : 0;

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -81,6 +81,7 @@ public:
 			JASPControl		*	getChildControl(QString key, QString name) override;
 
 	Q_INVOKABLE QString			getSourceType(QString name);
+	Q_INVOKABLE bool			areTypesAllowed(QStringList types);
 
 			const QVariant&		source()					const			{ return _source;				}
 			const QVariant&		values()					const			{ return _values;				}

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -364,7 +364,6 @@ void VariablesListBase::_setAllowedVariables()
 			implicitAllowedTypes.insert("nominalText");
 			implicitAllowedTypes.insert("ordinal");
 		}
-		setAllowedColumns(implicitAllowedTypes.values());
 	}
 
 	_variableTypesAllowed.clear();
@@ -374,7 +373,7 @@ void VariablesListBase::_setAllowedVariables()
 	// The suggectedColumnsIcons indicates which columns are allowed in the VariableList view.
 	// It shows per default the suggested columns list, but if empty, it shows the alloaed columns list.
 	QStringList iconTypeList,
-				columnTypes = suggestedColumns().isEmpty() ?  allowedColumns() : suggestedColumns();
+				columnTypes = allowedColumns().isEmpty() ? suggestedColumns() : allowedColumns();
 	for (const QString& columnTypeStr : columnTypes)
 	{
 		columnType type = columnTypeFromString(fq(columnTypeStr), columnType::unknown);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2429

There was some confusions with the displayed 'allowed types' icons in a Variables List, and the real allowed types.

The Test Variables Form (suggested vs allowed Section) in jaspTestModule explains exactly what the the suggested & allowed properties should work.