### PR TITLE
Better selecting!

### DIFF
--- a/Common/timers.cpp
+++ b/Common/timers.cpp
@@ -26,8 +26,17 @@ void _printAllTimers()
 {
 	if(timers == nullptr)
 		return;
+	
+	typedef std::pair<std::string, boost::timer::cpu_timer *> nameTimerPair;
+	
+	std::vector<nameTimerPair> sortMe(timers->begin(), timers->end());
+	
+	std::sort(sortMe.begin(), sortMe.end(), [](const nameTimerPair & l, const nameTimerPair & r)
+	{
+		return l.second->elapsed().user > r.second->elapsed().user;
+	});
 
-	for(auto keyval : *timers)
+	for(const nameTimerPair & keyval : sortMe)
 		std::cout << keyval.first << " ran for " << keyval.second->format() << std::endl;
 }
 

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1368,12 +1368,16 @@ void Column::rowDelete(size_t row)
 {
 	_dbls.erase(_dbls.begin() + row);
 	_ints.erase(_ints.begin() + row);
+	
+	labelsTempReset();
 }
 
 void Column::setRowCount(size_t rows)
 {
 	_dbls.resize(rows);
 	_ints.resize(rows);
+	
+	labelsTempReset();
 }
 
 Label *Column::labelByIntsId(int value) const

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -167,7 +167,7 @@ void Column::setHasCustomEmptyValues(bool hasCustom)
 	_emptyValues->setHasCustomEmptyValues(hasCustom);
 	db().columnSetEmptyVals(_id, _emptyValues->toJson().toStyledString());
 	
-	incRevision();
+	incRevision(false);
 }
 
 bool Column::setCustomEmptyValues(const stringset& customEmptyValues)
@@ -180,7 +180,7 @@ bool Column::setCustomEmptyValues(const stringset& customEmptyValues)
 	_emptyValues->setEmptyValues(customEmptyValues, _emptyValues->hasEmptyValues());
 	db().columnSetEmptyVals(_id, _emptyValues->toJson().toStyledString());
 	
-	incRevision();
+	incRevision(false);
 	
 	return true;
 }
@@ -628,7 +628,7 @@ void Column::_dbUpdateLabelOrder(bool noIncRevisionWhenBatchedPlease)
 
 	db().labelsSetOrder(orderPerDbIds);
 	
-	incRevision();
+	incRevision(false);
 }
 
 void Column::_sortLabelsByOrder()
@@ -642,9 +642,7 @@ void Column::labelsClear()
 	_labels.clear();
 	_labelByIntsIdMap.clear();
 	
-	labelsTempReset();
-
-	incRevision();
+	incRevision(false);
 }
 
 void Column::beginBatchedLabelsDB()
@@ -801,12 +799,12 @@ int Column::labelsTempCount()
 		for(size_t r=0; r<_labels.size(); r++)
 			if(!_labels[r]->isEmptyValue())
 			{
-				_labelsTemp.push_back(		_labels[r]->label());
-				_labelsTempDbls.push_back(	_labels[r]->originalValue().isDouble() ? _labels[r]->originalValue().asDouble() : EmptyValues::missingValueDouble);
+				_labelsTemp												. push_back(_labels[r]->label());
+				_labelsTempDbls											. push_back(_labels[r]->originalValue().isDouble() ? _labels[r]->originalValue().asDouble() : EmptyValues::missingValueDouble);
 				_labelsTempToIndex[_labelsTemp[_labelsTemp.size()-1]]	= _labelsTemp.size()-1; //We store the index in _labelsTemp in a map.
 			}
 		
-		//There might also be "double" values that should also be shown in the editor so we go through everything and add them to 	_labelsTemp and _labelsTempToIndex	
+		//There might also be "double" values that should also be shown in the editor so we go through everything and add them to _labelsTemp and _labelsTempToIndex	
 		for(size_t r=0; r<rowCount(); r++)
 			if(_ints[r] == Label::DOUBLE_LABEL_VALUE)
 			{

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -117,6 +117,7 @@ public:
 			
 			int						labelsTempCount(); ///< Generates the labelsTemp also!
 			const stringvec		&	labelsTemp();
+			void					labelsTempReset();
 			std::string				labelsTempDisplay(		size_t tempLabelIndex);
 			std::string				labelsTempValue(		size_t tempLabelIndex, bool fancyEmptyValue = false);
 			double					labelsTempValueDouble(	size_t tempLabelIndex);
@@ -223,7 +224,6 @@ protected:
 			void					_convertVectorIntToDouble(intvec & intValues, doublevec & doubleValues);
 			void					_resetLabelValueMap();
 			doublevec				valuesNumericOrdered();			
-			void					labelsTempReset();
 
 private:
 			DataSet			* const	_data;

--- a/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
@@ -192,8 +192,8 @@ Rectangle
 			{
 				headerRoot.forceActiveFocus()
 
-				if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
-					dataTableView.view.columnSelect(columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton)
+				if(mouseEvent.button === Qt.LeftButton)
+					dataTableView.view.select(-1, columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.modifiers & Qt.ControlModifier)
 
 				if(mouseEvent.button === Qt.RightButton)
 				{
@@ -206,10 +206,8 @@ Rectangle
 		onPositionChanged:	(mouseEvent) =>
 		{
 			if(ribbonModel.dataMode && Boolean(mouseEvent.modifiers & Qt.ShiftModifier))
-			{
-				dataTableView.view.pollSelectScroll(-1, columnIndex)
-				dataTableView.view.columnSelect(columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton)
-			}
+				dataTableView.view.selectHover(-1, columnIndex)
+
 		}
 
 		hoverEnabled:		true

--- a/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
@@ -193,7 +193,12 @@ Rectangle
 				headerRoot.forceActiveFocus()
 
 				if(mouseEvent.button === Qt.LeftButton)
-					dataTableView.view.select(-1, columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.modifiers & Qt.ControlModifier)
+				{
+					if(mouseEvent.modifiers & Qt.ShiftModifier || mouseEvent.modifiers & Qt.ControlModifier)
+						dataTableView.view.select(-1, columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.modifiers & Qt.ControlModifier)
+					else
+						columnModel.chosenColumn = columnIndex;
+				}
 
 				if(mouseEvent.button === Qt.RightButton)
 				{

--- a/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
@@ -194,10 +194,9 @@ Rectangle
 
 				if(mouseEvent.button === Qt.LeftButton)
 				{
-					if(mouseEvent.modifiers & Qt.ShiftModifier || mouseEvent.modifiers & Qt.ControlModifier)
-						dataTableView.view.select(-1, columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.modifiers & Qt.ControlModifier)
-					else
-						columnModel.chosenColumn = columnIndex;
+					dataTableView.view.select(-1, columnIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.modifiers & Qt.ControlModifier)
+					columnModel.chosenColumn = columnIndex;
+						
 				}
 
 				if(mouseEvent.button === Qt.RightButton)

--- a/Desktop/components/JASP/Widgets/DataTableViewEdit.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewEdit.qml
@@ -113,11 +113,8 @@ TextInput
 
 		if(arrowPressed)
 		{
-			if(!shiftPressed)
-				dataTableView.view.selectionStart	= arrowIndex;
-			else
-				dataTableView.view.selectionEnd  = arrowIndex;
-
+			dataTableView.view.select(arrowIndex.y, arrowIndex.x, shiftPressed, controlPressed);				
+			
 			dataTableView.view.edit(arrowIndex.y, arrowIndex.x);
 
 			event.accepted = true;

--- a/Desktop/components/JASP/Widgets/DataTableViewItem.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewItem.qml
@@ -73,10 +73,9 @@ Item
 					dataTableView.view.edit(rowIndex, columnIndex)
 
 			}
-			else if (columnModel.visible)
-			{
+			
+			if (columnModel.visible)
 				columnModel.chosenColumn = columnIndex
-			}
 		}
 
 		onPositionChanged:	(mouse) =>

--- a/Desktop/components/JASP/Widgets/DataTableViewItem.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewItem.qml
@@ -56,24 +56,20 @@ Item
 		{
 			if(ribbonModel.dataMode)
 			{
-				var shiftPressed = Boolean(mouse.modifiers & Qt.ShiftModifier)
-				var rightPressed = Boolean(mouse.buttons & Qt.RightButton)
-				var isSelected = dataTableView.view.isSelected(rowIndex, columnIndex)
-
-				if(!shiftPressed)
-				{
-					if (!rightPressed && !isSelected)
-						dataTableView.view.selectionStart = Qt.point(columnIndex, rowIndex)
-				}
+				var shiftPressed	= Boolean(mouse.modifiers & Qt.ShiftModifier)
+				var controlPressed	= Boolean(mouse.modifiers & Qt.ControlModifier)
+				var rightPressed	= Boolean(mouse.buttons & Qt.RightButton)
+				var isSelected		= dataTableView.view.isSelected(rowIndex, columnIndex)
+					
+				if(!rightPressed)
+					dataTableView.view.select(rowIndex, columnIndex, shiftPressed, controlPressed);
 				else
-					dataTableView.view.selectionEnd = Qt.point(columnIndex, rowIndex);
-
-				if(rightPressed)
 				{
 					dataTableView.view.clearEdit()
 					dataTableView.showPopupMenu(itemHighlight, mapToGlobal(mouse.x, mouse.y), rowIndex, columnIndex);
 				}
-				else if(!shiftPressed)
+							
+				if(!shiftPressed && !controlPressed && !rightPressed)
 					dataTableView.view.edit(rowIndex, columnIndex)
 
 			}
@@ -86,10 +82,7 @@ Item
 		onPositionChanged:	(mouse) =>
 		{
 			if(ribbonModel.dataMode && Boolean(mouse.modifiers & Qt.ShiftModifier))
-			{
-				dataTableView.view.pollSelectScroll(rowIndex, columnIndex)
-				dataTableView.view.selectionEnd = Qt.point(columnIndex, rowIndex)
-			}
+				dataTableView.view.selectHover(rowIndex, columnIndex)
 		}
 
 	}

--- a/Desktop/components/JASP/Widgets/DataTableViewRowHeader.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewRowHeader.qml
@@ -20,7 +20,7 @@ Rectangle
 	MouseArea
 	{
 		anchors.fill:		parent
-		enabled:			ribbonModel.dataMode
+		//enabled:			ribbonModel.dataMode
 		hoverEnabled:		true
 		ToolTip.visible:	containsMouse
 		ToolTip.text:		qsTr("Click here to select the row, hold shift for selecting multiple.")
@@ -30,8 +30,9 @@ Rectangle
 		acceptedButtons:	Qt.LeftButton | Qt.RightButton
 		onClicked: 			(mouseEvent)=>
 							{
-								if(mouseEvent.button === Qt.LeftButton || mouseEvent.button === Qt.RightButton)
-									dataTableView.view.rowSelect(rowIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton);
+								if(mouseEvent.button === Qt.LeftButton)
+									dataTableView.view.select(rowIndex, -1, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.modifiers & Qt.ControlModifier);
+								
 								if(mouseEvent.button === Qt.RightButton)
 									dataTableView.showPopupMenu(parent, mapToGlobal(mouseEvent.x, mouseEvent.y), rowIndex, -1);
 							}
@@ -39,10 +40,7 @@ Rectangle
 		onPositionChanged:	(mouseEvent) =>
 		{
 			if(ribbonModel.dataMode && Boolean(mouseEvent.modifiers & Qt.ShiftModifier))
-			{
-				dataTableView.view.pollSelectScroll(rowIndex, -1)
-				dataTableView.view.rowSelect(rowIndex, mouseEvent.modifiers & Qt.ShiftModifier, mouseEvent.button === Qt.RightButton)
-			}
+				dataTableView.view.selectHover(rowIndex, -1)
 		}
 	}
 }

--- a/Desktop/data/columnmodel.cpp
+++ b/Desktop/data/columnmodel.cpp
@@ -548,11 +548,11 @@ void ColumnModel::refresh()
 	setLabelMaxWidth();
 }
 
-void ColumnModel::changeSelectedColumn(QPoint selectionStart)
+/*void ColumnModel::changeSelectedColumn(QPoint selectionStart)
 {
 	if (selectionStart.x() != chosenColumn() && visible())
 		setChosenColumn(selectionStart.x());
-}
+}*/
 
 void ColumnModel::checkInsertedColumns(const QModelIndex &, int first, int)
 {

--- a/Desktop/data/columnmodel.h
+++ b/Desktop/data/columnmodel.h
@@ -116,7 +116,7 @@ public slots:
 	void setRowWidth(double len);
 	void onChosenColumnChanged();
 	void refresh();
-	void changeSelectedColumn(QPoint selectionStart);
+	//void changeSelectedColumn(QPoint selectionStart);
 	void checkRemovedColumns(int columnIndex, int count);
 	void checkInsertedColumns(const QModelIndex & parent, int first, int last);
 	void openComputedColumn(const QString & name);

--- a/Desktop/data/computedcolumnmodel.cpp
+++ b/Desktop/data/computedcolumnmodel.cpp
@@ -13,8 +13,6 @@ ComputedColumnModel::ComputedColumnModel()
 	assert(_singleton == nullptr);
 	_singleton = this;
 
-	_undoStack = DataSetPackage::pkg()->undoStack();
-
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnJsonChanged			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnRCodeChanged			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnErrorChanged			);
@@ -159,7 +157,7 @@ void ComputedColumnModel::emitSendComputeCode(Column * column)
 
 void ComputedColumnModel::sendCode(const QString & code, const QString & json)
 {
-	_undoStack->push(new SetComputedColumnCodeCommand(DataSetPackage::pkg(), _selectedColumn->name(), code, json));
+	DataSetPackage::pkg()->undoStack()->push(new SetComputedColumnCodeCommand(DataSetPackage::pkg(), _selectedColumn->name(), code, json));
 }
 
 
@@ -340,7 +338,7 @@ void ComputedColumnModel::removeColumn()
 		return;
 
 	// TODO pass RemoveColumnCommand aab
-	_undoStack->pushCommand(new RemoveColumnsCommand(DataSetPackage::pkg(), _selectedColumn->id(), 1));
+	DataSetPackage::pkg()->undoStack()->pushCommand(new RemoveColumnsCommand(DataSetPackage::pkg(), _selectedColumn->id(), 1));
 
 	DataSetPackage::pkg()->requestComputedColumnDestruction(_selectedColumn->name());
 	emit refreshData();

--- a/Desktop/data/computedcolumnmodel.h
+++ b/Desktop/data/computedcolumnmodel.h
@@ -100,7 +100,6 @@ public slots:
 private:
 	static	ComputedColumnModel		* _singleton;
 			Column					* _selectedColumn	= nullptr;
-			UndoStack				* _undoStack		= nullptr;
 };
 
 #endif // COMPUTEDCOLUMNSCODEITEM_H

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -547,7 +547,7 @@ QVariant DataSetPackage::data(const QModelIndex &index, int role) const
 		switch(role)
 		{
 		case int(specialRoles::filter):				return index.row() >= labels.size() || labels[index.row()]->filterAllows();
-		case int(specialRoles::value):				return tq(column->labelsTempValue(index.row(), true));
+		case int(specialRoles::value):				return tq(column->labelsTempValue(index.row()));
 		case int(specialRoles::description):		return index.row() >= labels.size() ? "" : tq(labels[index.row()]->description());
 		case int(specialRoles::labelsStrList):		return getColumnLabelsAsStringList(column->name());
 		case int(specialRoles::valuesDblList):		return getColumnValuesAsDoubleList(getColumnIndex(column->name()));

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1850,7 +1850,7 @@ void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<
 	bool	rowCountChanged = int(row + rowMax) > dataRowCount()	,
 			colCountChanged = int(col + colMax) > dataColumnCount()	;
 	
-	auto isSelected = [selected](int row, int col)
+	auto isSelected = [&selected](int row, int col)
 	{
 		return selected.size() == 0 || 	selected[col][row];
 	};

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1851,6 +1851,7 @@ void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<
 			colCountChanged = int(col + colMax) > dataColumnCount()	;
 
 	beginSynchingData(false);
+	_dataSet->beginBatchedToDB();
 	
 	if(colCountChanged || rowCountChanged)	
 		setDataSetSize(std::max(size_t(dataColumnCount()), colMax + col), std::max(size_t(dataRowCount()), rowMax + row));
@@ -1881,6 +1882,7 @@ void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<
 			changed.push_back(colName);
 	}
 
