### PR TITLE
Set default minimum and maximum levels for VariablesList

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -170,9 +170,22 @@ QTC.ScrollView
 						leftMargin: jaspTheme.generalAnchorMargin
 					}
 
-					KeyNavigation.tab:	missingValueDataLabelInput
+					KeyNavigation.tab:	maxLevels
 				}
 			}
+
+			SpinBox
+			{
+				id:					maxLevels
+				text:				qsTr("Default maximum levels for nominal or ordinal")
+				value:				preferencesModel.maxLevels
+				onValueChanged:		preferencesModel.maxLevels = value
+
+				KeyNavigation.tab:	missingValueDataLabelInput
+
+				toolTip:	qsTr("For analysis accepting only nominal or ordinal for some variables, this setting prevents from setting a variable having too many levels.")
+			}
+
 		}
 		
 

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -170,20 +170,20 @@ QTC.ScrollView
 						leftMargin: jaspTheme.generalAnchorMargin
 					}
 
-					KeyNavigation.tab:	maxLevels
+					KeyNavigation.tab:	maxScaleLevels
 				}
 			}
 
 			SpinBox
 			{
-				id:					maxLevels
-				text:				qsTr("Default maximum levels for nominal or ordinal")
-				value:				preferencesModel.maxLevels
-				onValueChanged:		preferencesModel.maxLevels = value
+				id:					maxScaleLevels
+				text:				qsTr("Maximum allowed levels for scale when used as nominal/ordinal")
+				value:				preferencesModel.maxScaleLevels
+				onValueChanged:		preferencesModel.maxScaleLevels = value
 
 				KeyNavigation.tab:	missingValueDataLabelInput
 
-				toolTip:	qsTr("For analysis accepting only nominal or ordinal for some variables, this setting prevents from setting a variable having too many levels.")
+				toolTip:	qsTr("For analysis accepting only nominal or ordinal for some variables, if a scale variable is used, JASP checks whether the number of levels of this variable exceeds this maximum.")
 			}
 
 		}

--- a/Desktop/gui/preferencesmodel.cpp.in
+++ b/Desktop/gui/preferencesmodel.cpp.in
@@ -124,7 +124,7 @@ GET_PREF_FUNC_BOOL( ALTNavModeActive,			Settings::ALTNAVMODE_ACTIVE							)
 GET_PREF_FUNC_BOOL( orderByValueByDefault,		Settings::ORDER_BY_VALUE_BY_DEFAULT					)
 GET_PREF_FUNC_BOOL( checkUpdatesAskUser,		Settings::CHECK_UPDATES_ASK_USER					)
 GET_PREF_FUNC_BOOL( checkUpdates,				Settings::CHECK_UPDATES								)
