### PR TITLE
Encode type recursively.

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolbase.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolbase.cpp
@@ -46,35 +46,6 @@ Json::Value BoundControlBase::createMeta()  const
 	return meta;
 }
 
-bool BoundControlBase::setValueType()
-{
-	bool hasChanges = false;
-	AnalysisForm* form = _control->form();
-
-	if (_control->encodeValue())
-	{
-		JASPListControl* listControl = qobject_cast<JASPListControl*>(_control);
-		if (listControl)
-		{
-			Json::Value jsonTypesOrg = form->boundValue(getName() + ".types", _control->getParentKeys());
-
-			columnTypeVec types = listControl->valueTypes();
-			Json::Value jsonTypes(Json::arrayValue);
-
-			for (columnType type : types)
-				jsonTypes.append(columnTypeToString(type));
-
-			if (jsonTypes != jsonTypesOrg)
-			{
-				form->setBoundValue(getName() + ".types", jsonTypes, Json::nullValue, _control->getParentKeys());
-				hasChanges = true;
-			}
-		}
-	}
-
-	return hasChanges;
-}
-
 void BoundControlBase::handleComputedColumn(const Json::Value& value)
 {
 	if (_isColumn && value.isString())

--- a/QMLComponents/boundcontrols/boundcontrolbase.h
+++ b/QMLComponents/boundcontrols/boundcontrolbase.h
@@ -46,7 +46,6 @@ public:
 
 protected:
 	std::string					getName()													const;
-	bool						setValueType();
 	void						handleComputedColumn(const Json::Value& value);
 
 	Json::Value					_getTableValueOption(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasMultipleTerms);

--- a/QMLComponents/boundcontrols/boundcontrolterms.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolterms.cpp
@@ -307,17 +307,6 @@ void BoundControlTerms::resetBoundValue()
 	}
 }
 
-Json::Value BoundControlTerms::_getTypes() const
-{
-	columnTypeVec types = _listView->valueTypes();
-	Json::Value jsonTypes(Json::arrayValue);
-
-	for (columnType type : types)
-		jsonTypes.append(columnTypeToString(type));
-
-	return jsonTypes;
-}
-
 void BoundControlTerms::setBoundValue(const Json::Value &value, bool emitChanges)
 {
 	Json::Value newValue;
@@ -329,7 +318,10 @@ void BoundControlTerms::setBoundValue(const Json::Value &value, bool emitChanges
 		else
 		{
 			newValue["value"] = value;
-			newValue["types"] = _getTypes();
+			Json::Value types = _listView->valueTypes();
+			if (_isSingleRow && types.isArray() && types.size() > 0)
+				types = types[0];
+			newValue["types"] = types;
 		}
 		if (_listView->hasRowComponent() || _listView->containsInteractions())
 			newValue["optionKey"] = _optionKey;

--- a/QMLComponents/boundcontrols/boundcontrolterms.h
+++ b/QMLComponents/boundcontrols/boundcontrolterms.h
@@ -41,7 +41,6 @@ private:
 	Terms		_getValuesFromOptions(const Json::Value& option)							const;
 	Json::Value	_adjustBindingValue(const Json::Value &value)								const;
 	Json::Value	_adjustBindingType(const Json::Value &value)								const;
-	Json::Value _getTypes()																	const;
 
 	ListModelAssignedInterface*		_termsModel				= nullptr;
 	JASPListControl*				_listView				= nullptr;

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -299,8 +299,7 @@ std::vector<std::string> JASPListControl::usedVariables() const
 Json::Value JASPListControl::valueTypes() const
 {
 	Json::Value types(Json::arrayValue);
-	std::map<std::string, std::string> variableTypeMap;
-	static columnType unknownType = columnType::unknown;
+	strstrmap variableTypeMap;
 
 	// An interaction term has components that can be variables: if the model contains also such variables, the interaction term should get the same types.
 	// So first check which terms have only 1 component: these terms might be variable names, so keep in a map their types. Use then this map to set the type for interaction terms.
@@ -316,12 +315,7 @@ Json::Value JASPListControl::valueTypes() const
 		{
 			Json::Value compTypes(Json::arrayValue);
 			for (const std::string& component : term.scomponents())
-			{
-				if (variableTypeMap.count(component) > 0)
-					compTypes.append(variableTypeMap[component]);
-				else
-					compTypes.append(columnTypeToString(unknownType));
-			}
+				compTypes.append(variableTypeMap.count(component) > 0 ? variableTypeMap[component] : columnTypeToString(columnType::unknown));
 			types.append(compTypes);
 		}
 	}

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -110,7 +110,7 @@ public:
 			bool					allowAnalysisOwnComputedColumns()	const	{ return _allowAnalysisOwnComputedColumns;	}
 			bool					isTypeAllowed(columnType type)		const;
 			columnType				defaultType()						const;
-			columnTypeVec			valueTypes()						const;
+			Json::Value				valueTypes()						const;
 	const	QStringList			&	columnsTypes()						const	{ return _columnsTypes;						}
 	const	QStringList			&	columnsNames()						const	{ return _columnsNames;						}
 	QAbstractListModel			*	allowedTypesModel();


### PR DESCRIPTION
The column are encoded with their types. This was not working well when Variables uses interactions, and when variable list are inside components list.
The jaspTestModule is updated to test this.