### PR TITLE
Source of VariablesList should keep the types of the variables

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolcontraststableview.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolcontraststableview.cpp
@@ -31,12 +31,12 @@ Json::Value BoundControlContrastsTableView::createJson() const
 	ListModelCustomContrasts* contrastsModel = qobject_cast<ListModelCustomContrasts*>(_tableView->tableModel());
 
 
-	QStringList variables;
+	Terms variables;
 	QVector<QVector<QVariant> > allLables;
 
 	contrastsModel->getVariablesAndLabels(variables, allLables);
 
-	if (variables.length() > 0)
+	if (variables.size() > 0)
 	{
 		Json::Value rowNames(Json::arrayValue);
 
@@ -44,10 +44,10 @@ Json::Value BoundControlContrastsTableView::createJson() const
 			rowNames.append(fq(contrastsModel->getDefaultRowName(size_t(row))));
 
 		int col = 0;
-		for (const QString& variable : variables)
+		for (const Term& variable : variables)
 		{
 			Json::Value row(Json::objectValue);
-			row["name"] = fq(variable);
+			row["name"] = variable.asString();
 			row["levels"] = rowNames;
 			row["isContrast"] = false;
 
@@ -68,7 +68,7 @@ Json::Value BoundControlContrastsTableView::createJson() const
 			for (int colIndex = 0; colIndex < _tableView->initialColumnCount(); colIndex++)
 			{
 				Json::Value row(Json::objectValue);
-				row["name"] = fq(contrastsModel->getDefaultColName(size_t(variables.length() + colIndex)));
+				row["name"] = fq(contrastsModel->getDefaultColName(size_t(variables.size() + colIndex)));
 				row["levels"] = rowNames;
 				row["isContrast"] = true;
 
@@ -93,7 +93,7 @@ void BoundControlContrastsTableView::fillTableTerms(const Json::Value &value, Li
 	for (const Json::Value& row : value)
 	{
 		if (!row["isContrast"].asBool())
-			tableTerms.variables.push_back(tableTerms.colNames[index]);
+			tableTerms.variables.add(tableTerms.colNames[index]);
 		index++;
 	}
 }
@@ -105,7 +105,7 @@ void BoundControlContrastsTableView::fillBoundValue(Json::Value& value, const Li
 	int i = 0;
 	for (Json::Value& row : value)
 	{
-		row["isContrast"] = (i >= tableTerms.variables.length());
+		row["isContrast"] = (i >= tableTerms.variables.size());
 		i++;
 	}
 }

--- a/QMLComponents/boundcontrols/boundcontrolterms.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolterms.cpp
@@ -127,7 +127,7 @@ void BoundControlTerms::bindTo(const Json::Value &value)
 	if (!hasTypes)
 	{
 		for (const Term& term : terms)
-			typesPart.append(columnTypeToString(_termsModel->getVariableType(term.asQString())));
+			typesPart.append(columnTypeToString(term.type()));
 	}
 
 	Json::Value newValue = Json::objectValue;

--- a/QMLComponents/components/JASP/Controls/AvailableVariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/AvailableVariablesList.qml
@@ -20,7 +20,8 @@ import JASP 1.0
 
 VariablesList
 {
-	listViewType:	JASP.AvailableVariables
-	showSortMenu:	true
-	isBound:		false
+	listViewType:		JASP.AvailableVariables
+	showSortMenu:		true
+	isBound:			false
+	allowTypeChange:	false
 }

--- a/QMLComponents/components/JASP/Controls/ModelTermsList.qml
+++ b/QMLComponents/components/JASP/Controls/ModelTermsList.qml
@@ -26,6 +26,7 @@ VariablesList
 	name					: "modelTerms"
 	title					: qsTr("Model Terms")
 	listViewType			: JASP.Interaction
+	allowTypeChange			: false
 
 	rowComponentTitle		: qsTr("Add to null model")
 	interactionHighOrderCheckBox : "isNuisance"

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -413,13 +413,14 @@ VariablesListBase
 				property int	offsetY:				0
 				property int	rank:					index
 				property bool	containsDragItem:		variablesList.itemContainingDrag === itemRectangle
-				property bool	isVirtual:			(typeof model.type !== "undefined") && model.type.includes("virtual")
-				property bool	isVariable:			(typeof model.type !== "undefined") && model.type.includes("variable")
-				property string	preview:			!isVariable ? "" : model.preview
+				property bool	isVirtual:				(typeof model.type !== "undefined") && model.type.includes("virtual")
+				property bool	isVariable:				(typeof model.type !== "undefined") && model.type.includes("variable")
+				property string	preview:				!isVariable ? "" : model.preview
 				property bool	isLayer:				(typeof model.type !== "undefined") && model.type.includes("layer")
-				property bool	draggable:			variablesList.draggable && model.selectable
-				property string	columnType:			isVariable && (typeof model.columnType !== "undefined") ? model.columnType : ""
+				property bool	draggable:				variablesList.draggable && model.selectable
+				property string	columnType:				isVariable && (typeof model.columnType !== "undefined") ? model.columnType : ""
 				property var	extraItem:				model.rowComponent
+				property bool	typeChangeable:			variablesList.allowTypeChange && (allowedColumnsId.count === 0 || allowedColumnsId.count > 1) && icon.source !== ""
 
 				enabled: !variablesList.draggable || model.selectable
 
@@ -473,7 +474,7 @@ VariablesListBase
 					visible:				source
 					mipmap:					true
 					smooth:					true
-					scale:					mouseArea.containsMouse && mouseArea.mouseX < icon.width ? 1.2 : 1
+					scale:					itemRectangle.typeChangeable && mouseArea.containsMouse && mouseArea.mouseX < icon.width ? 1.2 : 1
 
 					//So Im pushing this through a property because it seems to results in "undefined" during loading and this adds a ton of warnings to the output which is not helpful. I tried less heavyhanded approaches first but this works perfectly fine.
 					property var sourceVar:	variablesList.showVariableTypeIcon && itemRectangle.isVariable ? (enabled ? model.columnTypeIcon : model.columnTypeDisabledIcon) : ""
@@ -574,7 +575,7 @@ VariablesListBase
 						if (itemRectangle.clearOtherSelectedItemsWhenClicked)
 							variablesList.setSelectedItem(itemRectangle.rank)
 
-						if ((variablesList.listViewType != JASP.AvailableVariables) && (allowedColumnsId.count === 0 || allowedColumnsId.count > 1) && icon.source !== "" && mouse.x < icon.x + icon.width )
+						if (itemRectangle.typeChangeable && mouse.x < icon.x + icon.width)
 							customMenu.toggle(itemRectangle, props, 0, parent.height);
 					}
 					

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -277,7 +277,7 @@ columnTypeVec JASPListControl::valueTypes() const
 	columnTypeVec types;
 
 	for (const Term& term : model()->terms())
-		types.push_back(model()->getVariableType(term.asQString()));
+		types.push_back(term.type());
 
 	return types;
 }

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -45,6 +45,7 @@ class VariablesListBase : public JASPListControl, public BoundControl
 	Q_PROPERTY( int					maxNumericLevels				READ maxNumericLevels				WRITE setMaxNumericLevels				NOTIFY maxNumericLevelsChanged				)
 	Q_PROPERTY( int					minLevels						READ minLevels						WRITE setMinLevels						NOTIFY minLevelsChanged						)
 	Q_PROPERTY( int					maxLevels						READ maxLevels						WRITE setMaxLevels						NOTIFY maxLevelsChanged						)
+	Q_PROPERTY( bool				allowTypeChange					READ allowTypeChange				WRITE setAllowTypeChange				NOTIFY allowTypeChangeChanged				)
 
 public:
 	VariablesListBase(QQuickItem* parent = nullptr);
@@ -82,6 +83,7 @@ public:
 	int							maxLevels()																				const				{ return _maxLevels;			}
 	int							minNumericLevels()																		const				{ return _minNumericLevels;		}
 	int							maxNumericLevels()																		const				{ return _maxNumericLevels;		}
+	bool						allowTypeChange()																		const				{ return _allowTypeChange;		}
 
 signals:
 	void listViewTypeChanged();
@@ -97,6 +99,7 @@ signals:
 	void maxLevelsChanged();
 	void minNumericLevelsChanged();
 	void maxNumericLevelsChanged();
+	void allowTypeChangeChanged();
 
 public slots:
 	void setVariableType(int index, int type);
@@ -119,6 +122,7 @@ protected:
 	GENERIC_SET_FUNCTION(MaxLevels,						_maxLevels,						maxLevelsChanged,						int				)
 	GENERIC_SET_FUNCTION(MinNumericLevels,				_minNumericLevels,				minNumericLevelsChanged,				int				)
 	GENERIC_SET_FUNCTION(MaxNumericLevels,				_maxNumericLevels,				maxNumericLevelsChanged,				int				)
+	GENERIC_SET_FUNCTION(AllowTypeChange,				_allowTypeChange,				allowTypeChangeChanged,					bool			)
 
 	void						_setInitialized(const Json::Value& value = Json::nullValue)	override;
 	void						setDropKeys(const QStringList& dropKeys);
@@ -144,6 +148,7 @@ private:
 								_minLevels =			-1,
 								_maxLevels =			-1;
 
+	bool						_allowTypeChange =		true;
 	QStringList					_allowedColumns,
 								_columnsTypes,
 								_columnsNames,

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -104,7 +104,7 @@ public:
 signals:
 			void termsChanged();		// Used to signal all kinds of changes in the model. Do not call it directly
 			void namesChanged(QMap<QString, QString> map);
-			void columnTypeChanged(QString name);
+			void columnTypeChanged(Term term);
 			void labelsChanged(QString columnName, QMap<QString, QString> = {});
 			void labelsReordered(QString columnName);
 			void columnsChanged(QStringList columns);
@@ -114,7 +114,7 @@ signals:
 public slots:	
 	virtual void sourceTermsReset();
 	virtual void sourceNamesChanged(QMap<QString, QString> map);
-	virtual int  sourceColumnTypeChanged(QString colName);
+	virtual int  sourceColumnTypeChanged(Term sourceTerm);
 	virtual bool sourceLabelsChanged(QString columnName, QMap<QString, QString> changedLabels = {});
 	virtual bool sourceLabelsReordered(QString columnName);
 	virtual void sourceColumnsChanged(QStringList columns);
@@ -130,12 +130,12 @@ protected:
 			void	_removeTerm(const Term& term);
 			void	_removeLastTerm();
 			void	_addTerms(const Terms& terms);
-			void	_addTerm(const QString& term, bool isUnique = true);
+			void	_addTerm(const Term& term, bool isUnique = true);
 			void	_replaceTerm(int index, const Term& term);
 			void	_connectAllSourcesControls();
-			void	_checkTermsTypes(const Terms& terms);
-			void	_checkTermsTypes(const std::vector<Term>& terms);
-			void	_checkTermsType(const QString& terms);
+			Terms	_checkTermsTypes(const Terms& terms)				const;
+			Terms	_checkTermsTypes(const std::vector<Term>& terms)	const;
+			Term	_checkTermType(const Term& terms)					const;
 
 
 			QString							_itemType;
@@ -153,7 +153,6 @@ private:
 
 			JASPListControl*				_listView = nullptr;
 			Terms							_terms;
-			std::map<QString, columnType>	_tempTermTypes;	// If the type of a term is changed by the user, store this change here.
 
 };
 

