### PR TITLE
Check levels of filtered variables dynamically

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -799,6 +799,8 @@ void Column::labelsTempReset()
 	_labelsTempRevision = -1;
 	_labelsTempMaxWidth = 0;
 	_labelsTempNumerics = 0;
+	
+	nonFilteredCountersReset();
 }
 
 int Column::labelsTempCount()
@@ -855,9 +857,9 @@ int Column::labelsTempCount()
 	return _labelsTemp.size();
 }
 
-int Column::countTotalNonFilteredNumerics()
+int Column::nonFilteredTotalNumerics()
 {
-	if (_countNonFilteredNumerics == -1)
+	if (_nonFilteredNumericsCount == -1)
 	{
 		doubleset numerics;
 
@@ -865,15 +867,15 @@ int Column::countTotalNonFilteredNumerics()
 			if(_data->filter()->filtered()[r] && !std::isnan(_dbls[r]))
 					numerics.insert(_dbls[r]);
 
-		_countNonFilteredNumerics = numerics.size();
+		_nonFilteredNumericsCount = numerics.size();
 	}
 
-	return _countNonFilteredNumerics;
+	return _nonFilteredNumericsCount;
 }
 
-int Column::countTotalNonFilteredLevels()
+int Column::nonFilteredTotalLevels()
 {
-	if (_countNonFilteredLevels == -1)
+	if (_nonFilteredLevelsCount == -1)
 	{
 		Labelset	labels;
 		doubleset	numerics;
@@ -891,16 +893,16 @@ int Column::countTotalNonFilteredLevels()
 					numerics.insert(_dbls[r]);
 			}
 
-		_countNonFilteredLevels = numerics.size() + labels.size();
+		_nonFilteredLevelsCount = numerics.size() + labels.size();
 	}
 
-	return _countNonFilteredLevels;
+	return _nonFilteredLevelsCount;
 }
 
-void Column::resetFilterCounters()
+void Column::nonFilteredCountersReset()
 {
-	_countNonFilteredLevels = -1;
-	_countNonFilteredNumerics = -1;
+	_nonFilteredLevelsCount		= -1;
+	_nonFilteredNumericsCount	= -1;
 }
 
 int Column::labelsTempNumerics()

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -821,36 +821,13 @@ int Column::labelsTempCount()
 					_labelsTempNumerics++;
 			}
 		
-		doubleset dblset, dblNonFiltered, dblNoLabelNonFiltered;
-		Labelset labelsNonFiltered;
+		doubleset dblset;
 		
 		for(size_t r=0; r<rowCount(); r++)
 		{
-			if(!std::isnan(_dbls[r]))
-			{
-				if(_ints[r] == Label::DOUBLE_LABEL_VALUE)
-					dblset.insert(_dbls[r]);
-				if(_countNonFilteredNumerics == -1 && _data->filter()->filtered()[r])
-					dblNonFiltered.insert(_dbls[r]);
-			}
-
-			if(_countNonFilteredLevels == -1 && _data->filter()->filtered()[r])
-			{
-				if(_ints[r] != Label::DOUBLE_LABEL_VALUE)
-				{
-					Label * label = labelByIntsId(_ints[r]);
-					if(!label->isEmptyValue())
-						labelsNonFiltered.insert(label);
-				}
-				else if(!std::isnan(_dbls[r]))
-					dblNoLabelNonFiltered.insert(_dbls[r]);
-			}
+			if(!std::isnan(_dbls[r]) && _ints[r] == Label::DOUBLE_LABEL_VALUE)
+				dblset.insert(_dbls[r]);
 		}
-
-		if (_countNonFilteredNumerics == -1)
-			_countNonFilteredNumerics = dblNonFiltered.size();
-		if (_countNonFilteredLevels == -1)
-			_countNonFilteredLevels = labelsNonFiltered.size() + dblNoLabelNonFiltered.size();
 		
 		doublevec dbls(dblset.begin(), dblset.end());
 		

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -867,6 +867,39 @@ const stringvec &Column::labelsTemp()
 	return _labelsTemp;
 }
 
