### PR TITLE
Avoid looping in FactorsForm and handle interaction in options

### DIFF
--- a/QMLComponents/components/JASP/Controls/FactorsForm.qml
+++ b/QMLComponents/components/JASP/Controls/FactorsForm.qml
@@ -13,6 +13,8 @@ FactorsFormBase
 	height				: implicitHeight
 	width				: implicitWidth
 	Layout.columnSpan	: parent.columns
+	optionKey			: allowInteraction ? "components" : "indicators" // The option has the name, the title and the terms of each VariablesList: optionKey gives the key name for the terms.
+
 
 	property string availableVariablesListName: "allAvailableVariables"
 	property alias	availableVariablesList: availableVariablesList

--- a/QMLComponents/models/listmodelassignedinterface.cpp
+++ b/QMLComponents/models/listmodelassignedinterface.cpp
@@ -112,7 +112,7 @@ bool ListModelAssignedInterface::checkAllowedTerms(Terms& terms)
 	if (notAllowedTerms.size() == 0) return true;
 
 	terms.set(allowedTerms);
-	if (_availableModel->removeTermsWhenMoved())
+	if (!_availableModel->keepTerms())
 		_availableModel->addTerms(notAllowedTerms);
 
 	QString notAllowedTermsStr = notAllowedTerms.asQList().join(", ");

