### PR TITLE
Fix Results crash upon encountering a string var in a number type column

### DIFF
--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -99,6 +99,18 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 			log10 = true;
 	}
 
+	for (var rowNo = 0; rowNo < column.length; rowNo++) {
+		var cell = column[rowNo]
+		var content = cell.content
+
+		if (typeof(content) !== "number" || typeof(content) !== "Number") {
+			if (isNaN(parseFloat(content)))  // isn't a number
+				continue
+			console.warn("You are delivering a result that should be a number as a string, We will do our best :(");
+			cell.content = content = parseFloat(content)
+		}
+	}
+
 	if (isFinite(sf)) {
 
 		var upperLimit = 1e6


### PR DESCRIPTION
As discovered by @FBartos.
Its possible to throw strings in result json where numbers would be expected.
This causes the results screen to hang forever.

So I add an ugly loop to convert what can be converted

Ps. Dynamic typing is bad