### PR TITLE
Read sources of a listcontrol when initialized.

### DIFF
--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -291,3 +291,10 @@ void JASPListControl::sourceChangedHandler()
 	_setupSources();
 	model()->sourceTermsReset();
 }
+
+void JASPListControl::_setInitialized(const Json::Value &value)
+{
+	if (model() && hasSource()) model()->sourceTermsReset();
+
+	JASPControl::_setInitialized(value);
+}

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -146,6 +146,8 @@ protected slots:
 			GENERIC_SET_FUNCTION(AllowAnalysisOwnComputedColumns, _allowAnalysisOwnComputedColumns,	allowAnalysisOwnComputedColumnsChanged,	bool	)
 
 protected:
+	void					_setInitialized(const Json::Value& value = Json::nullValue)	override;
+
 	QVector<SourceItem*>	_sourceItems;
 	QSet<columnType>		_variableTypesAllowed;
 	QString					_optionKey				= "value";

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -91,10 +91,7 @@ void VariablesListBase::setUp()
 
 void VariablesListBase::_setInitialized(const Json::Value &value)
 {
-	ListModelAvailableInterface* availableModel = qobject_cast<ListModelAvailableInterface*>(_draggableModel);
-	if (availableModel)
-		availableModel->resetTermsFromSources(false);
-	else if (value == Json::nullValue && addAvailableVariablesToAssigned())
+	if (value == Json::nullValue && addAvailableVariablesToAssigned())
 	{
 		// If addAvailableVariablesToAssigned is true and this is initialized without value,
 		// maybe the availableAssignedList has some default values that must be assigned to this VariablesList

--- a/QMLComponents/models/listmodelavailableinterface.h
+++ b/QMLComponents/models/listmodelavailableinterface.h
@@ -36,7 +36,7 @@ public:
 	
 	virtual const Terms& allTerms()																											const { return _allSortedTerms; }
 			void initTerms(const Terms &terms, const RowControlsValues& _rowControlsValues = RowControlsValues(), bool reInit = false)	override;
-	virtual void resetTermsFromSources(bool updateAssigned = true)			= 0;
+	virtual void resetTermsFromSources()			= 0;
 	virtual void removeTermsInAssignedList();
 	
 			void sortItems(SortType sortType)											override;

--- a/QMLComponents/models/listmodelinteractionavailable.cpp
+++ b/QMLComponents/models/listmodelinteractionavailable.cpp
@@ -27,7 +27,7 @@ ListModelInteractionAvailable::ListModelInteractionAvailable(JASPListControl* li
 {
 }
 
-void ListModelInteractionAvailable::resetTermsFromSources(bool updateAssigned)
+void ListModelInteractionAvailable::resetTermsFromSources()
 {	
 	beginResetModel();
 	Terms termsAvailable;
@@ -81,8 +81,7 @@ void ListModelInteractionAvailable::resetTermsFromSources(bool updateAssigned)
 	
 	endResetModel();
 
-	if (updateAssigned)
-		emit availableTermsReset(addedTerms, removedTerms);
+	emit availableTermsReset(addedTerms, removedTerms);
 
 }
 

--- a/QMLComponents/models/listmodelinteractionavailable.h
+++ b/QMLComponents/models/listmodelinteractionavailable.h
@@ -29,7 +29,7 @@ class ListModelInteractionAvailable : public ListModelAvailableInterface, public
 public:
 	ListModelInteractionAvailable(JASPListControl* listView);
 	
-	void resetTermsFromSources(bool updateAssigned = true) override;
+	void resetTermsFromSources() override;
 };
 
 #endif // LISTMODELINTERACTIONAVAILABLE_H

--- a/QMLComponents/models/listmodellabelvalueterms.cpp
+++ b/QMLComponents/models/listmodellabelvalueterms.cpp
@@ -47,7 +47,7 @@ QVariant ListModelLabelValueTerms::data(const QModelIndex &index, int role) cons
 	return ListModelAvailableInterface::data(index, role);
 }
 
-void ListModelLabelValueTerms::resetTermsFromSources(bool )
+void ListModelLabelValueTerms::resetTermsFromSources()
 {
 	beginResetModel();
 

--- a/QMLComponents/models/listmodellabelvalueterms.h
+++ b/QMLComponents/models/listmodellabelvalueterms.h
@@ -29,7 +29,7 @@ public:
 	ListModelLabelValueTerms(JASPListControl* listView, const JASPListControl::LabelValueMap& values = JASPListControl::LabelValueMap());
 
 	QVariant					data(const QModelIndex &index, int role = Qt::DisplayRole)	const	override;
-	void						resetTermsFromSources(bool updateAssigned = true)					override;
+	void						resetTermsFromSources()												override;
 
 	std::vector<std::string>	getValues();
 	QString						getValue(const QString& label)								const;

--- a/QMLComponents/models/listmodeltermsavailable.cpp
+++ b/QMLComponents/models/listmodeltermsavailable.cpp
@@ -18,7 +18,7 @@
 
 #include "listmodeltermsavailable.h"
 
-void ListModelTermsAvailable::resetTermsFromSources(bool updateAssigned)
+void ListModelTermsAvailable::resetTermsFromSources()
 {
 	
 	beginResetModel();
@@ -38,6 +38,5 @@ void ListModelTermsAvailable::resetTermsFromSources(bool updateAssigned)
 
 	endResetModel();
 
-	if (updateAssigned)
-		emit availableTermsReset(addedTerms, removedTerms);
+	emit availableTermsReset(addedTerms, removedTerms);
 }

--- a/QMLComponents/models/listmodeltermsavailable.h
+++ b/QMLComponents/models/listmodeltermsavailable.h
@@ -27,7 +27,7 @@ class ListModelTermsAvailable : public ListModelAvailableInterface
 public:
 	ListModelTermsAvailable(JASPListControl* listView) : ListModelAvailableInterface(listView) {}
 		
-	void	resetTermsFromSources(bool updateAssigned = true)	override;
+	void	resetTermsFromSources()		override;
 };
 
 #endif // LISTMODELTERMSAVAILABLE_H


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/

When a listcontrol (a VariablesList) is initialized dynamically, it should read its sources.


