### PR TITLE
feat: Add debug info to about window

### DIFF
--- a/Desktop/components/JASP/Widgets/AboutWindow.qml
+++ b/Desktop/components/JASP/Widgets/AboutWindow.qml
@@ -17,7 +17,7 @@ WavyWindow
 
 	title:					qsTr("About JASP")
 	width:					600 * jaspTheme.uiScale
-	height:					550 * jaspTheme.uiScale
+	height:					600 * jaspTheme.uiScale
 
 
 	property int labelwidth:	10 + Math.max(	jaspVersionLabel.implicitWidth,
@@ -191,11 +191,11 @@ WavyWindow
 						cursorShape:			Qt.PointingHandCursor
 						focus:					true
 
-						property string _info: "-------- Application Info --------\n\n" +
+						property string _info: "-------- Application Info --------\n" +
 												"JASP Version: " + aboutModel.version + "\n" +
 												"Build Branch: " + aboutModel.branch + "\n" +
 												"Build Date: " + aboutModel.buildDate + "\n" +
-												"Last Commit: " + aboutModel.commit + "\n" +
+												"Last Commit: " + aboutModel.commit + "\n\n" +
 												aboutModel.systemInfo
 
 						onClicked:	(event) => {

--- a/Desktop/components/JASP/Widgets/AboutWindow.qml
+++ b/Desktop/components/JASP/Widgets/AboutWindow.qml
@@ -44,7 +44,7 @@ WavyWindow
 		}
 		
 		Column
-        {
+		{
 			spacing:					5 * preferencesModel.uiScale
 			anchors.horizontalCenter:	parent.horizontalCenter
 			width:						labelwidth * 4
@@ -102,7 +102,7 @@ WavyWindow
 			{
 				width:				parent.width
 		
-                Label
+				Label
 				{
 					id:				citationLabel
 					width:			aboutWindow.labelwidth
@@ -157,7 +157,7 @@ WavyWindow
 						}
 					}
 				}
-            }
+			}
 
 			Row
 			{

--- a/Desktop/components/JASP/Widgets/AboutWindow.qml
+++ b/Desktop/components/JASP/Widgets/AboutWindow.qml
@@ -44,7 +44,7 @@ WavyWindow
 		}
 		
 		Column
-		{
+        {
 			spacing:					5 * preferencesModel.uiScale
 			anchors.horizontalCenter:	parent.horizontalCenter
 			width:						labelwidth * 4
@@ -102,7 +102,7 @@ WavyWindow
 			{
 				width:				parent.width
 		
-				Label
+                Label
 				{
 					id:				citationLabel
 					width:			aboutWindow.labelwidth
@@ -157,9 +157,69 @@ WavyWindow
 						}
 					}
 				}
+            }
+
+			Row
+			{
+				width:                      parent.width
+				anchors.horizontalCenter:   parent.horizontalCenter
+
+				Rectangle
+				{
+					id:					debugInfoButton
+					z:                  15
+					color:				closebuttoncolor
+					radius:				5 * preferencesModel.uiScale
+					height:				25 * preferencesModel.uiScale
+					width:				parent.width * preferencesModel.uiScale
+
+					Text
+					{
+						id:                     copyInfoText
+						anchors.centerIn:		parent
+						text:					clicked ? qsTr("Copied to clipboard") : qsTr("Copy debug information")
+						color:					jaspTheme.white
+						horizontalAlignment:	Text.AlignHCenter
+						verticalAlignment:		Text.AlignVCenter
+
+						property bool clicked:  false
+					}
+
+					MouseArea
+					{
+						anchors.fill:			parent
+						cursorShape:			Qt.PointingHandCursor
+						focus:					true
+
+						property string _info: "-------- Application Info --------\n\n" +
+												"JASP Version: " + aboutModel.version + "\n" +
+												"Build Branch: " + aboutModel.branch + "\n" +
+												"Build Date: " + aboutModel.buildDate + "\n" +
+												"Last Commit: " + aboutModel.commit + "\n" +
+												aboutModel.systemInfo
+
+						onClicked:	(event) => {
+										resultsJsInterface.pushToClipboard("text/plain", _info, "")
+										debugInfoButton.color = jaspTheme.grayDarker
+										copyInfoText.clicked = true
+										changeButtonColorTimer.start()
+						}
+
+						Timer
+						{
+							id:				changeButtonColorTimer
+							interval:		1000
+							onTriggered:
+							{
+								debugInfoButton.color = closebuttoncolor
+								copyInfoText.clicked = false
+							}
+						}
+					}
+				}
 			}
 		}
