### PR TITLE
Fix help docs code block display

### DIFF
--- a/Resources/Help/darkTheme.css
+++ b/Resources/Help/darkTheme.css
@@ -61,6 +61,11 @@ li
   padding: 4px
 }
 
+pre code
+{
+  display: block;
+}
+
 body code
 {
   font-family: "Courier New", Courier, monospace;

--- a/Resources/Help/lightTheme.css
+++ b/Resources/Help/lightTheme.css
@@ -60,6 +60,11 @@ li
   padding: 4px
 }
 
+pre code
+{
+  display: block;
+}
+
 body code 
 {
   font-family: "Courier New", Courier, monospace;


### PR DESCRIPTION
For example in "Open"->"dataset" help docs the pre-code not showing as block.

previous:
![image](https://github.com/jasp-stats/jasp-desktop/assets/10348402/7a2f1213-53fd-43b8-ba0f-75eb0b84d229)

now:
```
cd somewhere/nice
sqlite3 helloWorld
# SQLite version 3.36.0 2021-06-18 18:58:49
# Enter ".help" for usage hints.
# sqlite> 
create table helloWorld ( aNumber int, aString varchar(30) );
insert into helloWorld values ( 1, "I"), (2, "am"), (3, "alive"), (4, ";)");
# check it worked:
select * from helloWorld;
# 1|I
# 2|am
# 3|alive
# 4|;)
```
