### PR TITLE
fix: use jaspTheme font for TabView

### DIFF
--- a/QMLComponents/components/JASP/Controls/TabView.qml
+++ b/QMLComponents/components/JASP/Controls/TabView.qml
@@ -92,6 +92,7 @@ ComponentsListBase
 					leftPadding			: jaspTheme.labelSpacing
 					color				: jaspTheme.black
 					text				: model.name
+					font				: jaspTheme.font
 					elide				: Text.ElideRight
 					width				: parent.width - jaspTheme.labelSpacing - (removeIconItem.visible ? removeIconItem.width  : 0)
 					visible				: !textFieldItem.visible


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/1612

so you can saw:
![image](https://github.com/user-attachments/assets/5539a060-662d-4eca-96c5-79e86197823a)