--- a/QMLComponents/models/listmodelassignedinterface.cpp
+++ b/QMLComponents/models/listmodelassignedinterface.cpp
@@ -57,26 +57,6 @@ void ListModelAssignedInterface::setAvailableModel(ListModelAvailableInterface *
 	_availableModel = source;
 }
 
-int ListModelAssignedInterface::sourceColumnTypeChanged(QString name)
-{
-	int index = ListModelDraggable::sourceColumnTypeChanged(name);
-	VariablesListBase* qmlListView = dynamic_cast<VariablesListBase*>(listView());
-
-	if (qmlListView && index >= 0 && index < int(terms().size()))
-	{
-		if (!isAllowed(terms().at(size_t(index))))
-		{
-			QList<int> indexes = {index};
-			qmlListView->moveItems(indexes, _availableModel);
-			ListModelDraggable::refresh();
-		}
-		// Force the analysis to be rerun
-		emit qmlListView->boundValueChanged(qmlListView);
-	}
-
-	return index;
-}
-
 bool ListModelAssignedInterface::sourceLabelsChanged(QString columnName, QMap<QString, QString> changedLabels)
 {
 	bool change = ListModelDraggable::sourceLabelsChanged(columnName, changedLabels);

--- a/QMLComponents/models/listmodelassignedinterface.h
+++ b/QMLComponents/models/listmodelassignedinterface.h
@@ -36,7 +36,6 @@ public:
 
 public slots:
 	virtual void availableTermsResetHandler(Terms termsAdded, Terms termsRemoved)				{}
-			int  sourceColumnTypeChanged(QString name)												override;
 			bool sourceLabelsChanged(QString columnName, QMap<QString, QString> changedLabels)		override;
 			bool sourceLabelsReordered(QString columnName)											override;
 

--- a/QMLComponents/models/listmodelavailableinterface.h
+++ b/QMLComponents/models/listmodelavailableinterface.h
@@ -40,6 +40,7 @@ public:
 	virtual void removeTermsInAssignedList();
 	
 			void sortItems(SortType sortType)											override;
+			Terms addTerms(const Terms& terms, int dropItemIndex = -1, const RowControlsValues& rowValues = RowControlsValues())	override;
 
 			void										addAssignedModel(ListModelAssignedInterface* model);
 			const QList<ListModelAssignedInterface*>&	assignedModels()	const			{ return _assignedModels; }
@@ -51,7 +52,7 @@ public slots:
 			void sourceTermsReset()															override;
 			void sourceNamesChanged(QMap<QString, QString> map)								override;
 			void sourceColumnsChanged(QStringList columns)									override;
-			int  sourceColumnTypeChanged(QString name)										override;
+			int  sourceColumnTypeChanged(Term name)											override;
 			bool sourceLabelsChanged(QString columnName, QMap<QString, QString> = {})		override;
 			bool sourceLabelsReordered(QString columnName)									override;
 			void removeAssignedModel(ListModelAssignedInterface *assignedModel);

--- a/QMLComponents/models/listmodelcustomcontrasts.h
+++ b/QMLComponents/models/listmodelcustomcontrasts.h
@@ -38,11 +38,11 @@ public:
 
 	void			reset()												override;
 	void			setup()												override;
-	bool			isEditable(const QModelIndex& index)		const	override	{ return index.column() >= _tableTerms.variables.length(); }
+	bool			isEditable(const QModelIndex& index)		const	override	{ return index.column() >= _tableTerms.variables.size(); }
 	QString			getItemInputType(const QModelIndex& index)	const	override;
 	QString			colName()									const				{ return _colName;	}
 
-	void			getVariablesAndLabels(QStringList& variables, QVector<QVector<QVariant> >& allLabels);
+	void			getVariablesAndLabels(Terms& variables, QVector<QVector<QVariant> >& allLabels);
 
 public slots:
 	void sourceTermsReset()														override;
@@ -59,18 +59,18 @@ signals:
 protected:
 	int									_variableCount	= 0;
 	double								_scaleFactor	= 1;
-	ListModelFactorLevels*	_factorsSourceModel;
+	ListModelFactorLevels*				_factorsSourceModel;
 	QString								_colName;
 	QMap<QString, QList<QString> >		_factors;
 
 
 private:
 	void		_resetValuesEtc();
-	bool		_labelChanged(const QString& columnName, const QString& originalLabel, const QString& newLabel);
+	bool		_labelChanged(const Term& columnName, const QString& originalLabel, const QString& newLabel);
 	void		_setFactorsSource(ListModelFactorLevels* factorsSourceModel);
 	void		_setFactors();
 	void		_loadColumnInfo();
-	QStringList	_getVariables();
+	Terms		_getVariables();
 
 
 };