+int Column::countTotalNonFilteredNumerics()
+{
+	doubleset numerics;
+
+	for(size_t r=0; r<_data->rowCount(); r++)
+		if(_data->filter()->filtered()[r] && !std::isnan(_dbls[r]))
+				numerics.insert(_dbls[r]);
+
+	return numerics.size();
+}
+
+int Column::countTotalNonFilteredLevels()
+{
+	Labelset	labels;
+	doubleset	numerics;
+
+	for(size_t r=0; r<_data->rowCount(); r++)
+		if(_data->filter()->filtered()[r])
+		{
+			if(_ints[r] != Label::DOUBLE_LABEL_VALUE)
+			{
+				Label * label = labelByIntsId(_ints[r]);
+				if(!label->isEmptyValue())
+					labels.insert(label);
+			}
+			else if(!std::isnan(_dbls[r]))
+				numerics.insert(_dbls[r]);
+		}
+
+
+	return numerics.size() + labels.size();
+}
+
 std::string Column::labelsTempDisplay(size_t tempLabelIndex)
 {
 	if(labelsTempCount() <= tempLabelIndex)

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -128,9 +128,9 @@ public:
 			int						labelsDoubleValueIsTempLabelRow(double dbl);
 			Label				*	labelDoubleDummy()		{ return _doubleDummy; }
 
-			int						countTotalNonFilteredNumerics();
-			int						countTotalNonFilteredLevels();
-			void					resetFilterCounters();
+			int						nonFilteredTotalNumerics();
+			int						nonFilteredTotalLevels();
+			void					nonFilteredCountersReset();
 
 			std::set<size_t>		labelsMoveRows(std::vector<qsizetype> rows, bool up);
 			void					labelsReverse();
@@ -258,8 +258,8 @@ private:
 			stringvec				_labelsTemp;				///< Contains displaystring for labels. Used to allow people to edit "double" labels. Initialized when necessary
 			doublevec				_labelsTempDbls;
 			strintmap				_labelsTempToIndex;
-			int						_countNonFilteredLevels		= -1,
-									_countNonFilteredNumerics	= -1;
+			int						_nonFilteredLevelsCount		= -1,
+			_nonFilteredNumericsCount	= -1;
 			bool					_invalidated		= false,
 									_forceTypes			= true, ///< If this is a computed column this means whether the source columns used in a computed columns calculation should be forcefully loaded as the desired type or just as their own.
 									_autoSortByValue;

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -130,6 +130,7 @@ public:
 
 			int						countTotalNonFilteredNumerics();
 			int						countTotalNonFilteredLevels();
+			void					resetFilterCounters();
 
 			std::set<size_t>		labelsMoveRows(std::vector<qsizetype> rows, bool up);
 			void					labelsReverse();
@@ -257,6 +258,8 @@ private:
 			stringvec				_labelsTemp;				///< Contains displaystring for labels. Used to allow people to edit "double" labels. Initialized when necessary
 			doublevec				_labelsTempDbls;
 			strintmap				_labelsTempToIndex;
+			int						_countNonFilteredLevels		= -1,
+									_countNonFilteredNumerics	= -1;
 			bool					_invalidated		= false,
 									_forceTypes			= true, ///< If this is a computed column this means whether the source columns used in a computed columns calculation should be forcefully loaded as the desired type or just as their own.
 									_autoSortByValue;

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -127,7 +127,10 @@ public:
 			double					labelsTempValueDouble(	size_t tempLabelIndex);
 			int						labelsDoubleValueIsTempLabelRow(double dbl);
 			Label				*	labelDoubleDummy()		{ return _doubleDummy; }
-			
+
+			int						countTotalNonFilteredNumerics();
+			int						countTotalNonFilteredLevels();
+
 			std::set<size_t>		labelsMoveRows(std::vector<qsizetype> rows, bool up);
 			void					labelsReverse();
 			void					valuesReverse();

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -18,12 +18,13 @@ ColumnsModel::ColumnsModel(DataSetTableModel *tableModel)
 	connect(_tableModel, &DataSetTableModel::labelsReordered,		this, &ColumnsModel::labelsReordered	);
 
 	auto * info = new VariableInfo(_singleton);
-	
+
 	connect(this, &ColumnsModel::namesChanged,							info, &VariableInfo::namesChanged		);
 	connect(this, &ColumnsModel::columnsChanged,						info, &VariableInfo::columnsChanged		);
 	connect(this, &ColumnsModel::columnTypeChanged,						info, &VariableInfo::columnTypeChanged	);
 	connect(this, &ColumnsModel::labelsChanged,							info, &VariableInfo::labelsChanged		);
 	connect(this, &ColumnsModel::labelsReordered,						info, &VariableInfo::labelsReordered	);
+	connect(this, &ColumnsModel::filterChanged,							info, &VariableInfo::filterChanged		);
 	connect(this, &QTransposeProxyModel::columnsInserted,				info, &VariableInfo::rowCountChanged	);
 	connect(this, &QTransposeProxyModel::columnsRemoved,				info, &VariableInfo::rowCountChanged	);
 	connect(this, &QTransposeProxyModel::modelReset,					info, &VariableInfo::rowCountChanged	);

--- a/Desktop/data/columnsmodel.h
+++ b/Desktop/data/columnsmodel.h
@@ -44,6 +44,7 @@ signals:
 	void columnTypeChanged(	QString					colName);
 	void labelsChanged(		QString					columnName, QMap<QString, QString> changedLabels);
 	void labelsReordered(	QString					columnName);
+	void filterChanged();
 
 private:
 	QVariant				_getLabels(int colId) const;

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -517,8 +517,8 @@ QVariant DataSetPackage::data(const QModelIndex &index, int role) const
 		case int(specialRoles::title):				return tq(column->title());
 		case int(specialRoles::filter):				return getRowFilter(index.row());
 		case int(specialRoles::columnType):			return int(column->type());
-		case int(specialRoles::totalNumericValues):	return column->countTotalNonFilteredNumerics();
-		case int(specialRoles::totalLevels):		return column->countTotalNonFilteredLevels();
+		case int(specialRoles::totalNumericValues):	return column->nonFilteredTotalNumerics();
+		case int(specialRoles::totalLevels):		return column->nonFilteredTotalLevels();
 		case int(specialRoles::computedColumnType):	return int(column->codeType());
 		case int(specialRoles::columnPkgIndex):		return index.column();
 		case int(specialRoles::lines):
@@ -1220,7 +1220,7 @@ int DataSetPackage::columnsFilteredCount()
 void DataSetPackage::resetFilterCounters()
 {
 	for(Column * col : _dataSet->columns())
-		col->resetFilterCounters();
+		col->nonFilteredCountersReset();
 }
 
 void DataSetPackage::resetAllFilters()

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -517,8 +517,8 @@ QVariant DataSetPackage::data(const QModelIndex &index, int role) const
 		case int(specialRoles::title):				return tq(column->title());
 		case int(specialRoles::filter):				return getRowFilter(index.row());
 		case int(specialRoles::columnType):			return int(column->type());
-		case int(specialRoles::totalNumericValues):	return column->labelsTempNumerics();	
-		case int(specialRoles::totalLevels):		return int(column->labelsTemp().size());
+		case int(specialRoles::totalNumericValues):	return column->countTotalNonFilteredNumerics();
+		case int(specialRoles::totalLevels):		return column->countTotalNonFilteredLevels();
 		case int(specialRoles::computedColumnType):	return int(column->codeType());
 		case int(specialRoles::columnPkgIndex):		return index.column();
 		case int(specialRoles::lines):
@@ -877,7 +877,7 @@ bool DataSetPackage::setLabelDisplay(const QModelIndex &index, const QString &ne
 		changedCols = {column->name()};
 	
 	endSynchingDataChangedColumns(changedCols, false, false);
-	
+
 	if(setManual)
 		setManualEdits(true);
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1217,6 +1217,12 @@ int DataSetPackage::columnsFilteredCount()
 	return colsFiltered;
 }
 
+void DataSetPackage::resetFilterCounters()
+{
+	for(Column * col : _dataSet->columns())
+		col->resetFilterCounters();
+}
+
 void DataSetPackage::resetAllFilters()
 {
 	for(Column * col : _dataSet->columns())

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -331,6 +331,7 @@ public slots:
 				void				requestComputedColumnDestruction(	const std::string & columnName);
 				void				checkDataSetForUpdates();
 				void				delayedRefresh();
+				void				resetFilterCounters();
 				
 private:
 				bool				isThisTheSameThreadAsEngineSync();

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -546,7 +546,7 @@ void MainWindow::makeConnections()
 	connect(_filterModel,			&FilterModel::refreshAllAnalyses,					_analyses,				&Analyses::refreshAllAnalyses,								Qt::QueuedConnection);
 	connect(_filterModel,			&FilterModel::updateColumnsUsedInConstructedFilter, _package,				&DataSetPackage::setColumnsUsedInEasyFilter					);
 	connect(_filterModel,			&FilterModel::filterUpdated,						_package,				&DataSetPackage::refresh									);
-	connect(_filterModel,			&FilterModel::filterUpdated,						_columnsModel,			&ColumnsModel::filterChanged								);
+	connect(_filterModel,			&FilterModel::filterUpdated,						[&]() { _package->resetFilterCounters(); emit _columnsModel->filterChanged(); }		);
 	connect(_filterModel,			&FilterModel::sendFilter,							_engineSync,			&EngineSync::sendFilter										);
 
 	connect(_labelFilterGenerator,	&labelFilterGenerator::setGeneratedFilter,			_filterModel,			&FilterModel::setGeneratedFilter,							Qt::QueuedConnection);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -546,6 +546,7 @@ void MainWindow::makeConnections()
 	connect(_filterModel,			&FilterModel::refreshAllAnalyses,					_analyses,				&Analyses::refreshAllAnalyses,								Qt::QueuedConnection);
 	connect(_filterModel,			&FilterModel::updateColumnsUsedInConstructedFilter, _package,				&DataSetPackage::setColumnsUsedInEasyFilter					);
 	connect(_filterModel,			&FilterModel::filterUpdated,						_package,				&DataSetPackage::refresh									);
+	connect(_filterModel,			&FilterModel::filterUpdated,						_columnsModel,			&ColumnsModel::filterChanged								);
 	connect(_filterModel,			&FilterModel::sendFilter,							_engineSync,			&EngineSync::sendFilter										);
 
 	connect(_labelFilterGenerator,	&labelFilterGenerator::setGeneratedFilter,			_filterModel,			&FilterModel::setGeneratedFilter,							Qt::QueuedConnection);

--- a/Engine/rbridge.cpp
+++ b/Engine/rbridge.cpp
@@ -712,7 +712,7 @@ std::vector<bool> rbridge_applyFilter(const std::string & filterCode, const std:
 	jaspRCPP_freeArrayPointer(&arrayPointer);
 
 	if(!atLeastOneRow)
-		throw filterException("Filtered out all data..");
+		throw filterException("Filtered out all data.");
 
 	if(arrayLength != rowCount)
 	{

--- a/QMLComponents/components/JASP/Controls/ControlErrorMessage.qml
+++ b/QMLComponents/components/JASP/Controls/ControlErrorMessage.qml
@@ -46,7 +46,7 @@ Rectangle
 
 	onContainerWidthChanged:	if (visible)				showMessage()
 	onControlChanged:			if (!control)				controlErrorMessage.opacity = 0
-	onVisibleChanged:			if (!visible && control)
+	onVisibleChanged:			if (!visible && opacity === 0 && control)
 	{
 		control.hasError	= false;
 		control.hasWarning	= false;

--- a/QMLComponents/controls/sourceitem.cpp
+++ b/QMLComponents/controls/sourceitem.cpp
@@ -133,6 +133,7 @@ void SourceItem::connectModels()
 		} );
 		connect(variableInfo,	&VariableInfo::labelsChanged,		controlModel, &ListModel::sourceLabelsChanged );
 		connect(variableInfo,	&VariableInfo::labelsReordered,		controlModel, &ListModel::sourceLabelsReordered );
+		connect(variableInfo,	&VariableInfo::filterChanged,		controlModel, &ListModel::filterChanged );
 		connect(variableInfo,	&VariableInfo::columnsChanged,		controlModel, &ListModel::sourceColumnsChanged );
 	}
 
@@ -142,6 +143,7 @@ void SourceItem::connectModels()
 		connect(_sourceListModel,		&ListModel::columnTypeChanged,		controlModel, &ListModel::sourceColumnTypeChanged);
 		connect(_sourceListModel,		&ListModel::labelsChanged,			controlModel, &ListModel::sourceLabelsChanged );
 		connect(_sourceListModel,		&ListModel::labelsReordered,		controlModel, &ListModel::sourceLabelsReordered );
+		connect(_sourceListModel,		&ListModel::filterChanged,			controlModel, &ListModel::filterChanged );
 		connect(_sourceListModel,		&ListModel::columnsChanged,			controlModel, &ListModel::sourceColumnsChanged );
 	}
 

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -88,7 +88,12 @@ void VariablesListBase::setUp()
 	//We use macros here because the signals come from QML
 	QQuickItem::connect(this, SIGNAL(itemDoubleClicked(int)),						this, SLOT(itemDoubleClickedHandler(int)));
 	QQuickItem::connect(this, SIGNAL(itemsDropped(QVariant, QVariant, int)),		this, SLOT(itemsDroppedHandler(QVariant, QVariant, int)));
-	connect(this,	&VariablesListBase::allowedColumnsChanged,						this, &VariablesListBase::_setAllowedVariables);
+	connect(this,				&VariablesListBase::allowedColumnsChanged,			this, &VariablesListBase::_setAllowedVariables			);
+	connect(_draggableModel,	&ListModelDraggable::filterChanged,					this, &VariablesListBase::checkLevelsConstraints		);
+	connect(this,				&VariablesListBase::maxLevelsChanged,				this, &VariablesListBase::checkLevelsConstraints		);
+	connect(this,				&VariablesListBase::minLevelsChanged,				this, &VariablesListBase::checkLevelsConstraints		);
+	connect(this,				&VariablesListBase::maxNumericLevelsChanged,		this, &VariablesListBase::checkLevelsConstraints		);
+	connect(this,				&VariablesListBase::minNumericLevelsChanged,		this, &VariablesListBase::checkLevelsConstraints		);
 }
 
 void VariablesListBase::_setInitialized(const Json::Value &value)
