### PR TITLE
Fix some sync bugs

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1751,6 +1751,7 @@ void DataSetPackage::setColumnName(size_t columnIndex, const std::string & newNa
 	if(resetModel)
 		endResetModel();
 
+	setManualEdits(true);
 	emit datasetChanged({}, {}, QMap<QString, QString>({{tq(oldName), tq(newName)}}), false, false);
 }
 
@@ -2674,7 +2675,8 @@ bool DataSetPackage::manualEdits() const
 
 void DataSetPackage::setManualEdits(bool newManualEdits)
 {
-	if (_manualEdits == newManualEdits)
+	// During synchronization, even if some data are changed, manualEdits should not be set to true
+	if ((_synchingData && newManualEdits) || _manualEdits == newManualEdits)
 		return;
 
 	_manualEdits = newManualEdits;

--- a/Desktop/data/importers/importer.cpp
+++ b/Desktop/data/importers/importer.cpp
@@ -108,6 +108,7 @@ void Importer::syncDataSet(const std::string &locator, std::function<void(int)> 
 	if (newColumns.size() > 0 || changedColumns.size() > 0 || missingColumns.size() > 0 || changeNameColumns.size() > 0 || rowCountChanged)
 			_syncPackage(importDataSet, newColumns, changedColumns, missingColumns, changeNameColumns, rowCountChanged);
 
+	DataSetPackage::pkg()->setManualEdits(false);
 	delete importDataSet;
 }
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2371

There was 2 bugs in this issue:
- Changing a column name does not switch off the synchronization.
- If synchronization is on, deleting a column in Excel, set the synchronization off.

Fixes also the following bug:
- Open a csv file with JASP.
- Make a change in JASP: Sync icon turns off
- Undo: Sync icon stays off
- Click on Sync icon: it reloads the data: Sync icon turns on . Change data in JASP: the Sync icon stays on: this is wrong. This is fixes by this PR. .

