### PR TITLE
JASP on the small screen

### DIFF
--- a/Desktop/components/JASP/Widgets/ColumnBasicInfo.qml
+++ b/Desktop/components/JASP/Widgets/ColumnBasicInfo.qml
@@ -1,0 +1,197 @@
+//
+// Copyright (C) 2013-2023 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+import QtQuick
+import JASP
+import JASP.Widgets
+import JASP.Controls
+import QtQuick.Controls as QTC
+import QtQuick.Layouts
+Item
+{
+	id:							common
+	implicitHeight:				Math.max(leftColumn.childrenRect.height, rightColumn.childrenRect.height) + 2 * jaspTheme.generalAnchorMargin
+	height:						implicitHeight
+	property bool closeIcon:	true
+
+	Column
+	{
+		id:			leftColumn
+		width:		Math.max(columnTypeVariableWindow.implicitWidth, computedTypeVariableWindow.implicitWidth, columnNameVariablesWindow.implicitWidth)
+		spacing:	jaspTheme.rowGroupSpacing
+
+		anchors
+		{
+			top:		common.top
+			left:		common.left
+			bottom:		common.bottom
+			margins:	jaspTheme.generalAnchorMargin
+		}
+
+		property int labelWidth:	Math.max(columnTypeVariableWindow.controlLabel.implicitWidth, computedTypeVariableWindow.controlLabel.implicitWidth, columnNameVariablesWindow.controlLabel.implicitWidth)
+
+		RowLayout
+		{
+			height:				longNameRow.height
+
+			TextField
+			{
+				id:					columnNameVariablesWindow
+				placeholderText:	qsTr("<Fill in the name of the column>")
+				value:				columnModel.columnName
+				onValueChanged:		if(columnModel.columnName !== value) columnModel.columnName = value
+				undoModel:			columnModel
+				editable:           columnModel.nameEditable
+				label:				qsTr("Name: ")
+				controlLabel.width:	leftColumn.labelWidth
+
+			}
+		}
+
+
+		DropDown
+		{
+			id: columnTypeVariableWindow
+
+			label:				qsTr("Column type: ")
+			isBound:			false
+			showVariableTypeIcon: true
+			values:				columnModel.columnTypeValues
+			currentValue:		columnModel.currentColumnType
+			onValueChanged:		columnModel.currentColumnType = currentValue
+			controlMinWidth:	200 * jaspTheme.uiScale
+			controlLabel.width:	leftColumn.labelWidth
+		}
+
+		DropDown
+		{
+			id: computedTypeVariableWindow
+
+			label:				qsTr("Computed type: ")
+			values:				columnModel.computedTypeValues
+			currentValue:		columnModel.computedType
+			onValueChanged:		columnModel.computedType = currentValue
+			visible:			columnModel.computedTypeEditable
+			controlMinWidth:	200 * jaspTheme.uiScale
+
+			controlLabel.width:	leftColumn.labelWidth
+		}
+
+		Item
+		{
+			implicitWidth:			parent.width
+			implicitHeight:			showAnalysisButton.height
+			visible:				columnModel.computedType === "analysisNotComputed" || columnModel.computedType === "analysisNotComputed"
+
+			RoundedButton
+			{
+				id:					showAnalysisButton
+				text:				qsTr("Show parent analysis")
+				width:				parent.width - x
+				x:					leftColumn.labelWidth
+				onClicked:			computedColumnsInterface.showAnalysisFormForColumn(columnModel.columnName)
+			}
+		}
+	}
+
+	Column
+	{
+		id:			rightColumn
+		spacing:	jaspTheme.rowGroupSpacing
+
+		anchors
+		{
+			top:		common.top
+			left:		leftColumn.right
+			right:		common.right
+			bottom:		common.bottom
+			margins:	jaspTheme.generalAnchorMargin
+		}
+
+		property int labelWidth:	Math.max(columnTitleVariablesWindow.controlLabel.implicitWidth, descriptionLabel.implicitWidth)
+
+		RowLayout
+		{
+			id:					longNameRow
+			width:				parent.width
+
+
+			TextField
+			{
+				id:					columnTitleVariablesWindow
+				label:				qsTr("Long name: ");
+				placeholderText:	qsTr("<Fill in a more descriptive name of the column>")
+				fieldWidth:			longNameRow.width - ( rightColumn.labelWidth + closeButton.width )
+				value:				columnModel.columnTitle
+				onValueChanged:		if(columnModel.columnTitle !== value) columnModel.columnTitle = value
+				undoModel:			columnModel
+				controlLabel.width:	rightColumn.labelWidth
+
+			}
+
+			MenuButton
+			{
+				id:					closeButton
+				height:				33 * jaspTheme.uiScale
+				width:				common.closeIcon? height : 0
+				iconSource:			jaspTheme.iconPath + "close-button.png"
+				onClicked:			{ computedColumnWindow.askIfChangedOrClose(); columnModel.visible = false }
+				toolTip:			qsTr("Close variable window")
+				radius:				height
+				visible:			common.closeIcon
+			}
+		}
+
+		Item
+		{
+			id:					descriptionRow
+			width:				parent.width
+			height:				Math.max(descriptionLabel.height, columnDescriptionVariablesWindow.height)
+
+			Label
+			{
+				id:				descriptionLabel
+				text:			qsTr("Description: ")
+				width:			rightColumn.labelWidth
+			}
+
+			TextArea
+			{
+				id:					columnDescriptionVariablesWindow
+				height:				implicitHeight
+				width:				implicitWidth
+				x:					rightColumn.labelWidth + jaspTheme.labelSpacing //Cause that happens inside TextField between labelRect and actual control
+				implicitHeight:		columnTypeVariableWindow.height + computedTypeVariableWindow.height + rightColumn.spacing
+				implicitWidth:		descriptionRow.width - x
+				control.padding:	3 * jaspTheme.uiScale
+
+				text:				columnModel.columnDescription
+				onEditingFinished: 	if(columnModel.columnDescription !== text) columnModel.columnDescription = text
+				applyScriptInfo:	""
+				placeholderText:	"..."
+				undoModel:			columnModel
+				useTabAsSpaces:		false
+
+
+
+			}
+		}
+	}
+
+
+}

--- a/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
@@ -69,27 +69,29 @@ FocusScope
 			}
 		}
 
