### PR TITLE
Fix bug where having empty values messes up labeledits

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1213,7 +1213,7 @@ std::map<double, Label*> Column::replaceDoubleWithLabel(doublevec dbls)
 		if(!std::isnan(_dbls[r]) && doubleIntIdMap.count(_dbls[r]))
 			_ints[r] = doubleIntIdMap[_dbls[r]]; 
 	
-	dbUpdateValues();
+	dbUpdateValues(false);
 	
 	return doubleLabelMap;
 }
@@ -1226,7 +1226,6 @@ Label *Column::replaceDoublesTillLabelsRowWithLabels(size_t row)
 	if(labelByIndexNotEmpty(row))
 		return labelByIndexNotEmpty(row);
 	
-	bool		labelsTempUpToDate = _revision == _labelsTempRevision; //If so we can just update it at the end. We dont not yet need to recreate them
 	doublevec	dbls;
 	double		dbl;
 	
@@ -1241,9 +1240,6 @@ Label *Column::replaceDoublesTillLabelsRowWithLabels(size_t row)
 
 	//the last dbl is the one we want so use it to get the right label from the map:
 	Label * label = replaceDoubleWithLabel(dbls)[dbl];
-	
-	if(labelsTempUpToDate)
-		_labelsTempRevision = _revision;
 	
 	return label;
 }

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -250,8 +250,9 @@ QModelIndex DataSetPackage::index(int row, int column, const QModelIndex &parent
 				
 			case dataSetBaseNodeType::column:
 			{
-				Column * col = dynamic_cast<Column*>(parentNode);
-				pointer = dynamic_cast<const void*>(col->labels().size() > row ? col->labels()[row] : col->labelDoubleDummy());
+				Column	* col	= dynamic_cast<Column*>(parentNode);
+				Label	* lab	= col->labelByIndexNotEmpty(row);
+				pointer			= dynamic_cast<const void*>(lab ? lab : col->labelDoubleDummy());
 				break;
 			}
 				


### PR DESCRIPTION
This is done by resetting labelsTemp

@kylelang this solves the problem you mentioned in the meeting?

For other (future) reviewers: 
Problem is that when you have a column like 'contBinom' and you change some values (in data editing) to a missing value (like NA) then editing the displayvalue of the label in the labeleditor will not update properly.
And from that point on further editing will make a mess of the data.

https://github.com/jasp-stats/INTERNAL-jasp/issues/2648