### PR TITLE
add an "upgrade" that resets the analysis to defaults

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -99,6 +99,12 @@ Analysis* Analyses::createFromJaspFileEntry(Json::Value analysisData, RibbonMode
 		
 		analysisEntry		= Modules::DynamicModules::dynMods()->retrieveCorrespondingAnalysisEntry(analysisData["dynamicModule"]);
 		analysis			= create(analysisData, analysisEntry, id, status, false, title, analysisData["dynamicModule"]["moduleVersion"].asString(), &optionsJson);
+		
+		if(msgs.count(Modules::analysisLog))
+		{
+			QStringList msgAna = tq(msgs[Modules::analysisLog]);
+			analysis->setErrorInResults(fq(msgAna.join("\n")));
+		}
 	}
 
 	if(wasUpgraded)

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -20,23 +20,18 @@
 
 #include <boost/uuid/uuid.hpp>
 
-#include "common.h"
-#include "version.h"
-
 #include "enginedefinitions.h"
-#include "controls/jaspcontrol.h"
 
 #include <set>
 #include "analysisbase.h"
-#include "modules/dynamicmodules.h"
-#include "data/datasetpackage.h"
 #include "utilities/qutils.h"
-#include "modules/upgrader/upgradechange.h"
+#include "modules/dynamicmodules.h"
 #include <QFileSystemWatcher>
 #include <QQuickItem>
 
 class Column;
 class AnalysisForm;
+
 
 ///
 /// A single instantiated analysis, aka it was clicked by the user and now has a qml-form loaded and some (rudimentary) output in the results or is on its way there.

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -18,15 +18,14 @@
 
 
 
-#include "dynamicmodules.h"
-#include "utilities/extractarchive.h"
-#include "utilities/settings.h"
-#include "utilities/messageforwarder.h"
-#include "utilities/appdirs.h"
-#include "utilities/qutils.h"
 #include "log.h"
-#include "modules/description/description.h"
-#include "modules/description/entrybase.h"
+#include "dynamicmodules.h"
+#include "utilities/qutils.h"
+#include <QRegularExpression>
+#include "utilities/appdirs.h"
+#include "utilities/settings.h"
+#include "utilities/extractarchive.h"
+#include "utilities/messageforwarder.h"
 #include "modules/upgrader/upgrades.h"
 #include "modules/upgrader/upgrade.h"
 #include "modules/upgrader/changejs.h"
@@ -34,9 +33,9 @@
 #include "modules/upgrader/changeremove.h"
 #include "modules/upgrader/changerename.h"
 #include "modules/upgrader/changesetvalue.h"
-#include "gui/preferencesmodel.h"
-#include "dirs.h"
-#include <QRegularExpression>
+#include "modules/upgrader/changeincompatible.h"
+#include "modules/description/description.h"
+#include "modules/description/entrybase.h"
 
 namespace Modules
 {
@@ -883,6 +882,7 @@ void DynamicModules::registerQMLTypes()
 	qmlRegisterType<Modules::ChangeCopy>						("JASP.Module", 1, 0, "ChangeCopy"						);
 	qmlRegisterType<Modules::ChangeRename>						("JASP.Module", 1, 0, "ChangeRename"					);
 	qmlRegisterType<Modules::ChangeRemove>						("JASP.Module", 1, 0, "ChangeRemove"					);
+	qmlRegisterType<Modules::ChangeIncompatible>				("JASP.Module", 1, 0, "ChangeIncompatible"				);
 	qmlRegisterType<Modules::ChangeSetValue>					("JASP.Module", 1, 0, "ChangeSetValue"					);
 	qmlRegisterUncreatableType<Modules::EntryBase>				("JASP.Module", 1, 0, "EntryBase",						"Superclass for menu entries, shouldn't be instantiated manually");
 	qmlRegisterUncreatableType<Modules::DynamicModule>			("JASP.Module", 1, 0, "DynamicModule",					"Can only be instantiated by JASP");

--- a/Desktop/modules/upgrader/changebase.h
+++ b/Desktop/modules/upgrader/changebase.h
@@ -27,7 +27,7 @@ public:
 	~ChangeBase();
 
 	virtual QString			toString() const = 0;
-	virtual void			 applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const = 0;
+	virtual void			applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const = 0;
 			bool			conditionSatisfied(const Json::Value & options) const;
 	
 			QJSValue		condition() const	{ return _condition;	}

--- a/Desktop/modules/upgrader/changecopy.cpp
+++ b/Desktop/modules/upgrader/changecopy.cpp
@@ -10,7 +10,7 @@ ChangeCopy::ChangeCopy()
 
 }
 
