### PR TITLE
Auto Sort labels bug and other label handling issues

### DIFF
--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -44,12 +44,17 @@ public:
 	typedef std::map<std::pair<std::string, std::string>, Label*>	LabelByStrStr;
 
 									Column(DataSet * data, int id = -1);
+private:
+									Column(DataSet * data, int id, columnType colType, computedColumnType computedType, bool autoSort);
+
+public:									
+			static Column *			addColumn(DataSet* data, int index = -1, const std::string & name = "", columnType colType = columnType::scale, computedColumnType computedType = computedColumnType::notComputed, bool alterDataSetTable = true);
+			static Column *			loadColumn(DataSet* data, int index);
 									~Column();
 									
 				DatabaseInterface & db();
 		const	DatabaseInterface & db() const;
 
-			void					dbCreate(	int index);
 			void					dbLoad(		int id=-1, bool getValues = true);	///< Loads *and* reloads from DB!
 			void					dbLoadIndex(int index, bool getValues = true);
 			void					dbUpdateComputedColumnStuff();
@@ -72,7 +77,7 @@ public:
 			void					setIndex(			int					index			);
 			void					setInvalidated(		bool				invalidated		);
 			void					setCompColStuff(	bool				invalidated, bool forceSourceColType, computedColumnType   codeType, const	std::string & rCode, const	std::string & error, const	Json::Value & constructorJson);
-			void					setDefaultValues(	enum columnType		columnType = columnType::unknown);
+			void					setDefaultValues();
 
 			bool					setAsNominalOrOrdinal(	const intvec	& values,									bool	is_ordinal = false);
 			bool					setAsNominalOrOrdinal(	const intvec	& values, intstrmap uniqueValues,			bool	is_ordinal = false);
@@ -242,7 +247,8 @@ protected:
 			columnTypeChangeResult	_changeColumnToScale();
 			void					_convertVectorIntToDouble(intvec & intValues, doublevec & doubleValues);
 			void					_resetLabelValueMap();
-			doublevec				valuesNumericOrdered();			
+			doublevec				valuesNumericOrdered();
+			stringvec				valuesAlphabeticOrdered();
 
 private:
 			DataSet			* const	_data;

--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -112,7 +112,7 @@ public:
 
 	//Columns & Data/Values
 	//Index stuff:
-	int			columnInsert(			int dataSetId, int index = -1, const std::string & name = "", columnType colType = columnType::unknown, bool alterTable=true);	///< Insert a row into Columns and create the corresponding columns in DataSet_? Also makes sure the indices are correct
+	int			columnInsert(			int dataSetId, int index, columnType colType, computedColumnType computedType, bool autoSort, bool alterTable=true);	///< Insert a row into Columns and create the corresponding columns in DataSet_? Also makes sure the indices are correct
 	int			columnLastFreeIndex(	int dataSetId);
 	void		columnIndexIncrements(	int dataSetId, int index);																			///< If index already is in use that column and all after are incremented by 1
 	void		columnIndexDecrements(	int dataSetId, int index);																			///< Indices bigger than index are decremented, assumption is that the previous one using it has been removed already

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -172,25 +172,26 @@ void DataSet::removeColumn(const std::string & name)
 		}
 }
 
