### PR TITLE
Translate all RibbonButtons dynamically

### DIFF
--- a/Desktop/modules/analysisentry.cpp
+++ b/Desktop/modules/analysisentry.cpp
@@ -23,8 +23,8 @@
 namespace Modules
 {
 
-AnalysisEntry::AnalysisEntry(std::function<void ()> specialFunc, std::string internalTitle, std::string menuTitle, bool requiresData, std::string icon)
-	: _title(internalTitle), _function(internalTitle), _menu(menuTitle), _isSeparator(false), _isGroupTitle(!specialFunc), _requiresData(requiresData), _icon(icon), _specialFunc(specialFunc)
+AnalysisEntry::AnalysisEntry(std::function<void ()> specialFunc, std::string internalTitle, std::function<std::string()> menuTitleF, bool requiresData, std::string icon)
+	: _title(internalTitle), _function(internalTitle), _menuF(menuTitleF), _isSeparator(false), _isGroupTitle(!specialFunc), _requiresData(requiresData), _icon(icon), _specialFunc(specialFunc)
 {}
 
 AnalysisEntry::AnalysisEntry(std::string menuTitle, std::string icon, bool smallIcon)

--- a/Desktop/modules/analysisentry.h
+++ b/Desktop/modules/analysisentry.h
@@ -39,12 +39,12 @@ class AnalysisEntry
 {
 	friend EntryBase;
 public:
-	AnalysisEntry(std::function<void()> specialFunc, std::string internalTitle, std::string menuTitle, bool requiresData=true, std::string icon = "");	///< AnalysisEntry with a callbackfunction to JASP, if !specialFunc then a grouptitle
+	AnalysisEntry(std::function<void()> specialFunc, std::string internalTitle, std::function<std::string()> menuTitleF, bool requiresData=true, std::string icon = "");	///< AnalysisEntry with a callbackfunction to JASP, if !specialFunc then a grouptitle
 	AnalysisEntry(std::string menuTitle, std::string icon = "", bool small=false);											///< AnalysisEntry grouptitle
 	AnalysisEntry(Json::Value & analysisEntry, DynamicModule * dynamicModule, bool defaultRequiresData = true);				///< AnalysisEntry from a modules Description.qml
 	AnalysisEntry();																										///< AnalysisEntry separator
 
-	std::string		menu()					const { return _menu;									}
+	std::string		menu()					const { return _menuF ? _menuF() : _menu;		}
 	std::string		title()					const { return _title;									}
 	std::string		function()				const { return _function;								}
 	std::string		qml()					const { return _qml != "" ? _qml : _function + ".qml";	}
@@ -75,20 +75,21 @@ public:
 	static bool		requiresDataEntries(const AnalysisEntries & entries);
 
 private:
-	std::string				_title			= "???"		,
-							_function		= "???"		,
-							_qml			= "???"		,
-							_menu			= "???"		,
-							_icon			= ""		;
-	DynamicModule*			_dynamicModule	= nullptr	;
-	bool					_isSeparator	= true		,
-							_isGroupTitle	= false		,
-							_isAnalysis		= false		,
-							_isEnabled		= true		,
-							_requiresData	= true		,
-							_hasWrapper		= false		,
-							_smallIcon		= false		;
-	std::function<void()>	_specialFunc	= nullptr	;
+	std::string						_title			= "???"		,
+									_function		= "???"		,
+									_qml			= "???"		,
+									_menu			= "???"		,
+									_icon			= ""		;
+	DynamicModule*					_dynamicModule	= nullptr	;
+	bool							_isSeparator	= true		,
+									_isGroupTitle	= false		,
+									_isAnalysis		= false		,
+									_isEnabled		= true		,
+									_requiresData	= true		,
+									_hasWrapper		= false		,
+									_smallIcon		= false		;
+	std::function<void()>			_specialFunc	= nullptr	;
+	std::function<std::string()>	_menuF			= nullptr	; //To make it translatable
 };
 
 }

--- a/Desktop/modules/ribbonbutton.h
+++ b/Desktop/modules/ribbonbutton.h
@@ -56,15 +56,15 @@ public:
 
 	RibbonButton(QObject *parent);
 	RibbonButton(QObject *parent, Modules::DynamicModule * module);
-	RibbonButton(QObject *parent, std::string name,	std::string title, std::string icon, bool requiresData, std::function<void()> justThisFunction, std::string toolTip = "", bool enabled = true, bool remember = false, bool defaultActiveBinding = true);
-	RibbonButton(QObject *parent, std::string name,	std::string title, std::string icon, Modules::AnalysisEntries * funcEntries, std::string toolTip = "", bool enabled = true, bool remember = false, bool defaultActiveBinding = true);
+	RibbonButton(QObject *parent, std::string name,	std::function<std::string()> titleF, std::string icon, bool requiresData, std::function<void()> justThisFunction,	std::function<QString()> toolTipF = [](){return "";}, bool enabled = true, bool remember = false, bool defaultActiveBinding = true);
+	RibbonButton(QObject *parent, std::string name,	std::function<std::string()> titleF, std::string icon, Modules::AnalysisEntries * funcEntries,						std::function<QString()> toolTipF = [](){return "";}, bool enabled = true, bool remember = false, bool defaultActiveBinding = true);
 	~RibbonButton();
 
 
 	bool						requiresData()												const			{ return _requiresData;										}
 	bool						isCommon()													const			{ return _isCommonModule;									}
