### PR TITLE
Add level constraints to DropDown

### DIFF
--- a/QMLComponents/components/JASP/Controls/ComboBox.qml
+++ b/QMLComponents/components/JASP/Controls/ComboBox.qml
@@ -29,6 +29,7 @@ ComboBoxBase
 	property bool	showEmptyValueAsNormal:	false
 	property bool	addLineAfterEmptyValue:	false
 	property double controlXOffset:			0
+	property bool	alignInGroup:			!setLabelAbove
 
 	onControlMinWidthChanged: _resetWidth(textMetrics.width)
 	

--- a/QMLComponents/components/JASP/Controls/GroupBox.qml
+++ b/QMLComponents/components/JASP/Controls/GroupBox.qml
@@ -105,7 +105,7 @@ GroupBoxBase
 		for (var i = 0; i < contentArea.children.length; i++)
 		{
 			var child = contentArea.children[i];
-			if (child.hasOwnProperty('controlType') && child.hasOwnProperty('controlXOffset'))//child.controlType === JASPControl.TextField)
+			if (child.hasOwnProperty('controlType') && child.hasOwnProperty('alignInGroup') && child.alignInGroup)
 				_allAlignableFields.push(child)
 		}
 

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -51,6 +51,8 @@ TextInputBase
 	property var	undoModel
 
 	property double controlXOffset:		0
+	property bool	alignInGroup:		true
+
 
 	signal editingFinished()	///< To get the entered value use `displayValue` in the slot instead of `value`
 	signal textEdited()

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -148,6 +148,7 @@ void ComboBoxBase::setUp()
 	connect(this,	&ComboBoxBase::activated,					this,	&ComboBoxBase::activatedSlot);
 	connect(this,	&JASPListControl::addEmptyValueChanged,		[this] () { _model->resetTermsFromSources(); }	);
 	connect(this,	&ComboBoxBase::currentIndexChanged,			[this] () { _setCurrentProperties(currentIndex()); } ); // Case when currentIndex is changed in QML
+	connect(this,	&ComboBoxBase::currentValueChanged,			[this] () { if (containsVariables()) checkLevelsConstraints(); } );
 
 	if (form())
 		connect(form(), &AnalysisForm::languageChanged,			[this] () { _model->resetTermsFromSources(); }	);
@@ -195,6 +196,11 @@ void ComboBoxBase::termsChangedHandler()
 void ComboBoxBase::activatedSlot(int index)
 {
 	_setCurrentProperties(index);
+}
+
+bool ComboBoxBase::_checkLevelsConstraints()
+{
+	return _checkLevelsConstraintsForVariable(_currentValue);
 }
 
 void ComboBoxBase::_resetItemWidth()

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -73,7 +73,7 @@ signals:
 	void fixedWidthChanged();
 
 protected slots:
-	void termsChangedHandler() override;
+	void termsChangedHandler()				override;
 	void setCurrentIndex(int index);
 	void setCurrentValue(QString value);
 	void setCurrentText(QString text);
@@ -82,6 +82,9 @@ protected slots:
 	GENERIC_SET_FUNCTION(StartValue,	_startValue,	startValueChanged,	QString	)
 
 protected:
+	bool _checkLevelsConstraints()			override;
+
+
 	ListModelLabelValueTerms*	_model					= nullptr;
 	QString						_currentText,
 								_currentValue,

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -158,11 +158,13 @@ protected slots:
 			void					sourceChangedHandler();
 
 			void					setOptionKey(const QString& optionKey)	{ _optionKey = optionKey; }
-			void					checkLevelsConstraints();
+			bool					checkLevelsConstraints();
 
 protected:
 	void							_setInitialized(const Json::Value& value = Json::nullValue)	override;
 	void							_setAllowedVariables();
+	virtual bool					_checkLevelsConstraints();
+	bool							_checkLevelsConstraintsForVariable(const QString& variable);
 
 	GENERIC_SET_FUNCTION(Source,							_source,							sourceChanged,							QVariant		)
 	GENERIC_SET_FUNCTION(RSource,							_rSource,							sourceChanged,							QVariant		)

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -81,9 +81,6 @@ void VariablesListBase::setUp()
 	//We use macros here because the signals come from QML
 	QQuickItem::connect(this, SIGNAL(itemDoubleClicked(int)),						this, SLOT(itemDoubleClickedHandler(int)));
 	QQuickItem::connect(this, SIGNAL(itemsDropped(QVariant, QVariant, int)),		this, SLOT(itemsDroppedHandler(QVariant, QVariant, int)));
-	connect(_draggableModel,	&ListModelDraggable::termsChanged,					this, &VariablesListBase::levelsChanged					);
-	connect(_draggableModel,	&ListModelDraggable::filterChanged,					this, &VariablesListBase::levelsChanged					);
-	connect(_draggableModel,	&ListModelDraggable::filterChanged,					this, &VariablesListBase::checkLevelsConstraints		);
 }
 
 void VariablesListBase::_setInitialized(const Json::Value &value)
@@ -309,10 +306,7 @@ void VariablesListBase::setVariableType(int index, int type)
 
 void VariablesListBase::termsChangedHandler()
 {
-	setColumnsTypes(model()->termsTypes());
-	setColumnsNames(model()->terms().asQList());
-
-	checkLevelsConstraints();
+	JASPListControl::termsChangedHandler();
 
 	if (_boundControl)	_boundControl->resetBoundValue();
 }


### PR DESCRIPTION
A variable type can be set for a DropDown, but the level constraints were not working yet. This PR adds the possibility to add constraints.
The Test Dropdown analysis has been updated in the jaspTestModule.

Also the Dropdowns should not be automatically aligned in a Group if the Label is set above the Dropdown.