### PR TITLE
Popup of dropdown is not set on the right place

### DIFF
--- a/QMLComponents/components/JASP/Controls/ComboBox.qml
+++ b/QMLComponents/components/JASP/Controls/ComboBox.qml
@@ -179,7 +179,7 @@ ComboBoxBase
 		popup: QTC.Popup
 		{
 			id:				popupRoot
-			y:				control.y + jaspTheme.comboBoxHeight
+			y:				control.height
 			width:			comboBoxBackground.width + scrollBar.width
 
 			property real	maxHeight: typeof mainWindowRoot !== 'undefined' ? mainWindowRoot.height // Case Dropdowns used in Desktop


### PR DESCRIPTION
The popup of a ComboBox shows up per default at the height of the ComboBox control. Since Qt 6.7, It is apparently not needed anymore to specify the y of the ComboBox control.
