### PR TITLE
Table title gets APA styles

### DIFF
--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -94,7 +94,6 @@ th {
 
 th .in-toolbar {
 	font-style: italic;
-	text-transform: capitalize;
 }
 
 th[colspan="2"] {

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -92,6 +92,11 @@ th {
 	font-weight: normal ;
 }
 
+th .in-toolbar {
+	font-style: italic;
+	text-transform: capitalize;
+}
+
 th[colspan="2"] {
 	padding-left : 1em ;
 	padding-right: 1em ;

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -94,10 +94,6 @@ JASPWidgets.Exporter = {
 		this.htmlImageFormat = JASPWidgets.ExportProperties.htmlImageFormat.temporary,
 		this.includeNotes = false;
 
-		this.isFormatted = function () {
-			return (this.format & JASPWidgets.ExportProperties.format.formatted) === JASPWidgets.ExportProperties.format.formatted
-		};
-
 		this.htmlOnly = function () {
 			return (this.format & JASPWidgets.ExportProperties.format.html) === JASPWidgets.ExportProperties.format.html
 		};
@@ -242,32 +238,19 @@ JASPWidgets.Exporter = {
 	},
 
 	getSpacingStyles: function (element, exportParams) {
-		if (exportParams.isFormatted())
-			return JASPWidgets.Exporter.getStyles(element, ["padding", "margin", "display", "float"]);
-		else
-			return "";//JASPWidgets.Exporter.getStyles(element, ["display", "float"]);
+		return JASPWidgets.Exporter.getStyles(element, ["padding", "margin", "display", "float"]);
 	},
 
 	getHeaderStyles: function (element, exportParams) {
-		// I commented isFormatted out because nonw of us knew the intention...
-		//if (exportParams.isFormatted())
-			return JASPWidgets.Exporter.getStyles(element, ["padding", "text-align", "margin", "display", "float", "vertical-align", "font-size", "font", "font-weight", "color", "font-style", "text-transform"]);
-		// else
-		// 	return "";//JASPWidgets.Exporter.getStyles(element, ["display", "float"]);
+		return JASPWidgets.Exporter.getStyles(element, ["padding", "text-align", "margin", "display", "float", "vertical-align", "font-size", "font", "font-weight", "color", "font-style", "text-transform"]);
 	},
 
 	getTableStyles: function (element, exportParams) {
-		if (exportParams.isFormatted())
 			return JASPWidgets.Exporter.getStyles(element, ["border-collapse", "border-top-width", "border-bottom-width", "border-left-width", "border-right-width", "border-color", "border-style", "padding", "text-align", "margin-bottom", "margin-top", "display", "float", "color"]);
-		else
-			return JASPWidgets.Exporter.getStyles(element, ["border-collapse", "border-top-width", "border-bottom-width", "border-left-width", "border-right-width", "border-color", "border-style", "display", "float"]);
 	},
 
 	getTableContentStyles: function (element, exportParams) {
-		if (exportParams.isFormatted())
 			return JASPWidgets.Exporter.getStyles(element, ["border-collapse", "border-top-width", "border-bottom-width", "border-left-width", "border-right-width", "border-color", "border-style", "padding", "text-align", "margin", "display", "float", "font-size", "font-weight", "font", "color"]);
-		else
-			return JASPWidgets.Exporter.getStyles(element, ["border-collapse", "border-top-width", "border-bottom-width", "border-left-width", "border-right-width", "border-color", "border-style", "display", "float", "text-align"]);
 	},
 
 	getErrorStyles: function (element, component) {
@@ -282,10 +265,7 @@ JASPWidgets.Exporter = {
 	},
 
 	getNoteStyles: function (element, exportParams) {
-		// if (exportParams.isFormatted())
 			return JASPWidgets.Exporter.getStyles(element, ["margin", "padding", "max-width", "min-width", "display", "font-size", "font-weight", "font", "color", "border-top-style", "border-top-width", "border-top-color", "border-bottom-style", "border-bottom-width", "border-bottom-color"]);
-		// else
-		// 	return JASPWidgets.Exporter.getStyles(element, ["max-width", "min-width"]);
 	},
 
 	exportErrorWindow: function (element, error) {

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -249,10 +249,10 @@ JASPWidgets.Exporter = {
 	},
 
 	getHeaderStyles: function (element, exportParams) {
-		if (exportParams.isFormatted())
-			return JASPWidgets.Exporter.getStyles(element, ["padding", "text-align", "margin", "display", "float", "vertical-align", "font-size", "font", "font-weight", "color"]);
-		else
-			return "";//JASPWidgets.Exporter.getStyles(element, ["display", "float"]);
+		//if (exportParams.isFormatted())
+			return JASPWidgets.Exporter.getStyles(element, ["padding", "text-align", "margin", "display", "float", "vertical-align", "font-size", "font", "font-weight", "color", "font-style", "text-transform"]);
+		// else
+		// 	return "";//JASPWidgets.Exporter.getStyles(element, ["display", "float"]);
 	},
 
 	getTableStyles: function (element, exportParams) {

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -249,6 +249,7 @@ JASPWidgets.Exporter = {
 	},
 
 	getHeaderStyles: function (element, exportParams) {
+		// I commented isFormatted out because nonw of us knew the intention...
 		//if (exportParams.isFormatted())
 			return JASPWidgets.Exporter.getStyles(element, ["padding", "text-align", "margin", "display", "float", "vertical-align", "font-size", "font", "font-weight", "color", "font-style", "text-transform"]);
 		// else

--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -541,8 +541,6 @@ var wrapHTML = function (html, exportParams, doctype = false) {
 	completehtml += "		<title>JASP</title>"
 	completehtml += "		<style>"
 	completehtml += "			p {margin-top:1em; margin-bottom:1em;}"
-	if (exportParams.isFormatted())
-		completehtml += "			body {font-family: sans-serif;}"
 	completehtml += "		</style>"
 	completehtml += "	</head>\n"
 


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/jasp-issues/issues/25
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/2123

**Not For 0.18.2**

Not a really 100% strict mode, for example this will also capitalize short conjunctions (e.g., “and,” “as,” “but,” “for,” “if,” “nor,” “or,” “so,” “yet”) where according to APA rules these shouldn't. But I don't think we need to care about this because one can always edit this minor point in their paper?