### PR TITLE
Generate properly the markdown help

### DIFF
--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -58,7 +58,7 @@
 #include "controls/radiobuttonbase.h"
 #include "controls/radiobuttonsgroupbase.h"
 #include "controls/jaspdoublevalidator.h"
-
+#include "controls/groupboxbase.h"
 
 #include "gui/jaspversionchecker.h"
 #include "gui/preferencesmodel.h"
@@ -171,6 +171,7 @@ MainWindow::MainWindow(QApplication * application) : QObject(application), _appl
 	qmlRegisterType<AnalysisForm>								("JASP",			1, 0, "AnalysisForm"					);
 	qmlRegisterType<RCommander>									("JASP",			1, 0, "RCommander"						);
 	qmlRegisterType<JASPControl>								("JASP",			1, 0, "JASPControl"						);
+	qmlRegisterType<GroupBoxBase>								("JASP",			1, 0, "GroupBoxBase"					);
 	qmlRegisterType<ExpanderButtonBase>							("JASP",			1, 0, "ExpanderButtonBase"				);
 	qmlRegisterType<CheckBoxBase>								("JASP",			1, 0, "CheckBoxBase"					);
 	qmlRegisterType<SliderBase>									("JASP",			1, 0, "SliderBase"						);

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -901,13 +901,13 @@ QString AnalysisForm::helpMD() const
 	markdown << metaHelpMD();
 	
 	if(!_info.bottom.isEmpty())
