### PR TITLE
fix: auto set line height for help docs

### DIFF
--- a/Resources/Help/darkTheme.css
+++ b/Resources/Help/darkTheme.css
@@ -11,7 +11,6 @@ body {
   background-color: #333;
   font-family: "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
-  line-height: 1.3em;
   word-break: break-word;
 }
 

--- a/Resources/Help/lightTheme.css
+++ b/Resources/Help/lightTheme.css
@@ -11,7 +11,6 @@ body
 	color: #333;
 	background-color: #FAFAFA;
 	font-size: 14px;
-	line-height: 1.3em;
 	word-break: break-word;
 }
 


### PR DESCRIPTION
Related to https://github.com/jasp-stats/jasp-issues/issues/2677#issuecomment-2071842137

css will automatically obtain the line height after line wrapping from the browser.