### PR TITLE
fix variables name display in variablesList

### DIFF
--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -488,7 +488,7 @@ VariablesListBase
 					id:						colName
 					anchors.left:			variablesList.showVariableTypeIcon ? icon.right : itemRectangle.left
 					anchors.leftMargin:		jaspTheme.generalAnchorMargin
-					text:					model.name
+					text:					model.name.trim()
 					width:					itemRectangle.width - x - (itemRectangle.extraItem ? itemRectangle.extraItem.width : 0)
 					elide:					Text.ElideRight
 					anchors.verticalCenter:	parent.verticalCenter


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/jasp-issues/issues/2703

Empty characters at both ends should be removed. in the sample file there are some newlines  at the end of variables name, I'm not sure we should allow this, it should be removed everywhere completely to be on the safe side, but only for display purposes this seems to be enough.

