### PR TITLE
DropDown should also be able to set the column type

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolbase.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolbase.cpp
@@ -218,3 +218,8 @@ void BoundControlBase::_setTableValue(const Terms& terms, const ListModel::RowCo
 	setBoundValue(_getTableValueOption(terms, componentValuesMap, key, hasMultipleTerms));
 }
 
+bool BoundControlBase::_isValueWithTypes(const Json::Value &value) const
+{
+	return value.isObject() && value.isMember("types") && value.isMember("value");
+}
+

--- a/QMLComponents/boundcontrols/boundcontrolbase.h
+++ b/QMLComponents/boundcontrols/boundcontrolbase.h
@@ -53,6 +53,7 @@ protected:
 	void						_setTableValue(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasMultipleTerms);
 
 	void						_readTableValue(const Json::Value& value, const std::string& key, bool hasMultipleTerms, Terms& terms, ListModel::RowControlsValues& allControlValues);
+	bool						_isValueWithTypes(const Json::Value &value)					const;
 
 	JASPControl*				_control			= nullptr;
 	bool						_isComputedColumn	= false,

--- a/QMLComponents/boundcontrols/boundcontrolterms.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolterms.cpp
@@ -287,7 +287,7 @@ bool BoundControlTerms::isJsonValid(const Json::Value &optionValue) const
 		}
 	}
 
-	return valid && typesPart.isArray() || typesPart.isString();
+	return valid && (typesPart.isArray() || typesPart.isString());
 }
 
 void BoundControlTerms::resetBoundValue()
@@ -322,11 +322,6 @@ Json::Value BoundControlTerms::_getTypes() const
 	return jsonTypes;
 }
 
-bool BoundControlTerms::_isValueWithTypes(const Json::Value &value) const
-{
-	return value.isObject() && value.isMember("types") && value.isMember("value");
-}
-
 void BoundControlTerms::setBoundValue(const Json::Value &value, bool emitChanges)
 {
 	Json::Value newValue;
@@ -341,15 +336,6 @@ void BoundControlTerms::setBoundValue(const Json::Value &value, bool emitChanges
 	}
 
 	BoundControlBase::setBoundValue(newValue.isNull() ? value : newValue, emitChanges);
-}
-
-Json::Value BoundControlTerms::createMeta() const
-{
-	Json::Value meta(BoundControlBase::createMeta());
-	if (_control->encodeValue())
-		meta["hasTypes"] = true;
-
-	return meta;
 }
 
 Json::Value BoundControlTerms::addTermsToOption(const Json::Value &option, const Terms &terms, const ListModel::RowControlsValues &extraTermsMap) const

--- a/QMLComponents/boundcontrols/boundcontrolterms.h
+++ b/QMLComponents/boundcontrols/boundcontrolterms.h
@@ -33,7 +33,6 @@ public:
 	void		bindTo(const Json::Value &value)													override;
 	void		resetBoundValue()																	override;
 	void		setBoundValue(const Json::Value &value, bool emitChanges = true)					override;
-	Json::Value	createMeta()																const	override;
 
 	Json::Value	addTermsToOption(const Json::Value &option, const Terms &terms, const ListModel::RowControlsValues &extraTermsMap = {}) const;
 	bool		areTermsInOption(const Json::Value& option,	Terms& terms)					const;
@@ -43,7 +42,6 @@ private:
 	Json::Value	_adjustBindingValue(const Json::Value &value)								const;
 	Json::Value	_adjustBindingType(const Json::Value &value)								const;
 	Json::Value _getTypes()																	const;
-	bool		_isValueWithTypes(const Json::Value &value)									const;
 
 	ListModelAssignedInterface*		_termsModel				= nullptr;
 	JASPListControl*				_listView				= nullptr;

--- a/QMLComponents/components/JASP/Controls/AllowedTypeIcons.qml
+++ b/QMLComponents/components/JASP/Controls/AllowedTypeIcons.qml
@@ -1,0 +1,25 @@
+import QtQuick
+
+Row
+{
+	property var iconModel
+	property int count: allowedColumnsId.count
+
+	spacing: jaspTheme.contentMargin
+
+	Repeater
+	{
+		id:		allowedColumnsId
+		model:	iconModel
+
+		Image
+		{
+			source:		modelData
+			height:		16 * preferencesModel.uiScale
+			width:		16 * preferencesModel.uiScale
+			z:			2
+			mipmap:		true
+			smooth:		true
+		}
+	}
+}

