### PR TITLE
noInteraction attribute in source property does no work anymore

### DIFF
--- a/QMLComponents/controls/sourceitem.h
+++ b/QMLComponents/controls/sourceitem.h
@@ -120,8 +120,9 @@ private:
 	ListModel			*			_sourceListModel			= nullptr;
 	QAbstractItemModel	*			_sourceNativeModel			= nullptr;
 	int								_nativeModelRole			= Qt::DisplayRole;
-	bool							_isDataSetVariables			= false;
-	bool							_combineWithOtherModels		= false;
+	bool							_isDataSetVariables			= false,
+									_combineWithOtherModels		= false,
+									_noInteractions				= false;
 	QString							_conditionExpression;
 	QVector<ConditionVariable>		_conditionVariables;
 	bool							_connected					= false;

--- a/QMLComponents/models/listmodelinteractionassigned.cpp
+++ b/QMLComponents/models/listmodelinteractionassigned.cpp
@@ -60,21 +60,6 @@ void ListModelInteractionAssigned::initTerms(const Terms &terms, const RowContro
 	ListModelAssignedInterface::initTerms(interactionTerms(), allValuesMap, reInit);
 }
 
-Terms ListModelInteractionAssigned::filterTerms(const Terms& terms, const QStringList& filters)
-{
-	Terms result;
-	if (filters.contains("noInteraction"))
-	{
-		result.add(_fixedFactors);
-		result.add(_randomFactors);
-		result.add(_covariates);
-	}
-	else
-		result = terms;
-
-	return ListModelAssignedInterface::filterTerms(result, filters);
-}
-
 void ListModelInteractionAssigned::removeTerms(const QList<int> &indices)
 {
 	if(!indices.count())

--- a/QMLComponents/models/listmodelinteractionassigned.h
+++ b/QMLComponents/models/listmodelinteractionassigned.h
@@ -36,7 +36,6 @@ public:
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)					override;
 	void			removeTerms(const QList<int> &indices)											override;
 	QString			getItemType(const Term &term)											const	override;
-	Terms			filterTerms(const Terms& terms, const QStringList& filters)						override;
 		
 public slots:
 	void availableTermsResetHandler(Terms termsToAdd, Terms termsToRemove)							override;


### PR DESCRIPTION
In MixesModels, the "Estimated marginal means" available VariablesList and the "Estimated trends/conditional slopes" Model variables are set to not allow interaction variables.

