### PR TITLE
Enh: Disable ms-gaming overlay pop while JASP starting

### DIFF
--- a/Tools/windows/msi/JASP.wxs
+++ b/Tools/windows/msi/JASP.wxs
@@ -93,6 +93,20 @@
 		</Directory>
 	</Directory>
 
+	<!-- Disable ms-gaming overlay pop while JASP starting -->
+	<DirectoryRef Id="TARGETDIR">
+		<Component Id="RegistryEntryHacky" Guid="4a21415f-a538-4cd4-a7d6-338390840bfb">
+			<RegistryKey Root="HKMU" Key="Software\Microsoft\Windows\CurrentVersion\GameDVR">
+				<RegistryValue Name="AppCaptureEnabled" Value="0" Type="integer"  />
+			</RegistryKey>
+			<RegistryKey Root="HKMU" Key="System\GameConfigStore">
+				<RegistryValue Name="GameDVR_Enabled" Value="0"   Type="integer" />
+			</RegistryKey>
+			<RegistryKey Root="HKMU" Key="Software\Policies\Microsoft\Windows\GameDVR">
+				<RegistryValue Name="AllowGameDVR" Value="0"   Type="integer"  />
+			</RegistryKey>
+		</Component>
+	</DirectoryRef>
 
 	<Icon       	Id="JASP.ico" SourceFile="$(var.JASP_SOURCE_DIR)\Desktop\icon.ico" />
 	<Property   	Id="ARPPRODUCTICON" 			Value="JASP.ico" />
@@ -160,9 +174,10 @@
 
 	<!-- Set the components defined in our fragment files that will be used for our feature  -->
 	<Feature Id="JASPFeature" Title="JASP" Level="1">
-		<ComponentGroupRef Id="JASPFiles" 							/>
-		<ComponentRef Id="ApplicationShortcut"				 		/>
-		<ComponentRef Id="FileTypeRegistration"					 	/>
+		<ComponentGroupRef Id="JASPFiles" 		/>
+		<ComponentRef Id="ApplicationShortcut"		/>
+		<ComponentRef Id="FileTypeRegistration"		/>
+		<ComponentRef Id="RegistryEntryHacky" 		/>
 	</Feature>
 
 	<Feature Id="VCRedist" Title="Visual C++ 14.0 Runtime" AllowAdvertise="no" Display="collapse" Level="10">


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/jasp-issues/issues/2479

This will change the rigistry of Windows system while install from msi installer, to disable annoying pop xbox gaming box message on some PC. this is a ready PR for merge.