### PR TITLE
make synching great again

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -485,6 +485,10 @@ columnType Column::setValues(const stringvec & values, const stringvec & labels,
 		}
 	}
 	
+	if(labelsRemoveOrphans() && aChange)
+		(*aChange) = true;
+	
+	
 	dbUpdateValues(false);
 	
 	//Now determine what the most logical columntype would be given the current values AND empty values!
@@ -1456,6 +1460,21 @@ bool Column::labelsMergeDuplicates()
 	}
 	
 	return thereWasDuplication;
+}
+
+bool Column::labelsRemoveOrphans()
+{
+	intset idsNotUsed;
+	
+	for(size_t labelIndex=0; labelIndex < _labels.size(); labelIndex++)
+		idsNotUsed.insert(_labels[labelIndex]->intsId());
+	
+	for(int anInt : _ints)
+		idsNotUsed.erase(anInt);
+	
+	labelsRemoveByIntsId(idsNotUsed);
+	
+	return idsNotUsed.size();
 }
 
 int Column::labelIndex(const Label *label) const

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1271,11 +1271,18 @@ bool Column::setValue(size_t row, const std::string & value, const std::string &
 	Label * newLabel		= justAValue ? labelByValue(value) : labelByValueAndDisplay(value, label);
 	Label * oldLabel		= _ints[row] == Label::DOUBLE_LABEL_VALUE ? nullptr : labelByIntsId(_ints[row]);
 	
-	if(justAValue && !newLabel && !itsADouble)
+	if(justAValue && !newLabel && itsADouble)
+	{
+		const std::string valueDbl = ColumnUtils::doubleToString(newDoubleToSet);
+		newLabel = labelByValue(valueDbl);
+		newLabel = newLabel ? newLabel : labelByValueAndDisplay(valueDbl, valueDbl);
+	}
+	
+	if(justAValue && !newLabel)
 		newLabel = labelByValueAndDisplay(value, value);
 	
-	if(!newLabel && !labelIsValue) //no new label found but value and label are different. Given that this exact combination does not occur we add a new label
-		newLabel = labelByIntsId( labelsAdd(justAValue ? value : label, "", itsADouble ? Json::Value(newDoubleToSet) : value));
+	if(!newLabel && (!justAValue && !labelIsValue)) //no new label found but value and label are different. Given that this exact combination does not occur we add a new label
+		newLabel = labelByIntsId( labelsAdd(label, "", itsADouble ? Json::Value(newDoubleToSet) : value));
 		
 	if(!oldLabel && !newLabel && itsADouble) //no labels and it is a double, easy peasy
 		return setValue(row, newDoubleToSet, writeToDB);
@@ -1297,7 +1304,7 @@ bool Column::setValue(size_t row, const std::string & value, const std::string &
 		return setValue(row, newDoubleToSet, writeToDB);
 	}
 	else
-		//there is no new label yet for this and it is not a double so we need to make a label
+		//there is no new label yet for this and so lets make one
 		return setValue(row, labelsAdd(justAValue ? value : label, "", itsADouble ? Json::Value(newDoubleToSet) : value), writeToDB);
 }
 

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1618,9 +1618,9 @@ bool Column::checkForUpdates()
 	return true;
 }
 
-bool Column::isColumnDifferentFromStringValues(const stringvec & strVals) const 
+bool Column::isColumnDifferentFromStringValues(const std::string & title, const stringvec & strVals, const stringvec & strLabs, const stringset & strEmptyVals) const 
 {
-	return strVals == valuesAsStrings();
+	return !(title == _title && strEmptyVals == emptyValues()->emptyStrings() && strVals == valuesAsStrings() && strLabs == labelsAsStrings());
 }
 
 void Column::upgradeSetDoubleLabelsInInts()

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -303,6 +303,14 @@ void Column::setAnalysisId(int analysisId)
 	dbUpdateComputedColumnStuff();
 }
 
