### PR TITLE
minor TextArea contentMargin adjust

### DIFF
--- a/QMLComponents/components/JASP/Controls/TextArea.qml
+++ b/QMLComponents/components/JASP/Controls/TextArea.qml
@@ -141,7 +141,7 @@ TextAreaBase
 				selectionColor:		jaspTheme.itemSelectedColor
 				font:				textArea.textType === JASP.TextTypeDefault || textArea.textType === JASP.TextTypeSource ? jaspTheme.font : jaspTheme.fontCode
 				color:				textArea.enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
-				leftPadding:		!textArea.showLineNumber ? 0 : lineNumbers.width + 2 * jaspTheme.contentMargin
+				leftPadding:		!textArea.showLineNumber ? 2 * jaspTheme.contentMargin : lineNumbers.width + 2 * jaspTheme.contentMargin
 				
 				Component.onCompleted:
 				{


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d0888a0e-3d48-43d2-b8d9-94abc8355233)

After:
![image](https://github.com/user-attachments/assets/63bf9096-d74c-497f-b8b2-6f528378908c)

Test case: see syntax highlighter textArea in jaspTestModules.
