### PR TITLE
Do not synchronize uncessarily with the datafile

### DIFF
--- a/Desktop/data/asyncloader.cpp
+++ b/Desktop/data/asyncloader.cpp
@@ -262,7 +262,10 @@ void AsyncLoader::loadPackage(QString id)
 
 			if (_currentEvent->type() != Utils::FileType::jasp)
 			{
-				pkg->setDataFilePath(_currentEvent->path().toStdString());
+				QFileInfo fileInfo(_currentEvent->path());
+				long timestamp = fileInfo.isFile() ? fileInfo.lastModified().toSecsSinceEpoch() : 0;
+
+				pkg->setDataFilePath(_currentEvent->path().toStdString(), timestamp);
 				pkg->setDatabaseJson(_currentEvent->database());
 			}
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -2439,7 +2439,7 @@ bool DataSetPackage::currentFileIsExample() const
 
 void DataSetPackage::setDataFilePath(std::string filePath, long timestamp)
 {
-	if(!_dataSet || _dataSet->dataFilePath() == filePath)
+	if(!_dataSet || (_dataSet->dataFilePath() == filePath && timestamp == _dataSet->dataFileTimestamp()))
 		return;
 
 	if (timestamp == 0 && !filePath.empty())
@@ -2452,6 +2452,7 @@ void DataSetPackage::setDataFilePath(std::string filePath, long timestamp)
 	if (tq(filePath).startsWith(AppDirs::examples()))
 		setDataFileReadOnly(true);
 
+	setModified(true);
 	emit synchingExternallyChanged(synchingExternally());
 }
 


### PR DESCRIPTION
When a JASP file is loaded, it tries always to synchronize with its data file, even if the datafile was not changed: this is because the right dataFile timestamp was not correctly set in the JASP file.

