### PR TITLE
Show (implicitly) allowed columntypes in variableslist clearly and sorted

### DIFF
--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -248,7 +248,7 @@ VariablesListBase
 			z:			2
 			mipmap:		true
 			smooth:		true
-			opacity:	1.0
+			opacity:	0.5
 			anchors
 			{
 				bottom:			itemRectangle.bottom;

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -238,7 +238,7 @@ VariablesListBase
 		
 	Repeater
 	{
-		model: allowedColumnsIcons.length > 0 ? allowedColumnsIcons : suggestedColumnsIcons
+		model: allowedColumnsIcons
 
 		Image
 		{
@@ -248,7 +248,7 @@ VariablesListBase
 			z:			2
 			mipmap:		true
 			smooth:		true
-			opacity:	allowedColumnsIcons.length > 0 ? 1.0 : 0.4
+			opacity:	1.0
 			anchors
 			{
 				bottom:			itemRectangle.bottom;
@@ -256,20 +256,6 @@ VariablesListBase
 				right:			itemRectangle.right;
 				rightMargin:	(index * 20 + 4)  * preferencesModel.uiScale + (scrollBar.visible ? scrollBar.width : 0)
 			}
-			
-			MouseArea
-			{
-				id:					iconImageMouseArea
-				anchors.fill:		parent
-				acceptedButtons:	Qt.NoButtons
-				hoverEnabled:		true
-				z:					3
-			}
-			
-			QTCONTROLS.ToolTip.delay:		jaspTheme.toolTipDelay
-			QTCONTROLS.ToolTip.timeout:		jaspTheme.toolTipTimeout
-			QTCONTROLS.ToolTip.visible:		iconImageMouseArea.containsMouse
-			QTCONTROLS.ToolTip.text:		allowedColumnsIcons.length > 0 ? qsTr("Only these types are allowed") : qsTr("These types are suggested")
 		}
 	}
 

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -238,16 +238,17 @@ VariablesListBase
 		
 	Repeater
 	{
-		model: suggestedColumnsIcons
+		model: allowedColumnsIcons.length > 0 ? allowedColumnsIcons : suggestedColumnsIcons
 
 		Image
 		{
-			source: modelData
-			height: 16 * preferencesModel.uiScale
-			width:	16 * preferencesModel.uiScale
-			z:		2
-			mipmap:	true
-			smooth:	true
+			source:		modelData
+			height:		16 * preferencesModel.uiScale
+			width:		16 * preferencesModel.uiScale
+			z:			2
+			mipmap:		true
+			smooth:		true
+			opacity:	allowedColumnsIcons.length > 0 ? 1.0 : 0.4
 			anchors
 			{
 				bottom:			itemRectangle.bottom;
@@ -255,6 +256,20 @@ VariablesListBase
 				right:			itemRectangle.right;
 				rightMargin:	(index * 20 + 4)  * preferencesModel.uiScale + (scrollBar.visible ? scrollBar.width : 0)
 			}
+			
+			MouseArea
+			{
+				id:					iconImageMouseArea
+				anchors.fill:		parent
+				acceptedButtons:	Qt.NoButtons
+				hoverEnabled:		true
+				z:					3
+			}
+			
+			QTCONTROLS.ToolTip.delay:		jaspTheme.toolTipDelay
+			QTCONTROLS.ToolTip.timeout:		jaspTheme.toolTipTimeout
+			QTCONTROLS.ToolTip.visible:		iconImageMouseArea.containsMouse
+			QTCONTROLS.ToolTip.text:		allowedColumnsIcons.length > 0 ? qsTr("Only these types are allowed") : qsTr("These types are suggested")
 		}
 	}
 

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -349,7 +349,7 @@ void VariablesListBase::_setAllowedAndSuggestedVariables()
 			suggestedTypes.push_back(type);
 	}
 