--- a/QMLComponents/components/JASP/Controls/ComboBox.qml
+++ b/QMLComponents/components/JASP/Controls/ComboBox.qml
@@ -62,7 +62,7 @@ ComboBoxBase
 	{
 		control.maxTextWidth = maxTextWidth
 		// The real field width is composed by the type icon (if displayed) + 2-padding + max width + 5-padding + dropdownIcon width + 2-padding
-		var newFieldWidth = (comboBox.showVariableTypeIcon ? contentIcon.x + contentIcon.width : 0) + maxTextWidth + dropdownIcon.width + 9 * preferencesModel.uiScale
+		var newFieldWidth = (comboBox.showVariableTypeIcon ? contentIcon.x + contentIcon.width : 0) + (allowedTypeIcons.count > 0 ? allowedTypeIcons.width + jaspTheme.itemPadding : 0) + maxTextWidth + dropdownIcon.width + 9 * preferencesModel.uiScale
 		if (newFieldWidth < controlMinWidth)
 			newFieldWidth = controlMinWidth
 
@@ -152,6 +152,19 @@ ComboBoxBase
 
 				property double widthWhenContralHasFixedWidth: control.width - (x + dropdownIcon.width + 4 * preferencesModel.uiScale) // 4 = leftMargin + 2 padding right of dropdownIcon)
 
+			}
+
+			AllowedTypeIcons
+			{
+				id:			allowedTypeIcons
+				iconModel:	allowedColumnsIcons
+
+				anchors
+				{
+					bottomMargin:	jaspTheme.contentMargin
+					right:			parent.right
+					rightMargin:	jaspTheme.contentMargin
+				}
 			}
 		}
 

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -225,31 +225,16 @@ VariablesListBase
 		}
 	}
 
-	Row
+	AllowedTypeIcons
 	{
+		id:			allowedTypeIcons
+		iconModel:	allowedColumnsIcons
 		anchors
 		{
 			bottom:			itemRectangle.bottom;
 			bottomMargin:	jaspTheme.contentMargin
 			right:			itemRectangle.right
 			rightMargin:	jaspTheme.contentMargin + (scrollBar.visible ? scrollBar.width : 0)
-		}
-		spacing: jaspTheme.contentMargin
-
-		Repeater
-		{
-			id:		allowedColumnsId
-			model:	allowedColumnsIcons
-
-			Image
-			{
-				source:		modelData
-				height:		16 * preferencesModel.uiScale
-				width:		16 * preferencesModel.uiScale
-				z:			2
-				mipmap:		true
-				smooth:		true
-			}
 		}
 	}
 
@@ -421,7 +406,7 @@ VariablesListBase
 				property bool	draggable:				variablesList.draggable && model.selectable
 				property string	columnType:				isVariable && (typeof model.columnType !== "undefined") ? model.columnType : ""
 				property var	extraItem:				model.rowComponent