-		markdown << _info.bottom  << "\n";
+		markdown << "\n\n---\n" << _info.bottom  << "\n";
 
 	auto printList = [&markdown](const QStringList& list, const QString& title) -> void
 	{
 		if(list.length() > 0)
 		{
-			markdown << ("\n\n---\n# " + title + "\n");
+			markdown << ("\n\n---\n### " + title + "\n");
 			for (const QString& elt : list)
 				markdown << "- " << elt << "\n";
 		}

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -884,7 +884,7 @@ std::set<string> AnalysisForm::usedVariables()
 ///Generates documentation based on the "info" entered on each component
 QString AnalysisForm::helpMD() const
 {
-	if(!_analysis) return "";
+	if(!_analysis || !initialized()) return "";
 
 	QStringList markdown =
 	{
@@ -901,7 +901,7 @@ QString AnalysisForm::helpMD() const
 	markdown << metaHelpMD();
 	
 	if(!_info.bottom.isEmpty())
-		markdown << (_info.bottom + "\n");
+		markdown << _info.bottom  << "\n";
 
 	auto printList = [&markdown](const QStringList& list, const QString& title) -> void
 	{

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -896,7 +896,7 @@ QString AnalysisForm::helpMD() const
 	QList<JASPControl*> orderedControls = JASPControl::getChildJASPControls(this);
 
 	for(JASPControl * control : orderedControls)
-		markdown << control->helpMD();
+		markdown << control->helpMD() << "\n";
 
 	markdown << metaHelpMD();
 	

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -35,13 +35,6 @@ class JASPControl;
 class ExpanderButtonBase;
 class RSyntax;
 
-struct InfoFormProps
-{
-	QVariant var;
-	QString top, bottom;
-	QStringList references, RPackages, examples;
-};
-
 ///
 /// The backend for the `Form{}` used in all JASP's well, qml forms
 /// This is directly a QQuickItem and connects to Analyses to inform it when the options change.
@@ -59,8 +52,8 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(bool			needsRefresh			READ needsRefresh											NOTIFY needsRefreshChanged			)
 	Q_PROPERTY(bool			hasVolatileNotes		READ hasVolatileNotes										NOTIFY hasVolatileNotesChanged		)
 	Q_PROPERTY(bool			runOnChange				READ runOnChange			WRITE setRunOnChange			NOTIFY runOnChangeChanged			)
-	Q_PROPERTY(QVariant		info					READ info					WRITE setInfo					NOTIFY infoChanged					)
-	Q_PROPERTY(QString		infoBottom				READ infoBottom				WRITE setInfoBottom				NOTIFY infoChanged					)
+	Q_PROPERTY(QString		info					READ info					WRITE setInfo					NOTIFY infoChanged					)
+	Q_PROPERTY(QString		infoBottom				READ infoBottom				WRITE setInfoBottom				NOTIFY infoBottomChanged			)
 	Q_PROPERTY(QString		helpMD					READ helpMD													NOTIFY helpMDChanged				)
 	Q_PROPERTY(QVariant		analysis				READ analysis												NOTIFY analysisChanged				)
 	Q_PROPERTY(QVariantList	optionNameConversion	READ optionNameConversion	WRITE setOptionNameConversion	NOTIFY optionNameConversionChanged	)
@@ -101,7 +94,6 @@ public:
 
 public slots:
 	void					runScriptRequestDone(const QString& result, const QString& requestId, bool hasError);
-	void					setInfo(const QVariant& info);
 	void					setAnalysis(AnalysisBase * analysis);
 	void					boundValueChangedHandler(JASPControl* control);
 	void					setOptionNameConversion(const QVariantList& conv);
@@ -123,6 +115,7 @@ signals:
 	void					hasVolatileNotesChanged();
 	void					runOnChangeChanged();
 	void					infoChanged();
+	void					infoBottomChanged();
 	void					helpMDChanged();
 	void					errorsChanged();
 	void					warningsChanged();
@@ -164,7 +157,8 @@ public:
 
 	bool			needsRefresh()			const;
 
-	QVariant		info()					const	{ return _info.var; }
+	QString			info()					const	{ return _info;								}
+	QString			infoBottom()			const	{ return _infoBottom;						}
 	QString			helpMD()				const;
 	QString			metaHelpMD()			const;
 	QString			errors()				const	{ return msgsListToString(_formErrors);		}
@@ -191,10 +185,10 @@ public:
 	JASPControl*	getActiveJASPControl()	{ return _activeJASPControl; }
 
 	static const QString	rSyntaxControlName;
-	
-	QString infoBottom() const							{ return _info.bottom;			};
-	void setInfoBottom(const QString &newInfoBottom)	{ _info.bottom = newInfoBottom; emit infoChanged(); }
-	
+		
+	GENERIC_SET_FUNCTION(Info					, _info					, infoChanged					, QString		)
+	GENERIC_SET_FUNCTION(InfoBottom				, _infoBottom			, infoBottomChanged				, QString		)
+
 private:
 
 	Json::Value	&	_getParentBoundValue(const QVector<JASPControl::ParentKey>& parentKeys);
@@ -237,7 +231,8 @@ private:
 													_hasVolatileNotes				= false,
 													_initialized					= false,
 													_valueChangedEmittedButBlocked	= false;
-	InfoFormProps									_info;
+	QString											_info,
+													_infoBottom;
 	int												_valueChangedSignalsBlocked		= 0;
 	std::queue<std::tuple<QString, QString, bool>>	_waitingRScripts; //Sometimes signals are blocked, and thus rscripts. But they shouldnt just disappear right?
 	RSyntax										*	_rSyntax						= nullptr;

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -35,6 +35,13 @@ class JASPControl;
 class ExpanderButtonBase;
 class RSyntax;
 
+struct InfoFormProps
+{
+	QVariant var;
+	QString top, bottom;
+	QStringList references, RPackages, examples;
+};
+
 ///
 /// The backend for the `Form{}` used in all JASP's well, qml forms
 /// This is directly a QQuickItem and connects to Analyses to inform it when the options change.
@@ -52,8 +59,8 @@ class AnalysisForm : public QQuickItem
 	Q_PROPERTY(bool			needsRefresh			READ needsRefresh											NOTIFY needsRefreshChanged			)
 	Q_PROPERTY(bool			hasVolatileNotes		READ hasVolatileNotes										NOTIFY hasVolatileNotesChanged		)
 	Q_PROPERTY(bool			runOnChange				READ runOnChange			WRITE setRunOnChange			NOTIFY runOnChangeChanged			)
-	Q_PROPERTY(QString		info					READ info					WRITE setInfo					NOTIFY infoChanged					)
-	Q_PROPERTY(QString		infoBottom				READ infoBottom				WRITE setInfoBottom				NOTIFY infoBottomChanged			)
+	Q_PROPERTY(QVariant		info					READ info					WRITE setInfo					NOTIFY infoChanged					)
+	Q_PROPERTY(QString		infoBottom				READ infoBottom				WRITE setInfoBottom				NOTIFY infoChanged					)
 	Q_PROPERTY(QString		helpMD					READ helpMD													NOTIFY helpMDChanged				)
 	Q_PROPERTY(QVariant		analysis				READ analysis												NOTIFY analysisChanged				)
 	Q_PROPERTY(QVariantList	optionNameConversion	READ optionNameConversion	WRITE setOptionNameConversion	NOTIFY optionNameConversionChanged	)
@@ -94,7 +101,7 @@ public:
 
 public slots:
 	void					runScriptRequestDone(const QString& result, const QString& requestId, bool hasError);
-	void					setInfo(QString info);
+	void					setInfo(const QVariant& info);
 	void					setAnalysis(AnalysisBase * analysis);
 	void					boundValueChangedHandler(JASPControl* control);
 	void					setOptionNameConversion(const QVariantList& conv);
@@ -128,9 +135,7 @@ signals:
 	void					rSyntaxTextChanged();
 	void					showAllROptionsChanged();
 	void					activeJASPControlChanged();
-	
-	void infoBottomChanged();
-	
+		
 public:
 	ListModel			*	getModel(const QString& modelName)								const	{ return _modelMap.count(modelName) > 0 ? _modelMap[modelName] : nullptr;	} // Maps create elements if they do not exist yet
 	void					addModel(ListModel* model)												{ if (!model->name().isEmpty())	_modelMap[model->name()] = model;			}
@@ -159,7 +164,7 @@ public:
 
 	bool			needsRefresh()			const;
 
-	QString			info()					const	{ return _info; }
+	QVariant		info()					const	{ return _info.var; }
 	QString			helpMD()				const;
 	QString			metaHelpMD()			const;
 	QString			errors()				const	{ return msgsListToString(_formErrors);		}
@@ -187,8 +192,8 @@ public:
 
 	static const QString	rSyntaxControlName;
 	
-	QString infoBottom() const;
-	void setInfoBottom(const QString &newInfoBottom);
+	QString infoBottom() const							{ return _info.bottom;			};
+	void setInfoBottom(const QString &newInfoBottom)	{ _info.bottom = newInfoBottom; emit infoChanged(); }
 	
 private:
 
@@ -232,7 +237,7 @@ private:
 													_hasVolatileNotes				= false,
 													_initialized					= false,
 													_valueChangedEmittedButBlocked	= false;
-	QString											_info;
+	InfoFormProps									_info;
 	int												_valueChangedSignalsBlocked		= 0;
 	std::queue<std::tuple<QString, QString, bool>>	_waitingRScripts; //Sometimes signals are blocked, and thus rscripts. But they shouldnt just disappear right?
 	RSyntax										*	_rSyntax						= nullptr;
@@ -240,7 +245,6 @@ private:
 													_developerMode					= false;
 	QString											_rSyntaxText;
 	JASPControl*									_activeJASPControl				= nullptr;
-	QString _infoBottom;
 };
 
 #endif // ANALYSISFORM_H

--- a/QMLComponents/components/JASP/Controls/GroupBox.qml
+++ b/QMLComponents/components/JASP/Controls/GroupBox.qml
@@ -16,19 +16,17 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-import QtQuick			2.11
-import QtQuick.Controls 2.4
-import QtQuick.Layouts	1.3 as L
-import JASP				1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts		as L
+import JASP
 
-
-JASPControl
+GroupBoxBase
 {
 	id						: groupBox
 	implicitWidth			: Math.max(label.realWidth, contentArea.x + contentArea.implicitWidth)
 	implicitHeight			: label.realHeight + jaspTheme.titleBottomMargin + contentArea.implicitHeight
 	L.Layout.leftMargin		: indent ? jaspTheme.indentationLength : 0
-	controlType				: JASPControl.GroupBox
 	isBound					: false
 	childControlsArea		: contentArea
 	focusOnTab				: false

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -262,7 +262,7 @@ QString	ComboBoxBase::helpMD(int depth) const
 		{
 			QString label = term.asQString(),
 					info = _model->getInfo(label);
-			markdown << ( QString{depth * 2, ' '} + "- *" + label + "*");
+			markdown << ( "\n" + QString{depth * 2, ' '} + "- *" + label + "*");
 			if (!info.isEmpty())
 				markdown << (": " + info);
 		}

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -251,9 +251,7 @@ QString	ComboBoxBase::helpMD(int depth) const
 	QStringList markdown;
 
 	printLabelMD(markdown, depth);
-
-	if(!infoText().isEmpty())
-		markdown << infoText();
+	markdown << infoText();
 
 	// If one of the option has an info property, then display the options as an unordered list
 	if (_hasOptionInfo())

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -251,7 +251,7 @@ QString	ComboBoxBase::helpMD(int depth) const
 	QStringList markdown;
 
 	printLabelMD(markdown, depth);
-	markdown << infoText();
+	markdown << info();
 
 	// If one of the option has an info property, then display the options as an unordered list
 	if (_hasOptionInfo())
@@ -289,5 +289,5 @@ bool ComboBoxBase::_hasOptionInfo() const
 
 bool ComboBoxBase::hasInfo() const
 {
-	return !infoText().isEmpty() || _hasOptionInfo();
+	return !info().isEmpty() || _hasOptionInfo();
 }

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -260,14 +260,17 @@ QString	ComboBoxBase::helpMD(int depth) const
 		{
 			QString label = term.asQString(),
 					info = _model->getInfo(label);
-			markdown << ( "\n" + QString{depth * 2, ' '} + "- *" + label + "*");
+			markdown << "\n" << QString{depth * 2, ' '} << "- *" << label << "*";
 			if (!info.isEmpty())
 				markdown << (": " + info);
 		}
 	}
 	else
+	{
+		markdown << "\n" << QString{depth * 2, ' '};
 		// Display the options in one line separated by a comma.
 		markdown << model()->terms().asQList().join(", ");
+	}
 
 
 	return markdown.join("") + "\n";

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -26,7 +26,6 @@ ComboBoxBase::ComboBoxBase(QQuickItem* parent)
 {
 	_controlType = ControlType::ComboBox;
 	_hasUserInteractiveValue = true;
-	_info.isHeader = true;
 }
 
 void ComboBoxBase::bindTo(const Json::Value& value)
@@ -247,17 +246,11 @@ void ComboBoxBase::_setCurrentProperties(int index, bool bindValue)
 }
 
 
-QString	ComboBoxBase::helpMD(int howDeep) const
+QString	ComboBoxBase::helpMD(int depth) const
 {
 	QStringList markdown;
 
-	if(!infoLabel().isEmpty() || _info.displayControlType)
-	{
-		markdown << "**";
-		if (_info.displayControlType)	markdown << (friendlyName() + " ");
-		markdown << infoLabel();
-		markdown << "**: ";
-	}
+	printLabelMD(markdown, depth);
 
 	if(!infoText().isEmpty())
 		markdown << infoText();
@@ -269,7 +262,7 @@ QString	ComboBoxBase::helpMD(int howDeep) const
 		{
 			QString label = term.asQString(),
 					info = _model->getInfo(label);
-			markdown << ( QString{howDeep * 2, ' '} + "- *" + label + "*");
+			markdown << ( QString{depth * 2, ' '} + "- *" + label + "*");
 			if (!info.isEmpty())
 				markdown << (": " + info);
 		}

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -44,7 +44,7 @@ public:
 	void				setUp()												override;
 	ListModel*			model()										const	override	{ return _model;				}
 	void				setUpModel()										override;
-	QString				helpMD(int howDeep = 0)						const	override;
+	QString				helpMD(int depth = 0)						const	override;
 	bool				hasInfo()									const	override;
 
 	const QString&		currentText()								const				{ return _currentText;			}

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -44,8 +44,8 @@ public:
 	void				setUp()												override;
 	ListModel*			model()										const	override	{ return _model;				}
 	void				setUpModel()										override;
-	QString				helpMD(SetConst & markdowned,
-							   int howDeep = 2, bool asList=true)	const	override;
+	QString				helpMD(int howDeep = 0)						const	override;
+	bool				hasInfo()									const	override;
 
 	const QString&		currentText()								const				{ return _currentText;			}
 	const QString&		currentValue()								const				{ return _currentValue;			}
@@ -84,9 +84,10 @@ protected:
 								_currentColumnTypeIcon;
 	int							_currentIndex			= -1;
 
-	int	 _getStartIndex() const;
+	int	 _getStartIndex()											const;
 	void _resetItemWidth();
 	void _setCurrentProperties(int index, bool bindValue = true);
+	bool _hasOptionInfo()											const;
 
 };
 

--- a/QMLComponents/controls/expanderbuttonbase.cpp
+++ b/QMLComponents/controls/expanderbuttonbase.cpp
@@ -23,7 +23,6 @@ ExpanderButtonBase::ExpanderButtonBase(QQuickItem *parent)
 	: JASPControl(parent)
 {
 	_controlType = ControlType::Expander;
-	_info.isHeader = true;
 }
 
 void ExpanderButtonBase::setUp()

--- a/QMLComponents/controls/expanderbuttonbase.cpp
+++ b/QMLComponents/controls/expanderbuttonbase.cpp
@@ -34,7 +34,7 @@ void ExpanderButtonBase::setUp()
 	setInitialized();
 }
 
-QString ExpanderButtonBase::helpMD(int howDeep) const
+QString ExpanderButtonBase::helpMD(int depth) const
 {
 	if (!hasInfo()) return "";
 

--- a/QMLComponents/controls/expanderbuttonbase.cpp
+++ b/QMLComponents/controls/expanderbuttonbase.cpp
@@ -23,6 +23,7 @@ ExpanderButtonBase::ExpanderButtonBase(QQuickItem *parent)
 	: JASPControl(parent)
 {
 	_controlType = ControlType::Expander;
+	_info.isHeader = true;
 }
 
 void ExpanderButtonBase::setUp()
@@ -31,4 +32,12 @@ void ExpanderButtonBase::setUp()
 		return;
 
 	setInitialized();
+}
+
+QString ExpanderButtonBase::helpMD(int howDeep) const
+{
+	if (!hasInfo()) return "";
+
+	// For Section, draw first a line, and reset the depth to 0.
+	return "\n---\n\n" + JASPControl::helpMD(0);
 }

--- a/QMLComponents/controls/expanderbuttonbase.h
+++ b/QMLComponents/controls/expanderbuttonbase.h
@@ -29,7 +29,8 @@ class ExpanderButtonBase : public JASPControl
 public:
 	explicit ExpanderButtonBase(QQuickItem *parent = nullptr);
 
-	void	setUp() override;
+	void	setUp()							override;
+	QString helpMD(int howDeep)		const	override;
 };
 
 #endif // EXPANDERBUTTONBASE_H

