### PR TITLE
bugfix: replace newlines with _ in CSV cell values

### DIFF
--- a/Desktop/data/importers/csv/csv.cpp
+++ b/Desktop/data/importers/csv/csv.cpp
@@ -536,7 +536,7 @@ bool CSV::readLine(vector<string> &items)
     for (size_t index = 0; index < items.size(); index++)
 	{
         string item = items.at(index);
-		boost::algorithm::replace_all(item, "\n", "_"); // so we should not newlines in values right?
+		boost::algorithm::replace_all(item, "\n", " "); // so we should not allow newlines in values right?
 		if (item.size() >= 2 && item[0] == '"' && item[item.size()-1] == '"')
 			item = item.substr(1, item.size()-2);
         items[index] = item;

--- a/Desktop/data/importers/csv/csv.cpp
+++ b/Desktop/data/importers/csv/csv.cpp
@@ -536,6 +536,7 @@ bool CSV::readLine(vector<string> &items)
     for (size_t index = 0; index < items.size(); index++)
 	{
         string item = items.at(index);
+		boost::algorithm::replace_all(item, "\n", "_"); // so we should not newlines in values right?
 		if (item.size() >= 2 && item[0] == '"' && item[item.size()-1] == '"')
 			item = item.substr(1, item.size()-2);
         items[index] = item;


### PR DESCRIPTION
Other data file will not have this problems because newlines in values were not allowed.

I think `_` is better than a space, because space invisible sometimes, so that we should also change: https://github.com/jasp-stats/jaspColumnEncoder/blob/3425813804558ea0246351e3b361c19fffcf73f4/stringutils.h#L188 ?