### PR TITLE
Copy/Paste with header should work

### DIFF
--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -505,7 +505,6 @@ FocusScope
 													dataTableView.showPopupMenu(parent, mapToGlobal(mouseEvent.x, mouseEvent.y), rowIndex, -1);
 											}
 					}
-
 				}
 
 			columnHeaderDelegate: Rectangle
@@ -516,6 +515,30 @@ FocusScope
 							property real	iconTextPadding:	10
 				readonly	property int	__iconDim:			baseBlockDim * preferencesModel.uiScale
 
+				Keys.onPressed: (event) =>
+				{
+					var controlPressed	= Boolean(event.modifiers & Qt.ControlModifier)
+
+					if (controlPressed)
+					{
+						switch(event.key)
+						{
+						case Qt.Key_C:
+							theView.copy(Qt.point(columnIndex, -1));
+							event.accepted = true;
+							break;
+						case Qt.Key_X:
+							theView.cut(Qt.point(columnIndex, -1));
+							event.accepted = true;
+							break;
+						case Qt.Key_V:
+							theView.paste(Qt.point(columnIndex, -1));
+							event.accepted = true;
+							break;
+						}
+					}
+				}
+
 				Image
 				{
 					id:						colIcon
@@ -525,7 +548,7 @@ FocusScope
 
 
 					source: String(dataSetModel.getColumnTypesWithIcons()[columnType]) === "" ? "" : jaspTheme.iconPath + dataSetModel.getColumnTypesWithIcons()[columnType]
-					width:	headerRoot.__iconDim
+					width:	source == "" ? 0 : headerRoot.__iconDim
 					height: headerRoot.__iconDim
 
 					sourceSize {	width:	width * 2
@@ -696,6 +719,8 @@ FocusScope
 					{
 						if(columnIndex >= 0)
 						{
+							headerRoot.forceActiveFocus()
+
 							if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
 								dataTableView.view.columnSelect(columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton)
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -2083,7 +2083,7 @@ void DataSetPackage::setWorkspaceEmptyValues(const stringset &emptyValues, bool 
 	emit workspaceEmptyValuesChanged();
 }
 
-void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, intvec coltypes)
+void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, const intvec & coltypes, const QStringList & colNames)
 {
 	JASPTIMER_SCOPE(DataSetPackage::pasteSpreadsheet);
 
@@ -2096,8 +2096,6 @@ void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<
 	
 	if(colCountChanged || rowCountChanged)	
 		setDataSetSize(std::max(size_t(dataColumnCount()), colMax + col), std::max(size_t(dataRowCount()), rowMax + row));
-
-	stringvec colNames = getColumnNames();
 	
 	stringvec changed;
 
@@ -2106,6 +2104,7 @@ void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<
 		int			dataCol		= c + col;
 		stringvec	colVals		= getColumnDataStrs(dataCol);
 		columnType	desiredType	= coltypes.size() > c ? columnType(coltypes[c]) : columnType::unknown;
+		std::string colName		= (colNames.size() > c && !colNames[c].isEmpty()) ? fq(colNames[c]) : getColumnName(dataCol);
 
 		for(int r=0; r<rowMax; r++)
 		{
@@ -2119,7 +2118,6 @@ void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<
 			colVals[r + row] = cellVal == ColumnUtils::emptyValue ? "" : cellVal;
 		}
 
-		std::string colName = getColumnName(dataCol);
 		initColumnWithStrings(dataCol, colName, colVals, "", desiredType);
 
 		changed.push_back(colName);

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -200,7 +200,7 @@ public:
 				void						initColumnWithStrings(			QVariant			colId,		const std::string & newName, const stringvec	& values,	const std::string & title = "", columnType desiredType = columnType::unknown);
 				void						initializeComputedColumns();
 				
-				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & cells, intvec colTypes = intvec());
+				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & cells, const intvec & colTypes = intvec(), const QStringList & colNames = {});
 
 				void						storeMissingData(		const std::string	& columnName, const intstrmap & missingData);
 

--- a/Desktop/data/datasettablemodel.cpp
+++ b/Desktop/data/datasettablemodel.cpp
@@ -74,10 +74,10 @@ bool DataSetTableModel::columnUsedInEasyFilter(int column) const
 			).toBool();
 }
 
-void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & cells, std::vector<int> colTypes)
+void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & cells, const std::vector<int> & colTypes, const QStringList & colNames)
 {
 	QModelIndex idx = mapToSource(index(row, col));
-	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), cells, colTypes);
+	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), cells, colTypes, colNames);
 }
 
 QString DataSetTableModel::insertColumnSpecial(int column, const QMap<QString, QVariant>& props)