+	_dataSet->endBatchedToDB();
 	
 	stringvec		missingColumns;
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -2076,16 +2076,18 @@ bool DataSetPackage::removeRows(int row, int count, const QModelIndex & aparent)
 
 	dataSet()->beginBatchedToDB();
 	
-	for(int c=0; c<dataColumnCount(); c++)
+	for(Column * column : dataSet()->columns())
 	{
-		const std::string & name = getColumnName(c);
-		changed.push_back(name);
+		changed.push_back(column->name());
+		
+		if(row+count > column->rowCount())
+			Log::log() << "???" << std::endl;
 	
 		for(int r=row+count; r>row; r--)
-			dataSet()->column(c)->rowDelete(r-1);
+			column->rowDelete(r-1);
 	}
 
-	setDataSetSize(dataColumnCount(), dataRowCount()-count);
+	dataSet()->setRowCount(dataSet()->rowCount() - count);
 	dataSet()->incRevision();
 	dataSet()->endBatchedToDB();
 

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -93,8 +93,6 @@ public:
 		bool				dataSetBaseNodeStillExists(	DataSetBaseNode		* node	) const;
 		
 		void				waitForExportResultsReady();
-		
-
 
 		void				beginLoadingData(	bool informEngines = true);
 		void				endLoadingData(		bool informEngines = true);
@@ -147,10 +145,10 @@ public:
 				QString				windowTitle()						const;
 				QString				description()						const;
 				QString				currentFile()						const	{ return _currentFile;						 }
-				bool				hasAnalyses()						const	{ return _analysesData.size() > 0;			  }
-				bool				synchingData()						const	{ return _synchingData;						  }
+				bool				hasAnalyses()						const	{ return _analysesData.size() > 0;				}
+				bool				synchingData()						const	{ return _synchingData;								}
 				std::string			dataFilePath()						const	{ return _dataSet ? _dataSet->dataFilePath() : "";  }
-				bool				isDatabase()						const	{ return _database != Json::nullValue;			}
+				bool				isDatabase()						const	{ return _database != Json::nullValue;				}
 		const	Json::Value		&	databaseJson()						const	{ return _database;								}
 		const	QString			&	analysesHTML()						const	{ return _analysesHTML;							}
 		const	Json::Value		&	analysesData()						const	{ return _analysesData;							}
@@ -160,7 +158,7 @@ public:
 
 				// The data file might be read-only if it comes from the examples or read from an external database
 				bool				dataFileReadOnly()					const	{ return _dataFileReadOnly;						}
-				bool				currentFileIsExample()					const;
+				bool				currentFileIsExample()				const;
 				uint				dataFileTimestamp()					const	{ return _dataFileTimestamp;					}
 				bool				isDatabaseSynching()				const	{ return _databaseIntervalSyncher.isActive();	}
 				bool				filterShouldRunInit()				const	{ return _filterShouldRunInit;					}

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -191,7 +191,7 @@ public:
 				bool						initColumnWithStrings(			QVariant			colId,		const std::string & newName, const stringvec	& values, const stringvec	& labels=stringvec(),	const std::string & title = "", columnType desiredType = columnType::unknown, const stringset & emptyValues = stringset());
 				void						initializeComputedColumns();
 				
-				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const intvec & colTypes, const QStringList & colNames);
+				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const intvec & colTypes, const QStringList & colNames, const std::vector<boolvec> & selected = {}); ///< If selected.size() >0 it is assumed to be the same size as labels/values. And it will make sure that it will only overwrite values where it is `true`
 
 				void						columnSetDefaultValues(	const std::string	& columnName, columnType colType = columnType::unknown, bool emitSignals = true);
 				Column *					createColumn(			const std::string	& name,		columnType colType);

--- a/Desktop/data/datasettablemodel.cpp
+++ b/Desktop/data/datasettablemodel.cpp
@@ -74,10 +74,10 @@ bool DataSetTableModel::columnUsedInEasyFilter(int column) const
 			).toBool();
 }
 
-void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & values, const std::vector<std::vector<QString>> & labels, const std::vector<int> & colTypes, const QStringList & colNames)
+void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & values, const std::vector<std::vector<QString>> & labels, const std::vector<int> & colTypes, const QStringList & colNames, const std::vector<boolvec> & selected)
 {
 	QModelIndex idx = mapToSource(index(row, col));
-	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), values, labels, colTypes, colNames);
+	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), values, labels, colTypes, colNames, selected);
 }
 
 QString DataSetTableModel::insertColumnSpecial(int column, const QMap<QString, QVariant>& props)

--- a/Desktop/data/datasettablemodel.cpp
+++ b/Desktop/data/datasettablemodel.cpp
@@ -77,7 +77,7 @@ bool DataSetTableModel::columnUsedInEasyFilter(int column) const
 void DataSetTableModel::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString> > & values, const std::vector<std::vector<QString>> & labels, const std::vector<int> & colTypes, const QStringList & colNames, const std::vector<boolvec> & selected)
 {
 	QModelIndex idx = mapToSource(index(row, col));
-	DataSetPackage::pkg()->pasteSpreadsheet(idx.row(), idx.column(), values, labels, colTypes, colNames, selected);
+	DataSetPackage::pkg()->pasteSpreadsheet(idx.row() == -1 ? row : idx.row(), idx.column() == -1 ? col : idx.column(), values, labels, colTypes, colNames, selected);
 }
 
 QString DataSetTableModel::insertColumnSpecial(int column, const QMap<QString, QVariant>& props)

--- a/Desktop/data/datasettablemodel.h
+++ b/Desktop/data/datasettablemodel.h
@@ -46,7 +46,7 @@ public:
 
 	int						getColumnIndex(const std::string& col)	const				{ return DataSetPackage::pkg()->getColumnIndex(col);								}
 	bool					synchingData()							const				{ return DataSetPackage::pkg()->synchingData();										}
