### PR TITLE
use remotes to install special version of renv

### DIFF
--- a/Modules/install-renv.R.in
+++ b/Modules/install-renv.R.in
@@ -1,4 +1,6 @@
 # Generated from install-renv.R.in
 # 
 .libPaths(c("@R_LIBRARY_PATH@"))
-install.packages('renv', lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')
+
+install.packages('remotes', lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')
+remotes::install_github("vandenman/renv", ref="fix_multiple_cache_error", lib='@R_LIBRARY_PATH@', repos='@R_REPOSITORY@', INSTALL_opts='--no-multiarch --no-docs --no-test-load')


### PR DESCRIPTION
also use newer jaspBase where renv is no longer a dependency

This is a bit ugly, but it works.