### PR TITLE
some filter improvements

### DIFF
--- a/CommonData/filter.h
+++ b/CommonData/filter.h
@@ -6,9 +6,9 @@
 #include <vector>
 #include "utils.h"
 
-#define DEFAULT_FILTER		"# Add filters using R syntax here, see info button for help.\n\ngeneratedFilter # by default: pass the non-R filter(s)"
 #define DEFAULT_FILTER_JSON	"{\"formulas\":[]}"
 #define DEFAULT_FILTER_GEN	"generatedFilter <- rep(TRUE, rowcount)"
+
 
 class DataSet;
 class DatabaseInterface;
@@ -61,7 +61,7 @@ private:
 	DataSet				*	_data				= nullptr;
 	int						_id					= -1,
 							_filteredRowCount	= 0;
-	std::string				_rFilter			= DEFAULT_FILTER,
+	std::string				_rFilter			= "",
 							_generatedFilter	= DEFAULT_FILTER_GEN,
 							_constructorJson	= DEFAULT_FILTER_JSON,
 							_constructorR		= "",

--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -121,6 +121,17 @@ FocusScope
 					property bool changed:	text != computedColumnsInterface.computeColumnRCode
 					
 					KeyNavigation.tab:		applyComputedColumnButton
+
+
+					Keys.onReturnPressed:	(keyEvent) => {
+												if(keyEvent.modifiers & Qt.ControlModifier)
+												{
+													if(changedSinceLastApply)
+														computedColumnContainer.applyComputedColumn()
+												}
+												else
+													keyEvent.accepted = false
+											}
 				}
 
 
@@ -190,6 +201,7 @@ FocusScope
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "replaceNA";		functionParameters: "column,replaceWith";	functionParamTypes: "string:boolean:number,string:boolean:number";              toolTip: qsTr("replace any missing values (NA) in column by the value in replaceWith") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "ifElse";			functionParameters: "test,then,else";		functionParamTypes: "boolean,boolean:string:number,boolean:string:number";      toolTip: qsTr("if-else statement") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "hasSubstring";	functionParameters: "string,substring";		functionParamTypes: "string,string";											toolTip: qsTr("returns true if string contains substring at least once") }
+					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "is.na";			functionParameters: "y";					functionParamTypes: "string:number:boolean";									toolTip: qsTr("returns a boolean vector with TRUE for each missing value in y") }
 
 					ListElement	{ type: "separator" }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "normalDist";     functionParameters: "mean,sd";                  functionParamTypes: "number,number";            toolTip: qsTr("generates data from a Gaussian distribution with specified mean and standard deviation sd") }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -56,7 +56,7 @@ DropArea {
 		return false
 	}
 
-	onEntered:
+	onEntered: (drag)=>
 	{
 		//console.log(__debugName," onEntered DROPSPOT")
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
@@ -242,7 +242,7 @@ Item
 				MouseArea
 				{
 					anchors.fill: parent
-					onPressed: { scriptColumn.focus = true; mouse.accepted = false; }
+					onPressed: (mouse) => { scriptColumn.focus = true; mouse.accepted = false; }
 				}
 
 				DropTrash

--- a/Desktop/components/JASP/Widgets/FilterConstructor/Function.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/Function.qml
@@ -18,7 +18,7 @@ Item
 	property variant functionNameToImageSource: { "sum": jaspTheme.iconPath + "/sum.png", "prod": jaspTheme.iconPath + "/product.png", "sd": jaspTheme.iconPath + "/sigma.png", "var": jaspTheme.iconPath + "/variance.png", "!": jaspTheme.iconPath + "/negative.png", "sqrt":jaspTheme.iconPath + "/rootHead.png"}
 	property string functionImageSource: functionNameToImageSource[functionName] !== undefined ? functionNameToImageSource[functionName] : ""
 	property bool isNested: false
-	property var booleanReturningFunctions: ["!", "hasSubstring"]
+	property var booleanReturningFunctions: ["!", "hasSubstring", "is.na"]
 
 	readonly property bool isIfElse: functionName === "ifelse"
 	property var ifElseReturn: ["string", "number", "boolean"]

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -128,6 +128,7 @@ FocusScope
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "median";			functionParameters: "values";			functionParamTypes: "number";												toolTip: qsTr("median") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "ifelse";			functionParameters: "test,then,else";	functionParamTypes: "boolean,boolean:string:number,boolean:string:number";		toolTip: qsTr("if-else statement") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "hasSubstring";	functionParameters: "string,substring";	functionParamTypes: "string,string";											toolTip: qsTr("returns true if string contains substring at least once") }
+					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "is.na";			functionParameters: "y";				functionParamTypes: "string:number:boolean";									toolTip: qsTr("Combine with not-operator to filter out rows with missing values (NA) for a column.") }
 				}
 
 				function askIfChanged(closeFunc)
@@ -357,6 +358,16 @@ FocusScope
 							color:					jaspTheme.textEnabled
 
 							property bool changedSinceLastApply: text !== filterModel.rFilter
