### PR TITLE
A computed column is not always computed when opening a JASP file

### DIFF
--- a/Common/columnencoder.cpp
+++ b/Common/columnencoder.cpp
@@ -128,6 +128,8 @@ std::string ColumnEncoder::decode(const std::string &in)
 
 void ColumnEncoder::setCurrentNames(const std::vector<std::string> & names)
 {
+	Log::log() << "ColumnEncoder::setCurrentNames(#"<< names.size() << ")" << std::endl;
+
 	_encodingMap.clear();
 	_decodingMap.clear();
 

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -8,6 +8,8 @@ stringset DataSet::_defaultEmptyvalues;
 DataSet::DataSet(int index)
 	: DataSetBaseNode(dataSetBaseNodeType::dataSet, nullptr)
 {
+	Log::log() << "DataSet::DataSet(index=" << index << ")" << std::endl;
+
 	_dataNode		= new DataSetBaseNode(dataSetBaseNodeType::data,	this);
 	_filtersNode	= new DataSetBaseNode(dataSetBaseNodeType::filters, this);
 	

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -877,7 +877,18 @@ DataSet * Engine::provideAndUpdateDataSet()
 
 		Log::log(false) << std::endl;
 	}
-	else if(_db->dataSetGetId() != -1)	_dataSet = new DataSet(_db->dataSetGetId());
+	else
+	{
+		Log::log() << "No dataset, ";
+		if(_db->dataSetGetId() != -1)
+		{
+			Log::log() << "create a new dataset" << std::endl;
+			_dataSet = new DataSet(_db->dataSetGetId());
+			ColumnEncoder::columnEncoder()->setCurrentNames(_dataSet->getColumnNames());
+		}
+		else
+			Log::log() << "No database" << std::endl;
+	}
 
 	JASPTIMER_STOP(Engine::provideDataSet());
 

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -862,33 +862,18 @@ void Engine::removeNonKeepFiles(const Json::Value & filesToKeepValue)
 
 DataSet * Engine::provideAndUpdateDataSet()
 {
-	JASPTIMER_RESUME(Engine::provideDataSet());
+	JASPTIMER_RESUME(Engine::provideAndUpdateDataSet());
+
+	bool setColumnNames = !_dataSet;
+
+	if(!_dataSet && _db->dataSetGetId() != -1)
+		_dataSet = new DataSet(_db->dataSetGetId());
 
 	if(_dataSet)
-	{
-		Log::log() << "There is a dataset, ";
-		if(_dataSet->checkForUpdates())
-		{
-			Log::log(false) << "updates found, loading them.";
-			ColumnEncoder::columnEncoder()->setCurrentNames(_dataSet->getColumnNames());
-		}
-		else
-			Log::log(false) << "no updates found.";
+		setColumnNames |= _dataSet->checkForUpdates();
 
-		Log::log(false) << std::endl;
-	}
-	else
-	{
-		Log::log() << "No dataset, ";
-		if(_db->dataSetGetId() != -1)
-		{
-			Log::log() << "create a new dataset" << std::endl;
-			_dataSet = new DataSet(_db->dataSetGetId());
-			ColumnEncoder::columnEncoder()->setCurrentNames(_dataSet->getColumnNames());
-		}
-		else
-			Log::log() << "No database" << std::endl;
-	}
+	if(_dataSet && setColumnNames)
+		ColumnEncoder::columnEncoder()->setCurrentNames(_dataSet->getColumnNames());
 
 	JASPTIMER_STOP(Engine::provideDataSet());
 


### PR DESCRIPTION
Make a JASP file with several analyses.
Add a computed column by using another column.
Save it, close it, and open it again: the computed column is not computed due to an engine crash.

This crash is due to the fact that when trying to compute the computed column, the ColumnEncoder in the Engine was not yet initilalized with the names of the columns.

