### PR TITLE
+ icon in empty ComponentsList not in the middle

### DIFF
--- a/QMLComponents/components/JASP/Controls/ComponentsList.qml
+++ b/QMLComponents/components/JASP/Controls/ComponentsList.qml
@@ -189,7 +189,8 @@ ComponentsListBase
 				anchors
 				{
 					top				: itemGrid.bottom
-					horizontalCenter: parent.horizontalCenter
+					left			: parent.left
+					leftMargin		: (itemRectangle.width - width) / 2
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2545

