### PR TITLE
make sure cmake find jaspColumnEncoder source

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 target_include_directories(
 	Common
 	PUBLIC # JASP
-	${CMAKE_SOURCE_DIR}/Common/jaspColumnEncoder
+	${PROJECT_SOURCE_DIR}/Common/jaspColumnEncoder
 	 # R
 	 ${R_INCLUDE_PATH}
 	 ${R_HOME_PATH}/include


### PR DESCRIPTION
I cannot build neither on Windows and Linux for a clean build if not change `CMAKE_SOURCE_DIR` to `PROJECT_SOURCE_DIR`.

but I'm not really sure this make sense because in this dir `CMAKE_SOURCE_DIR` and `PROJECT_SOURCE_DIR` point to same path.