-GET_PREF_FUNC_INT(	maxLevels,					Settings::MAX_LEVELS								)
+GET_PREF_FUNC_INT(	maxScaleLevels,				Settings::MAX_SCALE_LEVELS							)
 
 int PreferencesModel::maxEngines() const
 {
@@ -306,7 +306,7 @@ SET_PREF_FUNCTION(				bool,		setALTNavModeActive,		ALTNavModeActive,			ALTNavMod
 SET_PREF_FUNCTION(				bool,		setOrderByValueByDefault,	orderByValueByDefault,		orderByValueByDefaultChanged,	Settings::ORDER_BY_VALUE_BY_DEFAULT					)
 SET_PREF_FUNCTION(				bool,		setCheckUpdatesAskUser,		checkUpdatesAskUser,		checkUpdatesAskUserChanged,		Settings::CHECK_UPDATES_ASK_USER					)
 SET_PREF_FUNCTION(				bool,		setCheckUpdates,			checkUpdates,				checkUpdatesChanged,			Settings::CHECK_UPDATES								)
-SET_PREF_FUNCTION(				int,		setMaxLevels,				maxLevels,					maxLevelsChanged,				Settings::MAX_LEVELS								)
+SET_PREF_FUNCTION(				int,		setMaxScaleLevels,			maxScaleLevels,				maxScaleLevelsChanged,			Settings::MAX_SCALE_LEVELS							)
 
 
 void PreferencesModel::setGithubPatCustom(QString newPat)

--- a/Desktop/gui/preferencesmodel.cpp.in
+++ b/Desktop/gui/preferencesmodel.cpp.in
@@ -124,6 +124,7 @@ GET_PREF_FUNC_BOOL( ALTNavModeActive,			Settings::ALTNAVMODE_ACTIVE							)
 GET_PREF_FUNC_BOOL( orderByValueByDefault,		Settings::ORDER_BY_VALUE_BY_DEFAULT					)
 GET_PREF_FUNC_BOOL( checkUpdatesAskUser,		Settings::CHECK_UPDATES_ASK_USER					)
 GET_PREF_FUNC_BOOL( checkUpdates,				Settings::CHECK_UPDATES								)
+GET_PREF_FUNC_INT(	maxLevels,					Settings::MAX_LEVELS								)
 
 int PreferencesModel::maxEngines() const
 {
@@ -305,6 +306,7 @@ SET_PREF_FUNCTION(				bool,		setALTNavModeActive,		ALTNavModeActive,			ALTNavMod
 SET_PREF_FUNCTION(				bool,		setOrderByValueByDefault,	orderByValueByDefault,		orderByValueByDefaultChanged,	Settings::ORDER_BY_VALUE_BY_DEFAULT					)
 SET_PREF_FUNCTION(				bool,		setCheckUpdatesAskUser,		checkUpdatesAskUser,		checkUpdatesAskUserChanged,		Settings::CHECK_UPDATES_ASK_USER					)
 SET_PREF_FUNCTION(				bool,		setCheckUpdates,			checkUpdates,				checkUpdatesChanged,			Settings::CHECK_UPDATES								)
+SET_PREF_FUNCTION(				int,		setMaxLevels,				maxLevels,					maxLevelsChanged,				Settings::MAX_LEVELS								)
 
 
 void PreferencesModel::setGithubPatCustom(QString newPat)

--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -69,7 +69,7 @@ class PreferencesModel : public PreferencesModelBase
 	Q_PROPERTY(bool			orderByValueByDefault	READ orderByValueByDefault		WRITE setOrderByValueByDefault		NOTIFY orderByValueByDefaultChanged		)
 	Q_PROPERTY(bool			checkUpdatesAskUser		READ checkUpdatesAskUser		WRITE setCheckUpdatesAskUser		NOTIFY checkUpdatesAskUserChanged		)
 	Q_PROPERTY(bool			checkUpdates			READ checkUpdates				WRITE setCheckUpdates				NOTIFY checkUpdatesChanged				)
-	Q_PROPERTY(int			maxLevels				READ maxLevels					WRITE setMaxLevels					NOTIFY maxLevelsChanged					)
+	Q_PROPERTY(int			maxScaleLevels			READ maxScaleLevels				WRITE setMaxScaleLevels				NOTIFY maxScaleLevelsChanged			)
 
 
 public:
@@ -135,7 +135,7 @@ public:
 	bool		developerMode()							const;
 	bool		ALTNavModeActive()						const;
     bool		orderByValueByDefault()					const;
-	int			maxLevels()								const override;
+	int			maxScaleLevels()						const override;
 	
 	bool checkUpdatesAskUser() const;
 	void setCheckUpdatesAskUser(bool newCheckUpdatesAskUser);
@@ -200,7 +200,7 @@ public slots:
 	void currentThemeNameHandler();
 	void setALTNavModeActive(			bool		ALTNavModeActive);
 	void setOrderByValueByDefault(		bool		orderByValueByDefault);
-	void setMaxLevels(					int			maxLevels);
+	void setMaxScaleLevels(				int			maxScaleLevels);
 	
 signals:
 	void fixedDecimalsChanged(			bool		fixedDecimals);
@@ -253,7 +253,7 @@ signals:
 	void orderByValueByDefaultChanged(	bool		orderByValueByDefault);
 	void checkUpdatesAskUserChanged(	bool		checkAsk);
 	void checkUpdatesChanged(			bool		check);
-	void maxLevelsChanged(				int			maxLevels);
+	void maxScaleLevelsChanged(			int			maxScaleLevels);
 	
 private slots:
 	void dataLabelNAChangedSlot(QString label);

--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -69,6 +69,7 @@ class PreferencesModel : public PreferencesModelBase
 	Q_PROPERTY(bool			orderByValueByDefault	READ orderByValueByDefault		WRITE setOrderByValueByDefault		NOTIFY orderByValueByDefaultChanged		)
 	Q_PROPERTY(bool			checkUpdatesAskUser		READ checkUpdatesAskUser		WRITE setCheckUpdatesAskUser		NOTIFY checkUpdatesAskUserChanged		)
 	Q_PROPERTY(bool			checkUpdates			READ checkUpdates				WRITE setCheckUpdates				NOTIFY checkUpdatesChanged				)
+	Q_PROPERTY(int			maxLevels				READ maxLevels					WRITE setMaxLevels					NOTIFY maxLevelsChanged					)
 
 
 public:
@@ -134,6 +135,7 @@ public:
 	bool		developerMode()							const;
 	bool		ALTNavModeActive()						const;
     bool		orderByValueByDefault()					const;
+	int			maxLevels()								const override;
 	
 	bool checkUpdatesAskUser() const;
 	void setCheckUpdatesAskUser(bool newCheckUpdatesAskUser);
@@ -198,6 +200,7 @@ public slots:
 	void currentThemeNameHandler();
 	void setALTNavModeActive(			bool		ALTNavModeActive);
 	void setOrderByValueByDefault(		bool		orderByValueByDefault);
+	void setMaxLevels(					int			maxLevels);
 	
 signals:
 	void fixedDecimalsChanged(			bool		fixedDecimals);
@@ -250,6 +253,7 @@ signals:
 	void orderByValueByDefaultChanged(	bool		orderByValueByDefault);
 	void checkUpdatesAskUserChanged(	bool		checkAsk);
 	void checkUpdatesChanged(			bool		check);
+	void maxLevelsChanged(				int			maxLevels);
 	
 private slots:
 	void dataLabelNAChangedSlot(QString label);

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -92,7 +92,7 @@ const Settings::Setting Settings::Values[] = {
 	{"checkUpdatesAskUser",			true	},
 	{"checkUpdates",				false	},
 	{"checkUpdatesLastTime",		-1		},
-	{"maxLevels",					100		}
+	{"maxScaleLevels",				100		}
 	
 };	
 

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -91,7 +91,8 @@ const Settings::Setting Settings::Values[] = {
 	{"orderByValueByDefault",		true	},
 	{"checkUpdatesAskUser",			true	},
 	{"checkUpdates",				false	},
-	{"checkUpdatesLastTime",		-1		}
+	{"checkUpdatesLastTime",		-1		},
+	{"maxLevels",					100		}
 	
 };	
 

--- a/Desktop/utilities/settings.h
+++ b/Desktop/utilities/settings.h
@@ -76,7 +76,8 @@ public:
 		ORDER_BY_VALUE_BY_DEFAULT,
 		CHECK_UPDATES_ASK_USER,
 		CHECK_UPDATES,
-		LAST_CHECK
+		LAST_CHECK,
+		MAX_LEVELS
 	};
 
 	static QVariant value(Settings::Type key);

--- a/Desktop/utilities/settings.h
+++ b/Desktop/utilities/settings.h
@@ -77,7 +77,7 @@ public:
 		CHECK_UPDATES_ASK_USER,
 		CHECK_UPDATES,
 		LAST_CHECK,
-		MAX_LEVELS
+		MAX_SCALE_LEVELS
 	};
 
 	static QVariant value(Settings::Type key);

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -34,6 +34,8 @@ VariablesListBase
 	maxRows							: singleVariable ? 1 : -1
 	addAvailableVariablesToAssigned	: listViewType === JASP.Interaction
 	allowAnalysisOwnComputedColumns	: true
+	minNumericLevels				: allowedColumns.length === 1 && allowedColumns[0] === 'scale' ? 1 : -1
+	maxLevels						: allowedColumns.length > 0 && !allowedColumns.includes('scale') ? preferencesModel.maxLevels : -1
 
 	property alias	label							: variablesList.title
 	property alias	itemGridView					: itemGridView

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -35,7 +35,6 @@ VariablesListBase
 	addAvailableVariablesToAssigned	: listViewType === JASP.Interaction
 	allowAnalysisOwnComputedColumns	: true
 	minNumericLevels				: allowedColumns.length === 1 && allowedColumns[0] === 'scale' ? 1 : -1
-	maxLevels						: allowedColumns.length > 0 && !allowedColumns.includes('scale') ? preferencesModel.maxLevels : -1
 
 	property alias	label							: variablesList.title
 	property alias	itemGridView					: itemGridView

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -368,7 +368,7 @@ void VariablesListBase::termsChangedHandler()
 			}
 			else if (_maxNumericLevels >= 0 && nbNumValues > _maxNumericLevels)
 			{
-				addControlError(tr("Maximum number of numeric values is %1. Variable %2 has %3 different numeric values").arg(_maxNumericLevels).arg(term.asQString()).arg(nbNumValues));
+				addControlErrorPermanent(tr("Maximum number of numeric values is %1. Variable %2 has %3 different numeric values").arg(_maxNumericLevels).arg(term.asQString()).arg(nbNumValues));
 				hasError = true;
 			}
 

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -37,6 +37,7 @@
 #include <QQmlProperty>
 #include "log.h"
 #include "models/columntypesmodel.h"
+#include "preferencesmodelbase.h"
 
 VariablesListBase::VariablesListBase(QQuickItem* parent)
 	: JASPListControl(parent)
@@ -344,7 +345,10 @@ void VariablesListBase::termsChangedHandler()
 			}
 			else if (_maxLevels >= 0 && nbLevels > _maxLevels)
 			{
-				addControlErrorPermanent(tr("Maximum number of levels is %1. Variable %2 has %3 levels").arg(_maxLevels).arg(term.asQString()).arg(nbLevels));
+				QString msg = tr("Maximum number of levels is %1. Variable %2 has %3 levels.").arg(_maxLevels).arg(term.asQString()).arg(nbLevels);
+				if (_maxLevels == PreferencesModelBase::preferences()->maxLevels())
+					msg += "<br>" + tr("You may change this maximum in Preferences / Data menu.");
+				addControlErrorPermanent(msg);
 				hasError = true;
 			}
 			else if (_minNumericLevels >= 0 && nbNumValues < _minNumericLevels)
