### PR TITLE
bugfix: fix tooltip in the checkBox and RadioButton

### DIFF
--- a/QMLComponents/components/JASP/Controls/CheckBox.qml
+++ b/QMLComponents/components/JASP/Controls/CheckBox.qml
@@ -44,6 +44,7 @@ CheckBoxBase
 			property alias	fontInfo:				label.fontInfo
 			property alias	label:					control.text
 			property alias	labelTextFormat:		label.textFormat
+			property string toolTip:                ""
 			property alias	checked:				control.checked
 			property bool	childrenOnSameRow:		false
 			property alias	columns:				childControlsArea.columns
@@ -53,6 +54,20 @@ CheckBoxBase
 	function click()	{ control.toggle(); }
 	function toggle()	{ control.toggle(); }
 
+	MouseArea
+	{
+		id:					hoverMe
+		anchors.fill:		parent
+		hoverEnabled:		true
+	}
+
+	ToolTip
+	{
+		text: 		checkBox.toolTip
+		timeout:	jaspTheme.toolTipTimeout
+		delay:		jaspTheme.toolTipDelay
+		visible:	checkBox.toolTip !== "" &&  (hoverMe.containsMouse || control.hovered)
+	}
 
 	CheckBox
 	{

--- a/QMLComponents/components/JASP/Controls/CheckBox.qml
+++ b/QMLComponents/components/JASP/Controls/CheckBox.qml
@@ -16,10 +16,9 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-import QtQuick 2.11
-import QtQuick.Controls 2.4
-import QtQuick.Layouts	1.3 as L
-import JASP				1.0
+import QtQuick
+import QtQuick.Controls as QtC
+import JASP
 
 
 CheckBoxBase
@@ -44,7 +43,6 @@ CheckBoxBase
 			property alias	fontInfo:				label.fontInfo
 			property alias	label:					control.text
 			property alias	labelTextFormat:		label.textFormat
-			property string toolTip:                ""
 			property alias	checked:				control.checked
 			property bool	childrenOnSameRow:		false
 			property alias	columns:				childControlsArea.columns
@@ -54,22 +52,7 @@ CheckBoxBase
 	function click()	{ control.toggle(); }
 	function toggle()	{ control.toggle(); }
 
-	MouseArea
-	{
-		id:					hoverMe
-		anchors.fill:		parent
-		hoverEnabled:		true
-	}
-
-	ToolTip
-	{
-		text: 		checkBox.toolTip
-		timeout:	jaspTheme.toolTipTimeout
-		delay:		jaspTheme.toolTipDelay
-		visible:	checkBox.toolTip !== "" &&  (hoverMe.containsMouse || control.hovered)
-	}
-
-	CheckBox
+	QtC.CheckBox
 	{
 		id:						control
 		padding:				jaspTheme.jaspControlPadding

--- a/QMLComponents/components/JASP/Controls/RadioButton.qml
+++ b/QMLComponents/components/JASP/Controls/RadioButton.qml
@@ -41,6 +41,7 @@ RadioButtonBase
 	property alias	childrenArea:			childControlsArea
 	property alias	text:					control.text
 	property alias	label:					control.text
+	property string toolTip:                ""
 	property alias	checked:				control.checked
 	property alias	value:					radioButton.name
 	property bool	childrenOnSameRow:		false
@@ -51,6 +52,20 @@ RadioButtonBase
 	function click() { clicked(); }
 	onClicked: { radioButton.clickHandler(); }
 
+	MouseArea
+	{
+		id:					hoverMe
+		anchors.fill:		parent
+		hoverEnabled:		true
+	}
+
+	ToolTip
+	{
+		text:		radioButton.toolTip
+		timeout:	jaspTheme.toolTipTimeout
+		delay:		jaspTheme.toolTipDelay
+		visible:	radioButton.toolTip !== "" &&  (hoverMe.containsMouse || control.hovered)
+	}
 
 	RadioButton
 	{

--- a/QMLComponents/components/JASP/Controls/RadioButton.qml
+++ b/QMLComponents/components/JASP/Controls/RadioButton.qml
@@ -16,9 +16,9 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-import QtQuick			2.11
-import QtQuick.Controls	2.4
-import JASP				1.0
+import QtQuick
+import QtQuick.Controls	as QtC
+import JASP
 
 
 RadioButtonBase
@@ -41,7 +41,6 @@ RadioButtonBase
 	property alias	childrenArea:			childControlsArea
 	property alias	text:					control.text
 	property alias	label:					control.text
-	property string toolTip:                ""
 	property alias	checked:				control.checked
 	property alias	value:					radioButton.name
 	property bool	childrenOnSameRow:		false
@@ -52,22 +51,7 @@ RadioButtonBase
 	function click() { clicked(); }
 	onClicked: { radioButton.clickHandler(); }
 
-	MouseArea
-	{
-		id:					hoverMe
-		anchors.fill:		parent
-		hoverEnabled:		true
-	}
-
-	ToolTip
-	{
-		text:		radioButton.toolTip
-		timeout:	jaspTheme.toolTipTimeout
-		delay:		jaspTheme.toolTipDelay
-		visible:	radioButton.toolTip !== "" &&  (hoverMe.containsMouse || control.hovered)
-	}
-
-	RadioButton
+	QtC.RadioButton
 	{
 		id:					control
 		padding:			jaspTheme.jaspControlPadding

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -13,10 +13,15 @@ const QStringList JASPControl::_optionReservedNames = {"data", "version"};
 QMap<QQmlEngine*, QQmlComponent*> JASPControl::_mouseAreaComponentMap;
 QByteArray JASPControl::_mouseAreaDef = "\
 	import QtQuick\n\
+	import QtQuick.Controls\n\
 	MouseArea {\n\
 	z:					5\n\
 	anchors.fill:		parent\n\
 	acceptedButtons:	Qt.NoButton\n\
+	ToolTip.timeout:	jaspTheme.toolTipTimeout\n\
+	ToolTip.delay:		jaspTheme.toolTipDelay\n\
+	ToolTip.text:		parent ? parent.toolTip : ''\n\
+	ToolTip.visible:	ToolTip.text && containsMouse\n\
 }";
 
 QQmlComponent* JASPControl::getMouseAreaComponent(QQmlEngine* engine)
@@ -53,7 +58,6 @@ JASPControl::JASPControl(QQuickItem *parent) : QQuickItem(parent)
 	connect(this, &JASPControl::indentChanged,			[this] () { QQmlProperty(this, "Layout.leftMargin", qmlContext(this)).write( (indent() && JaspTheme::currentTheme()) ? JaspTheme::currentTheme()->indentationLength() : 0); });
 	connect(this, &JASPControl::debugChanged,			[this] () { _setBackgroundColor(); _setVisible(); } );
 	connect(this, &JASPControl::parentDebugChanged,		[this] () { _setBackgroundColor(); _setVisible(); } );
-	connect(this, &JASPControl::toolTipChanged,			[this] () { QQmlProperty(this, "ToolTip.text", qmlContext(this)).write(toolTip()); } );
 	connect(this, &JASPControl::boundValueChanged,		this, &JASPControl::_resetBindingValue);
 	connect(this, &JASPControl::activeFocusChanged,		this, &JASPControl::_setFocus);
 	connect(this, &JASPControl::activeFocusChanged,		this, &JASPControl::_notifyFormOfActiveFocus);
@@ -707,7 +711,7 @@ JASPControl *JASPControl::parentListViewEx() const
 bool JASPControl::hovered() const
 {
 	if (_mouseAreaObj)
-		return _mouseAreaObj->property("hovered").toBool();
+		return _mouseAreaObj->property("containsMouse").toBool();
 	else
 		return false;
 }

--- a/QMLComponents/jasptheme.h
+++ b/QMLComponents/jasptheme.h
@@ -721,7 +721,7 @@ private:
 	theme_timeType		_hoverTime							=  400,
 						_fileMenuSlideDuration				=  150,
 						_toolTipDelay						=  500,
-						_toolTipTimeout						=60000;
+						_toolTipTimeout						= 5000;
 
 	QFont				_font,
 						_fontLink,


### PR DESCRIPTION
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/2525
Fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/2366

The reason is that sometimes the checkbox and radioButton cannot actually detect the mouse hover event.