--- a/QMLComponents/controls/expanderbuttonbase.h
+++ b/QMLComponents/controls/expanderbuttonbase.h
@@ -30,7 +30,7 @@ public:
 	explicit ExpanderButtonBase(QQuickItem *parent = nullptr);
 
 	void	setUp()							override;
-	QString helpMD(int howDeep)		const	override;
+	QString helpMD(int depth)		const	override;
 };
 
 #endif // EXPANDERBUTTONBASE_H

--- a/QMLComponents/controls/groupboxbase.h
+++ b/QMLComponents/controls/groupboxbase.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2018 University of Amsterdam
+// Copyright (C) 2013-2024 University of Amsterdam
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -16,23 +16,20 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-#ifndef EXPANDERBUTTONBASE_H
-#define EXPANDERBUTTONBASE_H
+#ifndef GROUPBOXBASE_H
+#define GROUPBOXBASE_H
 
 #include "jaspcontrol.h"
 
-#include <QObject>
-
-class ExpanderButtonBase : public JASPControl
+class GroupBoxBase : public JASPControl
 {
 	Q_OBJECT
+
 public:
-	explicit ExpanderButtonBase(QQuickItem *parent = nullptr);
+	GroupBoxBase(QQuickItem* parent = nullptr) : JASPControl(parent) { _controlType = JASPControl::ControlType::GroupBox; }
 
-	void	setUp()							override;
-	QString helpMD(int depth)		const	override;
+	bool infoLabelIsHeader()	const	override { return true; }
 
-	bool infoLabelIsHeader()		const	override	{ return true; }
 };
 
