### PR TITLE
Fix filter crash

### DIFF
--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -114,6 +114,7 @@ public:
 			int						labelsAdd(			const std::string & display);
 			int						labelsAdd(			const std::string & display, const std::string & description, const Json::Value & originalValue);
 			int						labelsAdd(			int value, const std::string & display, bool filterAllows, const std::string & description, const Json::Value & originalValue, int order=-1, int id=-1);
+			int						labelsSet(int lbId,	int value, const std::string & display, bool filterAllows, const std::string & description, const Json::Value & originalValue, int order=-1, int id=-1);
 			void					labelsRemoveByIntsId(	intset valuesToRemove, bool updateOrder = true);
 			strintmap				labelsResetValues(	int & maxValue);
 			void					labelsRemoveBeyond( size_t indexToStartRemoving);
@@ -244,6 +245,7 @@ protected:
 			void					_resetLabelValueMap();
 			doublevec				valuesNumericOrdered();			
 			std::map<Label*,size_t> valuesAlphabeticalOffsets();
+			int						_labelMapIt(Label *label);
 
 private:
 			DataSet			* const	_data;
@@ -282,6 +284,7 @@ private:
 	static	bool					_autoSortByValuesByDefault;
 			
 			
+
 };
 
 typedef std::vector<Column*> Columns;

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -154,9 +154,9 @@ public:
             Label				* 	replaceDoublesTillLabelsRowWithLabels(size_t row, double returnForDbl = NAN);
 			bool					replaceDoubleLabelFromRowWithDouble(size_t row, double dbl); ///< Returns true if succes
 
-			void					labelValueChanged(Label * label,	double aDouble,	const Json::Value & previousOriginal); ///< Pass NaN for non-convertible values
-			void					labelValueChanged(Label * label,	int	anInteger,	const Json::Value & previousOriginal) { labelValueChanged(label, double(anInteger), previousOriginal); }
-			void					labelDisplayChanged(Label * label,	const std::string & previousDisplay);
+			void					labelValueChanged(		Label * label,	const Json::Value & previousOriginal); ///< Pass NaN for non-convertible values
+			void					labelDisplayChanged(	Label * label,	const std::string & previousDisplay);
+			void					labelValDisplayChanged(	Label * label,	const std::string & previousDisplay,	const Json::Value & previousOriginal);
 			
 			bool					setStringValue(				size_t row, const std::string & value, const std::string & label = "", bool writeToDB = true); ///< Does two things, if label=="" it will handle user input, as value or label depending on columnType. Otherwise it will simply try to use userEntered as a value. But this will trigger the setting of type
 			bool					setValue(					size_t row, const std::string & value, const std::string & label,	bool writeToDB = true);

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -1290,14 +1290,12 @@ void DatabaseInterface::labelsLoad(Column * column)
 
 		if (originalValueJson.isNull() && !originalValueJsonStr.empty())
 			originalValueJson = originalValueJsonStr; // For backward compatibility: in some JASP files the originalValueJson is not a json string but just the original string.
-		
-		if(column->labels().size() == row)	column->labelsAdd(value, label, filterAllows, description, originalValueJson, order, id);
-		else								column->labels()[row]->setInformation(column, id, order, label, value, filterAllows, description, originalValueJson);
 
+		column->labelsSet(row,	value, label, filterAllows, description, originalValueJson, order, id);
 	};
 
 	runStatements("SELECT id, value, label, ordering, filterAllows, description, originalValueJson FROM Labels WHERE columnId = ? ORDER BY ordering;", prepare, processRow);
-	
+
 	column->labelsRemoveBeyond(labelsSize);
 	 
 	column->endBatchedLabelsDB(false);

--- a/CommonData/label.cpp
+++ b/CommonData/label.cpp
@@ -147,18 +147,42 @@ bool Label::setLabel(const std::string & label)
 	return false;
 }
 
