### PR TITLE
add platform name to detect window server

### DIFF
--- a/Desktop/gui/aboutmodel.cpp
+++ b/Desktop/gui/aboutmodel.cpp
@@ -82,6 +82,7 @@ QString AboutModel::systemInfo()
 		info += "Kernel Version: "   + QSysInfo::kernelVersion() + "\n";
 		info += "Architecture: "     + QSysInfo::currentCpuArchitecture() + "\n";
 		info += "Install Path: "     + QCoreApplication::applicationDirPath() + "\n";
+		info += "Platfotm Name: "    + QGuiApplication::platformName() + "\n";
 		info += "System Local: "     + QLocale::system().name() + "\n\n";
 
 		process.start(command, arguments);


### PR DESCRIPTION
We had a good support on wayland with Qt6,so this on Linux will useful to detect wayland/X11 window display sever and let us know while debug needs.

