### PR TITLE
Misc: Build check workflow update

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,7 @@ name: 'Ubuntu'
 
 on:
    pull_request:
+     paths: ['**.cpp', '**.h', '**.R', '**.cmake', '**.txt', '**.in', '**.yml']
    workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,6 +28,7 @@ jobs:
             host: 'linux'
             target: 'desktop'
             arch: 'gcc_64'
+            cache: 'true'
             modules: 'qtpositioning qtwebchannel qtwebengine qtwebsockets qtwebview debug_info qt5compat qtshadertools qtwaylandcompositor'
             tools: 'tools_qtcreator,qt.tools.qtcreator tools_ninja tools_cmake'
             


### PR DESCRIPTION
We now trigger it while C++ and build system changes.

enabled cache for qt installer, first run will take more times but will speed up in the next running.