-void DataSet::insertColumn(size_t index,	bool alterDataSetTable)
+Column* DataSet::insertColumn(size_t index, bool alterDataSetTable, const std::string & name, columnType colType, computedColumnType computedType)
 {
-
 	assert(_dataSetID > 0);
 
-	Column * newColumn = new Column(this, db().columnInsert(_dataSetID, index, "", columnType::unknown, alterDataSetTable));
+	Column * newColumn = Column::addColumn(this, index, name, colType, computedType, alterDataSetTable);
 
 	_columns.insert(_columns.begin()+index, newColumn);
 
 	newColumn->setRowCount(_rowCount);
+	newColumn->setDefaultValues();
 
 	incRevision();
+
+	return newColumn;
 }
 
 Column * DataSet::newColumn(const std::string &name)
 {
 	assert(_dataSetID > 0);
-	Column * col = new Column(this, db().columnInsert(_dataSetID, -1, name));
-	col->setName(name);
+	Column * col = Column::addColumn(this, -1, name);
 
 	_columns.push_back(col);
 
@@ -281,9 +282,9 @@ void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, boo
 	for(size_t i=0; i<colCount; i++)
 	{
 		if(_columns.size() == i)
-			_columns.push_back(new Column(this));
-
-		_columns[i]->dbLoadIndex(i, false);
+			_columns.push_back(Column::loadColumn(this, i));
+		else
+			_columns[i]->dbLoadIndex(i, false);
 		
 		progressCallback(0.2 + (i * colProgressMult * 0.3)); //should end at 0.5
 	}

--- a/CommonData/dataset.h
+++ b/CommonData/dataset.h
@@ -44,7 +44,7 @@ public:
 			void			removeColumn(	const	std::string &	name	);
 			void			removeColumn(			size_t			index	);
 			void			removeColumnById(		size_t			id		);
-			void			insertColumn(			size_t			index,	bool alterDataSetTable = true);
+			Column		*	insertColumn(size_t index, bool alterDataSetTable = true, const std::string & name = "", columnType colType = columnType::unknown, computedColumnType computedType = computedColumnType::notComputed);
 			Column		*	newColumn(		const	std::string &	name);
 			int				getColumnIndex(	const	std::string &	name	) const;
 			int				columnIndex(	const	Column		*	col		) const;

--- a/Desktop/components/JASP/Widgets/LabelEditorWindow.qml
+++ b/Desktop/components/JASP/Widgets/LabelEditorWindow.qml
@@ -57,7 +57,7 @@ FocusScope
 					target:		columnModel
 					function	onChosenColumnChanged()
 					{
-						levelsTableView.lastRow = -1;
+						levelsTableView.selectedRow = -1;
 					}
 				}
 
@@ -65,7 +65,7 @@ FocusScope
 				property real	remainingWidth:	width - filterColWidth
 				property real	valueColWidth:	Math.min(columnModel.valueMaxWidth + 10, remainingWidth * 0.5) * jaspTheme.uiScale
 				property real	labelColWidth:	Math.min(columnModel.labelMaxWidth + 10, remainingWidth * 0.5) * jaspTheme.uiScale
-				property int	lastRow:		-1
+				property int	selectedRow:	-1
 				
 
 				columnHeaderDelegate:	Item
