### PR TITLE
Dont loop through the labels to avoid collisions

### DIFF
--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -116,7 +116,7 @@ public:
 			int						labelsAdd(			const std::string & display);
 			int						labelsAdd(			const std::string & display, const std::string & description, const Json::Value & originalValue);
 			int						labelsAdd(			int value, const std::string & display, bool filterAllows, const std::string & description, const Json::Value & originalValue, int order=-1, int id=-1);
-			void					labelsRemoveByIntsId(	intset valuesToRemove);
+			void					labelsRemoveByIntsId(	intset valuesToRemove, bool updateOrder = true);
 			strintmap				labelsResetValues(	int & maxValue);
 			void					labelsRemoveBeyond( size_t indexToStartRemoving);
 			
@@ -168,16 +168,16 @@ public:
 
 			Labels				&	labels()																						{ return _labels; }
 			const Labels		&	labels()																				const	{ return _labels; }
-			bool					labelsMergeDuplicates();
+			void					labelsMergeDuplicateInto(Label * label);
 			bool					labelsRemoveOrphans();
 			Labelset				labelsByDisplay(		const std::string	&	display)								const; ///< Might be nullptr for missing label
 			Labelset				labelsByValue(			const std::string	&	value)									const; ///< 
-			int						labelIndex(				const Label			*	label)									const;
+			int						labelIndexNonEmpty(		Label				*	label)									const;
 			Label				*	labelByRow(				int						row)									const; ///< 
 			Label				*	labelByValue(			const std::string	&	value)									const; ///< Might be nullptr for missing label, returns the first of labelsByValue
 			Label				*	labelByIntsId(			int						intsId)									const; ///< Might be nullptr for missing label
 			Label				*	labelByDisplay(			const std::string	&	display)								const; ///< Might be nullptr for missing label, returns the first of labelsByDisplay
-			Label				*	labelByIndexNotEmpty(	size_t					index)									const;
+			Label				*	labelByIndexNotEmpty(	int						index)									const;
 			Label				*	labelByValueAndDisplay(	const std::string	&	value, const std::string &	label)		const; ///< Might be nullptr for missing label, assumes you ran labelsMergeDuplicates before
 			void					labelsHandleAutoSort(	bool					doDbUpdateEtc = true);
 			size_t					labelCountNotEmpty()																	const;
@@ -270,7 +270,9 @@ private:
 			doublevec				_dbls;
 			intvec					_ints;
 			stringset				_dependsOnColumns;
-			std::map<int, Label*>	_labelByIntsIdMap;
+			std::map<int, Label*>	_labelByIntsIdMap,
+									_labelByNonEmptyIndex;
+			std::map<Label*, int>	_labelNonEmptyIndexByLabel;
 			LabelByStrStr			_labelByValDis;
 			int						_batchedLabelDepth	= 0;
 	static	bool					_autoSortByValuesByDefault;

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -41,6 +41,8 @@ class Analysis;
 class Column : public DataSetBaseNode
 {
 public:
+	typedef std::map<std::pair<std::string, std::string>, Label*>	LabelByStrStr;
+
 									Column(DataSet * data, int id = -1);
 									~Column();
 									
@@ -149,9 +151,9 @@ public:
             Label				* 	replaceDoublesTillLabelsRowWithLabels(size_t row);
 			bool					replaceDoubleLabelFromRowWithDouble(size_t row, double dbl); ///< Returns true if succes
 
-			void					labelValueChanged(Label * label, double aDouble); ///< Pass NaN for non-convertible values
-			void					labelValueChanged(Label * label, int	anInteger) { labelValueChanged(label, double(anInteger)); }
-			void					labelDisplayChanged(Label * label);
+			void					labelValueChanged(Label * label,	double aDouble,	const Json::Value & previousOriginal); ///< Pass NaN for non-convertible values
+			void					labelValueChanged(Label * label,	int	anInteger,	const Json::Value & previousOriginal) { labelValueChanged(label, double(anInteger), previousOriginal); }
+			void					labelDisplayChanged(Label * label,	const std::string & previousDisplay);
 			
 			bool					setStringValue(				size_t row, const std::string & value, const std::string & label = "", bool writeToDB = true); ///< Does two things, if label=="" it will handle user input, as value or label depending on columnType. Otherwise it will simply try to use userEntered as a value. But this will trigger the setting of type
 			bool					setValue(					size_t row, const std::string & value, const std::string & label,	bool writeToDB = true);
@@ -249,7 +251,8 @@ private:
 			int						_id					= -1,
 									_analysisId			= -1,	// Actually initialized in DatabaseInterface::columnInsert
 									_labelsTempRevision	= -1,	///< When were the "temporary labels" created?
-									_labelsTempNumerics = 0;	///< Use the labelsTemp step to calculate the amount of numeric labels
+									_labelsTempNumerics = 0,	///< Use the labelsTemp step to calculate the amount of numeric labels
+									_highestIntsId		= -1;
 			qsizetype				_labelsTempMaxWidth = 0;
 			stringvec				_labelsTemp;				///< Contains displaystring for labels. Used to allow people to edit "double" labels. Initialized when necessary
 			doublevec				_labelsTempDbls;
@@ -268,6 +271,7 @@ private:
 			intvec					_ints;
 			stringset				_dependsOnColumns;
 			std::map<int, Label*>	_labelByIntsIdMap;
+			LabelByStrStr			_labelByValDis;
 			int						_batchedLabelDepth	= 0;
 	static	bool					_autoSortByValuesByDefault;
 			

--- a/CommonData/label.h
+++ b/CommonData/label.h
@@ -45,7 +45,10 @@ public:
 			int					order()						const	{ return _order;			}
 			bool				filterAllows()				const	{ return _filterAllows;		}
 	const	Json::Value		&	originalValue()				const	{ return _originalValue;	}
+	std::pair<std::string
+		,std::string>			origValDisplay()			const	{ return std::make_pair(originalValueAsString(), labelDisplay()); }
 
+	static	std::string			originalValueAsString(const Column * column, const Json::Value & originalValue, bool fancyEmptyValue = false);
 			std::string			originalValueAsString(bool fancyEmptyValue = false)		const;
 			std::string			str() const;
 			
@@ -77,7 +80,7 @@ private:
 	bool			_filterAllows	= true;	///< Used in generating filters for when users disable and enable certain labels/levels
 };
 
-typedef std::vector<Label*> Labels;
-typedef std::set<Label*>	Labelset;
+typedef std::vector<Label*>				Labels;
+typedef std::set<Label*>				Labelset;
 
 #endif // LABEL_H

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -296,7 +296,7 @@ QModelIndex DataSetPackage::indexForSubNode(DataSetBaseNode * node) const
 		{
 			Label	* lab = dynamic_cast<Label*>( node);
 			Column	* col = lab ? dynamic_cast<Column*>(node->parent()) : nullptr;
-			int		i = col ? col->labelIndex(lab) : -1;
+			int		i = col ? col->labelIndexNonEmpty(lab) : -1;
 
 			return createIndex(i, 0, dynamic_cast<void*>(lab));
 		}


### PR DESCRIPTION
Instead a map is used to know what labels have what original value and display text, as they are uniquely defined by this. Before was naively looping through the labels to check and merge them in a preceding step. Same goes for intsId, it is simply tracked now instead of found by looping.

Both loops are now lookups at the cost of a little maintenance.

Fixes https://github.com/jasp-stats/jasp-issues/issues/2910 (extremely slow loading of semibig text file)

Basically now any LLL (label lookup loop) I could see in Column has been replaced by a map, which makes the linked file in the issue actually usable. 
As far as I can see the data is still read correctly.