+void Column::setIndex(int index)
+{
+	JASPTIMER_SCOPE(Column::setIndex);
+
+	db().columnSetIndex(id(), index);
+	incRevision();
+}
+
 bool Column::iShouldBeSentAgain()
 {
 	if(!invalidated()) 

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -66,6 +66,7 @@ public:
 			bool					setConstructorJson(	const Json::Value & constructorJson	);
 			bool					setConstructorJson(	const std::string & constructorJson	);
 			void					setAnalysisId(		int					analysisId		);
+			void					setIndex(			int					index			);
 			void					setInvalidated(		bool				invalidated		);
 			void					setForceType(		bool				force		);
 			void					setCompColStuff(bool   invalidated, bool forceSourceColType, computedColumnType   codeType, const	std::string & rCode, const	std::string & error, const	Json::Value & constructorJson);

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -164,6 +164,7 @@ public:
 			Labels				&	labels()																						{ return _labels; }
 			const Labels		&	labels()																				const	{ return _labels; }
 			bool					labelsMergeDuplicates();
+			bool					labelsRemoveOrphans();
 			Label				*	labelByDisplay(			const std::string	&	display)								const; ///< Might be nullptr for missing label, returns the first of labelsByDisplay
 			Label				*	labelByValue(			const std::string	&	value)									const; ///< Might be nullptr for missing label, returns the first of labelsByValue
 			Label				*	labelByIntsId(			int						intsId)									const; ///< Might be nullptr for missing label

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -112,7 +112,7 @@ public:
 			int						labelsAdd(			const std::string & display);
 			int						labelsAdd(			const std::string & display, const std::string & description, const Json::Value & originalValue);
 			int						labelsAdd(			int value, const std::string & display, bool filterAllows, const std::string & description, const Json::Value & originalValue, int order=-1, int id=-1);
-			void					labelsRemoveValues(	intset valuesToRemove);
+			void					labelsRemoveByIntsId(	intset valuesToRemove);
 			strintmap				labelsResetValues(	int & maxValue);
 			void					labelsRemoveBeyond( size_t indexToStartRemoving);
 			
@@ -151,10 +151,10 @@ public:
 			void					labelDisplayChanged(Label * label);
 			
 			bool					setStringValueToRow(size_t row, const std::string & value);
-			bool					setValue(					size_t row, const std::string & value, const std::string & label);
-			bool					setValue(					size_t row, int					value, bool writeToDB = true);
-			bool					setValue(					size_t row, double				value, bool writeToDB = true);
-			bool					setValue(					size_t row, int					valueInt, double valueDbl, bool writeToDB = true);
+			bool					setValue(					size_t row, const std::string & value, const std::string & label,	bool writeToDB = true);
+			bool					setValue(					size_t row, int					value,								bool writeToDB = true);
+			bool					setValue(					size_t row, double				value,								bool writeToDB = true);
+			bool					setValue(					size_t row, int					valueInt, double valueDbl,			bool writeToDB = true);
 			columnType				setValues(	const stringvec &	values, const stringvec &	labels, int thresholdScale, bool * changedSomething = nullptr); ///< Returns what would be the most sensible columntype
 			columnType				setValues(	const stringvec &	values,								int thresholdScale, bool * changedSomething = nullptr); ///< Returns what would be the most sensible columntype
 			bool					setDescriptions(			strstrmap labelToDescriptionMap); ///<Returns any changes
@@ -164,11 +164,12 @@ public:
 
 			Labels				&	labels()																						{ return _labels; }
 			const Labels		&	labels()																				const	{ return _labels; }
+			bool					labelsMergeDuplicates();
 			Label				*	labelByIntsId(			int						intsId)									const; ///< Might be nullptr for missing label
-			Label				*	labelByDisplay(			const std::string	&	display)								const; ///< Might be nullptr for missing label
-			Label				*	labelByValue(			const std::string	&	value)									const; ///< Might be nullptr for missing label
-			Label				*	labelByValueAndDisplay(	const std::string	&	value, const std::string &	label)		const; ///< Might be nullptr for missing label
-			Label				*	labelByRow(				int						row)									const; ///< Might be nullptr for missing label
+			Labelset				labelsByDisplay(			const std::string	&	display)								const; ///< Might be nullptr for missing label
+			Labelset				labelsByValue(			const std::string	&	value)									const; ///< 
+			Label				*	labelByValueAndDisplay(	const std::string	&	value, const std::string &	label)		const; ///< Might be nullptr for missing label, assumes you ran labelsMergeDuplicates before
+			Label				*	labelByRow(				int						row)									const; ///< 
 			int						labelIndex(				const Label			*	label)									const;
 
 			bool					isValueEqual(size_t row, double value)				 const;

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -155,9 +155,8 @@ public:
 			bool					setValue(					size_t row, int					value,								bool writeToDB = true);
 			bool					setValue(					size_t row, double				value,								bool writeToDB = true);
 			bool					setValue(					size_t row, int					valueInt, double valueDbl,			bool writeToDB = true);
-			columnType				setValues(	const stringvec &	values, const stringvec &	labels, int thresholdScale, bool * changedSomething = nullptr); ///< Returns what would be the most sensible columntype
-			columnType				setValues(	const stringvec &	values,								int thresholdScale, bool * changedSomething = nullptr); ///< Returns what would be the most sensible columntype
-			bool					setDescriptions(			strstrmap labelToDescriptionMap); ///<Returns any changes
+			columnType				setValues(			const stringvec &	values, const stringvec &	labels, int thresholdScale, bool * changedSomething = nullptr); ///< Returns what would be the most sensible columntype
+			bool					setDescriptions(	strstrmap labelToDescriptionMap); ///<Returns any changes
 			void					rowInsertEmptyVal(size_t row);
 			void					rowDelete(size_t row);
 			void					setRowCount(size_t row);

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -150,7 +150,7 @@ public:
 			void					labelValueChanged(Label * label, int	anInteger) { labelValueChanged(label, double(anInteger)); }
 			void					labelDisplayChanged(Label * label);
 			
-			bool					setStringValueToRow(size_t row, const std::string & value);
+			bool					setStringValueToRow(		size_t row, const std::string & value,								bool writeToDBAndSetType = true);
 			bool					setValue(					size_t row, const std::string & value, const std::string & label,	bool writeToDB = true);
 			bool					setValue(					size_t row, int					value,								bool writeToDB = true);
 			bool					setValue(					size_t row, double				value,								bool writeToDB = true);
@@ -165,8 +165,10 @@ public:
 			Labels				&	labels()																						{ return _labels; }
 			const Labels		&	labels()																				const	{ return _labels; }
 			bool					labelsMergeDuplicates();
+			Label				*	labelByDisplay(			const std::string	&	display)								const; ///< Might be nullptr for missing label, returns the first of labelsByDisplay
+			Label				*	labelByValue(			const std::string	&	value)									const; ///< Might be nullptr for missing label, returns the first of labelsByValue
 			Label				*	labelByIntsId(			int						intsId)									const; ///< Might be nullptr for missing label
-			Labelset				labelsByDisplay(			const std::string	&	display)								const; ///< Might be nullptr for missing label
+			Labelset				labelsByDisplay(		const std::string	&	display)								const; ///< Might be nullptr for missing label
 			Labelset				labelsByValue(			const std::string	&	value)									const; ///< 
 			Label				*	labelByValueAndDisplay(	const std::string	&	value, const std::string &	label)		const; ///< Might be nullptr for missing label, assumes you ran labelsMergeDuplicates before
 			Label				*	labelByRow(				int						row)									const; ///< 

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -82,7 +82,7 @@ public:
 			void					incRevision(bool labelsTempCanBeMaintained = true);
 			bool					checkForUpdates();
 
-			bool					isColumnDifferentFromStringValues(const stringvec & strVals) const;
+			bool					isColumnDifferentFromStringValues(const std::string & title, const stringvec & strVals, const stringvec & strLabs, const stringset & strEmptyVals) const;
 
 			columnType				type()					const	{ return _type;				}
 			int						id()					const	{ return _id;				}

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -413,7 +413,7 @@ int DatabaseInterface::columnInsert(int dataSetId, int index, const std::string 
 	runStatements(alterDatasetPrefix + addColumnFragment + "_DBL REAL NULL;");
 	runStatements(alterDatasetPrefix + addColumnFragment + "_INT INT  NULL;");
 
-	//The labels will be added separately later? Probably
+	//The labels will be added separately later
 
 	transactionWriteEnd();
 	return columnId;
@@ -446,8 +446,6 @@ void DatabaseInterface::columnIndexDecrements(int dataSetId, int index)
 	JASPTIMER_SCOPE(DatabaseInterface::columnIndexDecrements);
 	if(columnIdForIndex(dataSetId, index) == -1)
 		runStatements("UPDATE Columns SET colIdx=colIdx-1 WHERE dataSet=" + std::to_string(dataSetId) + " AND colIdx > " + std::to_string(index) +";");
-//	else
-//		throw std::runtime_error("columnIndexDecrements has a problem: colIdx " + std::to_string(index) + " in dataSet " + std::to_string(dataSetId) + " still exists!");
 }
 
 int DatabaseInterface::columnIdForIndex(int dataSetId, int index)
@@ -476,12 +474,12 @@ void DatabaseInterface::dataSetBatchedValuesUpdate(DataSet * data, Columns colum
 	transactionWriteBegin();
 
 	//Clear the entire dataset, then insert each row, including filter.
-	//Bear in mind that this will also erase any scalar values that a column mightve converted from earlier.
+	// But maybe we should update instead, maybe it speeds up the application?
 	//As this data isnt synced anyway this shouldnt be a problem because it'd be invalidated after a single edit anyway
 	runStatements("DELETE FROM " + dataSetName(data->id()));
 
 	std::stringstream statement;
-
+	
 	statement << "INSERT INTO " << dataSetName(data->id()) << " (";
 
 	//Add columnnames for data we want to insert

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -428,7 +428,7 @@ int DatabaseInterface::columnGetDataSetId(int columnId)
 int	DatabaseInterface::columnLastFreeIndex(int dataSetId)
 {
 	JASPTIMER_SCOPE(DatabaseInterface::columnLastFreeIndex);
-	return runStatementsId("SELECT MAX(colIdx) from Columns WHERE dataSet=" + std::to_string(dataSetId) + ";");
+	return 1 + runStatementsId("SELECT MAX(colIdx) from Columns WHERE dataSet=" + std::to_string(dataSetId) + ";");
 }
 
 void DatabaseInterface::columnIndexIncrements(int dataSetId, int index)

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -95,6 +95,34 @@ int DataSet::columnIndex(const Column * col) const
 	return -1;
 }
 
+void DataSet::columnsReorder(const stringvec &order)
+{
+	assert(order.size() == _columns								.size());
+	
+	stringset	orderSet(order.begin(), order.end()),
+				colSet;
+	
+	assert(order.size() == orderSet.size());
+	
+	std::map<std::string, Column*> nameColMap;
+	
+	for(Column * col : _columns)
+	{
+		nameColMap[col->name()] = col;
+		colSet.insert(col->name());
+	}
+	
+	assert(colSet == orderSet);
+	
+	for(size_t i=0; i<_columns.size(); i++)
+	{
+		_columns[i] =  nameColMap[order[i]];
+		_columns[i] -> setIndex(i);
+	}
+	
+	incRevision();
+}
+
 Column *DataSet::column(const std::string &name)
 {
 	for(Column * column : _columns)

--- a/CommonData/dataset.h
+++ b/CommonData/dataset.h
@@ -47,6 +47,7 @@ public:
 			Column		*	newColumn(		const	std::string &	name);
 			int				getColumnIndex(	const	std::string &	name	) const;
 			int				columnIndex(	const	Column		*	col		) const;
+			void			columnsReorder(	const	stringvec	&	order	); ///< Expects a sane order vector
 
 			bool			allColumnsPassFilter()					const;
 

--- a/CommonData/label.cpp
+++ b/CommonData/label.cpp
@@ -3,7 +3,6 @@
 #include <sstream>
 #include "databaseinterface.h"
 
-
 const int Label::MAX_LABEL_DISPLAY_LENGTH	= 64; //we can store the rest in description if necessary
 const int Label::DOUBLE_LABEL_VALUE			= -1; 
 

--- a/CommonData/label.h
+++ b/CommonData/label.h
@@ -5,6 +5,7 @@
 #include <json/json.h>
 #include "datasetbasenode.h"
 
+
 class Column;
 class DatabaseInterface;
 
@@ -78,5 +79,6 @@ private:
 };
 
 typedef std::vector<Label*> Labels;
+typedef std::set<Label*>	Labelset;
 
 #endif // LABEL_H

--- a/Desktop/data/columnmodel.cpp
+++ b/Desktop/data/columnmodel.cpp
@@ -454,7 +454,7 @@ void ColumnModel::setChosenColumn(int chosenColumn)
 		_dataSetTableModel->removeColumn(deleteMe);
 }
 
