### PR TITLE
Add explicit dependency for controls.

### DIFF
--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -215,6 +215,7 @@ void AnalysisForm::sortControls(QList<JASPControl*>& controls)
 {
 	for (JASPControl* control : controls)
 	{
+		control->addExplicitDependency();
 		std::vector<JASPControl*> depends(control->depends().begin(), control->depends().end());
 
 		// By adding at the end of the vector new dependencies, this makes sure that these dependencies of these new dependencies are

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -799,3 +799,25 @@ void JASPControl::_notifyFormOfActiveFocus()
 	if (_form && _focusReason >= Qt::MouseFocusReason && _focusReason <= Qt::OtherFocusReason)
 		_form->setActiveJASPControl(this, hasActiveFocus());
 }
+
+void JASPControl::_addExplicitDependency(const QVariant& depends)
+{
+	if (!depends.isValid() || depends.isNull()) return;
+
+	JASPControl* control = depends.value<JASPControl*>();
+	if (control)
+		_depends.insert(control);
+	else if (depends.canConvert<QString>())
+		_depends.insert(form()->getControl(depends.toString()));
+	else if (depends.canConvert<QVariantList>())
+	{
+		QVariantList varDeps = depends.toList();
+		for (const QVariant& varDep : varDeps)
+			_addExplicitDependency(varDep);
+	}
+}
+
+void JASPControl::addExplicitDependency()
+{
+	_addExplicitDependency(_explicitDepends);
+}

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -48,6 +48,7 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( bool								hovered					READ hovered												NOTIFY hoveredChanged				)
 	Q_PROPERTY( int									alignment				READ alignment				WRITE setAlignment													)
 	Q_PROPERTY( Qt::FocusReason						focusReason				READ getFocusReason																				)
+	Q_PROPERTY( QVariant							depends					READ explicitDepends		WRITE setExplicitDepends		NOTIFY explicitDependsChanged		)
 
 protected:
 	typedef std::set<JASPControl*>			Set;
@@ -147,6 +148,7 @@ public:
 	int					alignment()					const	{ return _alignment;				}
 	Qt::FocusReason		getFocusReason()			const	{ return _focusReason;				}
 	bool				dependsOnDynamicComponents() const	{ return _dependsOnDynamicComponents; }
+	const QVariant&		explicitDepends()			const	{ return _explicitDepends;			}
 
 	QString				humanFriendlyLabel()		const;
 	void				setInitialized(bool byFile = false);
@@ -169,7 +171,7 @@ public:
 	virtual void					rScriptDoneHandler(const QString& result);
 
 	virtual QString					friendlyName() const;
-
+	void							addExplicitDependency();
 protected:
 	Set								_depends;
 
@@ -207,6 +209,7 @@ public slots:
 	GENERIC_SET_FUNCTION(ShouldStealHover		, _shouldStealHover		, shouldStealHoverChanged		, bool			)
 	GENERIC_SET_FUNCTION(Background				, _background			, backgroundChanged				, QQuickItem*	)
 	GENERIC_SET_FUNCTION(DependencyMustContain	, _dependencyMustContain, dependencyMustContainChanged	, QStringList	)
+	GENERIC_SET_FUNCTION(ExplicitDepends		, _explicitDepends		, explicitDependsChanged		, QVariant		)
 
 private slots:
 	void	_setFocusBorder();
@@ -248,6 +251,7 @@ signals:
 	void	controlTypeChanged();			// Not used, defined only to suppress warning in QML
 	void	boundValueChanged(JASPControl* control);
 	void	usedVariablesChanged();
+	void	explicitDependsChanged();
 
 	void				requestColumnCreation(std::string columnName, columnType columnType);
 	void				requestComputedColumnCreation(std::string columnName);
@@ -261,6 +265,7 @@ protected:
 	void				focusInEvent(QFocusEvent* event) override;
 	bool				eventFilter(QObject *watched, QEvent *event) override;
 	bool				checkOptionName(const QString& name);
+	void				_addExplicitDependency(const QVariant& depends);
 
 protected:
 	ControlType				_controlType;
@@ -304,6 +309,7 @@ protected:
 	int						_alignment					= Qt::AlignTop | Qt::AlignLeft;
 	Qt::FocusReason			_focusReason				= Qt::FocusReason::NoFocusReason;
 	bool					_dependsOnDynamicComponents = false;
+	QVariant				_explicitDepends;
 
 	static QMap<QQmlEngine*, QQmlComponent*>		_mouseAreaComponentMap;
 	static QByteArray								_mouseAreaDef;


### PR DESCRIPTION
In the Process module a DropDown is created in a ComponentsList (of a TabView), and its option values depend on a VariablesList outside of the ComponentsList.
When loading a JASP file, JASP sets the values of each control. For this it first finds out which control depends on other controls, so that a control depending on another control will be set afterwards. The dependencies are mainly found via the `source` property of a control.
Problem is when controls are created dynamically (with a rowComponent): the controls are created only when the parent control is created, so the dependency of these controls cannot be determine before the parent control gets its value.
In the Process module, as the values of the DropDown depends on a VariablesList, when setting its current value (set in the JASP file), if the VariablesList did not get already its values, JASP will throw an error, since the current value of the DropDown does not appear to be one of its option values.
To handle this problem, I've just added an extra property `depends` with which you can set explicitly that the parent control depends on other control: in this way the values of the ComponentsList will be set (and the DropDown wil be created) only after the VariablesList will get its values. This is not a nice solution, since the QML developer must explicitly set this `depends` property, but most of them will not pay attention on this problem.
We should handle this problem in a more clever way later: the form should set the values to each control without caring of dependencies. The control self should be aware of its dependencies, and should wait for its dependent controls to be set, before setting self its value.