### PR TITLE
Order of variables should be kept in formula

### DIFF
--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -252,7 +252,8 @@ void AnalysisBase::setBoundValue(const std::string &name, const Json::Value &val
 	else
 		Log::log() << "Could not find parent keys " << _displayParentKeys(parentKeys) << " in options: " << _boundValues.toStyledString() << std::endl;
 
-	emit boundValuesChanged();
+	if (_analysisForm->initialized())
+		emit boundValuesChanged();
 }
 
 void AnalysisBase::setBoundValues(const Json::Value &boundValues)

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -132,9 +132,14 @@ void AnalysisForm::runScriptRequestDone(const QString& result, const QString& co
 				blockValueChangeSignal(true);
 				_analysis->clearOptions();
 				bindTo(Json::nullValue);
-				bindTo(options);
-				blockValueChangeSignal(false, false);
-				_analysis->boundValueChangedHandler();
+				// Some controls generate extra controls (rowComponents): these extra controls must be first destroyed, because they may disturb the binding of other controls
+				// For this, bind all controls to null and wait for the controls to be completely destroyed.
+				QTimer::singleShot(0, [=](){
+					bindTo(options);
+					blockValueChangeSignal(false, false);
+					_analysis->boundValueChangedHandler();
+				});
+
 			}
 		}
 
@@ -598,7 +603,6 @@ void AnalysisForm::setAnalysisUp()
 	// Don't bind boundValuesChanged before it is initialized: each setup of all controls will generate a boundValuesChanged
 	connect(_analysis,					&AnalysisBase::boundValuesChanged,		this,			&AnalysisForm::setRSyntaxText,				Qt::QueuedConnection	);
 
-	setRSyntaxText();
 	emit analysisChanged();
 }
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2689

This issue is reproduceable with Variables list with interactions: in ANOVA or MIxed Models for example.

Also in the Mixed Models, if several random effects are added, some effects are sometimes suddenly added or removed when applying the R Syntax. This was due to the fact that the controls dynamically created by the ComponentsList were not removed before setting the new options. 

At last, avoid generating R Syntax during the initialization of the form: each time a control gets a new value, the R Syntax is generated: this is not needed when the form is being initialized.