-		FocusScope
+		Rectangle
+		{
+			z:				3
+			color:			jaspTheme.fileMenuColorBackground
+			border.width:	1
+			border.color:	jaspTheme.uiBorder
+			anchors.fill:	actionMenu
+		}
+
+		Flickable
 		{
 			id:				actionMenu
 			anchors.left:	parent.left
 			width:			fileMenu.colWidths * preferencesModel.uiScale
 			height:			parent.height
-			z:				2
+			z:				4
+			contentWidth:	width
+			contentHeight:	fileAction.implicitHeight
 
 			ALTNavigation.enabled:		true
 			ALTNavigation.parent:		ribbon.fileMenuButton
 			ALTNavigation.scopeOnly:	true
 			ALTNavigation.foreground:	fileMenuModel.visible
-
-			Rectangle
-			{
-				z:				-1
-				color:			jaspTheme.fileMenuColorBackground
-				border.width:	1
-				border.color:	jaspTheme.uiBorder
-				anchors.fill:	parent
-			}
 
 			Column
 			{
@@ -176,7 +178,17 @@ FocusScope
 			}
 		}
 
-		FocusScope
+		Rectangle
+		{
+			z:				1
+			color:			jaspTheme.fileMenuColorBackground
+			border.width:	1
+			border.color:	jaspTheme.uiBorder
+			anchors.fill:	resourceMenu
+		}
+
+
+		Flickable
 		{
 			id:					resourceMenu
 
@@ -184,7 +196,9 @@ FocusScope
 			height:				parent.height
 			anchors.left:		actionMenu.right
 			anchors.leftMargin: hasButtons ? 0 : - fileMenu.colWidths * preferencesModel.uiScale
-			z:					1
+			z:					2
+			contentWidth:		width
+			contentHeight:		resourceLocation.implicitHeight
 
 			onFocusChanged:		if(focus) fileMenuModel.resourceButtons.selectFirstButtonIfNoneSelected();
 
@@ -203,14 +217,7 @@ FocusScope
 				}
 			}
 
-			Rectangle
-			{
-				color:			jaspTheme.fileMenuColorBackground
-				border.width:	1
-				border.color:	jaspTheme.uiBorder
-				z:				-1
-				anchors.fill:	parent
-			}
+
 
 			property bool hasButtons: resourceRepeaterId.count > 0
 

--- a/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
@@ -33,8 +33,6 @@ FocusScope
 
 	property int  actionButtionHeight:		35 * preferencesModel.uiScale
 	property int  resourceButtonHeight:		1.5 * actionButtionHeight
-	property int  nbColumns:				1 + (resourceRepeaterId.count > 0 ? 1 : 0 )
-	property int  colWidths:				190
 
 
 	Connections
@@ -54,7 +52,7 @@ FocusScope
 		property real desiredX: !fileMenuModel.visible ? -(resourceScreen.otherColumnsWidth + resourceScreen.width) : 0
 
 		x:		desiredX
-		width:	(fileMenu.nbColumns * fileMenu.colWidths * preferencesModel.uiScale) + (resourceScreen.aButtonVisible ? resourceScreen.width : 0)
+		width:	(actionMenu.width + resourceMenu.width ) + (resourceScreen.aButtonVisible ? resourceScreen.width : 0)
 		height: fileMenu.height
 
 		Behavior on x
