### PR TITLE
Handle comments in ODS better & more!

### DIFF
--- a/Desktop/data/importers/csvimporter.cpp
+++ b/Desktop/data/importers/csvimporter.cpp
@@ -25,7 +25,6 @@ using namespace std;
 
 CSVImporter::CSVImporter() : Importer()
 {
-    DataSetPackage::pkg()->setIsJaspFile(false);
 }
 
 ImportDataSet* CSVImporter::loadFile(const string &locator, std::function<void(int)> progressCallback)

--- a/Desktop/data/importers/databaseimporter.cpp
+++ b/Desktop/data/importers/databaseimporter.cpp
@@ -3,6 +3,7 @@
 #include <QSqlField>
 #include "database/databaseimportcolumn.h"
 #include "utils.h"
+#include "utilities/qutils.h"
 
 ImportDataSet * DatabaseImporter::loadFile(const std::string &locator, std::function<void(int)> progressCallback)
 {

--- a/Desktop/data/importers/databaseimporter.h
+++ b/Desktop/data/importers/databaseimporter.h
@@ -11,7 +11,7 @@ class DatabaseImporter : public Importer
 	typedef DatabaseConnectionInfo Info;
 	
 public:
-	DatabaseImporter(){}
+	DatabaseImporter() : Importer() {}
 	
 	ImportDataSet* loadFile(const std::string &locator, std::function<void(int)> progressCallback) override;
 	void initColumn(QVariant colId, ImportColumn * importColumn) override;

--- a/Desktop/data/importers/importcolumn.cpp
+++ b/Desktop/data/importers/importcolumn.cpp
@@ -4,8 +4,8 @@
 #include "columnutils.h"
 #include "log.h"
 
-ImportColumn::ImportColumn(ImportDataSet* importDataSet, std::string name)
-	: _importDataSet(importDataSet), _name(name)
+ImportColumn::ImportColumn(ImportDataSet* importDataSet,  const std::string & name,  const std::string & title)
+	: _importDataSet(importDataSet), _name(name), _title(title)
 {
 }
 
@@ -15,14 +15,27 @@ ImportColumn::~ImportColumn()
 }
 
 
-std::string ImportColumn::name() const
+const std::string & ImportColumn::name() const
 {
 	return _name;
 }
 
-void ImportColumn::changeName(const std::string & name)
+
+
+const std::string & ImportColumn::title() const
 {
-	Log::log() << "Changing name of column from '" << _name << "' to '" << name << "'\n." << std::endl;
+	return _title;
+}
+
+void ImportColumn::setName(const std::string & name)
+{
+	if(!_name.empty())
+		Log::log() << "Changing name of column from '" << _name << "' to '" << name << "'\n." << std::endl;
 
 	_name = name;
+}
+
+void ImportColumn::setTitle(const std::string & title)
+{
+	_title = title;
 }

--- a/Desktop/data/importers/importcolumn.cpp
+++ b/Desktop/data/importers/importcolumn.cpp
@@ -1,7 +1,4 @@
 #include "importcolumn.h"
-#include <cmath>
-#include "utils.h"
-#include "columnutils.h"
 #include "log.h"
 
 ImportColumn::ImportColumn(ImportDataSet* importDataSet,  const std::string & name,  const std::string & title)

--- a/Desktop/data/importers/importcolumn.h
+++ b/Desktop/data/importers/importcolumn.h
@@ -15,17 +15,23 @@ class ImportDataSet;
 class ImportColumn
 {
 public:
-										ImportColumn(ImportDataSet* importDataSet, std::string name);
+										ImportColumn(ImportDataSet* importDataSet, const std::string & name,  const std::string & title = "");
 	virtual								~ImportColumn();
 
 	virtual			size_t				size()									const = 0;
 	virtual const	stringvec		&	allValuesAsStrings()					const = 0;
-					std::string			name()									const;
-					void				changeName(const std::string & name);
-
+	virtual const	stringvec		&	allLabelsAsStrings()					const	{ return allValuesAsStrings(); };
+	virtual const	stringset		&	allEmptyValuesAsStrings()				const	{ static stringset a; return a; }
+	virtual			columnType			getColumnType()							const	{ return columnType::unknown; }
+			const	std::string		&	title()									const;
+			const	std::string		&	name()									const;
+			void						setName(const std::string & name);
+			void						setTitle(const std::string & title);
+					
 protected:
 	ImportDataSet * _importDataSet;
-	std::string		_name;
+	std::string		_name,
+					_title;
 };
 
 #endif // IMPORTCOLUMN_H

--- a/Desktop/data/importers/importdataset.cpp
+++ b/Desktop/data/importers/importdataset.cpp
@@ -90,17 +90,24 @@ void ImportDataSet::buildDictionary()
 		if(col->name() != "")
 			_nameToColMap[col->name()] = col;
 
-	size_t unnamedColumns = 0;
+	//Lets name the unnamed columns the same way csv does
+	size_t curCol = 0;
 
 	for(ImportColumn * col : *this)
+	{
+		curCol++;
+		
 		if(col->name() == "")
 		{
-			std::string newName = "";
-			while(newName == "" || _nameToColMap.count(newName) > 0)
-				newName = "Unnamed Column #" + std::to_string(++unnamedColumns);
+			std::string newName;
+			do
+				newName = "V" + std::to_string(curCol);
+			while(_nameToColMap.count(newName) > 0);
+				
 			col->setName(newName);
 
 			_nameToColMap[col->name()] = col;
 		}
+	}
 }
 

--- a/Desktop/data/importers/importdataset.cpp
+++ b/Desktop/data/importers/importdataset.cpp
@@ -98,7 +98,7 @@ void ImportDataSet::buildDictionary()
 			std::string newName = "";
 			while(newName == "" || _nameToColMap.count(newName) > 0)
 				newName = "Unnamed Column #" + std::to_string(++unnamedColumns);
-			col->changeName(newName);
+			col->setName(newName);
 
 			_nameToColMap[col->name()] = col;
 		}

--- a/Desktop/data/importers/importer.cpp
+++ b/Desktop/data/importers/importer.cpp
@@ -1,8 +1,14 @@
 #include "importer.h"
 #include "utilities/qutils.h"
