### PR TITLE
bugfix: translate factor names make lavaan syntax parser fail

### DIFF
--- a/QMLComponents/controls/factorsformbase.h
+++ b/QMLComponents/controls/factorsformbase.h
@@ -86,7 +86,7 @@ private:
 	int						_initNumberFactors			= 1,
 							_startIndex					= 1;
 	QString					_availableVariablesListName,
-							_baseName					= tr("Factor"),
+							_baseName					= "Factor",   // dont translate it, see: https://github.com/jasp-stats/jasp-issues/issues/2947
 							_baseTitle					= tr("Factor");
 	bool					_nested						= false,
 							_allowInteraction			= false;


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/jasp-issues/issues/2947

The lavaan doesn't support unicode variable names but we pass the Unicode character through the `tr()` translations. At the same time, I think maybe it is unreasonable to translate the "variable/factor name" itself? because we have a title/label to show the translation in the results.