### PR TITLE
Fix some issues found in the Test Module

### DIFF
--- a/QMLComponents/components/JASP/Controls/Button.qml
+++ b/QMLComponents/components/JASP/Controls/Button.qml
@@ -34,6 +34,7 @@ JASPControl
 	readonly	property alias control:		control
 				property alias text:		control.text
 				property alias label:		control.text
+				property alias textFormat:	control.textFormat
 				property alias iconSource:	control.iconSource
 	readonly	property alias pressed:		control._pressed
 

--- a/QMLComponents/components/JASP/Controls/CheckBox.qml
+++ b/QMLComponents/components/JASP/Controls/CheckBox.qml
@@ -42,8 +42,8 @@ CheckBoxBase
 			property alias	font:					label.font
 			property alias	fontInfo:				label.fontInfo
 			property alias	label:					control.text
-			property alias	labelTextFormat:		label.textFormat
 			property alias	checked:				control.checked
+			property int	textFormat:				Text.AutoText
 			property bool	childrenOnSameRow:		false
 			property alias	columns:				childControlsArea.columns
 			property bool	enableChildrenOnChecked: true
@@ -111,6 +111,7 @@ CheckBoxBase
 			font:				jaspTheme.font
 			leftPadding:		checkIndicator.width + control.spacing
 			verticalAlignment:	Text.AlignVCenter
+			textFormat:			checkBox.textFormat
 		}
 
 		background: Rectangle

--- a/QMLComponents/components/JASP/Controls/ComboBox.qml
+++ b/QMLComponents/components/JASP/Controls/ComboBox.qml
@@ -20,6 +20,7 @@ ComboBoxBase
 	property alias	value:					comboBox.currentValue
 	property alias	indexDefaultValue:		comboBox.currentIndex
 	property alias	fieldWidth:				control.width
+	property int	textFormat:				Text.AutoText
 	property bool	showVariableTypeIcon:	containsVariables
 	property var	enabledOptions:			[]
 	property bool	setLabelAbove:			false
@@ -87,6 +88,7 @@ ComboBoxBase
 			anchors.verticalCenter: parent.verticalCenter
 			color:		enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
 			width:		implicitWidth
+			textFormat: comboBox.textFormat
 		}
 	}
 

--- a/QMLComponents/components/JASP/Controls/ExpanderButton.qml
+++ b/QMLComponents/components/JASP/Controls/ExpanderButton.qml
@@ -46,6 +46,7 @@ FocusScope
 	readonly	property string iconsFolder				: jaspTheme.iconPath
 	readonly	property string	expanderButtonIcon		: "expander-arrow-up.png"
 				property alias	columns					: expanderArea.columns
+				property int	textFormat				: Text.AutoText
 	
 	states: [
 		State
@@ -131,6 +132,7 @@ FocusScope
 				anchors.verticalCenter	: parent.verticalCenter
 				font					: jaspTheme.font
 				color					: enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
+				textFormat				: expanderWrapper.textFormat
             }
         }
     }

--- a/QMLComponents/components/JASP/Controls/GroupBox.qml
+++ b/QMLComponents/components/JASP/Controls/GroupBox.qml
@@ -39,9 +39,10 @@ GroupBoxBase
 			property int	columnSpacing:		jaspTheme.columnGroupSpacing
 			property int	columns:			1
 			property bool	indent:				false
-			property bool	alignFields:	true
+			property bool	alignFields:		true
 			property alias	label:				label
 			property alias	preferredWidth:		contentArea.width
+			property int	textFormat:			Text.AutoText
 
 			property var	_allAlignableFields:		[]
 			property bool	_childrenConnected:	false
@@ -55,6 +56,7 @@ GroupBoxBase
 		color:			enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
 		font:			jaspTheme.font
 		visible:		groupBox.title ? true : false
+		textFormat:		groupBox.textFormat
 		
 		property int	realHeight: visible ? implicitHeight : 0
 		property int	realWidth:  visible ? implicitWidth  : 0

--- a/QMLComponents/components/JASP/Controls/RadioButton.qml
+++ b/QMLComponents/components/JASP/Controls/RadioButton.qml
@@ -43,6 +43,7 @@ RadioButtonBase
 	property alias	label:					control.text
 	property alias	checked:				control.checked
 	property alias	value:					radioButton.name
+	property int	textFormat:				Text.AutoText
 	property bool	childrenOnSameRow:		false
 	property alias	columns:				childControlsArea.columns
 	property bool	enableChildrenOnChecked: true
@@ -102,6 +103,7 @@ RadioButtonBase
 			leftPadding:	radioIndicator.width + control.spacing
 			font:			jaspTheme.font
 			color:			enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
+			textFormat:		radioButton.textFormat
 		}
 
 		background: Rectangle { color: "transparent" }