-				property bool	typeChangeable:			variablesList.allowTypeChange && (allowedColumnsId.count === 0 || allowedColumnsId.count > 1) && icon.visible
+				property bool	typeChangeable:			variablesList.allowTypeChange && (allowedTypeIcons.count === 0 || allowedTypeIcons.count > 1) && icon.visible
 
 				enabled: !variablesList.draggable || model.selectable
 

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -29,13 +29,13 @@ class ComboBoxBase : public JASPListControl, public BoundControlBase
 {
 	Q_OBJECT
 
-	Q_PROPERTY( int			currentIndex			READ currentIndex			WRITE setCurrentIndex		NOTIFY currentIndexChanged			)
-	Q_PROPERTY( QString		currentText				READ currentText			WRITE setCurrentText		NOTIFY currentTextChanged			)
-	Q_PROPERTY( QString		currentValue			READ currentValue			WRITE setCurrentValue		NOTIFY currentValueChanged			)
-	Q_PROPERTY( QString		startValue				READ startValue				WRITE setStartValue			NOTIFY startValueChanged			)
-	Q_PROPERTY( QString		currentColumnType		READ currentColumnType									NOTIFY currentColumnTypeChanged		)
-	Q_PROPERTY( QString		currentColumnTypeIcon	READ currentColumnTypeIcon								NOTIFY currentColumnTypeIconChanged	)
-	Q_PROPERTY( bool		fixedWidth				READ fixedWidth											NOTIFY fixedWidthChanged			)
+	Q_PROPERTY( int					currentIndex				READ currentIndex				WRITE setCurrentIndex		NOTIFY currentIndexChanged			)
+	Q_PROPERTY( QString				currentText					READ currentText				WRITE setCurrentText		NOTIFY currentTextChanged			)
+	Q_PROPERTY( QString				currentValue				READ currentValue				WRITE setCurrentValue		NOTIFY currentValueChanged			)
+	Q_PROPERTY( QString				startValue					READ startValue					WRITE setStartValue			NOTIFY startValueChanged			)
+	Q_PROPERTY( QString				currentColumnType			READ currentColumnType										NOTIFY currentColumnTypeChanged		)
+	Q_PROPERTY( QString				currentColumnTypeIcon		READ currentColumnTypeIcon									NOTIFY currentColumnTypeIconChanged	)
+	Q_PROPERTY( bool				fixedWidth					READ fixedWidth												NOTIFY fixedWidthChanged			)
 
 public:
 	ComboBoxBase(QQuickItem* parent = nullptr);
@@ -48,6 +48,7 @@ public:
 	void				setUpModel()										override;
 	QString				helpMD(int depth = 0)						const	override;
 	bool				hasInfo()									const	override;
+	void				setBoundValue(const Json::Value &value, bool emitChanges = true)	override;
 
 	const QString&		currentText()								const				{ return _currentText;			}
 	const QString&		currentValue()								const				{ return _currentValue;			}
@@ -58,6 +59,7 @@ public:
 	bool				fixedWidth()								const				{ return _fixedWidth;			}
 
 	std::vector<std::string> usedVariables()						const	override;
+	bool				encodeValue()								const	override	{ return containsVariables();	}
 
 
 signals:
@@ -94,6 +96,7 @@ protected:
 	void _resetItemWidth();
 	void _setCurrentProperties(int index, bool bindValue = true);
 	bool _hasOptionInfo()											const;
+	std::string _findType(std::string value)						const;
 
 };
 

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -33,28 +33,38 @@ class Options;
 class RowControls;
 class Terms;
 class SourceItem;
