### PR TITLE
Switching column in Variable Window should not generate any action

### DIFF
--- a/Desktop/components/JASP/Widgets/ColumnBasicInfo.qml
+++ b/Desktop/components/JASP/Widgets/ColumnBasicInfo.qml
@@ -108,11 +108,10 @@ Item
 			values:				columnModel.computedTypeValues
 			currentValue:		columnModel.computedType
 			onValueChanged:		columnModel.computedType = currentValue
-			visible:			columnModel.computedTypeEditable
 			controlMinWidth:	200 * jaspTheme.uiScale
 
 			controlLabel.width:	leftColumn.labelWidth
-			enabled:			!columnModel.isVirtual
+			enabled:			!columnModel.isVirtual && columnModel.computedTypeEditable
 		}
 
 		Item

--- a/Desktop/data/columnmodel.h
+++ b/Desktop/data/columnmodel.h
@@ -175,7 +175,8 @@ private:
 	bool					_visible			= false,
 							_editing			= false,
 							_virtual			= false,
-							_compactMode		= false;
+							_compactMode		= false,
+							_beingRefreshed		= false;
 	int						_currentColIndex	= -1;
 	double					_valueMaxWidth		= 10,
 							_labelMaxWidth		= 10,


### PR DESCRIPTION
In the VariableWindow, if you switch from a column added by an analysis, to a computed column, then this computed column becomes a not computed column.
This problem is due to the fact that, when the user switch from column to column, the ColumnModel is refreshed and all the signal are emitted to update the values in the VariableWindow. As the Computed Type is a dropdown, the possible values of the dropdown are also updated:

- A computed or not computed column has 3 values: 'Not computed', 'Computed with R Code' and 'Computed with drag & drop'
- A computed Column generated by an analysis has only 1 value: 'Column generated by analysis' (and it is disabled)
- A column added by a analysis has 4 values: 'Column added by analysis', 'Not computed', 'Computed with R Code' and 'Computed with drag & drop'

So when the user switch from a Column added by analysis to a computed column, the value of the dropdown does not exist, and the dropdown is set to a default value, that is a 'Not computed'. This leads to an action to change the column computed type. 
When the refresh emits the signal to update the real value of the DropDown, the column has got already its new type, so it will not be changed.

This problem is due to the fact that when the chosen column is changed in the VariableWindow. this may lead to an action that updates the current column: this should be anyway forbidden. That's why a beingRefreshed boolean is added to forbid any action in the ColumnModel when beingRefreshed is true.

Also I found awkward that when a column is a computed column generated by analysis, the Computed type is made invisible: it's nicer to have it visible and disabled.