### PR TITLE
Computed Columns should write to only filtered rows

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -598,7 +598,21 @@ bool Column::overwriteDataAndType(stringvec data, columnType colType)
 	JASPTIMER_SCOPE(Column::overwriteDataAndType);
 
 	if(data.size() != _data->rowCount())
-		data.resize(_data->rowCount());
+	{
+		if(data.size() == _data->filter()->filteredRowCount())
+		{
+			const boolvec & filtered = _data->filter()->filtered();
+			stringvec		newData;
+							newData	 . reserve(filtered.size());
+			
+			for(size_t iFilter=0, iData=0; iFilter < filtered.size() && iData < data.size(); iFilter++)
+				newData.push_back(filtered[iFilter] ? data[iData++] : "");
+				
+			data = newData;
+		}
+		else
+			data.resize(_data->rowCount());
+	}
 
 	bool changes = _type != colType;
 	setValues(data, data, 0, &changes);

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -331,7 +331,7 @@ void EngineRepresentation::runScriptOnProcess(RFilterStore * filterStore)
 
 	_lastRequestId			= filterStore->requestId;
 
-	QString dataFilter = filterStore->script == "" ? "*" : filterStore->script;
+	QString dataFilter = filterStore->script == "" ? "generatedFilter" : filterStore->script;
 	json["filter"] = dataFilter.toStdString();
 
 	Log::log() << "sending filter with requestID " << filterStore->requestId << " to engine" << std::endl;

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -840,8 +840,7 @@ bool _jaspRCPP_setColumnDataAndType(const std::string & columnName, Rcpp::RObjec
 	for(size_t i=0; i<convertedStrings.size(); i++)
 	{
 		bool	isNA  = convertedStrings[i] == "NA",
-				isLgl = convertedStrings[i] == "TRUE" || convertedStrings[i] == "FALSE",
-				isNan = std::isnan(dblData[i]);
+				isLgl = convertedStrings[i] == "TRUE" || convertedStrings[i] == "FALSE";
 		
 		nominals[i] = std::isnan(dblData[i])	// If the string could not be converted to a number its not TRUE or FALSE, but it might be NA. We do not want that as a result!
 					? (!isNA	? convertedStrings[i].c_str() : "") 


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-issues/issues/2972 (Bug: PC scores added on wrong row if data have pass-through filters)

What it *does* do is make sure that when the column (over)write functions get precisely the amount of filtered rows it fills the empty ones in with "". This way when an analysis writes it will write to the same rows it got the data from.

Doesnt yet take filters for user-added computed columns into account, Id prefer to add a proper interface for it.
And then immediately add support for multiple filters.
