### PR TITLE
Disable ms-gaming overlay pop up while JASP starting

### DIFF
--- a/Tools/wix/JASP.wxs
+++ b/Tools/wix/JASP.wxs
@@ -93,6 +93,15 @@
 		</Directory>
 	</Directory>
 
+	<!-- Disable ms-gaming overlay pop while JASP starting -->
+	<Component Id="RegistryEntryHacky">
+		<RegistryKey Root="HKCU" Key="Software\Microsoft\Windows\CurrentVersion\GameDVR">
+			<RegistryValue Name="AppCaptureEnabled" Value="0" Type="integer" />
+		</RegistryKey>
+		<RegistryKey Root="HKCU" Key="System\GameConfigStore">
+			<RegistryValue Name="GameDVR_Enabled" Value="0" Type="integer" />
+		</RegistryKey>
+	</Component>
 
 	<Icon       	Id="JASP.ico" SourceFile="$(var.JASP_SOURCE_DIR)\Desktop\icon.ico" />
 	<Property   	Id="ARPPRODUCTICON" 			Value="JASP.ico" />


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/jasp-issues/issues/2479
Fixes: https://github.com/jasp-stats/jasp-issues/issues/2506

This will disable MS gaming box pop on users Windows system,This will be a system item modification behavior!
I didn't test it cuz I have no such environment so we can make a installer then ask user to help test it.

not sure how to do it on msix so i leave it to you @RensDofferhoff 