@@ -129,7 +129,7 @@ FocusScope
 				{
 					id:						backgroundItem
 					
-					onActiveFocusChanged:	if(activeFocus)	levelsTableView.lastRow = rowIndex
+					onActiveFocusChanged:	if(activeFocus)	levelsTableView.selectedRow = rowIndex
 
 					MouseArea
 					{
@@ -440,7 +440,7 @@ FocusScope
 					iconSource:		jaspTheme.iconPath +  "menu-column-order-by-values.svg"
 					onClicked:		{ forceActiveFocus(); columnModel.toggleAutoSortByValues(); }
 	
-					toolTip:		qsTr("Automatically order labels by their numeric value")
+					toolTip:		qsTr("Automatically order labels by their value")
 	
 					height:			buttonColumnVariablesWindow.buttonHeight
 					implicitHeight: buttonColumnVariablesWindow.buttonHeight
@@ -458,7 +458,7 @@ FocusScope
 					height:			buttonColumnVariablesWindow.buttonHeight
 					implicitHeight: buttonColumnVariablesWindow.buttonHeight
 					width:			height
-					visible:		!columnModel.autoSort || columnModel.firstNonNumericRow > 1 //if there are at least 2 numerics we have something to reverse
+					visible:		columnModel.hasSeveralNumericValues //if there are at least 2 numerics we have something to reverse
 				}
 				
 				RoundedButton
@@ -466,41 +466,41 @@ FocusScope
 					iconSource:		jaspTheme.iconPath + "arrow-reverse.png"
 					onClicked:		{ forceActiveFocus(); columnModel.reverse(); }
 	
-					toolTip:		columnModel.autoSort ? qsTr("Reverse order of the labels with non-numeric values") : qsTr("Reverse order of all labels")
+					toolTip:		qsTr("Reverse order of all labels")
 	
 					height:			buttonColumnVariablesWindow.buttonHeight
 					implicitHeight: buttonColumnVariablesWindow.buttonHeight
 					width:			height
-					visible:		!columnModel.autoSort || columnModel.rowsTotal - columnModel.firstNonNumericRow > 1 //If there are at least 2 non numerics there is something to reverse
-					
+					visible:		!columnModel.autoSort
+					enabled:		columnModel.rowCount() > 1
 				}
 	
 				RoundedButton
 				{
 					iconSource:		jaspTheme.iconPath + "arrow-up.png"
 	
-					onClicked:		{ forceActiveFocus(); columnModel.moveSelectionUp(); levelsTableView.lastRow--; }
-					toolTip:		columnModel.autoSort ? qsTr("Move selected non-numeric labels up") : qsTr("Move selected labels up") 
+					onClicked:		{ forceActiveFocus(); columnModel.moveSelectionUp(); levelsTableView.selectedRow--; }
+					toolTip:		qsTr("Move selected labels up")
 	
 					height:			buttonColumnVariablesWindow.buttonHeight
 					implicitHeight: buttonColumnVariablesWindow.buttonHeight
 					width:			height
-					enabled:		levelsTableView.lastRow == -1 ? false : columnModel.firstNonNumericRow < levelsTableView.lastRow
-					visible:		!columnModel.autoSort || columnModel.rowsTotal - columnModel.firstNonNumericRow > 1 //If there are at least 2 non numerics there is something to move up
+					enabled:		levelsTableView.selectedRow > 0
+					visible:		!columnModel.autoSort
 				}
 	
 				RoundedButton
 				{
 					iconSource:		jaspTheme.iconPath + "arrow-down.png"
 	
-					onClicked:		{ forceActiveFocus(); columnModel.moveSelectionDown(); levelsTableView.lastRow++; }
-					toolTip:		columnModel.autoSort ? qsTr("Move selected non-numeric labels down") : qsTr("Move selected labels down")
+					onClicked:		{ forceActiveFocus(); columnModel.moveSelectionDown(); levelsTableView.selectedRow++; }
+					toolTip:		qsTr("Move selected labels down")
 	
 					height:			buttonColumnVariablesWindow.buttonHeight
 					implicitHeight: buttonColumnVariablesWindow.buttonHeight
 					width:			height
-					enabled:		levelsTableView.lastRow == -1  ? false :  ((columnModel.firstNonNumericRow <= levelsTableView.lastRow) && ( levelsTableView.lastRow < columnModel.rowsTotal - 1 ))
-					visible:		!columnModel.autoSort || columnModel.rowsTotal - columnModel.firstNonNumericRow > 1 //If there are at least 2 non numerics there is something to move down
+					enabled:		levelsTableView.selectedRow >= 0 && levelsTableView.selectedRow < columnModel.rowCount() - 1
+					visible:		!columnModel.autoSort
 				}
 	
 				RoundedButton

--- a/Desktop/data/columnmodel.cpp
+++ b/Desktop/data/columnmodel.cpp
@@ -187,27 +187,25 @@ int ColumnModel::rowsTotal() const
 	return rowCount();	
 }
 
-int ColumnModel::firstNonNumericRow() const
+bool ColumnModel::hasSeveralNumericValues() const
 {
-	if(!column() || !column()->autoSortByValue())
-		return 0;
+	if(!column())
+		return false;
 	
-	int nonEmptyNonNumerics = 0;
+	int numberOfNumericalValues = 0;
 	for(Label * label : column()->labels())	
 		if(!label->isEmptyValue())
 		{
 			static double dummy;
 			
-			if(!(label->originalValue().isDouble() || ColumnUtils::getDoubleValue(label->originalValueAsString(), dummy)))
-				return nonEmptyNonNumerics;
-			nonEmptyNonNumerics++;
+			if(label->originalValue().isDouble() && ColumnUtils::getDoubleValue(label->originalValueAsString(), dummy))
+				numberOfNumericalValues++;
+
+			if (numberOfNumericalValues > 1)
+				return true;
 		}
 	
-	//If we have more temporary labels then normal ones then those afterwards are all numeric (or something wouldve been replaced/sorted) so we can return labelsTempCount()
-	if(column()->labelsTempCount() > nonEmptyNonNumerics)
-		return column()->labelsTempCount();
-	
-	return nonEmptyNonNumerics;	
+	return column()->labelsTempNumerics() > 1;
 }
 
 void ColumnModel::setCustomEmptyValues(const QStringList& customEmptyValues)
