### PR TITLE
add stats::poly to r_functionwhitelist.cpp

### DIFF
--- a/Common/r_functionwhitelist.cpp
+++ b/Common/r_functionwhitelist.cpp
@@ -134,6 +134,7 @@ const std::set<std::string> R_FunctionWhiteList::functionWhiteList {
 	"pmatch",
 	"pmax",
 	"pmin",
+	"poly",
 	"powerTransform",
 	"power.t.test",
 	"predict",


### PR DESCRIPTION
Inspired by https://forum.cogsci.nl/discussion/9070/does-jasp-have-polynomial-regression

Ideally, this is handled within an analysis, but for now, this makes it possible to do it manually with computed columns.

@JorisGoosen An additional thing that would be nice is the option to create multiple computed columns with a single piece of R code. For example, poly returns a matrix:

```r
poly(1:10, degree = 3)
                1           2          3
 [1,] -0.49543369  0.52223297 -0.4534252
 [2,] -0.38533732  0.17407766  0.1511417
 [3,] -0.27524094 -0.08703883  0.3778543
 [4,] -0.16514456 -0.26111648  0.3346710
 [5,] -0.05504819 -0.34815531  0.1295501
 [6,]  0.05504819 -0.34815531 -0.1295501
 [7,]  0.16514456 -0.26111648 -0.3346710
 [8,]  0.27524094 -0.08703883 -0.3778543
 [9,]  0.38533732  0.17407766 -0.1511417
[10,]  0.49543369  0.52223297  0.4534252
```
here there are 3 columns for a 3rd degree polynomial. So with the change in this PR, if people want to do polynomial regression manually they have to create multiple columns with
```r
poly(contNormal, degree = 1)[, 1] # computed column 1
poly(contNormal, degree = 2)[, 2] # computed column 2
poly(contNormal, degree = 3)[, 3] # computed column 3
```
which is a bit ugly. Perhaps we can come up with some way to make the UX nicer?

Side note, doing `contNormal^1`, `contNormal^2`, `contNormal^3` can already be done (and also with the `poly` function) but that is suboptimal because the regression coefficients will change if you include a higher order polynomial term. With the `poly` function, if you run a quadratic regression and a cubic regression then the intercept, linear, and quadratic coefficients will be identical in both models.