### PR TITLE
Analysis constraint error should not be closeable

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -222,6 +222,9 @@ void Analysis::run()
 
 void Analysis::refresh()
 {
+	if (form() && form()->hasError())
+		return;
+
 	TempFiles::deleteAll(int(_id));
 	run();
 

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -398,7 +398,7 @@ void AnalysisForm::addFormWarning(const QString & warning)
 
 //This should be moved to JASPControl maybe?
 //Maybe even to full QML? Why don't we just use a loader...
-void AnalysisForm::addControlError(JASPControl* control, QString message, bool temporary, bool warning)
+void AnalysisForm::addControlError(JASPControl* control, QString message, bool temporary, bool warning, bool closeable)
 {
 	if (!control)
 	{
@@ -450,6 +450,7 @@ void AnalysisForm::addControlError(JASPControl* control, QString message, bool t
 
 		controlErrorMessageItem->setProperty("control", QVariant::fromValue(control));
 		controlErrorMessageItem->setProperty("warning", warning);
+		controlErrorMessageItem->setProperty("closeable", closeable);
 		controlErrorMessageItem->setParentItem(container);
 		QMetaObject::invokeMethod(controlErrorMessageItem, "showMessage", Qt::QueuedConnection, Q_ARG(QVariant, message), Q_ARG(QVariant, temporary));
 	}

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -74,12 +74,6 @@ void AnalysisForm::refreshAnalysis()
 	_analysis->refresh();
 }
 
-void AnalysisForm::runAnalysis()
-{
-	_analysis->run();
-	refreshTableViewModels();
-}
-
 QString AnalysisForm::generateWrapper() const
 {
 	return _rSyntax->generateWrapper();
@@ -466,7 +460,7 @@ bool AnalysisForm::hasError()
 	// Controls handling inside a form must indeed be done in anther way!
 
 	for (QQuickItem* item : _controlErrorMessageCache)
-		if (item->property("control").value<JASPControl*>() != nullptr)
+		if (item->property("control").value<JASPControl*>() != nullptr && !item->property("warning").toBool())
 			return true;
 
 	return false;

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -143,7 +143,6 @@ public:
 	Q_INVOKABLE void		addFormError(const QString& message);
 	Q_INVOKABLE void		addFormWarning(const QString& message);
 	Q_INVOKABLE void		refreshAnalysis();
-	Q_INVOKABLE void		runAnalysis();
 	Q_INVOKABLE bool		initialized()			const	{ return _initialized; }
 	Q_INVOKABLE QString		generateWrapper()		const;
 

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -147,7 +147,7 @@ public:
 	Q_INVOKABLE bool		initialized()			const	{ return _initialized; }
 	Q_INVOKABLE QString		generateWrapper()		const;
 
-	void			addControlError(JASPControl* control, QString message, bool temporary = false, bool warning = false);
+	void			addControlError(JASPControl* control, QString message, bool temporary = false, bool warning = false, bool closeable = true);
 	void			clearControlError(JASPControl* control);
 	void			cleanUpForm();
 	bool			hasError();

--- a/QMLComponents/components/JASP/Controls/ControlErrorMessage.qml
+++ b/QMLComponents/components/JASP/Controls/ControlErrorMessage.qml
@@ -36,6 +36,7 @@ Rectangle
 	property var control
 	property bool tmp			: false
 	property bool warning		: false
+	property bool closeable		: true
 	property var form
 	property var container		: parent
 	property int containerWidth	: container ? (container === form ? form.availableWidth : container.width) : 0
@@ -159,6 +160,7 @@ Rectangle
 
 	CrossButton
 	{
+		visible: closeable
 		onCrossClicked:
 		{
 			controlErrorMessage.opacity = 0

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -274,6 +274,12 @@ void JASPControl::addControlErrorTemporary(QString message)
 		_form->addControlError(this, message, true);
 }
 
+void JASPControl::addControlErrorPermanent(QString message)
+{
+	if (_form && message.size())
+		_form->addControlError(this, message, false, false, false);
+}
+
 void JASPControl::addControlWarning(QString message)
 {
 	if (_form && message.size())

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -193,6 +193,7 @@ public slots:
 
 	void	addControlError(			QString message);
 	void	addControlErrorTemporary(	QString message);
+	void	addControlErrorPermanent(	QString message);
 	void	addControlWarning(			QString message);
 	void	addControlWarningTemporary(	QString message);
 	void	clearControlError();

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -334,22 +334,22 @@ void VariablesListBase::termsChangedHandler()
 			int nbNumValues = model()->requestInfo(VariableInfo::TotalNumericValues, term.asQString()).toInt();
 			if (_minLevels >= 0 && nbLevels < _minLevels)
 			{
-				addControlError(tr("Minimum number of levels is %1. Variable %2 has only %3 levels").arg(_minLevels).arg(term.asQString()).arg(nbLevels));
+				addControlErrorPermanent(tr("Minimum number of levels is %1. Variable %2 has only %3 levels").arg(_minLevels).arg(term.asQString()).arg(nbLevels));
 				hasError = true;
 			}
 			else if (_maxLevels >= 0 && nbLevels > _maxLevels)
 			{
-				addControlError(tr("Maximum number of levels is %1. Variable %2 has %3 levels").arg(_maxLevels).arg(term.asQString()).arg(nbLevels));
+				addControlErrorPermanent(tr("Maximum number of levels is %1. Variable %2 has %3 levels").arg(_maxLevels).arg(term.asQString()).arg(nbLevels));
 				hasError = true;
 			}
 			else if (_minNumericLevels >= 0 && nbNumValues < _minNumericLevels)
 			{
-				addControlError(tr("Minumum number of numeric values is %1. Variable %2 has only %3 different numeric values").arg(_minNumericLevels).arg(term.asQString()).arg(nbNumValues));
+				addControlErrorPermanent(tr("Minumum number of numeric values is %1. Variable %2 has only %3 different numeric values").arg(_minNumericLevels).arg(term.asQString()).arg(nbNumValues));
 				hasError = true;
 			}
 			else if (_maxNumericLevels >= 0 && nbNumValues > _maxNumericLevels)
 			{
-				addControlError(tr("Maximum number of numeric values is %1. Variable %2 has %3 different numeric values").arg(_maxNumericLevels).arg(term.asQString()).arg(nbNumValues));
+				addControlErrorPermanent(tr("Maximum number of numeric values is %1. Variable %2 has %3 different numeric values").arg(_maxNumericLevels).arg(term.asQString()).arg(nbNumValues));
 				hasError = true;
 			}
 


### PR DESCRIPTION
When an error occurs because for example a variable does not have enough levels, this error should not be closeable: the user must remove it from the VariablesList first. As long such an error exists, the analysis cannot be run.