@@ -602,10 +600,9 @@ void ColumnModel::refresh()
 	emit nameEditableChanged();
 	emit columnDescriptionChanged();
 	emit computedTypeValuesChanged();
-	emit firstNonNumericRowChanged();
+	emit hasSeveralNumericValuesChanged();
 	emit computedTypeEditableChanged();
 	emit useCustomEmptyValuesChanged();
-	emit firstNonNumericRowChanged();
 	emit columnTypeValuesChanged();
 	emit computedTypeChanged();
 	emit emptyValuesChanged();

--- a/Desktop/data/columnmodel.h
+++ b/Desktop/data/columnmodel.h
@@ -38,7 +38,7 @@ class ColumnModel : public DataSetTableProxy
 	Q_PROPERTY(bool 		isVirtual					READ isVirtual													NOTIFY isVirtualChanged					)
 	Q_PROPERTY(bool			compactMode					READ compactMode				WRITE setCompactMode			NOTIFY compactModeChanged				)
 	Q_PROPERTY(bool			autoSort					READ autoSort					WRITE setAutoSort				NOTIFY autoSortChanged					)
-	Q_PROPERTY(int			firstNonNumericRow			READ firstNonNumericRow											NOTIFY firstNonNumericRowChanged		) //Only works when autosort is on
+	Q_PROPERTY(bool			hasSeveralNumericValues		READ hasSeveralNumericValues									NOTIFY hasSeveralNumericValuesChanged	) //Only works when autosort is on
 	Q_PROPERTY(int			rowsTotal					READ rowsTotal													NOTIFY rowsTotalChanged					)
 
 public:
@@ -58,7 +58,7 @@ public:
 	QVariantList	columnTypeValues()				const;
 	bool			useCustomEmptyValues()			const;
 	QStringList		emptyValues()					const;
-	int				firstNonNumericRow()			const;
+	bool			hasSeveralNumericValues()		const;
 	int				rowsTotal()						const;
 
 
@@ -158,7 +158,7 @@ signals:
 	void isVirtualChanged();
 	void compactModeChanged();
 	void autoSortChanged();
-	void firstNonNumericRowChanged();
+	void hasSeveralNumericValuesChanged();
 	
 private:
 	std::vector<qsizetype>	getSortedSelection()					const;

--- a/Desktop/data/computedcolumnmodel.cpp
+++ b/Desktop/data/computedcolumnmodel.cpp
@@ -249,7 +249,7 @@ void ComputedColumnModel::computeColumnFailed(QString columnNameQ, QString error
 	if(areLoopDependenciesOk(columnName) && column->setError(error) && shouldNotifyQML)
 		emit computeColumnErrorChanged();
 
-	DataSetPackage::pkg()->columnSetDefaultValues(columnName, columnType::unknown, false);
+	DataSetPackage::pkg()->columnSetDefaultValues(columnName, false);
 	emit refreshColumn(columnNameQ);
 
 	validate(tq(columnName));

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1882,7 +1882,7 @@ void DataSetPackage::labelReverse(size_t colIdx)
 	emit labelsReordered(tq(column->name()));
 }
 
