### PR TITLE
Solve contrast issues

### DIFF
--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -120,6 +120,7 @@ Json::Value& AnalysisBase::_getParentBoundValue(const QVector<JASPControl::Paren
 {
 	found = (parentKeys.size() == 0);
 	Json::Value* parentBoundValue = &_boundValues;
+	Json::Value* metaValue = &_boundValues[".meta"];
 
 	// A parentKey has 3 properties: <name>, <key> and <value>: it assumes that the json boundValue is an abject, one of its member is <name>,
 	// whom value is an array of json objects. These objects have a member <key>, and one of them has for value <value>.
@@ -148,6 +149,11 @@ Json::Value& AnalysisBase::_getParentBoundValue(const QVector<JASPControl::Paren
 		if (parentBoundValue->isMember(parent.name))
 		{
 			Json::Value& parentBoundValues = (*parentBoundValue)[parent.name];
+			metaValue = &(*metaValue)[parent.name];
+			bool hasTypes = !metaValue->isNull() && metaValue->isMember("hasTypes") ? (*metaValue)["hasTypes"].asBool() : false;
+			if (hasTypes && parentBoundValues.isObject() && parentBoundValues.isMember("value"))
+				parentBoundValues = parentBoundValues["value"];
+
 			if (!parentBoundValues.isNull() && parentBoundValues.isArray())
 			{
 				for (Json::Value & boundValue : parentBoundValues)

--- a/QMLComponents/boundcontrols/boundcontrolterms.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolterms.cpp
@@ -318,6 +318,15 @@ void BoundControlTerms::setBoundValue(const Json::Value &value, bool emitChanges
 	BoundControlBase::setBoundValue(newValue.isNull() ? value : newValue, emitChanges);
 }
 
+Json::Value BoundControlTerms::createMeta() const
+{
+	Json::Value meta(BoundControlBase::createMeta());
+	if (_control->encodeValue())
+		meta["hasTypes"] = true;
+
+	return meta;
+}
+
 Json::Value BoundControlTerms::addTermsToOption(const Json::Value &option, const Terms &terms, const ListModel::RowControlsValues &extraTermsMap) const
 {
 	Json::Value result = option;

--- a/QMLComponents/boundcontrols/boundcontrolterms.h
+++ b/QMLComponents/boundcontrols/boundcontrolterms.h
@@ -33,7 +33,8 @@ public:
 	void		bindTo(const Json::Value &value)													override;
 	void		resetBoundValue()																	override;
 	void		setBoundValue(const Json::Value &value, bool emitChanges = true)					override;
-	
+	Json::Value	createMeta()																const	override;
+
 	Json::Value	addTermsToOption(const Json::Value &option, const Terms &terms, const ListModel::RowControlsValues &extraTermsMap = {}) const;
 	bool		areTermsInOption(const Json::Value& option,	Terms& terms)					const;
 

--- a/QMLComponents/components/JASP/Controls/AssignedRepeatedMeasuresCells.qml
+++ b/QMLComponents/components/JASP/Controls/AssignedRepeatedMeasuresCells.qml
@@ -25,6 +25,6 @@ VariablesList
 	showElementBorder		: true
 	columns					: 2
 	showVariableTypeIcon	: false
-	suggestedColumns		: ["scale"]
+	allowedColumns			: ["scale"]
 	height					: 140
 }

--- a/QMLComponents/components/JASP/Controls/FactorsForm.qml
+++ b/QMLComponents/components/JASP/Controls/FactorsForm.qml
@@ -75,8 +75,7 @@ FactorsFormBase
 					editableTitle:      factorTitle
 					dropKeys:			availableVariablesListName
 					//dropMode:			JASP.DropReplace
-					suggestedColumns:	allowAll ? [] : ["scale", "ordinal"]
-					allowedColumns:     allowAll ? [] : ["scale", "ordinal"]
+					allowedColumns:     allowAll ? [] : ["scale"]
 					implicitHeight:		factorsForm.factorListHeight // preferredHeight does not work when changing the language: the height is set to the implicitHeight
 					implicitWidth:		listWidth
 					isBound:			false

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -491,19 +491,6 @@ bool JASPControl::checkOptionName(const QString &name)
 			if (!label.isEmpty())	addControlError(tr("Control with label '%1' has no name").arg(label));
 			else					addControlError(tr("A control has no name"));
 		}
-		else
-		{
-			bool hasNonAlphaNum = false;
-			for (const QChar& c : name)
-				if (!c.isLetterOrNumber() && c.toLatin1() != '_')
-					hasNonAlphaNum = true;
-
-			if (hasNonAlphaNum)
-			{
-				if (!label.isEmpty())	addControlError(tr("Name of control with label '%1' contains non alphanumeric characters").arg(label));
-				else					addControlError(tr("Name of control contains non alphanumeric characters"));
-			}
-		}
 		return false;
 	}
 

--- a/QMLComponents/controls/sourceitem.cpp
+++ b/QMLComponents/controls/sourceitem.cpp
@@ -602,6 +602,8 @@ Terms SourceItem::filterTermsWithCondition(ListModel* model, const Terms& terms,
 								value = value.toBool() || conditionValues[variable].toBool();
 							conditionValues[variable] = value;
 						}
+						else
+							Log::log() << "When evaluating condition '" << condition << "' the control " << control->name() << " could not be used because it has not a usable option: " << jsonValue.toStyledString() << std::endl;
 					}
 				}
 


### PR DESCRIPTION
Due to the addition of the types in the options for VariablesList, the search for a parent key when row components are used fails. Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2568

Also remove the alphanumeric constraints for name
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2569

Also remove suggestedColumns in AssignedRepeatedMeasuresCells & FactorsForm components