-#endif // EXPANDERBUTTONBASE_H
+#endif // GROUPBOXBASE_H

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -602,13 +602,10 @@ QString JASPControl::helpMD(int depth) const
 	if (childMDs.length() == 0)
 		markdown << "\n";
 	else if (childMDs.length() == 1)
-	{
-		if (_info.isHeader)
-			markdown << QString{depth * 2, ' '};
-		markdown << childMDs[0];
-	}
+		markdown << QString{depth * 2, ' '} << childMDs[0];
 	else
 	{
+		markdown << "\n";
 		for (const QString& childMD : childMDs)
 		{
 			markdown << QString{depth * 2, ' '};

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -558,16 +558,19 @@ bool JASPControl::hasInfo() const
 
 void JASPControl::printLabelMD(QStringList& md, int depth) const
 {
-	if(!infoLabel().isEmpty() || _info.displayControlType)
+	QString label = infoLabel().trimmed();
+	if(!label.isEmpty() || _info.displayControlType)
 	{
-		if(_info.isHeader)				md <<  QString{depth + 1, '#' } + " ";
-		else							md << "**"; // If not a header, make it bold
-		if (_info.displayControlType)	md << (" __" + friendlyName() + "__ ");
-		md << infoLabel();
-		if (!_info.isHeader)			md << "**";
+		if (depth == 0)					md << "\n";
+		if(_info.isHeader)				md << QString{depth + 2, '#' } << " ";
+		else							md << (_info.displayLabelItalic ? "*" : "**");
+		if (_info.displayControlType)	md << ("__" + friendlyName() + "__" + (!label.isEmpty() ? "- " : ""));
+		md << label;
+		if (!_info.isHeader)			md << (_info.displayLabelItalic ? "*" : "**");
 
-		if(!infoText().isEmpty())
-			md << ": ";
+		if(!infoText().isEmpty() && !label.endsWith(":"))
+			md << ":";
+		md << " ";
 	}
 }
 
@@ -594,7 +597,7 @@ QString JASPControl::helpMD(int depth) const
 	for (const QString& childMD : childMDs)
 	{
 		markdown << QString{depth * 2, ' '};
-		if(!infoLabel().isEmpty() && childMDs.length() > 1)	 markdown << "- "; // Add bullet only if more than 1 child exist
+		if(!infoLabel().isEmpty() && childMDs.length() > 1)	 markdown << "- "; // Add bullet list only if more than 1 child exists
 		markdown << childMD;
 	}
 

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -556,7 +556,22 @@ bool JASPControl::hasInfo() const
 	return false;
 }
 
-QString JASPControl::helpMD(int howDeep) const
+void JASPControl::printLabelMD(QStringList& md, int depth) const
+{
+	if(!infoLabel().isEmpty() || _info.displayControlType)
+	{
+		if(_info.isHeader)				md <<  QString{depth + 1, '#' } + " ";
+		else							md << "**"; // If not a header, make it bold
+		if (_info.displayControlType)	md << (" __" + friendlyName() + "__ ");
+		md << infoLabel();
+		if (!_info.isHeader)			md << "**";
+
+		if(!infoText().isEmpty())
+			md << ": ";
+	}
+}
+
+QString JASPControl::helpMD(int depth) const
 {
 	if (!hasInfo()) return "";
 		
@@ -564,45 +579,26 @@ QString JASPControl::helpMD(int howDeep) const
 
 	QList<JASPControl*> children =  getChildJASPControls(_childControlsArea ? _childControlsArea : this, true);
 
-	if(!infoLabel().isEmpty())
-		howDeep++;
-		
-	if (howDeep > 6)
-		howDeep = 6;
+	printLabelMD(markdown, depth);
 
 	for (JASPControl* childControl : children)
 	{
-		QString childMD = childControl->helpMD(howDeep);
+		QString childMD = childControl->helpMD(depth + 1);
 		if (!childMD.isEmpty())
 			childMDs.push_back(childMD);
 	}
 
-	if(!infoLabel().isEmpty() || _info.displayControlType)
-	{
-		if(_info.isHeader)				markdown <<  QString{howDeep + 1, '#' } + " ";
-		else							markdown << "**"; // If not a header, make it bold
-		if (_info.displayControlType)	markdown << (friendlyName() + " ");
-		markdown << infoLabel();
-		if (!_info.isHeader)			markdown << "**";
 
-		if(!infoText().isEmpty())
-			markdown << ": ";
-	}
-
-
-	if(!infoText().isEmpty())
-		markdown << infoText();
-
-	markdown << "\n\n";
+	markdown << infoText() << "\n";
 
 	for (const QString& childMD : childMDs)
 	{
-		markdown << QString{(howDeep - 1) * 2, ' '};
-		if(!infoLabel().isEmpty() && childMDs.length() > 1)	 markdown << "- ";
-		markdown << childMD << "\n";
+		markdown << QString{depth * 2, ' '};
+		if(!infoLabel().isEmpty() && childMDs.length() > 1)	 markdown << "- "; // Add bullet only if more than 1 child exist
+		markdown << childMD;
 	}
 
-	QString md = markdown.join("") + "\n";
+	QString md = markdown.join("");
 		
 	return md;
 }

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -276,7 +276,7 @@ protected:
 	void				_addExplicitDependency(const QVariant& depends);
 	bool				dependingControlsAreInitialized();
 	virtual void		_setInitialized(const Json::Value &value);
-	void				printLabelMD(QStringList& md, int depth)			const;
+	bool				printLabelMD(QStringList& md, int depth)			const;
 
 protected:
 	Set						_depends;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -17,7 +17,8 @@ struct InfoProps
 	QString text;
 	QString label;
 	bool	displayControlType	= false,
-			isHeader		= false;
+			isHeader			= false,
+			displayLabelItalic	= false;
 
 };
 

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -125,7 +125,7 @@ public:
 	QString				infoText()					const	{ return _info.text;				}
 	QString				infoLabel()					const	{ return _info.label.isEmpty() ? _title : _info.label;	}
 	QString				toolTip()					const	{ return _toolTip;					}
-	virtual QString		helpMD(int howDeep = 0)		const;
+	virtual QString		helpMD(int depth = 0)		const;
 	virtual bool		hasInfo()					const;
 	bool				isBound()					const	{ return _isBound;					}
 	bool				nameIsOptionValue()			const	{ return _nameIsOptionValue;		}
@@ -265,16 +265,17 @@ signals:
 	void				requestComputedColumnDestruction(std::string columnName);
 
 protected:
-	void				componentComplete() override;
+	void				componentComplete()									override;
 	void				_setType();
 	void				setCursorShape(int shape);
 	void				setParentDebugToChildren(bool debug);
-	void				focusInEvent(QFocusEvent* event) override;
-	bool				eventFilter(QObject *watched, QEvent *event) override;
+	void				focusInEvent(QFocusEvent* event)					override;
+	bool				eventFilter(QObject *watched, QEvent *event)		override;
 	bool				checkOptionName(const QString& name);
 	void				_addExplicitDependency(const QVariant& depends);
 	bool				dependingControlsAreInitialized();
 	virtual void		_setInitialized(const Json::Value &value);
