### PR TITLE
Add column in SEM analysis restart endlessly the analysis

### DIFF
--- a/QMLComponents/models/listmodeltermsavailable.cpp
+++ b/QMLComponents/models/listmodeltermsavailable.cpp
@@ -20,9 +20,7 @@
 
 void ListModelTermsAvailable::resetTermsFromSources()
 {
-	
-	beginResetModel();
-
+	Terms oldTerms = terms();
 	Terms termsAvailable = getSourceTerms();
 	Terms removedTerms, addedTerms;
 	
@@ -34,8 +32,11 @@ void ListModelTermsAvailable::resetTermsFromSources()
 		if (!_allTerms.contains(term))
 			addedTerms.add(term);
 
-	initTerms(termsAvailable);
+	if (oldTerms == termsAvailable)
+		return;
 
+	beginResetModel();
+	initTerms(termsAvailable);
 	endResetModel();
 
 	emit availableTermsReset(addedTerms, removedTerms);


### PR DESCRIPTION
Related to PR https://github.com/jasp-stats/jaspSem/pull/204 A new function adds the scores to the dataset: this restarts the SEM analysis endlessly.

