### PR TITLE
R Syntax: split analysis and analysisForm

### DIFF
--- a/CommonData/dataset.h
+++ b/CommonData/dataset.h
@@ -69,6 +69,7 @@ public:
 			
 			void			loadOldComputedColumnsJson(const Json::Value & json); ///< Should act the same as the old ComputedColumns::fromJson() to allow loading "older jaspfiles"
 			stringset		findUsedColumnNames(std::string searchThis);
+			bool			initColumnWithStrings(int colIndex, const std::string & newName, const stringvec &values, const stringvec & labels, const std::string & title, columnType desiredType, const stringset & emptyValues, int threshold, bool orderLabelsByValue);
 
 			DatabaseInterface	 &	db();
 	const	DatabaseInterface	 &	db() const;

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1488,24 +1488,10 @@ bool DataSetPackage::initColumnWithStrings(QVariant colId, const std::string & n
 {
 	JASPTIMER_SCOPE(DataSetPackage::initColumnWithStrings);
 	
-	int			colIndex		=	getColIndex(colId),
-				threshold		=	Settings::value(Settings::THRESHOLD_SCALE).toInt();
-	Column	*	column			=	_dataSet->columns()[colIndex];
-				column			->	setHasCustomEmptyValues(emptyValues.size());
-				column			->	setCustomEmptyValues(emptyValues);
-				column			->	setName(newName);
-				column			->	setTitle(title);
-				column			->	beginBatchedLabelsDB();
-	bool		anyChanges		=	title != column->title() || newName != column->name();
-	columnType	prevType		=	column->type(),
-				suggestedType	=	column->setValues(values, labels,	threshold, &anyChanges);  //If less unique integers than the thresholdScale then we think it must be ordinal: https://github.com/jasp-stats/INTERNAL-jasp/issues/270
-				column			->	setType(column->type() != columnType::unknown ? column->type() : desiredType == columnType::unknown ? suggestedType : desiredType);
-				column			->	endBatchedLabelsDB();
-				
-	if(PreferencesModel::prefs()->orderByValueByDefault())
-		column->labelsOrderByValue();
-	
-	return anyChanges || column->type() != prevType;
+	return _dataSet->initColumnWithStrings(
+				getColIndex(colId), newName, values, labels, title, desiredType, emptyValues,
+				Settings::value(Settings::THRESHOLD_SCALE).toInt(),
+				PreferencesModel::prefs()->orderByValueByDefault());
 }
 
 void DataSetPackage::initializeComputedColumns()

--- a/Engine/engine.h
+++ b/Engine/engine.h
@@ -20,7 +20,6 @@
 
 #include "enginebase.h"
 #include "enginedefinitions.h"
-#include "dataset.h"
 #include "ipcchannel.h"
 #include <json/json.h>
 #include "columnencoder.h"

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -30,8 +30,6 @@
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QTimer>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include "preferencesmodelbase.h"
 
 using namespace std;
@@ -277,8 +275,8 @@ QString AnalysisForm::parseOptions(QString options)
 	Json::Value	 jsonOptions;
 	Json::Value jsonResult(Json::objectValue);
 
-	QJsonDocument doc = QJsonDocument::fromJson(options.toUtf8());
-	jsonReader.parse(doc.toJson().toStdString(), jsonOptions, false);
+	
+	jsonReader.parse(fq(options), jsonOptions, false);
 
 	if (!_analysis)
 		setAnalysis(new AnalysisBase(this)); // Create a dummy analyis object

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -133,9 +133,9 @@ void AnalysisForm::runScriptRequestDone(const QString& result, const QString& co
 				// Some controls generate extra controls (rowComponents): these extra controls must be first destroyed, because they may disturb the binding of other controls
 				// For this, bind all controls to null and wait for the controls to be completely destroyed.
 				QTimer::singleShot(0, [=](){
-				bindTo(options);
+					bindTo(options);
 					blockValueChangeSignal(false, false);
-				_analysis->boundValueChangedHandler();
+					_analysis->boundValueChangedHandler();
 				});
 			}
 		}

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -20,7 +20,6 @@
 #include "knownissues.h"
 #include "boundcontrols/boundcontrol.h"
 #include "utilities/qutils.h"
-#include "models/listmodeltermsavailable.h"
 #include "controls/jasplistcontrol.h"
 #include "controls/expanderbuttonbase.h"
 #include "log.h"
