### PR TITLE
Setting computed column definition should wait for all property changes

### DIFF
--- a/Desktop/data/computedcolumnmodel.cpp
+++ b/Desktop/data/computedcolumnmodel.cpp
@@ -13,7 +13,7 @@ ComputedColumnModel::ComputedColumnModel()
 	assert(_singleton == nullptr);
 	_singleton = this;
 
-	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnJsonChanged			);
+	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnJsonChanged, Qt::QueuedConnection			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnRCodeChanged			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnErrorChanged			);
 	connect(this,					&ComputedColumnModel::refreshProperties,		this,					&ComputedColumnModel::computeColumnUsesRCodeChanged		);


### PR DESCRIPTION
Add a scale Computed column using drag-and-drop scale variables.
Click on a nominal column.
Click the header of the computed column: the drag-and-drop window is erroneous
It is because it thinks that the computed column is still a nominal

The ComputeColumnWindow is initialized from a Json string. This string gets all information to build the drag-and-drop QML window. The signal that this Json string has changed should be emitted when all changes has been made: this is important especially when the chosen column is changed and all properties are suddenly changed. So we must wait for all properties to be changed, before emitting the json change: this is done by connecting the signal with QueuedConnection.

