### PR TITLE
Calculate the right max height for the Dropdown popup

### DIFF
--- a/QMLComponents/components/JASP/Controls/ComboBox.qml
+++ b/QMLComponents/components/JASP/Controls/ComboBox.qml
@@ -181,7 +181,12 @@ ComboBoxBase
 			id:				popupRoot
 			y:				control.y + jaspTheme.comboBoxHeight
 			width:			comboBoxBackground.width + scrollBar.width
-			height:			mainWindowRoot === undefined && rcmdRoot === undefined ? popupView.contentHeight + (padding*2) : Math.min(popupView.contentHeight + (padding*2), mainWindowRoot !== undefined ? mainWindowRoot.height : rcmdRoot.height)
+
+			property real	maxHeight: typeof mainWindowRoot !== 'undefined' ? mainWindowRoot.height // Case Dropdowns used in Desktop
+																			 : (typeof rcmdRoot !== 'undefined' ? rcmdRoot.height // Case Dropdown used in R Command
+																												: (typeof backgroundForms !== 'undefined' ? backgroundForms.height // Case Dropdowns used in Analysis forms
+																																						  : Infinity))
+			height:			Math.min(popupView.contentHeight + (padding*2), maxHeight)
 			padding:		1
 
 			enter: Transition { NumberAnimation { property: "opacity"; from: 0.0; to: 1.0 } enabled: preferencesModel.animationsOn }


### PR DESCRIPTION
Last fix in https://github.com/jasp-stats/jasp-desktop/commit/d2aeb7612e38c3c1d2370a6d48d4a3dcea8172aa did not work for Dropdowns in Analysis forms. 
Remove warnings

