### PR TITLE
Datafile timestamp not stored in JASP file

### DIFF
--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -76,9 +76,9 @@ public:
 	int			dataSetGetId();
 	bool		dataSetExists(			int dataSetId);
 	void		dataSetDelete(			int dataSetId);
-	int			dataSetInsert(							const std::string & dataFilePath = "", const std::string & description = "", const std::string & databaseJson = "", const std::string & emptyValuesJson = "", bool dataSynch = false);		///< Inserts a new DataSet row into DataSets and creates an empty DataSet_#id. returns id
-	void		dataSetUpdate(			int dataSetId,	const std::string & dataFilePath = "", const std::string & description = "", const std::string & databaseJson = "", const std::string & emptyValuesJson = "", bool dataSynch = false);		///< Updates an existing DataSet row in DataSets
-	void		dataSetLoad(			int dataSetId,		  std::string & dataFilePath,			 std::string & description,			   std::string & databaseJson,			  std::string & emptyValuesJson, int & revision, bool & dataSynch);	///< Loads an existing DataSet row into arguments
+	int			dataSetInsert(							const std::string & dataFilePath = "", long dataFileTimestamp = 0, const std::string & description = "", const std::string & databaseJson = "", const std::string & emptyValuesJson = "", bool dataSynch = false);		///< Inserts a new DataSet row into DataSets and creates an empty DataSet_#id. returns id
+	void		dataSetUpdate(			int dataSetId,	const std::string & dataFilePath = "", long dataFileTimestamp = 0, const std::string & description = "", const std::string & databaseJson = "", const std::string & emptyValuesJson = "", bool dataSynch = false);		///< Updates an existing DataSet row in DataSets
+	void		dataSetLoad(			int dataSetId,		  std::string & dataFilePath,	long & dataFileTimestamp,		 std::string & description,			   std::string & databaseJson,			  std::string & emptyValuesJson, int & revision, bool & dataSynch);	///< Loads an existing DataSet row into arguments
 	static int	dataSetColCount(		int dataSetId);
 	static int	dataSetRowCount(		int dataSetId);
 	void		dataSetSetRowCount(		int dataSetId, size_t rowCount);

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -225,7 +225,7 @@ void DataSet::dbCreate()
 	db().transactionWriteBegin();
 
 	//The variables are probably empty though:
-	_dataSetID	= db().dataSetInsert(_dataFilePath, _description, _databaseJson, _emptyValues->toJson().toStyledString(), _dataFileSynch);
+	_dataSetID	= db().dataSetInsert(_dataFilePath, _dataFileTimestamp, _description, _databaseJson, _emptyValues->toJson().toStyledString(), _dataFileSynch);
 	_filter = new Filter(this);
 	_filter->dbCreate();
 	_columns.clear();
@@ -238,7 +238,7 @@ void DataSet::dbCreate()
 void DataSet::dbUpdate()
 {
 	assert(_dataSetID > 0);
-	db().dataSetUpdate(_dataSetID, _description, _dataFilePath, _databaseJson, _emptyValues->toJson().toStyledString(), _dataFileSynch);
+	db().dataSetUpdate(_dataSetID, _dataFilePath, _dataFileTimestamp, _description, _databaseJson, _emptyValues->toJson().toStyledString(), _dataFileSynch);
 	incRevision();
 }
 
@@ -263,7 +263,7 @@ void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, boo
 
 	std::string emptyVals;
 
-	db().dataSetLoad(_dataSetID, _description, _dataFilePath, _databaseJson, emptyVals, _revision, _dataFileSynch);
+	db().dataSetLoad(_dataSetID, _dataFilePath, _dataFileTimestamp, _description, _databaseJson, emptyVals, _revision, _dataFileSynch);
 	progressCallback(0.1);
 
 	if(!_filter)

--- a/CommonData/dataset.h
+++ b/CommonData/dataset.h
@@ -28,6 +28,7 @@ public:
 			int				rowCount()				const ;
 			bool			dataFileSynch()			const { return _dataFileSynch;			}
 	const	std::string &	dataFilePath()			const { return _dataFilePath;			}
+			int				dataFileTimestamp()		const { return _dataFileTimestamp;		}
 	const	std::string &	databaseJson()			const { return _databaseJson;			}
 			bool			writeBatchedToDB()		const { return _writeBatchedToDB;		}
 
@@ -54,7 +55,7 @@ public:
 			qsizetype		getMaximumColumnWidthInCharacters(size_t columnIndex) const;
 			stringvec		getColumnNames();
 
-			void			setDataFilePath(	const std::string & dataFilePath)	{ _dataFilePath		= dataFilePath;			dbUpdate(); }
+			void			setDataFile( const std::string & dataFilePath, long timestamp)	{ _dataFilePath	= dataFilePath;	_dataFileTimestamp = timestamp; dbUpdate(); }
 			void			setDatabaseJson(	const std::string & databaseJson)	{ _databaseJson		= databaseJson;			dbUpdate(); }
 			void			setDataFileSynch(	bool synchronizing)					{ _dataFileSynch	= synchronizing;		dbUpdate(); }
 
