### PR TITLE
Upgrade FactorsForm control with nested VariablesList feature

### DIFF
--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -426,7 +426,7 @@ VariablesListBase
 				property string columnType:			isVariable && (typeof model.columnType !== "undefined") ? model.columnType : ""
 				property var extraItem:				model.rowComponent
 
-				enabled: variablesList.listViewType != JASP.AvailableVariables || !columnType || variablesList.areTypesAllowed([columnType])
+				enabled: (variablesList.listViewType != JASP.AvailableVariables || !columnType || variablesList.areTypesAllowed([columnType])) && (!variablesList.draggable || model.selectable)
 				
 				function setRelative(draggedRect)
 				{

--- a/QMLComponents/controls/factorsformbase.cpp
+++ b/QMLComponents/controls/factorsformbase.cpp
@@ -71,12 +71,8 @@ Json::Value FactorsFormBase::createJson() const
 	for (int i = 0; i < _initNumberFactors; i++)
 	{
 		Json::Value row(Json::objectValue);
-		QString name("Factor");
-		name += QString::number(i+1);
-		QString title("Factor ");
-		title += QString::number(i+1);
-		row["name"] = fq(name);
-		row["title"] = fq(title);
+		row["name"] = fq(baseName() + QString::number(i + startIndex()));
+		row["title"] = fq(baseTitle() + " " + QString::number(i + startIndex()));
 		row["indicators"] = Json::Value(Json::arrayValue);
 
 		result.append(row);

--- a/QMLComponents/controls/factorsformbase.h
+++ b/QMLComponents/controls/factorsformbase.h
@@ -30,7 +30,11 @@ class FactorsFormBase :  public JASPListControl, public BoundControlBase
 
 	Q_PROPERTY( int		initNumberFactors		READ initNumberFactors		WRITE setInitNumberFactors	NOTIFY initNumberFactorsChanged	)
 	Q_PROPERTY( int		countVariables			READ countVariables										NOTIFY countVariablesChanged	)
-
+	Q_PROPERTY(QString	baseName				READ baseName				WRITE setBaseName			NOTIFY baseNameChanged			)
+	Q_PROPERTY(QString	baseTitle				READ baseTitle				WRITE setBaseTitle			NOTIFY baseTitleChanged			)
+	Q_PROPERTY(int		startIndex				READ startIndex				WRITE setStartIndex			NOTIFY startIndexChanged		)
+	Q_PROPERTY(bool		nested					READ nested					WRITE setNested				NOTIFY nestedChanged			)
+	Q_PROPERTY(bool		allowInteraction		READ allowInteraction		WRITE setAllowInteraction	NOTIFY allowInteractionChanged	)
 
 public:
 	FactorsFormBase(QQuickItem* parent = nullptr);
@@ -49,10 +53,26 @@ public:
 	int					initNumberFactors()						const				{ return _initNumberFactors;						}
 	int					countVariables()						const				{ return _initialized ? _factorsModel->countVariables() : 0; }
 	JASPListControl*	availableVariablesList()				const				{ return _availableVariablesListItem;				}
+	QString				baseName()								const				{ return _baseName;		}
+	QString				baseTitle()								const				{ return _baseTitle;	}
+	int					startIndex()							const				{ return _startIndex;	}
+	bool				nested()								const				{ return _nested;		}
+	bool				allowInteraction()						const				{ return _allowInteraction;		}
+
+	GENERIC_SET_FUNCTION(BaseName			, _baseName			, baseNameChanged			, QString		)
+	GENERIC_SET_FUNCTION(BaseTitle			, _baseTitle		, baseTitleChanged			, QString		)
+	GENERIC_SET_FUNCTION(StartIndex			, _startIndex		, startIndexChanged			, int			)
+	GENERIC_SET_FUNCTION(Nested				, _nested			, nestedChanged				, bool			)
+	GENERIC_SET_FUNCTION(AllowInteraction	, _allowInteraction	, allowInteractionChanged	, bool			)
 
 signals:
 	void initNumberFactorsChanged();
 	void countVariablesChanged();
+	void baseNameChanged();
+	void baseTitleChanged();
+	void startIndexChanged();
+	void nestedChanged();
+	void allowInteractionChanged();
 
 protected slots:
 	void			termsChangedHandler() override;
@@ -62,9 +82,15 @@ protected:
 
 private:
 	ListModelFactorsForm*	_factorsModel				= nullptr;
-	QString					_availableVariablesListName;
 	JASPListControl*		_availableVariablesListItem	= nullptr;
-	int						_initNumberFactors			= 1;
+	int						_initNumberFactors			= 1,
+							_startIndex					= 1;
+	QString					_availableVariablesListName,
+							_baseName					= tr("Factor"),
+							_baseTitle					= tr("Factor");
+	bool					_nested						= false,
+							_allowInteraction			= false;
+
 };
 
 #endif // FACTORSFORMBASE_H

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -263,7 +263,7 @@ void VariablesListBase::moveItems(QList<int> &indexes, ListModelDraggable* targe
 			Terms removedTermsWhenAdding;
 			QList<int> indexAdded = indexes;
 
-			if (!sourceModel->copyTermsWhenDropped())
+			if (targetModel->removeTermsWhenMoved()) // If the target keeps its terms anyway, don't add new terms
 			{
 				Terms terms = sourceModel->termsFromIndexes(indexes);
 				if (terms.size() == 0)
@@ -291,7 +291,7 @@ void VariablesListBase::moveItems(QList<int> &indexes, ListModelDraggable* targe
 				}
 			}
 				
-			if (!targetModel->copyTermsWhenDropped())
+			if (sourceModel->removeTermsWhenMoved())
 			{
 				if (indexAdded.size() > 0)
 				{
@@ -319,6 +319,7 @@ void VariablesListBase::moveItems(QList<int> &indexes, ListModelDraggable* targe
 
 void VariablesListBase::setDropKeys(const QStringList &dropKeys)
 {
+	Log::log() << "LOG setDropKeys " << name() << ": " << dropKeys.join('/') << std::endl;
 	if (dropKeys != _dropKeys)
 	{
 		_dropKeys = dropKeys;
@@ -421,6 +422,10 @@ void VariablesListBase::_setRelations()
 				addDependency(availableModel->listView());
 				setContainsVariables();
 				setContainsInteractions();
+
+				// When the assigned model is of type interaction or it has multiple columns, then the available model should keep its terms when they are moved to the assigned model
+				if (_listViewType == ListViewType::Interaction || columns() > 1)
+					availableModel->setRemoveTermsWhenMoved(false);
 			}
 		}
 	}

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -401,23 +401,24 @@ QVariant ListModel::data(const QModelIndex &index, int role) const
 	if (row_t >= myTerms.size())
 		return QVariant();
 
+	const Term& term = myTerms.at(row_t);
+
 	switch (role)
 	{
 	case Qt::DisplayRole:
-	case ListModel::NameRole:			return QVariant(myTerms.at(row_t).asQString());
-	case ListModel::SelectableRole:		return !myTerms.at(row_t).asQString().isEmpty();
+	case ListModel::NameRole:			return QVariant(term.asQString());
+	case ListModel::SelectableRole:		return !term.asQString().isEmpty() && term.isDraggable();
 	case ListModel::SelectedRole:		return _selectedItems.contains(row);
 	case ListModel::RowComponentRole:
 	{
-		QString term = myTerms.at(row_t).asQString();
-		return _rowControlsMap.contains(term) ? QVariant::fromValue(_rowControlsMap[term]->getRowObject()) : QVariant();
+		QString termStr = term.asQString();
+		return _rowControlsMap.contains(termStr) ? QVariant::fromValue(_rowControlsMap[termStr]->getRowObject()) : QVariant();
 	}
 	case ListModel::TypeRole:			return listView()->containsVariables() ? "variable" : "";
 	case ListModel::ColumnTypeRole:
 	case ListModel::ColumnTypeIconRole:
 	case ListModel::ColumnTypeDisabledIconRole:
 	{
-		const Term& term = myTerms.at(row_t);
 		if (!listView()->containsVariables() || term.size() != 1)	return "";
 		if (role == ListModel::ColumnTypeRole)						return requestInfo(VariableInfo::VariableTypeName, term.asQString());
 		else if (role == ListModel::ColumnTypeIconRole)				return requestInfo(VariableInfo::VariableTypeIcon, term.asQString());

--- a/QMLComponents/models/listmodelassignedinterface.cpp
+++ b/QMLComponents/models/listmodelassignedinterface.cpp
@@ -112,7 +112,7 @@ bool ListModelAssignedInterface::checkAllowedTerms(Terms& terms)
 	if (notAllowedTerms.size() == 0) return true;
 
 	terms.set(allowedTerms);
-	if (!_availableModel->copyTermsWhenDropped())
+	if (_availableModel->removeTermsWhenMoved())
 		_availableModel->addTerms(notAllowedTerms);
 
 	QString notAllowedTermsStr = notAllowedTerms.asQList().join(", ");

--- a/QMLComponents/models/listmodelavailableinterface.cpp
+++ b/QMLComponents/models/listmodelavailableinterface.cpp
@@ -179,17 +179,19 @@ bool ListModelAvailableInterface::sourceLabelsReordered(QString columnName)
 
 void ListModelAvailableInterface::removeTermsInAssignedList()
 {
+	if (!removeTermsWhenMoved())
+		return;
+
 	beginResetModel();
 	
 	Terms newTerms = _allSortedTerms;
 	
-	for (ListModelAssignedInterface* modelAssign : assignedModel())
+	for (ListModelAssignedInterface* modelAssign : assignedModels())
 	{
 		Terms assignedTerms = modelAssign->terms();
 		if (assignedTerms.discardWhatIsntTheseTerms(_allSortedTerms))
 			modelAssign->initTerms(assignedTerms, RowControlsValues(), true); // initTerms call removeTermsInAssignedList
-		if (!modelAssign->copyTermsWhenDropped())
-			newTerms.remove(assignedTerms);
+		newTerms.remove(assignedTerms);
 	}
 
 	_setTerms(newTerms, _allSortedTerms);
@@ -201,7 +203,7 @@ void ListModelAvailableInterface::addAssignedModel(ListModelAssignedInterface *a
 {
 	_assignedModels.push_back(assignedModel);
 
-	connect(assignedModel,	&ListModelAssignedInterface::destroyed,				this,						&ListModelAvailableInterface::removeAssignedModel		);
+//	connect(assignedModel,	&ListModelAssignedInterface::destroyed,				this,						&ListModelAvailableInterface::removeAssignedModel		);
 	connect(this,			&ListModelAvailableInterface::availableTermsReset,	assignedModel,				&ListModelAssignedInterface::availableTermsResetHandler	);
 	connect(this,			&ListModelAvailableInterface::namesChanged,			assignedModel,				&ListModelAssignedInterface::sourceNamesChanged			);
 	connect(this,			&ListModelAvailableInterface::columnsChanged,		assignedModel,				&ListModelAssignedInterface::sourceColumnsChanged		);
@@ -212,8 +214,8 @@ void ListModelAvailableInterface::addAssignedModel(ListModelAssignedInterface *a
 	connect(listView(),		&JASPListControl::containsInteractionsChanged,		assignedModel->listView(),	&JASPListControl::setContainsInteractions				);
 }
 
-void ListModelAvailableInterface::removeAssignedModel(ListModelDraggable* assignedModel)
+void ListModelAvailableInterface::removeAssignedModel(ListModelAssignedInterface *assignedModel)
 {
-	_assignedModels.removeAll(qobject_cast<ListModelAssignedInterface*>(assignedModel));
+	_assignedModels.removeAll(assignedModel);
 }
 

--- a/QMLComponents/models/listmodelavailableinterface.h
+++ b/QMLComponents/models/listmodelavailableinterface.h
@@ -42,7 +42,7 @@ public:
 			void sortItems(SortType sortType)											override;
 
 			void										addAssignedModel(ListModelAssignedInterface* model);
-			const QList<ListModelAssignedInterface*>&	assignedModel()	const			{ return _assignedModels; }
+			const QList<ListModelAssignedInterface*>&	assignedModels()	const			{ return _assignedModels; }
 
 signals:
 			void availableTermsReset(Terms termsAdded, Terms termsRemoved);
@@ -54,7 +54,7 @@ public slots:
 			int  sourceColumnTypeChanged(QString name)										override;
 			bool sourceLabelsChanged(QString columnName, QMap<QString, QString> = {})		override;
 			bool sourceLabelsReordered(QString columnName)									override;
-			void removeAssignedModel(ListModelDraggable* model);
+			void removeAssignedModel(ListModelAssignedInterface *assignedModel);
 			void clearAssignedModels() { _assignedModels.clear(); }
 
 protected:

--- a/QMLComponents/models/listmodeldraggable.cpp
+++ b/QMLComponents/models/listmodeldraggable.cpp
@@ -19,10 +19,10 @@
 #include "listmodeldraggable.h"
 #include "analysisform.h"
 #include "controls/jasplistcontrol.h"
+#include "log.h"
 
 ListModelDraggable::ListModelDraggable(JASPListControl* listView)
 	: ListModel(listView)
-	, _copyTermsWhenDropped(false)	
 {
 }
 

--- a/QMLComponents/models/listmodeldraggable.h
+++ b/QMLComponents/models/listmodeldraggable.h
@@ -32,11 +32,11 @@ public:
 	ListModelDraggable(JASPListControl* listView);
 	~ListModelDraggable();
 
-	bool copyTermsWhenDropped() const						{ return _copyTermsWhenDropped; }
+	bool removeTermsWhenMoved() const						{ return _removeTermsWhenMoved;	}
+	void setRemoveTermsWhenMoved(bool remove)				{ _removeTermsWhenMoved = remove; }
 	JASPControl::DropMode dropMode() const					{ return _dropMode; }
 	
 	void setDropMode(JASPControl::DropMode dropMode)		{ _dropMode = dropMode; }
-	void setCopyTermsWhenDropped(bool copy)					{ _copyTermsWhenDropped = copy; }
 	
 	virtual Terms termsFromIndexes(const QList<int> &indexes)					const;
 	virtual Terms canAddTerms(const Terms& terms)								const;
@@ -48,7 +48,7 @@ signals:
 	void destroyed(ListModelDraggable * me);
 
 protected:
-	bool						_copyTermsWhenDropped;
+	bool						_removeTermsWhenMoved					= true;
 	JASPControl::DropMode		_dropMode								= JASPControl::DropMode::DropNone;
 		
 	bool						isAllowed(const Term &term) const;

--- a/QMLComponents/models/listmodelfactorsform.h
+++ b/QMLComponents/models/listmodelfactorsform.h
@@ -60,19 +60,24 @@ public slots:
 signals:
 	void addListView(JASPListControl* listView);
 	
+protected slots:
+	void ensureNesting();
+	void setAllTermsDraggable();
+
 protected:
 	struct Factor
 	{
 		QString						name;
 		QString						title;
 		JASPListControl*			listView;
-		std::vector<std::string>	initTerms;
-		Factor(const QString& _name, const QString& _title, std::vector<std::string> _initTerms = std::vector<std::string>()) :
+		Terms						initTerms;
+		Factor(const QString& _name, const QString& _title, const Terms& _initTerms) :
 			name(_name), title(_title), listView(nullptr), initTerms(_initTerms) {}
 	};
 
 	QVector<Factor*>	_factors;
-	FactorsFormBase*	_factorsForm = nullptr;
+	FactorsFormBase*	_factorsForm		= nullptr;
+	bool				_ensuringNesting	= false;
 	
 };
 

--- a/QMLComponents/models/listmodelinteractionassigned.cpp
+++ b/QMLComponents/models/listmodelinteractionassigned.cpp
@@ -27,7 +27,6 @@ using namespace std;
 ListModelInteractionAssigned::ListModelInteractionAssigned(JASPListControl* listView, bool mustContainLowerTerms, bool addInteractionsByDefault)
 	: ListModelAssignedInterface(listView), InteractionModel ()
 {
-	_copyTermsWhenDropped		= true;
 	_mustContainLowerTerms		= mustContainLowerTerms;
 	_addInteractionsByDefault	= addInteractionsByDefault;
 }
@@ -130,10 +129,7 @@ void ListModelInteractionAssigned::_addTerms(const Terms& terms, bool combineWit
 				covariates.add(term);
 		}
 		else
-		{
-			if (!_interactionTerms.contains(term))
 				others.add(term);
-		}
 	}
 			
 	if (fixedFactors.size() > 0)

--- a/QMLComponents/models/listmodellayersassigned.cpp
+++ b/QMLComponents/models/listmodellayersassigned.cpp
@@ -42,11 +42,8 @@ void ListModelLayersAssigned::initLayers(const std::vector<std::vector<std::stri
 
 	_setTerms();
 
-	if (availableModel() != nullptr)
-	{
-		if (!_copyTermsWhenDropped)
-			availableModel()->removeTermsInAssignedList();
-	}
+	if (availableModel())
+		availableModel()->removeTermsInAssignedList();
 	
 	endResetModel();
 }

--- a/QMLComponents/models/listmodelmultitermsassigned.cpp
+++ b/QMLComponents/models/listmodelmultitermsassigned.cpp
@@ -27,7 +27,6 @@ ListModelMultiTermsAssigned::ListModelMultiTermsAssigned(JASPListControl* listVi
 	: ListModelAssignedInterface(listView)
 	, _columns(columns)
 {
-	_copyTermsWhenDropped = true;
 	_allowDuplicatesInMultipleColumns = listView->property("allowDuplicatesInMultipleColumns").toBool();
 }
 

--- a/QMLComponents/models/listmodeltermsassigned.cpp
+++ b/QMLComponents/models/listmodeltermsassigned.cpp
@@ -35,11 +35,8 @@ void ListModelTermsAssigned::initTerms(const Terms &terms, const RowControlsValu
 {
 	ListModelAssignedInterface::initTerms(terms, allValuesMap, reInit);
 
-	if (availableModel() != nullptr)
-	{
-		if (!_copyTermsWhenDropped)
-			availableModel()->removeTermsInAssignedList();
-	}
+	if (availableModel())
+		availableModel()->removeTermsInAssignedList();
 }
 
 void ListModelTermsAssigned::availableTermsResetHandler(Terms termsAdded, Terms termsRemoved)
@@ -50,7 +47,7 @@ void ListModelTermsAssigned::availableTermsResetHandler(Terms termsAdded, Terms 
 		_addTerms(termsAdded);
 		endResetModel();
 
-		if (!_copyTermsWhenDropped && availableModel())
+		if (availableModel())
 			availableModel()->removeTermsInAssignedList();
 	}
 

--- a/QMLComponents/models/term.h
+++ b/QMLComponents/models/term.h
@@ -43,6 +43,9 @@ public:
 	std::vector<std::string>	scomponents()	const;
 	std::string					asString()		const;
 
+	bool						isDraggable()	const			{ return _draggable; }
+	void						setDraggable(bool draggable)	{ _draggable = draggable; }
+
 	typedef QStringList::const_iterator const_iterator;
 	typedef QStringList::iterator		iterator;
 
@@ -72,6 +75,7 @@ private:
 
 	QStringList		_components;
 	QString			_asQString;
+	bool			_draggable = true;
 
 };
 

--- a/QMLComponents/models/terms.cpp
+++ b/QMLComponents/models/terms.cpp
@@ -149,13 +149,18 @@ void Terms::add(const Term &term, bool isUnique)
 
 		if (result > 0)
 			_terms.insert(itr, term);
+		else if (result == 0)
+			itr->setDraggable(term.isDraggable());
 		else if (result < 0)
 			_terms.push_back(term);
 	}
 	else
 	{
-		if ( ! contains(term))
+		int i = indexOf(term.asQString());
+		if (i < 0)
 			_terms.push_back(term);
+		else
+			_terms.at(i).setDraggable(term.isDraggable());
 	}
 }
 
@@ -450,6 +455,41 @@ bool Terms::operator!=(const Terms &terms) const
 {
 	return _terms != terms._terms;
 }
+
+bool Terms::strictlyEquals(const Terms &terms) const
+{
+	bool isEqual = _terms == terms._terms;
+
+	for (size_t i = 0; isEqual && (i < _terms.size()); i++)
+		isEqual = _terms.at(i).isDraggable() == terms._terms.at(i).isDraggable();
+
+	return isEqual;
+}
+
+void Terms::setDraggable(bool draggable)
+{
+	for (Term& term : _terms)
+		term.setDraggable(draggable);
+}
+
+void Terms::setUndraggableTerms(const Terms& undraggableTerms)
+{
+	std::vector<Term> newTerms = undraggableTerms._terms;
+	for (Term& term : newTerms)
+		term.setDraggable(false);
+
+	// Then add only the draggabled terms that are not in undraggableTerms and that are draggable
+	// All undraggable terms that are not in undraggableTerms will be then automatically removed.
+	for (Term term : _terms)
+	{
+		if (term.isDraggable() && !undraggableTerms.contains(term))
+			newTerms.push_back(term);
+	}
+
+	_terms = newTerms;
+}
+
+
 
 void Terms::set(const QByteArray & array, bool isUnique)
 {

--- a/QMLComponents/models/terms.h
+++ b/QMLComponents/models/terms.h
@@ -116,6 +116,10 @@ public:
 	bool operator!=(const Terms &terms) const;
 	const Term& operator[](size_t index) const { return at(index); }
 
+	bool strictlyEquals(const Terms &terms) const; // Also takes care of the draggable flag
+	void setDraggable(bool draggable);
+	void setUndraggableTerms(const Terms& undraggableTerms);
+
 private:
 
 	int		rankOf(const QString &component)						const;


### PR DESCRIPTION
Add properties to the `FactorsForm` control so that it can be used with nested `VariablesList`: the values of the n'th `VariablesList` should be inside the (n+1)th `VariablesList` as undraggable items.

Change the `_copyTermsWhenDropped` flag in `ListModelDraggable` to `_removeTermsWhenMoved`: `_copyTermsWhenDropped` was not used to determine the behaviour of its own `VariablesList`, but the one from whom the terms is taken from. That was quite difficult to understand and lead also to issue for the `FactorForm`.
`_removeTermsWhenMoved` indicates that the `VariablesList` of this model should remove the/its variables when they are moved to another `VariablesList`. 

The source, typically an `AvailableVariablesList`, of an assigned `VariablesList` with interactions or a `VariablesList` with paired variables (eg Paired Samples T-Test) should not lose their variables when they are moved to these assigned variableslists.

A new Test `FactorsForm` analysis has been added in the Test Module