-		
+
 		Text
 		{
 			id:						warrantyText
@@ -171,7 +231,7 @@ WavyWindow
 			width:					parent.width
 			horizontalAlignment:	Text.AlignHCenter
 		}
-	
+
 		Text
 		{
 			id:						openSourceText
@@ -180,7 +240,7 @@ WavyWindow
 			wrapMode:				Text.WrapAtWordBoundaryOrAnywhere
 			width:					parent.width
 			horizontalAlignment:	Text.AlignHCenter
-	
+
 			MouseArea
 			{
 				id:				mouseAreaOpenSource

--- a/Desktop/gui/aboutmodel.cpp
+++ b/Desktop/gui/aboutmodel.cpp
@@ -52,3 +52,44 @@ void AboutModel::setVisible(bool visible)
 	emit visibleChanged(_visible);
 }
 
+QString AboutModel::systemInfo()
+{
+    QString info;
+    QProcess process;
+    QString command;
+    QStringList arguments;
+
+#ifdef _WIN32
+    command = "powershell";
+    // so Windows use local code page and we change it to 65001 for print(will not available for global)
+    arguments << "-NoProfile" << "-Command" << "Write-Host \"Current code page\" chcp ; chcp 65001 ; systeminfo";
+#elif defined(__APPLE__)
+    command = "system_profiler";
+    arguments << "SPSoftwareDataType SPHardwareDataType";
+#elif defined(__linux__)
+    command = "bash";
+    arguments = << "-c" << "lshw -short";
+#endif
+
+    if(!AboutModel().visible())
+    {
+        info += "-------- Basic Info --------\n\n";
+        info += "Operating System: " + QSysInfo::prettyProductName() + "\n";
+        info += "Product Version: "  + QSysInfo::productVersion() + "\n";
+        info += "Kernel Type: "      + QSysInfo::kernelType() + "\n";
+        info += "Kernel Version: "   + QSysInfo::kernelVersion() + "\n";
+        info += "Architecture: "     + QSysInfo::currentCpuArchitecture() + "\n";
+        info += "Install Path: "     + QCoreApplication::applicationDirPath() + "\n";
+        info += "System Local: "     + QLocale::system().name() + "\n";
+
+        process.start(command, arguments);
+        process.waitForFinished(5000);
+
+        QByteArray outputData = process.readAllStandardOutput();
+        process.close();
+
+        info += "-------- Extra Info --------\n\n" + outputData;
+    }
+
+    return info;
+}

--- a/Desktop/gui/aboutmodel.cpp
+++ b/Desktop/gui/aboutmodel.cpp
@@ -54,43 +54,43 @@ void AboutModel::setVisible(bool visible)
 
 QString AboutModel::systemInfo()
 {
-    QString info;
-    QProcess process;
-    QString command;
-    QStringList arguments;
+	QString info;
+	QProcess process;
+	QString command;
+	QStringList arguments;
 
 #ifdef _WIN32
-    command = "powershell";
-    // so Windows use local code page and we change it to 65001 for print(will not available for global)
-    arguments << "-NoProfile" << "-Command" << "Write-Host \"Current code page\"; chcp ; chcp 65001 ; systeminfo";
+	command = "powershell";
+	// so Windows use local code page and we change it to 65001 for print(will not available for global)
+	arguments << "-NoProfile" << "-Command" << "Write-Host \"Current code page\"; chcp ; chcp 65001 ; systeminfo";
 #elif defined(__APPLE__)
-    command = "system_profiler";
-    arguments << "SPSoftwareDataType SPHardwareDataType";
+	command = "system_profiler";
+	arguments << "SPSoftwareDataType SPHardwareDataType";
 #elif defined(__linux__)
-    command = "bash";
-    arguments << "-c" << "lshw -short";
+	command = "bash";
+	arguments << "-c" << "lshw -short";
 #endif
 
-    if(!AboutModel().visible())
-    {
-        info += "-------- Basic Info --------\n";
-        info += "Operating System: " + QSysInfo::prettyProductName() + "\n";
-        info += "Product Version: "  + QSysInfo::productVersion() + "\n";
-        info += "Kernel Type: "      + QSysInfo::kernelType() + "\n";
-        info += "Kernel Version: "   + QSysInfo::kernelVersion() + "\n";
-        info += "Architecture: "     + QSysInfo::currentCpuArchitecture() + "\n";
-        info += "Install Path: "     + QCoreApplication::applicationDirPath() + "\n";
-        info += "System Local: "     + QLocale::system().name() + "\n\n";
+	if(!AboutModel().visible())
+	{
+		info += "-------- Basic Info --------\n";
+		info += "Operating System: " + QSysInfo::prettyProductName() + "\n";
+		info += "Product Version: "  + QSysInfo::productVersion() + "\n";
+		info += "Kernel Type: "      + QSysInfo::kernelType() + "\n";
+		info += "Kernel Version: "   + QSysInfo::kernelVersion() + "\n";
+		info += "Architecture: "     + QSysInfo::currentCpuArchitecture() + "\n";
+		info += "Install Path: "     + QCoreApplication::applicationDirPath() + "\n";
+		info += "System Local: "     + QLocale::system().name() + "\n\n";
 
-        process.start(command, arguments);
-        process.waitForFinished(5000);
+		process.start(command, arguments);
+		process.waitForFinished(5000);
 
-        QByteArray outputData = process.readAllStandardOutput();
-        process.close();
+		QByteArray outputData = process.readAllStandardOutput();
+		process.close();
 
 		if(outputData.trimmed().length())
 			info += "-------- Extra Info --------\n" + outputData + "\n";
-    }
+	}
 
-    return info;
+	return info;
 }

--- a/Desktop/gui/aboutmodel.cpp
+++ b/Desktop/gui/aboutmodel.cpp
@@ -73,14 +73,14 @@ QString AboutModel::systemInfo()
 
     if(!AboutModel().visible())
     {
-        info += "-------- Basic Info --------\n\n";
+        info += "-------- Basic Info --------\n";
         info += "Operating System: " + QSysInfo::prettyProductName() + "\n";
         info += "Product Version: "  + QSysInfo::productVersion() + "\n";
         info += "Kernel Type: "      + QSysInfo::kernelType() + "\n";
         info += "Kernel Version: "   + QSysInfo::kernelVersion() + "\n";
         info += "Architecture: "     + QSysInfo::currentCpuArchitecture() + "\n";
         info += "Install Path: "     + QCoreApplication::applicationDirPath() + "\n";
-        info += "System Local: "     + QLocale::system().name() + "\n";
+        info += "System Local: "     + QLocale::system().name() + "\n\n";
 
         process.start(command, arguments);
         process.waitForFinished(5000);
@@ -88,7 +88,8 @@ QString AboutModel::systemInfo()
         QByteArray outputData = process.readAllStandardOutput();
         process.close();
 
-        info += "-------- Extra Info --------\n\n" + outputData;
+		if(outputData.trimmed().length())
+			info += "-------- Extra Info --------\n" + outputData + "\n";
     }
 
     return info;

--- a/Desktop/gui/aboutmodel.cpp
+++ b/Desktop/gui/aboutmodel.cpp
@@ -62,13 +62,13 @@ QString AboutModel::systemInfo()
 #ifdef _WIN32
     command = "powershell";
     // so Windows use local code page and we change it to 65001 for print(will not available for global)
-    arguments << "-NoProfile" << "-Command" << "Write-Host \"Current code page\" chcp ; chcp 65001 ; systeminfo";
+    arguments << "-NoProfile" << "-Command" << "Write-Host \"Current code page\"; chcp ; chcp 65001 ; systeminfo";
 #elif defined(__APPLE__)
     command = "system_profiler";
     arguments << "SPSoftwareDataType SPHardwareDataType";
 #elif defined(__linux__)
     command = "bash";
-    arguments = << "-c" << "lshw -short";
+    arguments << "-c" << "lshw -short";
 #endif
 
     if(!AboutModel().visible())

--- a/Desktop/gui/aboutmodel.h
+++ b/Desktop/gui/aboutmodel.h
@@ -21,7 +21,7 @@ class AboutModel : public QObject
 	Q_PROPERTY(QString	commit				READ commit												NOTIFY dummyNotifyBecauseWarNeverChanges	)
 	Q_PROPERTY(QString	commitUrl			READ commitUrl											NOTIFY dummyNotifyBecauseWarNeverChanges	)
 	Q_PROPERTY(QString	branch				READ branch												NOTIFY dummyNotifyBecauseWarNeverChanges	)
-    Q_PROPERTY(QString systemInfo           READ systemInfo                                         NOTIFY dummyNotifyBecauseWarNeverChanges	)
+	Q_PROPERTY(QString	systemInfo			READ systemInfo											NOTIFY dummyNotifyBecauseWarNeverChanges	)
 
 public:
 	explicit AboutModel(QObject *parent = nullptr) : QObject(parent) {}
@@ -38,7 +38,7 @@ public:
 	static	QString commit();
 	static	QString commitUrl()			{ return "https://github.com/jasp-stats/jasp-desktop/commit/" + commit(); }
 	static	QString branch();
-    static  QString systemInfo();
+	static  QString systemInfo();
 
 public slots:
 	void setVisible(bool visible);

--- a/Desktop/gui/aboutmodel.h
+++ b/Desktop/gui/aboutmodel.h
@@ -21,6 +21,7 @@ class AboutModel : public QObject
 	Q_PROPERTY(QString	commit				READ commit												NOTIFY dummyNotifyBecauseWarNeverChanges	)
 	Q_PROPERTY(QString	commitUrl			READ commitUrl											NOTIFY dummyNotifyBecauseWarNeverChanges	)
 	Q_PROPERTY(QString	branch				READ branch												NOTIFY dummyNotifyBecauseWarNeverChanges	)
+    Q_PROPERTY(QString systemInfo           READ systemInfo                                         NOTIFY dummyNotifyBecauseWarNeverChanges	)
 
 public:
 	explicit AboutModel(QObject *parent = nullptr) : QObject(parent) {}
@@ -37,6 +38,7 @@ public:
 	static	QString commit();
 	static	QString commitUrl()			{ return "https://github.com/jasp-stats/jasp-desktop/commit/" + commit(); }
 	static	QString branch();
+    static  QString systemInfo();
 
 public slots:
 	void setVisible(bool visible);


### PR DESCRIPTION
close: https://github.com/jasp-stats/INTERNAL-jasp/issues/2087
fix: https://github.com/jasp-stats/jasp-issues/issues/766

For reviewer: note I didnt test it on macOS!

Now we have obtained basic and additional useful information through system local commands(Linux/macOS->shell, Windows->powershell) and Qt's basic functions to provide debugging environment information while users feedback.I added it to about window as a button to copy it. used my poor C++ skills...

Application Info: where JASP build information
Basic Info: where OS and CPU information
Extra Info: depends on OS to give software/hardware info.

_btw: maybe we should display the development team below, similar to how most open source software do acknowledgments here.to commemorate whether they are former/current  teamers or translators._