### PR TITLE
columnTypes & columnNames properties should be available for control with models

### DIFF
--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -148,6 +148,8 @@ std::vector<std::string> ComboBoxBase::usedVariables() const
 
 void ComboBoxBase::termsChangedHandler()
 {
+	JASPListControl::termsChangedHandler();
+
 	std::vector<std::string> values = _model->getValues();
 	int index = -1;
 

--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -204,6 +204,8 @@ bool ComponentsListBase::isJsonValid(const Json::Value &value) const
 
 void ComponentsListBase::termsChangedHandler()
 {
+	JASPListControl::termsChangedHandler();
+
 	_setTableValue(_termsModel->terms(), _termsModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions());
 	bindOffsets();
 	emit controlNameXOffsetMapChanged();

--- a/QMLComponents/controls/factorlevellistbase.cpp
+++ b/QMLComponents/controls/factorlevellistbase.cpp
@@ -117,6 +117,8 @@ bool FactorLevelListBase::isJsonValid(const Json::Value &value) const
 
 void FactorLevelListBase::termsChangedHandler()
 {
+	JASPListControl::termsChangedHandler();
+
 	Json::Value boundValue(Json::arrayValue);
 	const vector<pair<string, vector<string> > > &factors = _factorLevelsModel->getFactors();
 	

--- a/QMLComponents/controls/factorsformbase.cpp
+++ b/QMLComponents/controls/factorsformbase.cpp
@@ -134,6 +134,8 @@ void FactorsFormBase::termsChangedHandler()
 	// and during the initialization, the boundValues has to be set by the bindTo method anyway.
 	if (!initialized()) return;
 
+	JASPListControl::termsChangedHandler();
+
 	const ListModelFactorsForm::FactorVec &factors = _factorsModel->getFactors();
 	Json::Value boundValue(Json::arrayValue);
 	

--- a/QMLComponents/controls/inputlistbase.cpp
+++ b/QMLComponents/controls/inputlistbase.cpp
@@ -111,6 +111,8 @@ bool InputListBase::isJsonValid(const Json::Value &value) const
 
 void InputListBase::termsChangedHandler()
 {
+	JASPListControl::termsChangedHandler();
+
 	if (hasRowComponent())
 		_setTableValue(_inputModel->terms(), _inputModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions());
 	else

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -136,6 +136,12 @@ void JASPListControl::setContainsInteractions()
 	}
 }
 
+void JASPListControl::termsChangedHandler()
+{
+	setColumnsTypes(model()->termsTypes());
+	setColumnsNames(model()->terms().asQList());
+}
+
 void JASPListControl::_termsChangedHandler() 
 {
 	termsChangedHandler();

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -53,6 +53,8 @@ class JASPListControl : public JASPControl
 	Q_PROPERTY( QQmlComponent*	rowComponent					READ rowComponent						WRITE setRowComponent						NOTIFY rowComponentChanged			)
 	Q_PROPERTY( bool			addAvailableVariablesToAssigned	READ addAvailableVariablesToAssigned	WRITE setAddAvailableVariablesToAssigned	NOTIFY addAvailableVariablesToAssignedChanged )
 	Q_PROPERTY( bool			allowAnalysisOwnComputedColumns	READ allowAnalysisOwnComputedColumns	WRITE setAllowAnalysisOwnComputedColumns	NOTIFY allowAnalysisOwnComputedColumnsChanged )
+	Q_PROPERTY( QStringList		columnsTypes					READ columnsTypes																	NOTIFY columnsTypesChanged					)
+	Q_PROPERTY( QStringList		columnsNames					READ columnsNames																	NOTIFY columnsNamesChanged					)
 
 
 public:
@@ -99,6 +101,8 @@ public:
 			virtual bool			isTypeAllowed(columnType type)		const	{ return true;								}
 			virtual columnType		defaultType()						const	{ return columnType::unknown;				}
 			columnTypeVec			valueTypes()						const;
+	const	QStringList			&	columnsTypes()						const	{ return _columnsTypes;						}
+	const	QStringList			&	columnsNames()						const	{ return _columnsNames;						}
 
 signals:
 			void					modelChanged();
@@ -113,31 +117,36 @@ signals:
 			void					rowComponentChanged();
 			void					addAvailableVariablesToAssignedChanged();
 			void					allowAnalysisOwnComputedColumnsChanged();
+			void					columnsTypesChanged();
+			void					columnsNamesChanged();
 
 public slots:
 			void					setContainsVariables();
 			void					setContainsInteractions();
 
 protected slots:
-	virtual void					termsChangedHandler(){}; // This slot must be overriden in order to update the options when the model has changed
+	virtual void					termsChangedHandler();
 			void					_termsChangedHandler();
 			void					sourceChangedHandler();
 
 			void					setOptionKey(const QString& optionKey)	{ _optionKey = optionKey; }
 
-			GENERIC_SET_FUNCTION(Source,							_source,							sourceChanged,							QVariant		)
-			GENERIC_SET_FUNCTION(RSource,							_rSource,							sourceChanged,							QVariant		)
-			GENERIC_SET_FUNCTION(Values,							_values,							sourceChanged,							QVariant		)
-			GENERIC_SET_FUNCTION(AddEmptyValue,						_addEmptyValue,						addEmptyValueChanged,					bool			)
-			GENERIC_SET_FUNCTION(PlaceHolderText,					_placeHolderText,					placeHolderTextChanged,					QString			)
-			GENERIC_SET_FUNCTION(RowComponent,						_rowComponent,						rowComponentChanged,					QQmlComponent*	)
-			GENERIC_SET_FUNCTION(MaxRows,							_maxRows,							maxRows,								int				)
-			GENERIC_SET_FUNCTION(AddAvailableVariablesToAssigned,	_addAvailableVariablesToAssigned,	addAvailableVariablesToAssignedChanged,	bool			)
-			GENERIC_SET_FUNCTION(AllowAnalysisOwnComputedColumns,	_allowAnalysisOwnComputedColumns,	allowAnalysisOwnComputedColumnsChanged,	bool			)
-
 protected:
 	void					_setInitialized(const Json::Value& value = Json::nullValue)	override;
-			
+
+	GENERIC_SET_FUNCTION(Source,							_source,							sourceChanged,							QVariant		)
+	GENERIC_SET_FUNCTION(RSource,							_rSource,							sourceChanged,							QVariant		)
+	GENERIC_SET_FUNCTION(Values,							_values,							sourceChanged,							QVariant		)
+	GENERIC_SET_FUNCTION(AddEmptyValue,						_addEmptyValue,						addEmptyValueChanged,					bool			)
+	GENERIC_SET_FUNCTION(PlaceHolderText,					_placeHolderText,					placeHolderTextChanged,					QString			)
+	GENERIC_SET_FUNCTION(RowComponent,						_rowComponent,						rowComponentChanged,					QQmlComponent*	)
+	GENERIC_SET_FUNCTION(MaxRows,							_maxRows,							maxRows,								int				)
+	GENERIC_SET_FUNCTION(AddAvailableVariablesToAssigned,	_addAvailableVariablesToAssigned,	addAvailableVariablesToAssignedChanged,	bool			)
+	GENERIC_SET_FUNCTION(AllowAnalysisOwnComputedColumns,	_allowAnalysisOwnComputedColumns,	allowAnalysisOwnComputedColumnsChanged,	bool			)
+	GENERIC_SET_FUNCTION(ColumnsTypes,						_columnsTypes,						columnsTypesChanged,					QStringList		)
+	GENERIC_SET_FUNCTION(ColumnsNames,						_columnsNames,						columnsNamesChanged,					QStringList		)
+
+
 private:
 	void					_setupSources();
 	Terms					_getCombinedTerms(SourceItem* sourceToCombine);			
@@ -159,7 +168,8 @@ protected:
 	int						_maxRows							= -1;
 	QString					_placeHolderText					= tr("<no choice>");
 	QQmlComponent		*	_rowComponent						= nullptr;
-
+	QStringList				_columnsTypes,
+							_columnsNames;
 
 };
 

--- a/QMLComponents/controls/tableviewbase.cpp
+++ b/QMLComponents/controls/tableviewbase.cpp
@@ -195,6 +195,8 @@ void TableViewBase::refreshMe()
 
 void TableViewBase::termsChangedHandler()
 {
+	JASPListControl::termsChangedHandler();
+
 	if (_boundControl)
 		_boundControl->resetBoundValue();
 }

--- a/QMLComponents/controls/textareabase.cpp
+++ b/QMLComponents/controls/textareabase.cpp
@@ -106,6 +106,8 @@ void TextAreaBase::setText(const QString& text)
 
 void TextAreaBase::termsChangedHandler()
 {
+	JASPListControl::termsChangedHandler();
+
 	if ((_textType == TextType::TextTypeLavaan || _textType == TextType::TextTypeCSem) && form() && initialized())
 		form()->refreshAnalysis();
 }

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -328,8 +328,7 @@ void VariablesListBase::setVariableType(int index, int type)
 
 void VariablesListBase::termsChangedHandler()
 {
-	setColumnsTypes(model()->termsTypes());
-	setColumnsNames(model()->terms().asQList());
+	JASPListControl::termsChangedHandler();
 
 	bool noScaleAllowed = !_allowedTypesModel->hasType(columnType::scale);
 
@@ -389,7 +388,6 @@ void VariablesListBase::termsChangedHandler()
 	}
 
 	if (_boundControl)	_boundControl->resetBoundValue();
-	else JASPListControl::termsChangedHandler();
 }
 
 void VariablesListBase::_setAllowedVariables()

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -36,8 +36,6 @@ class VariablesListBase : public JASPListControl, public BoundControl
 	Q_PROPERTY( QStringList			suggestedColumns				READ allowedColumns					WRITE setAllowedColumns					NOTIFY allowedColumnsChanged				)
 	Q_PROPERTY( QStringList			allowedColumns					READ allowedColumns					WRITE setAllowedColumns					NOTIFY allowedColumnsChanged				)
 	Q_PROPERTY(	QStringList			allowedColumnsIcons				READ allowedColumnsIcons													NOTIFY allowedColumnsIconsChanged			)
-	Q_PROPERTY( QStringList			columnsTypes					READ columnsTypes															NOTIFY columnsTypesChanged					)
-	Q_PROPERTY( QStringList			columnsNames					READ columnsNames															NOTIFY columnsNamesChanged					)
 	Q_PROPERTY( QStringList			dropKeys						READ dropKeys						WRITE setDropKeys						NOTIFY dropKeysChanged						)
 	Q_PROPERTY( QString				interactionHighOrderCheckBox	READ interactionHighOrderCheckBox	WRITE setInteractionHighOrderCheckBox	NOTIFY interactionHighOrderCheckBoxChanged	)
 	Q_PROPERTY( QAbstractListModel* allowedTypesModel				READ allowedTypesModel														NOTIFY allowedTypesModelChanged				)
@@ -70,8 +68,6 @@ public:
 	int							columns()																				const				{ return _columns;									}
 	const QStringList		&	allowedColumns()																		const				{ return _allowedColumns;							}
 	QStringList					allowedColumnsIcons()																	const;
-	const QStringList		&	columnsTypes()																			const				{ return _columnsTypes;								}
-	const QStringList		&	columnsNames()																			const				{ return _columnsNames;								}
 	const QStringList		&	dropKeys()																				const				{ return _dropKeys;									}
 	const QString			&	interactionHighOrderCheckBox()															const				{ return _interactionHighOrderCheckBox;				}
 	bool						addRowControl(const QString& key, JASPControl* control)											override;
@@ -90,8 +86,6 @@ signals:
 	void columnsChanged();
 	void allowedColumnsChanged();
 	void allowedColumnsIconsChanged();
-	void columnsTypesChanged();
-	void columnsNamesChanged();
 	void dropKeysChanged();
 	void interactionHighOrderCheckBoxChanged();
 	void allowedTypesModelChanged();
@@ -115,8 +109,6 @@ protected:
 	GENERIC_SET_FUNCTION(ListViewType,					_listViewType,					listViewTypeChanged,					ListViewType	)
 	GENERIC_SET_FUNCTION(Columns,						_columns,						columnsChanged,							int				)
 	GENERIC_SET_FUNCTION(AllowedColumns,				_allowedColumns,				allowedColumnsChanged,					QStringList		)
-	GENERIC_SET_FUNCTION(ColumnsTypes,					_columnsTypes,					columnsTypesChanged,					QStringList		)
-	GENERIC_SET_FUNCTION(ColumnsNames,					_columnsNames,					columnsNamesChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(InteractionHighOrderCheckBox,	_interactionHighOrderCheckBox,	interactionHighOrderCheckBoxChanged,	QString			)
 	GENERIC_SET_FUNCTION(MinLevels,						_minLevels,						minLevelsChanged,						int				)
 	GENERIC_SET_FUNCTION(MaxLevels,						_maxLevels,						maxLevelsChanged,						int				)
@@ -150,8 +142,6 @@ private:
 
 	bool						_allowTypeChange =		false;
 	QStringList					_allowedColumns,
-								_columnsTypes,
-								_columnsNames,
 								_dropKeys;
 	QString						_interactionHighOrderCheckBox;
 


### PR DESCRIPTION
This helps to solve https://github.com/jasp-stats/jasp-issues/issues/2739 for CFA.



