### PR TITLE
Speedup autosort massively

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1055,10 +1055,7 @@ stringvec Column::dataAsRLevels(intvec & values, const boolvec & filter, bool us
 	stringvec	levels;
 	stringset	levelsIncluded,
 				levelsAdded;
-	
-	
-	
-	
+		
 	auto _addLabel = [&](const std::string & display, bool fromData)
 	{
 		if(!levelsAdded.count(display))
@@ -1621,8 +1618,6 @@ void Column::labelsReverse()
 void Column::labelsOrderByValue(bool doDbUpdateEtc)
 {
 	JASPTIMER_SCOPE(Column::labelsOrderByValue);
-	
-	replaceDoublesTillLabelsRowWithLabels(labelsTempCount());
 	
 	doublevec				asc			= valuesNumericOrdered();
 	size_t					curMax		= asc.size()+1;

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -828,6 +828,7 @@ int Column::labelsTempCount()
 				dblset.insert(_dbls[r]);
 		
 		doublevec dbls(dblset.begin(), dblset.end());
+		
 		std::sort(dbls.begin(), dbls.end());
 		
 		//There might also be "double" values that should also be shown in the editor so we go through everything and add them to _labelsTemp and _labelsTempToIndex	
@@ -1056,7 +1057,7 @@ stringvec Column::dataAsRLevels(intvec & values, const boolvec & filter, bool us
 				levelsAdded;
 	
 	
-	labelsTempCount();
+	
 	
 	auto _addLabel = [&](const std::string & display, bool fromData)
 	{
@@ -1070,10 +1071,21 @@ stringvec Column::dataAsRLevels(intvec & values, const boolvec & filter, bool us
 			levelsIncluded.insert(display);
 	};
 	
+	//make sure we have temp labels for any doubles/ints outside of labels
+	labelsTempCount();
+	size_t nonEmpty = 0;
+		
 	//First we try to find all levels, start with the known labels and then add any  doubles as labels.
 	for(Label * label : _labels)
 		if(!label->isEmptyValue())
+		{
 			_addLabel(useLabels ? label->labelDisplay() : label->originalValueAsString(false), false);
+			nonEmpty++;
+		}
+	
+	//Now we add the sorted temp dbl labels, so that we get the same order as shown in the variableswindow
+	for(size_t lti=nonEmpty; lti<_labelsTempDbls.size(); lti++)
+		_addLabel(doubleToDisplayString(_labelsTempDbls[lti], false), false);
 	
 	assert(filter.size() == rowCount() || filter.size() == 0);
 

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1019,6 +1019,8 @@ std::string Column::operator[](size_t row)
 
 stringvec Column::valuesAsStrings() const
 {
+	JASPTIMER_SCOPE(Column::valuesAsStrings);
+	
 	stringvec returnMe;
 	returnMe.resize(_dbls.size());
 	
@@ -1030,6 +1032,8 @@ stringvec Column::valuesAsStrings() const
 
 stringvec Column::labelsAsStrings() const
 {
+	JASPTIMER_SCOPE(Column::labelsAsStrings);
+	
 	stringvec returnMe;
 	returnMe.resize(_dbls.size());
 	
@@ -1041,6 +1045,8 @@ stringvec Column::labelsAsStrings() const
 
 stringvec Column::displaysAsStrings() const
 {
+	JASPTIMER_SCOPE(Column::displaysAsStrings);
+	
 	stringvec returnMe;
 	returnMe.resize(_dbls.size());
 	
@@ -1052,6 +1058,8 @@ stringvec Column::displaysAsStrings() const
 
 stringvec Column::dataAsRLevels(intvec & values, const boolvec & filter, bool useLabels )
 {
+	JASPTIMER_SCOPE(Column::dataAsRLevels);
+	
 	stringvec	levels;
 	stringset	levelsIncluded,
 				levelsAdded;
@@ -1153,6 +1161,9 @@ stringvec Column::dataAsRLevels(intvec & values, const boolvec & filter, bool us
 
 doublevec Column::dataAsRDoubles(const boolvec &filter) const
 {
+	JASPTIMER_SCOPE(Column::dataAsRDoubles);
+
+	
 	doublevec doubles;
 		
 	assert(filter.size() == rowCount() || filter.size() == 0);
@@ -1202,6 +1213,8 @@ std::map<double, Label*> Column::replaceDoubleWithLabel(doublevec dbls)
 
 Label *Column::replaceDoublesTillLabelsRowWithLabels(size_t row)
 {
+	JASPTIMER_SCOPE(Column::replaceDoublesTillLabelsRowWithLabels);
+	
 	//row here is in the label editor, not in the data!	
 	if(labelByIndexNotEmpty(row))
 		return labelByIndexNotEmpty(row);
@@ -1614,10 +1627,22 @@ void Column::labelsReverse()
 	_dbUpdateLabelOrder();
 }
 
-
 void Column::labelsOrderByValue(bool doDbUpdateEtc)
 {
 	JASPTIMER_SCOPE(Column::labelsOrderByValue);
+
+	bool replaceAllDoubles = false;
+	static double dummy;
+	
+	for(Label * label : labels())	
+		if(!label->isEmptyValue() && !(label->originalValue().isDouble() || ColumnUtils::getDoubleValue(label->originalValueAsString(), dummy)))
+		{
+				replaceAllDoubles = true;
+				break;
+		}
+	
+	if(replaceAllDoubles)
+		replaceDoublesTillLabelsRowWithLabels(labelsTempCount());
 	
 	doublevec				asc			= valuesNumericOrdered();
 	size_t					curMax		= asc.size()+1;

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -141,7 +141,7 @@ public:
 			stringvec				valuesAsStrings()																		const;
 			stringvec				labelsAsStrings()																		const;
 			stringvec				displaysAsStrings()																		const;
-			stringvec				dataAsRLevels(intvec & values, const boolvec & filter, bool useLabels = true)			const; ///< values is output! If filter is of different length than the data an error is thrown, if length is zero it is ignored. useLabels indicates whether the levels will be based on the label or on the value as specified in the label editor.
+			stringvec				dataAsRLevels(intvec & values, const boolvec & filter, bool useLabels = true)			; ///< values is output! If filter is of different length than the data an error is thrown, if length is zero it is ignored. useLabels indicates whether the levels will be based on the label or on the value as specified in the label editor.
 			doublevec				dataAsRDoubles(const boolvec & filter)													const; ///< If filter is of different length than the data an error is thrown, if length is zero it is ignored
 
 			std::map<double,Label*>	replaceDoubleWithLabel(doublevec dbls);

--- a/Desktop/data/columnmodel.cpp
+++ b/Desktop/data/columnmodel.cpp
@@ -188,7 +188,7 @@ int ColumnModel::firstNonNumericRow() const
 	if(!column() || !column()->autoSortByValue())
 		return 0;
 	
-	int nonEmptyNonNumerics = 0; //We do not need to take any "double-labels" into account, because we require autoSortByValue() to be true before continuing, which means everything got a label 
+	int nonEmptyNonNumerics = 0;
 	for(Label * label : column()->labels())	
 		if(!label->isEmptyValue())
 		{
@@ -198,6 +198,10 @@ int ColumnModel::firstNonNumericRow() const
 				return nonEmptyNonNumerics;
 			nonEmptyNonNumerics++;
 		}
+	
+	//If we have more temporary labels then normal ones then those afterwards are all numeric (or something wouldve been replaced/sorted) so we can return labelsTempCount()
+	if(column()->labelsTempCount() > nonEmptyNonNumerics)
+		return column()->labelsTempCount();
 	
 	return nonEmptyNonNumerics;	
 }
@@ -733,7 +737,9 @@ void ColumnModel::setValue(int rowIndex, const QString &value)
 {
 	JASPTIMER_SCOPE(ColumnModel::setValue);
 	
-	if(value == data(index(rowIndex,0), int(DataSetPackage::specialRoles::value)).toString() || value == data(index(rowIndex,0), int(DataSetPackage::specialRoles::value)).toString())
+	QString originalValue = data(index(rowIndex,0), int(DataSetPackage::specialRoles::value)).toString();
+	
+	if(value == originalValue)
 		return; //Its already that value
 	
 	_editing = true;
@@ -745,7 +751,9 @@ void ColumnModel::setLabel(int rowIndex, QString label)
 {
 	JASPTIMER_SCOPE(ColumnModel::setLabel);
 	
-	if(label == data(index(rowIndex,0), int(DataSetPackage::specialRoles::label)).toString())
+	QString originalLabel = data(index(rowIndex,0), int(DataSetPackage::specialRoles::label)).toString();
+	
+	if(label == originalLabel)
 		return; //Its already that value
 	
 	_editing = true;

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -889,6 +889,10 @@ bool DataSetPackage::setLabelValue(const QModelIndex &index, const QString &newL
 			}
 		}
 		
+		//if no a number then we will have to replace everything anyway because we wont be able to sort otherwise
+		if(replaceTill == -1 && column->autoSortByValue())
+				replaceTill = column->labelsTempCount();
+		
 		label = column->replaceDoublesTillLabelsRowWithLabels(replaceTill > -1 ? replaceTill : index.row());
 		aChange = true;
 	}

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -27,13 +27,18 @@ DataSetView::DataSetView(QQuickItem *parent)
 	//setFlag(QQuickItem::ItemIsFocusScope);
 
 	_material.setColor(Qt::gray);
+	
+	_delayViewportChangedTimer = new QTimer(this);
+	_delayViewportChangedTimer->setInterval(0);
+	_delayViewportChangedTimer->setSingleShot(true);
 
 	connect(this,						&DataSetView::parentChanged,					this, &DataSetView::myParentChanged);
 	
-	connect(this,						&DataSetView::viewportXChanged,					this, &DataSetView::viewportChanged);
-	connect(this,						&DataSetView::viewportYChanged,					this, &DataSetView::viewportChanged);
-	connect(this,						&DataSetView::viewportWChanged,					this, &DataSetView::viewportChanged);
-	connect(this,						&DataSetView::viewportHChanged,					this, &DataSetView::viewportChanged);
+	connect(this,						&DataSetView::viewportXChanged,					this, &DataSetView::viewportChangedDelayed);
+	connect(this,						&DataSetView::viewportYChanged,					this, &DataSetView::viewportChangedDelayed);
+	connect(this,						&DataSetView::viewportWChanged,					this, &DataSetView::viewportChangedDelayed);
+	connect(this,						&DataSetView::viewportHChanged,					this, &DataSetView::viewportChangedDelayed);
+	connect(_delayViewportChangedTimer, &QTimer::timeout,								this, &DataSetView::viewportChanged);
 
 	connect(this,						&DataSetView::itemDelegateChanged,				this, &DataSetView::reloadTextItems);
 	connect(this,						&DataSetView::rowNumberDelegateChanged,			this, &DataSetView::reloadRowNumbers);
@@ -57,6 +62,10 @@ DataSetView::DataSetView(QQuickItem *parent)
 	connect(_model,						&ExpandDataProxyModel::undoChanged,				this, &DataSetView::undoChanged);
 	
 	setZ(10);
+	
+	
+
+	
 }
 
 void DataSetView::setModel(QAbstractItemModel * model)
@@ -288,6 +297,11 @@ void DataSetView::calculateCellSizesAndClear(bool clearStorage)
 	viewportChanged();
 
 	JASPTIMER_STOP(DataSetView::calculateCellSizes);
+}
+
+void DataSetView::viewportChangedDelayed()
+{
+	_delayViewportChangedTimer->start();	
 }
 
 void DataSetView::viewportChanged()

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -198,6 +198,7 @@ public slots:
 	void		calculateCellSizes()	{ calculateCellSizesAndClear(false); }
 	void		aContentSizeChanged()	{ _recalculateCellSizes = true; }
 	void		viewportChanged();
+	void		viewportChangedDelayed();
 	void		myParentChanged(QQuickItem *);
 
 	void		reloadTextItems();
@@ -372,6 +373,7 @@ protected:
 	std::vector<qstringvec>									_lastJaspCopyValues,
 															_lastJaspCopyLabels;
 	std::vector<boolvec>									_lastJaspCopySelect;
+	QTimer												*	_delayViewportChangedTimer	= nullptr;
 };
 
 


### PR DESCRIPTION
fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2566

While thinking about the issue I realized I could speed up the reading of lots of random floats a lot!
The slowdown now only comes if someone decides to reverse values on levels or change some level-value to something non-numeric.

But better than that it is not going to get unless you disable auto sorting.