### PR TITLE
Encode rowValue of a componentList when it contains variables

### DIFF
--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -149,7 +149,7 @@ Json::Value& AnalysisBase::_getParentBoundValue(const QVector<JASPControl::Paren
 		{
 			Json::Value* parentBoundValues = &(*parentBoundValue)[parent.name];
 			if (parentBoundValues->isObject() && parentBoundValues->isMember("value") && parentBoundValues->isMember("types"))
-				parentBoundValues = &(*parentBoundValues)["value"];
+				parentBoundValues = &(*parentBoundValues)["value"]; // If the control contain variable names, the option values are inside the 'value' member
 
 			if (!parentBoundValues->isNull() && parentBoundValues->isArray())
 			{
@@ -157,17 +157,20 @@ Json::Value& AnalysisBase::_getParentBoundValue(const QVector<JASPControl::Paren
 				{
 					if (boundValue.isMember(parent.key))
 					{
-						Json::Value &val = boundValue[parent.key];
+						Json::Value* keyValue = &(boundValue[parent.key]);
+						if (keyValue->isObject() && keyValue->isMember("value") && keyValue->isMember("types"))
+							keyValue = &((*keyValue)["value"]); // The key can be also a variable name
+
 						// The value can be a string or an array of strings (for interaction terms)
-						if (val.isString() && parent.value.size() == 1)
+						if (keyValue->isString() && parent.value.size() == 1)
 						{
-							if (val.asString() == parent.value[0])	found = true;
+							if (keyValue->asString() == parent.value[0])	found = true;
 						}
-						else if (val.isArray() && val.size() == parent.value.size())
+						else if (keyValue->isArray() && keyValue->size() == parent.value.size())
 						{
 							found = true;
 							size_t i = 0;
-							for (const Json::Value& compVal : val)
+							for (const Json::Value& compVal : *keyValue)
 							{
 								if (!compVal.isString() || compVal.asString() != parent.value[i]) found = false;
 								i++;

--- a/QMLComponents/boundcontrols/boundcontrolbase.h
+++ b/QMLComponents/boundcontrols/boundcontrolbase.h
@@ -48,8 +48,8 @@ protected:
 	std::string					getName()													const;
 	void						handleComputedColumn(const Json::Value& value);
 
-	Json::Value					_getTableValueOption(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasMultipleTerms);
-	void						_setTableValue(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasMultipleTerms);
+	Json::Value					_getTableValueOption(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasInteraction, bool keyHasVariables);
+	void						_setTableValue(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasInteraction, bool keyHasVariables = false);
 
 	void						_readTableValue(const Json::Value& value, const std::string& key, bool hasMultipleTerms, Terms& terms, ListModel::RowControlsValues& allControlValues);
 	bool						_isValueWithTypes(const Json::Value &value)					const;

--- a/QMLComponents/boundcontrols/boundcontrolterms.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolterms.cpp
@@ -140,7 +140,17 @@ void BoundControlTerms::bindTo(const Json::Value &value)
 	for (Term& term : terms)
 	{
 		if (typesPart.size() > i) // If the type is given, use it
-			term.setType(columnTypeFromString(typesPart[i].asString(), columnType::unknown));
+		{
+			if (typesPart[i].isArray())
+			{
+				columnTypeVec types;
+				for (const Json::Value& jsonType : typesPart[i])
+					types.push_back(columnTypeFromString(jsonType.asString(), columnType::unknown));
+				term.setTypes(types);
+			}
+			else
+				term.setType(columnTypeFromString(typesPart[i].asString(), columnType::unknown));
+		}
 		else
 		{
 			if (term.type() == columnType::unknown)

--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -206,7 +206,7 @@ void ComponentsListBase::termsChangedHandler()
 {
 	JASPListControl::termsChangedHandler();
 
-	_setTableValue(_termsModel->terms(), _termsModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions());
+	_setTableValue(_termsModel->terms(), _termsModel->getTermsWithComponentValues(), fq(_optionKey), containsInteractions(), containsVariables());
 	bindOffsets();
 	emit controlNameXOffsetMapChanged();
 }
@@ -308,7 +308,7 @@ Json::Value ComponentsListBase::getJsonFromComponentValues(const ListModel::RowC
 	for (const QString& term : termsWithComponentValues.keys())
 		terms.add(Term::readTerm(term));
 
-	return _getTableValueOption(terms, termsWithComponentValues, fq(_optionKey), containsInteractions());
+	return _getTableValueOption(terms, termsWithComponentValues, fq(_optionKey), containsInteractions(), containsVariables());
 }
 
 void ComponentsListBase::addItemHandler()

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -299,13 +299,6 @@ std::vector<std::string> JASPListControl::usedVariables() const
 Json::Value JASPListControl::valueTypes() const
 {
 	Json::Value types(Json::arrayValue);
-	strstrmap variableTypeMap;
-
-	// An interaction term has components that can be variables: if the model contains also such variables, the interaction term should get the same types.
-	// So first check which terms have only 1 component: these terms might be variable names, so keep in a map their types. Use then this map to set the type for interaction terms.
-	for (const Term& term : model()->terms())
-		if (term.components().size() == 1)
-			variableTypeMap[term.asString()] = columnTypeToString(term.type());
 
 	for (const Term& term : model()->terms())
 	{
@@ -314,8 +307,8 @@ Json::Value JASPListControl::valueTypes() const
 		else
 		{
 			Json::Value compTypes(Json::arrayValue);
-			for (const std::string& component : term.scomponents())
-				compTypes.append(variableTypeMap.count(component) > 0 ? variableTypeMap[component] : columnTypeToString(columnType::unknown));
+			for (columnType type : term.types())
+				compTypes.append(columnTypeToString(type));
 			types.append(compTypes);
 		}
 	}

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -116,7 +116,7 @@ signals:
 public slots:	
 	virtual void sourceTermsReset();
 	virtual void sourceNamesChanged(QMap<QString, QString> map);
-	virtual int  sourceColumnTypeChanged(Term sourceTerm);
+	virtual bool sourceColumnTypeChanged(Term sourceTerm);
 	virtual bool sourceLabelsChanged(QString columnName, QMap<QString, QString> changedLabels = {});
 	virtual bool sourceLabelsReordered(QString columnName);
 	virtual void sourceColumnsChanged(QStringList columns);

--- a/QMLComponents/models/listmodelavailableinterface.cpp
+++ b/QMLComponents/models/listmodelavailableinterface.cpp
@@ -149,14 +149,14 @@ void ListModelAvailableInterface::sourceColumnsChanged(QStringList columns)
 		emit columnsChanged(changedColumns);
 }
 
-int ListModelAvailableInterface::sourceColumnTypeChanged(Term term)
+bool ListModelAvailableInterface::sourceColumnTypeChanged(Term term)
 {
-	int index = ListModelDraggable::sourceColumnTypeChanged(term);
+	bool change = ListModelDraggable::sourceColumnTypeChanged(term);
 
-	if (index == -1 && _allTerms.contains(term))
+	if (!change && _allTerms.contains(term))
 		emit columnTypeChanged(term);
 
-	return index;
+	return change;
 }
 
 bool ListModelAvailableInterface::sourceLabelsChanged(QString columnName, QMap<QString, QString> changedLabels)

--- a/QMLComponents/models/listmodelavailableinterface.h
+++ b/QMLComponents/models/listmodelavailableinterface.h
@@ -52,7 +52,7 @@ public slots:
 			void sourceTermsReset()															override;
 			void sourceNamesChanged(QMap<QString, QString> map)								override;
 			void sourceColumnsChanged(QStringList columns)									override;
-			int  sourceColumnTypeChanged(Term name)											override;
+			bool sourceColumnTypeChanged(Term name)											override;
 			bool sourceLabelsChanged(QString columnName, QMap<QString, QString> = {})		override;
 			bool sourceLabelsReordered(QString columnName)									override;
 			void removeAssignedModel(ListModelAssignedInterface *assignedModel);

--- a/QMLComponents/models/term.h
+++ b/QMLComponents/models/term.h
@@ -47,8 +47,11 @@ public:
 	bool						isDraggable()	const			{ return _draggable; }
 	void						setDraggable(bool draggable)	{ _draggable = draggable; }
 
-	columnType					type()			const			{ return _type; }
-	void						setType(columnType type)		{ _type = type; }
+	// If a term has several components, its type self is unknown, but the components have maybe a type.
+	columnType					type()			const			{ return _types.size() == 1 ? _types[0] : columnType::unknown; }
+	void						setType(columnType type)		{ _types = {type}; }
+	columnTypeVec				types()			const			{ return _types; }
+	void						setTypes(columnTypeVec types)	{ _types = types; }
 
 	typedef QStringList::const_iterator const_iterator;
 	typedef QStringList::iterator		iterator;
@@ -81,7 +84,7 @@ private:
 	QStringList		_components;
 	QString			_asQString;
 	bool			_draggable = true;
-	columnType		_type = columnType::unknown;
+	columnTypeVec	_types = {columnType::unknown};
 };
 
 #endif // TERM_H

--- a/QMLComponents/models/terms.cpp
+++ b/QMLComponents/models/terms.cpp
@@ -152,7 +152,7 @@ void Terms::add(const Term &term, bool isUnique)
 		else if (result == 0)
 		{
 			itr->setDraggable(term.isDraggable());
-			itr->setType(term.type());
+			itr->setTypes(term.types());
 		}
 		else if (result < 0)
 			_terms.push_back(term);
@@ -165,7 +165,7 @@ void Terms::add(const Term &term, bool isUnique)
 		else
 		{
 			_terms.at(i).setDraggable(term.isDraggable());
-			_terms.at(i).setType(term.type());
+			_terms.at(i).setTypes(term.types());
 		}
 	}
 }
@@ -348,19 +348,21 @@ Terms Terms::crossCombinations() const
 		do {
 
 			vector<string> combination;
+			columnTypeVec types;
 
 			for (uint i = 0; i < _terms.size(); i++) {
 				if (!v[i])
 				{
 					vector<string> components = _terms.at(i).scomponents();
+					columnTypeVec termTypes = _terms.at(i).types();
 					combination.insert(combination.end(), components.begin(), components.end());
+					types.insert(types.end(), termTypes.begin(), termTypes.end());
 				}
 			}
 
-			if (combination.size() == 1)
-				t.add(at(indexOf(combination[0])));
-			else
-				t.add(Term(combination));
+			Term newTerm(combination);
+			newTerm.setTypes(types);
+			t.add(newTerm);
 
 		} while (std::next_permutation(v.begin(), v.end()));
 	}
@@ -380,19 +382,21 @@ Terms Terms::wayCombinations(int ways) const
 		do {
 
 			vector<string> combination;
+			columnTypeVec types;
 
 			for (uint i = 0; i < _terms.size(); ++i) {
 				if (!v[i])
 				{
 					vector<string> components = _terms.at(i).scomponents();
+					columnTypeVec termTypes = _terms.at(i).types();
 					combination.insert(combination.end(), components.begin(), components.end());
+					types.insert(types.end(), termTypes.begin(), termTypes.end());
 				}
 			}
 
-			if (combination.size() == 1)
-				t.add(at(indexOf(combination[0])));
-			else
-				t.add(Term(combination));
+			Term newTerm(combination);
+			newTerm.setTypes(types);
+			t.add(newTerm);
 
 		} while (std::next_permutation(v.begin(), v.end()));
 	}
@@ -415,11 +419,15 @@ Terms Terms::ffCombinations(const Terms &terms)
 	{
 		for (uint j = 0; j < combos.size(); j++)
 		{
-			QStringList term = _terms.at(i).components();
-			QStringList newTerm = combos.at(j).components();
+			QStringList termComponents = _terms.at(i).components();
+			termComponents.append(combos.at(j).components());
+			columnTypeVec types = _terms.at(i).types();
+			columnTypeVec coTypes = combos.at(j).types();
+			types.insert(types.end(), coTypes.begin(), coTypes.end());
 
-			term.append(newTerm);
-			newTerms.add(Term(term));
+			Term newTerm(termComponents);
+			newTerm.setTypes(types);
+			newTerms.add(newTerm);
 		}
 	}
 


### PR DESCRIPTION
The MixedModels analyses do not work because the random effects ComponentsList has for source the "Random effects grouping factors" Variables List. So the rowValue of the componentsList (the key of a row in the ComponentsList) is a variable (with possible interactions), and it must be also encoded with the right type.

For this the Term object should contain not only the type when it is a single variable, but also the types of each interaction when it contains several variables.

Another test has been added in the jaspTestModule encoding analysis.

NB: The Mixed Models still do not work after this fix, but @FBartos knows why. He needs first this fix to be able to fix completely the Mixed Models.