-void DataSetPackage::columnSetDefaultValues(const std::string & columnName, columnType columnType, bool emitSignals)
+void DataSetPackage::columnSetDefaultValues(const std::string & columnName, bool emitSignals)
 {
 	if(!_dataSet)
 		return;
@@ -1892,7 +1892,7 @@ void DataSetPackage::columnSetDefaultValues(const std::string & columnName, colu
 	if(colIndex >= 0)
 	{
 		Column * column = _dataSet->columns()[colIndex];
-		column->setDefaultValues(columnType);
+		column->setDefaultValues();
 
 		QModelIndex p = indexForSubNode(_dataSet->dataNode());
 
@@ -2027,13 +2027,12 @@ QString DataSetPackage::insertColumnSpecial(int columnIndex, const QMap<QString,
 	beginInsertColumns(indexForSubNode(_dataSet->dataNode()), columnIndex, columnIndex);
 #endif
 
-	_dataSet->insertColumn(columnIndex);
-	
-	Column * column = _dataSet->column(columnIndex);
 
-	column->setName(			props.contains("name")		? fq(props["name"].toString())					: freeNewColumnName(columnIndex)	);
-	column->setDefaultValues(	props.contains("type")		? columnType(props["type"].toInt())				: columnType::scale					);
-	column->setCodeType(		props.contains("computed")	? computedColumnType(props["computed"].toInt())	: computedColumnType::notComputed	);
+	std::string name =				props.contains("name")		? fq(props["name"].toString())					: freeNewColumnName(columnIndex);
+	columnType	colType =			props.contains("type")		? columnType(props["type"].toInt())				: columnType::scale;
+	computedColumnType codeType =	props.contains("computed")	? computedColumnType(props["computed"].toInt())	: computedColumnType::notComputed;
+
+	Column * column = _dataSet->insertColumn(columnIndex, true, name, colType, codeType);
 
 	_dataSet->incRevision();
 
@@ -2075,10 +2074,8 @@ bool DataSetPackage::insertColumns(int column, int count, const QModelIndex & ap
 
 	for(int c = column; c<column+count; c++)
 	{
-		_dataSet->insertColumn(c);
 		const std::string & name = freeNewColumnName(c);
-		_dataSet->column(c)->setName(name);
-		_dataSet->column(c)->setDefaultValues(columnType::scale);
+		_dataSet->insertColumn(c, true, name, columnType::scale);
 
 		changed.push_back(name);
 	}
@@ -2227,9 +2224,7 @@ Column * DataSetPackage::createColumn(const std::string & name, columnType colum
 
 	enginesPrepareForData();
 	beginResetModel();
-	_dataSet->insertColumn(newColumnIndex);
-	_dataSet->column(newColumnIndex)->setName(name);
-	_dataSet->column(newColumnIndex)->setDefaultValues(columnType);
+	_dataSet->insertColumn(newColumnIndex, true, name, columnType);
 	endResetModel();
 	enginesReceiveNewData();
 

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -191,7 +191,7 @@ public:
 				
 				void						pasteSpreadsheet(size_t row, size_t column, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> & labels, const intvec & colTypes, const QStringList & colNames, const std::vector<boolvec> & selected = {}); ///< If selected.size() >0 it is assumed to be the same size as labels/values. And it will make sure that it will only overwrite values where it is `true`
 
-				void						columnSetDefaultValues(	const std::string	& columnName, columnType colType = columnType::unknown, bool emitSignals = true);
+				void						columnSetDefaultValues(	const std::string	& columnName, bool emitSignals = true);
 				Column *					createColumn(			const std::string	& name,		columnType colType);
 				Column *					createComputedColumn(	const std::string	& name,		columnType type, computedColumnType desiredType, Analysis * analysis = nullptr);
 				void						renameColumn(			const std::string	& oldColumnName, const std::string & newColumnName);

--- a/Desktop/po/jaspDesktop-de.po
+++ b/Desktop/po/jaspDesktop-de.po
@@ -5202,8 +5202,8 @@ msgid "Order labels by value by default"
 msgstr "Standardmäßig Beschriftungen nach Wert sortieren"
 
 msgctxt "LabelEditorWindow|"
-msgid "Automatically order labels by their numeric value"
-msgstr "Automatisch Beschriftungen nach deren numerischen Wert sortieren"
+msgid "Automatically order labels by their value"
+msgstr "Automatisch Beschriftungen nach deren Wert sortieren"
 
 msgctxt "LabelEditorWindow|"
 msgid "Reverse order of the labels with non-numeric values"

--- a/Desktop/po/jaspDesktop-es.po
+++ b/Desktop/po/jaspDesktop-es.po
@@ -5208,8 +5208,8 @@ msgid "Order labels by value by default"
 msgstr "Ordenar las etiquetas según valor, por defecto"
 
 msgctxt "LabelEditorWindow|"
-msgid "Automatically order labels by their numeric value"
-msgstr "Ordenar automaticamente las etiquetas según su valor numérico"
+msgid "Automatically order labels by their value"
+msgstr "Ordenar automaticamente las etiquetas según su valor"
 
 msgctxt "LabelEditorWindow|"
 msgid "Reverse order of the labels with non-numeric values"

--- a/Desktop/po/jaspDesktop-gl.po
+++ b/Desktop/po/jaspDesktop-gl.po
@@ -5185,8 +5185,8 @@ msgid "Order labels by value by default"
 msgstr "Arranxar por defecto as etiquetas segundo o valor"
 
 msgctxt "LabelEditorWindow|"
-msgid "Automatically order labels by their numeric value"
-msgstr "Arranxar automaticamente as etiquetas segundo seu valor numérico"
+msgid "Automatically order labels by their value"
+msgstr "Arranxar automaticamente as etiquetas segundo seu valor"
 
 msgctxt "LabelEditorWindow|"
 msgid "Reverse order of the labels with non-numeric values"

--- a/Desktop/po/jaspDesktop-nl.po
+++ b/Desktop/po/jaspDesktop-nl.po
@@ -5163,8 +5163,8 @@ msgid "Order labels by value by default"
 msgstr "Standaard labels ordenen op waarde"
 
 msgctxt "LabelEditorWindow|"
-msgid "Automatically order labels by their numeric value"
-msgstr "Labels automatisch ordenen op hun numerieke waarde"
+msgid "Automatically order labels by their value"
+msgstr "Labels automatisch ordenen op hun waarde"
 
 msgctxt "LabelEditorWindow|"
 msgid "Reverse order of the labels with non-numeric values"

--- a/Desktop/qquick/datasetview.cpp
+++ b/Desktop/qquick/datasetview.cpp
@@ -80,6 +80,7 @@ void DataSetView::setModel(QAbstractItemModel * model)
 		connect(model,				&QAbstractItemModel::modelAboutToBeReset,		this, &DataSetView::modelAboutToBeReset			);
 
 		connect(_selectionModel,	&QItemSelectionModel::selectionChanged,			this, &DataSetView::selectionChanged);
+		connect(_selectionModel,	&QItemSelectionModel::currentColumnChanged,		this, &DataSetView::currentSelectedColumnHandler);
 
 		connect(model,				&QAbstractItemModel::columnsAboutToBeInserted,	this, &DataSetView::columnsAboutToBeInserted	);
 		connect(model,				&QAbstractItemModel::columnsAboutToBeRemoved,	this, &DataSetView::columnsAboutToBeRemoved		);
@@ -1548,6 +1549,13 @@ void DataSetView::resizeData(int rows, int columns)
 {
 	// Argument row and column of the resize method are indices
 	_model->resize(rows - 1, columns - 1, false, tr("Resize data to %1 rows and %2 columns").arg(rows).arg(columns));
+}
+
+void DataSetView::currentSelectedColumnHandler(const QModelIndex &current, const QModelIndex &previous)
+{
+	int selectedColumn = current.column();
+	if (selectedColumn >= 0)
+		emit DataSetPackage::pkg()->chooseColumn(selectedColumn);
 }
 
 void DataSetView::columnReverseValues(int columnIndex)

--- a/Desktop/qquick/datasetview.h
+++ b/Desktop/qquick/datasetview.h
@@ -273,6 +273,7 @@ public slots:
 
 	void		setColumnType(int columnIndex, int newColumnType);
 	void		resizeData(int rows, int columns);
+	void		currentSelectedColumnHandler(const QModelIndex &current, const QModelIndex &previous);
 
 protected:
 	void		_copy(QPoint where, bool clear);


### PR DESCRIPTION
This solves several issues:

- The "Auto Sort Label per value" setting (true per default in the preferences) is not saved in the database. Now this setting is saved in the database and thus also in the JASP file.
- The "Auto Sort Label per value" works also for non numeric values. Now the labels are per default also alphabetically ordered.
- The Variable Window does not show always the selected column, especially when navigating in the Data view with the keyboard: the Variable Window was showing still the old selected column.
- The up/down/reverse buttons were not visible or/and enabled in the right way. Now if Auto Sort is on, all the other buttons are removed, except the 'Reverse order of all numerical values' if at least 2 labels have numerical values. If Auto Sort is off, all other buttons are displayed, and are enabled only if they really can change the order (the up button is disabled for example if the the selected row is the first one).