-	void					pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const std::vector<int> & colTypes = std::vector<int>(), const QStringList & colNames = {});
+	void					pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const std::vector<int> & colTypes = std::vector<int>(), const QStringList & colNames = {}, const std::vector<boolvec> & selected = {});
 	bool					showInactive()							const				{ return _showInactive;	}
 
 	QString					insertColumnSpecial(int column, const QMap<QString, QVariant>& props);

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -219,11 +219,10 @@ void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 		insertColumn(colNr, false, false);
 	
 	int rowNr = _sourceModel->rowCount(),
-		rowC  = row - rowNr;
+		rowC  = 1 + row - rowNr;
 	
-	if(rowC)
+	if(rowC > 0 && row )
 		insertRows(rowNr, rowC);
-
 }
 
 void ExpandDataProxyModel::setData(int row, int col, const QVariant &value, int role)

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -232,13 +232,13 @@ void ExpandDataProxyModel::setData(int row, int col, const QVariant &value, int 
 	_undoStack->endMacro(new SetDataCommand(_sourceModel, row, col, value, role));
 }
 
-void ExpandDataProxyModel::pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const QStringList& colNames)
+void ExpandDataProxyModel::pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const QStringList & colNames, const std::vector<boolvec> & selected)
 {
 	if (!_sourceModel || row < 0 || col < 0 || values.size() == 0 || values[0].size() == 0 )
 		return;
 
 	_expandIfNecessary(row + values[0].size() - 1, col + values.size() - 1);
-	_undoStack->endMacro(new PasteSpreadsheetCommand(_sourceModel, row, col, values, labels, colNames));
+	_undoStack->endMacro(new PasteSpreadsheetCommand(_sourceModel, row, col, values, labels, selected, colNames));
 }
 
 int ExpandDataProxyModel::setColumnType(intset columnIndexes, int columnType)

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -218,8 +218,11 @@ void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 	for (int colNr = _sourceModel->columnCount(); colNr <= col; colNr++)
 		insertColumn(colNr, false, false);
 	
-	int rowNr = _sourceModel->rowCount();
-	insertRows(rowNr, 1 + row - rowNr);
+	int rowNr = _sourceModel->rowCount(),
+		rowC  = row - rowNr;
+	
+	if(rowC)
+		insertRows(rowNr, rowC);
 
 }
 

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -218,11 +218,15 @@ void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 	for (int colNr = _sourceModel->columnCount(); colNr <= col; colNr++)
 		insertColumn(colNr, false, false);
 	
-	int rowNr = _sourceModel->rowCount(),
-		rowC  = 1 + row - rowNr;
 	
-	if(rowC > 0 && row )
-		insertRows(rowNr, rowC);
+	if(row >= _sourceModel->rowCount())
+	{	
+		int rowNr = _sourceModel->rowCount(),
+			rowC  = 1 + row - rowNr;
+		
+		if(rowC > 0)
+			insertRows(rowNr, rowC);
+	}
 }
 
 void ExpandDataProxyModel::setData(int row, int col, const QVariant &value, int role)

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -185,13 +185,14 @@ void ExpandDataProxyModel::removeColumns(int start, int count)
 	_undoStack->pushCommand(new RemoveColumnsCommand(_sourceModel, start, count));
 }
 
-void ExpandDataProxyModel::insertRow(int row)
+void ExpandDataProxyModel::insertRows(int row, int count)
 {
 	if (!_sourceModel)
 		return;
 
-	_undoStack->pushCommand(new InsertRowCommand(_sourceModel, row));
+	_undoStack->pushCommand(new InsertRowsCommand(_sourceModel, row, count));
 }
+
 
 void ExpandDataProxyModel::insertColumn(int col, bool computed, bool R)
 {
@@ -216,8 +217,9 @@ void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 
 	for (int colNr = _sourceModel->columnCount(); colNr <= col; colNr++)
 		insertColumn(colNr, false, false);
-	for (int rowNr = _sourceModel->rowCount(); rowNr <= row; rowNr++)
-		insertRow(rowNr);
+	
+	int rowNr = _sourceModel->rowCount();
+	insertRows(rowNr, 1 + row - rowNr);
 
 }
 

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -198,7 +198,7 @@ void ExpandDataProxyModel::insertColumns(int col, int count)
 	if (!_sourceModel)
 		return;
 
-	_undoStack->pushCommand(new InsertRowsCommand(_sourceModel, col, count));
+	_undoStack->pushCommand(new InsertColumnsCommand(_sourceModel, col, count));
 }
 
 
@@ -225,8 +225,8 @@ void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 
 	if(col >= _sourceModel->columnCount())
 	{	
-		int colNr = _sourceModel->rowCount(),
-			colC  = 1 + col - colNr;
+		int colNr = _sourceModel->columnCount(),
+			colC  = col - colNr;
 		
 		if(colC > 0)
 			insertColumns(colNr, colC);
@@ -236,7 +236,7 @@ void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 	if(row >= _sourceModel->rowCount())
 	{	
 		int rowNr = _sourceModel->rowCount(),
-			rowC  = 1 + row - rowNr;
+			rowC  = row - rowNr;
 		
 		if(rowC > 0)
 			insertRows(rowNr, rowC);

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -181,7 +181,7 @@ void ExpandDataProxyModel::removeColumns(int start, int count)
 
 	if (start + count >= _sourceModel->columnCount())
 		count = _sourceModel->columnCount() - start;
-
+	
 	_undoStack->pushCommand(new RemoveColumnsCommand(_sourceModel, start, count));
 }
 

--- a/Desktop/data/expanddataproxymodel.cpp
+++ b/Desktop/data/expanddataproxymodel.cpp
@@ -226,7 +226,7 @@ void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 	if(col >= _sourceModel->columnCount())
 	{	
 		int colNr = _sourceModel->columnCount(),
-			colC  = col - colNr;
+			colC  = 1 + col - colNr;
 		
 		if(colC > 0)
 			insertColumns(colNr, colC);
@@ -236,7 +236,7 @@ void ExpandDataProxyModel::_expandIfNecessary(int row, int col)
 	if(row >= _sourceModel->rowCount())
 	{	
 		int rowNr = _sourceModel->rowCount(),
-			rowC  = row - rowNr;
+			rowC  = 1 + row - rowNr;
 		
 		if(rowC > 0)
 			insertRows(rowNr, rowC);
@@ -257,7 +257,7 @@ void ExpandDataProxyModel::pasteSpreadsheet(int row, int col, const std::vector<
 	if (!_sourceModel || row < 0 || col < 0 || values.size() == 0 || values[0].size() == 0 )
 		return;
 
-	_expandIfNecessary(row + values[0].size(), col + values.size());
+	_expandIfNecessary(row + values[0].size() - 1, col + values.size() - 1);
 	_undoStack->endMacro(new PasteSpreadsheetCommand(_sourceModel, row, col, values, labels, selected, colNames));
 }
 

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -28,10 +28,6 @@ public:
 	void						setSourceModel(QAbstractItemModel* model);
 	QAbstractItemModel*			sourceModel()																				const { return _sourceModel; }
 
-	
-	void						removeRows(intset rows);
-	void						removeColumns(intset cols);
-	
 	void						removeRows(int start, int count);
 	void						removeColumns(int start, int count);
 	void						insertRows(int row, int count = 1);

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -28,11 +28,15 @@ public:
 	void						setSourceModel(QAbstractItemModel* model);
 	QAbstractItemModel*			sourceModel()																				const { return _sourceModel; }
 
+	
+	void						removeRows(intset rows);
+	void						removeColumns(intset cols);
+	
 	void						removeRows(int start, int count);
 	void						removeColumns(int start, int count);
 	void						insertRows(int row, int count = 1);
 	void						insertColumn(int col, bool computed, bool R);
-	void						pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const QStringList& colNames = {});
+	void						pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const QStringList& colNames = {}, const std::vector<boolvec> & selected = {});
 	int							setColumnType(intset columnIndex, int columnType);
 	void						columnReverseValues(intset columnIndexes);
 	void						columnOrderByValues(intset columnIndexes);

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -10,48 +10,48 @@ class ExpandDataProxyModel : public QObject
 	Q_OBJECT
 
 public:
-	explicit ExpandDataProxyModel(QObject *parent);
+	explicit					ExpandDataProxyModel(QObject *parent);
 
-	int					rowCount(bool includeVirtuals = true)														const;
-	int					columnCount(bool includeVirtuals = true)													const;
-	QVariant			headerData(	int section, Qt::Orientation orientation, int role = Qt::DisplayRole )			const;
-	void				setData(	int row, int col, const QVariant &value, int role);
-	Qt::ItemFlags		flags(int row, int column)																	const;
-	QModelIndex			index(int row, int column, const QModelIndex &parent = QModelIndex())						const;
-	QVariant			data(int row, int column, int role = Qt::DisplayRole)										const;
-	bool				filtered(int row, int column)																const;
-	bool				isRowVirtual(int row)																		const;
-	bool				isColumnVirtual(int col)																	const;
-	bool				expandDataSet()																				const { return _expandDataSet; }
-	void				setExpandDataSet(bool expand)																{ _expandDataSet = expand; }
+	int							rowCount(bool includeVirtuals = true)														const;
+	int							columnCount(bool includeVirtuals = true)													const;
+	QVariant					headerData(	int section, Qt::Orientation orientation, int role = Qt::DisplayRole )			const;
+	void						setData(	int row, int col, const QVariant &value, int role);
+	Qt::ItemFlags				flags(int row, int column)																	const;
+	QModelIndex					index(int row, int column, const QModelIndex &parent = QModelIndex())						const;
+	QVariant					data(int row, int column, int role = Qt::DisplayRole)										const;
+	bool						filtered(int row, int column)																const;
+	bool						isRowVirtual(int row)																		const;
+	bool						isColumnVirtual(int col)																	const;
+	bool						expandDataSet()																				const { return _expandDataSet; }
+	void						setExpandDataSet(bool expand)																{ _expandDataSet = expand; }
 
-	void				setSourceModel(QAbstractItemModel* model);
-	QAbstractItemModel* sourceModel()																				const { return _sourceModel; }
+	void						setSourceModel(QAbstractItemModel* model);
+	QAbstractItemModel*			sourceModel()																				const { return _sourceModel; }
 
-	void				removeRows(int start, int count);
-	void				removeColumns(int start, int count);
-	void				insertRow(int row);
-	void				insertColumn(int col, bool computed, bool R);
-	void				pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const QStringList& colNames = {});
-	int					setColumnType(intset columnIndex, int columnType);
-	void				columnReverseValues(intset columnIndexes);
-	void				columnOrderByValues(intset columnIndexes);
-	void				copyColumns(int startCol, const std::vector<Json::Value>& copiedColumns);
-	Json::Value			serializedColumn(int col);
+	void						removeRows(int start, int count);
+	void						removeColumns(int start, int count);
+	void						insertRows(int row, int count = 1);
+	void						insertColumn(int col, bool computed, bool R);
+	void						pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const QStringList& colNames = {});
+	int							setColumnType(intset columnIndex, int columnType);
+	void						columnReverseValues(intset columnIndexes);
+	void						columnOrderByValues(intset columnIndexes);
+	void						copyColumns(int startCol, const std::vector<Json::Value>& copiedColumns);
+	Json::Value					serializedColumn(int col);
 
-	int					getRole(const std::string& roleName)														const;
+	int							getRole(const std::string& roleName)														const;
 