--- a/QMLComponents/components/JASP/Controls/RadioButtonGroup.qml
+++ b/QMLComponents/components/JASP/Controls/RadioButtonGroup.qml
@@ -35,6 +35,7 @@ RadioButtonsGroupBase
 			property alias	columns:				contentArea.columns
 			property alias	text:					control.title
 			property int	leftPadding:			jaspTheme.groupContentPadding
+			property int	textFormat:				Text.AutoText
 
 	implicitWidth:	radioButtonsOnSameRow
 						? contentArea.x + contentArea.implicitWidth
@@ -57,6 +58,7 @@ RadioButtonsGroupBase
 		verticalAlignment: Text.AlignVCenter
 		font:			jaspTheme.font
 		color:			enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled		
+		textFormat:		control.textFormat
     }
     
 

--- a/QMLComponents/components/JASP/Controls/RectangularButton.qml
+++ b/QMLComponents/components/JASP/Controls/RectangularButton.qml
@@ -24,8 +24,7 @@ Rectangle
 {
 	id:				filterButtonRoot
 
-	
-
+	property alias  textFormat:			buttonText.textFormat
 	property string	text:				""
 	property string	toolTip:			""
 	property string textColor:			"default"

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -34,6 +34,7 @@ TextInputBase
 	property alias	control:			control
 	property alias	text:				textField.label
 	property alias	displayValue:		control.text	///< In onEditingFinished this contains the "value" entered by the user
+	property int	textFormat:			Text.AutoText
 	property var	lastValidValue:		defaultValue
 	property int	fieldWidth:			jaspTheme.textFieldWidth
 	property int	fieldHeight:		0
@@ -151,6 +152,7 @@ TextInputBase
 			color:					enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
 			text:					textField.label
 			width:					implicitWidth
+			textFormat:				textField.textFormat
 		}
 	}
 
@@ -279,6 +281,7 @@ TextInputBase
 			anchors.verticalCenter: parent.verticalCenter
 			color:					enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
 			text:					textField.afterLabel
+			textFormat:				textField.textFormat
 		}
 	}
 }

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -43,6 +43,7 @@ VariablesListBase
 	property alias	itemRectangle					: itemRectangle
 	property alias	scrollBar						: scrollBar
 	property alias	itemTitle						: itemTitle
+	property int	textFormat						: Text.AutoText
 	property string	rowComponentTitle				: ""
 	property string itemType						: "variables"
 	property int	dropMode						: JASP.DropNone
@@ -146,6 +147,7 @@ VariablesListBase
 		height			: title ? jaspTheme.variablesListTitle : 0
 		font			: jaspTheme.font
 		color			: enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
+		textFormat		: variablesList.textFormat
 	}
 
 	Text
@@ -156,6 +158,7 @@ VariablesListBase
 		height			: rowComponentTitle ? jaspTheme.variablesListTitle : 0
 		font			: jaspTheme.font
 		color			: enabled ? jaspTheme.textEnabled : jaspTheme.textDisabled
+		textFormat		: variablesList.textFormat
 	}
 
 	Rectangle

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -83,7 +83,11 @@ void ComboBoxBase::bindTo(const Json::Value& value)
 		}
 	}
 	else if (!selectedValue.empty())
-		_lostValue = selectedValue;
+		// The control is bound with a value, but its model is empty.
+		// Probably the values are set with a direct reference of a property of another control, like varList.levels, and this control is not yet initialized.
+		// (as the combobox has no direct reference to the varList self, it cannot add a dependency in _depends).
+		// So keep this value, and use it if the model is reset during the initialization of the form.
+		_unusedInitialValue = selectedValue;
 
 	_setCurrentProperties(index);
 
@@ -155,7 +159,7 @@ void ComboBoxBase::setUp()
 	if (form())
 	{
 		connect(form(), &AnalysisForm::languageChanged,			[this] () { _model->resetTermsFromSources(); }	);
-		connect(form(), &AnalysisForm::analysisChanged,			[this] () { _lostValue = ""; });
+		connect(form(), &AnalysisForm::analysisChanged,			[this] () { _unusedInitialValue = ""; });
 	}
 }
 
@@ -184,14 +188,14 @@ void ComboBoxBase::termsChangedHandler()
 		{
 			auto itr = std::find(values.begin(), values.end(), fq(_currentValue));
 
-			if (!_lostValue.empty())
+			if (!_unusedInitialValue.empty())
 			{
-				auto lostValueItr = std::find(values.begin(), values.end(), _lostValue);
+				auto lostValueItr = std::find(values.begin(), values.end(), _unusedInitialValue);
 				if (lostValueItr != values.end())
 				{
 					itr = lostValueItr;
-					_orgValue = _lostValue;
-					_lostValue = "";
+					_orgValue = _unusedInitialValue;
+					_unusedInitialValue = "";
 				}
 			}
 

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -82,6 +82,8 @@ void ComboBoxBase::bindTo(const Json::Value& value)
 			index = int(std::distance(values.begin(), itr));
 		}
 	}
