### PR TITLE
bugfix: fix cell content imported from .ods files

### DIFF
--- a/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
+++ b/Desktop/data/importers/ods/odsxmlcontentshandler.cpp
@@ -275,7 +275,7 @@ bool ODSXmlContentsHandler::characters(const QString &ch)
 			switch(_docDepth)
 			{
 			case text:
-				if(_currentCell != ch)
+				if(_currentCell.isEmpty()) 	// see: https://github.com/jasp-stats/jasp-issues/issues/2963 and https://github.com/jasp-stats/jasp-issues/issues/2789
 					_currentCell.push_back(ch);
 				break;
 			


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/jasp-issues/issues/2963 
Fix: https://github.com/jasp-stats/jasp-issues/issues/2789

```xml
<table:table-row table:style-name="ro1">
        <table:table-cell table:style-name="ce1" office:value-type="float" office:value="0.2" calcext:value-type="float">
                 <text:p>0,2</text:p>
        </table:table-cell>
</table:table-row>
```

I'm not entirely sure about this behavior, but it seems shoud just get depth of `<table:table-cell>` but not concatenating strings `<text:p>`  unless it's empty?