-	void				undo()				{ _undoStack->undo(); }
-	void				redo()				{ _undoStack->redo(); }
-	QString				undoText()			{ return _undoStack->undoText(); }
-	QString				redoText()			{ return _undoStack->redoText(); }
+	void						undo()				{ _undoStack->undo(); }
+	void						redo()				{ _undoStack->redo(); }
+	QString						undoText()			{ return _undoStack->undoText(); }
+	QString						redoText()			{ return _undoStack->redoText(); }
 
 signals:
-	void				undoChanged();
+	void						undoChanged();
 
 protected:
-	void				_setRolenames();
-	void				_expandIfNecessary(int row, int col);
+	void						_setRolenames();
+	void						_expandIfNecessary(int row, int col);
 
 	QAbstractItemModel*			_sourceModel			= nullptr;
 	bool						_expandDataSet			= false;

--- a/Desktop/data/expanddataproxymodel.h
+++ b/Desktop/data/expanddataproxymodel.h
@@ -31,6 +31,7 @@ public:
 	void						removeRows(int start, int count);
 	void						removeColumns(int start, int count);
 	void						insertRows(int row, int count = 1);
+	void						insertColumns(int col, int count = 1);
 	void						insertColumn(int col, bool computed, bool R);
 	void						pasteSpreadsheet(int row, int col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const QStringList& colNames = {}, const std::vector<boolvec> & selected = {});
 	int							setColumnType(intset columnIndex, int columnType);

--- a/Desktop/data/importers/readstat/readstatimportdataset.cpp
+++ b/Desktop/data/importers/readstat/readstatimportdataset.cpp
@@ -91,5 +91,5 @@ void ReadStatImportDataSet::setCurrentRow(int row)
 
 	_currentRow = row;
 
-	_progressCallback(int(float(_currentRow) / float(_expectedRows) * 100.0));
+	_progressCallback(int(float(_currentRow) / float(_expectedRows) * 50.0));
 }

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -25,8 +25,10 @@ void UndoStack::pushCommand(UndoModelCommand *command)
 void UndoStack::startMacro(const QString &text)
 {
 	if (_parentCommand)
-		Log::log() << "Macro started though last one is not finished!" << std::endl;
+		Log::log() << "Macro started though last one is not finished!" << std::endl; //I think this should be an assert...
+	
 	_parentCommand = new UndoModelCommand();
+	
 	if (!text.isEmpty())
 		_parentCommand->setText(text);
 }
@@ -35,11 +37,12 @@ void UndoStack::endMacro(UndoModelCommand *command)
 {
 	if (command)
 	{
-		if (_parentCommand)
+		if (_parentCommand && _parentCommand->text().isEmpty())
 			_parentCommand->setText(command->text());
 		else
 			push(command); // Case when macro was not started
 	}
+	
 	if (_parentCommand)
 		push(_parentCommand);
 

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -93,20 +93,20 @@ void InsertColumnCommand::redo()
 		dataSetTable->insertColumnSpecial(_col, _props);
 }
 
-InsertRowCommand::InsertRowCommand(QAbstractItemModel *model, int row)
-	: UndoModelCommand(model), _row{row}
+InsertRowsCommand::InsertRowsCommand(QAbstractItemModel *model, int row, int count)
+	: UndoModelCommand(model), _row{row}, _count{count}
 {
-	setText(QObject::tr("Insert row %1").arg(rowName(_row)));
+	setText(QObject::tr("Insert %2 rows at %1").arg(rowName(_row)).arg(_count));
 }
 
-void InsertRowCommand::undo()
+void InsertRowsCommand::undo()
 {
-	_model->removeRow(_row);
+	_model->removeRows(_row, _count);
 }
 
-void InsertRowCommand::redo()
+void InsertRowsCommand::redo()
 {
-	_model->insertRow(_row);
+	_model->insertRows(_row, _count);
 }
 
 RemoveColumnsCommand::RemoveColumnsCommand(QAbstractItemModel *model, int start, int count)

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -212,6 +212,11 @@ PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int 
 		setObsolete(true);
 		return;
 	}
+	
+	auto isSelected = [&](int R, int C)
+	{
+		return _selected.size() == 0 || _selected[C][R];
+	};
 
 	for (int c = 0; c < _newValues.size(); c++)
 	{
@@ -221,8 +226,8 @@ PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int 
 		_oldColNames.push_back(_model->headerData(_col + c, Qt::Horizontal).toString());
 		for (int r = 0; r < _newValues[c].size(); r++)
 		{
-			_oldValues[c].push_back(_model->data(_model->index(_row + r, _col + c),	int(DataSetPackage::specialRoles::value)).toString());
-			_oldLabels[c].push_back(_model->data(_model->index(_row + r, _col + c),	int(DataSetPackage::specialRoles::label)).toString());
+			_oldValues[c].push_back(!isSelected(r,c) ? "" : _model->data(_model->index(_row + r, _col + c),	int(DataSetPackage::specialRoles::value)).toString());
+			_oldLabels[c].push_back(!isSelected(r,c) ? "" : _model->data(_model->index(_row + r, _col + c),	int(DataSetPackage::specialRoles::label)).toString());
 		}
 	}
 }

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -5,7 +5,6 @@
 #include "filtermodel.h"
 #include "computedcolumnmodel.h"
 #include "utilities/qutils.h"
-#include "columnutils.h"
 
 UndoStack* UndoStack::_undoStack = nullptr;
 
@@ -35,20 +34,21 @@ void UndoStack::startMacro(const QString &text)
 
 void UndoStack::endMacro(UndoModelCommand *command)
 {
-	if (command)
+	if(!_parentCommand)
 	{
-		if (_parentCommand && _parentCommand->text().isEmpty())
-			_parentCommand->setText(command->text());
-		else
-			push(command); // Case when macro was not started
+		push(command);
+		return;
 	}
+	
+	if (command && _parentCommand->text().isEmpty())
+		_parentCommand->setText(command->text());
+	
 	
 	if (_parentCommand)
 		push(_parentCommand);
 
 	_parentCommand = nullptr;
 }
-
 
 SetDataCommand::SetDataCommand(QAbstractItemModel *model, int row, int col, const QVariant &value, int role)
 	: UndoModelCommand(model), _newValue{value}, _row{row}, _col{col}, _role{role}

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -192,8 +192,8 @@ intset ___sneakyConvertToIntSetFunction(int col, int colCount)
 	return out;
 }
 
-PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString> > & values, const std::vector<std::vector<QString> > & labels, const QStringList& colNames)
-	: UndoModelCommandMultipleColumns(model, ___sneakyConvertToIntSetFunction(col, values.size())), _row{row}, _col{col}, _newValues{values}, _newLabels{labels}, _newColNames{colNames}
+PasteSpreadsheetCommand::PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString> > & values, const std::vector<std::vector<QString> > & labels, const std::vector<boolvec> & selected, const QStringList& colNames)
+	: UndoModelCommandMultipleColumns(model, ___sneakyConvertToIntSetFunction(col, values.size())), _row{row}, _col{col}, _values{values}, _labels{labels}, _colNames{colNames}, _selected{selected}
 {
 	setText(QObject::tr("Paste values at row %1 column '%2'").arg(rowName(_row)).arg(columnName(_col)));
 }
@@ -203,7 +203,7 @@ void PasteSpreadsheetCommand::redo()
 	DataSetTableModel* dataSetTable = qobject_cast<DataSetTableModel*>(_model);
 
 	if (dataSetTable)
-		dataSetTable->pasteSpreadsheet(_row, _col, _newValues, _newLabels, {}, _newColNames);
+		dataSetTable->pasteSpreadsheet(_row, _col, _values, _labels, {}, _colNames, _selected);
 }
 
 

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -391,6 +391,21 @@ private:
 								_oldEmptyValues;
 };
 
+/*
+class ChangeSelectionCommand: public UndoModelCommand
+{
+public:
+	ChangeSelectionCommand(???);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	stringset					_newEmptyValues,
+								_oldEmptyValues;
+};
+*/
+
 class UndoStack : public QUndoStack
 {
 	Q_OBJECT
@@ -403,7 +418,7 @@ public:
 	void				startMacro(const QString& text = QString());
 	void				endMacro(UndoModelCommand* command = nullptr);
 	QUndoCommand*		parentCommand()		{ return _parentCommand; }
-
+	
 private:
 
 	UndoModelCommand*			_parentCommand			= nullptr;

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -292,16 +292,17 @@ private:
 	QMap<QString, QVariant>	_props;
 };
 
-class InsertRowCommand : public UndoModelCommand
+class InsertRowsCommand : public UndoModelCommand
 {
 public:
-	InsertRowCommand(QAbstractItemModel *model, int row);
+	InsertRowsCommand(QAbstractItemModel *model, int row, int count = 1);
 
 	void undo()					override;
 	void redo()					override;
 
 private:
-	int						_row = -1;
+	int						_row = -1,
+							_count;
 };
 
 class RemoveColumnsCommand : public UndoModelCommand

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -229,24 +229,26 @@ private:
 	std::map<int, Json::Value>	_serializedColumns;
 };
 
-class PasteSpreadsheetCommand : public UndoModelCommandMultipleColumns
+
+class PasteSpreadsheetCommand : public UndoModelCommand
 {
 public:
 	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& values, const std::vector<std::vector<QString>>& labels, const std::vector<boolvec> & selected, const QStringList & colNames);
 
-
+	void undo()					override;
 	void redo()					override;
 
 private:
-	std::vector<std::vector<QString>>	_values,
-										_labels;
+	std::vector<std::vector<QString>>	_newValues,
+										_newLabels,
+										_oldValues,
+										_oldLabels;
 	std::vector<boolvec>				_selected;
-	QStringList							_colNames;
+	QStringList							_newColNames,
+										_oldColNames;
 	int									_row = -1,
 										_col = -1;
 };
-
-
 
 class SetColumnTypeCommand : public UndoModelCommandMultipleColumns
 {

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -229,7 +229,7 @@ private:
 	std::map<int, Json::Value>	_serializedColumns;
 };
 
-
+class DataSetTableModel;
 class PasteSpreadsheetCommand : public UndoModelCommand
 {
 public:
@@ -239,15 +239,16 @@ public:
 	void redo()					override;
 
 private:
-	std::vector<std::vector<QString>>	_newValues,
-										_newLabels,
-										_oldValues,
-										_oldLabels;
-	std::vector<boolvec>				_selected;
-	QStringList							_newColNames,
-										_oldColNames;
-	int									_row = -1,
-										_col = -1;
+	DataSetTableModel					*	_dataSetTableModel;
+	std::vector<std::vector<QString>>		_newValues,
+											_newLabels,
+											_oldValues,
+											_oldLabels;
+	std::vector<boolvec>					_selected;
+	QStringList								_newColNames,
+											_oldColNames;
+	int										_row = -1,
+											_col = -1;
 };
 
 class SetColumnTypeCommand : public UndoModelCommandMultipleColumns
@@ -292,6 +293,19 @@ public:
 private:
 	int						_col		= -1;
 	QMap<QString, QVariant>	_props;
+};
+
+class InsertColumnsCommand : public UndoModelCommand
+{
+public:
+	InsertColumnsCommand(QAbstractItemModel *model, int col, int count = 1);
+
+	void undo()					override;
+	void redo()					override;
+
+private:
+	int						_col = -1,
+							_count;
 };
 
 class InsertRowsCommand : public UndoModelCommand

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -215,25 +215,6 @@ private:
 							_oldColType = -1;
 };
 
