### PR TITLE
chore: Auto bump R release version in buildbot

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
       
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: '4.3.2'
+          r-version: 'release'
       
       - name: Install Qt6
         uses: jurplel/install-qt-action@v3


### PR DESCRIPTION
always install new release R version for build test.