-bool Label::setOriginalValue(const Json::Value & originalLabel)
+bool Label::setOriginalValue(const Json::Value & originalValue)
 {
-	if(_originalValue != originalLabel)
+	if(_originalValue != originalValue)
 	{
-		Json::Value previous = _originalValue;
-		_originalValue = originalLabel;
+		Json::Value previous	= _originalValue;
+		_originalValue			= originalValue;
 		dbUpdate();
 		
-		if(_originalValue.isDouble())	_column->labelValueChanged(this, _originalValue.asDouble(),			previous);
-		else if(_originalValue.isInt())	_column->labelValueChanged(this, _originalValue.asInt(),			previous);
-		else							_column->labelValueChanged(this, EmptyValues::missingValueDouble,	previous);
+		_column->labelValueChanged(this, previous);
 		
+		return true;
+	}
+	return false;
+}
+
+bool Label::setOrigValLabel(const Json::Value &originalValue)
+{
+	std::string oldLabel	= _label,
+				newLabel	= !originalValue.isDouble() ? originalValue.asString() : _column->doubleToDisplayString(originalValue.asDouble(), false, false);
+	Json::Value previous	= _originalValue;
+	bool		labelChange = _label			!= newLabel,
+				valChange	= _originalValue	!= originalValue,
+				aChange		= labelChange		|| valChange;
+	
+	if(labelChange)
+		_label = newLabel;
+	
+	if(valChange)
+		_originalValue			= originalValue;
+	
+	
+	if(aChange)
+	{
+		dbUpdate();
+	
+		_column->labelValDisplayChanged(this, oldLabel, previous);
 		return true;
 	}
 	return false;

--- a/CommonData/label.cpp
+++ b/CommonData/label.cpp
@@ -92,7 +92,8 @@ void Label::dbUpdate()
 
 void Label::setInformation(Column * column, int id, int order, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue)
 {
-	_dbId				= id;
+	assert(_column == column);
+	_dbId			= id;
 	_order			= order;
 	_label			= label;
 	_intsId			= value;	

--- a/CommonData/label.h
+++ b/CommonData/label.h
@@ -57,6 +57,7 @@ public:
 			void				setDbId(			int id) { _dbId = id; }
 			bool				setLabel(			const std::string & label);
 			bool				setOriginalValue(	const Json::Value & originalValue);
+			bool				setOrigValLabel(	const Json::Value & originalValue);
 			bool				setDescription(		const std::string & description);
 			bool				setFilterAllows(	bool allowFilter);
 			void				setInformation(Column * column, int id, int order, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue);

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -719,6 +719,7 @@ bool DataSetPackage::setData(const QModelIndex &index, const QVariant &value, in
 						setManualEdits(true); //Don't synch with external file after editing
 						
 						column->labelsRemoveOrphans();
+						column->labelsTempReset();
 						column->labelsHandleAutoSort();
 
 						stringvec	changedCols = {column->name()};
@@ -2195,8 +2196,8 @@ bool DataSetPackage::removeRows(int row, int count, const QModelIndex & aparent)
 	{
 		changed.push_back(column->name());
 		
-		if(row+count > column->rowCount())
-			Log::log() << "???" << std::endl;
+		//if(row+count > column->rowCount())
+		//	Log::log() << "???" << std::endl;
 	
 		for(int r=row+count; r>row; r--)
 			column->rowDelete(r-1);

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -952,19 +952,22 @@ bool DataSetPackage::setLabelValue(const QModelIndex &index, const QString &newL
 		aChange = true;
 	}
 	
-	//If the user is changing the value of a column to a string we want the display/label to also change if its the same
-	//to a double/int however might mean recoding so it would be a bit impractical to have the label dissappear
-	if(	label->originalValueAsString(false) == label->labelDisplay())
 	{
-		if(!originalValue.isDouble())
-			aChange = label->setLabel(originalValue.asString()) || aChange;
+		// Here we will overwrite the original value with the new origval.
+		// but if the label is the same as the original value we want to make the users life easier and replace it as well.
+		// this makes sense if the user is changing a string or number. But if the user is recoding, so turning values from str => dbl
+		// then we dont want to do this, because then the label should be different afterwards.
 		
-		else if(label->originalValue().isDouble())
-				label->setLabel(column->doubleToDisplayString(originalValue.asDouble(), false));
+		//summarized:
+		// if orgval == label then: 
+		// if (oldorigval == dbl && newOrigVal == dbl) || (olorigval != dbl && newOrigVal != dbl)  then replace both
+		// if neworigval == dbl and oldorigval != dbl then replace only value
 		
+		if(	label->originalValueAsString(false) != label->labelDisplay() || (originalValue.isDouble() && !label->originalValue().isDouble()))
+			aChange = label->setOriginalValue(originalValue) || aChange;
+		else 
+			aChange = label->setOrigValLabel(originalValue) || aChange;
 	}
-	
-	aChange = label->setOriginalValue(originalValue) || aChange;
 	
 	column->labelsHandleAutoSort();
 	


### PR DESCRIPTION
A bug happened where if you entered in new data:
(one by one)
column1, "c", "1"
column2, "2" 

the engine would crash because of some bad housekeeping of data...

this is because labelsAdd was used which checks the valDisMap and then doesnt really add anything.
The db was iterating over rows though...
But ive now replaced it with column->labelsSet. 
It takes the honor of either adding a label or overwriting one on a particular place. 
And adds them to the also freshly cleaned valDisMap and intsIdMap.
Also, try not to resize the labels to be bigger then it needs to be to avoid all those 0pointer exceptions :crying_cat_face: 