-	for (const QString& columnTypeStr : implicitAllowedTypes)
+	for (const QString& columnTypeStr : allowedColumns())
 	{
 		columnType type = columnTypeFromString(fq(columnTypeStr), columnType::unknown);
 		if (type != columnType::unknown)

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -339,33 +339,22 @@ void VariablesListBase::_setAllowedAndSuggestedVariables()
 
 	// The suggectedColumnsIcons indicates which columns are suggested in the VariableList view.
 	// The allowedColumnsIcons indicate which columns are allowed in the view
-	QStringList				suggestedIcons, allowedIcons;
-	std::vector<columnType> suggestedTypes, allowedTypes;
+	QStringList				allowedIcons;
+	std::vector<columnType> allowedTypes;
 	
-	for (const QString& columnTypeStr : suggestedColumns())
-	{
-		columnType type = columnTypeFromString(fq(columnTypeStr), columnType::unknown);
-		if (type != columnType::unknown)
-			suggestedTypes.push_back(type);
-	}
 
-	for (const QString& columnTypeStr : allowedColumns())
+	for (const QString& columnTypeStr : implicitAllowedTypes)
 	{
 		columnType type = columnTypeFromString(fq(columnTypeStr), columnType::unknown);
 		if (type != columnType::unknown)
 			allowedTypes.push_back(type);
 	}
 	
-	std::sort(suggestedTypes.begin(),	suggestedTypes.end());
 	std::sort(allowedTypes.begin(),		allowedTypes.end());
-	
-	for(columnType type : suggestedTypes)
-		suggestedIcons.push_back(VariableInfo::getIconFile(type, VariableInfo::DefaultIconType));
 	
 	for(columnType type : allowedTypes)
 		allowedIcons.push_back(VariableInfo::getIconFile(type, VariableInfo::DefaultIconType));
 	
-	setSuggestedColumnsIcons(suggestedIcons);
 	setAllowedColumnsIcons(allowedIcons);
 
 	if (form() && form()->initialized())

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -35,6 +35,7 @@ class VariablesListBase : public JASPListControl, public BoundControl
 	Q_PROPERTY( QStringList		allowedColumns					READ allowedColumns					WRITE setAllowedColumns					NOTIFY allowedColumnsChanged				)
 	Q_PROPERTY( QStringList		suggestedColumns				READ suggestedColumns				WRITE setSuggestedColumns				NOTIFY suggestedColumnsChanged				)
 	Q_PROPERTY(	QStringList		suggestedColumnsIcons			READ suggestedColumnsIcons													NOTIFY suggestedColumnsIconsChanged			)
+	Q_PROPERTY(	QStringList		allowedColumnsIcons				READ allowedColumnsIcons													NOTIFY allowedColumnsIconsChanged			)
 	Q_PROPERTY( QStringList		columnsTypes					READ columnsTypes															NOTIFY columnsTypesChanged					)
 	Q_PROPERTY( QStringList		columnsNames					READ columnsNames															NOTIFY columnsNamesChanged					)
 	Q_PROPERTY( QStringList		dropKeys						READ dropKeys						WRITE setDropKeys						NOTIFY dropKeysChanged						)
@@ -65,6 +66,7 @@ public:
 	const QStringList&			allowedColumns()							const				{ return _allowedColumns;							}
 	const QStringList&			suggestedColumns()							const				{ return _suggestedColumns;							}
 	const QStringList&			suggestedColumnsIcons()						const				{ return _suggestedColumnsIcons;					}
+	const QStringList&			allowedColumnsIcons()						const				{ return _allowedColumnsIcons;						}
 	const QStringList&			columnsTypes()								const				{ return _columnsTypes;								}
 	const QStringList&			columnsNames()								const				{ return _columnsNames;								}
 	const QStringList&			dropKeys()									const				{ return _dropKeys;									}
@@ -78,6 +80,7 @@ signals:
 	void allowedColumnsChanged();
 	void suggestedColumnsChanged();
 	void suggestedColumnsIconsChanged();
+	void allowedColumnsIconsChanged();
 	void columnsTypesChanged();
 	void columnsNamesChanged();
 	void dropKeysChanged();
@@ -89,6 +92,7 @@ protected:
 	GENERIC_SET_FUNCTION(AllowedColumns,				_allowedColumns,				allowedColumnsChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(SuggestedColumns,				_suggestedColumns,				suggestedColumnsChanged,				QStringList		)
 	GENERIC_SET_FUNCTION(SuggestedColumnsIcons,			_suggestedColumnsIcons,			suggestedColumnsIconsChanged,			QStringList		)
+	GENERIC_SET_FUNCTION(AllowedColumnsIcons,			_allowedColumnsIcons,			allowedColumnsIconsChanged,				QStringList		)
 	GENERIC_SET_FUNCTION(ColumnsTypes,					_columnsTypes,					columnsTypesChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(ColumnsNames,					_columnsNames,					columnsNamesChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(InteractionHighOrderCheckBox,	_interactionHighOrderCheckBox,	interactionHighOrderCheckBoxChanged,	QString			)
@@ -109,7 +113,7 @@ protected slots:
 	void interactionHighOrderHandler(JASPControl* checkBoxControl);
 
 private:
-	void						_setAllowedVariables();
+	void						_setAllowedAndSuggestedVariables();
 	void						_setRelations();
 
 	int							_columns				= 1;
@@ -121,6 +125,7 @@ private:
 	QStringList					_allowedColumns,
 								_suggestedColumns,
 								_suggestedColumnsIcons,
+								_allowedColumnsIcons,
 								_columnsTypes,
 								_columnsNames,
 								_dropKeys;

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -34,7 +34,6 @@ class VariablesListBase : public JASPListControl, public BoundControl
 	Q_PROPERTY( int				columns							READ columns						WRITE setColumns						NOTIFY columnsChanged						)
 	Q_PROPERTY( QStringList		allowedColumns					READ allowedColumns					WRITE setAllowedColumns					NOTIFY allowedColumnsChanged				)
 	Q_PROPERTY( QStringList		suggestedColumns				READ suggestedColumns				WRITE setSuggestedColumns				NOTIFY suggestedColumnsChanged				)
-	Q_PROPERTY(	QStringList		suggestedColumnsIcons			READ suggestedColumnsIcons													NOTIFY suggestedColumnsIconsChanged			)
 	Q_PROPERTY(	QStringList		allowedColumnsIcons				READ allowedColumnsIcons													NOTIFY allowedColumnsIconsChanged			)
 	Q_PROPERTY( QStringList		columnsTypes					READ columnsTypes															NOTIFY columnsTypesChanged					)
 	Q_PROPERTY( QStringList		columnsNames					READ columnsNames															NOTIFY columnsNamesChanged					)
@@ -65,7 +64,6 @@ public:
 	int							columns()									const				{ return _columns;									}
 	const QStringList&			allowedColumns()							const				{ return _allowedColumns;							}
 	const QStringList&			suggestedColumns()							const				{ return _suggestedColumns;							}
-	const QStringList&			suggestedColumnsIcons()						const				{ return _suggestedColumnsIcons;					}
 	const QStringList&			allowedColumnsIcons()						const				{ return _allowedColumnsIcons;						}
 	const QStringList&			columnsTypes()								const				{ return _columnsTypes;								}
 	const QStringList&			columnsNames()								const				{ return _columnsNames;								}
@@ -79,7 +77,6 @@ signals:
 	void columnsChanged();
 	void allowedColumnsChanged();
 	void suggestedColumnsChanged();
-	void suggestedColumnsIconsChanged();
 	void allowedColumnsIconsChanged();
 	void columnsTypesChanged();
 	void columnsNamesChanged();
@@ -91,7 +88,6 @@ protected:
 	GENERIC_SET_FUNCTION(Columns,						_columns,						columnsChanged,							int				)
 	GENERIC_SET_FUNCTION(AllowedColumns,				_allowedColumns,				allowedColumnsChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(SuggestedColumns,				_suggestedColumns,				suggestedColumnsChanged,				QStringList		)
-	GENERIC_SET_FUNCTION(SuggestedColumnsIcons,			_suggestedColumnsIcons,			suggestedColumnsIconsChanged,			QStringList		)
 	GENERIC_SET_FUNCTION(AllowedColumnsIcons,			_allowedColumnsIcons,			allowedColumnsIconsChanged,				QStringList		)
 	GENERIC_SET_FUNCTION(ColumnsTypes,					_columnsTypes,					columnsTypesChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(ColumnsNames,					_columnsNames,					columnsNamesChanged,					QStringList		)


### PR DESCRIPTION
fixes jasp-stats/INTERNAL-jasp#2532 sort of

Makes sure that whatever ends up being "allowed" in a variableslist is what the user sees.
Because who could guess the logic of:
- scale suggested -> scale, ordinal, nominal allowed
- ordinal suggested -> ordinal allowed
- nominal suggested -> ordinal, nominal allowed
- whatever allowed -> thatever allowed

So I made some code to nicely show suggested icons transparently and allowed columns clearly.
But then, it is kind of hard to know what to drop in the boxes in the end...
So I removed that code and just show the implicitely allowed types.

Im wondering whether I should also just remove the `scale, ordinal, nominal` entirely, because that is what an empty one does anyway.