--- a/QMLComponents/models/listmodeltableviewbase.h
+++ b/QMLComponents/models/listmodeltableviewbase.h
@@ -34,8 +34,8 @@ public:
 	{
 		QVector<QVector<QVariant> >	values;
 		QStringList					rowNames,
-									colNames,
-									variables;
+									colNames;
+		Terms						variables;
 		QString						colName,
 									extraCol,
 									filter;
@@ -64,7 +64,7 @@ public:
 
 				int					rowCount(	const QModelIndex & = QModelIndex())									const	override { return _tableTerms.rowNames.length();	}
 				int					columnCount(const QModelIndex & = QModelIndex())									const	override { return _tableTerms.colNames.length();	}
-				int					variableCount()																		const			 { return _tableTerms.variables.length();	}
+				int					variableCount()																		const			 { return _tableTerms.variables.size();		}
 				QVariant			data(		const QModelIndex &index, int role = Qt::DisplayRole)					const	override;
 				Qt::ItemFlags		flags(		const QModelIndex &index)												const	override;
 				QVariant			headerData ( int section, Qt::Orientation orientation, int role = Qt::DisplayRole )	const	override;

--- a/QMLComponents/models/term.h
+++ b/QMLComponents/models/term.h
@@ -24,6 +24,7 @@
 
 #include <QString>
 #include <QStringList>
+#include "columntype.h"
 
 ///
 /// A term is a basic element of a VariablesList
@@ -45,6 +46,9 @@ public:
 
 	bool						isDraggable()	const			{ return _draggable; }
 	void						setDraggable(bool draggable)	{ _draggable = draggable; }
+
+	columnType					type()			const			{ return _type; }
+	void						setType(columnType type)		{ _type = type; }
 
 	typedef QStringList::const_iterator const_iterator;
 	typedef QStringList::iterator		iterator;
@@ -77,7 +81,7 @@ private:
 	QStringList		_components;
 	QString			_asQString;
 	bool			_draggable = true;
-
+	columnType		_type = columnType::unknown;
 };
 
 #endif // TERM_H

