### PR TITLE
fix some things in computed columns

### DIFF
--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -155,6 +155,15 @@ FocusScope
 				anchors.fill:			parent
                 anchors.leftMargin:     1
 				visible:				!computedColumnsInterface.computeColumnUsesRCode
+				forceColumnInputs:		!computedColumnsInterface.computeColumnForceType 
+										? "" 
+										: computedColumnsInterface.columnType === columnTypeScale 
+											? "scale" 
+											: computedColumnsInterface.columnType === columnTypeOrdinal 
+												? "ordinal" 
+												: computedColumnsInterface.columnType === columnTypeNominal 
+													? "nominal" 
+													: "unknown"
 
 				showGeneratedRCode:		false
 				KeyNavigation.tab:		applyComputedColumnButton
@@ -287,7 +296,7 @@ FocusScope
 			{
 				id:				forceSourceColTypeButton
 
-				toolTip:		qsTr("The columns used above can be read in the type of the computed column, or as their own type.\nKeep types will import columns with the type they have, while convert will force it to the type of the computed column in question.")	
+				toolTip:		qsTr("- Keep types: use columns with their defined columntype.\n- Convert types: convert all used columns to the columntype of this computed column before use.\n\nThe button displays the *current setting*, not what will happen when you press it!")	
 				text:			!computedColumnsInterface.computeColumnForceType 
 									? qsTr("Keep types")
 									: qsTr("Convert types")

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ColumnDrag.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ColumnDrag.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 
-DragGeneric {
+DragGeneric 
+{
 	property string columnName: "?"
 	property string columnIcon: ""
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
@@ -21,6 +21,8 @@ FocusScope
 				property alias	functionModel:			functieLijst.model
 				property string	rCode:					""
 				property string jsonConstructed:		""
+				property string forceColumnInputs:		""
+						
 
 	onSomethingChangedChanged:
 	{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
@@ -18,6 +18,7 @@ Item
 				property bool	lastCheckPassed:		true
 				property bool	showStartupMsg:			true
 				property alias	functionModel:			functieLijst.model
+				property string forceColumnInputs:		""
 
 	signal rCodeChanged(string rScript)
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -21,7 +21,7 @@ Item
 	Image
 	{
 		id:				colIcon
-		source:			columnIcon
+		source:			filterConstructor.forceColumnInputs === "" ? columnIcon : computedColumnsInterface.computeColumnIconSource
 		width:			height
 		sourceSize
 		{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -12,8 +12,8 @@ Item
 					height:			filterConstructor.blockDim
 					implicitWidth:	colIcon.width + colName.width
                     width:          implicitWidth
-	property bool	isNumerical:	columnIcon.indexOf("scale") >= 0
-	property bool	isOrdinal:		columnIcon.indexOf("ordinal") >= 0
+	property bool	isNumerical:	(filterConstructor.forceColumnInputs !== "" && filterConstructor.forceColumnInputs === "scale")		|| columnIcon.indexOf("scale")		>= 0
+	property bool	isOrdinal:		(filterConstructor.forceColumnInputs !== "" && filterConstructor.forceColumnInputs === "ordinal")	|| columnIcon.indexOf("ordinal")	>= 0
 
 
 	property var	dragKeys:		isOrdinal ? ["string", "ordered"] : isNumerical ? ["number"] : ["string"]
@@ -40,7 +40,7 @@ Item
 	TextMetrics
 	{
 		id:				columnNameMeasure
-		font.pixelSize:	colName.font.pixelSize
+		font:			colName.font
 		text:			colName.text
 	}
 
@@ -49,16 +49,15 @@ Item
 		id:				colName
 		anchors
 		{
-			top:		parent.top
-			left:		colIcon.right
-			bottom:		parent.bottom
+			verticalCenter:	parent.vertivalCenter
+			left:			colIcon.right
 		}
 
         width:          Math.min(columnNameMeasure.width + 10, jaspColumnRoot.maxSize - (colIcon.width + 2*colIcon.anchors.margins))
 		font.pixelSize: baseFontSize * preferencesModel.uiScale
 		font.family:	jaspTheme.font.family
 		color:			jaspTheme.textEnabled
-		leftPadding:	2
+		leftPadding:	4 * preferencesModel.uiScale
 
 		text:			columnName
 		elide:			Text.ElideMiddle

--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -263,7 +263,7 @@ Window
 	}
 	
 	//Utility:
-	readonly property Item _toolTipOverrideItem: Item
+	property Item _toolTipOverrideItem: Item
 	{
 		//These properties override those for ALL attached ToolTips in the application
 		//ToolTip.toolTip shouldn't be changed anywhere else otherwise we get hard to debug behaviour

--- a/Desktop/data/computedcolumnmodel.cpp
+++ b/Desktop/data/computedcolumnmodel.cpp
@@ -2,6 +2,7 @@
 #include "jsonutilities.h"
 #include "utilities/qutils.h"
 #include "columnencoder.h"
+#include "analysis/analyses.h"
 
 ComputedColumnModel * ComputedColumnModel::_singleton = nullptr;
 
@@ -13,11 +14,12 @@ ComputedColumnModel::ComputedColumnModel()
 
 	_undoStack = DataSetPackage::pkg()->undoStack();
 
-	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnJsonChanged				);
+	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnJsonChanged			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnRCodeChanged			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnErrorChanged			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnUsesRCodeChanged		);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnForceTypeChanged		);
+	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::columnTypeChanged					);
 	
 	connect(this,					&ComputedColumnModel::refreshColumn,			DataSetPackage::pkg(),	&DataSetPackage::refreshColumn,								Qt::QueuedConnection);
 	connect(this,					&ComputedColumnModel::refreshData,				DataSetPackage::pkg(),	&DataSetPackage::refresh,									Qt::QueuedConnection);
@@ -56,6 +58,11 @@ QString ComputedColumnModel::computeColumnJson()
 	QString json = !_selectedColumn ? "" : tq(_selectedColumn->constructorJsonStr());
 
 	return json;
+}
+
+int ComputedColumnModel::computedColumnColumnType()
+{
+	return int(!_selectedColumn ? columnType::unknown : _selectedColumn->type());
 }
 
 QString ComputedColumnModel::computeColumnError()
@@ -443,6 +450,11 @@ Column * ComputedColumnModel::createComputedColumn(const std::string & name, int
 		selectColumn(createdColumn);
 
 	return createdColumn;
+}
+
+void ComputedColumnModel::createComputedColumn(const QString &name, int columnType, bool jsonPlease)	
+{ 
+	createComputedColumn(fq(name), columnType, jsonPlease ? computedColumnType::constructorCode : computedColumnType::rCode);	
 }
 
 

--- a/Desktop/data/computedcolumnmodel.cpp
+++ b/Desktop/data/computedcolumnmodel.cpp
@@ -3,6 +3,7 @@
 #include "utilities/qutils.h"
 #include "columnencoder.h"
 #include "analysis/analyses.h"
+#include "variableinfo.h"
 
 ComputedColumnModel * ComputedColumnModel::_singleton = nullptr;
 
@@ -19,6 +20,7 @@ ComputedColumnModel::ComputedColumnModel()
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnErrorChanged			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnUsesRCodeChanged		);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnForceTypeChanged		);
+	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnIconSourceChanged	);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::columnTypeChanged					);
 	
 	connect(this,					&ComputedColumnModel::refreshColumn,			DataSetPackage::pkg(),	&DataSetPackage::refreshColumn,								Qt::QueuedConnection);
