### PR TITLE
Fix missing helpfiles on linux

### DIFF
--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -295,7 +295,7 @@ FocusScope
 				iconSource:		jaspTheme.iconPath + "info-button.png"
 				anchors.right:	parent.right
 				anchors.bottom: parent.bottom
-				onClicked:		helpModel.showOrTogglePage("other/ComputedColumns");
+				onClicked:		helpModel.showOrTogglePage("other/computedcolumns");
 				toolTip:		qsTr("Open Documentation")
 			}
 		}

--- a/Desktop/components/JASP/Widgets/CreateComputeColumnDialog.qml
+++ b/Desktop/components/JASP/Widgets/CreateComputeColumnDialog.qml
@@ -339,7 +339,7 @@ Popup
 				iconSource:				jaspTheme.iconPath + "info-button.png"
 				width:					height
 				height:					createButton.height
-				onClicked:				helpModel.showOrTogglePage("other/ComputedColumns");
+				onClicked:				helpModel.showOrTogglePage("other/computedcolumns");
 				toolTip:				qsTr("Open Documentation")
 				KeyNavigation.right:	createButton
 				anchors

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -162,7 +162,7 @@ FocusScope
 				width:				height
 				radius:				height
 				iconSource:			jaspTheme.iconPath + "info-button.png"
-				onClicked:			helpModel.showOrTogglePage("other/EasyFilterConstructor");
+				onClicked:			helpModel.showOrTogglePage("other/easyfilterconstructor");
 				toolTip:			qsTr("Open Documentation")
 				anchors
 				{
@@ -519,7 +519,7 @@ FocusScope
 					anchors.bottom: parent.bottom
 					anchors.top:	closeRectangularButton.top
 
-					onClicked:		helpModel.showOrTogglePage("other/RFilterConstructor");
+					onClicked:		helpModel.showOrTogglePage("other/rfilterconstructor");
 					toolTip:		qsTr("Open Documentation")
 				}
 


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/jasp-issues/issues/2374

Linux/unix is case sensitive so the incorrect casing of  filenames only worked on windows and mac and we never noticed.