### PR TITLE
Fix cells border showing in tableView

### DIFF
--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -184,11 +184,14 @@ TextInputBase
 
 		background: Rectangle
 		{
-			id:				controlBackground
-			color:			jaspTheme.controlBackgroundColor
-			border.width:	textField.showBorder && !control.activeFocus	? 1					: 0
-			border.color:	jaspTheme.borderColor //If the border width is zero the color is inconsequential
-			radius:			jaspTheme.borderRadius
+			id:					controlBackground
+			color:				jaspTheme.controlBackgroundColor
+			border.width:		textField.showBorder && !control.activeFocus	? 1					: 0
+			border.color:		jaspTheme.borderColor //If the border width is zero the color is inconsequential
+			radius:				jaspTheme.borderRadius
+			width:				parent.width   - 2 // (parent+self) border width
+			height:				parent.height  - 2
+			anchors.centerIn:	parent
 		}
 
 		Rectangle


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/2231
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/1759
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/1789

The reason is input field background component larger than the parent component so it will block the border of cells.