-	std::string					title()														const			{ return _title;											}
-	QString						titleQ()													const			{ return QString::fromStdString(_title);					}
+	std::string					title()														const			{ return _titleF ? _titleF() : _title;						}
+	QString						titleQ()													const			{ return QString::fromStdString(title());					}
 	QString						iconSource()												const			{ return _iconSource;										}
 	bool						enabled()													const			{ return _enabled;											}
 	std::string					name()														const			{ return _name;												}
@@ -75,7 +75,7 @@ public:
 	stringvec					getAllEntries()												const;
 	bool						dataLoaded()												const			{ return Modules::DynamicModules::dynMods() &&  Modules::DynamicModules::dynMods()->dataLoaded();	}
 	bool						active()													const			{ return _active;											}
-	QString						toolTip()													const			{ return _toolTip;											}
+	QString						toolTip()													const			{ return _toolTipF ? _toolTipF() : _toolTip;											}
 	bool						isBundled()													const			{ return _module && _module->isBundled();					}
 	QString						version()													const			{ return !_module ? "?" : _module->versionQ();				}
 	bool						ready()														const			{ return _ready;											}
@@ -83,31 +83,31 @@ public:
 	bool						remember()													const			{ return _remember;											}
 	bool						isSpecial()													const			{ return _special; }
 
-	static QString					getJsonDescriptionFilename();	
+	static QString				getJsonDescriptionFilename();	
 
 	bool separator() const;
 	void setSeparator(bool newSeparator);
 
+	
 public slots:
-	void setDynamicModule(Modules::DynamicModule * module);
-	void setRequiresData(bool requiresData);
-	void setIsCommon(bool isCommonModule);
-	void setTitle(std::string title);
-	void setTitleQ(QString title)									{ setTitle(title.toStdString()); }
-	void setIconSource(QString iconSource);
-	void setEnabled(bool enabled);
-	void setModuleName(std::string moduleName);
-	void setModuleNameQ(QString moduleName)							{ setModuleName(moduleName.toStdString()); }
-	void somePropertyChanged()										{ emit iChanged(this); }
-	void setToolTip(QString toolTip);
-	void setReady(bool ready);
-	void setError(bool error);
-	void setRemember(bool remember);
-	void setActive(bool active);
-
-
-	void runSpecial(QString func);;
-	void reloadDynamicModule(Modules::DynamicModule * dynMod);
+	void setDynamicModule(		Modules::DynamicModule *	module);
+	void setRequiresData(		bool						requiresData);
+	void setIsCommon(			bool						isCommonModule);
+	void setTitle(				std::string					title);
+	void setTitleQ(				QString						title)				{ setTitle(title.toStdString()); }
+	void setIconSource(			QString						iconSource);
+	void setEnabled(			bool						enabled);
+	void setModuleName(			std::string					moduleName);
+	void setModuleNameQ(		QString						moduleName)			{ setModuleName(moduleName.toStdString()); }
+	void somePropertyChanged()													{ emit iChanged(this); }
+	void setToolTip(			QString						toolTip);
+	void setToolTipF(			std::function<QString ()>	toolTipF);
+	void setReady(				bool						ready);
+	void setError(				bool						error);
+	void setRemember(			bool						remember);
+	void setActive(				bool						active);
+	void runSpecial(			QString						func);
+	void reloadDynamicModule(	Modules::DynamicModule *	dynMod);
 
 
 signals:
@@ -152,6 +152,8 @@ private:
 	QString							_iconSource,
 									_toolTip;
 	std::function<void()>			_specialButtonFunc	= nullptr;
+	std::function<std::string()>	_titleF				= nullptr;
+	std::function<QString()>		_toolTipF			= nullptr;
 };
 
 

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -130,7 +130,7 @@ public slots:
 	void setHighlightedModuleIndex(int highlightedModuleIndex);
 	void analysisClicked(QString analysisFunction, QString analysisQML, QString analysisTitle, QString module);
 	void setCurrentRow(int currentRow);
-
+	void refreshButtons();
 
 private slots:
 	void dynamicModuleChanged(	Modules::DynamicModule * module);


### PR DESCRIPTION
Using lambda to define titles and tooltips allows for dynamic translations in "special ribbonbuttons"
Fixes jasp-stats/INTERNAL-jasp#2372 without the need for destroying and recreating buttons

