### PR TITLE
Determines type for empty columns based on what user types

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1238,7 +1238,7 @@ bool Column::setStringValueToRow(size_t row, const std::string & userEntered)
 			oldDouble		= _dbls[row];	
 	bool	itsADouble		= ColumnUtils::getDoubleValue(userEntered, newDoubleToSet),
 			nothingThereYet	=	_ints.size() == std::count_if(_ints.begin(), _ints.end(), [&](int i)	{ return i == Label::DOUBLE_LABEL_VALUE || i == EmptyValues::missingValueInteger || labelByIntsId(i)->isEmptyValue(); }) 
-							&&	_dbls.size() == std::count_if(_dbls.begin(), _dbls.end(), [](double d)	{ return std::isnan(d); });
+							&&	_dbls.size() == std::count_if(_dbls.begin(), _dbls.end(), [&](double d)	{ return std::isnan(d) || isEmptyValue(d); });
 	Label * newLabel		= labelByDisplay(userEntered);
 	Label * oldLabel		= _ints[row] == Label::DOUBLE_LABEL_VALUE ? nullptr : labelByIntsId(_ints[row]);
 	

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1236,15 +1236,29 @@ bool Column::setStringValueToRow(size_t row, const std::string & userEntered)
 	
 	double	newDoubleToSet	= EmptyValues::missingValueDouble,
 			oldDouble		= _dbls[row];	
-	bool	itsADouble		= ColumnUtils::getDoubleValue(userEntered, newDoubleToSet);
+	bool	itsADouble		= ColumnUtils::getDoubleValue(userEntered, newDoubleToSet),
+			nothingThereYet	=	_ints.size() == std::count_if(_ints.begin(), _ints.end(), [&](int i)	{ return i == Label::DOUBLE_LABEL_VALUE || i == EmptyValues::missingValueInteger || labelByIntsId(i)->isEmptyValue(); }) 
+							&&	_dbls.size() == std::count_if(_dbls.begin(), _dbls.end(), [](double d)	{ return std::isnan(d); });
 	Label * newLabel		= labelByDisplay(userEntered);
 	Label * oldLabel		= _ints[row] == Label::DOUBLE_LABEL_VALUE ? nullptr : labelByIntsId(_ints[row]);
+	
+	if(nothingThereYet)
+	{
+		if(itsADouble)
+		{
+			if(!isEmptyValue(newDoubleToSet))
+				setType(columnType::scale);
+		}
+		else if(!isEmptyValue(userEntered))
+			setType(columnType::nominal);
+	}
 		
 	if(!oldLabel && !newLabel && itsADouble) //no labels and it is a double, easy peasy
 		return setValue(row, newDoubleToSet);
 
 	if(newLabel)
 		return setValue(row, newLabel->intsId(), newDoubleToSet);
+	
 		
 	if(itsADouble)
 	{

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1237,8 +1237,8 @@ bool Column::setStringValueToRow(size_t row, const std::string & userEntered)
 	double	newDoubleToSet	= EmptyValues::missingValueDouble,
 			oldDouble		= _dbls[row];	
 	bool	itsADouble		= ColumnUtils::getDoubleValue(userEntered, newDoubleToSet),
-			nothingThereYet	=	_ints.size() == std::count_if(_ints.begin(), _ints.end(), [&](int i)	{ return i == Label::DOUBLE_LABEL_VALUE || i == EmptyValues::missingValueInteger || labelByIntsId(i)->isEmptyValue(); }) 
-							&&	_dbls.size() == std::count_if(_dbls.begin(), _dbls.end(), [&](double d)	{ return std::isnan(d) || isEmptyValue(d); });
+			nothingThereYet	=	!std::any_of(_ints.begin(), _ints.end(), [&](int i)		{ return !(i == Label::DOUBLE_LABEL_VALUE || i == EmptyValues::missingValueInteger || labelByIntsId(i)->isEmptyValue()); }) 
+							&&	!std::any_of(_dbls.begin(), _dbls.end(), [&](double d)	{ return !(std::isnan(d) || isEmptyValue(d)); });
 	Label * newLabel		= labelByDisplay(userEntered);
 	Label * oldLabel		= _ints[row] == Label::DOUBLE_LABEL_VALUE ? nullptr : labelByIntsId(_ints[row]);
 	


### PR DESCRIPTION
when a user enters a new value in data-editing mode this code will:
- check whether no data is in the column yet (so no values at all, or only empty/missing values)
- is the first non-missing-value thing a user enters a number? convert/keep scalar type
- is the first non-missing-value thing a user enters a string? convert/keep nominal type
- implements request from https://github.com/jasp-stats/INTERNAL-jasp/issues/2490