@@ -326,11 +331,8 @@ void VariablesListBase::setVariableType(int index, int type)
 	model()->setVariableType(index, columnType(type));
 }
 
-void VariablesListBase::termsChangedHandler()
+void VariablesListBase::checkLevelsConstraints()
 {
-	setColumnsTypes(model()->termsTypes());
-	setColumnsNames(model()->terms().asQList());
-
 	bool noScaleAllowed = !_allowedTypesModel->hasType(columnType::scale);
 
 	if (_minLevels >= 0 || _maxLevels >= 0 || _minNumericLevels >= 0 || _maxNumericLevels >= 0 || noScaleAllowed)
@@ -387,6 +389,14 @@ void VariablesListBase::termsChangedHandler()
 		if (!hasError)
 			clearControlError();
 	}
+}
+
+void VariablesListBase::termsChangedHandler()
+{
+	setColumnsTypes(model()->termsTypes());
+	setColumnsNames(model()->terms().asQList());
+
+	checkLevelsConstraints();
 
 	if (_boundControl)	_boundControl->resetBoundValue();
 	else JASPListControl::termsChangedHandler();

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -110,6 +110,7 @@ protected slots:
 	void itemDoubleClickedHandler(int index);
 	void itemsDroppedHandler(QVariant indexes, QVariant vdropList, int dropItemIndex);
 	void interactionHighOrderHandler(JASPControl* checkBoxControl);
+	void checkLevelsConstraints();
 
 protected:
 	GENERIC_SET_FUNCTION(ListViewType,					_listViewType,					listViewTypeChanged,					ListViewType	)

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -107,6 +107,7 @@ signals:
 			void columnTypeChanged(Term term);
 			void labelsChanged(QString columnName, QMap<QString, QString> = {});
 			void labelsReordered(QString columnName);
+			void filterChanged();
 			void columnsChanged(QStringList columns);
 			void selectedItemsChanged();
 			void oneTermChanged(const QString& oldName, const QString& newName);

--- a/QMLComponents/models/listmodelavailableinterface.cpp
+++ b/QMLComponents/models/listmodelavailableinterface.cpp
@@ -179,6 +179,7 @@ bool ListModelAvailableInterface::sourceLabelsReordered(QString columnName)
 	return change;
 }
 