--- a/QMLComponents/models/listmodelavailableinterface.cpp
+++ b/QMLComponents/models/listmodelavailableinterface.cpp
@@ -179,7 +179,7 @@ bool ListModelAvailableInterface::sourceLabelsReordered(QString columnName)
 
 void ListModelAvailableInterface::removeTermsInAssignedList()
 {
-	if (!removeTermsWhenMoved())
+	if (keepTerms())
 		return;
 
 	beginResetModel();

--- a/QMLComponents/models/listmodelavailableinterface.cpp
+++ b/QMLComponents/models/listmodelavailableinterface.cpp
@@ -203,7 +203,6 @@ void ListModelAvailableInterface::addAssignedModel(ListModelAssignedInterface *a
 {
 	_assignedModels.push_back(assignedModel);
 
-//	connect(assignedModel,	&ListModelAssignedInterface::destroyed,				this,						&ListModelAvailableInterface::removeAssignedModel		);
 	connect(this,			&ListModelAvailableInterface::availableTermsReset,	assignedModel,				&ListModelAssignedInterface::availableTermsResetHandler	);
 	connect(this,			&ListModelAvailableInterface::namesChanged,			assignedModel,				&ListModelAssignedInterface::sourceNamesChanged			);
 	connect(this,			&ListModelAvailableInterface::columnsChanged,		assignedModel,				&ListModelAssignedInterface::sourceColumnsChanged		);

--- a/QMLComponents/models/listmodeldraggable.cpp
+++ b/QMLComponents/models/listmodeldraggable.cpp
@@ -19,7 +19,6 @@
 #include "listmodeldraggable.h"
 #include "analysisform.h"
 #include "controls/jasplistcontrol.h"
-#include "log.h"
 
 ListModelDraggable::ListModelDraggable(JASPListControl* listView)
 	: ListModel(listView)
@@ -28,24 +27,32 @@ ListModelDraggable::ListModelDraggable(JASPListControl* listView)
 
 ListModelDraggable::~ListModelDraggable()
 {
-	emit destroyed(this);
 }
 
 Terms ListModelDraggable::termsFromIndexes(const QList<int> &indexes) const
 {
 	Terms result;
-	const Terms& myTerms = terms();
+
 	for (int index : indexes)
-	{
-		size_t index_t = size_t(index);
-		if (index_t < myTerms.size())
-		{
-			const Term& term = myTerms.at(index_t);
-			result.add(term);
-		}
-	}
+		if (size_t(index) < terms().size())
+			result.add(terms().at(index));
 	
 	return result;
+}
+
+QList<int> ListModelDraggable::indexesFromTerms(const  Terms & termsIn) const
+{
+	std::set<int>		result;
+	std::map<Term, int> termToIndex;
+	
+	for(size_t t=0; t<terms().size(); t++)
+		termToIndex[terms().at(t)] = t;
+
+	for(const Term & term : termsIn)
+		if(termToIndex.count(term))
+			result.insert(termToIndex[term]);
+	
+	return tql(result);
 }
 
 void ListModelDraggable::removeTerms(const QList<int> &indices)
@@ -74,15 +81,12 @@ void ListModelDraggable::moveTerms(const QList<int> &indexes, int dropItemIndex)
 	Terms terms = termsFromIndexes(indexes);
 	removeTerms(indexes); // Remove first before adding: we cannot add terms that already exist
 	for (int index : indexes)
-	{
 		if (index < dropItemIndex)
 			dropItemIndex--;
-	}
+
 	Terms removedTerms = addTerms(terms, dropItemIndex);
 	if (removedTerms.size() > 0)
-	{
 		addTerms(removedTerms);
-	}
 	
 	endResetModel();
 }

--- a/QMLComponents/models/listmodeldraggable.cpp
+++ b/QMLComponents/models/listmodeldraggable.cpp
@@ -57,6 +57,9 @@ QList<int> ListModelDraggable::indexesFromTerms(const  Terms & termsIn) const
 
 void ListModelDraggable::removeTerms(const QList<int> &indices)
 {
+	if(!indices.count())
+		return;
+	
 	beginResetModel();
 
 	Terms termsToRemove;
@@ -73,6 +76,9 @@ void ListModelDraggable::removeTerms(const QList<int> &indices)
 
 void ListModelDraggable::moveTerms(const QList<int> &indexes, int dropItemIndex)
 {
+	if(!indexes.count())
+		return;
+
 	JASPControl::DropMode _dropMode = dropMode();
 	if (indexes.length() == 0 || _dropMode == JASPControl::DropMode::DropNone)
 		return;	

--- a/QMLComponents/models/listmodeldraggable.h
+++ b/QMLComponents/models/listmodeldraggable.h
@@ -32,8 +32,8 @@ public:
 	ListModelDraggable(JASPListControl* listView);
 	~ListModelDraggable();
 
-	bool removeTermsWhenMoved() const						{ return _removeTermsWhenMoved;	}
-	void setRemoveTermsWhenMoved(bool remove)				{ _removeTermsWhenMoved = remove; }
+	bool keepTerms() const									{ return _keepTerms;	}
+	void setKeepTerms(bool keep)							{ _keepTerms = keep; }
 	JASPControl::DropMode dropMode() const					{ return _dropMode; }
 	
 	void setDropMode(JASPControl::DropMode dropMode)		{ _dropMode = dropMode; }
@@ -48,7 +48,7 @@ signals:
 	void destroyed(ListModelDraggable * me);
 
 protected:
-	bool						_removeTermsWhenMoved					= true;
+	bool						_keepTerms								= false;
 	JASPControl::DropMode		_dropMode								= JASPControl::DropMode::DropNone;
 		
 	bool						isAllowed(const Term &term) const;

--- a/QMLComponents/models/listmodeldraggable.h
+++ b/QMLComponents/models/listmodeldraggable.h
@@ -32,21 +32,19 @@ public:
 	ListModelDraggable(JASPListControl* listView);
 	~ListModelDraggable();
 
-	bool keepTerms() const									{ return _keepTerms;	}
-	void setKeepTerms(bool keep)							{ _keepTerms = keep; }
-	JASPControl::DropMode dropMode() const					{ return _dropMode; }
+	bool					keepTerms() const									{ return _keepTerms;	}
+	JASPControl::DropMode	dropMode()	const									{ return _dropMode; }
 	
-	void setDropMode(JASPControl::DropMode dropMode)		{ _dropMode = dropMode; }
+	void					setKeepTerms(bool keep)								{ _keepTerms = keep; }
+	void					setDropMode(JASPControl::DropMode dropMode)			{ _dropMode = dropMode; }
 	
-	virtual Terms termsFromIndexes(const QList<int> &indexes)					const;
-	virtual Terms canAddTerms(const Terms& terms)								const;
-	virtual Terms addTerms(const Terms& terms, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues());
-	virtual void removeTerms(const QList<int>& indexes);
-	virtual void moveTerms(const QList<int>& indexes, int dropItemIndex = -1);
-
-signals:
-	void destroyed(ListModelDraggable * me);
-
+	virtual QList<int>		indexesFromTerms(	const Terms		& terms)		const;
+	virtual Terms			canAddTerms(		const Terms		& terms)		const;
+	virtual Terms			addTerms(			const Terms		& terms,	int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues());
+	virtual void			moveTerms(			const QList<int>& indexes,	int dropItemIndex = -1);
+	virtual void			removeTerms(		const QList<int>& indexes);
+	virtual Terms			termsFromIndexes(	const QList<int>& indexes)		const;
+	
 protected:
 	bool						_keepTerms								= false;
 	JASPControl::DropMode		_dropMode								= JASPControl::DropMode::DropNone;

--- a/QMLComponents/models/listmodelfactorsform.h
+++ b/QMLComponents/models/listmodelfactorsform.h
@@ -35,7 +35,18 @@ public:
         FactorNameRole = Qt::UserRole + 1,
 		FactorTitleRole
     };
-	typedef std::vector<std::tuple<std::string, std::string, std::vector<std::string> > > FactorVec;
+
+	struct Factor
+	{
+		QString						name;
+		QString						title;
+		JASPListControl*			listView;
+		Terms						initTerms;
+		Factor(const QString& _name, const QString& _title, const Terms& _initTerms) :
+			name(_name), title(_title), listView(nullptr), initTerms(_initTerms) {}
+	};
+
+	typedef std::vector<Factor> FactorVec;
 
 	ListModelFactorsForm(JASPListControl* listView);
 	
@@ -47,7 +58,7 @@ public:
 	void					initFactors(const FactorVec &factors);
 	int						count()														const				{ return int(_factors.size()); }
 	int						countVariables()											const;
-	FactorVec				getFactors();
+	const FactorVec&		getFactors()												const				{ return _factors;	}
 	
 	void					addFactor();
 	void					removeFactor();
@@ -56,26 +67,16 @@ public:
 public slots:
 	void titleChangedSlot(int index, QString title);
 	void resetModelTerms();
+	void ensureNesting();
 
 signals:
 	void addListView(JASPListControl* listView);
 	
 protected slots:
-	void ensureNesting();
-	void setAllTermsDraggable();
+	void nestedChangedHandler();
 
 protected:
-	struct Factor
-	{
-		QString						name;
-		QString						title;
-		JASPListControl*			listView;
-		Terms						initTerms;
-		Factor(const QString& _name, const QString& _title, const Terms& _initTerms) :
-			name(_name), title(_title), listView(nullptr), initTerms(_initTerms) {}
-	};
-
-	QVector<Factor*>	_factors;
+	FactorVec			_factors;
 	FactorsFormBase*	_factorsForm		= nullptr;
 	bool				_ensuringNesting	= false;
 	

--- a/QMLComponents/models/listmodelinteractionassigned.cpp
+++ b/QMLComponents/models/listmodelinteractionassigned.cpp
@@ -77,6 +77,9 @@ Terms ListModelInteractionAssigned::filterTerms(const Terms& terms, const QStrin
 
 void ListModelInteractionAssigned::removeTerms(const QList<int> &indices)
 {
+	if(!indices.count())
+		return;
+	
 	Terms toRemove;
 
 	for (int i : indices)

--- a/QMLComponents/models/listmodellayersassigned.cpp
+++ b/QMLComponents/models/listmodellayersassigned.cpp
@@ -122,6 +122,10 @@ Terms ListModelLayersAssigned::termsFromIndexes(const QList<int> &indexes) const
 Terms ListModelLayersAssigned::addTerms(const Terms& terms, int dropItemIndex, const RowControlsValues&)
 {
 	Terms result;
+	
+	if(!terms.size())
+		return result;
+	
 	beginResetModel();
 	
 	int layer = _variables.length();
@@ -211,6 +215,9 @@ void ListModelLayersAssigned::moveTerms(const QList<int> &indexes, int dropItemI
 
 void ListModelLayersAssigned::removeTerms(const QList<int> &indexes)
 {
+	if(!indexes.count())
+		return;
+	
 	beginResetModel();
 	
 	QList<int> sortedIndexes = indexes;

--- a/QMLComponents/models/listmodelmeasurescellsassigned.cpp
+++ b/QMLComponents/models/listmodelmeasurescellsassigned.cpp
@@ -103,6 +103,9 @@ void ListModelMeasuresCellsAssigned::initTerms(const Terms &terms, const ListMod
 
 Terms ListModelMeasuresCellsAssigned::addTerms(const Terms& termsToAdd, int dropItemIndex, const RowControlsValues&)
 {
+	if(!termsToAdd.size())
+		return Terms();
+	
 	beginResetModel();
 	if (dropItemIndex >= 0)
 		dropItemIndex = dropItemIndex / 2;
@@ -169,6 +172,9 @@ void ListModelMeasuresCellsAssigned::moveTerms(const QList<int> &indexes, int dr
 
 void ListModelMeasuresCellsAssigned::removeTerms(const QList<int> &indexes)
 {
+	if(!indexes.count())
+		return;
+	
 	beginResetModel();
 	for (int i = 0; i < indexes.length(); i++)
 	{

--- a/QMLComponents/models/listmodelmultitermsassigned.cpp
+++ b/QMLComponents/models/listmodelmultitermsassigned.cpp
@@ -164,12 +164,12 @@ void ListModelMultiTermsAssigned::_setTerms()
 
 Terms ListModelMultiTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemIndex, const RowControlsValues&)
 {
-	beginResetModel();
 	Terms termsToReturn;
 	
 	if (termsToAdd.size() == 0)
 		return termsToReturn;
 	
+	beginResetModel();
 	bool done = false;
 	if (termsToAdd.size() == 1 && dropItemIndex >= 0)
 	{

--- a/QMLComponents/models/term.cpp
+++ b/QMLComponents/models/term.cpp
@@ -120,6 +120,12 @@ bool Term::operator!=(const Term &other) const
 	return this->operator==(other) == false;
 }
 
+bool Term::operator<(const Term &other) const
+{
+	return asQString() < other.asQString();
+}
+
+
 size_t Term::size() const
 {
 	return _components.size();

--- a/QMLComponents/models/term.h
+++ b/QMLComponents/models/term.h
@@ -60,6 +60,7 @@ public:
 
 	bool operator==(const Term &other) const;
 	bool operator!=(const Term &other) const;
+	bool operator<(const Term &other) const;
 
 	size_t size() const;
 

--- a/QMLComponents/utilities/qutils.h
+++ b/QMLComponents/utilities/qutils.h
@@ -54,6 +54,7 @@ inline	std::string							fq (const QString							 & from)	{ return from.toUtf8()
 inline	QString								tq (const std::string						 & from)	{ return QString::fromUtf8(from.c_str(), from.length()); }
 		QVector<QString>					tq (const std::vector<std::string>			 & vec);
 inline	QStringList							tql(const std::set<std::string>				 & from)	{ return tq(std::vector<std::string>(from.begin(), from.end())); }
+inline	QList<int>							tql(const std::set<int>						 & from)	{ return QList<int>(from.begin(), from.end()); }
 		std::set<std::string>				fql(const QStringList						 & from);
 
 		//These need to have a different name because otherwise the default Json::Value(const std::string & str) constructor steals any fq(std::string()) call...


### PR DESCRIPTION
The options sent to the analyses should give the interaction terms in the right form, that as an array (only if allowInteraction property is true, so that CFA that uses also FactorsForm gets still the same options):
```
"nestedFactors" : 
        [
            {
                "components" : [],
                "name" : "model0",
                "title" : "Model 0"
            },
            {
                "components" : 
                [
                    ["facExperim"],
                    ["facFive"],
                    ["facExperim", "facFive"]
                ],
                "name" : "model1",
                "title" : "Model 1"
            }
        ]
```

Also the code ensuring the nestingness could lead to a loop. This is also solved.


