### PR TITLE
Show the right implicit empty values in tooltip

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -2381,13 +2381,15 @@ stringvec Column::previewTransform(columnType transformType)
 			for(Label * label : _labels)
 				if(!label->isEmptyValue() && !ColumnUtils::isDoubleValue(label->originalValueAsString()))
 				{
-					if(count++ < showThisMany)
-						someImplicitEmptyValues << (count++ > 0 ? ", " : "") << '"' << label->originalValueAsString() << '"';
+					if(count < showThisMany)
+						someImplicitEmptyValues << (count > 0 ? ", " : "") << '"' << label->originalValueAsString() << '"';
 					else
 					{
 						someImplicitEmptyValues << ", ...";
 						break; // Do not need to loop further over the labels.
 					}
+
+					count++;
 				}	
 		}
 		

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -2379,7 +2379,6 @@ stringvec Column::previewTransform(columnType transformType)
 			int count = 0;
 			
 			for(Label * label : _labels)
-			{
 				if(!label->isEmptyValue() && !ColumnUtils::isDoubleValue(label->originalValueAsString()))
 				{
 					if(count < showThisMany)
@@ -2388,8 +2387,7 @@ stringvec Column::previewTransform(columnType transformType)
 						someImplicitEmptyValues << ", ...";
 					else
 						break; // Do not need to loop further over the labels.
-				}
-			}
+				}	
 		}
 		
 		out.push_back(someImplicitEmptyValues.str());

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -2381,12 +2381,13 @@ stringvec Column::previewTransform(columnType transformType)
 			for(Label * label : _labels)
 				if(!label->isEmptyValue() && !ColumnUtils::isDoubleValue(label->originalValueAsString()))
 				{
-					if(count < showThisMany)
+					if(count++ < showThisMany)
 						someImplicitEmptyValues << (count++ > 0 ? ", " : "") << '"' << label->originalValueAsString() << '"';
-					else if(count++ == showThisMany)
-						someImplicitEmptyValues << ", ...";
 					else
+					{
+						someImplicitEmptyValues << ", ...";
 						break; // Do not need to loop further over the labels.
+					}
 				}	
 		}
 		

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -2380,7 +2380,7 @@ stringvec Column::previewTransform(columnType transformType)
 			
 			for(Label * label : _labels)
 			{
-				if(!label->isEmptyValue() && !ColumnUtils::isDoubleValue(label->label()))
+				if(!label->isEmptyValue() && !ColumnUtils::isDoubleValue(label->originalValueAsString()))
 				{
 					if(count < showThisMany)
 						someImplicitEmptyValues << (count++ > 0 ? ", " : "") << '"' << label->originalValueAsString() << '"';

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -2372,20 +2372,27 @@ stringvec Column::previewTransform(columnType transformType)
 	}
 	
 	{
-		std::stringstream someEmptyValues;
+		std::stringstream someImplicitEmptyValues;
 		
 		if(transformType == columnType::scale && labelsTempCount() > _labelsTempNumerics)
 		{
 			int count = 0;
 			
 			for(Label * label : _labels)
-				if(!label->isEmptyValue() && count < showThisMany)
-					someEmptyValues << (count++ > 0 ? ", " : "") << '"' << label->originalValueAsString() << '"';
-				else if(!label->isEmptyValue() && count++ == showThisMany)
-					someEmptyValues << ", ...";
+			{
+				if(!label->isEmptyValue() && !ColumnUtils::isDoubleValue(label->label()))
+				{
+					if(count < showThisMany)
+						someImplicitEmptyValues << (count++ > 0 ? ", " : "") << '"' << label->originalValueAsString() << '"';
+					else if(count++ == showThisMany)
+						someImplicitEmptyValues << ", ...";
+					else
+						break; // Do not need to loop further over the labels.
+				}
+			}
 		}
 		
-		out.push_back(someEmptyValues.str());
+		out.push_back(someImplicitEmptyValues.str());
 	}
 	
 	return out;

--- a/CommonData/label.cpp
+++ b/CommonData/label.cpp
@@ -248,7 +248,7 @@ std::string Label::labelIgnoreEmpty() const
 
 bool Label::isEmptyValue() const
 {
-	return _column->isEmptyValue(_label);
+	return _column->isEmptyValue(originalValueAsString(false)) || _column->isEmptyValue(label());
 }
 
 std::string Label::originalValueAsString(bool fancyEmptyValue) const


### PR DESCRIPTION
If you set a nominal or ordinal variable in a scale VariablesList, a tooltip tells you how the values are transformed into scale. It gives also a list of 'implicit' empty values: that is the not empty values that could not be converted into a double value. This list was not correct, it gave all the convertable values.