--- a/QMLComponents/models/terms.cpp
+++ b/QMLComponents/models/terms.cpp
@@ -150,7 +150,10 @@ void Terms::add(const Term &term, bool isUnique)
 		if (result > 0)
 			_terms.insert(itr, term);
 		else if (result == 0)
+		{
 			itr->setDraggable(term.isDraggable());
+			itr->setType(term.type());
+		}
 		else if (result < 0)
 			_terms.push_back(term);
 	}
@@ -160,7 +163,10 @@ void Terms::add(const Term &term, bool isUnique)
 		if (i < 0)
 			_terms.push_back(term);
 		else
+		{
 			_terms.at(i).setDraggable(term.isDraggable());
+			_terms.at(i).setType(term.type());
+		}
 	}
 }
 
@@ -207,6 +213,11 @@ void Terms::add(const Terms &terms)
 }
 
 const Term& Terms::at(size_t index) const
+{
+	return _terms.at(index);
+}
+
+Term &Terms::at(size_t index)
 {
 	return _terms.at(index);
 }
@@ -346,7 +357,10 @@ Terms Terms::crossCombinations() const
 				}
 			}
 
-			t.add(Term(combination));
+			if (combination.size() == 1)
+				t.add(at(indexOf(combination[0])));
+			else
+				t.add(Term(combination));
 
 		} while (std::next_permutation(v.begin(), v.end()));
 	}
