### PR TITLE
bugfix: fix missing html content in notes

### DIFF
--- a/Desktop/html/js/jaspNotes.js
+++ b/Desktop/html/js/jaspNotes.js
@@ -540,7 +540,7 @@ JASPWidgets.NoteBox = JASPWidgets.View.extend({
 				html = this.model.get("text");
 			}
 
-			delt = this.$quill.clipboard.convert(html);
+			delt = this.$quill.clipboard.convert({"html" : html});    //see:https://github.com/slab/quill/issues/4135
 		}
 
 		this.$quill.setContents(delt);


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/jasp-test-release/issues/2776

This is Quill's issue, after upgrading to Quill v2, converting HTML should to be inserted as an object.

Note: Should update all data libraries from 0.19.1 to avoid description loss issues introduced by the test version.In addition, we may need to consider why automated testing does not cover this point.