### PR TITLE
Fixes filter after closing and loading a new workspace

### DIFF
--- a/CommonData/filter.h
+++ b/CommonData/filter.h
@@ -61,7 +61,7 @@ private:
 	DataSet				*	_data				= nullptr;
 	int						_id					= -1,
 							_filteredRowCount	= 0;
-	std::string				_rFilter			= "",
+	std::string				_rFilter			= "generatedFilter",
 							_generatedFilter	= DEFAULT_FILTER_GEN,
 							_constructorJson	= DEFAULT_FILTER_JSON,
 							_constructorR		= "",

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -31,6 +31,7 @@
 #include "databaseconnectioninfo.h"
 #include "utilities/settings.h"
 #include "modules/ribbonmodel.h"
+#include "filtermodel.h"
 
 //Im having problems getting the proxy models to play nicely with beginRemoveRows etc
 //So just reset the whole thing as that is what happens in datasetview
@@ -1271,6 +1272,8 @@ void DataSetPackage::createDataSet()
 	setDefaultWorkspaceEmptyValues();
 	_dataSubModel->selectNode(_dataSet->dataNode());
 	_filterSubModel->selectNode(_dataSet->filtersNode());
+	
+	_dataSet->filter()->setRFilter(FilterModel::defaultRFilter());
 	
 	_dataSet->setModifiedCallback([&](){ setModified(true); }); //DataSet and co dont use Qt so instead we just use a callback
 }

--- a/Desktop/data/filtermodel.cpp
+++ b/Desktop/data/filtermodel.cpp
@@ -13,11 +13,11 @@ FilterModel::FilterModel(labelFilterGenerator * labelFilterGenerator)
 	connect(DataSetPackage::pkg(),	&DataSetPackage::modelInit,		this, &FilterModel::modelInit				);
 }
 
-QString FilterModel::rFilter()			const	{ return !DataSetPackage::filter() ? "" : tq(DataSetPackage::filter()->rFilter());					}
-QString FilterModel::constructorR()		const	{ return !DataSetPackage::filter() ? "" : tq(DataSetPackage::filter()->constructorR());				}
-QString FilterModel::filterErrorMsg()	const	{ return !DataSetPackage::filter() ? "" : tq(DataSetPackage::filter()->errorMsg());					}
-QString FilterModel::generatedFilter()	const	{ return !DataSetPackage::filter() ? "" : tq(DataSetPackage::filter()->generatedFilter());			}
-QString FilterModel::constructorJson()	const	{ return !DataSetPackage::filter() ? "" : tq(DataSetPackage::filter()->constructorJson());			}
+QString FilterModel::rFilter()			const	{ return !DataSetPackage::filter() ? defaultRFilter()		: tq(DataSetPackage::filter()->rFilter());					}
+QString FilterModel::constructorR()		const	{ return !DataSetPackage::filter() ? ""						: tq(DataSetPackage::filter()->constructorR());				}
+QString FilterModel::filterErrorMsg()	const	{ return !DataSetPackage::filter() ? ""						: tq(DataSetPackage::filter()->errorMsg());					}
+QString FilterModel::generatedFilter()	const	{ return !DataSetPackage::filter() ? DEFAULT_FILTER_GEN		: tq(DataSetPackage::filter()->generatedFilter());			}
+QString FilterModel::constructorJson()	const	{ return !DataSetPackage::filter() ? DEFAULT_FILTER_JSON	: tq(DataSetPackage::filter()->constructorJson());			}
 
 const char * FilterModel::defaultRFilter()
 {
@@ -36,7 +36,7 @@ void FilterModel::reset()
 	setConstructorJson(	DEFAULT_FILTER_JSON	);
 	_setRFilter(		defaultRFilter()		);
 
-	if(DataSetPackage::pkg()->rowCount() > 0)
+	if(DataSetPackage::pkg()->dataRowCount() > 0)
 		sendGeneratedAndRFilter();
 }
 
@@ -216,7 +216,7 @@ void FilterModel::updateStatusBar()
 
 void FilterModel::rescanRFilterForColumns()
 {
-	_columnsUsedInRFilter = DataSetPackage::pkg()->dataSet()->findUsedColumnNames(fq(rFilter()));
+	_columnsUsedInRFilter = DataSetPackage::pkg() && DataSetPackage::pkg()->dataSet() ? DataSetPackage::pkg()->dataSet()->findUsedColumnNames(fq(rFilter())) : stringset();
 }
 
 void FilterModel::computeColumnSucceeded(QString columnName, QString, bool dataChanged)

--- a/Desktop/data/importers/readstatimporter.cpp
+++ b/Desktop/data/importers/readstatimporter.cpp
@@ -148,7 +148,7 @@ void ReadStatImporter::initColumn(QVariant colId, ImportColumn * importColumn)
 
 	default:
 		Log::log() << "Column " << col->name() << " has unknown type after loading so presumably doesn't contain any data whatsoever. We will make it into a scalar column to get it to show up.\n";
-		DataSetPackage::pkg()->initColumnAsScale(colId, col->name(), std::vector<double>(DataSetPackage::pkg()->rowCount(), ReadStatImportColumn::missingValueDouble()));
+		DataSetPackage::pkg()->initColumnAsScale(colId, col->name(), std::vector<double>(DataSetPackage::pkg()->dataRowCount(), ReadStatImportColumn::missingValueDouble()));
 		break;
 	}
 }


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/2531 

Also makes sure DataSetPackage::dataRowCount is used where the rowCount of the actual data is meant and not the datasetpackage

