### PR TITLE
Better handling of labeleditor for computed columns

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1817,8 +1817,18 @@ void Column::labelsOrderByValue(bool doDbUpdateEtc)
 {
 	JASPTIMER_SCOPE(Column::labelsOrderByValue);
 
+	bool replaceAllDoubles = false;
 	static double dummy;
-	replaceDoublesTillLabelsRowWithLabels(labelsTempCount());
+
+	for(Label * label : labels())	
+		if(!label->isEmptyValue() && !(label->originalValue().isDouble() || ColumnUtils::getDoubleValue(label->originalValueAsString(), dummy)))
+		{
+				replaceAllDoubles = true;
+				break;
+		}
+
+	if(replaceAllDoubles)
+		replaceDoublesTillLabelsRowWithLabels(labelsTempCount());
 	
 	doublevec				asc			= valuesNumericOrdered();
 	auto					alpha		= valuesAlphabeticalOffsets();

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1821,9 +1821,9 @@ void Column::labelsOrderByValue(bool doDbUpdateEtc)
 	static double dummy;
 
 	for(Label * label : labels())	
-		if(!label->isEmptyValue() && !(label->originalValue().isDouble() || ColumnUtils::getDoubleValue(label->originalValueAsString(), dummy)))
+		if(!label->isEmptyValue())
 		{
-				replaceAllDoubles = true;
+				replaceAllDoubles = true; // because if there is any label at all it will show up at the end after the doubles without a Label. If this label is a double and the same as the label we could try to turn it back into a non-Label. But it still would break for Labels with a double value and a non-double label. So instead lets just make a label for everything. We keep the doubles only if there are only doubles. This should speed up a lot of operations for massive double datasets so its worth the extra hassle I guess. Just like you, who just read to the end of this line that really really breaks the 80's guideline of 80 characterwide code ;)
 				break;
 		}
 

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -642,6 +642,9 @@ bool Column::overwriteDataAndType(stringvec data, columnType colType)
 	
 	setValues(values, labels, 0, &changes);
 	setType(colType);
+	labelsTempReset();
+	
+	labelsHandleAutoSort();
 	
 	return changes;
 }
@@ -1711,8 +1714,6 @@ Labelset Column::labelsByValue(const std::string & value) const
 	return Labelset(found.begin(), found.end());
 }
 
-
-
 Label * Column::labelByValueAndDisplay(const std::string &value, const std::string &labelText) const
 {
 	JASPTIMER_SCOPE(Column::labelsByValueAndDisplay);
@@ -1816,18 +1817,8 @@ void Column::labelsOrderByValue(bool doDbUpdateEtc)
 {
 	JASPTIMER_SCOPE(Column::labelsOrderByValue);
 
-	bool replaceAllDoubles = false;
 	static double dummy;
-	
-	for(Label * label : labels())	
-		if(!label->isEmptyValue() && !(label->originalValue().isDouble() || ColumnUtils::getDoubleValue(label->originalValueAsString(), dummy)))
-		{
-				replaceAllDoubles = true;
-				break;
-		}
-	
-	if(replaceAllDoubles)
-		replaceDoublesTillLabelsRowWithLabels(labelsTempCount());
+	replaceDoublesTillLabelsRowWithLabels(labelsTempCount());
 	
 	doublevec				asc			= valuesNumericOrdered();
 	auto					alpha		= valuesAlphabeticalOffsets();

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -614,8 +614,33 @@ bool Column::overwriteDataAndType(stringvec data, columnType colType)
 			data.resize(_data->rowCount());
 	}
 
-	bool changes = _type != colType;
-	setValues(data, data, 0, &changes);
+	bool			changes		= _type != colType,
+					toScale		= colType == columnType::scale;
+	stringvec		otherData	= data,
+				&	values		= toScale  ? data : otherData,
+				&	labels		= !toScale ? data : otherData;
+	
+	// If we are going to allow users to edit things it would be nice if we didnt just throw it away so rough
+	// See: https://github.com/jasp-stats/INTERNAL-jasp/issues/2680
+	// All we have to do is find the value/label per label/value given depending on the selected columnType
+	
+	
+	strstrmap											replacePerKey;
+	std::function<std::string(const std::string &)>		getOther		= [&](const std::string & in) 
+	{ 
+		if(!replacePerKey.count(in))
+		{
+			Label * tmp = toScale ? labelByValue(in) : labelByDisplay(in); 
+			replacePerKey[in] = !tmp ? in : toScale ? tmp->label() : tmp->originalValueAsString();
+		}
+		
+		return replacePerKey.at(in);
+	};
+	
+	for(size_t i=0; i<data.size(); i++)
+		otherData[i] = getOther(data[i]);
+	
+	setValues(values, labels, 0, &changes);
 	setType(colType);
 	
 	return changes;

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -173,8 +173,8 @@ public:
 			const Labels		&	labels()																				const	{ return _labels; }
 			void					labelsMergeDuplicateInto(Label * label);
 			bool					labelsRemoveOrphans();
-			Labelset				labelsByDisplay(		const std::string	&	display)								const; ///< Might be nullptr for missing label
-			Labelset				labelsByValue(			const std::string	&	value)									const; ///< 
+			Labelset				labelsByDisplay(		const std::string	&	display)								const; ///< SLOW! Might be nullptr for missing label
+			Labelset				labelsByValue(			const std::string	&	value)									const; ///< SLOW!
 			int						labelIndexNonEmpty(		Label				*	label)									const;
 			Label				*	labelByRow(				int						row)									const; ///< 
 			Label				*	labelByValue(			const std::string	&	value)									const; ///< Might be nullptr for missing label, returns the first of labelsByValue

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -15,20 +15,21 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#include "log.h"
+#include "utils.h"
 #include "analysis.h"
-#include <boost/bind.hpp>
 #include "tempfiles.h"
 #include "appinfo.h"
 #include "dirs.h"
 #include "analyses.h"
 #include "analysisform.h"
+//#include <boost/bind.hpp>
 #include "utilities/qutils.h"
-#include "log.h"
-#include "utils.h"
 #include "utilities/settings.h"
-#include "gui/preferencesmodel.h"
 #include "utilities/reporter.h"
+#include "gui/preferencesmodel.h"
 #include "results/resultsjsinterface.h"
+#include "utilities/messageforwarder.h"
 
 Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::string title, std::string moduleVersion, Json::Value *data) :
 	  AnalysisBase(Analyses::analyses(), moduleVersion),