+	void				printLabelMD(QStringList& md, int depth)			const;
 
 protected:
 	Set						_depends;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -11,17 +11,6 @@ class AnalysisForm;
 class JASPListControl;
 class BoundControl;
 
-struct InfoProps
-{
-	QVariant var;
-	QString text;
-	QString label;
-	bool	displayControlType	= false,
-			isHeader			= false,
-			displayLabelItalic	= false;
-
-};
-
 ///
 /// Basic class for all our qml controls
 /// Contains all the properties that *must* be there for the QML components defined under Desktop/components/Controls and their bases in Desktop/widgets to function
@@ -33,8 +22,8 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( ControlType							controlType				READ controlType			WRITE setControlType			NOTIFY controlTypeChanged			)
 	Q_PROPERTY( QString								name					READ name					WRITE setName					NOTIFY nameChanged					)
 	Q_PROPERTY( QString								title					READ title					WRITE setTitle					NOTIFY titleChanged					) //Basically whatever a human sees on their screen when they look at this specific item.
-	Q_PROPERTY( QVariant							info					READ info					WRITE setInfo					NOTIFY infoChanged					)
-	Q_PROPERTY( QString								infoLabel				READ infoLabel				WRITE setInfoLabel				NOTIFY infoChanged					)
+	Q_PROPERTY( QString								info					READ info					WRITE setInfo					NOTIFY infoChanged					)
+	Q_PROPERTY( QString								infoLabel				READ infoLabel				WRITE setInfoLabel				NOTIFY infoLabelChanged				)
 	Q_PROPERTY( QString								toolTip					READ toolTip				WRITE setToolTip				NOTIFY toolTipChanged				)
 	Q_PROPERTY( QString								helpMD					READ helpMD													NOTIFY helpMDChanged				)
 	Q_PROPERTY( bool								isBound					READ isBound				WRITE setIsBound				NOTIFY isBoundChanged				)
@@ -122,9 +111,12 @@ public:
 	ControlType			controlType()				const	{ return _controlType;				}
 	const QString	&	name()						const	{ return _name;						}
 	QString				title()						const	{ return _title;					}
-	QVariant			info()						const	{ return _info.var;					}
-	QString				infoText()					const	{ return _info.text;				}
-	QString				infoLabel()					const	{ return _info.label.isEmpty() ? _title : _info.label;	}
+	QString				info()						const	{ return _info;						}
+	QString				infoLabel()					const	{ return _infoLabel;				}
+	virtual bool		infoAddControlType()		const	{ return  false;					}
+	virtual bool		infoLabelIsHeader()			const	{ return  false;					}
+	virtual bool		infoLabelItalic()			const	{ return  false;					}
+
 	QString				toolTip()					const	{ return _toolTip;					}
 	virtual QString		helpMD(int depth = 0)		const;
 	virtual bool		hasInfo()					const;
@@ -208,8 +200,6 @@ public slots:
 	void	reconnectWithYourChildren();
 	void	parentListViewKeyChanged(const QString& oldName, const QString& newName);
 	void	setName(const QString& name);
-	void	setInfo(const QVariant& info);
-	void	setInfoLabel(const QString& label)		{ _info.label = label; emit infoChanged(); }
 
 	GENERIC_SET_FUNCTION(ToolTip				, _toolTip				, toolTipChanged				, QString		)
 	GENERIC_SET_FUNCTION(Title					, _title				, titleChanged					, QString		)
@@ -220,6 +210,8 @@ public slots:
 	GENERIC_SET_FUNCTION(Background				, _background			, backgroundChanged				, QQuickItem*	)
 	GENERIC_SET_FUNCTION(DependencyMustContain	, _dependencyMustContain, dependencyMustContainChanged	, QStringList	)
 	GENERIC_SET_FUNCTION(ExplicitDepends		, _explicitDepends		, explicitDependsChanged		, QVariant		)
+	GENERIC_SET_FUNCTION(Info					, _info					, infoChanged					, QString		)
+	GENERIC_SET_FUNCTION(InfoLabel				, _infoLabel			, infoLabelChanged				, QString		)
 
 private slots:
 	void	_hightlightBorder();
@@ -249,6 +241,7 @@ signals:
 	void	backgroundChanged();
 	void	focusIndicatorChanged();
 	void	infoChanged();
+	void	infoLabelChanged();
 	void	toolTipChanged();
 	void	titleChanged();
 	void	helpMDChanged();
@@ -320,7 +313,8 @@ protected:
 	Qt::FocusReason			_focusReason				= Qt::FocusReason::NoFocusReason;
 	bool					_dependsOnDynamicComponents = false;
 	QVariant				_explicitDepends;
-	InfoProps				_info;
+	QString					_info,
+							_infoLabel;
 
 
 	static QMap<QQmlEngine*, QQmlComponent*>		_mouseAreaComponentMap;

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -47,8 +47,6 @@ class JASPListControl : public JASPControl
 	Q_PROPERTY( QString			optionKey				READ optionKey				WRITE setOptionKey													)
 	Q_PROPERTY( bool			addEmptyValue			READ addEmptyValue			WRITE setAddEmptyValue			NOTIFY addEmptyValueChanged			)
 	Q_PROPERTY( QString			placeholderText			READ placeholderText		WRITE setPlaceHolderText		NOTIFY placeHolderTextChanged		)
-	Q_PROPERTY( QString			labelRole				READ labelRole				WRITE setLabelRole				NOTIFY labelRoleChanged				)
-	Q_PROPERTY( QString			valueRole				READ valueRole				WRITE setValueRole				NOTIFY valueRoleChanged				)
 	Q_PROPERTY( bool			containsVariables		READ containsVariables										NOTIFY containsVariablesChanged		)
 	Q_PROPERTY( bool			containsInteractions	READ containsInteractions									NOTIFY containsInteractionsChanged	)
 	Q_PROPERTY( double			maxTermsWidth			READ maxTermsWidth											NOTIFY maxTermsWidthChanged			)
@@ -58,8 +56,6 @@ class JASPListControl : public JASPControl
 
 
 public:
-	typedef QVector<std::pair<QString, QString> > LabelValueMap;
-
 	JASPListControl(QQuickItem* parent);
 	
 	virtual ListModel		*	model()						const	= 0;
@@ -94,8 +90,6 @@ public:
 			int					maxRows()					const			{ return _maxRows;				}
 			bool				addEmptyValue()				const			{ return _addEmptyValue;		}
 			const QString&		placeholderText()			const			{ return _placeHolderText;		}
-			const QString&		labelRole()					const			{ return _labelRole;			}
-			const QString&		valueRole()					const			{ return _valueRole;			}
 			bool				containsVariables()			const			{ return _containsVariables;	}
 			bool				containsInteractions()		const			{ return _containsInteractions;	}
 			bool				encodeValue()				const override	{ return containsVariables() || containsInteractions();	}
