### PR TITLE
Keep type info in ComboBox values

### DIFF
--- a/QMLComponents/components/JASP/Controls/ComboBox.qml
+++ b/QMLComponents/components/JASP/Controls/ComboBox.qml
@@ -126,7 +126,7 @@ ComboBoxBase
 				width:					15 * preferencesModel.uiScale
 				x:						3  * preferencesModel.uiScale
 				anchors.verticalCenter: parent.verticalCenter
-				source:					!visible ? "" : ((comboBox.currentColumnTypeIcon && comboBox.isBound) ? comboBox.currentColumnTypeIcon : comboBox.values[comboBox.currentIndex].columnTypeIcon)
+				source:					!visible ? "" : ((comboBox.currentColumnTypeIcon && comboBox.isBound) ? comboBox.currentColumnTypeIcon : (comboBox.values && comboBox.currentIndex >= 0 && comboBox.currentIndex < comboBox.values.length ? comboBox.values[comboBox.currentIndex].columnTypeIcon : ""))
 				visible:				comboBox.showVariableTypeIcon && !control.isEmptyValue && (comboBox.currentColumnType || !comboBox.isBound)
 			}
 

--- a/QMLComponents/controls/sourceitem.h
+++ b/QMLComponents/controls/sourceitem.h
@@ -49,8 +49,9 @@ public:
 
 	struct SourceValuesItem
 	{
-		QString label, value, info;
-		SourceValuesItem(const QString& l, const QString& v, const QString& i) : label{l}, value{v}, info{i} {}
+		Term label;
+		QString value, info;
+		SourceValuesItem(const Term& l, const QString& v, const QString& i) : label{l}, value{v}, info{i} {}
 
 	};
 

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -491,8 +491,8 @@ QVariant ListModel::data(const QModelIndex &index, int role) const
 			{
 			case ListModel::ColumnTypeRole:								return columnTypeToQString(colType);
 			case ListModel::ColumnRealTypeRole:							return columnTypeToQString(colRealType);
-			case ListModel::ColumnTypeIconRole:							return VariableInfo::info()->getIconFile(colType, colType == colRealType ? VariableInfo::DefaultIconType : VariableInfo::TransformedIconType);
-			case ListModel::ColumnTypeDisabledIconRole:					return VariableInfo::info()->getIconFile(colType, VariableInfo::DisabledIconType);
+			case ListModel::ColumnTypeIconRole:							return colType == columnType::unknown ? "" : (VariableInfo::info()->getIconFile(colType, colType == colRealType ? VariableInfo::DefaultIconType : VariableInfo::TransformedIconType));
+			case ListModel::ColumnTypeDisabledIconRole:					return colType == columnType::unknown ? "" : (VariableInfo::info()->getIconFile(colType, VariableInfo::DisabledIconType));
 			}
 		}
 	}


### PR DESCRIPTION
Use Term in place of QString in SourceValueItem, so that the type information is conserved. 
Remove also warning when type is undefined: don't display an icon in this case. 
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2593 
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2589

