### PR TITLE
Do not reset model during analysis initialization

### DIFF
--- a/QMLComponents/models/listmodelinteractionassigned.cpp
+++ b/QMLComponents/models/listmodelinteractionassigned.cpp
@@ -21,6 +21,7 @@
 #include "listmodeltermsavailable.h"
 #include "listmodeltermsassigned.h"
 #include "controls/jasplistcontrol.h"
+#include "analysisform.h"
 
 using namespace std;
 
@@ -123,6 +124,9 @@ void ListModelInteractionAssigned::_addTerms(const Terms& terms, bool combineWit
 
 void ListModelInteractionAssigned::availableTermsResetHandler(Terms termsAdded, Terms termsRemoved)
 {
+	if (listView()->form() && !listView()->form()->initialized())
+		return;
+
 	if (termsAdded.size() > 0 && listView()->addAvailableVariablesToAssigned())
 	{
 		_addTerms(termsAdded, _addInteractionsByDefault);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2684

If an assigned VariablesList has a 'addAvailableVariablesToAssigned' flag on, then it gets automatically the variables set of the Available VariablesList, This feature should not be activate during the initialization of the analysis: this overwrites the terms in the assigned VariablesList (set by the options saved in the JASP file)

