### PR TITLE
Set default type for conversion

### DIFF
--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -288,7 +288,7 @@ bool VariablesListBase::isTypeAllowed(columnType type) const
 
 columnType VariablesListBase::defaultType() const
 {
-	return _allowedTypesModel->firstType();
+	return _allowedTypesModel->defaultType();
 }
 
 void VariablesListBase::setDropKeys(const QStringList &dropKeys)
@@ -366,7 +366,7 @@ void VariablesListBase::termsChangedHandler()
 				// This is the case when a scale variable is transformed into a nominal or ordinal, and the variable has more than the default maximum number of levels
 				// This should not be checked if maxLevels is explicitly set (that is if _maxLevels >= 0)
 				addControlErrorPermanent(tr("Attempt to transform scale variable %1 into a %2 variable, but its number of levels %3 exceeds the maximum %4. If you still want to use this variable, either change its type, or change 'Maximum allowed levels for scale' in Preferences / Data menu")
-										 .arg(termStr).arg(columnTypeToQString(_allowedTypesModel->firstType())).arg(nbLevels).arg(maxScaleLevels));
+										 .arg(termStr).arg(columnTypeToQString(_allowedTypesModel->defaultType())).arg(nbLevels).arg(maxScaleLevels));
 				hasError = true;
 			}
 			else if (_minNumericLevels >= 0 && nbNumValues < _minNumericLevels)

--- a/QMLComponents/models/columntypesmodel.cpp
+++ b/QMLComponents/models/columntypesmodel.cpp
@@ -42,7 +42,8 @@ void ColumnTypesModel::setTypes(columnTypeVec types)
 		return;
 
 	beginResetModel();
-	_types = types;	
+	_types = types;
+	_defaultType = _types.size() > 0 ? _types[0] : columnType::unknown;
 	std::sort(_types.begin(), _types.end());
 	endResetModel();
 }
@@ -99,14 +100,6 @@ bool ColumnTypesModel::hasAllTypes() const
 			return false;
 
 	return true;
-}
-
-columnType ColumnTypesModel::firstType() const
-{
-	if (_types.size() > 0)
-		return _types[0];
-	else
-		return columnType::unknown;
 }
 
 QStringList ColumnTypesModel::iconList() const

--- a/QMLComponents/models/columntypesmodel.h
+++ b/QMLComponents/models/columntypesmodel.h
@@ -50,13 +50,14 @@ public:
 	void									setTypes(columnTypeVec types);
 	bool									hasType(columnType type)									const;
 	bool									hasAllTypes()												const;
-	columnType								firstType()													const;
+	columnType								defaultType()												const			{ return _defaultType;	}
 	QStringList								iconList()													const;
 
 private:
-	static columnTypeVec						_allTypes;
+	static columnTypeVec					_allTypes;
 
-	columnTypeVec								_types;
+	columnTypeVec							_types;
+	columnType								_defaultType = columnType::unknown;
 
 };
 


### PR DESCRIPTION
When a VariablesList allows only 2 types, if a not allowed type is dragged into this VariablesList, the variables will be converted to the first allowed type: this will be the default type.