@@ -82,7 +80,7 @@ FocusScope
 		{
 			id:				actionMenu
 			anchors.left:	parent.left
-			width:			fileMenu.colWidths * preferencesModel.uiScale
+			width:			fileMenuModel.actionButtons.width + jaspTheme.subMenuIconHeight + jaspTheme.generalAnchorMargin * 5
 			height:			parent.height
 			z:				4
 			contentWidth:	width
@@ -95,15 +93,14 @@ FocusScope
 
 			Column
 			{
-				id: fileAction
-				spacing: 4
-				width: parent.width - jaspTheme.generalAnchorMargin
+				id:			fileAction
+				spacing:	jaspTheme.menuSpacing
+				width:		parent.width
 
 				anchors
 				{
-					top: parent.top
-					topMargin: 5
-					horizontalCenter: parent.horizontalCenter
+					fill:		parent
+					margins:	jaspTheme.generalAnchorMargin
 				}
 
 				Repeater
@@ -114,7 +111,7 @@ FocusScope
 					Item
 					{
 						id:				itemActionMenu
-						width:			parent.width - (6 * preferencesModel.uiScale)
+						width:			parent.width
 						anchors.left:	parent.left
 						height:			actionButtionHeight + actionToolSeperator.height
 						enabled:		enabledRole
@@ -123,17 +120,11 @@ FocusScope
 						{
 							id:					actionMenuButton
 							hasSubMenu:			hasSubMenuRole
-							width:				itemActionMenu.width
+							width:				parent.width
 							height:				actionButtionHeight
 							text:				nameRole
 							selected:			selectedRole
 							focus:				selectedRole
-
-							anchors
-							{
-								leftMargin: 3  * preferencesModel.uiScale
-								left:		itemActionMenu.left
-							}
 
 							ALTNavigation.enabled:		true
 							ALTNavigation.x:			width * 0.9
@@ -165,10 +156,15 @@ FocusScope
 						ToolSeparator
 						{
 							id:					actionToolSeperator
-							anchors.top:		actionMenuButton.bottom
-							width:				actionMenuButton.width
-							anchors.topMargin:	(showToolSeperator(typeRole) ? 3 : 0)  * preferencesModel.uiScale
-							anchors.left:		actionMenuButton.left
+							anchors
+							{
+								top:			actionMenuButton.bottom
+								topMargin:		(showToolSeperator(typeRole) ? 3 : 0)  * preferencesModel.uiScale
+								left:			parent.left
+								right:			parent.right
+								leftMargin:		-jaspTheme.generalAnchorMargin
+								rightMargin:	-jaspTheme.generalAnchorMargin
+							}
 
 							orientation:		Qt.Horizontal
 							visible:			showToolSeperator(typeRole)
@@ -192,10 +188,10 @@ FocusScope
 		{
 			id:					resourceMenu
 
-			width:				fileMenu.colWidths * preferencesModel.uiScale
+			width:				!hasButtons ? 0 : fileMenuModel.resourceButtons.width + jaspTheme.subMenuIconHeight + jaspTheme.generalAnchorMargin * 5
 			height:				parent.height
 			anchors.left:		actionMenu.right
-			anchors.leftMargin: hasButtons ? 0 : - fileMenu.colWidths * preferencesModel.uiScale
+			anchors.leftMargin: hasButtons ? 0 : -width
 			z:					2
 			contentWidth:		width
 			contentHeight:		resourceLocation.implicitHeight
@@ -204,6 +200,12 @@ FocusScope
 
 			Keys.onLeftPressed:		actionMenu.forceActiveFocus();
 			Keys.onEscapePressed:	actionMenu.forceActiveFocus();
+			
+			
+			
+			property bool hasButtons: resourceRepeaterId.count > 0
+
+			visible: hasButtons
 
 			Behavior on anchors.leftMargin
 			{
@@ -217,20 +219,16 @@ FocusScope
 				}
 			}
 
-
-
-			property bool hasButtons: resourceRepeaterId.count > 0
-
-			visible: hasButtons
-
 			Column
 			{
 				id:							resourceLocation
 
-				anchors.top:				parent.top
-				anchors.topMargin:			5 * preferencesModel.uiScale
-				anchors.horizontalCenter:	parent.horizontalCenter
-				width:						parent.width - jaspTheme.generalAnchorMargin
+				anchors
+				{
+					fill:		parent
+					margins:	jaspTheme.generalAnchorMargin
+				}
+				
 
 				spacing:					6 * preferencesModel.uiScale
 
@@ -243,10 +241,8 @@ FocusScope
 					{
 
 						id:					itemResourceMenu
-						width:				parent.width - (6 * preferencesModel.uiScale)
+						width:				parent.width
 						height:				resourceButtonHeight
-						anchors.leftMargin: 3 * preferencesModel.uiScale
-						anchors.left:		parent.left
 						enabled:			enabledRole
 
 						MenuButton
@@ -310,7 +306,7 @@ FocusScope
 
 		Rectangle
 		{
-			property real otherColumnsWidth:	fileMenu.colWidths * fileMenu.nbColumns * preferencesModel.uiScale
+			property real otherColumnsWidth:	actionMenu.width + resourceMenu.width
 			property bool aButtonVisible:		resourceRepeaterId.count > 0 && fileMenuModel.resourceButtons.currentQML !== ''
 
 			property real desiredWidth:			Math.min(mainWindowRoot.width - otherColumnsWidth, 600 * preferencesModel.uiScale)

--- a/Desktop/components/JASP/Widgets/FileMenu/OSF.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/OSF.qml
@@ -386,8 +386,7 @@ Item
 		visible:	!loggedin && !processing
 		focus:		visible
 
-		anchors.horizontalCenter	: parent.horizontalCenter
-		anchors.top					: firstSeparator.bottom
-		anchors.topMargin			: 40 * preferencesModel.uiScale
+		anchors.fill:		parent
+		anchors.topMargin:	menuHeader.height
 	}
 }

--- a/Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/OSFLogin.qml
@@ -16,319 +16,302 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-import QtQuick				2.12
-import QtQuick.Controls		2.2
-import JASP.Controls		1.0
-import JASP.Widgets			1.0
+import QtQuick				
+import QtQuick.Controls		
+import JASP.Controls		
+import JASP.Widgets
+import QtQuick.Layouts
 
 FocusScope
 {
-	id: osfLogin
-
-	Rectangle
-	{
-		color:			jaspTheme.grayMuchLighter
-		z:				-1
-		anchors.fill:	parent
-	}
+	id:		osfLogin
+	
+	property bool minimal: osfLogin.height < 450 * preferencesModel.uiScale
+	
 
 	Component.onCompleted:
 	{
 		usernameText.focus = true
 	}
-
-	Image
+	
+	ColumnLayout
 	{
-		id: osfLogo
+			
+		id:						osfLogoColumn
+		width:					250 * preferencesModel.uiScale
+		anchors
+		{
+			top:				parent.top
+			bottom:				parent.bottom
+			horizontalCenter:	parent.horizontalCenter
+		}
+		
+		Item
+		{
+			implicitHeight:		(osfLogin.minimal ? 40 : 160) * preferencesModel.uiScale 
+			Layout.fillWidth:	true
 
-		height: 100 * preferencesModel.uiScale
-		width : 100 * preferencesModel.uiScale
-		source: jaspTheme.iconPath + "osf-logo.png"
-		smooth: true
+			Image
+			{
+				id:					osfLogo
+		
+				anchors.fill:		parent
+				
+				source:				jaspTheme.iconPath + "osf-logo.png"
+				smooth:				true
+				fillMode:			Image.PreserveAspectFit
+		
+				sourceSize.width:	height * 2
+				sourceSize.height:	height * 2
+		
+				Layout.alignment:	Qt.AlignHCenter
+			}
+		}
+	
+		Label
+		{
+			id: labelOSF
+	
+			Layout.fillWidth:	true
+	
+			verticalAlignment  : Text.AlignVCenter
+			horizontalAlignment: Text.AlignHCenter
+	
+			text : qsTr("OSF")
+			
+			color: jaspTheme.black
+			font : jaspTheme.fontLabel
+		}
+	
+		Text
+		{
+			id:						labelExplain
+			text :					qsTr("Sign in with your OSF account to continue")
+			color:					jaspTheme.textEnabled
+			font.pointSize:			(osfLogin.minimal ? 8 : 11) * preferencesModel.uiScale
+			font.family:			jaspTheme.font.family
+			verticalAlignment:		Text.AlignVCenter
+			horizontalAlignment:	Text.AlignHCenter
+			Layout.fillWidth:		true
 
-		sourceSize.width : width  * 2
-		sourceSize.height: height * 2
-
-		anchors.horizontalCenter: parent.horizontalCenter
-		anchors.bottomMargin    : 20 * preferencesModel.uiScale
-	}
-
-	Label
-	{
-		id: labelOSF
-
-		width : osfLoginBox.width
-		height: 40 * preferencesModel.uiScale
-
-		verticalAlignment  : Text.AlignVCenter
-		horizontalAlignment: Text.AlignHCenter
-
-		anchors.horizontalCenter: parent.horizontalCenter
-		anchors.top: osfLogo.bottom
-		anchors.bottomMargin: 20 * preferencesModel.uiScale
-
-		text : qsTr("OSF")
-		color: jaspTheme.black
-		font : jaspTheme.fontLabel
-	}
-
-	Text
-	{
-		id: labelExplain
-
-		text :	qsTr("Sign in with your OSF account to continue")
-		color:	jaspTheme.textEnabled
-		font.pointSize: 11 * preferencesModel.uiScale
-		font.family:	jaspTheme.font.family
-
-		verticalAlignment  : Text.AlignVCenter
-		horizontalAlignment: Text.AlignHCenter
-
-		anchors.horizontalCenter: parent.horizontalCenter
-		anchors.top             : labelOSF.bottom
-		anchors.topMargin       : 20 * preferencesModel.uiScale
-	}
-
-	Rectangle
-	{
-		id: osfLoginBox
-
-		height: 240 * preferencesModel.uiScale
-		width : 250 * preferencesModel.uiScale
-		color : jaspTheme.grayMuchLighter
-
-		border.width: 1
-		border.color: jaspTheme.grayDarker
-
-		anchors.horizontalCenter: parent.horizontalCenter
-		anchors.top: labelExplain.bottom
-		anchors.topMargin: 10 * preferencesModel.uiScale
-
+		}
+	
 		Rectangle
 		{
-			id: usernameInput
-
-			anchors.left : parent.left
-			anchors.right: parent.right
-			anchors.top  : parent.top
-
-			anchors.leftMargin : 20 * preferencesModel.uiScale
-			anchors.rightMargin: 20 * preferencesModel.uiScale
-			anchors.topMargin  : 30 * preferencesModel.uiScale
-
-			height		: 35 * preferencesModel.uiScale
-			width		: 100 * preferencesModel.uiScale
-			clip		: true
-			color		: jaspTheme.white
-			border.width: usernameText.activeFocus ? 3 : 1
-			border.color: usernameText.activeFocus ? jaspTheme.focusBorderColor : jaspTheme.grayDarker
-
-			TextInput
+			id:					osfLoginBox
+			Layout.fillWidth:	true
+			implicitHeight:		(osfLogin.minimal ? 160 : 200) * preferencesModel.uiScale
+			color:				jaspTheme.grayMuchLighter
+			border.width:		1
+			border.color:		jaspTheme.grayDarker
+	
+	
+			ColumnLayout
 			{
-				id					: usernameText
-				text				: fileMenuModel.osf.username
+				id:					loginColumn
+				anchors.fill:		parent
+				anchors.margins:	jaspTheme.generalAnchorMargin
+				spacing:			(height - (buttonHeight * 4)) / 4
+				
+				property real buttonHeight:	35 * preferencesModel.uiScale
+				
+				Item
+				{
+					implicitHeight:			loginColumn.buttonHeight
+					Layout.fillWidth:		true
+					
+					Rectangle
+					{
+						id:					usernameInput
+			
+						clip:				true
+						color:				jaspTheme.white
+						border.width:		usernameText.activeFocus ? 3 : 1
+						border.color:		usernameText.activeFocus ? jaspTheme.focusBorderColor : jaspTheme.grayDarker
+						anchors.fill:		parent
+			
+						TextInput
+						{
+							id					: usernameText
+							text				: fileMenuModel.osf.username
+			
+							anchors.fill		: parent
+							anchors.leftMargin	: 10 * preferencesModel.uiScale
+							selectByMouse		: true
+							selectedTextColor	: jaspTheme.textDisabled
+							selectionColor		: jaspTheme.itemSelectedColor
+							color				: jaspTheme.textEnabled
+			
+			
+							verticalAlignment	: Text.AlignVCenter
+							font				: jaspTheme.fontRibbon
+			
+							onTextChanged		: fileMenuModel.osf.username = text
+							onAccepted			: passwordText.focus = true
+			
+							KeyNavigation.tab	: passwordText
+							focus				: true
+						}
+					}
+			
+					Text
+					{
+						text			: "<sup>*</sup>"
+						textFormat		: Text.RichText
+						font.pointSize	: 12 * preferencesModel.uiScale
+						font.family		: jaspTheme.font.family
+						color			: jaspTheme.textEnabled
+			
+						anchors
+						{
+							top:				usernameInput.top
+							left:				usernameInput.right
+							leftMargin:			2 * jaspTheme.uiScale
+						}
+					}
+				}
+		
+				Rectangle
+				{
+					id:					passwordInput
+		
+					implicitHeight:		loginColumn.buttonHeight
+					Layout.fillWidth:	true
+					clip:				true
+					color:				jaspTheme.white
+		
+					border.width:		passwordText.activeFocus ? 3 : 1
+					border.color:		passwordText.activeFocus ? jaspTheme.focusBorderColor  : jaspTheme.grayDarker
+		
+					TextInput
+					{
+						id:						passwordText
+		
+						text:					fileMenuModel.osf.password
+						anchors.fill:			parent
+						anchors.leftMargin:		10 * preferencesModel.uiScale
+						verticalAlignment:		Text.AlignVCenter
+						echoMode:				TextInput.Password
+						selectByMouse:			true
+						selectedTextColor:		jaspTheme.textDisabled
+						selectionColor:			jaspTheme.itemSelectedColor
+						color:					jaspTheme.textEnabled
+		
+						font.pixelSize:			14 * preferencesModel.uiScale
+		
+		
+						onTextChanged:	fileMenuModel.osf.password = text;
+						onAccepted:		fileMenuModel.osf.loginRequested(fileMenuModel.osf.username, fileMenuModel.osf.password)
+		
+						KeyNavigation.tab		: loginButton
+		
+					}
+				}
+		
+				RoundedButton
+				{
+					id:					loginButton
+		
+					implicitHeight:		loginColumn.buttonHeight
+					Layout.fillWidth:	true
+					text:				qsTr("Sign in")
+					color:				jaspTheme.jaspGreen
+					border.width:		loginButton.activeFocus ? 3 : 1
+					border.color:		loginButton.activeFocus ? jaspTheme.focusBorderColor : jaspTheme.grayDarker
+		
+					textColor:			jaspTheme.white
 
-				anchors.fill		: parent
-				anchors.leftMargin	: 10 * preferencesModel.uiScale
-				selectByMouse		: true
-				selectedTextColor	: jaspTheme.textDisabled
-				selectionColor		: jaspTheme.itemSelectedColor
-				color				: jaspTheme.textEnabled
-
-
-				verticalAlignment	: Text.AlignVCenter
-				font				: jaspTheme.fontRibbon
-
-				onTextChanged		: fileMenuModel.osf.username = text
-				onAccepted			: passwordText.focus = true
-
-				KeyNavigation.tab	: passwordText
-				focus				: true
+		
+					onClicked:			fileMenuModel.osf.loginRequested(fileMenuModel.osf.username, fileMenuModel.osf.password)
+		
+					KeyNavigation.tab: idRememberMe
+				}
+		
+				CheckBox
+				{
+					id:						idRememberMe
+					checked:				fileMenuModel.osf.rememberme
+					label:					qsTr("Remember me")
+					onCheckedChanged:		fileMenuModel.osf.rememberme = checked
+					KeyNavigation.tab:		usernameText
+					Layout.fillWidth:		true
+				}
+			}
+		}
+	
+		Item
+		{
+			id:						linksBox
+	
+			Layout.fillWidth:		true
+			implicitHeight:			40 * preferencesModel.uiScale
+	
+			Text 
+			{
+				id: linkOSF
+	
+				text			: qsTr("About the OSF")
+				textFormat		: Text.StyledText
+				font.pointSize	: 11 * preferencesModel.uiScale
+				font.family		: jaspTheme.font.family
+				font.underline	: true
+				color			: jaspTheme.blueDarker
+	
+				anchors.left    : parent.left
+				anchors.top	    : parent.top
+				anchors.leftMargin: 5 * preferencesModel.uiScale
+	
+				MouseArea
+				{
+					anchors.fill: parent
+					hoverEnabled: true
+					cursorShape : Qt.PointingHandCursor
+					onClicked   : Qt.openUrlExternally("http://help.osf.io")
+				}
+			}
+	
+			Text
+			{
+				id: linkRegister
+	
+				text			: qsTr("Register")
+				textFormat		: Text.StyledText
+				font.pointSize	: 11 * preferencesModel.uiScale
+				font.family		: jaspTheme.font.family
+				font.underline	: true
+				color			: jaspTheme.blueDarker
+	
+				anchors.top        : parent.top
+				anchors.right      : parent.right
+				anchors.rightMargin: 5 * preferencesModel.uiScale
+	
+				MouseArea
+				{
+					anchors.fill: parent
+					hoverEnabled: true
+					cursorShape : Qt.PointingHandCursor
+					onClicked   : Qt.openUrlExternally("https://osf.io")
+				}
+			}
+	
+			Text
+			{
+				text			: qsTr("<sup>*</sup>OSF account login only, ORCID or institutional login are not supported.")
+				textFormat		: Text.RichText
+				font.pointSize	: 8 * preferencesModel.uiScale
+				font.family		: jaspTheme.font.family
+				font.italic		: true
+				color			: jaspTheme.textEnabled
+				wrapMode		: Text.Wrap
+	
+				anchors
+				{
+					bottom:				parent.bottom
+					left:				parent.left
+					right:				parent.right
+				}
 			}
 		}
 
-		Text
-		{
-			text			: "<sup>*</sup>"
-			textFormat		: Text.RichText
-			font.pointSize	: 12 * preferencesModel.uiScale
-			font.family		: jaspTheme.font.family
-			color			: jaspTheme.textEnabled
-
-			anchors
-			{
-				top:				usernameInput.top
-				left:				usernameInput.right
-				leftMargin:			2 * jaspTheme.uiScale
-			}
-		}
-
-		Rectangle
-		{
-			id: passwordInput
-
-			anchors.left  : parent.left
-			anchors.right : parent.right
-			anchors.top   : usernameInput.bottom
-
-			anchors.leftMargin : 20 * preferencesModel.uiScale
-			anchors.rightMargin: 20 * preferencesModel.uiScale
-			anchors.topMargin  : 15 * preferencesModel.uiScale
-
-			height: 35 * preferencesModel.uiScale
-			width : 100 * preferencesModel.uiScale
-			clip  : true
-			color : jaspTheme.white
-
-			border.width: passwordText.activeFocus ? 3 : 1
-			border.color: passwordText.activeFocus ? jaspTheme.focusBorderColor  : jaspTheme.grayDarker
-
-			TextInput
-			{
-				id: passwordText
-
-				text:fileMenuModel.osf.password
-
-				anchors.fill		: parent
-				anchors.leftMargin	: 10 * preferencesModel.uiScale
-				verticalAlignment	: Text.AlignVCenter
-				echoMode			: TextInput.Password
-				selectByMouse		: true
-				selectedTextColor	: jaspTheme.textDisabled
-				selectionColor		: jaspTheme.itemSelectedColor
-				color				: jaspTheme.textEnabled
-
-				font.pixelSize    : 14 * preferencesModel.uiScale
-
-
-				onTextChanged:	fileMenuModel.osf.password = text;
-				onAccepted:		fileMenuModel.osf.loginRequested(fileMenuModel.osf.username, fileMenuModel.osf.password)
-
-				KeyNavigation.tab		: loginButton
-
-			}
-		}
-
-		RoundedButton
-		{
-			id: loginButton
-
-			height   : 35  * preferencesModel.uiScale
-			text     : qsTr("Sign in")
-			color    : jaspTheme.jaspGreen
-			border.width: loginButton.activeFocus ? 3 : 1
-			border.color: loginButton.activeFocus ? jaspTheme.focusBorderColor : jaspTheme.grayDarker
-
-			textColor: jaspTheme.white
-
-			anchors.top  : passwordInput.bottom
-			anchors.right: parent.right
-			anchors.left : parent.left
-
-			anchors.topMargin  : 15  * preferencesModel.uiScale
-			anchors.rightMargin: 20  * preferencesModel.uiScale
-			anchors.leftMargin : 20  * preferencesModel.uiScale
-
-			onClicked:			fileMenuModel.osf.loginRequested(fileMenuModel.osf.username, fileMenuModel.osf.password)
-
-			KeyNavigation.tab		: idRememberMe
-		}
-
-		CheckBox
-		{
-			id: idRememberMe
-
-			checked:				fileMenuModel.osf.rememberme
-			label   :				qsTr("Remember me")
-
-			anchors.left  :			parent.left
-			anchors.right :			parent.right
-			anchors.bottom:			parent.bottom
-
-			anchors.bottomMargin:	30 * preferencesModel.uiScale
-			anchors.leftMargin  :	20 * preferencesModel.uiScale
-			anchors.topMargin   :	10 * preferencesModel.uiScale
-
-			onCheckedChanged:		fileMenuModel.osf.rememberme = checked
-
-			KeyNavigation.tab:		usernameText
-		}
-	}
-
-	Item
-	{
-		id: linksBox
-
-		width : osfLoginBox.width
-		height: 60 * preferencesModel.uiScale
-
-		anchors.top             : osfLoginBox.bottom
-		anchors.horizontalCenter: parent.horizontalCenter
-		anchors.topMargin       : 10 * preferencesModel.uiScale
-
-		Text {
-			id: linkOSF
-
-			text			: qsTr("About the OSF")
-			textFormat		: Text.StyledText
-			font.pointSize	: 11 * preferencesModel.uiScale
-			font.family		: jaspTheme.font.family
-			font.underline	: true
-			color			: jaspTheme.blueDarker
-
-			anchors.left    : parent.left
-			anchors.top	    : parent.top
-			anchors.leftMargin: 5 * preferencesModel.uiScale
-
-			MouseArea
-			{
-				anchors.fill: parent
-				hoverEnabled: true
-				cursorShape : Qt.PointingHandCursor
-				onClicked   : Qt.openUrlExternally("http://help.osf.io")
-			}
-		}
-
-		Text
-		{
-			id: linkRegister
-
-			text			: qsTr("Register")
-			textFormat		: Text.StyledText
-			font.pointSize	: 11 * preferencesModel.uiScale
-			font.family		: jaspTheme.font.family
-			font.underline	: true
-			color			: jaspTheme.blueDarker
-
-			anchors.top        : parent.top
-			anchors.right      : parent.right
-			anchors.rightMargin: 5 * preferencesModel.uiScale
-
-			MouseArea
-			{
-				anchors.fill: parent
-				hoverEnabled: true
-				cursorShape : Qt.PointingHandCursor
-				onClicked   : Qt.openUrlExternally("https://osf.io")
-			}
-		}
-
-		Text
-		{
-			text			: qsTr("<sup>*</sup>OSF account login only, ORCID or institutional login are not supported.")
-			textFormat		: Text.RichText
-			font.pointSize	: 8 * preferencesModel.uiScale
-			font.family		: jaspTheme.font.family
-			font.italic		: true
-			color			: jaspTheme.textEnabled
-			wrapMode		: Text.Wrap
-
-			anchors
-			{
-				bottom:				parent.bottom
-				left:				parent.left
-				right:				parent.right
-			}
-		}
 	}
 }

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -133,13 +133,13 @@ ScrollView
 
 			Item  //Scale threshold
 			{
-				height:		customThreshold.height
-				width:		customThreshold.width + thresholdScale.width
+				height:		customThreshold.height + thresholdScale.height
+				width:		customThreshold.width 
 
 				CheckBox
 				{
 					id:					customThreshold
-					label:				qsTr("Import threshold between Categorical or Scale")
+					label:				qsTr("Import threshold between Categorical or Scale") + ":"
 					checked:			preferencesModel.customThresholdScale
 					onCheckedChanged:	preferencesModel.customThresholdScale = checked
 					ToolTip.delay:		500
@@ -161,9 +161,9 @@ ScrollView
 
 					anchors
 					{
-						left:			customThreshold.right
-						leftMargin:		jaspTheme.generalAnchorMargin
-						verticalCenter:	parent.verticalCenter
+						top:			customThreshold.bottom
+						left:			customThreshold.left
+						leftMargin:		jaspTheme.subOptionOffset
 					}
 				}
 			}

--- a/Desktop/components/JASP/Widgets/FilterConstructor/Function.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/Function.qml
@@ -356,10 +356,10 @@ Item
 
 	Text
 	{
-		id: haakjesRechts
-		anchors.top: meanBar.top
+		id:				haakjesRechts
+		anchors.top:	meanBar.top
 		anchors.bottom: parent.bottom
-		x: dropRow.x + dropRow.width
+		x:				dropRow.x + dropRow.width
 
 		verticalAlignment: Text.AlignVCenter
 		horizontalAlignment: Text.AlignHCenter

--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -31,7 +31,7 @@ Window
 	flags:				Qt.Window | Qt.WindowFullscreenButtonHint
 	color:				jaspTheme.white
 	minimumWidth:		jaspTheme.formWidth + 2 * jaspTheme.splitHandleWidth + jaspTheme.scrollbarBoxWidthBig + 3
-	minimumHeight:		640 * jaspTheme.uiScale
+	minimumHeight:		400 * jaspTheme.uiScale
 
 	onVisibleChanged:
 		if(!visible)

--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -91,8 +91,8 @@ FocusScope
 		{
 			id:						modulesFlick
 			flickableDirection:		Flickable.VerticalFlick
-			contentHeight:			modules.height
-			contentWidth:			modules.width
+			contentHeight:			workspaceSpecs.visible ? workspaceSpecs.height : modules.height
+			contentWidth:			width
 
 			anchors
 			{

--- a/Desktop/components/JASP/Widgets/Ribbon/MenuArrowButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/MenuArrowButton.qml
@@ -52,7 +52,7 @@ Rectangle
 
 	ToolTip.text:				toolTip
 	ToolTip.timeout:			jaspTheme.toolTipTimeout
-	ToolTip.delay:				jaspTheme.toolTipDelay / 5
+	ToolTip.delay:				jaspTheme.toolTipDelay
 	ToolTip.visible:			toolTip !== "" && mice.containsMouse
 
 	signal clicked

--- a/Desktop/data/columnmodel.cpp
+++ b/Desktop/data/columnmodel.cpp
@@ -197,19 +197,17 @@ QVariantList ColumnModel::tabs() const
 {
 	QVariantList tabs;
 	Column* col = column();
+	
 	if(col)
 	{
+		if(_compactMode)
+			tabs.push_back(QMap<QString, QVariant>({  std::make_pair("name", "basicInfo"), std::make_pair("title", tr("Column definition"))}));
+		
 		if (col->isComputed() && (col->codeType() == computedColumnType::rCode || col->codeType() == computedColumnType::constructorCode))
-		{
-			QMap<QString, QVariant> computed =	{  std::make_pair("name", "computed"), std::make_pair("title", tr("Computed column definition"))};
-			tabs.push_back(computed);
-		}
+			tabs.push_back(QMap<QString, QVariant>({  std::make_pair("name", "computed"), std::make_pair("title", tr("Computed column definition"))}));
 
 		if (col->type() != columnType::scale && rowCount() > 0)
-		{
-			QMap<QString, QVariant> label =	{  std::make_pair("name", "label"), std::make_pair("title", tr("Label editor"))};
-			tabs.push_back(label);
-		}
+			tabs.push_back(QMap<QString, QVariant>({  std::make_pair("name", "label"), std::make_pair("title", tr("Label editor"))}));
 	}
 
 	QMap<QString, QVariant> misingValues =	{  std::make_pair("name", "missingValues"), std::make_pair("title", tr("Missing Values"))};
@@ -704,4 +702,19 @@ void ColumnModel::clearVirtual()
 
 	_dummyColumn.type			= columnType::scale;
 	_dummyColumn.computedType	= computedColumnType::notComputed;
+}
+
+bool ColumnModel::compactMode() const
+{
+	return _compactMode;
+}
+
+void ColumnModel::setCompactMode(bool newCompactMode)
+{
+	if (_compactMode == newCompactMode)
+		return;
+	_compactMode = newCompactMode;
+	emit compactModeChanged();
+	
+	emit tabsChanged();
 }

--- a/Desktop/data/columnmodel.cpp
+++ b/Desktop/data/columnmodel.cpp
@@ -198,11 +198,11 @@ QVariantList ColumnModel::tabs() const
 	QVariantList tabs;
 	Column* col = column();
 	
+	if(_compactMode)
+		tabs.push_back(QMap<QString, QVariant>({  std::make_pair("name", "basicInfo"), std::make_pair("title", tr("Column definition"))}));
+	
 	if(col)
 	{
-		if(_compactMode)
-			tabs.push_back(QMap<QString, QVariant>({  std::make_pair("name", "basicInfo"), std::make_pair("title", tr("Column definition"))}));
-		
 		if (col->isComputed() && (col->codeType() == computedColumnType::rCode || col->codeType() == computedColumnType::constructorCode))
 			tabs.push_back(QMap<QString, QVariant>({  std::make_pair("name", "computed"), std::make_pair("title", tr("Computed column definition"))}));
 

--- a/Desktop/data/columnmodel.h
+++ b/Desktop/data/columnmodel.h
@@ -36,6 +36,7 @@ class ColumnModel : public DataSetTableProxy
 	Q_PROPERTY(QStringList	emptyValues					READ emptyValues				WRITE setCustomEmptyValues		NOTIFY emptyValuesChanged				)
 	Q_PROPERTY(QVariantList	tabs						READ tabs														NOTIFY tabsChanged						)
 	Q_PROPERTY(bool 		isVirtual					READ isVirtual													NOTIFY isVirtualChanged					)
+	Q_PROPERTY(bool			compactMode					READ compactMode				WRITE setCompactMode			NOTIFY compactModeChanged				)
 
 public:
 	ColumnModel(DataSetTableModel* dataSetTableModel);
@@ -94,7 +95,9 @@ public:
 
 	bool columnIsFiltered() const;
 	bool isVirtual()		const	{ return _virtual; }
-
+	bool compactMode()		const;
+	
+	
 public slots:
 	void filteredOutChangedHandler(int col);
 	void setVisible(bool visible);
@@ -111,7 +114,7 @@ public slots:
 	void checkRemovedColumns(int columnIndex, int count);
 	void openComputedColumn(const QString & name);
 	void checkCurrentColumn( QStringList changedColumns, QStringList missingColumns, QMap<QString, QString>	changeNameColumns, bool rowCountChanged, bool hasNewColumns);
-
+	void setCompactMode(bool newCompactMode);
 
 signals:
 	void visibleChanged(bool visible);
@@ -136,7 +139,8 @@ signals:
 	void useCustomEmptyValuesChanged();
 	void emptyValuesChanged();
 	void isVirtualChanged();
-
+	void compactModeChanged();
+	
 private:
 	std::vector<size_t> getSortedSelection()					const;
 	void				setValueMaxWidth();
@@ -151,7 +155,8 @@ private:
 
 	bool					_visible			= false,
 							_editing			= false,
-							_virtual			= false;
+							_virtual			= false,
+							_compactMode		= false;
 	int						_currentColIndex	= -1;
 	double					_valueMaxWidth		= 10,
 							_labelMaxWidth		= 10,

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -473,6 +473,8 @@ void MainWindow::makeConnections()
 	connect(_preferences,			&PreferencesModel::developerModeChanged,			_analyses,				&Analyses::refreshAllAnalyses								);
 	connect(_preferences,			&PreferencesModel::currentJaspThemeChanged,			this,					&MainWindow::setCurrentJaspTheme							);
 	connect(_preferences,			&PreferencesModel::currentThemeNameChanged,			_resultsJsInterface,	&ResultsJsInterface::setThemeCss							);
+	connect(_preferences,			&PreferencesModel::currentThemeNameChanged,			_fileMenu,				&FileMenu::refresh											);
+	connect(_preferences,			&PreferencesModel::uiScaleChanged,					_fileMenu,				&FileMenu::refresh											);
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_resultsJsInterface,	&ResultsJsInterface::setFontFamily							);
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_engineSync,			&EngineSync::refreshAllPlots								);
 	connect(_preferences,			&PreferencesModel::restartAllEngines,				_engineSync,			&EngineSync::haveYouTriedTurningItOffAndOnAgain				);
@@ -647,12 +649,12 @@ void MainWindow::loadQML()
 		connect(_preferences,		&PreferencesModel::maxFlickVelocityChanged, 	keyval.second,		&JaspTheme::maxFlickVeloHandler				);
 	}
 
-
+	_fileMenu->refresh(); //Now that the theme is loaded we can determine the proper width for the buttons in the filemenu
 
 	Log::log() << "Loading HelpWindow"			<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/HelpWindow.qml"));
 	Log::log() << "Loading AboutWindow"			<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/AboutWindow.qml"));
 	Log::log() << "Loading ContactWindow"		<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/ContactWindow.qml"));
-	Log::log() << "Loading CommunityWindow"	<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/CommunityWindow.qml"));
+	Log::log() << "Loading CommunityWindow"		<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/CommunityWindow.qml"));
 	Log::log() << "Loading MainWindow"			<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/MainWindow.qml"));
 
 	

--- a/Desktop/widgets/filemenu/actionbuttons.cpp
+++ b/Desktop/widgets/filemenu/actionbuttons.cpp
@@ -2,12 +2,11 @@
 #include <QObject>
 #include <QtQml>
 #include "log.h"
+#include "jasptheme.h"
 
-ActionButtons::ActionButtons(QObject *parent) : QAbstractListModel (parent),
-  _data()
-
+ActionButtons::ActionButtons(QObject *parent) : QAbstractListModel (parent)
 {
-	loadButtonData(_data);
+	loadButtonData();
 
 	for(size_t i=0; i<_data.size(); i++)
 		_opToIndex[_data[i].operation] = i;
@@ -17,9 +16,11 @@ ActionButtons::ActionButtons(QObject *parent) : QAbstractListModel (parent),
 	connect(this, &ActionButtons::buttonClicked, this, &ActionButtons::setSelectedAction);
 }
 
-void ActionButtons::loadButtonData(std::vector<ActionButtons::DataRow> &data)
+void ActionButtons::loadButtonData()
 {
-	_data =
+	_width = 0;
+	
+	_data = 
 	{
 		{FileOperation::Open,			tr("Open"),				true,	{ResourceButtons::Computer, ResourceButtons::OSF, ResourceButtons::Database, ResourceButtons::RecentFiles,	ResourceButtons::DataLibrary }		},
 		{FileOperation::Save,			tr("Save"),				false,	{}																																				},
@@ -33,6 +34,18 @@ void ActionButtons::loadButtonData(std::vector<ActionButtons::DataRow> &data)
 		{FileOperation::Community,		tr("Community"),		true,	{}																																				},
 		{FileOperation::About,			tr("About"),			true,	{}																																				}
 	  };
+	
+	
+	if(JaspTheme::currentTheme())
+	{
+		
+		QFontMetricsF ribbonMetrics(JaspTheme::currentTheme()->fontRibbon());
+		
+		for(const auto & action : _data)
+			_width = std::max(_width, int(ribbonMetrics.boundingRect(action.name).width()));
+		
+		emit widthChanged();
+	}
 }
 
 QVariant ActionButtons::data(const QModelIndex &index, int role)	const
@@ -113,7 +126,7 @@ void ActionButtons::refresh()
 
 	std::vector<DataRow> savedata = _data;
 
-	loadButtonData(_data);
+	loadButtonData();
 
 	for(int i=0 ; i < savedata.size() ; i++)
 		_data[i].enabled = savedata[i].enabled;
@@ -157,4 +170,17 @@ void ActionButtons::selectButtonDown()
 			return;
 		}
 	}
+}
+
+int ActionButtons::width() const
+{
+	return _width;
+}
+
+void ActionButtons::setWidth(int newWidth)
+{
+	if (_width == newWidth)
+		return;
+	_width = newWidth;
+	emit widthChanged();
 }

--- a/Desktop/widgets/filemenu/actionbuttons.h
+++ b/Desktop/widgets/filemenu/actionbuttons.h
@@ -9,7 +9,8 @@ class ActionButtons : public QAbstractListModel
 {
 	Q_OBJECT
 
-	Q_PROPERTY(FileOperation selectedAction READ selectedAction WRITE setSelectedAction NOTIFY selectedActionChanged)
+	Q_PROPERTY(FileOperation	selectedAction	READ selectedAction WRITE setSelectedAction NOTIFY selectedActionChanged)
+	Q_PROPERTY(int				width			READ width			WRITE setWidth			NOTIFY widthChanged			)
 
 public:
 	enum FileOperation {None = 0, Open, Save, SaveAs, ExportResults, ExportData, SyncData, Close, Preferences, Contact, Community, About};
@@ -34,22 +35,27 @@ public:
 
 	std::set<ResourceButtons::ButtonType> resourceButtonsForButton(FileOperation button);
 	void refresh();
-
+	
+	int width() const;
+	void setWidth(int newWidth);
+	
 signals:
 	void selectedActionChanged(	ActionButtons::FileOperation selectedAction);
 	void buttonClicked(			ActionButtons::FileOperation selectedAction);
-
+	
+	void widthChanged();
+	
 public slots:
 	void setEnabled(			ActionButtons::FileOperation operation, bool enabledState);
 	void setSelectedAction(		ActionButtons::FileOperation selectedAction);
 
-
 private:
-	void loadButtonData(std::vector<DataRow> & data);
+	void loadButtonData();
 
 	std::vector<DataRow>				_data;
 	std::map<FileOperation, size_t>		_opToIndex;
 	FileOperation						_selected = None;
+	int									_width = 0;
 };
 
 #endif // ACTIONBUTTONS_H

--- a/Desktop/widgets/filemenu/resourcebuttons.cpp
+++ b/Desktop/widgets/filemenu/resourcebuttons.cpp
@@ -1,15 +1,16 @@
 #include "resourcebuttons.h"
+#include "jasptheme.h"
 
 ResourceButtons::ResourceButtons(QObject *parent) : QAbstractListModel (parent),
 	_data()
 {
-	loadButtonData(_data);
+	loadButtonData();
 
 	for(size_t i=0; i<_data.size(); i++)
 		_buttonToIndex[_data[i].button] = i;
 }
 
-void ResourceButtons::loadButtonData(std::vector<ResourceButtons::DataRow> &data)
+void ResourceButtons::loadButtonData()
 {
 	_data = {
 		{ButtonType::RecentFiles,	tr("Recent Files"),	false,	"./RecentFiles.qml"		, true},
@@ -23,7 +24,6 @@ void ResourceButtons::loadButtonData(std::vector<ResourceButtons::DataRow> &data
 		{ButtonType::PrefsUI,		tr("Interface"),	false,	"./PrefsUI.qml"			, true},
 		{ButtonType::PrefsAdvanced,	tr("Advanced"),		false,	"./PrefsAdvanced.qml"	, true}
 	};
-
 }
 
 QVariant ResourceButtons::data(const QModelIndex &index, int role)	const
@@ -197,14 +197,37 @@ void ResourceButtons::refresh()
 
 	std::vector<DataRow> savedata = _data;
 
-	loadButtonData(_data);
+	loadButtonData();
 
 	for(int i=0 ; i < savedata.size() ; i++)
 	{
 		_data[i].enabled = savedata[i].enabled;
 		_data[i].visible = savedata[i].visible;
 	}
+	
+	if(JaspTheme::currentTheme())
+	{
+		_width = 0;
+		QFontMetricsF ribbonMetrics(JaspTheme::currentTheme()->fontRibbon());
+		
+		for(const auto & resource : _data)
+			_width = std::max(_width, int(ribbonMetrics.boundingRect(resource.name).width()));
+		
+		emit widthChanged();
+	}
 
 	endResetModel();
+}
 
+int ResourceButtons::width() const
+{
+	return _width;
+}
+
+void ResourceButtons::setWidth(int newWidth)
+{
+	if (_width == newWidth)
+		return;
+	_width = newWidth;
+	emit widthChanged();
 }

--- a/Desktop/widgets/filemenu/resourcebuttons.h
+++ b/Desktop/widgets/filemenu/resourcebuttons.h
@@ -12,6 +12,7 @@ class ResourceButtons : public QAbstractListModel
 	Q_OBJECT
 	Q_PROPERTY(QString		currentQML		READ currentQML		WRITE setCurrentQML		NOTIFY currentQMLChanged	)
 	Q_PROPERTY(ButtonType	selectedButton	READ selectedButton WRITE setSelectedButton	NOTIFY selectedButtonChanged)
+	Q_PROPERTY(int			width			READ width			WRITE setWidth			NOTIFY widthChanged			)
 
 public:
 	//["Recent Files", "Current File", "Computer", "OSF", "Data Library"]
@@ -42,22 +43,29 @@ public:
 	Q_INVOKABLE	void		selectButtonUp();
 	Q_INVOKABLE	void		selectButtonDown();
 	void refresh();
-
+	
+	int width() const;
+	void setWidth(int newWidth);
+	
 signals:
 	void currentQMLChanged(QString currentQML);
 	void selectedButtonChanged(ResourceButtons::ButtonType selectedButton);
-
+	
+	void widthChanged();
+	
 public slots:
 	void setVisible(ResourceButtons::ButtonType button, bool visibility);
 	void setCurrentQML(QString currentQML);
 	void setSelectedButton(ResourceButtons::ButtonType selectedButton);
 
 private:
-	void loadButtonData(std::vector<DataRow> & data);
+	void loadButtonData();
+	
 	std::vector<DataRow>			_data;
 	std::map<ButtonType, size_t>	_buttonToIndex;
 	QString							_currentQML;
 	ButtonType						_selectedButton = None;
+	int								_width;
 };
 
 #endif // ResourceButtons_H


### PR DESCRIPTION
- FileMenu should be scrollable
- OSF Login now has a minified version for tiny windows
- MainWindow now can be minimum 400 * scaling insteead of 640 * scaling
- VariablesWindow column info now moves into a tab if it gets too small (Allows computed columns drag&drop to actually be usable)

OSF Login:
Big:
<img width="1300" alt="afbeelding" src="https://github.com/jasp-stats/jasp-desktop/assets/29062713/ab40c2f2-aa78-4740-92d0-5002c18e0524">

Small:
<img width="693" alt="afbeelding" src="https://github.com/jasp-stats/jasp-desktop/assets/29062713/32b27d5a-4dfb-4d87-b999-e7f601148f9d">

Variables:
Small:
<img width="711" alt="afbeelding" src="https://github.com/jasp-stats/jasp-desktop/assets/29062713/b1bddee5-1544-46ac-91ac-d89948c7c04c">

Small computed column Drag&drop:
<img width="722" alt="afbeelding" src="https://github.com/jasp-stats/jasp-desktop/assets/29062713/084e0be1-4724-444e-be1c-fd6ac9ef1d8e">

big:
<img width="740" alt="afbeelding" src="https://github.com/jasp-stats/jasp-desktop/assets/29062713/e67c9fd2-244e-472e-8e9d-573976a4ead4">
