### PR TITLE
Test: fix Qt installation in the workflow

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,7 +30,7 @@ jobs:
             arch: 'gcc_64'
             cache: 'true'
             modules: 'qtpositioning qtwebchannel qtwebengine qtwebsockets qtwebview debug_info qt5compat qtshadertools qtwaylandcompositor'
-            tools: 'tools_qtcreator,qt.tools.qtcreator tools_ninja tools_cmake'
+            tools: 'tools_qtcreator,qt.tools.qtcreator tools_cmake'
             
       - name: Install dependencies of build system
         run: |     


### PR DESCRIPTION
don't know why but seems Qt removed the ninja tools from installer.