-void ChangeCopy::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
+void ChangeCopy::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const
 {
 	//It is ok to overwrite whatever is in newName? Because it is a sort of "set value"
 

--- a/Desktop/modules/upgrader/changecopy.h
+++ b/Desktop/modules/upgrader/changecopy.h
@@ -17,7 +17,7 @@ class ChangeCopy : public ChangeBase
 public:
 	ChangeCopy();
 
-	void	applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const override;
+	void	applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const override;
 	
 	QString	toString()	const override	{ return _toString() + " copying option from '" + from() + "' to '" + to() + "'"; };
 	QString from()		const			{ return _from;	}

--- a/Desktop/modules/upgrader/changeincompatible.cpp
+++ b/Desktop/modules/upgrader/changeincompatible.cpp
@@ -1,0 +1,19 @@
+#include "changeincompatible.h"
+
+namespace Modules
+{
+
+ChangeIncompatible::ChangeIncompatible() 
+{
+	
+}
+
+void ChangeIncompatible::applyUpgrade(Json::Value &options, UpgradeMsgs &msgs, bool inMeta) const
+{
+	options = Json::objectValue;	
+	
+	if(!inMeta)
+		msgs[analysisLog].push_back(prefixLog + "Reset analysis because of '" + (msg().isEmpty() ? "???" : msg()).toStdString() + "'");
+}
+
+}

--- a/Desktop/modules/upgrader/changeincompatible.cpp
+++ b/Desktop/modules/upgrader/changeincompatible.cpp
@@ -13,7 +13,7 @@ void ChangeIncompatible::applyUpgrade(Json::Value &options, UpgradeMsgs &msgs, b
 	options = Json::objectValue;	
 	
 	if(!inMeta)
-		msgs[analysisLog].push_back(prefixLog + "Reset analysis because of '" + (msg().isEmpty() ? "???" : msg()).toStdString() + "'");
+		msgs[analysisLog].push_back(prefixLog + tr("Reset analysis because of '%1'").arg(msg().isEmpty() ? "???" : msg()).toStdString());
 }
 
 }

--- a/Desktop/modules/upgrader/changeincompatible.h
+++ b/Desktop/modules/upgrader/changeincompatible.h
@@ -1,0 +1,25 @@
+#ifndef CHANGEINCOMPATIBLE_H
+#define CHANGEINCOMPATIBLE_H
+
+#include "changebase.h"
+
+
+namespace Modules
+{
+
+/// Removes all options and adds a message that from version * onwards it was reset.
+class ChangeIncompatible : public ChangeBase
+{
+	Q_OBJECT
+public:
+	ChangeIncompatible();
+	
+	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const override;
+	
+	QString	toString()	const override	{ return _toString() + " removing all options, because '" + msg() + "'"; };
+};
+
+
+}
+
+#endif // CHANGEINCOMPATIBLE_H

--- a/Desktop/modules/upgrader/changejs.cpp
+++ b/Desktop/modules/upgrader/changejs.cpp
@@ -10,7 +10,7 @@ ChangeJS::ChangeJS()
 
 }
 
-void ChangeJS::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
+void ChangeJS::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const
 {
 	const std::string name = fq(_name);
 

--- a/Desktop/modules/upgrader/changejs.h
+++ b/Desktop/modules/upgrader/changejs.h
@@ -20,7 +20,7 @@ class ChangeJS : public ChangeBase
 public:
 	ChangeJS();
 
-	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const override;
+	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const override;
 
 	QString		toString()		const override	{ return _toString() + " running javascript function for option '" + name() + "', function: '" + jsFunction().toString() + "'"; };
 	QString		name()			const			{ return _name;		}

--- a/Desktop/modules/upgrader/changeremove.cpp
+++ b/Desktop/modules/upgrader/changeremove.cpp
@@ -9,7 +9,7 @@ ChangeRemove::ChangeRemove()
 
 }
 
-void ChangeRemove::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
+void ChangeRemove::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const
 {
 	const std::string name = fq(_name);
 

--- a/Desktop/modules/upgrader/changeremove.h
+++ b/Desktop/modules/upgrader/changeremove.h
@@ -17,7 +17,7 @@ class ChangeRemove : public ChangeBase
 public:
 	ChangeRemove();
 
-	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const override;
+	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const override;
 
 	QString	name()		const			{ return _name; }
 	QString	toString()	const override	{ return _toString() + " removing option '" + name() + "'"; };

--- a/Desktop/modules/upgrader/changerename.cpp
+++ b/Desktop/modules/upgrader/changerename.cpp
@@ -10,7 +10,7 @@ ChangeRename::ChangeRename()
 
 }
 