@@ -31,7 +30,8 @@
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QTimer>
-#include "controls/variableslistbase.h"
+#include <QJsonDocument>
+#include <QJsonObject>
 #include "preferencesmodelbase.h"
 
 using namespace std;
@@ -110,7 +110,7 @@ void AnalysisForm::cleanUpForm()
 }
 
 void AnalysisForm::runScriptRequestDone(const QString& result, const QString& controlName, bool hasError)
-{	
+{
 	if(_removed)
 		return;
 
@@ -135,11 +135,10 @@ void AnalysisForm::runScriptRequestDone(const QString& result, const QString& co
 				// Some controls generate extra controls (rowComponents): these extra controls must be first destroyed, because they may disturb the binding of other controls
 				// For this, bind all controls to null and wait for the controls to be completely destroyed.
 				QTimer::singleShot(0, [=](){
-					bindTo(options);
+				bindTo(options);
 					blockValueChangeSignal(false, false);
-					_analysis->boundValueChangedHandler();
+				_analysis->boundValueChangedHandler();
 				});
-
 			}
 		}
 
@@ -170,7 +169,6 @@ void AnalysisForm::filterByNameDone(const QString & name, const QString & error)
 		control->filterDoneHandler(name, error);
 }
 
-
 void AnalysisForm::addControl(JASPControl *control)
 {
 	const QString & name = control->name();
@@ -178,7 +176,7 @@ void AnalysisForm::addControl(JASPControl *control)
 	if (_analysis && control->isBound())
 	{
 		connect(control, &JASPControl::requestColumnCreation, _analysis, &AnalysisBase::requestColumnCreationHandler);
-		
+
 		connect(control, &JASPControl::usedVariablesChanged, _analysis, &AnalysisBase::onUsedVariablesChanged);
 	}
 
@@ -272,16 +270,28 @@ void AnalysisForm::setHasVolatileNotes(bool hasVolatileNotes)
 	emit hasVolatileNotesChanged();
 }
 
-bool AnalysisForm::parseOptions(Json::Value &options)
+
+QString AnalysisForm::parseOptions(QString options)
 {
-	if (_rSyntax->parseRSyntaxOptions(options))
+	Json::Reader jsonReader;
+	Json::Value	 jsonOptions;
+	Json::Value jsonResult(Json::objectValue);
+
+	QJsonDocument doc = QJsonDocument::fromJson(options.toUtf8());
+	jsonReader.parse(doc.toJson().toStdString(), jsonOptions, false);
+
+	if (!_analysis)
+		setAnalysis(new AnalysisBase(this)); // Create a dummy analyis object
+
+	if (_rSyntax->parseRSyntaxOptions(jsonOptions))
 	{
-		bindTo(options);
-		options = _analysis->boundValues();
-		return true;
+		bindTo(jsonOptions);
+		jsonOptions = _analysis->boundValues();
 	}
 
-	return false;
+	jsonResult["options"] = jsonOptions;
+	jsonResult["error"] = fq(getError());
+	return tq(jsonResult.toStyledString());
 }
 
 void AnalysisForm::_setUp()
@@ -311,7 +321,7 @@ void AnalysisForm::reset()
 
 void AnalysisForm::exportResults()
 {
-    _analysis->exportResults();
+	_analysis->exportResults();
 }
 
 QString AnalysisForm::msgsListToString(const QStringList & list) const
