### PR TITLE
Fix some errors when moving variables in QML

### DIFF
--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -262,7 +262,7 @@ void VariablesListBase::moveItems(QList<int> &indexes, ListModelDraggable* targe
 				termsRejected;
 
 		//if a model keeps terms we dont need to bother adding or removing anything
-		if (!targetModel->keepTerms())	termsToAdd				=	targetModel->canAddTerms(	sourceModel->termsFromIndexes(indexes)		);	// Check which terms can be added in the target model (especially terms that have not the right types might be refused).
+		if (!targetModel->keepTerms())	termsToAdd				=	targetModel->canAddTerms(	termsToAdd									);	// Check which terms can be added in the target model (especially terms that have not the right types might be refused).
 		if (!sourceModel->keepTerms())								sourceModel->removeTerms(	sourceModel->indexesFromTerms(termsToAdd)	);	// Then remove the terms in the source model. This must be done before adding them in the target model: for nested FactorsForm, it is important that the term is first removed from the source and afterwards added to the target.	
 		if (!targetModel->keepTerms())	termsRejected			=	targetModel->addTerms(		termsToAdd, dropItemIndex					);	// Add the terms in the target model
 		if (!sourceModel->keepTerms())								sourceModel->addTerms(		termsRejected								);	// Any possible overflow (such as for single-variable-list) gets returned to the source

--- a/QMLComponents/models/listmodelinteractionassigned.cpp
+++ b/QMLComponents/models/listmodelinteractionassigned.cpp
@@ -94,19 +94,6 @@ void ListModelInteractionAssigned::removeTerms(const QList<int> &indices)
 	setTerms();
 }
 
-Terms ListModelInteractionAssigned::termsFromIndexes(const QList<int> &indexes) const
-{
-	Terms result;
-	for (int i : indexes)
-	{
-		int index = i;
-		if (index < rowCount())
-			result.add(terms().at(size_t(index)));
-	}
-	
-	return result;
-}
-
 void ListModelInteractionAssigned::_addTerms(const Terms& terms, bool combineWithExistingTerms)
 {
 	Terms fixedFactors;

--- a/QMLComponents/models/listmodelinteractionassigned.h
+++ b/QMLComponents/models/listmodelinteractionassigned.h
@@ -31,7 +31,6 @@ public:
 	ListModelInteractionAssigned(JASPListControl* listView, bool mustContainLowerTerms, bool addInteractionsByDefault);
 
 	void			initTerms(const Terms &terms, const RowControlsValues& = RowControlsValues(), bool reInit = false)	override;
-	Terms			termsFromIndexes(const QList<int> &indexes)								const	override;
 	Terms			canAddTerms(const Terms& terms) const override;
 	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues())	override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)					override;

--- a/QMLComponents/models/listmodellayersassigned.cpp
+++ b/QMLComponents/models/listmodellayersassigned.cpp
@@ -101,24 +101,6 @@ void ListModelLayersAssigned::_setTerms()
 	ListModel::_setTerms(newTerms);
 }
 
-Terms ListModelLayersAssigned::termsFromIndexes(const QList<int> &indexes) const
-{
-	Terms terms;
-
-	for (int index : indexes)
-	{
-		int indexInLayer = -1;
-		int layer = _getLayer(index, indexInLayer);
-		if (layer < _variables.length())
-		{
-			if (indexInLayer >= 0 && indexInLayer < _variables[layer].length())
-				terms.add(Term(_variables[layer][indexInLayer]));
-		}
-	}
-	
-	return terms;
-}
-
 Terms ListModelLayersAssigned::addTerms(const Terms& terms, int dropItemIndex, const RowControlsValues&)
 {
 	Terms result;

--- a/QMLComponents/models/listmodellayersassigned.h
+++ b/QMLComponents/models/listmodellayersassigned.h
@@ -28,7 +28,6 @@ public:
 	ListModelLayersAssigned(JASPListControl* listView);
 
 	QVariant	data(const QModelIndex &index, int role = Qt::DisplayRole)					const	override;
-	Terms		termsFromIndexes(const QList<int> &indexes)									const	override;
 	Terms		addTerms(const Terms& terms, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues())	override;
 	void		moveTerms(const QList<int>& indexes, int dropItemIndex = -1)						override;
 	void		removeTerms(const QList<int>& indexes)												override;

--- a/QMLComponents/models/listmodelmeasurescellsassigned.cpp
+++ b/QMLComponents/models/listmodelmeasurescellsassigned.cpp
@@ -95,6 +95,15 @@ Terms ListModelMeasuresCellsAssigned::termsFromIndexes(const QList<int> &indexes
 	return result;
 }
 
+QList<int> ListModelMeasuresCellsAssigned::indexesFromTerms(const Terms &terms) const
+{
+	QList<int> indexes = ListModelAssignedInterface::indexesFromTerms(terms);
+
+	std::for_each(indexes.begin(), indexes.end(), [](int &n) { n *= 2; });
+
+	return indexes;
+}
+
 void ListModelMeasuresCellsAssigned::initTerms(const Terms &terms, const ListModel::RowControlsValues &allValuesMap, bool reInit)
 {
 	ListModelAssignedInterface::initTerms(terms, allValuesMap, reInit);

--- a/QMLComponents/models/listmodelmeasurescellsassigned.h
+++ b/QMLComponents/models/listmodelmeasurescellsassigned.h
@@ -32,6 +32,7 @@ public:
 	int				rowCount(const QModelIndex &parent = QModelIndex())												const	override { return _levels.size() * 2; }
 	QVariant		data(const QModelIndex &index, int role = Qt::DisplayRole)										const	override;
 	Terms			termsFromIndexes(const QList<int> &indexes)														const	override;
+	QList<int>		indexesFromTerms(const Terms &terms)															const	override;
 	void			initTerms(const Terms &terms, const RowControlsValues& allValuesMap = RowControlsValues(), bool reInit = false)		override;
 	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues()) override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)											override;

--- a/QMLComponents/models/terms.cpp
+++ b/QMLComponents/models/terms.cpp
@@ -156,7 +156,7 @@ void Terms::add(const Term &term, bool isUnique)
 	}
 	else
 	{
-		int i = indexOf(term.asQString());
+		int i = indexOf(term);
 		if (i < 0)
 			_terms.push_back(term);
 		else
@@ -233,6 +233,16 @@ int Terms::indexOf(const QString &component) const
 
 	return -1;
 }
+
+int Terms::indexOf(const Term &term) const
+{
+	auto it = std::find(_terms.begin(), _terms.end(), term);
+	if (it == _terms.end())
+		return -1;
+	else
+		return it - _terms.begin();
+}
+
 
 bool Terms::contains(const QString & component)
 {

--- a/QMLComponents/models/terms.h
+++ b/QMLComponents/models/terms.h
@@ -94,6 +94,7 @@ public:
 	bool contains(const QString		&	component);
 	bool contains(const std::string &	component);
 	int	 indexOf(const QString		&	component)				const;
+	int	 indexOf(const Term			&	component)				const;
 
 	std::vector<std::string>				asVector()			const;
 	std::set<std::string>					asSet()				const;


### PR DESCRIPTION
Several fixes:

- In a VariablesList with interactions (eg. in an ANOVA analysis), move in Model Terms an interaction term, a variable may disappear (fix in indexOf method in terms.cpp)
- In Repeated Measures ANOVA, in the Repeated Measures Cell, if you add some variables, and try to remove some of them: the wrong variables are removed (ListModelMeasuresCellsAssigned::indexesFromTerms is added)
- Some overriden termsFromIndexes functions are useless, and are removed.