@@ -457,7 +459,6 @@ void ComputedColumnModel::createComputedColumn(const QString &name, int columnTy
 	createComputedColumn(fq(name), columnType, jsonPlease ? computedColumnType::constructorCode : computedColumnType::rCode);	
 }
 
-
 bool ComputedColumnModel::showAnalysisFormForColumn(const QString & columnName)
 {
 	try
@@ -490,4 +491,9 @@ void ComputedColumnModel::analysisRemoved(Analysis * analysis)
 
 	for(const std::string & col : colsToRemove)
 		DataSetPackage::pkg()->requestComputedColumnDestruction(col);
+}
+
+QString ComputedColumnModel::computeColumnIconSource() const
+{
+	return VariableInfo::getIconFile(!_selectedColumn ? columnType::unknown : _selectedColumn->type(), VariableInfo::DefaultIconType);
 }

--- a/Desktop/data/computedcolumnmodel.h
+++ b/Desktop/data/computedcolumnmodel.h
@@ -17,6 +17,7 @@ class ComputedColumnModel : public QObject
 	Q_PROPERTY(QString	computeColumnError			READ computeColumnError														NOTIFY computeColumnErrorChanged		)
 	Q_PROPERTY(int		columnType					READ computedColumnColumnType												NOTIFY columnTypeChanged				)
 	Q_PROPERTY(bool		datasetLoaded				READ datasetLoaded															NOTIFY refreshProperties				)