@@ -370,7 +380,7 @@ void AnalysisForm::_addLoadingError(QStringList wrongJson)
 void AnalysisForm::bindTo(const Json::Value & defaultOptions)
 {
 	std::set<std::string> controlsJsonWrong;
-	
+
 	for (JASPControl* control : _dependsOrderedCtrls)
 	{
 		BoundControl* boundControl = control->boundControl();
@@ -567,7 +577,7 @@ void AnalysisForm::setTitle(QString title)
 		_analysis->setTitle(fq(title.simplified()));
 }
 
-void AnalysisForm::setOptionNameConversion(const QVariantList & conv)
+void AnalysisForm::setOptionNameConversion(const QVariantList &conv)
 {
 	if (_rSyntax->setControlNameToRSyntaxMap(conv))
 		emit optionNameConversionChanged();
@@ -691,7 +701,7 @@ void AnalysisForm::blockValueChangeSignal(bool block, bool notifyOnceUnblocked)
 	else
 	{
 		_valueChangedSignalsBlocked--;
-		
+
 		if (_valueChangedSignalsBlocked < 0)
 			_valueChangedSignalsBlocked = 0;
 
@@ -701,7 +711,7 @@ void AnalysisForm::blockValueChangeSignal(bool block, bool notifyOnceUnblocked)
 				_analysis->boundValueChangedHandler();
 
 			_valueChangedEmittedButBlocked = false;
-		
+
 			if(_analysis && (notifyOnceUnblocked || _analysis->wasUpgraded())) //Maybe something was upgraded and we want to run the dropped rscripts (for instance for https://github.com/jasp-stats/INTERNAL-jasp/issues/1399)
 			{
 				while(_waitingRScripts.size() > 0)
@@ -713,7 +723,7 @@ void AnalysisForm::blockValueChangeSignal(bool block, bool notifyOnceUnblocked)
 
 				for(const auto & filterName : _waitingFilters)
 					_analysis->sendFilter(filterName);
-				
+
 				_waitingFilters.clear();
 			}
 			else //Otherwise just clean it up
@@ -912,14 +922,14 @@ QString AnalysisForm::helpMD() const
 		markdown << control->helpMD() << "\n";
 
 	markdown << metaHelpMD();
-	
+
 	if(!_infoBottom.isEmpty())
 		markdown << "\n\n---\n" << _infoBottom  << "\n";
 
 	QString md = markdown.join("");
-	
+
 	_analysis->preprocessMarkdownHelp(md);
-	
+
 	return md;
 }
 

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -575,7 +575,7 @@ void AnalysisForm::setTitle(QString title)
 		_analysis->setTitle(fq(title.simplified()));
 }
 
-void AnalysisForm::setOptionNameConversion(const QVariantList &conv)
+void AnalysisForm::setOptionNameConversion(const QVariantList & conv)
 {
 	if (_rSyntax->setControlNameToRSyntaxMap(conv))
 		emit optionNameConversionChanged();

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -145,6 +145,7 @@ public:
 	Q_INVOKABLE void		refreshAnalysis();
 	Q_INVOKABLE bool		initialized()			const	{ return _initialized; }
 	Q_INVOKABLE QString		generateWrapper()		const;
+    Q_INVOKABLE QString     parseOptions(QString options);
 
 	void					addControlError(JASPControl* control, QString message, bool temporary = false, bool warning = false, bool closeable = true);
 	void					clearControlError(JASPControl* control);
@@ -180,9 +181,8 @@ public:
 	void					sortControls(QList<JASPControl*>& controls);
 	QString					getSyntaxName(const QString& name)				const;
 	void					setHasVolatileNotes(bool hasVolatileNotes);
-	bool					parseOptions(Json::Value& options);
-	void					setActiveJASPControl(JASPControl* control, bool hasActiveFocus);
-	JASPControl*			getActiveJASPControl()	{ return _activeJASPControl; }
+    void					setActiveJASPControl(JASPControl* control, bool hasActiveFocus);
+    JASPControl*			getActiveJASPControl()	{ return _activeJASPControl; }
 
 	static const QString	rSyntaxControlName;
 		

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -145,7 +145,7 @@ public:
 	Q_INVOKABLE void		refreshAnalysis();
 	Q_INVOKABLE bool		initialized()			const	{ return _initialized; }
 	Q_INVOKABLE QString		generateWrapper()		const;
-    Q_INVOKABLE QString     parseOptions(QString options);
+	Q_INVOKABLE QString		parseOptions(QString options);
 
 	void					addControlError(JASPControl* control, QString message, bool temporary = false, bool warning = false, bool closeable = true);
 	void					clearControlError(JASPControl* control);
@@ -181,8 +181,8 @@ public:
 	void					sortControls(QList<JASPControl*>& controls);
 	QString					getSyntaxName(const QString& name)				const;
 	void					setHasVolatileNotes(bool hasVolatileNotes);
-    void					setActiveJASPControl(JASPControl* control, bool hasActiveFocus);
-    JASPControl*			getActiveJASPControl()	{ return _activeJASPControl; }
+	void					setActiveJASPControl(JASPControl* control, bool hasActiveFocus);
+	JASPControl*			getActiveJASPControl()	{ return _activeJASPControl; }
 
 	static const QString	rSyntaxControlName;
 		


### PR DESCRIPTION
As described in the JASP Architecture for R Syntax document, we need to split the analysis and analysisForm objects. For this the AnalysisFormBase is added (AnalysisBase existed already), the Base objects contain all calls from Analysis to AnalysisForm and vice-versa.

The initColumnWithString is function is moved to the DataSet object so that the RDataFrame importer can use it.

The parseOptions function in the AnalysisForm is already added.