-void ChangeRename::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
+void ChangeRename::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const
 {
 	const std::string	oldName = fq(_from),
 						newName = fq(_to);

--- a/Desktop/modules/upgrader/changerename.h
+++ b/Desktop/modules/upgrader/changerename.h
@@ -17,7 +17,7 @@ class ChangeRename : public ChangeBase
 public:
 	ChangeRename();
 
-	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const override;
+	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const override;
 
 	QString from()	const { return _from;	}
 	QString to()	const { return _to;		}

--- a/Desktop/modules/upgrader/changesetvalue.cpp
+++ b/Desktop/modules/upgrader/changesetvalue.cpp
@@ -10,7 +10,7 @@ ChangeSetValue::ChangeSetValue()
 
 }
 
-void ChangeSetValue::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const
+void ChangeSetValue::applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const
 {
 	const std::string name = fq(_name);
 

--- a/Desktop/modules/upgrader/changesetvalue.h
+++ b/Desktop/modules/upgrader/changesetvalue.h
@@ -20,7 +20,7 @@ class ChangeSetValue : public ChangeBase
 public:
 	ChangeSetValue();
 
-	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs) const override;
+	void applyUpgrade(Json::Value & options, UpgradeMsgs & msgs, bool inMeta) const override;
 
 	QString		toString()	const override;
 	QString		name()		const { return _name;		}

--- a/Desktop/modules/upgrader/upgrade.cpp
+++ b/Desktop/modules/upgrader/upgrade.cpp
@@ -43,11 +43,11 @@ void Upgrade::applyUpgrade(const std::string & function, const Version & version
 			if(change->conditionSatisfied(analysesJson["options"]))
 			{
 				Log::log(false) << "it is and applying the change!" << std::endl;
-				change->applyUpgrade(analysesJson["options"], msgs);
+				change->applyUpgrade(analysesJson["options"], msgs, false);
 				
 				try //Also try it on .meta
 				{
-					change->applyUpgrade(analysesJson["options"][".meta"], msgs);
+					change->applyUpgrade(analysesJson["options"][".meta"], msgs, true);
 				}
 				catch(upgradeError & e)
 				{

--- a/Desktop/modules/upgrader/upgradeDefinitions.cpp
+++ b/Desktop/modules/upgrader/upgradeDefinitions.cpp
@@ -5,6 +5,7 @@ namespace Modules
 
 const std::string		prefixLog	= "\t\t";
 const char			*	logId		= "!log!"; //To add general logging to UpgradeMsgs as opposed to for a specific option
+const char			*	analysisLog	= "!analysis!"; //On the level of an analysis
 
 const char * upgradeError::what() const noexcept
 {

--- a/Desktop/modules/upgrader/upgradeDefinitions.h
+++ b/Desktop/modules/upgrader/upgradeDefinitions.h
@@ -15,6 +15,8 @@ typedef std::map<std::string, std::vector<std::string>> UpgradeMsgs; //option na
 
 extern const std::string		prefixLog;
 extern const char			*	logId;
+extern const char			*	analysisLog;
+
 
 struct upgradeError  : public std::runtime_error
 {

--- a/Desktop/modules/upgrader/upgrader.cpp
+++ b/Desktop/modules/upgrader/upgrader.cpp
@@ -97,6 +97,8 @@ bool Upgrader::upgradeAnalysisData(Json::Value & analysis, UpgradeMsgs & msgs) c
 	try
 	{
 		_upgradeOptionsFromJaspFile(analysis, msgs, stepsTaken);
+		
+		
 
 #ifdef JASP_DEBUG
 		Log::log() << "Options are now: " << analysis["options"].toStyledString() << std::endl;

--- a/Desktop/results/resultsjsinterface.cpp
+++ b/Desktop/results/resultsjsinterface.cpp
@@ -26,10 +26,9 @@
 
 #include "utilities/qutils.h"
 #include "gui/aboutmodel.h"
-#include "appinfo.h"
 #include "tempfiles.h"
+#include "data/datasetpackage.h"
 #include <functional>
-#include "timers.h"
 #include "utilities/settings.h"
 #include <QMimeData>
 #include <QAction>


### PR DESCRIPTION
add an "upgrade" that resets the analysis to defaults

Implements https://github.com/jasp-stats/INTERNAL-jasp/issues/2660

Show an error in Analysis after loading.
There is a testcase in testModule

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/142e9ab7-4ce4-4d75-98b1-f612954cfa4c">
