### PR TITLE
Condition on source using components

### DIFF
--- a/QMLComponents/controls/sourceitem.h
+++ b/QMLComponents/controls/sourceitem.h
@@ -79,7 +79,7 @@ public:
 	void									disconnectModels();
 	static QVector<SourceItem*>				readAllSources(JASPListControl* _listControl);
 	static QList<QVariant>					getListVariant(QVariant var);
-	static Terms							filterTermsWithCondition(ListModel* model, const Terms& terms, const QString& condition, const QVector<ConditionVariable>& conditionVariables = {});
+	static Terms							filterTermsWithCondition(ListModel* model, const Terms& terms, const QString& condition, const QVector<ConditionVariable>& conditionVariables = {}, const QMap<QString, QStringList> &termsMap = {});
 
 
 private:


### PR DESCRIPTION
If a source use a component like a dropdown for example:
    'source: myVariables.drop' // if drop is the dropdown name.
And is this source use some condition using another component:
    'source: [{name: "myVariables.drop", condition: "check" }] // if check the name of checkbox component of the source.
Then the condition should be applied for the values of the source model.

To understand better what happens, see in the jaspTestModule, the "Test Sources with special attributes" analysis, "Source with controls" section

