### PR TITLE
set default button focus on showYesNo dialogs

### DIFF
--- a/QMLComponents/utilities/messageforwarder.cpp
+++ b/QMLComponents/utilities/messageforwarder.cpp
@@ -55,6 +55,8 @@ bool MessageForwarder::showYesNo(QString title, QString message, QString YesButt
 
 	QPushButton* yesButton =	box.addButton(YesButtonText,	QMessageBox::ButtonRole::YesRole);
 	QPushButton* noButton =		box.addButton(NoButtonText,		QMessageBox::ButtonRole::NoRole);
+
+	box.setDefaultButton(yesButton);
 	box.exec();
 
 	return box.clickedButton() == yesButton;


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/2576

set to Yes button as default focus to ensure consistent user interaction guidance.