+class ColumnTypesModel;
 
 class JASPListControl : public JASPControl
 {
 	Q_OBJECT
 
-	Q_PROPERTY( ListModel*		model							READ model																			NOTIFY modelChanged					)
-	Q_PROPERTY( QVariant		source							READ source								WRITE setSource								NOTIFY sourceChanged				)
-	Q_PROPERTY( QVariant		rSource							READ rSource							WRITE setRSource							NOTIFY sourceChanged				)
-	Q_PROPERTY( QVariant		values							READ values								WRITE setValues								NOTIFY sourceChanged				)
-	Q_PROPERTY( int				count							READ count																			NOTIFY countChanged					)
-	Q_PROPERTY( int				maxRows							READ maxRows							WRITE setMaxRows							NOTIFY maxRowsChanged				)
-	Q_PROPERTY( QString			optionKey						READ optionKey							WRITE setOptionKey																)
-	Q_PROPERTY( bool			addEmptyValue					READ addEmptyValue						WRITE setAddEmptyValue						NOTIFY addEmptyValueChanged			)
-	Q_PROPERTY( QString			placeholderText					READ placeholderText					WRITE setPlaceHolderText					NOTIFY placeHolderTextChanged		)
-	Q_PROPERTY( bool			containsVariables				READ containsVariables																NOTIFY containsVariablesChanged		)
-	Q_PROPERTY( bool			containsInteractions			READ containsInteractions															NOTIFY containsInteractionsChanged	)
-	Q_PROPERTY( double			maxTermsWidth					READ maxTermsWidth																	NOTIFY maxTermsWidthChanged			)
-	Q_PROPERTY( QQmlComponent*	rowComponent					READ rowComponent						WRITE setRowComponent						NOTIFY rowComponentChanged			)
-	Q_PROPERTY( bool			addAvailableVariablesToAssigned	READ addAvailableVariablesToAssigned	WRITE setAddAvailableVariablesToAssigned	NOTIFY addAvailableVariablesToAssignedChanged )
-	Q_PROPERTY( bool			allowAnalysisOwnComputedColumns	READ allowAnalysisOwnComputedColumns	WRITE setAllowAnalysisOwnComputedColumns	NOTIFY allowAnalysisOwnComputedColumnsChanged )
-	Q_PROPERTY( QStringList		columnsTypes					READ columnsTypes																	NOTIFY columnsTypesChanged					)
-	Q_PROPERTY( QStringList		columnsNames					READ columnsNames																	NOTIFY columnsNamesChanged					)
+	Q_PROPERTY( ListModel*			model							READ model																			NOTIFY modelChanged					)
+	Q_PROPERTY( QVariant			source							READ source								WRITE setSource								NOTIFY sourceChanged				)
+	Q_PROPERTY( QVariant			rSource							READ rSource							WRITE setRSource							NOTIFY sourceChanged				)
+	Q_PROPERTY( QVariant			values							READ values								WRITE setValues								NOTIFY sourceChanged				)
+	Q_PROPERTY( int					count							READ count																			NOTIFY countChanged					)
+	Q_PROPERTY( int					maxRows							READ maxRows							WRITE setMaxRows							NOTIFY maxRowsChanged				)
+	Q_PROPERTY( QString				optionKey						READ optionKey							WRITE setOptionKey																)
+	Q_PROPERTY( bool				addEmptyValue					READ addEmptyValue						WRITE setAddEmptyValue						NOTIFY addEmptyValueChanged			)
+	Q_PROPERTY( QString				placeholderText					READ placeholderText					WRITE setPlaceHolderText					NOTIFY placeHolderTextChanged		)
+	Q_PROPERTY( bool				containsVariables				READ containsVariables																NOTIFY containsVariablesChanged		)
+	Q_PROPERTY( bool				containsInteractions			READ containsInteractions															NOTIFY containsInteractionsChanged	)
+	Q_PROPERTY( double				maxTermsWidth					READ maxTermsWidth																	NOTIFY maxTermsWidthChanged			)
+	Q_PROPERTY( QQmlComponent*		rowComponent					READ rowComponent						WRITE setRowComponent						NOTIFY rowComponentChanged			)
+	Q_PROPERTY( bool				addAvailableVariablesToAssigned	READ addAvailableVariablesToAssigned	WRITE setAddAvailableVariablesToAssigned	NOTIFY addAvailableVariablesToAssignedChanged )
+	Q_PROPERTY( bool				allowAnalysisOwnComputedColumns	READ allowAnalysisOwnComputedColumns	WRITE setAllowAnalysisOwnComputedColumns	NOTIFY allowAnalysisOwnComputedColumnsChanged )
+	Q_PROPERTY( QStringList			columnsTypes					READ columnsTypes																	NOTIFY columnsTypesChanged					)
+	Q_PROPERTY( QStringList			columnsNames					READ columnsNames																	NOTIFY columnsNamesChanged					)
+	Q_PROPERTY( QAbstractListModel* allowedTypesModel				READ allowedTypesModel																NOTIFY allowedTypesModelChanged		)
+	Q_PROPERTY( bool				allowTypeChange					READ allowTypeChange					WRITE setAllowTypeChange					NOTIFY allowTypeChangeChanged		)
+	Q_PROPERTY( int					minNumericLevels				READ minNumericLevels					WRITE setMinNumericLevels					NOTIFY minNumericLevelsChanged		)
+	Q_PROPERTY( int					maxNumericLevels				READ maxNumericLevels					WRITE setMaxNumericLevels					NOTIFY maxNumericLevelsChanged		)
+	Q_PROPERTY( int					minLevels						READ minLevels							WRITE setMinLevels							NOTIFY minLevelsChanged				)
+	Q_PROPERTY( int					maxLevels						READ maxLevels							WRITE setMaxLevels							NOTIFY maxLevelsChanged				)
+	Q_PROPERTY( QStringList			levels							READ levels																			NOTIFY levelsChanged				)
+	Q_PROPERTY( QStringList			allowedColumns					READ allowedColumns						WRITE setAllowedColumns						NOTIFY allowedColumnsChanged		)
+	Q_PROPERTY(	QStringList			allowedColumnsIcons				READ allowedColumnsIcons															NOTIFY allowedColumnsIconsChanged	)
 
 
 public:
@@ -98,11 +108,20 @@ public:
 	virtual stringvec				usedVariables()				const;
 			bool					addAvailableVariablesToAssigned()	const	{ return _addAvailableVariablesToAssigned;	}
 			bool					allowAnalysisOwnComputedColumns()	const	{ return _allowAnalysisOwnComputedColumns;	}
-			virtual bool			isTypeAllowed(columnType type)		const	{ return true;								}
-			virtual columnType		defaultType()						const	{ return columnType::unknown;				}
+			bool					isTypeAllowed(columnType type)		const;
+			columnType				defaultType()						const;
 			columnTypeVec			valueTypes()						const;
 	const	QStringList			&	columnsTypes()						const	{ return _columnsTypes;						}
 	const	QStringList			&	columnsNames()						const	{ return _columnsNames;						}
+	QAbstractListModel			*	allowedTypesModel();
+	bool							allowTypeChange()					const	{ return _allowTypeChange;		}
+	QStringList						levels()							const;
+	int								minLevels()							const	{ return _minLevels;			}
+	int								maxLevels()							const	{ return _maxLevels;			}
+	int								minNumericLevels()					const	{ return _minNumericLevels;		}
+	int								maxNumericLevels()					const	{ return _maxNumericLevels;		}
+	const QStringList			&	allowedColumns()					const	{ return _allowedColumns;		}
+	QStringList						allowedColumnsIcons()				const;
 
 signals:
 			void					modelChanged();
@@ -119,6 +138,15 @@ signals:
 			void					allowAnalysisOwnComputedColumnsChanged();
 			void					columnsTypesChanged();
 			void					columnsNamesChanged();
+			void					allowedTypesModelChanged();
+			void					allowTypeChangeChanged();
+			void					levelsChanged();
+			void					minLevelsChanged();
+			void					maxLevelsChanged();
+			void					minNumericLevelsChanged();
+			void					maxNumericLevelsChanged();
+			void					allowedColumnsChanged();
+			void					allowedColumnsIconsChanged();
 
 public slots:
 			void					setContainsVariables();
@@ -130,9 +158,11 @@ protected slots:
 			void					sourceChangedHandler();
 
 			void					setOptionKey(const QString& optionKey)	{ _optionKey = optionKey; }
+			void					checkLevelsConstraints();
 
 protected:
-	void					_setInitialized(const Json::Value& value = Json::nullValue)	override;
+	void							_setInitialized(const Json::Value& value = Json::nullValue)	override;
+	void							_setAllowedVariables();
 
 	GENERIC_SET_FUNCTION(Source,							_source,							sourceChanged,							QVariant		)
 	GENERIC_SET_FUNCTION(RSource,							_rSource,							sourceChanged,							QVariant		)
@@ -145,6 +175,12 @@ protected:
 	GENERIC_SET_FUNCTION(AllowAnalysisOwnComputedColumns,	_allowAnalysisOwnComputedColumns,	allowAnalysisOwnComputedColumnsChanged,	bool			)
 	GENERIC_SET_FUNCTION(ColumnsTypes,						_columnsTypes,						columnsTypesChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(ColumnsNames,						_columnsNames,						columnsNamesChanged,					QStringList		)
+	GENERIC_SET_FUNCTION(AllowTypeChange,					_allowTypeChange,					allowTypeChangeChanged,					bool			)
+	GENERIC_SET_FUNCTION(MinLevels,							_minLevels,							minLevelsChanged,						int				)
+	GENERIC_SET_FUNCTION(MaxLevels,							_maxLevels,							maxLevelsChanged,						int				)
+	GENERIC_SET_FUNCTION(MinNumericLevels,					_minNumericLevels,					minNumericLevelsChanged,				int				)
+	GENERIC_SET_FUNCTION(MaxNumericLevels,					_maxNumericLevels,					maxNumericLevelsChanged,				int				)
+	GENERIC_SET_FUNCTION(AllowedColumns,					_allowedColumns,					allowedColumnsChanged,					QStringList		)
 
 
 private:
@@ -163,13 +199,21 @@ protected:
 							_termsAreInteractions				= false,
 							_useSourceLevels					= false,
 							_addAvailableVariablesToAssigned	= false,
-							_allowAnalysisOwnComputedColumns	= true;
+							_allowAnalysisOwnComputedColumns	= true,
+							_allowTypeChange					= false;
 
-	int						_maxRows							= -1;
+	int						_maxRows							= -1,
+							_minNumericLevels					= -1,
+							_maxNumericLevels					= -1,
+							_minLevels							= -1,
+							_maxLevels							= -1;
+
 	QString					_placeHolderText					= tr("<no choice>");
 	QQmlComponent		*	_rowComponent						= nullptr;
 	QStringList				_columnsTypes,
-							_columnsNames;
+							_columnsNames,
+							_allowedColumns;
+	ColumnTypesModel	*	_allowedTypesModel					= nullptr;
 
 };
 

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -25,7 +25,6 @@
 
 class ListModelDraggable;
 class CheckBoxBase;
-class ColumnTypesModel;
 
 class VariablesListBase : public JASPListControl, public BoundControl
 {
@@ -33,18 +32,8 @@ class VariablesListBase : public JASPListControl, public BoundControl
 
 	Q_PROPERTY( ListViewType		listViewType					READ listViewType					WRITE setListViewType					NOTIFY listViewTypeChanged					)
 	Q_PROPERTY( int					columns							READ columns						WRITE setColumns						NOTIFY columnsChanged						)
-	Q_PROPERTY( QStringList			suggestedColumns				READ allowedColumns					WRITE setAllowedColumns					NOTIFY allowedColumnsChanged				)
-	Q_PROPERTY( QStringList			allowedColumns					READ allowedColumns					WRITE setAllowedColumns					NOTIFY allowedColumnsChanged				)
-	Q_PROPERTY(	QStringList			allowedColumnsIcons				READ allowedColumnsIcons													NOTIFY allowedColumnsIconsChanged			)
 	Q_PROPERTY( QStringList			dropKeys						READ dropKeys						WRITE setDropKeys						NOTIFY dropKeysChanged						)
-	Q_PROPERTY( QStringList			levels							READ levels																	NOTIFY levelsChanged						)
 	Q_PROPERTY( QString				interactionHighOrderCheckBox	READ interactionHighOrderCheckBox	WRITE setInteractionHighOrderCheckBox	NOTIFY interactionHighOrderCheckBoxChanged	)
-	Q_PROPERTY( QAbstractListModel* allowedTypesModel				READ allowedTypesModel														NOTIFY allowedTypesModelChanged				)
-	Q_PROPERTY( int					minNumericLevels				READ minNumericLevels				WRITE setMinNumericLevels				NOTIFY minNumericLevelsChanged				)
-	Q_PROPERTY( int					maxNumericLevels				READ maxNumericLevels				WRITE setMaxNumericLevels				NOTIFY maxNumericLevelsChanged				)
-	Q_PROPERTY( int					minLevels						READ minLevels						WRITE setMinLevels						NOTIFY minLevelsChanged						)
-	Q_PROPERTY( int					maxLevels						READ maxLevels						WRITE setMaxLevels						NOTIFY maxLevelsChanged						)
-	Q_PROPERTY( bool				allowTypeChange					READ allowTypeChange				WRITE setAllowTypeChange				NOTIFY allowTypeChangeChanged				)
 
 public:
 	VariablesListBase(QQuickItem* parent = nullptr);
@@ -67,36 +56,16 @@ public:
 	ListViewType				listViewType()																			const				{ return _listViewType;								}
 	BoundControl			*	boundControl()																					override	{ return _boundControl;								}
 	int							columns()																				const				{ return _columns;									}
-	const QStringList		&	allowedColumns()																		const				{ return _allowedColumns;							}
-	QStringList					allowedColumnsIcons()																	const;
 	const QStringList		&	dropKeys()																				const				{ return _dropKeys;									}
 	const QString			&	interactionHighOrderCheckBox()															const				{ return _interactionHighOrderCheckBox;				}
 	bool						addRowControl(const QString& key, JASPControl* control)											override;
 	void						moveItems(QList<int> &indexes, ListModelDraggable* dropModel, int dropItemIndex = -1);
-	QAbstractListModel		*	allowedTypesModel();
-	bool						isTypeAllowed(columnType type)															const	override;
-	columnType					defaultType()																			const	override;
-	QStringList					levels()																				const;
-	int							minLevels()																				const				{ return _minLevels;			}
-	int							maxLevels()																				const				{ return _maxLevels;			}
-	int							minNumericLevels()																		const				{ return _minNumericLevels;		}
-	int							maxNumericLevels()																		const				{ return _maxNumericLevels;		}
-	bool						allowTypeChange()																		const				{ return _allowTypeChange;		}
 
 signals:
 	void listViewTypeChanged();
 	void columnsChanged();
-	void allowedColumnsChanged();
-	void allowedColumnsIconsChanged();
 	void dropKeysChanged();
 	void interactionHighOrderCheckBoxChanged();
-	void allowedTypesModelChanged();
-	void levelsChanged();
-	void minLevelsChanged();
-	void maxLevelsChanged();
-	void minNumericLevelsChanged();
-	void maxNumericLevelsChanged();
-	void allowTypeChangeChanged();
 
 public slots:
 	void setVariableType(int index, int type);
@@ -107,25 +76,17 @@ protected slots:
 	void itemDoubleClickedHandler(int index);
 	void itemsDroppedHandler(QVariant indexes, QVariant vdropList, int dropItemIndex);
 	void interactionHighOrderHandler(JASPControl* checkBoxControl);
-	void checkLevelsConstraints();
 
 protected:
 	GENERIC_SET_FUNCTION(ListViewType,					_listViewType,					listViewTypeChanged,					ListViewType	)
 	GENERIC_SET_FUNCTION(Columns,						_columns,						columnsChanged,							int				)
-	GENERIC_SET_FUNCTION(AllowedColumns,				_allowedColumns,				allowedColumnsChanged,					QStringList		)
 	GENERIC_SET_FUNCTION(InteractionHighOrderCheckBox,	_interactionHighOrderCheckBox,	interactionHighOrderCheckBoxChanged,	QString			)
-	GENERIC_SET_FUNCTION(MinLevels,						_minLevels,						minLevelsChanged,						int				)
-	GENERIC_SET_FUNCTION(MaxLevels,						_maxLevels,						maxLevelsChanged,						int				)
-	GENERIC_SET_FUNCTION(MinNumericLevels,				_minNumericLevels,				minNumericLevelsChanged,				int				)
-	GENERIC_SET_FUNCTION(MaxNumericLevels,				_maxNumericLevels,				maxNumericLevelsChanged,				int				)
-	GENERIC_SET_FUNCTION(AllowTypeChange,				_allowTypeChange,				allowTypeChangeChanged,					bool			)
 
 	void						_setInitialized(const Json::Value& value = Json::nullValue)	override;
 	void						setDropKeys(const QStringList& dropKeys);
 	ListModel*					getRelatedModel();
 
 private:
-	void						_setAllowedVariables();
 	void						_setRelations();
 	
 protected:
@@ -138,18 +99,11 @@ private:
 
 	ListModelDraggable	*		_tempDropModel = nullptr;
 	QList<int>					_tempIndexes;
-	int							_tempDropItemIndex,
-								_minNumericLevels =		-1,
-								_maxNumericLevels =		-1,
-								_minLevels =			-1,
-								_maxLevels =			-1;
+	int							_tempDropItemIndex;
 
-	bool						_allowTypeChange =		false;
-	QStringList					_allowedColumns,
-								_dropKeys;
+	QStringList					_dropKeys;
 	QString						_interactionHighOrderCheckBox;
 
-	ColumnTypesModel *			_allowedTypesModel = nullptr;
 	
 };
 


### PR DESCRIPTION
Move allowed type code from VariablesList to JASPControlList, so that allowedColumns property and all the contraints are also possible to DropDown control.

Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2662