-class PasteSpreadsheetCommand : public UndoModelCommand
-{
-public:
-	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& values, const std::vector<std::vector<QString>>& labels, const QStringList & colNames);
-
-	void undo()					override;
-	void redo()					override;
-
-private:
-	std::vector<std::vector<QString>>	_newValues,
-										_newLabels,
-										_oldValues,
-										_oldLabels;
-	QStringList							_newColNames,
-										_oldColNames;
-	int									_row = -1,
-										_col = -1;
-};
-
 class UndoModelCommandMultipleColumns : public UndoModelCommand
 {
 public:
@@ -247,6 +228,24 @@ protected:
 private:
 	std::map<int, Json::Value>	_serializedColumns;
 };
+
+class PasteSpreadsheetCommand : public UndoModelCommandMultipleColumns
+{
+public:
+	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& values, const std::vector<std::vector<QString>>& labels, const QStringList & colNames);
+
+
+	void redo()					override;
+
+private:
+	std::vector<std::vector<QString>>	_newValues,
+										_newLabels;
+	QStringList							_newColNames;
+	int									_row = -1,
+										_col = -1;
+};
+
+
 
 class SetColumnTypeCommand : public UndoModelCommandMultipleColumns
 {

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -232,15 +232,16 @@ private:
 class PasteSpreadsheetCommand : public UndoModelCommandMultipleColumns
 {
 public:
-	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& values, const std::vector<std::vector<QString>>& labels, const QStringList & colNames);
+	PasteSpreadsheetCommand(QAbstractItemModel *model, int row, int col, const std::vector<std::vector<QString>>& values, const std::vector<std::vector<QString>>& labels, const std::vector<boolvec> & selected, const QStringList & colNames);
 
 
 	void redo()					override;
 
 private:
-	std::vector<std::vector<QString>>	_newValues,
-										_newLabels;
-	QStringList							_newColNames;
+	std::vector<std::vector<QString>>	_values,
+										_labels;
+	std::vector<boolvec>				_selected;
+	QStringList							_colNames;
 	int									_row = -1,
 										_col = -1;
 };

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -685,7 +685,7 @@ void MainWindow::loadQML()
 	connect(_ribbonModel, &RibbonModel::dataUndo,						DataSetView::lastInstancedDataSetView(),	&DataSetView::undo);
 	connect(_ribbonModel, &RibbonModel::dataRedo,						DataSetView::lastInstancedDataSetView(),	&DataSetView::redo);
 
-	connect(DataSetView::lastInstancedDataSetView(), &DataSetView::selectionStartChanged,	_columnModel,	&ColumnModel::changeSelectedColumn);
+	//connect(DataSetView::lastInstancedDataSetView(), &DataSetView::selectionStartChanged,	_columnModel,	&ColumnModel::changeSelectedColumn);
 
 	Log::log() << "QML Initialized!"  << std::endl;
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -670,20 +670,21 @@ void MainWindow::loadQML()
 
 	
 	//To make sure we connect to the "main datasetview":
-	connect(_preferences, &PreferencesModel::uiScaleChanged,			DataSetView::lastInstancedDataSetView(),	&DataSetView::viewportChanged, Qt::QueuedConnection);
-	connect(_preferences, &PreferencesModel::interfaceFontChanged,		DataSetView::lastInstancedDataSetView(),	&DataSetView::viewportChanged, Qt::QueuedConnection);
-	connect(_ribbonModel, &RibbonModel::dataInsertComputedColumnBefore,	DataSetView::lastInstancedDataSetView(),	&DataSetView::columnComputedInsertBefore);
-	connect(_ribbonModel, &RibbonModel::dataInsertComputedColumnAfter,	DataSetView::lastInstancedDataSetView(),	&DataSetView::columnComputedInsertAfter);
-	connect(_ribbonModel, &RibbonModel::dataInsertColumnBefore,			DataSetView::lastInstancedDataSetView(),	&DataSetView::columnInsertBefore);
-	connect(_ribbonModel, &RibbonModel::dataInsertColumnAfter,			DataSetView::lastInstancedDataSetView(),	&DataSetView::columnInsertAfter);
-	connect(_ribbonModel, &RibbonModel::finishCurrentEdit,				DataSetView::lastInstancedDataSetView(),	&DataSetView::commitLastEdit);
-	connect(_ribbonModel, &RibbonModel::dataInsertRowBefore,			DataSetView::lastInstancedDataSetView(),	&DataSetView::rowInsertBefore);
-	connect(_ribbonModel, &RibbonModel::dataInsertRowAfter,				DataSetView::lastInstancedDataSetView(),	&DataSetView::rowInsertAfter);
-	connect(_ribbonModel, &RibbonModel::dataRemoveColumn,				DataSetView::lastInstancedDataSetView(),	&DataSetView::columnsDeleteSelected);
-	connect(_ribbonModel, &RibbonModel::dataRemoveRow,					DataSetView::lastInstancedDataSetView(),	&DataSetView::rowsDeleteSelected);
-	connect(_ribbonModel, &RibbonModel::cellsClear,						DataSetView::lastInstancedDataSetView(),	&DataSetView::cellsClear);
-	connect(_ribbonModel, &RibbonModel::dataUndo,						DataSetView::lastInstancedDataSetView(),	&DataSetView::undo);
-	connect(_ribbonModel, &RibbonModel::dataRedo,						DataSetView::lastInstancedDataSetView(),	&DataSetView::redo);
+	connect(_preferences, &PreferencesModel::uiScaleChanged,			DataSetView::mainDataViewer(),	&DataSetView::viewportChanged, Qt::QueuedConnection);
+	connect(_preferences, &PreferencesModel::interfaceFontChanged,		DataSetView::mainDataViewer(),	&DataSetView::viewportChanged, Qt::QueuedConnection);
+	connect(_ribbonModel, &RibbonModel::dataInsertComputedColumnBefore,	DataSetView::mainDataViewer(),	&DataSetView::columnComputedInsertBefore);
+	connect(_ribbonModel, &RibbonModel::dataInsertComputedColumnAfter,	DataSetView::mainDataViewer(),	&DataSetView::columnComputedInsertAfter);
+	connect(_ribbonModel, &RibbonModel::dataInsertColumnBefore,			DataSetView::mainDataViewer(),	&DataSetView::columnInsertBefore);
+	connect(_ribbonModel, &RibbonModel::dataInsertColumnAfter,			DataSetView::mainDataViewer(),	&DataSetView::columnInsertAfter);
+	connect(_ribbonModel, &RibbonModel::finishCurrentEdit,				DataSetView::mainDataViewer(),	&DataSetView::commitLastEdit);
+	connect(_ribbonModel, &RibbonModel::dataInsertRowBefore,			DataSetView::mainDataViewer(),	&DataSetView::rowInsertBefore);
+	connect(_ribbonModel, &RibbonModel::dataInsertRowAfter,				DataSetView::mainDataViewer(),	&DataSetView::rowInsertAfter);
+	connect(_ribbonModel, &RibbonModel::dataRemoveColumn,				DataSetView::mainDataViewer(),	&DataSetView::columnsDeleteSelected);
+	connect(_ribbonModel, &RibbonModel::dataRemoveRow,					DataSetView::mainDataViewer(),	&DataSetView::rowsDeleteSelected);
+	connect(_ribbonModel, &RibbonModel::cellsClear,						DataSetView::mainDataViewer(),	&DataSetView::cellsClear);
+	connect(_ribbonModel, &RibbonModel::dataUndo,						DataSetView::mainDataViewer(),	&DataSetView::undo);
+	connect(_ribbonModel, &RibbonModel::dataRedo,						DataSetView::mainDataViewer(),	&DataSetView::redo);
+	
 
 	//connect(DataSetView::lastInstancedDataSetView(), &DataSetView::selectionStartChanged,	_columnModel,	&ColumnModel::changeSelectedColumn);
 

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -168,7 +168,7 @@ void RibbonModel::addSpecialRibbonButtonsEarly()
 	connect(this, &RibbonModel::synchronisationChanged, _synchroniseOffButton,	[=](bool synching){ _synchroniseOffButton->setEnabled(synching); });
 
 	{
-		DataSetView * view = DataSetView::lastInstancedDataSetView();
+		DataSetView * view = DataSetView::mainDataViewer();
 
 		auto setUnAndRedoButtonLambda = [&,view]()
 		{

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1227,6 +1227,8 @@ void DataSetView::paste(QPoint where)
 				labs[c].erase(labs[c].begin());
 			}
 			
+			use _lastJaspCopySelect !
+			
 			_model->pasteSpreadsheet(isColumnHeader(where) ? 0 : where.y(), where.x(), vals, labs, colNames);
 		}	
 	}

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1328,7 +1328,8 @@ void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPresse
 													_model->index(std::max(maxNewSelection.y(), maxOldSelection.y()), std::max(maxNewSelection.x(), maxOldSelection.x())));
 	}
 	
-	if(shiftPressed || ctrlCmdPressed)
+	//Reset edit if we are selecting things with shift or ctrl/cmd, or when the last clicked place is not the same as the editthing
+	if(shiftPressed || ctrlCmdPressed || row != _prevEditRow || col != _prevEditCol)
 		clearEdit();
 
 	
@@ -1656,7 +1657,7 @@ void DataSetView::edit(int row, int col)
 	if (row == -1 || col == -1)
 		return;
 