+
 void ListModelAvailableInterface::removeTermsInAssignedList()
 {
 	if (keepTerms())
@@ -215,6 +216,7 @@ void ListModelAvailableInterface::addAssignedModel(ListModelAssignedInterface *a
 	connect(this,			&ListModelAvailableInterface::columnTypeChanged,	assignedModel,				&ListModelAssignedInterface::sourceColumnTypeChanged	);
 	connect(this,			&ListModelAvailableInterface::labelsChanged,		assignedModel,				&ListModelAssignedInterface::sourceLabelsChanged		);
 	connect(this,			&ListModelAvailableInterface::labelsReordered,		assignedModel,				&ListModelAssignedInterface::sourceLabelsReordered		);
+	connect(this,			&ListModelAvailableInterface::filterChanged,		assignedModel,				&ListModelAssignedInterface::filterChanged				);
 	connect(listView(),		&JASPListControl::containsVariablesChanged,			assignedModel->listView(),	&JASPListControl::setContainsVariables					);
 	connect(listView(),		&JASPListControl::containsInteractionsChanged,		assignedModel->listView(),	&JASPListControl::setContainsInteractions				);
 }

--- a/QMLComponents/variableinfo.h
+++ b/QMLComponents/variableinfo.h
@@ -61,6 +61,7 @@ signals:
 	void columnTypeChanged(QString colName);
 	void labelsChanged(QString columnName, QMap<QString, QString> changedLabels);
 	void labelsReordered(QString columnName);
+	void filterChanged();
 	void rowCountChanged();
 	void dataAvailableChanged();
 


### PR DESCRIPTION
The levels constraints in Variables Lists did not take the label filtering into account.
Also the levels constraints should be checked dynamically, that is each time the filtering is changed, or the constraints self changes.
Fixes https://github.com/jasp-stats/jasp-issues/issues/2853
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2639
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2640
Fixes https://github.com/jasp-stats/jasp-issues/issues/2853