### PR TITLE
Check valid computed column from old JASP file

### DIFF
--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -381,8 +381,13 @@ const Columns & DataSet::computedColumns() const
 
 void DataSet::loadOldComputedColumnsJson(const Json::Value &json)
 {
+	if (!json.isArray()) return;
+
 	for(const Json::Value & colJson : json)
 	{
+		Log::log() << "Old computed column: " << colJson.toStyledString() << std::endl;
+		if (!colJson.isObject() || colJson["error"].asString().rfind("The engine crashed", 0) == 0) continue;
+
 		const std::string name = colJson["name"].asString();
 
 		Column * col = column(name);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/2428

Apparently in the JASP file of the issue, a computed column was made that made the engine crash. This computed column is still written in the metadata.json, but it is ignored in 0.17.3. When upgrading to 0.18.1, this computed column is added and makes the engine crash. So just ignore this computed column when upgrading.

