### PR TITLE
syntaxhighlighting improvements

### DIFF
--- a/QMLComponents/controls/rsyntaxhighlighter.cpp
+++ b/QMLComponents/controls/rsyntaxhighlighter.cpp
@@ -28,7 +28,7 @@ RSyntaxHighlighter::RSyntaxHighlighter(QTextDocument *parent)
 	}
 
 	HighlightingRule rule;
-	// all these R regExp are copied from: https://github.com/PrismJS/prism/blob/master/components/prism-r.js
+	// most of these R regExp are copied from: https://github.com/PrismJS/prism/blob/master/components/prism-r.js
 
 	// operators
 	_operatorFormat.setForeground(Qt::red);
@@ -44,7 +44,7 @@ RSyntaxHighlighter::RSyntaxHighlighter(QTextDocument *parent)
 
 	// string
 	_stringFormat.setForeground(Qt::darkGreen);
-	rule.pattern = QRegularExpression(R"((['"])(?:\\.|(?!\1)[^\\\r\n])*\1)");
+	rule.pattern = QRegularExpression(R"(([`'"])(?:\\.|(?!\1)[^\\\r\n])*\1)");
 	rule.format = _stringFormat;
 	_highlightingRules.append(rule);
 
@@ -75,15 +75,11 @@ RSyntaxHighlighter::RSyntaxHighlighter(QTextDocument *parent)
 	// comments
 	_commentFormat.setForeground(Qt::darkGray);
 	_commentFormat.setFontItalic(true);
-	rule.pattern = QRegularExpression(R"(#[^\n]*)");
-	rule.format = _commentFormat;
-	_commentRule = rule;
-	//_highlightingRules.append(rule);
+	_commentRule.pattern = QRegularExpression(R"(#[^\n]*)");
+	_commentRule.format = _commentFormat;
 	
 	// columns
 	_columnFormat.setForeground(Qt::blue);
-	//_columnFormat.setUnderlineStyle(QTextCharFormat::DashUnderline);
-	//_columnFormat.setUnderlineColor(Qt::green);
 	_columnFormat.setFontItalic(true);
 }
 

--- a/QMLComponents/controls/rsyntaxhighlighter.h
+++ b/QMLComponents/controls/rsyntaxhighlighter.h
@@ -24,31 +24,49 @@
 #include <QRegularExpression>
 #include <QQuickItem>
 #include <QQuickTextDocument>
+#include "variableinfo.h"
 
-class RSyntaxHighlighter : public QSyntaxHighlighter
+class RSyntaxHighlighter : public QSyntaxHighlighter, public VariableInfoConsumer
 {
+	Q_OBJECT
+	
+	struct HighlightingRule
+	{
+		QRegularExpression		pattern;
+		QTextCharFormat			format;
+	};
+	
 public:
 				RSyntaxHighlighter(QTextDocument *parent);
 				
 	void		highlightBlock(const QString &text) override;
     void		setStringsFormat(const QString &text, QChar c);
+	
+	void		applyRule(const QString & text,  const HighlightingRule   & rule)											{ applyRule(text, rule.pattern, rule.format); }
+	void		applyRule(const QString & text,  const QRegularExpression & pattern, const QTextCharFormat & format);
+	
+	
+	
+protected slots:
+	void		handleNamesChanged(QMap<QString, QString> changedNames)	{ rehighlight(); }
+	void		handleRowCountChanged()									{ rehighlight(); }
 
 private:
-	struct HighlightingRule
-	{
-		QRegularExpression pattern;
-		QTextCharFormat format;
-	};
+
 	
-	QVector<HighlightingRule>	highlightingRules;
-	QTextCharFormat				operatorFormat,
-								variableFormat,
-								commentFormat,
-								keywordFormat,
-								stringFormat,
-								booleanFormat,
-								numberFormat,
-								punctuationFormat;
+	QTextDocument			*	_textDocument = nullptr;
+	
+	QVector<HighlightingRule>	_highlightingRules;
+	QTextCharFormat				_punctuationFormat,
+								_operatorFormat,
+								_variableFormat,
+								_commentFormat,
+								_keywordFormat,
+								_stringFormat,
+								_booleanFormat,
+								_numberFormat,
+								_columnFormat;
+	HighlightingRule			_commentRule;
 };
 
 class RSyntaxHighlighterQuick : public QQuickItem
@@ -62,7 +80,7 @@ public:
 	QQuickTextDocument * textDocument() { return _textDocument; }
 	
 	void setTextDocument(QQuickTextDocument * textDocument);
-
+	
 signals:
 	void textDocumentChanged();
 	


### PR DESCRIPTION
adds support for highlighting columnnames from JASP (including names with spaces that are allowed within JASP) also makes sure to do the comment rule only at the end to make sure comments are entirely commented to avoid confusing users

Looks like:
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/db570697-eb55-4edb-8f9c-65d59b6794f4">
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/4d4814ec-4281-4be0-ba16-93bec8b5a3c6">
