### PR TITLE
Enable column encoding in textinputbase for columns added

### DIFF
--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -290,6 +290,11 @@ QString	TextInputBase::helpMD(SetConst & markdowned, int howDeep, bool) const
 	return md.join("");
 }
 
+bool TextInputBase::encodeValue() const
+{
+	return _inputType == TextInputType::ComputedColumnType || _inputType == TextInputType::AddColumnType;
+}
+
 
 bool TextInputBase::_formulaResultInBounds(double result)
 {

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -44,6 +44,7 @@ public:
 	void		rScriptDoneHandler(const QString& result)			override;
 	QString		helpMD(SetConst & markdowned,
 					   int howDeep = 2, bool asList=true)	const	override;
+	bool		encodeValue()								const	override;
 
 	TextInputType	inputType()										{ return _inputType; }
 	QString			friendlyName() const override;


### PR DESCRIPTION
Make sure that columns that have already been added by the desktop (through ComputedColumnField or AddColumnField) are sent encoded to the analysis (because I guess they were before)

Should probably not break anything?
And should fix https://github.com/jasp-stats/INTERNAL-jasp/issues/2488 (audit broken)