@@ -95,6 +96,7 @@ private:
 	EmptyValues				*	_emptyValues			= nullptr;
 	int							_dataSetID				= -1,
 								_rowCount				= -1;
+	long						_dataFileTimestamp		= 0;
 	std::string					_dataFilePath,
 								_databaseJson;
 	

--- a/CommonData/internalDbDefinition.sql
+++ b/CommonData/internalDbDefinition.sql
@@ -3,6 +3,7 @@
 CREATE TABLE DataSets ( 
 	id				INTEGER PRIMARY KEY, 
 	dataFilePath	TEXT, 
+	dataFileTimestamp INT DEFAULT 0,
 	description		TEXT,
 	databaseJson	TEXT, 
 	emptyValuesJson TEXT, 

--- a/Desktop/data/asyncloader.cpp
+++ b/Desktop/data/asyncloader.cpp
@@ -258,7 +258,6 @@ void AsyncLoader::loadPackage(QString id)
 			if (_currentEvent->type() != Utils::FileType::jasp)
 			{
 				pkg->setDataFilePath(_currentEvent->path().toStdString());
-                pkg->setDataFileTimestamp(_currentEvent->isOnlineNode() ? 0 : QFileInfo(_currentEvent->path()).lastModified().toSecsSinceEpoch());
 				pkg->setDatabaseJson(_currentEvent->database());
 			}
 

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -160,7 +160,7 @@ public:
 				// The data file might be read-only if it comes from the examples or read from an external database
 				bool				dataFileReadOnly()					const	{ return _dataFileReadOnly;						}
 				bool				currentFileIsExample()				const;
-				uint				dataFileTimestamp()					const	{ return _dataFileTimestamp;					}
+				long				dataFileTimestamp()					const	{ return _dataSet ? _dataSet->dataFileTimestamp() : 0;	}
 				bool				isDatabaseSynching()				const	{ return _databaseIntervalSyncher.isActive();	}
 				bool				filterShouldRunInit()				const	{ return _filterShouldRunInit;					}
 
@@ -171,10 +171,9 @@ public:
 				void				setJaspVersion(Version jaspVersion)					{ _jaspVersion					= jaspVersion;		}
 				void				updateDbToCurrentVersion();							///< Should be ran immediately after loading the jasp file
 				void				setWarningMessage(std::string message)				{ _warningMessage				= message;			}
-				void				setDataFilePath(std::string filePath);
+				void				setDataFilePath(std::string filePath, long timestamp = 0);
 				void				setDatabaseJson(const Json::Value & dbInfo);
 				void				setInitialMD5(std::string initialMD5)				{ _initialMD5					= initialMD5;		}
-				void				setDataFileTimestamp(uint timestamp)				{ _dataFileTimestamp			= timestamp;		}
 				void				setDataFileReadOnly(bool readOnly)					{ _dataFileReadOnly				= readOnly;			}
 				void				setAnalysesHTML(const QString & html)				{ _analysesHTML					= html;				}
 				void				setIsJaspFile(bool isJaspFile)						{ _isJaspFile					= isJaspFile;		}
@@ -371,8 +370,6 @@ private:
 								_database					= Json::nullValue;
 	Version						_archiveVersion,
 								_jaspVersion;
-
-	uint						_dataFileTimestamp;
 
 	bool						_synchingData				= false;
 	std::map<std::string, bool> _columnNameUsedInEasyFilter;

--- a/Desktop/data/importers/jaspimporterold.cpp
+++ b/Desktop/data/importers/jaspimporterold.cpp
@@ -98,9 +98,8 @@ void JASPImporterOld::loadDataArchive_1_00(const std::string &path, std::functio
 
 	packageData->createDataSet();
 
-	packageData->setDataFilePath(		metaData.get("dataFilePath",		"")				.asString());
+	packageData->setDataFilePath( metaData.get("dataFilePath",	"").asString(), metaData.get("dataFileTimestamp", 0).asUInt());
 	packageData->setDataFileReadOnly(	metaData.get("dataFileReadOnly",	false)			.asBool());
-	packageData->setDataFileTimestamp(	metaData.get("dataFileTimestamp",	0)				.asUInt());
 	packageData->setDatabaseJson(		metaData.get("database",			Json::nullValue));
 
 	packageData->dataSet()->setDataFileSynch(true);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2611

The datafile timestamp was not stored in the JASP file, so when loading a JASP file, the data were always compared with the datafile. As the labels are not correctly compared, it thinks that the file has changed (cf https://github.com/jasp-stats/INTERNAL-jasp/issues/2614).

Moreover there was a bug in the JASP files in 0.18.3 (and earlier): when reading the sqlite database, the description and the datafile path were exchanged.