+	Q_PROPERTY(QString	computeColumnIconSource		READ computeColumnIconSource												NOTIFY computeColumnIconSourceChanged	)
 
 public:
     explicit	ComputedColumnModel();
@@ -30,6 +31,7 @@ public:
 				QString				computeColumnJson();
 				int					computedColumnColumnType();
 				bool				computeColumnForceType()	const;
+				QString				computeColumnIconSource()	const;
 				Column			*	column()					const;
 				bool				computeColumnUsesRCode();
 
@@ -54,8 +56,6 @@ public:
 
                                 static		ComputedColumnModel * singleton()		{ return _singleton; }
 
-	
-								
 								
 private:
 				void				revertToDefaultInvalidatedColumns();
@@ -81,6 +81,8 @@ signals:
 				void	computeColumnForceTypeChanged();
 				void	columnTypeChanged();
 				
+				void computeColumnIconSourceChanged();
+				
 public slots:
 				void	checkForDependentColumnsToBeSent(QString columnName, bool refreshMe = false);
 				void	computeColumnSucceeded(QString columnName, QString warning, bool dataChanged);
@@ -98,11 +100,7 @@ public slots:
 private:
 	static	ComputedColumnModel		* _singleton;
 			Column					* _selectedColumn	= nullptr;
-
 			UndoStack				* _undoStack		= nullptr;
-
-			
-			
 };
 
 #endif // COMPUTEDCOLUMNSCODEITEM_H

--- a/Desktop/data/computedcolumnmodel.h
+++ b/Desktop/data/computedcolumnmodel.h
@@ -2,9 +2,7 @@
 #define COMPUTEDCOLUMNSCODEITEM_H
 
 #include <QQuickItem>
-#include <QObject>
 #include "datasetpackage.h"
-#include "analysis/analyses.h"
 
 /// 
 /// A model for use by the computed columns editor in QML
@@ -17,6 +15,7 @@ class ComputedColumnModel : public QObject
 	Q_PROPERTY(bool		computeColumnForceType		READ computeColumnForceType			WRITE setComputeColumnForceType			NOTIFY computeColumnForceTypeChanged	)
 	Q_PROPERTY(QString	computeColumnJson			READ computeColumnJson														NOTIFY computeColumnJsonChanged			)
 	Q_PROPERTY(QString	computeColumnError			READ computeColumnError														NOTIFY computeColumnErrorChanged		)
+	Q_PROPERTY(int		columnType					READ computedColumnColumnType												NOTIFY columnTypeChanged				)
 	Q_PROPERTY(bool		datasetLoaded				READ datasetLoaded															NOTIFY refreshProperties				)
 
 public:
@@ -29,6 +28,7 @@ public:
 				QString				computeColumnRCodeCommentStripped();
 				QString				computeColumnError();
 				QString				computeColumnJson();
+				int					computedColumnColumnType();
 				bool				computeColumnForceType()	const;
 				Column			*	column()					const;
 				bool				computeColumnUsesRCode();
@@ -45,7 +45,7 @@ public:
 	Q_INVOKABLE bool				isColumnNameFree(const QString & name)						{ return DataSetPackage::pkg()->isColumnNameFree(name.toStdString()); }
 
 				Column			*	createComputedColumn(const std::string & name, int columnType, computedColumnType computeType, Analysis * analysis = nullptr);
-	Q_INVOKABLE void				createComputedColumn(const QString     & name, int columnType, bool jsonPlease)	{ createComputedColumn(fq(name), columnType, jsonPlease ? computedColumnType::constructorCode : computedColumnType::rCode);	}
+	Q_INVOKABLE void				createComputedColumn(const QString     & name, int columnType, bool jsonPlease);
 
 				bool				areLoopDependenciesOk(const std::string & columnName);
 				bool				areLoopDependenciesOk(const std::string & columnName, const std::string & code);
@@ -73,12 +73,13 @@ signals:
 				void	computeColumnJsonChanged();
 				void	refreshColumn(QString columnName);
 				void	headerDataChanged(Qt::Orientation orientation, int first, int last);
-				void	sendComputeCode(QString columnName, QString code, columnType columnType, bool forceType);
+				void	sendComputeCode(QString columnName, QString code, enum columnType columnType, bool forceType);
 				void	computeColumnUsesRCodeChanged();
 				void	showAnalysisForm(Analysis *analysis);
 				void	dataColumnAdded(QString columnName);
 				void	refreshData();
 				void	computeColumnForceTypeChanged();
+				void	columnTypeChanged();
 				
 public slots:
 				void	checkForDependentColumnsToBeSent(QString columnName, bool refreshMe = false);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -580,6 +580,7 @@ void MainWindow::loadQML()
 	_qml->rootContext()->setContextProperty("columnTypeOrdinal",						int(columnType::ordinal)						);
 	_qml->rootContext()->setContextProperty("columnTypeNominal",						int(columnType::nominal)						);
 	_qml->rootContext()->setContextProperty("columnTypeNominalText",					int(columnType::nominalText)					);
+	_qml->rootContext()->setContextProperty("columnTypeUnknown",						int(columnType::unknown)						);
 
 	_qml->rootContext()->setContextProperty("computedColumnTypeRCode",					int(computedColumnType::rCode)					);
 	_qml->rootContext()->setContextProperty("computedColumnTypeAnalysis",				int(computedColumnType::analysis)				);

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -36,13 +36,6 @@ JASPControl::JASPControl(QQuickItem *parent) : QQuickItem(parent)
 {
 	setFlag(ItemIsFocusScope);
 	setActiveFocusOnTab(true);
-	/*if (JaspTheme::currentTheme()) // THis does not work...
-	{
-		// TODO: Add currentTheme changed font changed
-		QQmlProperty(this, "ToolTip.timeout", qmlContext(this)).write(JaspTheme::currentTheme()->toolTipTimeout());
-		setProperty("ToolTip.delay", JaspTheme::currentTheme()->toolTipDelay());
-		setProperty("ToolTip.tooltip.font", JaspTheme::currentTheme()->font());
-	}*/
 
 	connect(this, &JASPControl::titleChanged,			this, &JASPControl::helpMDChanged);
 	connect(this, &JASPControl::infoChanged,			this, &JASPControl::helpMDChanged);


### PR DESCRIPTION
- better tooltip on "force types button"
- make sure the width of the columnnames in constructor are set correctly
- dropping a column now uses the types according to the "convert/keep types" button
- does not recheck validity afterwards though.