### PR TITLE
apply all upgrades and also try it on meta

### DIFF
--- a/Desktop/modules/upgrader/upgrade.cpp
+++ b/Desktop/modules/upgrader/upgrade.cpp
@@ -38,11 +38,21 @@ void Upgrade::applyUpgrade(const std::string & function, const Version & version
 	for(ChangeBase * change : _changes)
 		try
 		{
+			Log::log() << "Currently options are: " << analysesJson["options"] << std::endl;
 			Log::log() << "Checking if condition for change " << change->toString() << " is satisfied, ";
 			if(change->conditionSatisfied(analysesJson["options"]))
 			{
 				Log::log(false) << "it is and applying the change!" << std::endl;
 				change->applyUpgrade(analysesJson["options"], msgs);
+				
+				try //Also try it on .meta
+				{
+					change->applyUpgrade(analysesJson["options"][".meta"], msgs);
+				}
+				catch(upgradeError & e)
+				{
+					Log::log() << "Applying upgrade to meta had error: " << e.what() << std::endl;
+				}
 			}
 			else
 				Log::log(false) << "it isn't and moving on." << std::endl;

--- a/Desktop/modules/upgrader/upgrades.cpp
+++ b/Desktop/modules/upgrader/upgrades.cpp
@@ -20,7 +20,7 @@ bool Upgrades::findClosestVersion(const std::string & function, Version & versio
 			_steps.at(version).count(function)	== 0	||	//Or there is nothing registered for this version + function
 			_steps.at(version).count("*")		== 0	)	//Or there is nothing registered for this version and module (function == "*" which means all functions)
 		for(auto & versionSteps : _steps)
-			if(versionSteps.first > version && (versionSteps.second.count(function) > 0 || versionSteps.second.count("*") > 0)) //This works because _steps is ordered on Version and we can thus assume each version is > than the last
+			if(versionSteps.first >= version && (versionSteps.second.count(function) > 0 || versionSteps.second.count("*") > 0)) //This works because _steps is ordered on Version and we can thus assume each version is > than the last
 			{
 				closestVersion = versionSteps.first;
 				break;


### PR DESCRIPTION
previously a bug could occur in a specific situation: say a module QC has an upgrade from 0.18.1 to 0.18.2 ijn 0.18.2. This works! now some time later in version 0.19 an upgrade is added going from 0.18.2 to 0.19. Because of flawed logic this dropped the 0.18.1->2 upgrade...

Besides that Ive added logging of options between each upgrade step, this should help module developers out and bugreports as well

Then there is an attempt added to also update the `.meta` in options, this should work for renames etc, and I dont think it will break anything else?

