### PR TITLE
Some fixes

### DIFF
--- a/Desktop/components/JASP/Widgets/RCommanderWindow.qml
+++ b/Desktop/components/JASP/Widgets/RCommanderWindow.qml
@@ -252,7 +252,7 @@ Window
 				}
 			}
 
-			JC.RoundedButton
+			JC.RectangularButton
 			{
 				id:				runButton
 				text:			qsTr("Run code")
@@ -291,7 +291,7 @@ Window
 				}
 			}
 
-			JC.RoundedButton
+			JC.RectangularButton
 			{
 				id:			addAnalysisItem
 				text:		qsTr("Add analysis")
@@ -310,7 +310,7 @@ Window
 				function addAnalysis() { if(addAnalysisItem.enabled && rCmd.addAnalysis(codeEntry.text)) codeEntry.text = ""; }
 			}
 
-			JC.RoundedButton
+			JC.RectangularButton
 			{
 				id:			clearOutput
 				text:		qsTr("Clear output")
@@ -330,9 +330,10 @@ Window
 			{
 				id:							selectModule
 				values:		 				dynamicModules.loadedModulesTitles
-				//startValue:				 	"Module selection"
+				//startValue:			 	"Module selection"
 				onValueChanged:				rCmd.loadModule(dynamicModules.loadedModules[currentIndex])
-				control.height:						runButton.height
+				control.height:				runButton.height
+				control.width:				clearOutput.width
 
 				anchors
 				{

--- a/Desktop/components/JASP/Widgets/WelcomePage.qml
+++ b/Desktop/components/JASP/Widgets/WelcomePage.qml
@@ -356,6 +356,7 @@ FocusScope
 				width:		jaspLogo.width  * 2
 				height:		jaspLogo.height * 2
 			}
+			scale:			logoMouse.containsMouse ? 1.05 : 1
 
 			anchors
 			{
@@ -366,6 +367,7 @@ FocusScope
 			
 			MouseArea
 			{
+				id:						logoMouse
 				hoverEnabled:			true
 				onClicked:				Qt.openUrlExternally("https://www.jasp-stats.org");
 				anchors.fill:			parent

--- a/Modules/install-jaspBase.R.in
+++ b/Modules/install-jaspBase.R.in
@@ -43,17 +43,6 @@ if (md5SumsChanged(modulePkg, moduleLibrary)) {
 
   if (correctlyInstalled)
     writeMd5Sums(modulePkg, moduleLibrary)
-
-
-#This is necessary because of conflicts with Matrix dep of base R lib.
-#Can be removed when a new version of R updates its Matrix
-  if (!@IS_FLATPAK_USED@) {
-
-    if (Sys.info()["sysname"] == "Darwin")
-	  options(pkgType = "source")
-
-    renv::install("Matrix", library = moduleLibrary, prompt = prompt)
-  }
 }
 
 # Converting the absolute symlinks to relative symlinks on macOS

--- a/Modules/install-module.R.in
+++ b/Modules/install-module.R.in
@@ -1,15 +1,16 @@
 # Generated from install-module.R.in
 #
-Sys.setenv(PATH=paste0("@R_HOME_PATH@/bin", .Platform$path.sep, Sys.getenv("PATH"))) #Make sure any Rscript calls use ours
-Sys.setenv(RHOME="@R_HOME_PATH@") #Rscript looks for RHOME not R_HOME
-Sys.setenv(GITHUB_PAT="@GITHUB_PAT@")
-Sys.setenv(RENV_PATHS_ROOT="@MODULES_RENV_ROOT_PATH@")
-Sys.setenv(RENV_PATHS_CACHE="@MODULES_RENV_CACHE_PATH@")
-Sys.setenv(JASPENGINE_LOCATION="@JASP_ENGINE_PATH@/JASPEngine")
-Sys.setenv(JAGS_PREFIX="@jags_HOME@")
-Sys.setenv(JAGS_INCLUDEDIR="@jags_INCLUDE_DIRS@")
-Sys.setenv(JAGS_LIBDIR="@jags_LIBRARY_DIRS@")
-Sys.setenv(JASP_R_INTERFACE_LIBRARY="Yes, do it")
+Sys.setenv(PATH						=paste0("@R_HOME_PATH@/bin", .Platform$path.sep, Sys.getenv("PATH"))) #Make sure any Rscript calls use ours
+Sys.setenv(RHOME					="@R_HOME_PATH@") #Rscript looks for RHOME not R_HOME
+Sys.setenv(R_HOME					="@R_HOME_PATH@") #Some configure scripts need R_HOME (Im looking at you blavaan)
+Sys.setenv(GITHUB_PAT				="@GITHUB_PAT@")
+Sys.setenv(RENV_PATHS_ROOT			="@MODULES_RENV_ROOT_PATH@")
+Sys.setenv(RENV_PATHS_CACHE			="@MODULES_RENV_CACHE_PATH@")
+Sys.setenv(JASPENGINE_LOCATION		="@JASP_ENGINE_PATH@/JASPEngine")
+Sys.setenv(JAGS_PREFIX				="@jags_HOME@")
+Sys.setenv(JAGS_INCLUDEDIR			="@jags_INCLUDE_DIRS@")
+Sys.setenv(JAGS_LIBDIR				="@jags_LIBRARY_DIRS@")
+Sys.setenv(JASP_R_INTERFACE_LIBRARY	="Yes, do it")
 
 options(renv.config.install.verbose = TRUE)
 
@@ -32,10 +33,8 @@ options(
   configure.vars = c(jaspBase = "INCLUDE_DIR='@PROJECT_SOURCE_DIR@/Common/jaspColumnEncoder'") #Needed for flatpak build as it keeps recompiling jaspBase (which it shouldnt of course but I dont know why) and this is an easy fix to get it to work now
 )
 
-if (jaspBase::getOS() == "osx") {
-  options(pkgType = "mac.binary")
-} else if (jaspBase::getOS() == "windows") {
-  options(pkgType = "win.binary")
+if (jaspBase::getOS() == "osx" || jaspBase::getOS() == "windows") {
+  options(pkgType = "@R_BINARY_TYPE@")
 }
 
 # Related to the comment above, there is variable here called, 

--- a/QMLComponents/components/JASP/Controls/ComboBox.qml
+++ b/QMLComponents/components/JASP/Controls/ComboBox.qml
@@ -181,7 +181,7 @@ ComboBoxBase
 			id:				popupRoot
 			y:				control.y + jaspTheme.comboBoxHeight
 			width:			comboBoxBackground.width + scrollBar.width
-			height:			Math.min(popupView.contentHeight + (padding*2), mainWindowRoot !== undefined ?  mainWindowRoot.height : form.height)
+			height:			mainWindowRoot === undefined ? popupView.contentHeight + (padding*2) : Math.min(popupView.contentHeight + (padding*2), mainWindowRoot.height)
 			padding:		1
 
 			enter: Transition { NumberAnimation { property: "opacity"; from: 0.0; to: 1.0 } enabled: preferencesModel.animationsOn }

--- a/QMLComponents/knownissues.cpp
+++ b/QMLComponents/knownissues.cpp
@@ -1,5 +1,4 @@
 #include "knownissues.h"
-#include "utilities/messageforwarder.h"
 #include "appinfo.h"
 #include "jsonutilities.h"
 #include "log.h"

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -49,14 +49,17 @@ else()
     set(GFORTRAN_REPOSITORY "${STATIC_DEVELOPMENT_REPOSITORY}")
 
     if(APPLE)
-            if(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
-                    set(R_BINARY_REPOSITORY "https://cran.r-project.org/bin/macosx/big-sur-arm64/base/")
-            else()
-                    set(R_BINARY_REPOSITORY "https://cran.r-project.org/bin/macosx/big-sur-x86_64/base/")
-            endif()
-            set(XQUARTZ_REPOSITORY "https://github.com/XQuartz/XQuartz/releases/download/XQuartz-${XQUARTZ_VERSION}/")
+		set(R_BINARY_ARCH "x86_64")
+		if(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+			set(R_BINARY_ARCH "arm64")
+		endif()
+		
+		set(R_BINARY_REPOSITORY		"${R_REPOSITORY}/bin/macosx/big-sur-${R_BINARY_ARCH}/base/")
+        set(XQUARTZ_REPOSITORY		"https://github.com/XQuartz/XQuartz/releases/download/XQuartz-${XQUARTZ_VERSION}/")
+		set(R_BINARY_TYPE			"mac.binary.${R_BINARY_ARCH}")
     elseif(WINDOWS)
-            set(R_BINARY_REPOSITORY "https://cran.r-project.org/bin/macosx/windows/base/")
+		set(R_BINARY_REPOSITORY		"${R_REPOSITORY}/bin/windows/base/")
+		set(R_BINARY_TYPE			"win.binary")
     endif()
 endif()
 
@@ -93,6 +96,7 @@ set(AVAILABLE_R_VERSIONS
 	"R-4.4.0-arm64"
 	"R-4.4.0-win"
 )
+
 set(R_BINARY_HASHES
     # sha1sums
     # 4.1.2


### PR DESCRIPTION
- rcommander: align dropdown with buttons and make them rectangular 
- welcomepage: make logo jump out a bit on hover 
- combobox/dropdown cant refer to form because it probably doesnt exist. 
- remove Matrix workaround 
- some repository related stuff:

we were getting R always from https://cran.r-project.org/, completely ignoring the setting of `R_REPOSITORY`. This is now used instead

Also, the repository itself wasnt getting properly loaded for certain installs. because it would try http://cloud.r-project.org/bin/macosx/contrib/4.4/ instead http://cloud.r-project.org/bin/macosx/big-sur-arm64/contrib/4.4/.
This is rectified by setting the binary type for r to `mac.binary.arm64` or `mac.binary.x86_64` instead of `mac.binary`