-	//_selectionModel->setCurrentIndex(_model->index(row, col), QItemSelectionModel::Current);
+	_selectionModel->setCurrentIndex(_model->index(row, col), QItemSelectionModel::Current);
 
 	clearEdit();
 	

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1268,8 +1268,8 @@ void DataSetView::paste(QPoint where)
 
 void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPressed)
 {
-	bool	wholeRow	= row < 0,
-			wholeColumn	= col < 0;
+	bool	wholeRow	= col < 0,
+			wholeColumn	= row < 0;
 	
 	if(wholeRow && wholeColumn)
 	{
@@ -1284,18 +1284,22 @@ void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPresse
 				? QItemSelection(_model->index(0,	col),	_model->index(_model->rowCount(),	col)					)
 				: QItemSelection(_model->index(row,	col),	_model->index(row,					col)					);
 	
-	QItemSelectionModel::SelectionFlags		flags  = QItemSelectionModel::Current; //Current means we will update the stored selection, so we commit here
-	if(!shiftPressed && !ctrlCmdPressed)	flags |= QItemSelectionModel::ClearAndSelect;
-	else if(ctrlCmdPressed)					flags |= QItemSelectionModel::Toggle;
-	else if(shiftPressed)					flags |= QItemSelectionModel::Select;
-		
+	QItemSelectionModel::SelectionFlags		flags  = QItemSelectionModel::Current | QItemSelectionModel::ClearAndSelect; //Current means we will update the stored selection, so we commit here
 	
-	if(shiftPressed)
+	if(ctrlCmdPressed)
+	{
+		QItemSelection old = _selectionModel->selection();
+		old.merge(selection, QItemSelectionModel::Toggle);
+		selection = old;
+	}
+	else if(shiftPressed)
 	{
 		QPoint	minNewSelection = minQModelIndex(selection.indexes()),
 				maxNewSelection = maxQModelIndex(selection.indexes()),
 				minOldSelection = selectionMin(),
 				maxOldSelection = selectionMax();
+		
+		if(minOldSelection != QPoint{-1, -1} && minNewSelection != QPoint{-1, -1})
 				selection		= QItemSelection(	_model->index(std::min(minNewSelection.y(), minOldSelection.y()), std::min(minNewSelection.x(), minOldSelection.x())), 
 													_model->index(std::max(maxNewSelection.y(), maxOldSelection.y()), std::max(maxNewSelection.x(), maxOldSelection.x())));
 	}

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1098,9 +1098,10 @@ void DataSetView::_copy(QPoint where, bool clear)
 
 	std::vector<QStringList>	rows;
 
-	QPoint	minIdx = selectionMin(), 
-			maxIdx = selectionMax();
-	
+	QPoint	minIdx		= selectionMin(), 
+			maxIdx		= selectionMax();
+	bool	allSelected = minIdx.x() <= 0 && minIdx.y() <= 0 && maxIdx.x() + 1 >= _model->columnCount(false) && maxIdx.y() + 1 >= _model->rowCount(false);
+		
 	for(size_t r=minIdx.y(); r<=maxIdx.y(); r++)
 	{
 		rows.push_back({});
@@ -1174,24 +1175,30 @@ void DataSetView::_copy(QPoint where, bool clear)
 
 	if(clear)
 	{
-		QPoint topLeft = selectionMin();
-
+		/*if(allSelected)
+		{
+			_model->pasteSpreadsheet(0, 0, {{""}}, {{""}}, {""}); 
+			
+			_model->removeColumns(	1 + minIdx.x(), (maxIdx.x() - minIdx.x()));
+			_model->removeRows(		1 + minIdx.y(), rowsSelected - 1);
+		}
+		else */
 		if(isColumnHeader(where))
 			_model->removeColumns(minIdx.x(), 1 + (maxIdx.x() - minIdx.x()));
 		else if(isRowHeader(where))
-			_model->removeRows(topLeft.y(), rowsSelected);
+			_model->removeRows(minIdx.y(), rowsSelected);
 		else
 		{
-			Log::log() << "DataSetView about to clear at row: " << topLeft.y() << " and col: " << topLeft.x() << std::endl;
+			Log::log() << "DataSetView about to clear at row: " << minIdx.y() << " and col: " << minIdx.x() << std::endl;
 			auto emptyCells = 	std::vector<std::vector<QString>>(
-											 (maxIdx.x() - minIdx.x()) + 1,
+											 1+(maxIdx.x() - minIdx.x()),
 											 std::vector<QString>(
 												 rowsSelected,
 												 ""
 											 )
 										 );
 			
-			_model->pasteSpreadsheet(topLeft.y(), topLeft.x(), emptyCells, emptyCells);
+			_model->pasteSpreadsheet(minIdx.y(), minIdx.x(), emptyCells, emptyCells, {}, _lastJaspCopySelect);
 		}
 	}
 }

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1212,12 +1212,13 @@ void DataSetView::paste(QPoint where)
 	else if(_lastJaspCopyValues.size())
 	{
 		if (!isColumnHeader(where))
-			_model->pasteSpreadsheet(where.y(), where.x(), _lastJaspCopyValues, _lastJaspCopyLabels);
+			_model->pasteSpreadsheet(where.y(), where.x(), _lastJaspCopyValues, _lastJaspCopyLabels, {}, _lastJaspCopySelect);
 		else
 		{
 			QStringList	colNames;
 			auto		vals = _lastJaspCopyValues,
 						labs = _lastJaspCopyLabels;
+			auto		sels = _lastJaspCopySelect;
 			
 			for(size_t c=0; c<vals.size(); c++)
 			{
@@ -1225,11 +1226,10 @@ void DataSetView::paste(QPoint where)
 				
 				vals[c].erase(vals[c].begin());
 				labs[c].erase(labs[c].begin());
+				sels[c].erase(sels[c].begin());
 			}
 			
-			use _lastJaspCopySelect !
-			
-			_model->pasteSpreadsheet(isColumnHeader(where) ? 0 : where.y(), where.x(), vals, labs, colNames);
+			_model->pasteSpreadsheet(isColumnHeader(where) ? 0 : where.y(), where.x(), vals, labs, colNames, sels);
 		}	
 	}
 	else
@@ -1377,7 +1377,8 @@ void DataSetView::columnIndexSelectedApply(int columnIndex, std::function<void(i
 	
 	intset ints;
 	for	(columnIndex	= columnA; columnIndex <= columnB; columnIndex++)
-		ints.insert(columnIndex);
+		if(_selectionModel->columnIntersectsSelection(columnIndex))
+			ints.insert(columnIndex);
 	
 	applyThis(ints);
 }

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1350,6 +1350,11 @@ void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPresse
 	_selectionModel->select(selection, flags);
 }
 
+void DataSetView::selectionClear()
+{
+	_selectionModel->clear();
+}
+
 void DataSetView::selectHover(int row, int col)
 {
 	pollSelectScroll(row, col);

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1282,7 +1282,6 @@ void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPresse
 
 	QModelIndex		tl	= _model->index(row,					col),
 					br	= _model->index(row,					col);
-	
 
 	if(wholeRow)	br	= _model->index(row,						_model->columnCount(false)-1);
 	if(wholeCol)	br	= _model->index(_model->rowCount(false)-1,	col);
@@ -1294,7 +1293,18 @@ void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPresse
 	if(ctrlCmdPressed)
 	{
 		QItemSelection old = _selectionModel->selection();
-		old.merge(selection, QItemSelectionModel::Toggle);
+		if(!wholeRow && !wholeCol)	old.merge(selection, QItemSelectionModel::Toggle);
+		else if(wholeRow) //If a whole row is "toggled" we first make it all selected if it isnt yet fully, otherwise we deselect
+		{
+			if(_selectionModel->isRowSelected(row))		old.merge(selection, QItemSelectionModel::Deselect);
+			else										old.merge(selection, QItemSelectionModel::Select);
+		}
+		else if(wholeCol) //We do the same for the column
+		{
+			if(_selectionModel->isColumnSelected(col))		old.merge(selection, QItemSelectionModel::Deselect);
+			else											old.merge(selection, QItemSelectionModel::Select);
+		}
+			
 		selection = old;
 	}
 	else if(shiftPressed)

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1276,12 +1276,15 @@ void DataSetView::paste(QPoint where)
 
 void DataSetView::selectAll()
 {
+	JASPTIMER_SCOPE(DataSetView::selectAll);
 	clearEdit();
-	_selectionModel->select(QItemSelection(_model->index(0, 0), _model->index(_model->rowCount(false)-1, _model->columnCount(false)-1)), QItemSelectionModel::Select);
+	_selectionModel->select(QItemSelection(_model->index(0, 0), _model->index(_model->rowCount(false)-1, _model->columnCount(false)-1)), QItemSelectionModel::Current | QItemSelectionModel::ClearAndSelect);
 }
 
 void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPressed)
 {
+	JASPTIMER_SCOPE(DataSetView::select);
+	
 	bool	wholeRow	= col < 0,
 			wholeCol	= row < 0;
 	
@@ -1323,8 +1326,8 @@ void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPresse
 	}
 	else if(shiftPressed)
 	{
-		QPoint	minNewSelection = minQModelIndex(selection.indexes()),
-				maxNewSelection = maxQModelIndex(selection.indexes()),
+		QPoint	minNewSelection = minQModelIndex(selection),
+				maxNewSelection = maxQModelIndex(selection),
 				minOldSelection = selectionMin(),
 				maxOldSelection = selectionMax();
 		
@@ -1338,7 +1341,7 @@ void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPresse
 		clearEdit();
 
 	
-/* Even if you reenable this we prob dont want this in release par accident
+/* //Even if you reenable this we prob dont want this in release par accident
 #ifdef JASP_DEBUG
 	{	
 		QStringList l;
@@ -1358,22 +1361,26 @@ void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPresse
 
 void DataSetView::selectionClear()
 {
+	JASPTIMER_SCOPE(DataSetView::selectClear);
 	_selectionModel->clear();
 }
 
 void DataSetView::selectHover(int row, int col)
 {
+	JASPTIMER_SCOPE(DataSetView::selectHover);
 	pollSelectScroll(row, col);
 }
 
 QPoint DataSetView::selectionMin() const	
 { 
-	return minQModelIndex(_selectionModel->selectedIndexes());	
+	JASPTIMER_SCOPE(DataSetView::selectionMin);
+	return minQModelIndex(_selectionModel->selection());	
 }
 
 QPoint DataSetView::selectionMax() const	
 { 
-	return maxQModelIndex(_selectionModel->selectedIndexes());
+	JASPTIMER_SCOPE(DataSetView::selectionMax);
+	return maxQModelIndex(_selectionModel->selection());
 }
 
 void DataSetView::columnIndexSelectedApply(int columnIndex, std::function<void(intset columnIndexes)> applyThis)

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1405,18 +1405,16 @@ QPoint DataSetView::selectionMax() const
 
 void DataSetView::columnIndexSelectedApply(int columnIndex, std::function<void(intset columnIndexes)> applyThis)
 {
-	int columnA	= selectionMin().x(),
-		columnB	= selectionMax().x();
-
-	if(columnA > columnB)
-		std::swap(columnA, columnB);
+	int		columnA			= selectionMin().x(),
+			columnB			= selectionMax().x();
+	bool	outSelection	= columnA == -1 || columnB == -1 || !(columnIndex >= columnA && columnIndex <= columnB);
 	
-	if(columnA == -1 || columnB == -1 || !(columnIndex >= columnA && columnIndex <= columnB))
+	if(outSelection)
 		columnA = columnB = columnIndex;
 	
 	intset ints;
 	for	(columnIndex	= columnA; columnIndex <= columnB; columnIndex++)
-		if(_selectionModel->columnIntersectsSelection(columnIndex))
+		if(outSelection || _selectionModel->columnIntersectsSelection(columnIndex))
 			ints.insert(columnIndex);
 	
 	applyThis(ints);

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1139,6 +1139,10 @@ void DataSetView::_copy(QPoint where, bool clear)
 			}
 	}
 	
+	_lastJaspCopyValues.clear();
+	_lastJaspCopyLabels.clear();
+	_lastJaspCopySelect.clear();
+	
 	//Collect values and labels shown for internal lossless copying, will obviously not work for copying to external jasp.
 	for(int c=minIdx.x(); c<=maxIdx.x(); c++)
 		if(_selectionModel->columnIntersectsSelection(c))
@@ -1208,11 +1212,11 @@ void DataSetView::paste(QPoint where)
 		_lastJaspCopySelect	.clear();
 	}
 
-	if (isColumnHeader(where) && where.x() >= 0 && _copiedColumns.size())
+	if (isColumnHeader(where) && _copiedColumns.size() && where.x() >= 0) //internal column copy:
 		_model->copyColumns(where.x(), _copiedColumns);
-	else if(_lastJaspCopyValues.size())
+	else if(_lastJaspCopyValues.size()) //internal data copy:
 	{
-		if (!isColumnHeader(where))
+		if(!isColumnHeader(where))
 			_model->pasteSpreadsheet(where.y(), where.x(), _lastJaspCopyValues, _lastJaspCopyLabels, {}, _lastJaspCopySelect);
 		else
 		{
@@ -1230,10 +1234,11 @@ void DataSetView::paste(QPoint where)
 				sels[c].erase(sels[c].begin());
 			}
 			
-			_model->pasteSpreadsheet(isColumnHeader(where) ? 0 : where.y(), where.x(), vals, labs, colNames, sels);
-		}	
+			_model->pasteSpreadsheet(0, where.x(), vals, labs, colNames, sels);
+		}
+			
 	}
-	else
+	else //its external data:
 	{
 		std::vector<qstringvec> newData;
 		QStringList				colNames,

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1457,7 +1457,26 @@ void DataSetView::columnsDelete(int col)
 	if(columnA == -1 || columnA > col || columnB < col)
 		_model->removeColumns(col, 1);
 	else
-		_model->removeColumns(columnA, 1 + (columnB - columnA));
+	{
+		//Go through all columns and make separate removals for each contiguously selected set of columns	
+		std::vector<std::pair<int, int>> removals;
+		int lastStart = columnA,
+			c;
+		for(c=columnA; c<=columnB; c++)
+			if(!_selectionModel->columnIntersectsSelection(c))
+			{
+				removals.push_back(std::make_pair(lastStart, (c - lastStart))); //Dont do +1 because c is not contiguous with lastStart!
+				lastStart = -1;
+			}
+			else if(lastStart == -1)
+				lastStart = c;
+				
+		
+		removals.push_back(std::make_pair(lastStart, 1 + (c - lastStart)));
+		std::reverse(removals.begin(), removals.end());
+		for(auto & removal : removals)
+			_model->removeColumns(removal.first, removal.second);
+	}
 
 	_selectionModel->clear();
 }
@@ -1502,7 +1521,26 @@ void DataSetView::rowsDelete(int row)
 	if(rowA == -1 || rowA > row || rowB < row)
 		_model->removeRows(row, 1);
 	else
-		_model->removeRows(rowA, 1 + (rowB -  rowA));
+	{
+		//Go through all rows and make separate removals for each contiguously selected set of rows	
+		std::vector<std::pair<int, int>> removals;
+		int lastStart = rowA,
+			r;
+		for(r=rowA; r<=rowB; r++)
+			if(!_selectionModel->rowIntersectsSelection(r))
+			{
+				removals.push_back(std::make_pair(lastStart, (r - lastStart))); //Dont do +1 because r is not contiguous with lastStart!
+				lastStart = -1;
+			}
+			else if(lastStart == -1)
+				lastStart = r;
+				
+		
+		removals.push_back(std::make_pair(lastStart, 1 + (r - lastStart)));
+		std::reverse(removals.begin(), removals.end());
+		for(auto & removal : removals)
+			_model->removeRows(removal.first, removal.second);
+	}
 
 	_selectionModel->clear();
 }

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -15,7 +15,7 @@
 #include <QClipboard>
 #include "utils.h"
 
-DataSetView * DataSetView::_lastInstancedDataSetView = nullptr;
+DataSetView * DataSetView::_mainDataSetView = nullptr;
 
 
 DataSetView::DataSetView(QQuickItem *parent)
@@ -58,7 +58,8 @@ DataSetView::DataSetView(QQuickItem *parent)
 	
 	setZ(10);
 
-	_lastInstancedDataSetView = this;
+	if(!_mainDataSetView) //Lets just make sure we always create this one first!
+		_mainDataSetView = this;
 }
 
 void DataSetView::setModel(QAbstractItemModel * model)
@@ -1650,7 +1651,7 @@ void DataSetView::edit(int row, int col)
 	if (row == -1 || col == -1)
 		return;
 
-	_selectionModel->setCurrentIndex(_model->index(row, col), QItemSelectionModel::Current);
+	//_selectionModel->setCurrentIndex(_model->index(row, col), QItemSelectionModel::Current);
 
 	clearEdit();
 	

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1027,11 +1027,6 @@ bool DataSetView::isSelected(int row, int col)
 	return _selectionModel->isSelected(_model->index(row, col));
 }
 
-void DataSetView::selectAll()
-{
-	_selectionModel->select(QItemSelection(_model->index(0, 0), _model->index(_model->rowCount(false), _model->columnCount(false))), QItemSelectionModel::Select);
-}
-
 
 bool DataSetView::relaxForSelectScroll()
 {
@@ -1266,6 +1261,12 @@ void DataSetView::paste(QPoint where)
 	}
 }
 
+void DataSetView::selectAll()
+{
+	clearEdit();
+	_selectionModel->select(QItemSelection(_model->index(0, 0), _model->index(_model->rowCount(false)-1, _model->columnCount(false)-1)), QItemSelectionModel::Select);
+}
+
 void DataSetView::select(int row, int col, bool shiftPressed, bool ctrlCmdPressed)
 {
 	bool	wholeRow	= col < 0,
@@ -1461,7 +1462,7 @@ void DataSetView::rowInsertBefore(int row)
 	if(row == -1)
 		row = selectionMin().y() != -1 ? selectionMin().y() : 0;
 
-	_model->insertRow(row);
+	_model->insertRows(row);
 }
 
 void DataSetView::rowInsertAfter(int row)

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -1190,9 +1190,11 @@ void DataSetView::_copy(QPoint where, bool clear)
 		if(allSelected)
 		{
 			UndoStack::singleton()->startMacro(tr("Cutting all data"));
-			_model->removeColumns(	1 + minIdx.x(), (maxIdx.x() - minIdx.x()));
-			_model->removeRows(		1 + minIdx.y(), rowsSelected - 1);
-			UndoStack::singleton()->endMacro(new PasteSpreadsheetCommand(_model->sourceModel(), 0, 0, {{""}}, {{""}}, {}, {}));
+			_model->removeColumns(	minIdx.x(), 1+(maxIdx.x() - minIdx.x()));
+			_model->removeRows(		minIdx.y(), rowsSelected);
+			_model->insertColumns(0);
+			_model->insertRows(0);
+			UndoStack::singleton()->endMacro();//new PasteSpreadsheetCommand(_model->sourceModel(), 0, 0, {{""}}, {{""}}, {}, {}));
 		}
 		else if(isColumnHeader(where))
 			_model->removeColumns(minIdx.x(), 1 + (maxIdx.x() - minIdx.x()));

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -58,8 +58,6 @@ class DataSetView : public QQuickItem
 	Q_PROPERTY( bool					expandDataSet			READ expandDataSet			WRITE setExpandDataSet			NOTIFY expandDataSetChanged			)
 	Q_PROPERTY( QQuickItem			*	tableViewItem			READ tableViewItem			WRITE setTableViewItem												)
 	Q_PROPERTY( QItemSelectionModel *	selection				READ selectionModel											NOTIFY selectionModelChanged		)
-	Q_PROPERTY(	QPoint					selectionStart			READ selectionStart			WRITE setSelectionStart			NOTIFY selectionStartChanged		)
-	Q_PROPERTY(	QPoint					selectionEnd			READ selectionEnd			WRITE setSelectionEnd			NOTIFY selectionEndChanged			)
 	Q_PROPERTY(	QPoint					selectionMin			READ selectionMin											NOTIFY selectionMinChanged			)
 	Q_PROPERTY(	QPoint					selectionMax			READ selectionMax											NOTIFY selectionMaxChanged			)
 	Q_PROPERTY(	bool					editing					READ editing				WRITE setEditing				NOTIFY editingChanged				)
@@ -96,8 +94,6 @@ public:
 
 	bool					cacheItems()						const	{ return _cacheItems;				}
 	bool					expandDataSet()						const	{ return _model ? _model->expandDataSet() : false;			}
-	QPoint					selectionStart()					const	{ return _selectionStart;			}
-	QPoint					selectionEnd()						const	{ return _selectionEnd;				}
 	QPoint					selectionMin()						const;
 	QPoint					selectionMax()						const;
 	bool					editing()							const	{ return _editing;					}
@@ -149,6 +145,7 @@ signals:
 	void		editDelegateChanged(QQmlComponent * editDelegate);
 
 	void		itemSizeChanged();
+	void		selectionChanged();
 
 	void		headerHeightChanged();
 	void		rowNumberWidthChanged();
@@ -156,8 +153,6 @@ signals:
 	void		cacheItemsChanged();
 	void		expandDataSetChanged();
 	
-	void		selectionStartChanged(	QPoint selectionStart);
-	void		selectionEndChanged(	QPoint selectionEnd);
 	void		selectionMinChanged();
 	void		selectionMaxChanged();
 	
@@ -186,9 +181,7 @@ public slots:
 	void		modelWasReset();
 	void		setExtraColumnX();
 	
-	void		setSelectionStart(	QPoint selectionStart);
-	void		setSelectionEnd(	QPoint selectionEnd	);
-	bool		isSelected(int row, int col);
+	bool		isSelected(			int row, int col);
 	void		pollSelectScroll(	int row, int column);
 	void		setEditing(bool shiftSelectActive);
 	bool		relaxForSelectScroll();
@@ -202,7 +195,8 @@ public slots:
 	void		copy(	QPoint where = QPoint(-1,-1)) { _copy(where, false); }
 	void		paste(	QPoint where = QPoint(-1,-1));
 
-	void		columnSelect(				int col,		bool shiftPressed = false, bool rightClicked = false);
+	void		select(						int row, int column,	bool shiftPressed,			bool ctrlCmdPressed);
+	void		selectHover(				int row, int column);
 	QString		columnInsertBefore(			int col = -1,	bool computed = false, bool R = false);
 	QString		columnInsertAfter(			int col = -1,	bool computed = false, bool R = false);
 	void		columnComputedInsertAfter(	int col = -1,	bool R=true);
@@ -211,7 +205,6 @@ public slots:
 	void		columnsDelete(				int col);
 	void		columnReverseValues(		int col = -1);
 	void		columnOrderByValues(		int col = -1);
-	void		rowSelect(					int row,		bool shiftPressed = false, bool rightClicked = false);
 	void		rowInsertBefore(			int row = -1);
 	void		rowInsertAfter(				int row = -1);
 	void		rowsDelete(					int row);
@@ -230,6 +223,7 @@ public slots:
 	int			rowCount()								{ return _model->rowCount();	}
 	int			columnCount()							{ return _model->columnCount(); }
 
+	
 	void		selectAll();
 	void		undo()									{ _model->undo(); }
 	void		redo()									{ _model->redo(); }
@@ -338,8 +332,6 @@ protected:
 															_prevEditCol			= -1;
 	size_t													_linesActualSize		= 0;
 	long													_selectScrollMs			= 0;
-	QPoint													_selectionStart			= QPoint(-1, -1),
-															_selectionEnd			= QPoint(-1, -1);
 	std::vector<Json::Value>								_copiedColumns;
 	QString													_lastJaspCopyIntoClipboard;
 	std::vector<qstringvec>									_lastJaspCopyValues,

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -196,6 +196,7 @@ public slots:
 	void		paste(	QPoint where = QPoint(-1,-1));
 
 	void		select(						int row, int column,	bool shiftPressed,			bool ctrlCmdPressed);
+	void		selectionClear();
 	void		selectHover(				int row, int column);
 	QString		columnInsertBefore(			int col = -1,	bool computed = false, bool R = false);
 	QString		columnInsertAfter(			int col = -1,	bool computed = false, bool R = false);

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -336,6 +336,7 @@ protected:
 	QString													_lastJaspCopyIntoClipboard;
 	std::vector<qstringvec>									_lastJaspCopyValues,
 															_lastJaspCopyLabels;
+	std::vector<boolvec>									_lastJaspCopySelect;
 };
 
 

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -67,7 +67,7 @@ public:
 
 							DataSetView(QQuickItem *parent = nullptr);
 
-	static DataSetView *	lastInstancedDataSetView()					{ return _lastInstancedDataSetView; }
+							static DataSetView *	mainDataViewer()								{ return _mainDataSetView;}
 
 	void					setModel(QAbstractItemModel * model);
 	
@@ -304,7 +304,8 @@ protected:
 	QSGFlatColorMaterial									_material;
 	std::map<size_t, std::map<size_t, unsigned char>>		_storedLineFlags;
 	std::map<size_t, std::map<size_t, QString>>				_storedDisplayText;
-	static DataSetView									*	_lastInstancedDataSetView;
+	static DataSetView									*	_lastInstancedDataSetView,
+														*	_mainDataSetView;
 	bool													_cacheItems				= false,
 															_recalculateCellSizes	= false,
 															_ignoreViewpoint		= true,

--- a/QMLComponents/components/JASP/Controls/RectangularButton.qml
+++ b/QMLComponents/components/JASP/Controls/RectangularButton.qml
@@ -97,22 +97,23 @@ Item
 
 		Image
 		{
-			id: buttonIcon
-			x:	!filterButtonRoot.showIconAndText ?
-					(parent.width / 2) - (width / 2) :
-					filterButtonRoot.iconLeft ?
-						filterButtonRoot.buttonWidthPadding :
-						parent.width - (width + filterButtonRoot.buttonWidthPadding)
+			id:					buttonIcon
+			x:					!filterButtonRoot.showIconAndText 
+								?	(parent.width / 2) - (width / 2) 
+								:	filterButtonRoot.iconLeft 
+								?	filterButtonRoot.buttonWidthPadding 
+								:	parent.width - (width + filterButtonRoot.buttonWidthPadding)
+			y:					(parent.height / 2) - (height / 2)
 
-			y:			(parent.height / 2) - (height / 2)
+			width:				Math.min(filterButtonRoot.width - (2 * buttonWidthPadding), height)
+			height:				filterButtonRoot.height - (2 * buttonPadding)
 
-			width:		Math.min(filterButtonRoot.width - (2 * buttonWidthPadding), height)
-			height:		filterButtonRoot.height - (2 * buttonPadding)
-
-			visible:	filterButtonRoot.iconSource != "" || filterButtonRoot.showIconAndText
-			source:		filterButtonRoot.iconSource
-			mipmap:		true
-			smooth:		true
+			visible:			filterButtonRoot.iconSource != "" || filterButtonRoot.showIconAndText
+			source:				filterButtonRoot.iconSource
+			sourceSize.width:	width  * 2
+			sourceSize.height:	height * 2
+			mipmap:				true
+			smooth:				true
 		}
 
 		Text

--- a/QMLComponents/utilities/qutils.cpp
+++ b/QMLComponents/utilities/qutils.cpp
@@ -301,8 +301,8 @@ QPoint minQModelIndex(const QItemSelection &list)
 	
 	for(const QItemSelectionRange & mi : list)
 	{
-		r = std::min(r, mi.top());
-		c = std::min(c, mi.left());
+		r = std::min(r, std::min(mi.bottom(), mi.top()));
+		c = std::min(c, std::min(mi.right() , mi.left()));
 	}
 	
 	return QPoint(c, r);
@@ -318,8 +318,8 @@ QPoint maxQModelIndex(const QItemSelection &list)
 	
 	for(const QItemSelectionRange & mi : list)
 	{
-		r = std::max(r, mi.bottom());
-		c = std::max(c, mi.right());
+		r = std::max(r, std::max(mi.bottom(), mi.top()));
+		c = std::max(c, std::max(mi.right() , mi.left()));
 	}
 	
 	return QPoint(c, r);

--- a/QMLComponents/utilities/qutils.cpp
+++ b/QMLComponents/utilities/qutils.cpp
@@ -291,7 +291,7 @@ std::set<string> fql(const QStringList & from)
 	return std::set<std::string>(vec.begin(), vec.end()); 
 }
 
-QPoint minQModelIndex(const QModelIndexList &list)
+QPoint minQModelIndex(const QItemSelection &list)
 {
 	if(list.size() == 0)
 		return QPoint(-1, -1);
@@ -299,16 +299,16 @@ QPoint minQModelIndex(const QModelIndexList &list)
 	int r = std::numeric_limits<int>::max(),
 		c = std::numeric_limits<int>::max();
 	
-	for(const QModelIndex & mi : list)
+	for(const QItemSelectionRange & mi : list)
 	{
-		r = std::min(r, mi.row());
-		c = std::min(c, mi.column());
+		r = std::min(r, mi.left());
+		c = std::min(c, mi.top());
 	}
 	
 	return QPoint(c, r);
 }
 
-QPoint maxQModelIndex(const QModelIndexList &list)
+QPoint maxQModelIndex(const QItemSelection &list)
 {
 	if(list.size() == 0)
 		return QPoint(-1, -1);
@@ -316,10 +316,10 @@ QPoint maxQModelIndex(const QModelIndexList &list)
 	int r = std::numeric_limits<int>::min(),
 		c = std::numeric_limits<int>::min();
 	
-	for(const QModelIndex & mi : list)
+	for(const QItemSelectionRange & mi : list)
 	{
-		r = std::max(r, mi.row());
-		c = std::max(c, mi.column());
+		r = std::max(r, mi.right());
+		c = std::max(c, mi.bottom());
 	}
 	
 	return QPoint(c, r);

--- a/QMLComponents/utilities/qutils.cpp
+++ b/QMLComponents/utilities/qutils.cpp
@@ -301,8 +301,8 @@ QPoint minQModelIndex(const QItemSelection &list)
 	
 	for(const QItemSelectionRange & mi : list)
 	{
-		r = std::min(r, mi.left());
-		c = std::min(c, mi.top());
+		r = std::min(r, mi.top());
+		c = std::min(c, mi.left());
 	}
 	
 	return QPoint(c, r);
@@ -318,8 +318,8 @@ QPoint maxQModelIndex(const QItemSelection &list)
 	
 	for(const QItemSelectionRange & mi : list)
 	{
-		r = std::max(r, mi.right());
-		c = std::max(c, mi.bottom());
+		r = std::max(r, mi.bottom());
+		c = std::max(c, mi.right());
 	}
 	
 	return QPoint(c, r);

--- a/QMLComponents/utilities/qutils.cpp
+++ b/QMLComponents/utilities/qutils.cpp
@@ -290,3 +290,37 @@ std::set<string> fql(const QStringList & from)
 	const std::vector<std::string> vec(fq(from));
 	return std::set<std::string>(vec.begin(), vec.end()); 
 }
+
+QPoint minQModelIndex(const QModelIndexList &list)
+{
+	if(list.size() == 0)
+		return QPoint(-1, -1);
+	
+	int r = std::numeric_limits<int>::max(),
+		c = std::numeric_limits<int>::max();
+	
+	for(const QModelIndex & mi : list)
+	{
+		r = std::min(r, mi.row());
+		c = std::min(c, mi.column());
+	}
+	
+	return QPoint(c, r);
+}
+
+QPoint maxQModelIndex(const QModelIndexList &list)
+{
+	if(list.size() == 0)
+		return QPoint(-1, -1);
+	
+	int r = std::numeric_limits<int>::min(),
+		c = std::numeric_limits<int>::min();
+	
+	for(const QModelIndex & mi : list)
+	{
+		r = std::max(r, mi.row());
+		c = std::max(c, mi.column());
+	}
+	
+	return QPoint(c, r);
+}

--- a/QMLComponents/utilities/qutils.h
+++ b/QMLComponents/utilities/qutils.h
@@ -35,6 +35,7 @@
 #include <vector>
 #include <sstream>
 #include <json/json.h>
+#include <QModelIndexList>
 
 /// This file collect a set of useful functions for interop between Qt and stdlib, like `fq` and `tq` for easily converting to and fro normal strings and whatnot
 /// These could have been collected into a class but because we use `fq` and `tq` in so many places that would probably not have made our life easier anyway.
@@ -60,6 +61,8 @@ inline	QList<int>							tql(const std::set<int>						 & from)	{ return QList<int
 		//These need to have a different name because otherwise the default Json::Value(const std::string & str) constructor steals any fq(std::string()) call...
 		Json::Value							fqj(const QJSValue							 & jsVal);
 		QJSValue							tqj(const Json::Value						 & json,	const QQuickItem * qItem);
+		QPoint								minQModelIndex(const QModelIndexList		 & list);
+		QPoint								maxQModelIndex(const QModelIndexList		 & list);
 
 template<typename T> inline		std::vector<T>	fq(QVector<T>		in) { return in.toStdVector();				}
 template<typename T> inline		QVector<T>		tq(std::vector<T>	in) { return QVector<T>::fromStdVector(in); }

--- a/QMLComponents/utilities/qutils.h
+++ b/QMLComponents/utilities/qutils.h
@@ -35,7 +35,7 @@
 #include <vector>
 #include <sstream>
 #include <json/json.h>
-#include <QModelIndexList>
+#include <QItemSelection>
 
 /// This file collect a set of useful functions for interop between Qt and stdlib, like `fq` and `tq` for easily converting to and fro normal strings and whatnot
 /// These could have been collected into a class but because we use `fq` and `tq` in so many places that would probably not have made our life easier anyway.
@@ -61,8 +61,8 @@ inline	QList<int>							tql(const std::set<int>						 & from)	{ return QList<int
 		//These need to have a different name because otherwise the default Json::Value(const std::string & str) constructor steals any fq(std::string()) call...
 		Json::Value							fqj(const QJSValue							 & jsVal);
 		QJSValue							tqj(const Json::Value						 & json,	const QQuickItem * qItem);
-		QPoint								minQModelIndex(const QModelIndexList		 & list);
-		QPoint								maxQModelIndex(const QModelIndexList		 & list);
+		QPoint								minQModelIndex(const QItemSelection			 & list);
+		QPoint								maxQModelIndex(const QItemSelection			 & list);
 
 template<typename T> inline		std::vector<T>	fq(QVector<T>		in) { return in.toStdVector();				}
 template<typename T> inline		QVector<T>		tq(std::vector<T>	in) { return QVector<T>::fromStdVector(in); }


### PR DESCRIPTION
started work on jasp-stats/INTERNAL-jasp#2495

this PR will:
- allow for selecting disjunct sections of the data
- actions on selected stuff should only do things for those selected
- copy pasting within jasp will only copy those cells selected
- to spreadsheet it will copy nonselected cells as ""
- cmd/shift clicking now should work

I couldnt get the nice shift-select on hover to work properly for now but that is way less important than being able to change columntypes or reversing levels so here we are.
Ive turned on a build of `betterSelecting` for @JohnnyDoorn to review, if the static server with the nightlies does not go down in the meantime