--- a/Desktop/components/JASP/Widgets/ColumnBasicInfo.qml
+++ b/Desktop/components/JASP/Widgets/ColumnBasicInfo.qml
@@ -34,21 +34,21 @@ Item
 	property alias columnComputedTypeValue:	computedTypeVariableWindow.value
 	property alias columnTypeValue:			columnTypeVariableWindow.value
 
+	function focusOnTheNamePlease()
+	{
+		if (visible && columnModel.isVirtual)
+			columnNameVariablesWindow.forceActiveFocus()
+	}
+	
 	Connections
 	{
 		target: columnModel
-		function onVisibleChanged()
-		{
-			if (visible && columnModel.isVirtual)
-				columnNameVariablesWindow.forceActiveFocus()
-		}
-
-		function onChosenColumnChanged()
-		{
-			if (visible && columnModel.isVirtual)
-				columnNameVariablesWindow.forceActiveFocus()
-		}
+		function onVisibleChanged()			{ focusOnTheNamePlease(); }
+		function onChosenColumnChanged()	{ focusOnTheNamePlease(); }
+		function onIsVirtualChanged()		{ focusOnTheNamePlease(); }
 	}
+	
+
 
 	Column
 	{

--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -45,6 +45,7 @@ FocusScope
 			computedColumnsInterface.sendCode(computeColumnEdit.text)
 		else
 		{
+			computedColumnConstructor.forceActiveFocus();
 			computedColumnConstructor.checkAndApplyFilter()
 			computedColumnsInterface.sendCode(computedColumnConstructor.rCode, computedColumnConstructor.jsonConstructed)
 		}
@@ -52,10 +53,9 @@ FocusScope
 
 	function askIfChangedOrClose()
 	{
-		if(computedColumnContainer.changed)	saveDialog.open()
+		if(computedColumnContainer.changed)	
+			saveDialog.open()
 	}
-
-
 
 	Item
 	{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
@@ -34,7 +34,6 @@ FocusScope
 
 	function checkAndApplyFilter()
 	{
-		forceActiveFocus();
 		filterConstructor.somethingChanged = false
 
 		var allCorrect		= true

--- a/Desktop/components/JASP/Widgets/LabelEditorWindow.qml
+++ b/Desktop/components/JASP/Widgets/LabelEditorWindow.qml
@@ -61,12 +61,16 @@ FocusScope
 					}
 				}
 
-				property real	filterColWidth:	60  * jaspTheme.uiScale
-				property real	remainingWidth:	width - filterColWidth
-				property real	valueColWidth:	Math.min(columnModel.valueMaxWidth + 10, remainingWidth * 0.5) * jaspTheme.uiScale
-				property real	labelColWidth:	Math.min(columnModel.labelMaxWidth + 10, remainingWidth * 0.5) * jaspTheme.uiScale
-				property int	selectedRow:	-1
+				property real	filterColWidth:		60  * jaspTheme.uiScale
+				property real	remainingWidth:		width - filterColWidth
+				property real	valueColWidth:		Math.min(columnModel.valueMaxWidth + 10, remainingWidth * 0.5) * jaspTheme.uiScale
+				property real	labelColWidth:		Math.min(columnModel.labelMaxWidth + 10, remainingWidth * 0.5) * jaspTheme.uiScale
+				property int	selectedRow:		-1
 				
+				property bool	isBasicComputed:	columnModel.computedType == "rCode" || columnModel.computedType == "constructorCode"
+				property bool	valueEditable:		!isBasicComputed || columnModel.currentColumnType != "scale"
+				property bool	labelEditable:		!isBasicComputed || columnModel.currentColumnType == "scale"
+				property bool	filterEditable:		true // columnModel.computedType == "notComputed"
 
 				columnHeaderDelegate:	Item
 				{
@@ -85,7 +89,7 @@ FocusScope
 							{
 								text:					qsTr("Filter")
 								font:					jaspTheme.font
-								color:					jaspTheme.textEnabled
+								color:					levelsTableView.filterEditable ? jaspTheme.textEnabled : jaspTheme.textDisabled
 								width:					levelsTableView.filterColWidth;
 								anchors.verticalCenter:	parent.verticalCenter
 								horizontalAlignment:	Text.AlignHCenter
@@ -100,7 +104,7 @@ FocusScope
 							{
 								text:					qsTr("Value")
 								font:					jaspTheme.font
-								color:					jaspTheme.textEnabled
+								color:					levelsTableView.valueEditable ? jaspTheme.textEnabled : jaspTheme.textDisabled
 								width:					levelsTableView.valueColWidth;
 								leftPadding:			3 * jaspTheme.uiScale
 								anchors.verticalCenter:	parent.verticalCenter
@@ -115,7 +119,7 @@ FocusScope
 							{
 								text:					qsTr("Label")
 								font:					jaspTheme.font
-								color:					jaspTheme.textEnabled
+								color:					levelsTableView.labelEditable ? jaspTheme.textEnabled : jaspTheme.textDisabled
 								leftPadding:			3 * jaspTheme.uiScale
 								anchors.verticalCenter:	parent.verticalCenter
 								width:					levelsTableView.labelColWidth;
@@ -208,6 +212,7 @@ FocusScope
 								height:					parent.height
 								z:						-1
 								cursorShape:			Qt.PointingHandCursor
+								enabled:				levelsTableView.filterEditable
 								
 	
 								onClicked:				
@@ -251,6 +256,7 @@ FocusScope
 								width:				levelsTableView.valueColWidth;
 								height:				parent.height
 								clip:				true
+								enabled:			levelsTableView.valueEditable
 							
 								MouseArea
 								{
@@ -336,6 +342,7 @@ FocusScope
 								width:				levelsTableView.remainingWidth - (levelsTableView.valueColWidth + 2 + (2 * levelsTableView.itemHorizontalPadding)) //+2 for line-rectangles!
 								height:				parent.height
 								clip:				true
+								enabled:			levelsTableView.labelEditable
 								
 								MouseArea
 								{

--- a/Desktop/data/computedcolumnmodel.cpp
+++ b/Desktop/data/computedcolumnmodel.cpp
@@ -264,7 +264,7 @@ void ComputedColumnModel::recomputeColumn(QString columnName)
 	std::string		colName = fq(columnName);
 	Column		*	col		= dataSet()->column(colName);
 
-	if(col && col->isComputed() && col->codeType() != computedColumnType::analysis && col->codeType() == computedColumnType::analysisNotComputed)
+	if(col && col->isComputed() && col->codeType() == computedColumnType::analysisNotComputed)
 		DataSetPackage::pkg()->columnSetDefaultValues(colName);
 
 	checkForDependentColumnsToBeSent(columnName, col && col->isComputed());
@@ -295,23 +295,23 @@ void ComputedColumnModel::checkForDependentColumnsToBeSent(QString columnNameQ, 
 void ComputedColumnModel::checkForDependentAnalyses(const std::string & columnName)
 {
 	Analyses::analyses()->applyToAll([&](Analysis * analysis)
+	{
+		stringset	usedCols	= analysis->usedVariables(),
+					createdCols = analysis->createdVariables();
+
+		//Dont create an infinite loop please, but do this only for non-computed columns created by an analysis (aka distributions, because otherwise it breaks things like planning from audit)
+		if(usedCols.count(columnName) && (!createdCols.count(columnName) || !DataSetPackage::pkg()->isColumnAnalysisNotComputed(columnName)))
 		{
-			stringset	usedCols	= analysis->usedVariables(),
-						createdCols = analysis->createdVariables();
+			bool allColsValidated = true;
 
-			//Dont create an infinite loop please, but do this only for non-computed columns created by an analysis (aka distributions, because otherwise it breaks things like planning from audit)
-			if(usedCols.count(columnName) && (!createdCols.count(columnName) || !DataSetPackage::pkg()->isColumnAnalysisNotComputed(columnName)))
-			{
-				bool allColsValidated = true;
+			for(Column * col : computedColumns())
+				if(usedCols.count(col->name()) > 0 && col->invalidated())
+					allColsValidated = false;
 
-				for(Column * col : computedColumns())
-					if(usedCols.count(col->name()) > 0 && col->invalidated())
-						allColsValidated = false;
-
-				if(allColsValidated)
-					analysis->refresh();
-			}
-		});
+			if(allColsValidated)
+				analysis->refresh();
+		}
+	});
 }
 
 void ComputedColumnModel::removeColumn()

--- a/Desktop/data/computedcolumnmodel.cpp
+++ b/Desktop/data/computedcolumnmodel.cpp
@@ -228,6 +228,8 @@ void ComputedColumnModel::computeColumnSucceeded(QString columnNameQ, QString wa
 
 	if(dataChanged)
 		checkForDependentColumnsToBeSent(columnNameQ);
+	
+	DataSetPackage::pkg()->labelFilterChanged(); //in case the user had enabled some labelfilter on the computed column?
 }
 
 void ComputedColumnModel::computeColumnFailed(QString columnNameQ, QString errorQ)

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1495,7 +1495,7 @@ bool DataSetPackage::initColumnWithStrings(QVariant colId, const std::string & n
 				column			->	setType(column->type() != columnType::unknown ? column->type() : desiredType == columnType::unknown ? suggestedType : desiredType);
 				column			->	endBatchedLabelsDB();
 				
-                                if(PreferencesModel::prefs()->orderByValueByDefault())
+	if(PreferencesModel::prefs()->orderByValueByDefault())
 		column->labelsOrderByValue();
 	
 	return anyChanges || column->type() != prevType;

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -963,10 +963,17 @@ bool DataSetPackage::setLabelValue(const QModelIndex &index, const QString &newL
 		// if (oldorigval == dbl && newOrigVal == dbl) || (olorigval != dbl && newOrigVal != dbl)  then replace both
 		// if neworigval == dbl and oldorigval != dbl then replace only value
 		
-		if(	label->originalValueAsString(false) != label->labelDisplay() || (originalValue.isDouble() && !label->originalValue().isDouble()))
-			aChange = label->setOriginalValue(originalValue) || aChange;
-		else 
-			aChange = label->setOrigValLabel(originalValue) || aChange;
+		// But only if we are allowed to change both because of https://github.com/jasp-stats/INTERNAL-jasp/issues/2680 (allow editing of only value/label and disable the other one for computed columns
+		// which means that if this column is a computed column of scale type we are only allowed to change the label and only the value for the other types.
+		// so in this case this means that if it is a computed column, and of type !scale we do *not* also update the label when updating the value. Because otherwise it would override the data from the computed column...
+		
+		bool dontSetLabel = label->originalValueAsString(false) != label->labelDisplay() || (originalValue.isDouble() && !label->originalValue().isDouble());
+		
+		if(!dontSetLabel && column->isComputed() && column->type() != columnType::scale)
+			dontSetLabel = true;
+		
+		if(dontSetLabel)	aChange = label->setOriginalValue(originalValue)	||	aChange;
+		else				aChange = label->setOrigValLabel(originalValue)		||	aChange;
 	}
 	
 	column->labelsHandleAutoSort();

--- a/Desktop/data/labelfiltergenerator.cpp
+++ b/Desktop/data/labelfiltergenerator.cpp
@@ -76,8 +76,8 @@ std::string	labelFilterGenerator::generateLabelFilter(size_t col)
 	std::stringstream	out;
 	
 	for(size_t row=0; row<filterAllows.size(); row++)
-		if(filterAllows[row] == bePositive)
-			out << (cnt++ > 0 ? (bePositive ? " | " : " & ") : "") << columnName << (bePositive ? " == \"" : " != \"") << labels[row] << "\"";
+		if(filterAllows[row] == bePositive) //Also make sure we use .nominal because otherwise we might be comparing to the value instead...
+			out << (cnt++ > 0 ? (bePositive ? " | " : " & ") : "") << columnName << ".nominal" << (bePositive ? " == \"" : " != \"") << labels[row] << "\"";
 	
 	return "(" + out.str() + ")";
 }

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -39,8 +39,6 @@
 #include "gui/aboutmodel.h"
 #include "models/columntypesmodel.h"
 #include "gui/preferencesmodel.h"
-#include "modules/dynamicmodule.h"
-#include "modules/ribbonbutton.h"
 #include "modules/ribbonmodelfiltered.h"
 #include "modules/ribbonmodel.h"
 #include "modules/upgrader/upgrader.h"
@@ -49,15 +47,13 @@
 #include "results/resultsjsinterface.h"
 #include "modules/ribbonmodeluncommon.h"
 #include "results/resultmenumodel.h"
-#include "jsonutilities.h"
 #include "utilities/helpmodel.h"
+#include "utilities/messageforwarder.h"
 #include "utilities/reporter.h"
 #include "utilities/codepageswindows.h"
 #include "widgets/filemenu/filemenu.h"
 #include "data/workspacemodel.h"
-
 #include "utilities/languagemodel.h"
-#include <vector>
 
 using namespace std;
 

--- a/Desktop/modules/upgrader/changeincompatible.cpp
+++ b/Desktop/modules/upgrader/changeincompatible.cpp
@@ -13,7 +13,7 @@ void ChangeIncompatible::applyUpgrade(Json::Value &options, UpgradeMsgs &msgs, b
 	options = Json::objectValue;	
 	
 	if(!inMeta)
-		msgs[analysisLog].push_back(prefixLog + tr("Reset analysis because of '%1'").arg(msg().isEmpty() ? "???" : msg()).toStdString());
+		msgs[analysisLog].push_back((msg().isEmpty() ? "???" : msg()).toStdString());
 }
 
 }

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -25,8 +25,6 @@
 #include "boundcontrols/boundcontrol.h"
 #include "analysisbase.h"
 #include "models/listmodel.h"
-#include "models/listmodeltermsavailable.h"
-#include "utilities/messageforwarder.h"
 #include "utilities/qutils.h"
 #include <queue>
 

--- a/QMLComponents/controls/rsyntaxhighlighter.cpp
+++ b/QMLComponents/controls/rsyntaxhighlighter.cpp
@@ -96,7 +96,7 @@ void RSyntaxHighlighter::highlightBlock(const QString &text)
 	QStringList			names = requestInfo(VariableInfo::InfoType::VariableNames).toStringList();
 	
 	for(const QString & name : names)
-		applyRule(text, QRegularExpression(QString(R"(%1)").arg(name)), _columnFormat);
+		applyRule(text, QRegularExpression(QString(R"(%1(\.(scale|ordinal|nominal))?)").arg(name)), _columnFormat);
 	
 	applyRule(text, _commentRule);
 }


### PR DESCRIPTION
Now computed columns handle the data they get based on their type, which means that:
- scale columns assume that the data they get from R (so either an R-column or contstructor column) is the values. If a value already had a label it picks one (but this will usually be 1 ofc)
- ordinal/nominal assume its labels and thus will use an existing value coupled with that label

If the corresponding value/label is missing it just uses the label/value it got.

This is all made clear to the user by the column in the labeleditor not being editable.
Ive also made sure that you can also filter by clicking labels out. I noticed a small bug where if the computed column is a scale it wont actually filter properly, so ive made sure that each column used in the label-filter-thing (generatedFilter) is always read as nominal and that solves that.

Fixes and or implements https://github.com/jasp-stats/INTERNAL-jasp/issues/2680

There also seemed to be an issue with the autosort but that was easily fixed by just generating `Label` for each (double-type) label.