### PR TITLE
bugfix: ribbon menu translations hot update

### DIFF
--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -38,6 +38,7 @@ RibbonModel::RibbonModel() : QAbstractListModel(DynamicModules::dynMods())
 	connect(DynamicModules::dynMods(), &DynamicModules::dynamicModuleUninstalled,	this, &RibbonModel::removeDynamicRibbonButtonModel			);
 	connect(DynamicModules::dynMods(), &DynamicModules::dynamicModuleReplaced,		this, &RibbonModel::dynamicModuleReplaced					);
 	connect(DynamicModules::dynMods(), &DynamicModules::dynamicModuleChanged,		this, &RibbonModel::dynamicModuleChanged					);
+    connect(PreferencesModel::prefs(), &PreferencesModel::languageCodeChanged,      this, &RibbonModel::reloadModulesMenu   );
 }
 
 void RibbonModel::loadModules(std::vector<std::string> commonModulesToLoad, std::vector<std::string> extraModulesToLoad)
@@ -108,6 +109,27 @@ void RibbonModel::loadModules(std::vector<std::string> commonModulesToLoad, std:
 				_buttonModelsByName[mod]->setEnabled(true);
 		}
 	}
+}
+
+// So we reload the special module to ensure translations can be hot updated.
+void RibbonModel::reloadModulesMenu()
+{
+    std::vector<std::string> allButtons;
+
+    for (const auto& rowButtons : _buttonNames)
+    {
+        for (const auto& button : rowButtons)
+        {
+            allButtons.push_back(button);
+        }
+    }
+
+    for (const auto& button : allButtons)
+    {
+        removeRibbonButtonModel(button);
+    }
+
+    loadModules();
 }
 
 void RibbonModel::addRibbonButtonModelFromDynamicModule(Modules::DynamicModule * module)
@@ -308,7 +330,7 @@ void RibbonModel::removeRibbonButtonModel(std::string moduleName)
 	if(!isModuleName(moduleName))
 		return;
 
-	for(size_t row=0; row<size_t(RowType::Data); row++)
+    for(size_t row=0; row<=size_t(RowType::Data); row++)
 	{
 		int indexRemoved = -1;
 

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -66,7 +66,7 @@ public:
 	virtual QHash<int, QByteArray>	roleNames()													const override;
 
 	void						loadModules(std::vector<std::string> commonModulesToLoad = {}, std::vector<std::string> extraModulesToLoad = {});
-
+    void                        reloadModulesMenu();
 	void						addSpecialRibbonButtonsEarly();
 	void						addSpecialRibbonButtonsLate();
 	void						setDataMode(bool data);

--- a/Modules/pkgdepends.lock
+++ b/Modules/pkgdepends.lock
@@ -57,7 +57,7 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "5.0.2",
+      "Version": "5.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -99,7 +99,7 @@
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.8.7",
+      "Version": "1.8.8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -109,7 +109,7 @@
     },
     "lpSolve": {
       "Package": "lpSolve",
-      "Version": "5.6.18",
+      "Version": "5.6.20",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "12c7a918599d5700e4265dd8a21f684f"


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/2372

So we just remove/renew the menu ribbon button to "reload" it to apply the translations.