@@ -354,7 +358,7 @@ void VariablesListBase::termsChangedHandler()
 			}
 			else if (_maxNumericLevels >= 0 && nbNumValues > _maxNumericLevels)
 			{
-				addControlErrorPermanent(tr("Maximum number of numeric values is %1. Variable %2 has %3 different numeric values").arg(_maxNumericLevels).arg(term.asQString()).arg(nbNumValues));
+				addControlError(tr("Maximum number of numeric values is %1. Variable %2 has %3 different numeric values").arg(_maxNumericLevels).arg(term.asQString()).arg(nbNumValues));
 				hasError = true;
 			}
 

--- a/QMLComponents/models/columntypesmodel.cpp
+++ b/QMLComponents/models/columntypesmodel.cpp
@@ -92,6 +92,15 @@ bool ColumnTypesModel::hasType(columnType type) const
 	return std::find(_types.begin(), _types.end(), type) != _types.end();
 }
 
+bool ColumnTypesModel::hasAllTypes() const
+{
+	for (columnType type : _allTypes)
+		if (!hasType(type))
+			return false;
+
+	return true;
+}
+
 columnType ColumnTypesModel::firstType() const
 {
 	if (_types.size() > 0)

--- a/QMLComponents/models/columntypesmodel.h
+++ b/QMLComponents/models/columntypesmodel.h
@@ -49,6 +49,7 @@ public:
 	Q_INVOKABLE	int							getType(int index)											const;
 	void									setTypes(columnTypeVec types);
 	bool									hasType(columnType type)									const;
+	bool									hasAllTypes()												const;
 	columnType								firstType()													const;
 	QStringList								iconList()													const;
 

--- a/QMLComponents/preferencesmodelbase.h
+++ b/QMLComponents/preferencesmodelbase.h
@@ -14,7 +14,7 @@ public:
 	virtual int		maxFlickVelocity()		const	{ return 808;	}
 	virtual bool	showRSyntax()			const	{ return false; }
 	virtual bool	showAllROptions()		const	{ return false; }
-	virtual int		maxLevels()				const	{ return 100;	}
+	virtual int		maxScaleLevels()		const	{ return 100;	}
 
 	static PreferencesModelBase* preferences();
 

--- a/QMLComponents/preferencesmodelbase.h
+++ b/QMLComponents/preferencesmodelbase.h
@@ -14,6 +14,7 @@ public:
 	virtual int		maxFlickVelocity()		const	{ return 808;	}
 	virtual bool	showRSyntax()			const	{ return false; }
 	virtual bool	showAllROptions()		const	{ return false; }
+	virtual int		maxLevels()				const	{ return 100;	}
 
 	static PreferencesModelBase* preferences();
 

--- a/Resources/Help/preferences/PrefsData.md
+++ b/Resources/Help/preferences/PrefsData.md
@@ -39,6 +39,13 @@ This means that if you have fewer (or equal) than 10 different integers in the d
 gets the Ordinal type (Nominal type if only 2 different integers are found) else it will get the Scale type. Be aware that this value is used when
 importing the data, so data needs to be reloaded (or synchronized) to take effect.
 
+#### Default Maximum levels for nominal or ordinal
+
+Analyses may specify that some variables should be nominal or ordinal. But mostly, the analyses cannot accept too many levels for nominal or ordinal variables.
+This setting specifies what is the default maximum number of levels that will be accepted.
+An analysis may overwrite this setting: i.e. for 'Grouping Variables' in Independent Samples T-Test, the maximun (and minimum) of levels of a variables is set to 2.
+But for most analyses this default setting is used: this prevent the user from using wrong variables, and make the engine running too long.
+
 ### Show missing values as
 
 JASP shows missing values as blank in cells by default, you can also label them as others (e.g., it can even be defined as "😀" or other characters) in text field to display friendly on data pane. Note that this is different from a valid value label and means it won't appear in the results.

--- a/Resources/Help/preferences/PrefsData.md
+++ b/Resources/Help/preferences/PrefsData.md
@@ -39,11 +39,11 @@ This means that if you have fewer (or equal) than 10 different integers in the d
 gets the Ordinal type (Nominal type if only 2 different integers are found) else it will get the Scale type. Be aware that this value is used when
 importing the data, so data needs to be reloaded (or synchronized) to take effect.
 
-#### Default Maximum levels for nominal or ordinal
+#### Maximum allowed levels for scale when used as nominal/ordinal
 
-Analyses may specify that some variables should be nominal or ordinal. But mostly, the analyses cannot accept too many levels for nominal or ordinal variables.
-This setting specifies what is the default maximum number of levels that will be accepted.
-An analysis may overwrite this setting: i.e. for 'Grouping Variables' in Independent Samples T-Test, the maximun (and minimum) of levels of a variables is set to 2.
+Analyses may specify that some variables should be nominal or ordinal. But a scale variable might be used and interpreted as nominal or ordinal. However many scale variables cannot really be interpreted as nominal or ordinal and will generate too many levels, that most analyses cannot accept.
+To prevent this, this setting specifies what is the maximum number of levels that will be accepted for a scale value to be interpretable as a nominal or ordinal.
+This setting is not used if an analysis specifies explicitly a maximum number of levels: i.e. for 'Grouping Variables' in Independent Samples T-Test, the maximun (and minimum) of levels of a variables is set to 2.
 But for most analyses this default setting is used: this prevent the user from using wrong variables, and make the engine running too long.
 
 ### Show missing values as

--- a/Resources/Help/preferences/PrefsData.md
+++ b/Resources/Help/preferences/PrefsData.md
@@ -42,8 +42,8 @@ importing the data, so data needs to be reloaded (or synchronized) to take effec
 #### Maximum allowed levels for scale when used as nominal/ordinal
 
 Analyses may specify that some variables should be nominal or ordinal. But a scale variable might be used and interpreted as nominal or ordinal. However many scale variables cannot really be interpreted as nominal or ordinal and will generate too many levels, that most analyses cannot accept.
-To prevent this, this setting specifies what is the maximum number of levels that will be accepted for a scale value to be interpretable as a nominal or ordinal.
-This setting is not used if an analysis specifies explicitly a maximum number of levels: i.e. for 'Grouping Variables' in Independent Samples T-Test, the maximun (and minimum) of levels of a variables is set to 2.
+To prevent this, this setting specifies what is the maximum number of levels that will be accepted for a scale value to be interpretable as a nominal or ordinal.<br>
+This setting is not used if an analysis specifies explicitly a maximum number of levels: i.e. for 'Grouping Variables' in Independent Samples T-Test, the maximun (and minimum) of levels of a variables is set to 2.<br>
 But for most analyses this default setting is used: this prevent the user from using wrong variables, and make the engine running too long.
 
 ### Show missing values as


### PR DESCRIPTION
- If a VariablesList accepts only scale variables, the default value of minNumericLevels is 1, otherwise -1.
- If a VariablesList accepts only nominal and/or ordinal, and its maxLevels property is not explicitly set (still -1), then if a scale value is added in this VariablesList, JASP checks whether the variable exceeds the 'Default maximum levels' setting in Data/Preferences (default 100). Also the error message tells the user where he can change this maximum.