@@ -113,8 +107,6 @@ signals:
 			void				maxRowsChanged();
 			void				addEmptyValueChanged();
 			void				placeHolderTextChanged();
-			void				labelRoleChanged();
-			void				valueRoleChanged();
 			void				containsVariablesChanged();
 			void				containsInteractionsChanged();
 			void				maxTermsWidthChanged();
@@ -138,8 +130,6 @@ protected slots:
 			GENERIC_SET_FUNCTION(Values,				_values,				sourceChanged,					QVariant		)
 			GENERIC_SET_FUNCTION(AddEmptyValue,			_addEmptyValue,			addEmptyValueChanged,			bool			)
 			GENERIC_SET_FUNCTION(PlaceHolderText,		_placeHolderText,		placeHolderTextChanged,			QString			)
-			GENERIC_SET_FUNCTION(LabelRole,				_labelRole,				labelRoleChanged,				QString			)
-			GENERIC_SET_FUNCTION(ValueRole,				_valueRole,				valueRoleChanged,				QString			)
 			GENERIC_SET_FUNCTION(RowComponent,			_rowComponent,			rowComponentChanged,			QQmlComponent*	)
 			GENERIC_SET_FUNCTION(MaxRows,				_maxRows,				maxRows,						int				)
 			GENERIC_SET_FUNCTION(AddAvailableVariablesToAssigned, _addAvailableVariablesToAssigned,	addAvailableVariablesToAssignedChanged,	bool	)
@@ -163,9 +153,7 @@ protected:
 							_allowAnalysisOwnComputedColumns = true;
 
 	int						_maxRows				= -1;
-	QString					_placeHolderText		= tr("<no choice>"),
-							_labelRole				= "label",
-							_valueRole				= "value";
+	QString					_placeHolderText		= tr("<no choice>");
 	QQmlComponent		*	_rowComponent			= nullptr;
 
 private:

--- a/QMLComponents/controls/radiobuttonbase.cpp
+++ b/QMLComponents/controls/radiobuttonbase.cpp
@@ -25,6 +25,7 @@ RadioButtonBase::RadioButtonBase(QQuickItem* item)
 	_controlType		= ControlType::RadioButton;
 	_isBound			= false;
 	_nameIsOptionValue	= true;
+	_info.displayLabelItalic = true;
 
 	connect(this, &QQuickItem::parentChanged, this, &RadioButtonBase::registerWithParent);
 	connect(this, &JASPControl::nameChanged, this, &RadioButtonBase::valueChangeHandler);

--- a/QMLComponents/controls/radiobuttonbase.cpp
+++ b/QMLComponents/controls/radiobuttonbase.cpp
@@ -25,7 +25,6 @@ RadioButtonBase::RadioButtonBase(QQuickItem* item)
 	_controlType		= ControlType::RadioButton;
 	_isBound			= false;
 	_nameIsOptionValue	= true;
-	_info.displayLabelItalic = true;
 
 	connect(this, &QQuickItem::parentChanged, this, &RadioButtonBase::registerWithParent);
 	connect(this, &JASPControl::nameChanged, this, &RadioButtonBase::valueChangeHandler);

--- a/QMLComponents/controls/radiobuttonbase.h
+++ b/QMLComponents/controls/radiobuttonbase.h
@@ -31,6 +31,8 @@ class RadioButtonBase : public JASPControl
 public:
 	RadioButtonBase(QQuickItem* parent = nullptr);
 
+	bool infoLabelItalic()	const	override	{ return true; }
+
 	JASPControl* group();
 
 public slots:

--- a/QMLComponents/controls/radiobuttonsgroupbase.cpp
+++ b/QMLComponents/controls/radiobuttonsgroupbase.cpp
@@ -29,6 +29,7 @@ RadioButtonsGroupBase::RadioButtonsGroupBase(QQuickItem* item)
 {
 	_controlType = ControlType::RadioButtonGroup;
 	_dependsOnDynamicComponents = true;
+	_info.isHeader = true;
 }
 
 void RadioButtonsGroupBase::setUp()

--- a/QMLComponents/controls/radiobuttonsgroupbase.cpp
+++ b/QMLComponents/controls/radiobuttonsgroupbase.cpp
@@ -29,7 +29,6 @@ RadioButtonsGroupBase::RadioButtonsGroupBase(QQuickItem* item)
 {
 	_controlType = ControlType::RadioButtonGroup;
 	_dependsOnDynamicComponents = true;
-	_info.isHeader = true;
 }
 
 void RadioButtonsGroupBase::setUp()

--- a/QMLComponents/controls/sourceitem.h
+++ b/QMLComponents/controls/sourceitem.h
@@ -47,17 +47,27 @@ public:
 		ConditionVariable() {}
 	};
 
+	struct SourceValuesItem
+	{
+		QString label, value, info;
+		SourceValuesItem(const QString& l, const QString& v, const QString& i) : label{l}, value{v}, info{i} {}
+
+	};
+
+	static const QString SourceValueLabel, SourceValueValue, SourceValueInfo;
+	typedef QVector<SourceValuesItem> SourceValuesType;
+
 	SourceItem(
 			  JASPListControl* targetListControl
 			, QMap<QString, QVariant>& map
-			, const JASPListControl::LabelValueMap& values
+			, const SourceValuesType& values
 			, const QVector<SourceItem*> rSources
 			, QAbstractItemModel* nativeModel = nullptr
 			, const QVector<SourceItem*>& discardSources = QVector<SourceItem*>()
 			, const QVector<QMap<QString, QVariant> >& conditionVariables = QVector<QMap<QString, QVariant> >()
 			);
 
-	SourceItem(JASPListControl* _listControl, const JASPListControl::LabelValueMap& _values);
+	SourceItem(JASPListControl* _listControl, const SourceValuesType& _values);
 
 	SourceItem(JASPListControl* _listControl, const QString& sourceName, const QString& sourceUse);
 
@@ -75,19 +85,19 @@ public:
 	QSet<QString>			usedControls()				const;
 
 
-	void									connectModels();
-	void									disconnectModels();
-	static QVector<SourceItem*>				readAllSources(JASPListControl* _listControl);
-	static QList<QVariant>					getListVariant(QVariant var);
-	static Terms							filterTermsWithCondition(ListModel* model, const Terms& terms, const QString& condition, const QVector<ConditionVariable>& conditionVariables = {}, const QMap<QString, QStringList> &termsMap = {});
+	void										connectModels();
+	void										disconnectModels();
+	static QVector<SourceItem*>					readAllSources(JASPListControl* _listControl);
+	static QList<QVariant>						getListVariant(QVariant var);
+	static Terms								filterTermsWithCondition(ListModel* model, const Terms& terms, const QString& condition, const QVector<ConditionVariable>& conditionVariables = {}, const QMap<QString, QStringList> &termsMap = {});
 
 
 private:
 	static QString							_readSourceName(const QString& sourceNameExt, QString& sourceControl, QString& sourceUse);
 	static QString							_readRSourceName(const QString& sourceNameExt, QString& sourceUse);
