### PR TITLE
Enh: Disable Windows GameDVR in msix

### DIFF
--- a/Tools/windows/msix/windowsGameDVR.reg
+++ b/Tools/windows/msix/windowsGameDVR.reg
@@ -1,0 +1,10 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\GameDVR]
+"AppCaptureEnabled"=dword:00000000
+
+[HKEY_CURRENT_USER\System\GameConfigStore]
+"GameDVR_Enabled"=dword:00000000
+
+[HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\GameDVR]
+"AllowGameDVR"=dword:00000000


### PR DESCRIPTION
to disable Windows GameDVR in msix.

Im just added the .reg file but not make it work with Msix installer, I leave it to you @RensDofferhoff and you may push some commit in this PR.

Or we can do it by cmd/powershell script like:

```cmd
reg add HKCU\Software\Microsoft\Windows\CurrentVersion\GameDVR /v AppCaptureEnabled /t REG_DWORD /d 0 /f
reg add HKCU\System\GameConfigStore /v GameDVR_Enabled /t REG_DWORD /d 0 /f
reg add HKLM\Software\Policies\Microsoft\Windows\GameDVR /v AllowGameDVR /t REG_DWORD /d 0 /f
```

Which is more easier?