+	else if (!selectedValue.empty())
+		_lostValue = selectedValue;
 
 	_setCurrentProperties(index);
 
@@ -133,7 +135,7 @@ Json::Value ComboBoxBase::createJson() const
 
 bool ComboBoxBase::isJsonValid(const Json::Value &optionValue) const
 {
-	return optionValue.type() == Json::stringValue || optionValue.type() == Json::arrayValue;
+	return optionValue.type() == Json::stringValue || optionValue.type() == Json::objectValue;
 }
 
 void ComboBoxBase::setUp()
@@ -151,8 +153,10 @@ void ComboBoxBase::setUp()
 	connect(this,	&ComboBoxBase::currentValueChanged,			[this] () { if (containsVariables()) checkLevelsConstraints(); } );
 
 	if (form())
+	{
 		connect(form(), &AnalysisForm::languageChanged,			[this] () { _model->resetTermsFromSources(); }	);
-
+		connect(form(), &AnalysisForm::analysisChanged,			[this] () { _lostValue = ""; });
+	}
 }
 
 void ComboBoxBase::setUpModel()
@@ -179,6 +183,17 @@ void ComboBoxBase::termsChangedHandler()
 		if (initialized())
 		{
 			auto itr = std::find(values.begin(), values.end(), fq(_currentValue));
+
+			if (!_lostValue.empty())
+			{
+				auto lostValueItr = std::find(values.begin(), values.end(), _lostValue);
+				if (lostValueItr != values.end())
+				{
+					itr = lostValueItr;
+					_orgValue = _lostValue;
+					_lostValue = "";
+				}
+			}
 
 			if (itr == values.end())	index = _getStartIndex();
 			else						index = int(std::distance(values.begin(), itr));

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -92,7 +92,7 @@ protected:
 								_currentColumnType,
 								_currentColumnRealType,
 								_currentColumnTypeIcon;
-	std::string					_lostValue;
+	std::string					_unusedInitialValue;
 	int							_currentIndex			= -1;
 	bool						_fixedWidth				= false;
 

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -92,6 +92,7 @@ protected:
 								_currentColumnType,
 								_currentColumnRealType,
 								_currentColumnTypeIcon;
+	std::string					_lostValue;
 	int							_currentIndex			= -1;
 	bool						_fixedWidth				= false;
 

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -410,7 +410,7 @@ bool JASPListControl::checkLevelsConstraints()
 
 QStringList JASPListControl::levels() const
 {
-	return initialized() ? model()->allLevels(model()->terms()) : QStringList();
+	return model() ? model()->allLevels(model()->terms()) : QStringList();
 }
 
 QStringList JASPListControl::allowedColumnsIcons() const

--- a/QMLComponents/models/listmodelinteractionassigned.cpp
+++ b/QMLComponents/models/listmodelinteractionassigned.cpp
@@ -166,7 +166,7 @@ Terms ListModelInteractionAssigned::addTerms(const Terms& terms, int , const Row
 	Terms dropped;
 	if (availableModel())
 		dropped.setSortParent(availableModel()->allTerms());
-	dropped.set(terms);
+	dropped.set(checkTermsTypes(terms));
 
 	Terms newTerms = dropped.combineTerms(JASPControl::CombinationType::CombinationCross);
 


### PR DESCRIPTION
- In Test Variable Encoding, Simple Variables Form Section, set some variables so that the dropdown gets some values. Duplicate the analysis: error telling that an option cannot be set. The isJsonValid function of the ComboBox control was not up-to-date, and should allow object Json value. 
- In Test Variable Encoding, if you drag & drop 2 variables in an Interaction VariablesList, it adds automatically the interaction term. If there is an allowed type, the terms should get automatically this type even if they have another type. This does not work for the interaction term: in the result, we can still see that it keeps the original types.
- In Test Sources with special attributes analysis, in the source with levels section. If you set a nominal/ordinal variable, you see the levels of the variable in the dropdown. If you duplicate the analysis, it loses these values. This is due to the fact that when the values of a dropdown is directly set to the levels of another control, there is here no way to know the dependency of the controls between them: during the initialization of the form, the Dropdown can get its value before the Variable list (it actually depends on), and as the binding value is not a possible value of the dropdown, it loses. For this a special if the binding value does not correspond of the possible values, this value is kept in the _lostValue member. In case that the possible values of the dropdown change (because the Variables list is finally set, the dropdown checks whether the _lostValue could fit. This must be done only before the form is completely initialized.
- Add textFormat propery to controls. A Test Format analysis is also added in the Test Module.