-	static QMap<QString, QVariant>			_readSource(JASPListControl* _listControl, const QVariant& source, JASPListControl::LabelValueMap& sourceValues, QVector<SourceItem*>& rSources, QAbstractItemModel*& _nativeModel);
-	static JASPListControl::LabelValueMap	_readValues(JASPListControl* _listControl, const QVariant& _values);
+	static QMap<QString, QVariant>			_readSource(JASPListControl* _listControl, const QVariant& source, SourceValuesType& sourceValues, QVector<SourceItem*>& rSources, QAbstractItemModel*& _nativeModel);
 	static SourceItem*						_readRSource(JASPListControl* listControl, const QVariant& rSource);
+	static SourceValuesType					_readValues(JASPListControl* _listControl, const QVariant& _values);
 
 	void									_setUp();
 	Terms									_readAllTerms();
@@ -104,7 +114,7 @@ private:
 	QStringList						_sourceFilter;
 	QVector<SourceItem*>			_discardSources;
 	QVector<SourceItem*>			_rSources;
-	JASPListControl::LabelValueMap	_values;
+	SourceValuesType				_values;
 	bool							_isValuesSource				= false;
 	bool							_isRSource					= false;
 	ListModel			*			_sourceListModel			= nullptr;

--- a/QMLComponents/controls/tableviewbase.cpp
+++ b/QMLComponents/controls/tableviewbase.cpp
@@ -35,7 +35,6 @@ TableViewBase::TableViewBase(QQuickItem* parent)
 	: JASPListControl(parent)
 {
 	_controlType = ControlType::TableView;
-	_info.displayControlType = true;
 }
 
 void TableViewBase::setUpModel()

--- a/QMLComponents/controls/tableviewbase.cpp
+++ b/QMLComponents/controls/tableviewbase.cpp
@@ -35,6 +35,7 @@ TableViewBase::TableViewBase(QQuickItem* parent)
 	: JASPListControl(parent)
 {
 	_controlType = ControlType::TableView;
+	_info.displayControlType = true;
 }
 
 void TableViewBase::setUpModel()
@@ -271,3 +272,18 @@ void TableViewBase::setItemTypePerColumn(QVariantList list)
 		emit itemTypePerColumnChanged();
 	}
 }
+
+QString TableViewBase::friendlyName() const
+{
+	switch (modelType())
+	{
+	case ModelType::MultinomialChi2Model	: return tr("Mutinomial Chi2 Table");
+	case ModelType::JAGSDataInputModel		: return tr("JAGS Table");
+	case ModelType::CustomContrasts			: return tr("Custom Contrasts Table");
+	case ModelType::FilteredDataEntryModel	: return tr("Filterd Data Entry Table");
+	case ModelType::GridInput				: return tr("Grid Table");
+	case ModelType::Simple					:
+	default									: return tr("Table");
+	}
+}
+

--- a/QMLComponents/controls/tableviewbase.h
+++ b/QMLComponents/controls/tableviewbase.h
@@ -66,6 +66,7 @@ public:
 	void						setUpModel()										override;
 	void						setUp()												override;
 	void						rScriptDoneHandler(const QString & result)			override;
+	bool						infoAddControlType()						const	override	{ return true; }
 
 	ItemType itemTypePerItem(int col = -1, int row = -1) const;
 

--- a/QMLComponents/controls/tableviewbase.h
+++ b/QMLComponents/controls/tableviewbase.h
@@ -92,6 +92,7 @@ public:
 
 	void						setRowCount(int rows)											{ setSize(rows, -1);									}
 	void						setColumnCount(int columns)										{ setSize(-1, columns);									}
+	QString						friendlyName()								const	override;
 
 	Q_INVOKABLE void addColumn(int col = -1, bool left = true);
 	Q_INVOKABLE void removeColumn(int col);

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -27,6 +27,7 @@ TextInputBase::TextInputBase(QQuickItem* parent)
 	: JASPControl(parent), BoundControlBase(this)
 {
 	_controlType = ControlType::TextField;
+	_info.displayControlType = true;
 }
 
 QString TextInputBase::_getPercentValue(double dblVal)
@@ -255,7 +256,7 @@ QString TextInputBase::friendlyName() const
 	switch (_inputType)
 	{
 	case TextInputType::IntegerInputType:		return tr("Integer Field");
-	case TextInputType::NumberInputType:		return tr("Number Field");
+	case TextInputType::NumberInputType:		return tr("Double Field");
 	case TextInputType::PercentIntputType:		return tr("Percentage Field");
 	case TextInputType::IntegerArrayInputType:	return tr("Integers Field");
 	case TextInputType::DoubleArrayInputType:	return tr("Doubles Field");

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -27,7 +27,6 @@ TextInputBase::TextInputBase(QQuickItem* parent)
 	: JASPControl(parent), BoundControlBase(this)
 {
 	_controlType = ControlType::TextField;
-	_info.displayControlType = true;
 }
 
 QString TextInputBase::_getPercentValue(double dblVal)

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -268,11 +268,9 @@ QString TextInputBase::friendlyName() const
 	}
 }
 
-QString	TextInputBase::helpMD(SetConst & markdowned, int howDeep, bool) const
+QString	TextInputBase::helpMD(int howDeep) const
 {
-	markdowned.insert(this);
-
-	if(info() == "" || (label() == "" && afterLabel() == ""))
+	if(infoText() == "" || (label() == "" && afterLabel() == ""))
 		return "";
 
 	QStringList md;
@@ -284,7 +282,7 @@ QString	TextInputBase::helpMD(SetConst & markdowned, int howDeep, bool) const
 			  
 	md	<< "\n"
 		<< "`" << label() << " ... " << afterLabel() << "`\n\n"
-		<< info() << "\n";
+		<< infoText() << "\n";
 
 
 	return md.join("");

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -268,31 +268,10 @@ QString TextInputBase::friendlyName() const
 	}
 }
 
-QString	TextInputBase::helpMD(int howDeep) const
-{
-	if(infoText() == "" || (label() == "" && afterLabel() == ""))
-		return "";
-
-	QStringList md;
-
-	md	<< QString{howDeep, '#' } << " " << friendlyName();
-	
-	if(infoLabel().size())
-		md << " - " << infoLabel();
-			  
-	md	<< "\n"
-		<< "`" << label() << " ... " << afterLabel() << "`\n\n"
-		<< infoText() << "\n";
-
-
-	return md.join("");
-}
-
 bool TextInputBase::encodeValue() const
 {
 	return _inputType == TextInputType::ComputedColumnType || _inputType == TextInputType::AddColumnType;
 }
