### PR TITLE
Initialize controls only if their dependencies are already initialized

### DIFF
--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -355,33 +355,11 @@ void AnalysisForm::_addLoadingError(QStringList wrongJson)
 
 void AnalysisForm::bindTo(const Json::Value & defaultOptions)
 {
-	QVector<ListModelAvailableInterface*> availableModelsToBeReset;
-
 	std::set<std::string> controlsJsonWrong;
 	
 	for (JASPControl* control : _dependsOrderedCtrls)
 	{
 		BoundControl* boundControl = control->boundControl();
-		JASPListControl* listControl = dynamic_cast<JASPListControl *>(control);
-
-		if (listControl && listControl->hasSource())
-		{
-			ListModelAvailableInterface* availableModel = qobject_cast<ListModelAvailableInterface*>(listControl->model());
-			// The availableList control are not bound with options, but they have to be updated from their sources when the form is initialized.
-			// The availableList cannot signal their assigned models now because they are not yet bound (the controls are ordered by dependency)
-			// When the options come from a JASP file, an assigned model needs sometimes the available model (eg. to determine the kind of terms they have).
-			// So in this case resetTermsFromSourceModels has to be called now but with updateAssigned argument set to false.
-			// When the options come from default options (from source models), the availableList needs sometimes to signal their assigned models (e.g. when addAvailableVariablesToAssigned if true).
-			// As their assigned models are not yet bound, resetTermsFromSourceModels (with updateAssigned argument set to true) must be called afterwards.
-			if (availableModel)
-			{
-				if (defaultOptions.size() != 0 || _analysis->isDuplicate())
-					availableModel->resetTermsFromSources(false);
-				else
-					availableModelsToBeReset.push_back(availableModel);
-			}
-		}
-
 		Json::Value optionValue = Json::nullValue;
 		if (boundControl)
 		{
@@ -399,9 +377,6 @@ void AnalysisForm::bindTo(const Json::Value & defaultOptions)
 
 		control->setInitialized(optionValue);
 	}
-
-	for (ListModelAvailableInterface* availableModel : availableModelsToBeReset)
-		availableModel->resetTermsFromSources(true);
 
 	_addLoadingError(tql(controlsJsonWrong));
 

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -24,14 +24,16 @@ import JASP				1.0
 
 VariablesListBase
 {
-	id						: variablesList
-	implicitHeight			: maxRows === 1 ? jaspTheme.defaultSingleItemListHeight : jaspTheme.defaultVariablesFormHeight
-	background				: itemRectangle
-	implicitWidth 			: parent.width
-	shouldStealHover		: false
-	innerControl			: itemGridView
-	optionKey				: listViewType === JASP.Interaction ? "components" : "variable"
-	maxRows					: singleVariable ? 1 : -1
+	id								: variablesList
+	implicitHeight					: maxRows === 1 ? jaspTheme.defaultSingleItemListHeight : jaspTheme.defaultVariablesFormHeight
+	background						: itemRectangle
+	implicitWidth					: parent.width
+	shouldStealHover				: false
+	innerControl					: itemGridView
+	optionKey						: listViewType === JASP.Interaction ? "components" : "variable"
+	maxRows							: singleVariable ? 1 : -1
+	addAvailableVariablesToAssigned	: listViewType === JASP.Interaction
+	allowAnalysisOwnComputedColumns	: true
 
 	property alias	label							: variablesList.title
 	property alias	itemGridView					: itemGridView
@@ -53,8 +55,6 @@ VariablesListBase
 	property bool	showVariableTypeIcon			: containsVariables
 	property bool	addInteractionsByDefault		: true
 	property bool	interactionContainLowerTerms	: true
-	property bool	addAvailableVariablesToAssigned	: listViewType === JASP.Interaction
-	property bool	allowAnalysisOwnComputedColumns	: true
 	property bool	allowDuplicatesInMultipleColumns: false // This property is used in the constructor and is not updatable afterwards.
 
 	property int	indexInDroppedListViewOfDraggedItem:	-1

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -30,7 +30,7 @@ ComboBoxBase::ComboBoxBase(QQuickItem* parent)
 
 void ComboBoxBase::bindTo(const Json::Value& value)
 {
-	// Do not call BoundControlBase::bindTo now because the value might be changed to the default value.
+	_model->resetTermsFromSources();
 
 	std::vector<std::string> values = _model->getValues();
 	std::string selectedValue = value.asString();

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -832,7 +832,7 @@ void JASPControl::setInitialized(const Json::Value &value)
 	{
 		for (JASPControl* c : _depends)
 			if (!c->initialized())
-				connect(c, &JASPControl::initializedChanged, [this, value]() { if (dependingControlsAreInitialized()) _setInitialized(value); });
+				connect(c, &JASPControl::initializedChanged, this, [this, value]() { if (dependingControlsAreInitialized()) _setInitialized(value); });
 	}
 }
 

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -157,7 +157,7 @@ void JASPControl::_resetBindingValue()
 	// If a control gets a value from a JASP file, this value may differ from its default value sets by a QML binding:
 	// this QML binding may then change the value during the initialization of the form.
 	// In this case, restore the original value.
-	if (isBound() && hasUserInteractiveValue() && initializedFromJaspFile() && form() && !form()->initialized())
+	if (isBound() && hasUserInteractiveValue() && initializedWithValue() && form() && !form()->initialized())
 		boundControl()->resetBoundValue();
 }
 
@@ -742,16 +742,6 @@ QString JASPControl::humanFriendlyLabel() const
 
 	return label;
 
-		}
-
-void JASPControl::setInitialized(bool byFile)
-{
-	if (!_initialized)
-	{
-		_initialized = true;
-		_initializedFromJaspFile = byFile;
-		emit initializedChanged();
-	}
 }
 
 QVector<JASPControl::ParentKey> JASPControl::getParentKeys()
@@ -820,4 +810,42 @@ void JASPControl::_addExplicitDependency(const QVariant& depends)
 void JASPControl::addExplicitDependency()
 {
 	_addExplicitDependency(_explicitDepends);
+}
+
+bool JASPControl::dependingControlsAreInitialized()
+{
+	bool dependenciesAreInitialized = true;
+
+	for (JASPControl* c : _depends)
+	{
+		if (!c->initialized())
+			dependenciesAreInitialized = false;
+	}
+	return dependenciesAreInitialized;
+}
+
+void JASPControl::setInitialized(const Json::Value &value)
+{
+	if (dependingControlsAreInitialized())
+		_setInitialized(value);
+	else
+	{
+		for (JASPControl* c : _depends)
+			if (!c->initialized())
+				connect(c, &JASPControl::initializedChanged, [this, value]() { if (dependingControlsAreInitialized()) _setInitialized(value); });
+	}
+}
+
+void JASPControl::_setInitialized(const Json::Value &value)
+{
+	BoundControl* bControl = boundControl();
+	if (bControl)
+	{
+		bControl->setDefaultBoundValue(bControl->createJson());
+		bControl->bindTo(value == Json::nullValue ? bControl->createJson() : value);
+	}
+
+	_initialized = true;
+	_initializedWithValue = (value != Json::nullValue);
+	emit initializedChanged();
 }

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -151,7 +151,6 @@ public:
 	const QVariant&		explicitDepends()			const	{ return _explicitDepends;			}
 
 	QString				humanFriendlyLabel()		const;
-	void				setInitialized(const Json::Value& value = Json::nullValue);
 
 	QVector<JASPControl::ParentKey>	getParentKeys();
 
@@ -159,6 +158,7 @@ public:
 	static QList<JASPControl*>		getChildJASPControls(const QQuickItem* item);
 
 	virtual void					setUp()										{}
+	void							setInitialized(const Json::Value& value = Json::nullValue);
 	virtual void					cleanUp()									{ disconnect(); }
 	virtual BoundControl		*	boundControl();
 	virtual bool					encodeValue()						const	{ return false; }
@@ -265,7 +265,7 @@ protected:
 	bool				checkOptionName(const QString& name);
 	void				_addExplicitDependency(const QVariant& depends);
 	bool				dependingControlsAreInitialized();
-	void				_setInitialized(const Json::Value &value);
+	virtual void		_setInitialized(const Json::Value &value);
 
 protected:
 	Set						_depends;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -120,7 +120,7 @@ public:
 	bool				indent()					const	{ return _indent;					}
 	bool				isDependency()				const	{ return _isDependency;				}
 	bool				initialized()				const	{ return _initialized;				}
-	bool				initializedFromJaspFile()	const	{ return _initializedFromJaspFile;	}
+	bool				initializedWithValue()		const	{ return _initializedWithValue;		}
 	bool				shouldShowFocus()			const	{ return _shouldShowFocus;			}
 	bool				shouldStealHover()			const	{ return _shouldStealHover;			}
 	bool				debug()						const	{ return _debug;					}
@@ -151,7 +151,7 @@ public:
 	const QVariant&		explicitDepends()			const	{ return _explicitDepends;			}
 
 	QString				humanFriendlyLabel()		const;
-	void				setInitialized(bool byFile = false);
+	void				setInitialized(const Json::Value& value = Json::nullValue);
 
 	QVector<JASPControl::ParentKey>	getParentKeys();
 
@@ -172,8 +172,6 @@ public:
 
 	virtual QString					friendlyName() const;
 	void							addExplicitDependency();
-protected:
-	Set								_depends;
 
 public slots:
 	void	setControlType(			ControlType			controlType)		{ _controlType = controlType; }
@@ -266,8 +264,11 @@ protected:
 	bool				eventFilter(QObject *watched, QEvent *event) override;
 	bool				checkOptionName(const QString& name);
 	void				_addExplicitDependency(const QVariant& depends);
+	bool				dependingControlsAreInitialized();
+	void				_setInitialized(const Json::Value &value);
 
 protected:
+	Set						_depends;
 	ControlType				_controlType;
 	AnalysisForm*			_form						= nullptr;
 	QString					_name,
@@ -278,7 +279,7 @@ protected:
 	bool					_isBound					= true,
 							_indent						= false,
 							_initialized				= false,
-							_initializedFromJaspFile	= false,
+							_initializedWithValue	= false,
 							_debug						= false,
 							_parentDebug				= false,
 							_hasError					= false,

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -48,9 +48,9 @@ void JASPListControl::_setupSources()
 {
 	for (SourceItem* sourceItem : _sourceItems)
 	{
-		if (sourceItem->listModel())
+		if (sourceItem->sourceListModel())
 		{
-			JASPListControl* sourceControl = sourceItem->listModel()->listView();
+			JASPListControl* sourceControl = sourceItem->sourceListModel()->listView();
 			disconnect(sourceControl, &JASPListControl::containsVariablesChanged,		this, &JASPListControl::setContainsVariables);
 			disconnect(sourceControl, &JASPListControl::containsInteractionsChanged,	this, &JASPListControl::setContainsInteractions);
 		}
@@ -62,9 +62,9 @@ void JASPListControl::_setupSources()
 
 	for (SourceItem* sourceItem : _sourceItems)
 	{
-		if (sourceItem->listModel())
+		if (sourceItem->sourceListModel())
 		{
-			JASPListControl* sourceControl = sourceItem->listModel()->listView();
+			JASPListControl* sourceControl = sourceItem->sourceListModel()->listView();
 			connect(sourceControl, &JASPListControl::containsVariablesChanged,		this, &JASPListControl::setContainsVariables);
 			connect(sourceControl, &JASPListControl::containsInteractionsChanged,	this, &JASPListControl::setContainsInteractions);
 		}
@@ -86,10 +86,10 @@ void JASPListControl::setContainsVariables()
 	{
 		for (SourceItem* sourceItem : _sourceItems)
 		{
-			if (sourceItem->isColumnsModel())	containsVariables = true;
-			else if (sourceItem->listModel())
+			if (sourceItem->isAnalysisDataSet())	containsVariables = true;
+			else if (sourceItem->sourceListModel())
 			{
-				if (sourceItem->listModel()->listView()->containsVariables() && sourceItem->controlName().isEmpty() && !sourceItem->modelUse().contains("levels"))
+				if (sourceItem->sourceListModel()->listView()->containsVariables() && sourceItem->rowControlName().isEmpty() && !sourceItem->sourceFilter().contains("levels"))
 					containsVariables = true;
 			}
 		}
@@ -120,9 +120,9 @@ void JASPListControl::setContainsInteractions()
 	{
 		for (SourceItem* sourceItem : _sourceItems)
 		{
-			if (sourceItem->listModel())
+			if (sourceItem->sourceListModel())
 			{
-				JASPListControl* sourceControl = sourceItem->listModel()->listView();
+				JASPListControl* sourceControl = sourceItem->sourceListModel()->listView();
 				if (sourceControl->containsInteractions() || sourceItem->generateInteractions())
 					containsInteractions = true;
 			}

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -53,6 +53,8 @@ class JASPListControl : public JASPControl
 	Q_PROPERTY( bool			containsInteractions	READ containsInteractions									NOTIFY containsInteractionsChanged	)
 	Q_PROPERTY( double			maxTermsWidth			READ maxTermsWidth											NOTIFY maxTermsWidthChanged			)
 	Q_PROPERTY( QQmlComponent*	rowComponent			READ rowComponent			WRITE setRowComponent			NOTIFY rowComponentChanged			)
+	Q_PROPERTY( bool			addAvailableVariablesToAssigned	READ addAvailableVariablesToAssigned WRITE setAddAvailableVariablesToAssigned NOTIFY addAvailableVariablesToAssignedChanged )
+	Q_PROPERTY( bool			allowAnalysisOwnComputedColumns	READ allowAnalysisOwnComputedColumns WRITE setAllowAnalysisOwnComputedColumns NOTIFY allowAnalysisOwnComputedColumnsChanged )
 
 
 public:
@@ -100,6 +102,8 @@ public:
 			void				setUseSourceLevels(bool b)					{ _useSourceLevels = b;			}
 			double				maxTermsWidth();
 	virtual stringvec			usedVariables()				const;
+			bool				addAvailableVariablesToAssigned()	const	{ return _addAvailableVariablesToAssigned;	}
+			bool				allowAnalysisOwnComputedColumns()	const	{ return _allowAnalysisOwnComputedColumns;	}
 
 signals:
 			void				modelChanged();
@@ -114,6 +118,8 @@ signals:
 			void				containsInteractionsChanged();
 			void				maxTermsWidthChanged();
 			void				rowComponentChanged();
+			void				addAvailableVariablesToAssignedChanged();
+			void				allowAnalysisOwnComputedColumnsChanged();
 
 public slots:
 			void				setContainsVariables();
@@ -135,6 +141,8 @@ protected slots:
 			GENERIC_SET_FUNCTION(ValueRole,				_valueRole,				valueRoleChanged,				QString			)
 			GENERIC_SET_FUNCTION(RowComponent,			_rowComponent,			rowComponentChanged,			QQmlComponent*	)
 			GENERIC_SET_FUNCTION(MaxRows,				_maxRows,				maxRows,						int				)
+			GENERIC_SET_FUNCTION(AddAvailableVariablesToAssigned, _addAvailableVariablesToAssigned,	addAvailableVariablesToAssignedChanged,	bool	)
+			GENERIC_SET_FUNCTION(AllowAnalysisOwnComputedColumns, _allowAnalysisOwnComputedColumns,	allowAnalysisOwnComputedColumnsChanged,	bool	)
 
 protected:
 	QVector<SourceItem*>	_sourceItems;
@@ -147,7 +155,10 @@ protected:
 							_containsVariables		= false,
 							_containsInteractions	= false,
 							_termsAreInteractions	= false,
-							_useSourceLevels		= false;
+							_useSourceLevels		= false,
+							_addAvailableVariablesToAssigned = false,
+							_allowAnalysisOwnComputedColumns = true;
+
 	int						_maxRows				= -1;
 	QString					_placeHolderText		= tr("<no choice>"),
 							_labelRole				= "label",

--- a/QMLComponents/controls/rowcontrols.h
+++ b/QMLComponents/controls/rowcontrols.h
@@ -52,7 +52,7 @@ public:
 
 private:
 
-	void										_setupControls(bool reuseBoundValue = false);
+	void										_initializeControls(bool useInitialValue = true);
 
 	ListModel*								_parentModel;
 	QQmlComponent*							_rowComponent	= nullptr;

--- a/QMLComponents/controls/sourceitem.h
+++ b/QMLComponents/controls/sourceitem.h
@@ -48,13 +48,13 @@ public:
 	};
 
 	SourceItem(
-			  JASPListControl* _listControl
+			  JASPListControl* targetListControl
 			, QMap<QString, QVariant>& map
-			, const JASPListControl::LabelValueMap& _values
-			, const QVector<SourceItem*> _rSources
-			, QAbstractItemModel* _nativeModel = nullptr
-			, const QVector<SourceItem*>& _discardSources = QVector<SourceItem*>()
-			, const QVector<QMap<QString, QVariant> >& _conditionVariables = QVector<QMap<QString, QVariant> >()
+			, const JASPListControl::LabelValueMap& values
+			, const QVector<SourceItem*> rSources
+			, QAbstractItemModel* nativeModel = nullptr
+			, const QVector<SourceItem*>& discardSources = QVector<SourceItem*>()
+			, const QVector<QMap<QString, QVariant> >& conditionVariables = QVector<QMap<QString, QVariant> >()
 			);
 
 	SourceItem(JASPListControl* _listControl, const JASPListControl::LabelValueMap& _values);
@@ -63,14 +63,14 @@ public:
 
 	SourceItem(JASPListControl* _listControl = nullptr);
 
-	ListModel*				listModel()							{ return _listModel;				}
-	const QString&			controlName()				const	{ return _controlName;				}
-	const QStringList&		modelUse()					const	{ return _modelUse;					}
+	ListModel*				sourceListModel()					{ return _sourceListModel;			}
+	const QString&			rowControlName()			const	{ return _rowControlName;			}
+	const QStringList&		sourceFilter()				const	{ return _sourceFilter;					}
 	bool					combineWithOtherModels()	const	{ return _combineWithOtherModels;	}
 	bool					generateInteractions()		const	{ return _combineWithOtherModels || (_combineTerms != JASPControl::CombinationType::NoCombination); }
-	bool					isColumnsModel()			const	{ return _isVariableInfoModel;			}
-	bool					isNativeModel()				const	{ return _nativeModel != nullptr;	}
-	QAbstractItemModel*		nativeModel()						{ return _nativeModel;				}
+	bool					isAnalysisDataSet()			const	{ return _isDataSetVariables;		}
+	bool					isNativeModel()				const	{ return _sourceNativeModel != nullptr;	}
+	QAbstractItemModel*		nativeModel()						{ return _sourceNativeModel;				}
 	Terms					getTerms();
 	QSet<QString>			usedControls()				const;
 
@@ -98,19 +98,19 @@ private slots:
 	void									_rSourceChanged(const QString& name);
 
 private:
-	JASPListControl		*			_listControl				= nullptr;
-	QString							_name,
-									_controlName;
-	QStringList						_modelUse;
+	JASPListControl		*			_targetListControl			= nullptr;
+	QString							_sourceName,
+									_rowControlName;
+	QStringList						_sourceFilter;
 	QVector<SourceItem*>			_discardSources;
 	QVector<SourceItem*>			_rSources;
 	JASPListControl::LabelValueMap	_values;
 	bool							_isValuesSource				= false;
 	bool							_isRSource					= false;
-	ListModel			*			_listModel					= nullptr;
-	QAbstractItemModel	*			_nativeModel				= nullptr;
+	ListModel			*			_sourceListModel			= nullptr;
+	QAbstractItemModel	*			_sourceNativeModel			= nullptr;
 	int								_nativeModelRole			= Qt::DisplayRole;
-	bool							_isVariableInfoModel		= false;
+	bool							_isDataSetVariables			= false;
 	bool							_combineWithOtherModels		= false;
 	QString							_conditionExpression;
 	QVector<ConditionVariable>		_conditionVariables;

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -89,6 +89,22 @@ void VariablesListBase::setUp()
 	connect(this,	&VariablesListBase::suggestedColumnsChanged,					this, &VariablesListBase::_setAllowedVariables);
 }
 
+void VariablesListBase::_setInitialized(const Json::Value &value)
+{
+	ListModelAvailableInterface* availableModel = qobject_cast<ListModelAvailableInterface*>(_draggableModel);
+	if (availableModel)
+		availableModel->resetTermsFromSources(false);
+	else if (value == Json::nullValue && addAvailableVariablesToAssigned())
+	{
+		// If addAvailableVariablesToAssigned is true and this is initialized without value,
+		// maybe the availableAssignedList has some default values that must be assigned to this VariablesList
+		ListModelAssignedInterface* assignedModel = qobject_cast<ListModelAssignedInterface*>(_draggableModel);
+		if (assignedModel)
+			assignedModel->initTerms(assignedModel->availableModel()->terms());
+	}
+
+	JASPListControl::_setInitialized(value);
+}
 
 
 ListModel *VariablesListBase::model() const

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -52,7 +52,7 @@ void VariablesListBase::setUp()
 	{
 		for (SourceItem* sourceItem : _sourceItems)
 		{
-			ListModelFactorLevels* factorsModel = dynamic_cast<ListModelFactorLevels*>(sourceItem->listModel());
+			ListModelFactorLevels* factorsModel = dynamic_cast<ListModelFactorLevels*>(sourceItem->sourceListModel());
 			if (!factorsModel)
 				addControlError(tr("Source model of %1 must be from a Factor List").arg(name()));
 			else

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -40,6 +40,7 @@ class VariablesListBase : public JASPListControl, public BoundControl
 	Q_PROPERTY( QStringList		dropKeys						READ dropKeys						WRITE setDropKeys						NOTIFY dropKeysChanged						)
 	Q_PROPERTY( QString			interactionHighOrderCheckBox	READ interactionHighOrderCheckBox	WRITE setInteractionHighOrderCheckBox	NOTIFY interactionHighOrderCheckBoxChanged	)
 
+
 public:
 	VariablesListBase(QQuickItem* parent = nullptr);
 	
@@ -92,8 +93,8 @@ protected:
 	GENERIC_SET_FUNCTION(ColumnsNames,					_columnsNames,					columnsNamesChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(InteractionHighOrderCheckBox,	_interactionHighOrderCheckBox,	interactionHighOrderCheckBoxChanged,	QString			)
 
+	void						_setInitialized(const Json::Value& value = Json::nullValue)	override;
 	void						setDropKeys(const QStringList& dropKeys);
-
 	ListModel*					getRelatedModel();
 
 	ListModelDraggable*			_draggableModel	= nullptr;

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -104,7 +104,7 @@ void ListModel::_connectSourceControls(SourceItem* sourceItem)
 	// Connect option changes from controls in sourceModel that influence the terms of this model:
 	// either the source uses direclty a control in sourceModel (controlName()), or the source uses
 	// a conditional expression.
-	ListModel* sourceModel = sourceItem->listModel();
+	ListModel* sourceModel = sourceItem->sourceListModel();
 	if (!sourceModel) 
 		return;
 
@@ -150,7 +150,7 @@ ListModel *ListModel::getSourceModelOfTerm(const Term &term)
 	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
 		if (terms.contains(term))
-			result = sourceItem->listModel();
+			result = sourceItem->sourceListModel();
 	});
 
 	return result;

--- a/QMLComponents/models/listmodeldraggable.cpp
+++ b/QMLComponents/models/listmodeldraggable.cpp
@@ -24,8 +24,6 @@ ListModelDraggable::ListModelDraggable(JASPListControl* listView)
 	: ListModel(listView)
 	, _copyTermsWhenDropped(false)	
 {
-	_allowAnalysisOwnComputedColumns = listView->property("allowAnalysisOwnComputedColumns").toBool();
-	_addNewAvailableTermsToAssignedModel = listView->property("addAvailableVariablesToAssigned").toBool();
 }
 
 ListModelDraggable::~ListModelDraggable()
@@ -115,7 +113,7 @@ Terms ListModelDraggable::canAddTerms(const Terms& terms) const
 
 bool ListModelDraggable::isAllowed(const Term &term) const
 {
-	if (!_allowAnalysisOwnComputedColumns)
+	if (!listView()->allowAnalysisOwnComputedColumns())
 	{
 		if (listView()->form()->isOwnComputedColumn(term.asString()))
 			return false;

--- a/QMLComponents/models/listmodeldraggable.h
+++ b/QMLComponents/models/listmodeldraggable.h
@@ -49,8 +49,6 @@ signals:
 
 protected:
 	bool						_copyTermsWhenDropped;
-	bool						_addNewAvailableTermsToAssignedModel	= false;
-	bool						_allowAnalysisOwnComputedColumns		= true;
 	JASPControl::DropMode		_dropMode								= JASPControl::DropMode::DropNone;
 		
 	bool						isAllowed(const Term &term) const;

--- a/QMLComponents/models/listmodelinteractionassigned.cpp
+++ b/QMLComponents/models/listmodelinteractionassigned.cpp
@@ -20,6 +20,7 @@
 #include "utilities/qutils.h"
 #include "listmodeltermsavailable.h"
 #include "listmodeltermsassigned.h"
+#include "controls/jasplistcontrol.h"
 
 using namespace std;
 
@@ -151,7 +152,7 @@ void ListModelInteractionAssigned::_addTerms(const Terms& terms, bool combineWit
 
 void ListModelInteractionAssigned::availableTermsResetHandler(Terms termsAdded, Terms termsRemoved)
 {
-	if (termsAdded.size() > 0 && _addNewAvailableTermsToAssignedModel)
+	if (termsAdded.size() > 0 && listView()->addAvailableVariablesToAssigned())
 	{
 		_addTerms(termsAdded, _addInteractionsByDefault);
 		setTerms();

--- a/QMLComponents/models/listmodelinteractionavailable.cpp
+++ b/QMLComponents/models/listmodelinteractionavailable.cpp
@@ -38,7 +38,7 @@ void ListModelInteractionAvailable::resetTermsFromSources(bool updateAssigned)
 
 	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
-		ListModel* sourceModel = sourceItem->listModel();
+		ListModel* sourceModel = sourceItem->sourceListModel();
 		for (const Term& term : terms)
 		{
 			QString itemType = sourceModel ? sourceModel->getItemType(term) : "";

--- a/QMLComponents/models/listmodellabelvalueterms.cpp
+++ b/QMLComponents/models/listmodellabelvalueterms.cpp
@@ -120,7 +120,7 @@ void ListModelLabelValueTerms::setLabelValuesFromSource()
 
 	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
-		ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceItem->listModel());
+		ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceItem->sourceListModel());
 		for (const Term& term : terms)
 		{
 			QString label = term.asQString();
@@ -153,7 +153,7 @@ void ListModelLabelValueTerms::sourceNamesChanged(QMap<QString, QString> map)
 			QString newValue = oldValue;
 			listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 			{
-				ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceItem->listModel());
+				ListModelLabelValueTerms* labelValueSourceModel = qobject_cast<ListModelLabelValueTerms*>(sourceItem->sourceListModel());
 				if (terms.contains(newName) && labelValueSourceModel)
 					newValue = labelValueSourceModel->getValue(newName);
 			});

--- a/QMLComponents/models/listmodeltermsassigned.cpp
+++ b/QMLComponents/models/listmodeltermsassigned.cpp
@@ -44,7 +44,7 @@ void ListModelTermsAssigned::initTerms(const Terms &terms, const RowControlsValu
 
 void ListModelTermsAssigned::availableTermsResetHandler(Terms termsAdded, Terms termsRemoved)
 {
-	if (termsAdded.size() > 0 && _addNewAvailableTermsToAssignedModel)
+	if (termsAdded.size() > 0 && listView()->addAvailableVariablesToAssigned())
 	{
 		beginResetModel();
 		_addTerms(termsAdded);

--- a/QMLComponents/rsyntax/formulasource.cpp
+++ b/QMLComponents/rsyntax/formulasource.cpp
@@ -172,7 +172,7 @@ QStringList FormulaSource::modelSources() const
 		const QVector<SourceItem*>& sourceItems = model->listView()->sourceItems();
 		for (SourceItem* sourceItem : sourceItems)
 		{
-			ListModel* listModel = sourceItem->listModel();
+			ListModel* listModel = sourceItem->sourceListModel();
 			if (listModel) sources.append(listModel->name());
 		}
 	};
@@ -452,7 +452,7 @@ FormulaParser::ParsedTerms FormulaSource::_fillOptionsWithFixedTerms(ListModel* 
 	const QVector<SourceItem*>& sourceItems = model->listView()->sourceItems();
 	for (SourceItem* sourceItem : sourceItems)
 	{
-		ListModelAssignedInterface* assignedSourceModel = qobject_cast<ListModelAssignedInterface*>(sourceItem->listModel());
+		ListModelAssignedInterface* assignedSourceModel = qobject_cast<ListModelAssignedInterface*>(sourceItem->sourceListModel());
 		if (assignedSourceModel)
 		{
 			if (specifiedByUserSources.contains(assignedSourceModel->name()))	specifiedSourceModels.push_back(assignedSourceModel);
@@ -466,7 +466,7 @@ FormulaParser::ParsedTerms FormulaSource::_fillOptionsWithFixedTerms(ListModel* 
 		const QVector<SourceItem*>& sourceItems = availableModel->listView()->sourceItems();
 		for (SourceItem* sourceItem : sourceItems)
 		{
-			ListModelAssignedInterface* assignedSourceModel = qobject_cast<ListModelAssignedInterface*>(sourceItem->listModel());
+			ListModelAssignedInterface* assignedSourceModel = qobject_cast<ListModelAssignedInterface*>(sourceItem->sourceListModel());
 			if (assignedSourceModel)
 			{
 				if (specifiedByUserSources.contains(assignedSourceModel->name()))	specifiedSourceModels.push_back(assignedSourceModel);
@@ -563,7 +563,7 @@ FormulaParser::ParsedTerms FormulaSource::_fillOptionsWithRandomTerms(const Form
 	const QVector<SourceItem*>& sourceItems = _model->listView()->sourceItems();
 	for (SourceItem* sourceItem : sourceItems)
 	{
-		ListModelAssignedInterface* assignedSourceModel = qobject_cast<ListModelAssignedInterface*>(sourceItem->listModel());
+		ListModelAssignedInterface* assignedSourceModel = qobject_cast<ListModelAssignedInterface*>(sourceItem->sourceListModel());
 		if (assignedSourceModel)
 			sourceModels.push_back(assignedSourceModel);
 	}


### PR DESCRIPTION
When setting values of the controls (when reading a JASP file or when duplicating an analysis), the order of setting the values is important, since some controls are dependent on other controls (via their source property or an assigned variables list is also dependent on its available variables list). 
This order can be set usually when the controls are statically build, but when they are dynamically build, the dependency is known only when they are build. Typically: when a ComponentList (or a VariableList with rowComponent) gets its value, the rows with their controls are then build, but these controls might depend on a source control which is not yet initialized. These row controls must then wait that the source control is first initialized before being initialized with a value: for example if a row control is a dropdown, with option values depending on another control, the dropdown cannot get its own value before knowing its option values, if not it will throw an error "this value is not possible".

This fixes this issue by telling the control to wait that all its dependencies must be initialized before getting its value.

Also some function and property renaming has been made, so that the code become (a bit) clearer.

Also, I took advantage of this PR to remove quite old ugly code... the Initialization of the available variablesList was quite ugly: a long comment in the bindTo method of the AnalysisForm object tried to explain how this initialization was done, but with this PR, I try to do it in the 'right way'.
The available VariablesLists have no bound value (they don't give values for the analysis), but they must be initialized. For this, as the setInitialized is called even for these controls, just override this method in VaraibelListBase, so that:
. when it has an avalable list model, then it should get its values from its sources.
. when it has an assigned list model, handle the particular case when the addAvailableVariablesToAssigned prperty is true, and it is initialized with no value, then it should take the values of its available list model (which might have default values).