--- a/Desktop/data/datasettablemodel.h
+++ b/Desktop/data/datasettablemodel.h
@@ -46,7 +46,7 @@ public:
 
 	int						getColumnIndex(const std::string& col)	const				{ return DataSetPackage::pkg()->getColumnIndex(col);								}
 	bool					synchingData()							const				{ return DataSetPackage::pkg()->synchingData();										}
-	void					pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, std::vector<int> colTypes = std::vector<int>());
+	void					pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & cells, const std::vector<int> & colTypes = std::vector<int>(), const QStringList & colNames = {});
 	bool					showInactive()							const				{ return _showInactive;	}
 
 	QString					insertColumnSpecial(int column, const QMap<QString, QVariant>& props);

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -230,13 +230,13 @@ void ExpandDataProxyModel::setData(int row, int col, const QVariant &value, int 
 	_undoStack->endMacro(new SetDataCommand(_sourceModel, row, col, value, role));
 }
 
-void ExpandDataProxyModel::pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells)
+void ExpandDataProxyModel::pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells, const QStringList& colNames)
 {
 	if (!_sourceModel || row < 0 || col < 0 || cells.size() == 0 || cells[0].size() == 0)
 		return;
 
 	_expandIfNecessary(row + cells[0].size() - 1, col + cells.size() - 1);
-	_undoStack->endMacro(new PasteSpreadsheetCommand(_sourceModel, row, col, cells));
+	_undoStack->endMacro(new PasteSpreadsheetCommand(_sourceModel, row, col, cells, colNames));
 }
 
 int ExpandDataProxyModel::setColumnType(int columnIndex, int columnType)

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -32,7 +32,7 @@ public:
 	void				removeColumns(int start, int count);
 	void				insertRow(int row);
 	void				insertColumn(int col, bool computed, bool R);
-	void				pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells);
+	void				pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & cells, const QStringList& colNames = {});
 	int					setColumnType(int columnIndex, int columnType);
 	void				copyColumns(int startCol, const std::vector<Json::Value>& copiedColumns);
 	Json::Value			serializedColumn(int col);

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -179,8 +179,8 @@ void RemoveRowsCommand::redo()
 	_model->removeRows(_start, _count);
 }
 
-PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString> > &cells)
-	: UndoModelCommand(model), _row{row}, _col{col}, _newCells{cells}
+PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString> > &cells, const QStringList& colNames)
+	: UndoModelCommand(model), _row{row}, _col{col}, _newCells{cells}, _newColNames{colNames}
 {
 	setText(QObject::tr("Paste values at row %1 column '%2'").arg(rowName(_row)).arg(columnName(_col)));
 }
@@ -190,7 +190,7 @@ void PasteSpreadsheetCommand::undo()
 	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_model);
 
 	if (dataSetTable)
-		dataSetTable->pasteSpreadsheet(_row, _col, _oldCells);
+		dataSetTable->pasteSpreadsheet(_row, _col, _oldCells, {}, _oldColNames);
 }
 
 void PasteSpreadsheetCommand::redo()
@@ -199,6 +199,7 @@ void PasteSpreadsheetCommand::redo()
 	for (int c = 0; c < _newCells.size(); c++)
 	{
 		_oldCells.push_back(std::vector<QString>());
+		_oldColNames.push_back(_model->headerData(_col + c, Qt::Horizontal).toString());
 		for (int r = 0; r < _newCells[c].size(); r++)
 			_oldCells[c].push_back(_model->data(_model->index(_row + r, _col + c)).toString());
 	}
@@ -206,7 +207,7 @@ void PasteSpreadsheetCommand::redo()
 	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_model);
 
 	if (dataSetTable)
-		dataSetTable->pasteSpreadsheet(_row, _col, _newCells);
+		dataSetTable->pasteSpreadsheet(_row, _col, _newCells, {}, _newColNames);
 }
 
 

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -201,7 +201,7 @@ private:
 class PasteSpreadsheetCommand : public UndoModelCommand
 {
 public:
-	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& cells);
+	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& cells, const QStringList & colNames);
 
 	void undo()					override;
 	void redo()					override;
@@ -209,6 +209,8 @@ public:
 private:
 	std::vector<std::vector<QString>>	_newCells,
 										_oldCells;
+	QStringList							_newColNames,
+										_oldColNames;
 	int									_row = -1,
 										_col = -1;
 };

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -333,7 +333,8 @@ protected:
 	long		_selectScrollMs			= 0;
 	QPoint		_selectionStart			= QPoint(-1, -1),
 				_selectionEnd			= QPoint(-1, -1);
-	std::vector<Json::Value> _copiedColumns;
+	std::vector<Json::Value>	_copiedColumns;
+	QString						_lastJaspCopyIntoClipboard;
 
 
 };


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2432

Copy/paste with/without header from JASP to JASP and JASP from/to Excel. Test with empty values.
Test also copy/paste with shortkeys