-
 
 bool TextInputBase::_formulaResultInBounds(double result)
 {

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -42,9 +42,8 @@ public:
 	void		bindTo(const Json::Value& value)					override;
 	void		setUp()												override;
 	void		rScriptDoneHandler(const QString& result)			override;
-	QString		helpMD(SetConst & markdowned,
-					   int howDeep = 2, bool asList=true)	const	override;
 	bool		encodeValue()								const	override;
+	QString		helpMD(int howDeep = 0)						const	override;
 
 	TextInputType	inputType()										{ return _inputType; }
 	QString			friendlyName() const override;

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -50,8 +50,9 @@ public:
 	QVariant		defaultValue()							const	{ return _defaultValue;			}
 	QVariant		value()									const	{ return _value.isNull() ? _defaultValue : _value; } // Sometimes the value is asked before the control is setup, so in this case give the default value
 
-	const QString &label()									const	{ return _label;				}
-	const QString &afterLabel()								const	{ return _afterLabel;			}
+	const QString	&label()								const	{ return _label;				}
+	const QString	&afterLabel()							const	{ return _afterLabel;			}
+	bool			infoAddControlType()					const	override		{ return true;	}
 
 signals:
 	void		formulaCheckSucceeded();

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -43,7 +43,6 @@ public:
 	void		setUp()												override;
 	void		rScriptDoneHandler(const QString& result)			override;
 	bool		encodeValue()								const	override;
-	QString		helpMD(int howDeep = 0)						const	override;
 
 	TextInputType	inputType()										{ return _inputType; }
 	QString			friendlyName() const override;

--- a/QMLComponents/controls/variablesformbase.cpp
+++ b/QMLComponents/controls/variablesformbase.cpp
@@ -23,6 +23,7 @@
 VariablesFormBase::VariablesFormBase(QQuickItem* parent) : JASPControl(parent)
 {
 	_controlType = ControlType::VariablesForm;
+	_info.isHeader = true;
 }
 
 void VariablesFormBase::componentComplete()

--- a/QMLComponents/controls/variablesformbase.cpp
+++ b/QMLComponents/controls/variablesformbase.cpp
@@ -23,7 +23,6 @@
 VariablesFormBase::VariablesFormBase(QQuickItem* parent) : JASPControl(parent)
 {
 	_controlType = ControlType::VariablesForm;
-	_info.isHeader = true;
 }
 
 void VariablesFormBase::componentComplete()

--- a/QMLComponents/controls/variablesformbase.h
+++ b/QMLComponents/controls/variablesformbase.h
@@ -36,6 +36,7 @@ class VariablesFormBase : public JASPControl
 public:
 	VariablesFormBase(QQuickItem* parent = nullptr);
 
+	bool					infoLabelIsHeader()				const	override	{ return true; }
 	JASPControl*			availableVariablesList()		const;
 	QList<JASPControl*>		allAssignedVariablesList()		const	{ return _allAssignedVariablesList;		}
 	QList<JASPControl*>		allJASPControls()				const	{ return _allJASPControls;				}

--- a/QMLComponents/models/listmodellabelvalueterms.cpp
+++ b/QMLComponents/models/listmodellabelvalueterms.cpp
@@ -122,10 +122,10 @@ void ListModelLabelValueTerms::_setLabelValues(const SourceItem::SourceValuesTyp
 
 void ListModelLabelValueTerms::setLabelValuesFromSource()
 {
-	SourceItem::SourceValuesType labelValuePairs;
+	SourceItem::SourceValuesType labelValues;
 
 	if (listView()->addEmptyValue())
-		labelValuePairs.push_back(SourceItem::SourceValuesItem(listView()->placeholderText(), "", ""));
+		labelValues.push_back(SourceItem::SourceValuesItem(listView()->placeholderText(), "", ""));
 
 	listView()->applyToAllSources([&](SourceItem *sourceItem, const Terms& terms)
 	{
@@ -134,11 +134,12 @@ void ListModelLabelValueTerms::setLabelValuesFromSource()
 		{
 			QString label = term.asQString();
 			QString value = labelValueSourceModel ? labelValueSourceModel->getValue(label) : label;
-			labelValuePairs.push_back(SourceItem::SourceValuesItem(label, value, ""));
+			QString info = labelValueSourceModel ? labelValueSourceModel->getInfo(label) : "";
+			labelValues.push_back(SourceItem::SourceValuesItem(label, value, info));
 		}
 	});
 
-	_setLabelValues(labelValuePairs);
+	_setLabelValues(labelValues);
 }
 
 void ListModelLabelValueTerms::sourceNamesChanged(QMap<QString, QString> map)

--- a/QMLComponents/models/listmodellabelvalueterms.h
+++ b/QMLComponents/models/listmodellabelvalueterms.h
@@ -21,12 +21,13 @@
 
 #include "controls/jasplistcontrol.h"
 #include "listmodelavailableinterface.h"
+#include "controls/sourceitem.h"
 
 class ListModelLabelValueTerms : public ListModelAvailableInterface
 {
 	Q_OBJECT
 public:
-	ListModelLabelValueTerms(JASPListControl* listView, const JASPListControl::LabelValueMap& values = JASPListControl::LabelValueMap());
+	ListModelLabelValueTerms(JASPListControl* listView, const SourceItem::SourceValuesType& values = SourceItem::SourceValuesType());
 
 	QVariant					data(const QModelIndex &index, int role = Qt::DisplayRole)	const	override;
 	void						resetTermsFromSources()												override;
@@ -34,6 +35,7 @@ public:
 	std::vector<std::string>	getValues();
 	QString						getValue(const QString& label)								const;
 	QString						getLabel(const QString& value)								const;
+	QString						getInfo(const QString& label)								const;
 	int							getIndexOfValue(const QString& value)						const;
 	int							getIndexOfLabel(const QString& label)						const;
 
@@ -43,10 +45,11 @@ public slots:
 	void						sourceNamesChanged(QMap<QString, QString> map)					override;
 
 protected:
-	void						_setLabelValues(const JASPListControl::LabelValueMap& values);
+	void						_setLabelValues(const SourceItem::SourceValuesType& values);
 
-	QMap<QString, QString>		_valueToLabelMap;
-	QMap<QString, QString>		_labelToValueMap;
+	QMap<QString, int>				_valuesMap;
+	QMap<QString, int>				_labelsMap;
+	SourceItem::SourceValuesType	_labelValues;
 
 };
 


### PR DESCRIPTION
The JASPControl::helpMD function has been simplified, so that all specific display needed for a control, has been moved to the overriden control function. 

The info property is changed into a QVariant, so that more information can be set. 
For controls: if it is a string, this is, as before, just the text of the info. But it can be used as an object like this: 
`{ text: "....", label: "....", useControlType: true, isHeader: true}` 
In this way the developer can specify whether the label can have another value than the title, whether the type of the control should be displayed, and whether the info should be displayed as an header. Other kind of information can be later easily added.

For Form, the info can be also just a string but also an object: 
`{ top: "..",, bottom: "...", references: ["ref1, "ref2"], RPackages: ["pack1", "pack2"], examples: ["example1", "example2"] }`