@@ -375,7 +389,10 @@ Terms Terms::wayCombinations(int ways) const
 				}
 			}
 
-			t.add(Term(combination));
+			if (combination.size() == 1)
+				t.add(at(indexOf(combination[0])));
+			else
+				t.add(Term(combination));
 
 		} while (std::next_permutation(v.begin(), v.end()));
 	}
@@ -742,6 +759,16 @@ Terms::const_iterator Terms::begin() const
 }
 
 Terms::const_iterator Terms::end() const
+{
+	return _terms.end();
+}
+
+Terms::iterator Terms::begin()
+{
+	return _terms.begin();
+}
+
+Terms::iterator Terms::end()
 {
 	return _terms.end();
 }

--- a/QMLComponents/models/terms.h
+++ b/QMLComponents/models/terms.h
@@ -75,6 +75,8 @@ public:
 
 	const_iterator begin() const;
 	const_iterator end() const;
+	iterator begin();
+	iterator end();
 
 	void remove(const Term &term);
 	void remove(const Terms &terms);
@@ -90,6 +92,7 @@ public:
 	void clear();
 
 	const Term &at(size_t index)								const;
+	Term &at(size_t index);
 	bool contains(const Term		&	term)					const;
 	bool contains(const QString		&	component);
 	bool contains(const std::string &	component);


### PR DESCRIPTION
For this the type of a variable is kept in the Term object (and not in the VariablesList). We have then to make sure that the Term object is used to copy the terms from one VariablesList to another one.

Also add allowTypeChange property for VariablesList to set whether a VariablesList allow the user to change the types of the variables.

