### PR TITLE
Type backward compatibility

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolbase.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolbase.cpp
@@ -117,7 +117,7 @@ std::string BoundControlBase::getName() const
 	return fq(_control->name());
 }
 
-void BoundControlBase::_readTableValue(const Json::Value &value, const std::string& key, bool hasMultipleTerms, Terms& terms, ListModel::RowControlsValues& allControlValues)
+void BoundControlBase::_readTableValue(const Json::Value &value, const std::string& key, bool hasMultipleTerms, Terms& terms, ListModel::RowControlsValues& allControlValues, const Terms& sourceTerms)
 {
 	for (const Json::Value& row : value)
 	{
@@ -126,6 +126,9 @@ void BoundControlBase::_readTableValue(const Json::Value &value, const std::stri
 		Term term = Term::readTerm(keyValue);
 		if (term.size() > 0)
 		{
+			int termInd = sourceTerms.indexOf(term);
+			if (termInd >= 0)
+				term.setTypes(sourceTerms[termInd].types());
 			terms.add(term);
 
 			QMap<QString, Json::Value> controlMap;

--- a/QMLComponents/boundcontrols/boundcontrolbase.h
+++ b/QMLComponents/boundcontrols/boundcontrolbase.h
@@ -51,7 +51,7 @@ protected:
 	static Json::Value			_getTableValueOption(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasInteraction, bool keyHasVariables);
 	void						_setTableValue(const Terms& terms, const ListModel::RowControlsValues& componentValuesMap, const std::string& key, bool hasInteraction, bool keyHasVariables = false);
 
-	void						_readTableValue(const Json::Value& value, const std::string& key, bool hasMultipleTerms, Terms& terms, ListModel::RowControlsValues& allControlValues);
+	void						_readTableValue(const Json::Value& value, const std::string& key, bool hasMultipleTerms, Terms& terms, ListModel::RowControlsValues& allControlValues, const Terms& sourceTerms = Terms());
 	bool						_isValueWithTypes(const Json::Value &value)					const;
 
 	JASPControl*				_control			= nullptr;

--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -47,7 +47,7 @@ void ComponentsListBase::bindTo(const Json::Value& value)
 	Terms terms;
 	ListModel::RowControlsValues allControlValues;
 
-	_readTableValue(value, keyName, containsInteractions(), terms, allControlValues);
+	_readTableValue(value, keyName, containsInteractions(), terms, allControlValues, _termsModel->getSourceTerms());
 
 	_termsModel->initTerms(terms, allControlValues);
 }


### PR DESCRIPTION
Refresh the Larks and Owls JASP file from the Mixed Models Data Library gives an error. This is due to backward compatibility with types: the interaction terms had no type in 0.19.1. This could lead to errors because the analysis needs to read the variables according to their types.

Fixes https://github.com/jasp-stats/jasp-test-release/issues/2775