+
+							Keys.onReturnPressed:	(keyEvent) => {
+														if(keyEvent.modifiers & Qt.ControlModifier)
+														{
+															if(filterEdit.changedSinceLastApply)
+																filterWindow.applyAndSendFilter(filterEdit.text)
+														}
+														else
+															keyEvent.accepted = false
+													}
 
 							anchors
 							{

--- a/Desktop/data/filtermodel.h
+++ b/Desktop/data/filtermodel.h
@@ -3,7 +3,6 @@
 
 #include <QObject>
 #include "utilities/qutils.h"
-#include "datasetpackage.h"
 #include "labelfiltergenerator.h"
 
 ///
@@ -22,27 +21,27 @@ class FilterModel : public QObject
 	Q_PROPERTY( QString defaultRFilter		READ defaultRFilter									NOTIFY defaultRFilterChanged	)
 
 public:
-	explicit FilterModel(labelFilterGenerator * labelfilterGenerator);
+	explicit					FilterModel(labelFilterGenerator * labelfilterGenerator);
 
-	void init();
+				void			init();
 
-	QString rFilter()				const;
-	QString constructorR()			const;
-	QString statusBarText()			const	{ return _statusBarText;			}
-	QString filterErrorMsg()		const;
-	QString generatedFilter()		const;
-	QString constructorJson()		const;
-	QString defaultRFilter()		const	{ return DEFAULT_FILTER;			}
+				QString			rFilter()				const;
+				QString			constructorR()			const;
+				QString			statusBarText()			const	{ return _statusBarText;			}
+				QString			filterErrorMsg()		const;
+				QString			generatedFilter()		const;
+				QString			constructorJson()		const;
+	static		const char *	defaultRFilter();
 
-	bool	hasFilter()				const	{ return rFilter() != DEFAULT_FILTER || constructorJson() != DEFAULT_FILTER_JSON; }
+				bool			hasFilter()				const	{ return rFilter() != defaultRFilter() || constructorJson() != DEFAULT_FILTER_JSON; }
 
 
-	Q_INVOKABLE void resetRFilter()				{ applyRFilter(DEFAULT_FILTER); }
-	void		sendGeneratedAndRFilter();
+	Q_INVOKABLE void			resetRFilter()				{ applyRFilter(defaultRFilter()); }
+				void			sendGeneratedAndRFilter();
 
-	void updateStatusBar();
-	void reset();
-	void modelInit();
+				void			updateStatusBar();
+				void			reset();
+				void			modelInit();
 
 public slots:
 	GENERIC_SET_FUNCTION(StatusBarText,			_statusBarText,			statusBarTextChanged,		QString)

--- a/Desktop/data/importers/jaspimporterold.cpp
+++ b/Desktop/data/importers/jaspimporterold.cpp
@@ -16,7 +16,7 @@
 //
 
 #include "jaspimporterold.h"
-#include "columnutils.h"
+#include "data/filtermodel.h"
 #include <fstream>
 
 #include <sys/stat.h>
@@ -106,7 +106,7 @@ void JASPImporterOld::loadDataArchive_1_00(const std::string &path, std::functio
 
 	packageData->dataSet()->setDataFileSynch(true);
 
-	DataSetPackage::filter()->setRFilter(	metaData.get("filterData",			DEFAULT_FILTER)	.asString());
+	DataSetPackage::filter()->setRFilter(	metaData.get("filterData",			FilterModel::defaultRFilter())	.asString());
 
 	Json::Value jsonFilterConstructor = metaData.get("filterConstructorJSON", DEFAULT_FILTER_JSON);
 	DataSetPackage::filter()->setConstructorJson(jsonFilterConstructor.isObject() ? jsonFilterConstructor.toStyledString() : jsonFilterConstructor.asString());
@@ -229,8 +229,8 @@ void JASPImporterOld::loadDataArchive_1_00(const std::string &path, std::functio
 	//Filter should be run if filterVector was not filled and either of the filters was different from default.
 	bool filterShouldBeRun =
 			filterVector.size() == 0 &&
-			(	metaData.get("filterData",				DEFAULT_FILTER).asString()		!= DEFAULT_FILTER
-			||	metaData.get("filterConstructorJSON",	DEFAULT_FILTER_JSON).asString() != DEFAULT_FILTER_JSON	);
+			(	metaData.get("filterData",				FilterModel::defaultRFilter()).asString()	!= FilterModel::defaultRFilter()
+			||	metaData.get("filterConstructorJSON",	DEFAULT_FILTER_JSON).asString()				!= DEFAULT_FILTER_JSON	);
 
 	packageData->setFilterShouldRunInit(filterShouldBeRun);
 }

--- a/Desktop/data/labelfiltergenerator.cpp
+++ b/Desktop/data/labelfiltergenerator.cpp
@@ -1,4 +1,5 @@
 #include "labelfiltergenerator.h"
+#include "filtermodel.h"
 
 labelFilterGenerator::labelFilterGenerator(ColumnModel *columnModel, QObject *parent)
 	: QObject(parent), _columnModel(columnModel)

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -342,6 +342,7 @@ void EngineRepresentation::processFilterReply(Json::Value & json)
 {
 	checkIfExpectedReplyType(engineState::filter);
 
+
 	setState(engineState::idle);
 
 #ifdef PRINT_ENGINE_MESSAGES
@@ -350,10 +351,15 @@ void EngineRepresentation::processFilterReply(Json::Value & json)
 
 	int requestId = json.get("requestId", -1).asInt();
 
-	emit filterDone(requestId);
-
 	if(requestId == _lastRequestId)
-		emit processNewFilterResult(requestId);
+	{
+		emit filterDone(requestId);
+
+		if(json.isMember("error"))
+			emit processFilterErrorMsg(tq(json["error"].asString()), requestId);
+		else
+			emit processNewFilterResult(requestId);
+	}
 }
 
 void EngineRepresentation::runScriptOnProcess(const QString & rCmdCode)

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -300,6 +300,8 @@ void Engine::runFilter(const std::string & filter, const std::string & generated
 		std::vector<bool> filterResult	= rbridge_applyFilter(strippedFilter, generatedFilter);
 		std::string RPossibleWarning	= jaspRCPP_getLastErrorMsg();
 
+		Log::log() << "Engine::runFilter ran:\n\t" << strippedFilter << "\n\tRPossibleWarning='" << RPossibleWarning << "'\n\t\tfor revision " << _dataSet->filter()->revision() << std::endl;
+
 		_dataSet->db().transactionWriteBegin();
 		_dataSet->filter()->setRFilter(filter);
 		_dataSet->filter()->setFilterVector(filterResult);
@@ -313,7 +315,14 @@ void Engine::runFilter(const std::string & filter, const std::string & generated
 	}
 	catch(filterException & e)
 	{
-		sendFilterError(filterRequestId, std::string(e.what()).length() > 0 ? e.what() : "Something went wrong with the filter but it is unclear what.");
+		std::string error = std::string(e.what()).length() > 0 ? e.what() : "Something went wrong with the filter but it is unclear what.";
+
+		_dataSet->db().transactionWriteBegin();
+		_dataSet->filter()->setErrorMsg(error);
+		_dataSet->filter()->incRevision();
+		_dataSet->db().transactionWriteEnd();
+
+		sendFilterError(filterRequestId, error);
 	}
 
 	_engineState = engineState::idle;
@@ -336,10 +345,11 @@ void Engine::sendFilterError(int filterRequestId, const std::string & errorMessa
 {
 	Json::Value filterResponse = Json::Value(Json::objectValue);
 
-        provideAndUpdateDataSet()->filter()->setErrorMsg(errorMessage);
+	Log::log() << "Engine::sendFilterError(filterRequestId=" << filterRequestId << ", errorMsg='" << errorMessage << "')" << std::endl;
 
 	filterResponse["typeRequest"]	= engineStateToString(engineState::filter);
 	filterResponse["requestId"]		= filterRequestId;
+	filterResponse["error"]			= errorMessage;
 
 	sendString(filterResponse.toStyledString());
 }
@@ -863,6 +873,7 @@ void Engine::removeNonKeepFiles(const Json::Value & filesToKeepValue)
 DataSet * Engine::provideAndUpdateDataSet()
 {
 	JASPTIMER_RESUME(Engine::provideAndUpdateDataSet());
+	Log::log() << "Engine::provideAndUpdateDataSet()" << std::endl;
 
 	bool setColumnNames = !_dataSet;
 

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -345,7 +345,7 @@ int STDCALL jaspRCPP_runFilter(const char * filterCode, bool ** arrayPointer)
 {
 	jaspRCPP_logString("jaspRCPP_runFilter runs: \n\"" + std::string(filterCode) + "\"\n" );
 
-	lastErrorMessage = "";
+	jaspRCPP_resetErrorMsg();
 	rinside->instance()[".filterCode"] = filterCode;
 
 	const std::string filterTryCatch(


### PR DESCRIPTION
The text will now look like (as suggested in https://github.com/jasp-stats/jasp-issues/issues/2515#issuecomment-1881235945):
```
# Add filters using R syntax here. By default the non-R filter(s) are passed with generatedFilter.
# To include generated filters, append clauses with "&": generatedFilter & ...
# Click the (i) icon in the lower right corner for further help.

generatedFilter
``` 
What do you think @EJWagenmakers @JohnnyDoorn ?

It is now also translatable, which it wasnt before.

This PR also fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2462 in that the statusbar now gives sensible feedback. It also is translatable now.

I was also annoyed that I couldnt run rcode in the filter and computed column windows by pressing ctrl/cmd+return.
So I added that too

And then there was the fact that filtererrors were being ignored by the desktop... This is now also fixed.

For the kicker I also added the `is.na` function to the filter/compcolconstructor function lists as suggested in https://github.com/jasp-stats/jasp-issues/issues/2493