### PR TITLE
fix: auto set CMAKE_GENERATOR for conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ if (UNIX)
 add_compile_options(-Werror=return-type)
 endif()
 
+if(WIN32)
+  add_compile_options(/utf-8)  #Make sure to compile in utf-8 on the locale code page.
+endif()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(APPLE)

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -35,6 +35,7 @@ if(USE_CONAN)
       COMMAND
       conan install ${CONAN_FILE_PATH} --output-folder=${CMAKE_BINARY_DIR}/conan_build
       -s build_type=${CMAKE_BUILD_TYPE}
+      -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
       -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing)
 
   elseif(APPLE)


### PR DESCRIPTION
I cannot make a clean build boost if dont set it manually so let's set it automatically in conan.

and on some windows locale codepage the msvc cannot build without `utf-8` codepage(for example my cpdepage 936), it good also for build bot to build and run JASP with utf-8 I guess.