-#include "utilities/settings.h"
 #include "log.h"
 #include <QVariant>
+#include "../datasetpackage.h"
+
+Importer::Importer() 
+{
+	//Turns out that jasp importer and jaspiporter old are not Importers... Great...
+	DataSetPackage::pkg()->setIsJaspFile(false);
+}
 
 Importer::~Importer() {}
 
@@ -48,7 +54,12 @@ void Importer::loadDataSet(const std::string &locator, std::function<void(int)> 
 void Importer::initColumn(QVariant colId, ImportColumn *importColumn)
 {
 	JASPTIMER_SCOPE(Importer::initColumn);
-	initColumnWithStrings(colId, importColumn->name(),  importColumn->allValuesAsStrings());
+	initColumnWithStrings(colId, importColumn->name(),  importColumn->allValuesAsStrings(), importColumn->allLabelsAsStrings(), importColumn->title(), importColumn->getColumnType(), importColumn->allEmptyValuesAsStrings());
+}
+
+void Importer::initColumnWithStrings(QVariant colId, const std::string &newName, const std::vector<std::string> &values, const std::vector<std::string> &labels, const std::string & title, columnType desiredType, const stringset & emptyValues) 
+{ 
+	DataSetPackage::pkg()->initColumnWithStrings(colId, newName, values, labels, title, desiredType, emptyValues); 																																							 
 }
 
 void Importer::syncDataSet(const std::string &locator, std::function<void(int)> progress)

--- a/Desktop/data/importers/importer.h
+++ b/Desktop/data/importers/importer.h
@@ -2,14 +2,11 @@
 #define IMPORTER_H
 
 #include <boost/function.hpp>
-#include "../datasetpackage.h"
 #include "importdataset.h"
-#include "timers.h"
 
 class ImportDataSet;
 class ImportColumn;
 #include <QCoreApplication>
-#include "utilities/qutils.h"
 
 ///
 /// Base class for all importers
@@ -18,7 +15,7 @@ class Importer
 {
 	Q_DECLARE_TR_FUNCTIONS(Importer)
 public:
-	Importer() {}
+	Importer();
 	virtual ~Importer();
     void loadDataSet(const std::string &locator, std::function<void (int)> progressCallback);
     void syncDataSet(const std::string &locator, std::function<void (int)> progressCallback);
@@ -29,7 +26,7 @@ protected:
 	///colID can be either an integer (the column index in the data) or a string (the (old) name of the column in the data)
 	virtual void initColumn(QVariant colId, ImportColumn *importColumn);
 
-	void initColumnWithStrings(QVariant colId, const std::string & newName, const std::vector<std::string> & values, const std::vector<std::string> & labels=stringvec()) { DataSetPackage::pkg()->initColumnWithStrings(colId, newName, values, labels); }
+	void initColumnWithStrings(QVariant colId, const std::string & newName, const std::vector<std::string> & values, const std::vector<std::string> & labels=stringvec(), const std::string & title="", columnType desiredTyp = columnType::unknown, const stringset & emptyValues = {});
 
 private:
 	void _syncPackage(

--- a/Desktop/data/importers/jaspimporter.cpp
+++ b/Desktop/data/importers/jaspimporter.cpp
@@ -32,7 +32,6 @@
 #include "../exporters/jaspexporter.h"
 
 #include "resultstesting/compareresults.h"
-#include "log.h"
 
 void JASPImporter::loadDataSet(const std::string &path, std::function<void(int)> progressCallback)
 {	

--- a/Desktop/data/importers/jaspimporterold.h
+++ b/Desktop/data/importers/jaspimporterold.h
@@ -26,13 +26,14 @@
 #include "json/value.h"
 #include "columntype.h"
 #include "version.h"
+#include "importer.h"
 
 ///
 /// Loads a jasp file
 /// We generally try to make sure to always stay backwards compatible as far as we can.
 /// Which as of 0.17.2 is still all the way back to 0.8.? something like that at least
 /// In 0.18 a new class is added for saving workspaces with sqlite in there, this class is kept for backwards compatibility
-class JASPImporterOld
+class JASPImporterOld : public Importer
 {
 	Q_DECLARE_TR_FUNCTIONS(JASPImporter)
 public:

--- a/Desktop/data/importers/ods/odsimportcolumn.cpp
+++ b/Desktop/data/importers/ods/odsimportcolumn.cpp
@@ -62,6 +62,17 @@ const stringvec & ODSImportColumn::allValuesAsStrings() const
 	return values;
 }
 
+const stringvec & ODSImportColumn::allLabelsAsStrings() const
+{
+	static stringvec labels;
+	labels.resize(_rows.size());
+	
+	for(size_t i=0; i<_rows.size(); i++)
+		labels[i] = _rows[i].labelAsString();
+
+	return labels;
+}
+
 
 /**
  * @brief insert Inserts string value for cell, irrespective of type.
@@ -103,6 +114,17 @@ void ODSImportColumn::setValue(int row, const string &data)
 
 	ODSSheetCell & cell = _rows.at(row);
 	cell.setValue(data);	
+}
+
+void ODSImportColumn::setComment(int row, const string &data)
+{
+	//Log::log() << "Inserting " << data << ", row " << row << ", column " << _columnNumber << "." << std::endl;
+
+	// Big enough?
+	createSpace(row);
+
+	ODSSheetCell & cell = _rows.at(row);
+	cell.setComment(data);	
 }
 
 /**

--- a/Desktop/data/importers/ods/odsimportcolumn.cpp
+++ b/Desktop/data/importers/ods/odsimportcolumn.cpp
@@ -73,43 +73,16 @@ const stringvec & ODSImportColumn::allLabelsAsStrings() const
 	return labels;
 }
 
-
-/**
- * @brief insert Inserts string value for cell, irrespective of type.
- * @param row
- * @param data
- */
 void insert(int row, const std::string& data);
 
-
-/**
- * @brief _createSpace Ensures that we have enough elements in _rows.
- * @param row Row number to check for.
- */
 void ODSImportColumn::createSpace(size_t row)
 {
-#ifdef JASP_DEBUG
-	size_t numAdded = 0;
-#endif
-
-	while (_rows.size() <= row)
-#ifdef JASP_DEBUG
-	{
-		numAdded++;
-#endif
-		_rows.push_back(ODSSheetCell());
-#ifdef JASP_DEBUG
-	}
-
-	//if (numAdded != 0) 	Log::log() << "ODSImportColumn::_createSpace(" << row << ") - added " << numAdded << " row" <<((numAdded != 1) ? "s" : "") << "." << std::endl;
-#endif
+	if(_rows.size() <= row)
+		_rows.resize(row+1);
 }
 
 void ODSImportColumn::setValue(int row, const string &data)
 {
-	//Log::log() << "Inserting " << data << ", row " << row << ", column " << _columnNumber << "." << std::endl;
-
-	// Big enough?
 	createSpace(row);
 
 	ODSSheetCell & cell = _rows.at(row);
@@ -118,50 +91,9 @@ void ODSImportColumn::setValue(int row, const string &data)
 
 void ODSImportColumn::setComment(int row, const string &data)
 {
-	//Log::log() << "Inserting " << data << ", row " << row << ", column " << _columnNumber << "." << std::endl;
-
-	// Big enough?
 	createSpace(row);
 
 	ODSSheetCell & cell = _rows.at(row);
 	cell.setComment(data);	
 }
 
-/**
- * @brief postLoadProcess Performs posy load processing.
- * @param dataSet Dataset we are a member of.
- *
- * This includes finding the long column name,
- * and the type of the column, and converting all
- * the cells to the same type.
- */
-void ODSImportColumn::postLoadProcess()
-{
-}
-
-/**
- * @brief colNumberAsExcel Returns the column number as a string (base 26 digits A-Z).
- * @param column Column number
- * @return
- */
-string ODSImportColumn::_colNumberAsExcel(int column)
-{
-	string result;
-	int divisor = 26 * 26 * 26 * 26 * 26 * 26;	// give up after col ZZZZZZ
-
-	// In essence, the the classic number base conversion.
-	bool found = false;
-	while(divisor > 0)
-	{
-		int c = column / divisor;
-		// supress leading zeros (i.e. 'A')
-		if ((c > 0) || (divisor == 1))
-			found = true;
-		if (found)
-			result.push_back((char) (c + 'A'));
-		column = column % divisor;
-		divisor = divisor / 26;
-	}
-
-	return result;
-}

--- a/Desktop/data/importers/ods/odsimportcolumn.h
+++ b/Desktop/data/importers/ods/odsimportcolumn.h
@@ -36,6 +36,7 @@ class ODSImportDataSet;
 class ODSImportColumn : public ImportColumn
 {
 public:
+	typedef std::map< int, size_t > CellIndex;
 
 	// The empty value for a cell.
 	static const ODSSheetCell EmptySheetCell;
@@ -46,98 +47,35 @@ public:
 	ODSImportColumn(ODSImportDataSet* importDataSet, int columnNumber, std::string name);
 	virtual ~ODSImportColumn();
 
-
-
-	// ImportColumn interface
-	/**
-	 * @brief size Returns the size of (i.e. number of) rows.
-	 * @return The size of (i.e. number of) rows.
-	 */
 	size_t size() const override;
 
 	const stringvec &	allValuesAsStrings()					const	override;
 	const stringvec &	allLabelsAsStrings()					const	override;
 
-	/**
-	 * @brief hasCall Checks for presence of a cell at row.
-	 * @param row Row check for.
-	 * @return true if value in column.
-	 */
 	inline bool hasCell(size_t row) const
 	{
 		return (_index.find(row) != _index.end());
 	}
 
-	/**
-	 * @brief _createSpace Ensures that we have enough elements in _rows.
-	 * @param row Row number to check for.
-	 */
 	void createSpace(size_t row);
 
-	/**
-	 * @brief setValue Inserts string value for cell, irrespective of type.
-	 * @param row
-	 * @param data
-	 */
 	void setValue(int row, const std::string& data);
 	
 	void setComment(int row, const std::string& data);
 
 	const ODSSheetCell &getCell(int row) const { return _rows.at(row); }
 
-	/**
-	 * @brief postLoadProcess Performs posy load processing.
-	 *
-	 * This includes finding the long column name,
-	 * and the type of the column, and converting all
-	 * the cells to the same type.
-	 *
-	 */
-	void postLoadProcess();
-
 	columnType	getColumnType() const override { return _columnType; }
 
 
 private:
-
-	// The cells/rows (as read).
 	Cases				_rows;
 
-	typedef std::map< int, size_t > CellIndex;
+	
 	CellIndex			_index;		///< cell indexes indexed by row.
 	int					_columnNumber; //<- We know our own column number
 	columnType			_columnType; // Our column type.
 
-	/**
-	 * @brief colNumberAsExcel Returns the column number as a string (base 26 A-Z).
-	 * @param column Column number
-	 * @return
-	 */
-	static std::string _colNumberAsExcel(int column);
-
-	/**
-	 * @brief setColumnConvertStringData Sets String data into the column, after doing a code page convert.
-	 * @param column The columns to insert into.
-	 */
-//	void _setColumnConvertStringData(Column *column);
-
-	/**
-	 * @brief setColumnConvertDblToString Sets String data into the column.
-	 * @param column The columns to insert into.
-	 */
-	//void _setColumnConvertDblToString(Column *column);
-
-	/**
-	 * @brief setColumnLabeledData Sets numeric data into the column, with labels.
-	 * @param column The columns to insert into.
-	 */
-	//void _setColumnLabeledData(Column *column);
-
-	/**
-	 * @brief setColumnScaleData Sets floating point / scalar data into the column.
-	 * @param column The columns to insert into.
-	 */
-	// _setColumnScaleData(Column *column);
 
 };
 

--- a/Desktop/data/importers/ods/odsimportcolumn.h
+++ b/Desktop/data/importers/ods/odsimportcolumn.h
@@ -46,12 +46,6 @@ public:
 	ODSImportColumn(ODSImportDataSet* importDataSet, int columnNumber, std::string name);
 	virtual ~ODSImportColumn();
 
-	/**
-	 * @brief setName Setter for long name (label).
-	 * @param longname The long name (label) to set.
-	 */
-//	void setLongName(const string &longname) { _longName = longname; }
-	void setName(const std::string &name) { _name = name; }
 
 
 	// ImportColumn interface
@@ -62,6 +56,7 @@ public:
 	size_t size() const override;
 
 	const stringvec &	allValuesAsStrings()					const	override;
+	const stringvec &	allLabelsAsStrings()					const	override;
 
 	/**
 	 * @brief hasCall Checks for presence of a cell at row.
@@ -85,6 +80,8 @@ public:
 	 * @param data
 	 */
 	void setValue(int row, const std::string& data);
+	
+	void setComment(int row, const std::string& data);
 
 	const ODSSheetCell &getCell(int row) const { return _rows.at(row); }
 
@@ -98,15 +95,13 @@ public:
 	 */
 	void postLoadProcess();
 
-	columnType	getColumnType() const { return _columnType; }
+	columnType	getColumnType() const override { return _columnType; }
 
-	// Getters.
-	columnType	getJASPColumnType() const { return _columnType; }
 
 private:
 
 	// The cells/rows (as read).
-	Cases	_rows;
+	Cases				_rows;
 
 	typedef std::map< int, size_t > CellIndex;
 	CellIndex			_index;		///< cell indexes indexed by row.

--- a/Desktop/data/importers/ods/odsimportdataset.cpp
+++ b/Desktop/data/importers/ods/odsimportdataset.cpp
@@ -78,17 +78,9 @@ ODSImportColumn & ODSImportDataSet::getOrCreate (const int index)
 	if (index < columnCount())
 		return static_cast<ODSImportColumn &>(*(_columns[index]));
 	else
-	{
-		stringstream ss;
-		ss << "_col" << columnCount() + 1;
-		return createColumn(ss.str());
-	}
+		return createColumn("");
 }
 
-
-/**
- * @brief postLoadProcess Performs post load processing.
- */
 void ODSImportDataSet::postLoadProcess()
 {
 	size_t numRows = 0;

--- a/Desktop/data/importers/ods/odsimportdataset.cpp
+++ b/Desktop/data/importers/ods/odsimportdataset.cpp
@@ -20,7 +20,6 @@
 */
 
 #include "odsimportdataset.h"
-#include "log.h"
 #include "../importdataset.h"
 #include "odsimportcolumn.h"
 #include "../odsimporter.h"
@@ -50,6 +49,12 @@ ODSImportColumn & ODSImportDataSet::createColumn(string name)
 	ODSImportColumn* column = new ODSImportColumn(this, columnCount(), name);
 	addColumn(column);
 	return *column;
+}
+
+void ODSImportDataSet::createSpace(size_t row)
+{
+	for(ImportColumn * colBase : _columns)
+		static_cast<ODSImportColumn*>(colBase)->createSpace(row);
 }
 
 

--- a/Desktop/data/importers/ods/odsimportdataset.cpp
+++ b/Desktop/data/importers/ods/odsimportdataset.cpp
@@ -91,7 +91,6 @@ void ODSImportDataSet::postLoadProcess()
 	for (ImportColumns::iterator colI = begin(); colI != end(); ++colI)
 	{
 		ODSImportColumn * col = static_cast<ODSImportColumn *>(*colI);
-		col->postLoadProcess();
 		numRows = max(numRows, col->size());
 	}
 

--- a/Desktop/data/importers/ods/odsimportdataset.h
+++ b/Desktop/data/importers/ods/odsimportdataset.h
@@ -69,9 +69,6 @@ public:
 	ODSImportColumn & operator [] (const int index);
 	ODSImportColumn & getOrCreate (const int index);
 
-	/**
-	 * @brief postLoadProcess Performs post load processing.
-	 */
 	void postLoadProcess();
 
 

--- a/Desktop/data/importers/ods/odsimportdataset.h
+++ b/Desktop/data/importers/ods/odsimportdataset.h
@@ -58,6 +58,8 @@ public:
 	const std::string &getContentFilename() const { return _contentFilename; }
 
 	ODSImportColumn & createColumn(std::string name);
+	
+	void	createSpace(size_t row);
 
 	/**
 	 * @brief operator [] Exposes the underlying vector of the ImportDataSet.

--- a/Desktop/data/importers/ods/odssheetcell.cpp
+++ b/Desktop/data/importers/ods/odssheetcell.cpp
@@ -106,3 +106,14 @@ const
 {
 	return _string;
 }
+
+const string &ODSSheetCell::commentAsString()
+const
+{
+	return _comment;
+}
+
+const string &ODSSheetCell::labelAsString() const
+{
+	return _comment.empty() ? _string : _comment;
+}

--- a/Desktop/data/importers/ods/odssheetcell.cpp
+++ b/Desktop/data/importers/ods/odssheetcell.cpp
@@ -101,6 +101,11 @@ void ODSSheetCell::setValue(const string &value)
 		_xmlType = odsType_string;
 }
 
+void ODSSheetCell::setComment(const std::string &comment) 
+{ 
+	_comment = comment; 
+}
+
 const string &ODSSheetCell::valueAsString()
 const
 {

--- a/Desktop/data/importers/ods/odssheetcell.h
+++ b/Desktop/data/importers/ods/odssheetcell.h
@@ -41,16 +41,20 @@ public:
 	const XmlDatatype& xmlType() const { return _xmlType; }
 
 	void setTypeAndValue(XmlDatatype type, const QString &data);
-	const std::string &valueAsString() const;
+	const std::string &	valueAsString() const;
+	const std::string &	labelAsString() const;
+	const std::string &	commentAsString() const;
 
 
 private:
 	// The data types
 	XmlDatatype				_xmlType;
-	std::string				_string;
+	std::string				_string,
+							_comment;
 
 	void setValue(const QString &value);
 	void setValue(const std::string &value);
+	void setComment(const std::string &comment) { _comment = comment; }
 };
 
 } // end namespace ods

--- a/Desktop/data/importers/ods/odssheetcell.h
+++ b/Desktop/data/importers/ods/odssheetcell.h
@@ -54,7 +54,7 @@ private:
 
 	void setValue(const QString &value);
 	void setValue(const std::string &value);
-	void setComment(const std::string &comment) { _comment = comment; }
+	void setComment(const std::string &comment);
 };
 
 } // end namespace ods

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
@@ -144,18 +144,22 @@ bool XmlContentsHandler::endElement(const QString &namespaceURI, const QString &
 		{
 		case not_in_doc:
 			break;
+			
 		case document_content:
 			if (localName == _nameDocContent)
 				_docDepth = not_in_doc;
 			break;
+			
 		case body:
 			if (localName == _nameBody)
 				_docDepth = document_content;
 			break;
+			
 		case spreadsheet:
 			if (localName == _nameSpreadsheet)
 				_docDepth = body;
 			break;
+			
 		case table:
 			if (localName == _nameTable)
 			{
@@ -163,6 +167,7 @@ bool XmlContentsHandler::endElement(const QString &namespaceURI, const QString &
 				_tableRead = true;
 			}
 			break;
+			
 		case table_row:
 			if (localName == _nameTableRow)
 			{
@@ -174,7 +179,8 @@ bool XmlContentsHandler::endElement(const QString &namespaceURI, const QString &
 					{
 						for (int j = 0; j < _dataSet->columnCount(); j++)
 						{
-							(*_dataSet)[j].setValue(_row, (*_dataSet)[j].getCell(_row - 1).valueAsString());
+							(*_dataSet)[j].setValue(_row,	(*_dataSet)[j].getCell(_row - 1).valueAsString());
+							(*_dataSet)[j].setComment(_row, (*_dataSet)[j].getCell(_row - 1).commentAsString());
 						}
 						_row++;
 					}
@@ -189,6 +195,7 @@ bool XmlContentsHandler::endElement(const QString &namespaceURI, const QString &
 				_rowRepeat			= 1;
 			}
 			break;
+			
 		case table_cell:
 			if (localName == _nameTableCell)
 			{
@@ -206,7 +213,11 @@ bool XmlContentsHandler::endElement(const QString &namespaceURI, const QString &
 							_dataSet->createColumn(ss.str());
 						}
 						// Create the column with the current cell name
-						_dataSet->createColumn(_currentCell.toStdString());
+						auto & col = _dataSet->createColumn(_currentCell.toStdString());
+						
+						if(!_currentComment.isEmpty())
+							col.setTitle(fq(_currentComment));
+						
 						// Repeat create column if necessary
 						for (int i = 1; i < _colRepeat; i++)
 						{
@@ -223,7 +234,13 @@ bool XmlContentsHandler::endElement(const QString &namespaceURI, const QString &
 							_dataSet->getOrCreate(i).setValue(_row - 1, string());
 						}
 						for (int i = 0; i < _colRepeat; i++)
-							_dataSet->getOrCreate(_column + i).setValue(_row - 1, _currentCell.toStdString());
+						{
+							ODSImportColumn & col = _dataSet->getOrCreate(_column + i);
+							col.setValue(_row - 1, _currentCell.toStdString());
+							
+							if(!_currentComment.isEmpty())
+								col.setComment(_row - 1, _currentComment.toStdString());
+						}
 					}
 					_lastNotEmptyColumn = _column + _colRepeat - 1;
 				}

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
@@ -195,18 +195,14 @@ bool ODSXmlContentsHandler::endElement(const QString &namespaceURI, const QStrin
 		case table_cell:
 			if (localName == _nameTableCell)
 			{
-				if (!_currentCell.isEmpty() && _row == 0)
+				if ((!_currentCell.isEmpty() || _lastNotEmptyColumn > -1) && _row == 0)
 				{
 					// There is some celldata and we dont have any rows yet, so create headers:
 					// Deals with header
 					// First add columns that had no name
 					for (int i = _lastNotEmptyColumn + 1; i < _column; i++)
-					{
-						// Set some names for columns that have no header.
-						stringstream ss;
-						ss << "_col" << (i + 1);
-						_dataSet->createColumn(ss.str());
-					}
+						_dataSet->createColumn("");
+
 					// Create the column with the current cell name
 					auto & col = _dataSet->createColumn(_currentCell.toStdString());
 					
@@ -218,11 +214,7 @@ bool ODSXmlContentsHandler::endElement(const QString &namespaceURI, const QStrin
 					// Repeat create column if necessary
 					if(_column + _colRepeat != _excelMaxCols)
 						for (int i = 1; i < _colRepeat; i++)
-						{
-							stringstream ss;
-							ss << "_col" << (_column + i + 1);
-							_dataSet->createColumn(ss.str());
-						}
+							_dataSet->createColumn(_currentCell.toStdString());
 				}
 				
 				if(_row > 0) 

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
@@ -112,7 +112,8 @@ bool XmlContentsHandler::startElement(const QString &namespaceURI, const QString
 			break;
 			
 		case annotation:
-			_docDepth = text_annotation;
+			if (localName == _nameText)
+				_docDepth = text_annotation;
 			break;
 		
 		case text:
@@ -294,6 +295,8 @@ bool XmlContentsHandler::characters(const QString &ch)
 				break;
 			
 			case text_annotation:
+				if(_currentComment.size())
+					_currentComment.push_back("\t");
 				_currentComment.push_back(ch);
 				break;
 				

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
@@ -11,6 +11,7 @@ const QString XmlContentsHandler::_nameSpreadsheet("spreadsheet");
 const QString XmlContentsHandler::_nameTable("table");
 const QString XmlContentsHandler::_nameTableRow("table-row");
 const QString XmlContentsHandler::_nameTableCell("table-cell");
+const QString XmlContentsHandler::_nameAnnotation("annotation");
 const QString XmlContentsHandler::_nameText("p");
 
 const QString XmlContentsHandler::_attValueType("office:value-type");
@@ -103,7 +104,9 @@ bool XmlContentsHandler::startElement(const QString &namespaceURI, const QString
 			break;
 
 		case table_cell:
-			if (localName == _nameText)
+			if (localName == _nameAnnotation)
+				_docDepth = annotation;
+			else if (localName == _nameText)
 				_docDepth = text;
 			break;
 
@@ -224,6 +227,11 @@ bool XmlContentsHandler::endElement(const QString &namespaceURI, const QString &
 				_colRepeat = 1;
 				_currentCell.clear();
 			}
+			break;
+		
+		case annotation:
+			if (localName == _nameAnnotation)
+				_docDepth = table_cell;
 			break;
 
 		case text:

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.h
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.h
@@ -21,6 +21,7 @@ class XmlContentsHandler : public XmlHandler
 		table,
 		table_row,
 		table_cell,
+		annotation,
 		text			// Only for string cells.
 	} DocDepth;
 
@@ -77,17 +78,18 @@ private:
 	QString			_currentCell;
 
 	// Names we search for.
-	static const QString _nameDocContent;
 	static const QString _nameBody;
-	static const QString _nameSpreadsheet;
 	static const QString _nameTable;
 	static const QString _nameTableRow;
+	static const QString _nameDocContent;
+	static const QString _nameSpreadsheet;
+	static const QString _nameAnnotation;
 	static const QString _nameTableCell;
 	static const QString _nameText;
 
 	// Attribute names we search for.
-	static const QString _attValueType;
 	static const QString _attValue;
+	static const QString _attValueType;
 	static const QString _attDateValue;
 	static const QString _attTimeValue;
 	static const QString _attBoolValue;
@@ -95,11 +97,11 @@ private:
 	static const QString _attRowRepeatCount;
 
 	// Values of the attribute attValueType.
-	static const QString _typeFloat;
 	static const QString _typeCurrency;
 	static const QString _typePercent;
 	static const QString _typeBoolean;
 	static const QString _typeString;
+	static const QString _typeFloat;
 	static const QString _typeDate;
 	static const QString _typeTime;
 

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.h
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.h
@@ -68,13 +68,13 @@ public:
 	void resetDocument();
 
 private:
-	DocDepth 		_docDepth			= DocDepth::not_in_doc;			///< Current depth of document.
-	int				_row				= 0,				///< Current row in document/table.
-					_column				= 0,			///< Current column in document/table.
+	DocDepth 		_docDepth			= DocDepth::not_in_doc;		///< Current depth of document.
+	size_t			_row				= 0;						///< Current row in document/table.
+	int				_column				= 0,						///< Current column in document/table.
 					_lastNotEmptyColumn	= -1;
-	bool			_tableRead			= false;			///< True if first table read.
+	bool			_tableRead			= false;					///< True if first table read.
 	XmlDatatype		_lastType			= odsType_unknown;			///< The last type we found in a opening tag.
-	int				_colRepeat			= 1,			///< Number cells this XML element spans.
+	int				_colRepeat			= 1,						///< Number cells this XML element spans.
 					_rowRepeat			= 1;
 	QString			_currentCell,
 					_currentComment;
@@ -108,6 +108,7 @@ private:
 	static const QString _typeTime;
 	
 	// Excel sometimes exports too many "repeat columns/row" elements, only to make sure that it looks the same as in excel.
+	// In the sense of looking the same as the entire editable table in excel...
 	// It then wants you to repeat empty cells that many times.
 	// This is of course not very sensible so instead we detect that and ignore such cells.
 	// To do this we need to know the maximum size of an excelspreadsheet and it is:

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.h
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.h
@@ -22,6 +22,7 @@ class XmlContentsHandler : public XmlHandler
 		table_row,
 		table_cell,
 		annotation,
+		text_annotation,
 		text			// Only for string cells.
 	} DocDepth;
 
@@ -68,14 +69,15 @@ public:
 
 private:
 	DocDepth 		_docDepth;			///< Current depth of document.
-	int				_row;				///< Current row in document/table.
-	int				_column;			///< Current column in document/table.
-	int				_lastNotEmptyColumn;
+	int				_row,				///< Current row in document/table.
+					_column,			///< Current column in document/table.
+					_lastNotEmptyColumn;
 	bool			_tableRead;			///< True if first table read.
-	XmlDatatype		_lastType;		///< The last type we found in a opening tag.
-	int				_colRepeat;			///< Number cells this XML element spans.
-	int				_rowRepeat;
-	QString			_currentCell;
+	XmlDatatype		_lastType;			///< The last type we found in a opening tag.
+	int				_colRepeat,			///< Number cells this XML element spans.
+					_rowRepeat;
+	QString			_currentCell,
+					_currentComment;
 
 	// Names we search for.
 	static const QString _nameBody;

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.h
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.h
@@ -9,7 +9,7 @@
 namespace ods
 {
 
-class XmlContentsHandler : public XmlHandler
+class ODSXmlContentsHandler : public XmlHandler
 {
 	// Depth in XML document.
 	typedef enum e_docDepth
@@ -27,7 +27,7 @@ class XmlContentsHandler : public XmlHandler
 	} DocDepth;
 
 public:
-	XmlContentsHandler(ODSImportDataSet *dta);
+	ODSXmlContentsHandler(ODSImportDataSet *dta);
 
 	/**
 	 * @brief startElement Called on the start of an element.
@@ -106,6 +106,13 @@ private:
 	static const QString _typeFloat;
 	static const QString _typeDate;
 	static const QString _typeTime;
+	
+	// Excel sometimes exports too many "repeat columns/row" elements, only to make sure that it looks the same as in excel.
+	// It then wants you to repeat empty cells that many times.
+	// This is of course not very sensible so instead we detect that and ignore such cells.
+	// To do this we need to know the maximum size of an excelspreadsheet and it is:
+	const int				_excelMaxRows = 1048576, 
+							_excelMaxCols = 16384;
 
 
 	/**

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.h
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.h
@@ -68,14 +68,14 @@ public:
 	void resetDocument();
 
 private:
-	DocDepth 		_docDepth;			///< Current depth of document.
-	int				_row,				///< Current row in document/table.
-					_column,			///< Current column in document/table.
-					_lastNotEmptyColumn;
-	bool			_tableRead;			///< True if first table read.
-	XmlDatatype		_lastType;			///< The last type we found in a opening tag.
-	int				_colRepeat,			///< Number cells this XML element spans.
-					_rowRepeat;
+	DocDepth 		_docDepth			= DocDepth::not_in_doc;			///< Current depth of document.
+	int				_row				= 0,				///< Current row in document/table.
+					_column				= 0,			///< Current column in document/table.
+					_lastNotEmptyColumn	= -1;
+	bool			_tableRead			= false;			///< True if first table read.
+	XmlDatatype		_lastType			= odsType_unknown;			///< The last type we found in a opening tag.
+	int				_colRepeat			= 1,			///< Number cells this XML element spans.
+					_rowRepeat			= 1;
 	QString			_currentCell,
 					_currentComment;
 

--- a/Desktop/data/importers/ods/odsxmlhandler.h
+++ b/Desktop/data/importers/ods/odsxmlhandler.h
@@ -20,8 +20,6 @@
 #define __ODSXMLERRORHANDLER_H_
 
 #include <QXmlDefaultHandler>
-
-//#include "odsdata.h"
 #include "odsimportdataset.h"
 
 namespace ods
@@ -30,46 +28,8 @@ namespace ods
 class XmlHandler : public QXmlDefaultHandler
 {
 public:
-	/**
-	 * @brief OdsXmlHandler Ctor
-	 * @param data A
-	 */
-//	XmlHandler(Data *data);
 	XmlHandler(ODSImportDataSet *data);
-	virtual ~XmlHandler();
-
-	/**
-	 * @brief startElement Called on the start of an element.
-	 * @param namespaceURI - the URI.
-	 * @param localName - local name (name without prefix).
-	 * @param qName - Qualified name.
-	 * @param atts- Attributes.
-	 * @return true on no error found.
-	 *
-	 * Called when a <tag ...> construction found.
-	 *
-	 */
-	virtual bool startElement(const QString &namespaceURI, const QString &localName, const QString &qName, const QXmlAttributes &atts) = 0;
-
-	/**
-	 * @brief endElement Called on the end of an element.
-	 * @param namespaceURI - the URI.
-	 * @param localName - local name (name without prefix).
-	 * @param qName - Qualified name.
-	 * @param atts- Attributes.
-	 * @return true on no error found.
-	 *
-	 * Called when a </tag> construction found.
-	 *
-	 */
-	virtual bool endElement(const QString &namespaceURI, const QString &localName, const QString &qName) = 0;
-
-	/**
-	 * @brief characters Called when char data found.
-	 * @param ch The found data.
-	 * @return true on no error.
-	 */
-	virtual bool characters(const QString &ch) = 0;
+	~XmlHandler() override;
 
 protected:
 	ODSImportDataSet * _dataSet;

--- a/Desktop/data/importers/odsimporter.cpp
+++ b/Desktop/data/importers/odsimporter.cpp
@@ -20,7 +20,6 @@
 #include "ods/odsxmlmanifesthandler.h"
 #include "ods/odsxmlcontentshandler.h"
 #include "archivereader.h"
-#include "ods/odsimportcolumn.h"
 #include <QXmlInputSource>
 #include "log.h"
 #include "timers.h"

--- a/Desktop/data/importers/odsimporter.cpp
+++ b/Desktop/data/importers/odsimporter.cpp
@@ -22,7 +22,7 @@
 #include "archivereader.h"
 
 #include <QXmlInputSource>
-
+#include "log.h"
 #include "timers.h"
 
 namespace ods
@@ -91,6 +91,7 @@ void ODSImporter::readContents(const std::string &path, ODSImportDataSet *datase
 		int errorCode = 0;
 		if (((tmp = contents.readAllData(4096, errorCode)).size() == 0) || (errorCode < 0))
 			throw std::runtime_error("Error reading contents in ODS.");
+		Log::log() << tmp << std::endl;
 		src.setData(QString::fromStdString(tmp));
 	}
 

--- a/Desktop/data/importers/odsimporter.cpp
+++ b/Desktop/data/importers/odsimporter.cpp
@@ -20,7 +20,7 @@
 #include "ods/odsxmlmanifesthandler.h"
 #include "ods/odsxmlcontentshandler.h"
 #include "archivereader.h"
-
+#include "ods/odsimportcolumn.h"
 #include <QXmlInputSource>
 #include "log.h"
 #include "timers.h"
@@ -29,6 +29,9 @@ namespace ods
 {
 
 // Implmemtation of Inporter base class.
+ODSImporter::ODSImporter()  : Importer() 
+{}
+
 ImportDataSet* ODSImporter::loadFile(const std::string &locator, std::function<void(int)> progressCallback)
 {
 	JASPTIMER_RESUME(ODSImporter::loadFile);

--- a/Desktop/data/importers/odsimporter.cpp
+++ b/Desktop/data/importers/odsimporter.cpp
@@ -98,7 +98,7 @@ void ODSImporter::readContents(const std::string &path, ODSImportDataSet *datase
 	}
 
 	{
-		XmlContentsHandler * contentsHandler = new XmlContentsHandler(dataset);
+		ODSXmlContentsHandler * contentsHandler = new ODSXmlContentsHandler(dataset);
 		QXmlSimpleReader reader;
 		reader.setContentHandler(contentsHandler);
 		reader.setErrorHandler(contentsHandler);

--- a/Desktop/data/importers/odsimporter.h
+++ b/Desktop/data/importers/odsimporter.h
@@ -32,13 +32,13 @@ class ODSImportDataSet;
 class ODSImporter : public Importer
 {
 public:
-    ODSImporter()  : Importer() {	DataSetPackage::pkg()->setIsJaspFile(false); }
+    ODSImporter();
 	virtual ~ODSImporter() {}
 
 protected:
 	// Implmemtation of Inporter base class.
-	virtual ImportDataSet* loadFile(const std::string &locator, std::function<void(int)> progressCallback);
-
+	ImportDataSet* loadFile(const std::string &locator, std::function<void(int)> progressCallback) override;
+	
 private:
 	static const std::string _contentFile;
 

--- a/Desktop/data/importers/readstat/readstatimportcolumn.cpp
+++ b/Desktop/data/importers/readstat/readstatimportcolumn.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 
 ReadStatImportColumn::ReadStatImportColumn(readstat_variable_t * readstat_var, ReadStatImportDataSet* importDataSet, string name, std::string title, std::string labelsID, columnType columnType)
-    : ImportColumn(importDataSet, name), _readstatDataSet(importDataSet), _readstatVariable(readstat_var), _labelsID(labelsID), _title(title), _type(columnType)
+    : ImportColumn(importDataSet, name, title), _readstatDataSet(importDataSet), _readstatVariable(readstat_var), _labelsID(labelsID), _type(columnType)
 {}
 
 ReadStatImportColumn::~ReadStatImportColumn()

--- a/Desktop/data/importers/readstat/readstatimportcolumn.h
+++ b/Desktop/data/importers/readstat/readstatimportcolumn.h
@@ -19,10 +19,12 @@ public:
 				~ReadStatImportColumn()							override;
 
 			size_t						size()									const	override;
-			columnType					getColumnType()							const				{ return _type; }
-			const stringvec		&		allValuesAsStrings()					const	override;	///< Reference returned only valid till the next time this function is called. (static stringvec)
-			bool						hasLabels()								const				{ return _labelsID != ""; }
-			const std::string	&		labelsID()								const				{ return  _labelsID;	}
+			columnType					getColumnType()							const	override	{ return _type; }
+			const stringvec		&		allValuesAsStrings()					const	override;
+			const stringvec		&		allLabelsAsStrings()					const	override	{ return labels();			}
+			const stringset		&		allEmptyValuesAsStrings()				const	override	{ return emptyValues();		}
+			bool						hasLabels()								const				{ return _labelsID != "";	}
+			const std::string	&		labelsID()								const				{ return  _labelsID;		}
 
 			void						addValue(const readstat_value_t & val);
 			
@@ -45,8 +47,7 @@ public:
 private:
     ReadStatImportDataSet   *   _readstatDataSet    = nullptr;
     readstat_variable_t		*	_readstatVariable   = nullptr;
-	std::string					_labelsID,
-								_title;
+	std::string					_labelsID;
 	columnType					_type;
 	stringvec					_values;
 	stringset					_missing;

--- a/Desktop/data/importers/readstat/readstatimportdataset.h
+++ b/Desktop/data/importers/readstat/readstatimportdataset.h
@@ -45,7 +45,7 @@ public:
 	void						addNote(int note_index, const std::string & note);
 	const std::string		&	description() const override;
 
-	void						addColumn(int index, ReadStatImportColumn * col); //Calls hidden virtual function addColumn(ImportColumn*)
+	void						addColumn(int index, ReadStatImportColumn * col); ///<Calls hidden virtual function addColumn(ImportColumn*)
 	ReadStatImportColumn	*	column(int index);
 	ReadStatImportColumn	*	operator[](int index) { return column(index); };
 

--- a/Desktop/data/importers/readstatimporter.cpp
+++ b/Desktop/data/importers/readstatimporter.cpp
@@ -131,12 +131,3 @@ ImportDataSet* ReadStatImporter::loadFile(const std::string &locator, std::funct
 	return data;
 }
 
-/*void ReadStatImporter::initColumn(QVariant colId, ImportColumn * importColumn)
-{
-	JASPTIMER_SCOPE(ReadStatImporter::initColumn);
-	
-	ReadStatImportColumn * col = static_cast<ReadStatImportColumn*>(importColumn);
-	
-	DataSetPackage::pkg()->initColumnWithStrings(colId, col->name(), col->values(), col->labels(), "", col->getColumnType(), col->emptyValues());
-}*/
-

--- a/Desktop/data/importers/readstatimporter.cpp
+++ b/Desktop/data/importers/readstatimporter.cpp
@@ -131,12 +131,12 @@ ImportDataSet* ReadStatImporter::loadFile(const std::string &locator, std::funct
 	return data;
 }
 
-void ReadStatImporter::initColumn(QVariant colId, ImportColumn * importColumn)
+/*void ReadStatImporter::initColumn(QVariant colId, ImportColumn * importColumn)
 {
 	JASPTIMER_SCOPE(ReadStatImporter::initColumn);
 	
 	ReadStatImportColumn * col = static_cast<ReadStatImportColumn*>(importColumn);
 	
 	DataSetPackage::pkg()->initColumnWithStrings(colId, col->name(), col->values(), col->labels(), "", col->getColumnType(), col->emptyValues());
-}
+}*/
 

--- a/Desktop/data/importers/readstatimporter.h
+++ b/Desktop/data/importers/readstatimporter.h
@@ -13,15 +13,13 @@ class ReadStatImporter : public Importer
 public:
 	ReadStatImporter(std::string ext) : Importer(), _ext(stringUtils::toLower(ext))
 	{
-            DataSetPackage::pkg()->setIsJaspFile(false);
-
 		if(_ext.size() == 0)	throw std::runtime_error("ReadStatImporter NEEDS to know the extension!");
 		if(_ext[0] == '.')		_ext = _ext.substr(1);
 	}
 	~ReadStatImporter() override;
 
 	static bool extSupported(const std::string & ext);
-	void initColumn(QVariant colId, ImportColumn * importColumn) override;
+	//void initColumn(QVariant colId, ImportColumn * importColumn) override;
 
 protected:
 	ImportDataSet *	loadFile(const std::string &locator, std::function<void(int)> progressCallback)	override;

--- a/Desktop/data/importers/readstatimporter.h
+++ b/Desktop/data/importers/readstatimporter.h
@@ -19,7 +19,6 @@ public:
 	~ReadStatImporter() override;
 
 	static bool extSupported(const std::string & ext);
-	//void initColumn(QVariant colId, ImportColumn * importColumn) override;
 
 protected:
 	ImportDataSet *	loadFile(const std::string &locator, std::function<void(int)> progressCallback)	override;


### PR DESCRIPTION
I tried to make the importers all a bit more generic by moving some handy functions to Importer from Readstat and reusing that for ODS etc. Although I didnt integrate he jaspImporter and jaspImporterOld. As they arent even derived from Importer... But I left that this way as those "importers" is rather different anyway.

This should make sure that the title of a column is derived from the label in readstat or a comment in ODS
Any cell-comments in ODS are used as labels now

Should implement https://github.com/jasp-stats/jasp-issues/issues/352
Also implements https://github.com/jasp-stats/jasp-issues/issues/2660