-void ColumnModel::setChosenColumn(const QString & chosenName)
+void ColumnModel::setChosenColumnByName(const QString & chosenName)
 {
 	DataSet * data	= DataSetPackage::pkg()->dataSet();
 	Column	* col	= data->column(fq(chosenName));
@@ -464,7 +464,7 @@ void ColumnModel::setChosenColumn(const QString & chosenName)
 
 void ColumnModel::columnAddedManuallyHandler(const QString &chosenName) 
 { 
-	setChosenColumn(chosenName); 
+	setChosenColumnByName(chosenName); 
 	setVisible(true);
 }
 
@@ -575,7 +575,7 @@ void ColumnModel::checkRemovedColumns(int columnIndex, int count)
 
 void ColumnModel::openComputedColumn(const QString & name)
 {
-	setChosenColumn(name);
+	setChosenColumnByName(name);
 	setVisible(true);
 }
 

--- a/Desktop/data/columnmodel.h
+++ b/Desktop/data/columnmodel.h
@@ -107,7 +107,7 @@ public slots:
 	void filteredOutChangedHandler(int col);
 	void setVisible(bool visible);
 	void setChosenColumn(int chosenColumn);
-	void setChosenColumn(const QString & chosenName);
+	void setChosenColumnByName(const QString & chosenName);
 	void columnAddedManuallyHandler(const QString & chosenName);
 	void setSelected(int row, int modifier);
 	void setColumnNameQ(QString newColumnName);

--- a/Desktop/data/computedcolumnmodel.cpp
+++ b/Desktop/data/computedcolumnmodel.cpp
@@ -428,15 +428,12 @@ void ComputedColumnModel::datasetChanged(	QStringList				changedColumns,
 
 Column * ComputedColumnModel::createComputedColumn(const std::string & name, int colType, computedColumnType computeType, Analysis * analysis)
 {
-	bool success			= false;
-
-	bool	createActualComputedColumn	= computeType != computedColumnType::analysisNotComputed,
+	bool	success						= false,
+			createActualComputedColumn	= computeType != computedColumnType::analysisNotComputed,
 			showComputedColumn			= computeType != computedColumnType::analysis			&& createActualComputedColumn;
 
-	if (createActualComputedColumn)
-		DataSetPackage::pkg()->undoStack()->pushCommand(new CreateComputedColumnCommand(DataSetPackage::pkg(), tq(name), colType, int(computeType)));
-	else
-		DataSetPackage::pkg()->createColumn(name, columnType(colType));
+	if (createActualComputedColumn)	DataSetPackage::pkg()->undoStack()->pushCommand(new CreateComputedColumnCommand(tq(name), colType, int(computeType)));
+	else							DataSetPackage::pkg()->createColumn(name, columnType(colType));
 
 	Column  * createdColumn = DataSetPackage::pkg()->getColumn(name);
 
@@ -447,7 +444,10 @@ Column * ComputedColumnModel::createComputedColumn(const std::string & name, int
 		emit dataColumnAdded(tq(name));
 
 	if(showComputedColumn)
+	{
 		selectColumn(createdColumn);
+		emit chooseColumn(tq(createdColumn->name()));
+	}
 
 	return createdColumn;
 }

--- a/Desktop/data/computedcolumnmodel.h
+++ b/Desktop/data/computedcolumnmodel.h
@@ -80,8 +80,8 @@ signals:
 				void	refreshData();
 				void	computeColumnForceTypeChanged();
 				void	columnTypeChanged();
-				
-				void computeColumnIconSourceChanged();
+				void	chooseColumn(QString colId);
+				void	computeColumnIconSourceChanged();
 				
 public slots:
 				void	checkForDependentColumnsToBeSent(QString columnName, bool refreshMe = false);

--- a/Desktop/data/datasetloader.cpp
+++ b/Desktop/data/datasetloader.cpp
@@ -82,7 +82,7 @@ void DataSetLoader::loadPackage(const string &locator, const string &extension, 
 
 void DataSetLoader::syncPackage(const string &locator, const string &extension, std::function<void(int)> progress)
 {
-	Utils::sleep(100);
+	Utils::sleep(100); // :'(
 
 	Importer* importer = getImporter(locator, extension);
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -655,6 +655,8 @@ bool DataSetPackage::setData(const QModelIndex &index, const QVariant &value, in
 						JASPTIMER_SCOPE(DataSetPackage::setData reset model);
 
 						setManualEdits(true); //Don't synch with external file after editing
+						
+						column->labelsRemoveOrphans();
 
 						stringvec	changedCols = {column->name()};
 	

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -662,7 +662,6 @@ bool DataSetPackage::setData(const QModelIndex &index, const QVariant &value, in
 	
 						refresh();
 						emit datasetChanged(tq(changedCols), {}, {}, false, false);
-
 						emit labelsReordered(tq(column->name()));
 						
 						if(column->hasFilter())

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -733,7 +733,6 @@ bool DataSetPackage::setData(const QModelIndex &index, const QVariant &value, in
 				return false;
 
 			setManualEdits(true);
-			
 			return setLabelAllowFilter(index, value.toBool());
 
 		case int(specialRoles::description):
@@ -812,7 +811,13 @@ bool DataSetPackage::setLabelDisplay(const QModelIndex &index, const QString &ne
 		aChange = true;
 	}
 	
-	aChange = label->setLabel(newLabel.toStdString()) || aChange;
+	if(label->setLabel(newLabel.toStdString()))
+	{
+		aChange = true;
+		
+		if(dataFileCanHaveLabels())
+			setManualEdits(true);
+	}
 	
 	if(aChange)
 		changedCols = {column->name()};
@@ -1020,10 +1025,15 @@ QString DataSetPackage::description() const
 	return tq(_dataSet ? _dataSet->description() : "");
 }
 
+bool DataSetPackage::dataFileCanHaveLabels() const
+{ 
+	return _dataSet && !tq(_dataSet->dataFilePath()).endsWith(".csv");  
+}
+
 void DataSetPackage::setDescription(const QString &description)
 {
 	if (!_dataSet) return;
-
+	
 	_dataSet->setDescription(fq(description));
 
 	emit descriptionChanged();

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1405,12 +1405,12 @@ stringvec DataSetPackage::getColumnNames()
 	return names;
 }
 
-bool DataSetPackage::isColumnDifferentFromStringValues(const std::string & columnName, const stringvec & strVals)
+bool DataSetPackage::isColumnDifferentFromStringValues(const std::string & columnName, const std::string & title, const stringvec & strVals, const stringvec & strLabs, const stringset & strEmptyVals)
 {
 	Column * col = _dataSet->column(columnName);
 	
 	if(col)
-		return col->isColumnDifferentFromStringValues(strVals);
+		return col->isColumnDifferentFromStringValues(title, strVals, strLabs, strEmptyVals);
 
 	return true;
 }

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1238,9 +1238,9 @@ void DataSetPackage::endSynchingDataChangedColumns(stringvec &	changedColumns, b
 	endSynchingData(changedColumns, missingColumns, changeNameColumns, hasNewColumns, informEngines);
 }
 
-void DataSetPackage::endSynchingData(	stringvec		&	changedColumns,
-										stringvec		&	missingColumns,
-										strstrmap		&	changeNameColumns,  //origname -> newname
+void DataSetPackage::endSynchingData(	const stringvec	&	changedColumns,
+										const stringvec	&	missingColumns,
+										const strstrmap	&	changeNameColumns,  //origname -> newname
 										bool				rowCountChanged,
 										bool				hasNewColumns,
 										bool				informEngines)
@@ -2139,6 +2139,13 @@ bool DataSetPackage::columnExists(Column *column)
 				return true;
 		
 	return false;
+}
+
+void DataSetPackage::columnsReorder(const stringvec &order)
+{
+	beginResetModel();
+	_dataSet->columnsReorder(order);
+	endResetModel();
 }
 
 boolvec DataSetPackage::filterVector()

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1381,7 +1381,7 @@ bool DataSetPackage::initColumnWithStrings(QVariant colId, const std::string & n
 				suggestedType	=	labels.size() == 0
 					? column	->	setValues(values,			threshold, &anyChanges)
 					: column	->	setValues(values, labels,	threshold, &anyChanges);  //If less unique integers than the thresholdScale then we think it must be ordinal: https://github.com/jasp-stats/INTERNAL-jasp/issues/270
-				column			->	setType(desiredType == columnType::unknown ? suggestedType : desiredType);
+				column			->	setType(column->type() != columnType::unknown ? column->type() : desiredType == columnType::unknown ? suggestedType : desiredType);
 				column			->	endBatchedLabelsDB();
 	
 	return anyChanges || column->type() != prevType;

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -199,7 +199,7 @@ public:
 				bool						columnExists(			Column				* column);
 
 				stringvec					getColumnNames();
-				bool						isColumnDifferentFromStringValues(const std::string & columnName, const stringvec & strVals);
+				bool						isColumnDifferentFromStringValues(const std::string & columnName, const std::string & title, const stringvec & strVals, const stringvec & strLabs, const stringset & strEmptyVals);
 				int							findIndexByName(const std::string & name)	const;
 
 				bool						getRowFilter(				int						row)		const;

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -98,9 +98,9 @@ public:
 		void				endLoadingData(		bool informEngines = true);
 		void				beginSynchingData(	bool informEngines = true);
 		void				endSynchingDataChangedColumns(stringvec	&	changedColumns,		bool hasNewColumns = false, bool informEngines = true);
-		void				endSynchingData(stringvec				&	changedColumns,
-											stringvec				&	missingColumns,
-											std::map<std::string, std::string>		&	changeNameColumns,  //origname -> newname
+		void				endSynchingData(const stringvec		&	changedColumns,
+											const stringvec		&	missingColumns,
+											const strstrmap		&	changeNameColumns,  //origname -> newname
 											bool										rowCountChanged,
 											bool										hasNewColumns,		bool informEngines = true);
 
@@ -197,6 +197,7 @@ public:
 				void						renameColumn(			const std::string	& oldColumnName, const std::string & newColumnName);
 				void						removeColumn(			const std::string	& name);
 				bool						columnExists(			Column				* column);
+				void						columnsReorder(			const stringvec		& order);
 
 				stringvec					getColumnNames();
 				bool						isColumnDifferentFromStringValues(const std::string & columnName, const std::string & title, const stringvec & strVals, const stringvec & strLabs, const stringset & strEmptyVals);
@@ -217,6 +218,7 @@ public:
 
 				bool						setColumnType(int		columnIndex,	columnType newColumnType);
 				bool						setColumnTypes(intset	columnIndexes,	columnType newColumnType);
+				
 
 				int							columnsFilteredCount();
 

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -148,6 +148,7 @@ public:
 				bool				hasAnalyses()						const	{ return _analysesData.size() > 0;				}
 				bool				synchingData()						const	{ return _synchingData;								}
 				std::string			dataFilePath()						const	{ return _dataSet ? _dataSet->dataFilePath() : "";  }
+				bool				dataFileCanHaveLabels()				const;
 				bool				isDatabase()						const	{ return _database != Json::nullValue;				}
 		const	Json::Value		&	databaseJson()						const	{ return _database;								}
 		const	QString			&	analysesHTML()						const	{ return _analysesHTML;							}

--- a/Desktop/data/importers/csvimporter.h
+++ b/Desktop/data/importers/csvimporter.h
@@ -20,9 +20,7 @@
 
 #include "importer.h"
 #include <QCoreApplication>
-#include "utilities/qutils.h"
 
-///
 /// This description is never going to be more useful than the name of the class
 class CSVImporter : public Importer
 {
@@ -30,6 +28,8 @@ class CSVImporter : public Importer
 public:
 	CSVImporter();
 
+	bool importerDeliversLabels() const override { return false; } 
+	
 protected:
 	ImportDataSet* loadFile(const std::string &locator, std::function<void(int)> progressCallback) override;
 

--- a/Desktop/data/importers/importer.cpp
+++ b/Desktop/data/importers/importer.cpp
@@ -120,7 +120,7 @@ void Importer::syncDataSet(const std::string &locator, std::function<void(int)> 
 	for (auto & changeNameColumnIt : changeNameColumns)
 		missingColumns.erase(changeNameColumnIt.first);
 
-	if (newColumns.size() > 0 || changedColumns.size() > 0 || missingColumns.size() > 0 || changeNameColumns.size() > 0 || rowCountChanged)
+	if (newColumns.size() > 0 || changedColumns.size() > 0 || missingColumns.size() > 0 || changeNameColumns.size() > 0 || orgColumnNames != newOrder || rowCountChanged)
 			_syncPackage(importDataSet, newColumns, changedColumns, missingColumns, changeNameColumns, newOrder, rowCountChanged);
 
 	DataSetPackage::pkg()->setManualEdits(false);

--- a/Desktop/data/importers/importer.h
+++ b/Desktop/data/importers/importer.h
@@ -30,11 +30,12 @@ protected:
 
 private:
 	void _syncPackage(
-			ImportDataSet								*	syncDataSet,
-			std::vector<std::pair<std::string, int>>	&	newColumns,
-			std::vector<std::pair<int, std::string>>	&	changedColumns,
-			std::set<std::string>						&	missingColumns,
-			std::map<std::string, std::string>			&	changeNameColumns,
+			ImportDataSet									*	syncDataSet,
+			const std::vector<std::pair<std::string, int>>	&	newColumns,
+			const std::vector<std::pair<int, std::string>>	&	changedColumns,
+			const stringset									&	missingColumns,
+			const strstrmap									&	changeNameColumns,
+			const stringvec									&	newOrder,	///<can be empty
 			bool											rowCountChanged);
 };
 

--- a/Desktop/data/importers/importer.h
+++ b/Desktop/data/importers/importer.h
@@ -19,6 +19,8 @@ public:
 	virtual ~Importer();
     void loadDataSet(const std::string &locator, std::function<void (int)> progressCallback);
     void syncDataSet(const std::string &locator, std::function<void (int)> progressCallback);
+	
+	virtual bool importerDeliversLabels() const { return true; } //They all do except csv, so for synchronization to work we want labels to be ignored for csv when synching, this to allow people to enter better labels and not lose them on every sync
 
 protected:
     virtual ImportDataSet* loadFile(const std::string &locator, std::function<void(int)> progressCallback) = 0;
@@ -27,6 +29,8 @@ protected:
 	virtual void initColumn(QVariant colId, ImportColumn *importColumn);
 
 	void initColumnWithStrings(QVariant colId, const std::string & newName, const std::vector<std::string> & values, const std::vector<std::string> & labels=stringvec(), const std::string & title="", columnType desiredTyp = columnType::unknown, const stringset & emptyValues = {});
+	
+	bool	_synching = false;
 
 private:
 	void _syncPackage(

--- a/Desktop/data/importers/jaspimporterold.cpp
+++ b/Desktop/data/importers/jaspimporterold.cpp
@@ -215,7 +215,7 @@ void JASPImporterOld::loadDataArchive_1_00(const std::string &path, std::functio
 				else if(columnNameToMissingData.count(column->name()) && columnNameToMissingData[column->name()].count(r))
 				{
 					const std::string & missingValue = columnNameToMissingData[column->name()][r];
-                                        label = column->labelsByDisplay(missingValue);
+                                        label = column->labelByDisplay(missingValue);
 					
 					if(!label)
 						label = column->labelByIntsId(column->labelsAdd(missingValue));

--- a/Desktop/data/importers/jaspimporterold.cpp
+++ b/Desktop/data/importers/jaspimporterold.cpp
@@ -215,7 +215,7 @@ void JASPImporterOld::loadDataArchive_1_00(const std::string &path, std::functio
 				else if(columnNameToMissingData.count(column->name()) && columnNameToMissingData[column->name()].count(r))
 				{
 					const std::string & missingValue = columnNameToMissingData[column->name()][r];
-					label = column->labelByDisplay(missingValue);
+                                        label = column->labelsByDisplay(missingValue);
 					
 					if(!label)
 						label = column->labelByIntsId(column->labelsAdd(missingValue));

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
@@ -209,7 +209,7 @@ bool ODSXmlContentsHandler::endElement(const QString &namespaceURI, const QStrin
 						if(!_currentComment.isEmpty())
 							col.setTitle(fq(_currentComment));
 						
-						_lastNotEmptyColumn = _column;	
+						_lastNotEmptyColumn = _column;
 					}
 					
 					_column += _colRepeat;
@@ -220,7 +220,7 @@ bool ODSXmlContentsHandler::endElement(const QString &namespaceURI, const QStrin
 					for (int i = _lastNotEmptyColumn+1; i < _column; i++)
 						_dataSet->getOrCreate(i).setValue(_row - 1, "");
 					
-					if(_column + _colRepeat != _excelMaxCols)
+					if((!_currentCell.isEmpty() || !_currentComment.isEmpty()) && _column + _colRepeat != _excelMaxCols)
 					{
 						for (int i = 0; i < _colRepeat; i++)
 						{
@@ -231,8 +231,7 @@ bool ODSXmlContentsHandler::endElement(const QString &namespaceURI, const QStrin
 								col.setComment(_row - 1, fq(_currentComment));
 						}
 					
-						if(!_currentCell.isEmpty())
-							_lastNotEmptyColumn = _column + _colRepeat - 1;
+						_lastNotEmptyColumn = _column + _colRepeat - 1;
 					}
 					
 					_column += _colRepeat;

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
@@ -265,12 +265,6 @@ bool ODSXmlContentsHandler::endElement(const QString &namespaceURI, const QStrin
 	return true;
 }
 
-
-/**
- * @brief characters Called when char data found.
- * @param ch The found data.
- * @return true on no error.
- */
 bool ODSXmlContentsHandler::characters(const QString &ch)
 {
 

--- a/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
@@ -282,7 +282,8 @@ bool ODSXmlContentsHandler::characters(const QString &ch)
 			switch(_docDepth)
 			{
 			case text:
-				_currentCell.push_back(ch);
+				if(_currentCell != ch)
+					_currentCell.push_back(ch);
 				break;
 			
 			case text_annotation:
@@ -318,31 +319,18 @@ void ODSXmlContentsHandler::resetDocument()
 	_dataSet->clear();
 }
 
-/**
- * @brief XmlContentsHandler::setLastType Sets the lastType value, and gets value
- * @param QValue value OUTPIT value found.
- * @param QXmlAttributes atts Attriutes to find.
- * @return value of lastType;
- */
 XmlDatatype ODSXmlContentsHandler::_setLastTypeGetValue(QString &value, const QXmlAttributes &atts)
 {
 	_lastType = odsType_unknown;
 	QString fromfile = atts.value(_attValueType);
 
-	if (fromfile == _typeFloat)
-		_lastType = odsType_float;
-	else if (fromfile == _typeCurrency)
-		_lastType = odsType_currency;
-	else if (fromfile == _typePercent)
-		_lastType = odsType_percent;
-	else if (fromfile == _typeBoolean)
-		_lastType = odsType_boolean;
-	else if (fromfile == _typeDate)
-		_lastType = odsType_date;
-	else if (fromfile == _typeTime)
-		_lastType = odsType_time;
-	else if (fromfile == _typeString)
-		_lastType = odsType_string;
+	if (fromfile == _typeFloat)				_lastType = odsType_float;
+	else if (fromfile == _typeCurrency)		_lastType = odsType_currency;
+	else if (fromfile == _typePercent)		_lastType = odsType_percent;
+	else if (fromfile == _typeBoolean)		_lastType = odsType_boolean;
+	else if (fromfile == _typeDate)			_lastType = odsType_date;
+	else if (fromfile == _typeTime)			_lastType = odsType_time;
+	else if (fromfile == _typeString)		_lastType = odsType_string;
 
 	switch(_lastType)
 	{
@@ -351,15 +339,19 @@ XmlDatatype ODSXmlContentsHandler::_setLastTypeGetValue(QString &value, const QX
 	case odsType_percent:
 		value = atts.value(_attValue);
 		break;
+		
 	case odsType_boolean:
 		value = atts.value(_attBoolValue);
 		break;
+	
 	case odsType_date:
 		value = atts.value(_attDateValue);
 		break;
+	
 	case odsType_time:
 		value = atts.value(_attTimeValue);
 		break;
+	
 	case odsType_string:
 	case odsType_unknown:
 		value.clear();

--- a/Desktop/data/importers/odsimporter.cpp
+++ b/Desktop/data/importers/odsimporter.cpp
@@ -92,8 +92,8 @@ void ODSImporter::readContents(const std::string &path, ODSImportDataSet *datase
 		std::string tmp;
 		int errorCode = 0;
 		if (((tmp = contents.readAllData(4096, errorCode)).size() == 0) || (errorCode < 0))
-			throw std::runtime_error("Error reading contents in ODS.");
-		Log::log() << tmp << std::endl;
+			throw std::runtime_error("Error reading contents in ODS.");	
+		//Log::log() << tmp << std::endl;
 		src.setData(QString::fromStdString(tmp));
 	}
 

--- a/Desktop/data/importers/odsimporter.cpp
+++ b/Desktop/data/importers/odsimporter.cpp
@@ -93,7 +93,9 @@ void ODSImporter::readContents(const std::string &path, ODSImportDataSet *datase
 		int errorCode = 0;
 		if (((tmp = contents.readAllData(4096, errorCode)).size() == 0) || (errorCode < 0))
 			throw std::runtime_error("Error reading contents in ODS.");	
-		//Log::log() << tmp << std::endl;
+#ifdef JASP_DEBUG
+		Log::log()  << "ODS XML looks like:\n" << tmp << std::endl;
+#endif
 		src.setData(QString::fromStdString(tmp));
 	}
 

--- a/Desktop/data/undostack.cpp
+++ b/Desktop/data/undostack.cpp
@@ -664,8 +664,8 @@ void SetRFilterCommand::redo()
 	_filterModel->setRFilter(_newRFilter);
 }
 
-CreateComputedColumnCommand::CreateComputedColumnCommand(QAbstractItemModel *model, const QString &name, int columnType, int computedColumnType)
-	: UndoModelCommand(model), _name{name}, _columnType{columnType}, _computedColumnType{computedColumnType}
+CreateComputedColumnCommand::CreateComputedColumnCommand(const QString &name, int columnType, int computedColumnType)
+	: UndoModelCommand(DataSetPackage::pkg()), _name{name}, _columnType{columnType}, _computedColumnType{computedColumnType}
 {
 	setText(QObject::tr("Create a computed column with name '%1'").arg(name));
 }

--- a/Desktop/data/undostack.h
+++ b/Desktop/data/undostack.h
@@ -169,7 +169,7 @@ private:
 class CreateComputedColumnCommand: public UndoModelCommand
 {
 public:
-	CreateComputedColumnCommand(QAbstractItemModel *model, const QString& name, int columnType, int computedColumnType);
+	CreateComputedColumnCommand(const QString& name, int columnType, int computedColumnType);
 
 	void undo()					override;
 	void redo()					override;

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -429,6 +429,7 @@ void MainWindow::makeConnections()
 	connect(_computedColumnsModel,	&ComputedColumnModel::dataColumnAdded,				_fileMenu,				&FileMenu::dataColumnAdded									);
 	connect(_computedColumnsModel,	&ComputedColumnModel::showAnalysisForm,				_analyses,				&Analyses::selectAnalysis									);
 	connect(_computedColumnsModel,	&ComputedColumnModel::showAnalysisForm,				this,					&MainWindow::showAnalysis									);
+	connect(_computedColumnsModel,	&ComputedColumnModel::chooseColumn,					_columnModel,			&ColumnModel::setChosenColumnByName,						Qt::QueuedConnection);
 			
 	connect(_languageModel,			&LanguageModel::currentLanguageChanged,				_columnModel,			&ColumnModel::languageChangedHandler,						Qt::QueuedConnection);
 

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -761,7 +761,6 @@ std::string Engine::createColumn(const std::string &columnName)
 
 	col->setAnalysisId(_analysisId);
 	col->setCodeType(computedColumnType::analysisNotComputed);
-	data->db().columnSetIndex(col->id(), data->columnCount() - 1);
 
 	reloadColumnNames();
 


### PR DESCRIPTION
This makes synchronisation work and adds some nuance:
- csvs are assumed to only have values, so users are allowed to enter labels for those values and those labels will then be used for new entries of those values.
- ODS (and readstat stuff) however can have labels, so there a user that overwrites a label will disable synchronisation
- Columns are also reordered to reflect the order they have in the datafile
- on synch any duplicate labels (value and display are the same) are merged into the first one
- also after a synch (or manual entering of data in editor) any orphaned labels (not in the data anymore) are removed

I did not test with readstat files because I do not have any of those proprietary messes installed on any of my systems.
But I assume that works fine as they all use the same interface internally anyway