### PR TITLE
Only show known issues warnings in debug mode, log the warning otherwise 

### DIFF
--- a/QMLComponents/knownissues.cpp
+++ b/QMLComponents/knownissues.cpp
@@ -32,15 +32,25 @@ void KnownIssues::loadLocalJson(const std::string & filePath, bool saveIt)
 
 void KnownIssues::loadJson(const std::string & jsonTxt,	bool saveIt)
 {
-	if(jsonTxt == "") 
+	if(jsonTxt == "")
 	{
-		MessageForwarder::showWarning(tr("Problem loading known issues"), tr("JASP ran into a problem downloading the known issues for this version, it probably could not connect to the server. Don't worry, JASP will work fine it just might not tell you about a few small known issues."));
+		Log::log() << "## " <<  tr("Problem loading known issues") << "\n" << tr("JASP ran into a problem downloading the known issues for this version, it probably could not connect to the server. Don't worry, JASP will work fine it just might not tell you about a few small known issues.")  << std::endl;
+#if JASP_DEBUG
+		MessageForwarder::showWarning("Known issues from server was empty!");
+#endif
 		return;
 	}
 	
 	Json::Value known;
-	if(Json::Reader().parse(jsonTxt, known))	loadJson(known, saveIt);
-	else										MessageForwarder::showWarning(tr("Problem loading known issues"), tr("JASP ran into a problem loading the known issues for this version, this isn't necessarily a problem but if it keeps occuring you could contact the JASP team for assistance."));
+	if(Json::Reader().parse(jsonTxt, known))
+		loadJson(known, saveIt);
+	else
+	{
+		Log::log() << "## " << tr("Problem loading known issues") << "\n" << tr("JASP ran into a problem loading the known issues for this version, this isn't necessarily a problem but if it keeps occuring you could contact the JASP team for assistance.") << std::endl;
+#if JASP_DEBUG
+		MessageForwarder::showWarning("Known issues could not be parsed!");
+#endif
+	}
 }
 
 
@@ -66,8 +76,13 @@ void KnownIssues::loadJson(const Json::Value & json, bool saveIt)
 							addIssue(module, analysis, entry);
 				}
 	}
-	catch(const std::runtime_error & e) { MessageForwarder::showWarning(tr("Problem loading known issues"), tr("JASP ran into a problem ('%1') loading the known issues for this version, this isn't necessarily a problem but if it keeps occuring you could contact the JASP team for assistance.").arg(e.what())); }
-	catch(...)							{ MessageForwarder::showWarning(tr("Problem loading known issues"), tr("JASP ran into a problem loading the known issues for this version, this isn't necessarily a problem but if it keeps occuring you could contact the JASP team for assistance.")); }
+	catch(const std::exception & e)
+	{
+		Log::log() << "## " << tr("Problem loading known issues") << "\n" << tr("JASP ran into a problem ('%1') loading the known issues for this version, this isn't necessarily a problem but if it keeps occuring you could contact the JASP team for assistance.").arg(e.what()) << std::endl;
+#if JASP_DEBUG
+		MessageForwarder::showWarning(QString("Loading known issues had exception: '%1'!").arg(e.what()));
+#endif
+	}
 
 	emit knownIssuesUpdated();
 


### PR DESCRIPTION
Should stop getting people getting scared as mentioned in https://github.com/jasp-stats/jasp-issues/issues/2512

