### PR TITLE
chore: patch and build freexl locally

### DIFF
--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -59,12 +59,22 @@ if(USE_CONAN)
                 -s build_type=${CMAKE_BUILD_TYPE}
                 -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
                 -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing
-                #--test-missing
+                --test-missing
             )
         else()
           message(CHECK_FAIL "build freexl failed")
         endif()
     endif()
+
+    # find conan_toolchain.cmake generated in local
+    file(GLOB_RECURSE CONAN_TOOLCHAIN_PATH ${freexl_SOURCE_DIR}/freexl/test_package/build/*/generators/conan_toolchain.cmake)
+    list(GET CONAN_TOOLCHAIN_PATH 0 CONAN_TOOLCHAIN_PATH)
+    if (EXISTS ${CONAN_TOOLCHAIN_PATH})
+        get_filename_component(CONAN_TOOLCHAIN_PATH_DIR ${CONAN_TOOLCHAIN_PATH} DIRECTORY)
+        message(STATUS "freexl conan toolchain directory: ${CONAN_TOOLCHAIN_PATH_DIR}")
+    else ()
+        message(FATAL_ERROR "freexl conan toolchain not found!")
+    endif ()
 
   elseif(APPLE)
 
@@ -100,7 +110,7 @@ if(USE_CONAN)
   endif()
 
   include(${CMAKE_BINARY_DIR}/_conan_build/conan_toolchain.cmake)
-  include(${freexl_SOURCE_DIR}/freexl/test_package/build/msvc-194-x86_64-17-${CMAKE_BUILD_TYPE}/generators/conan_toolchain.cmake)
+  include(${CONAN_TOOLCHAIN_PATH})
 
 endif()
 

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -28,15 +28,43 @@ if(USE_CONAN)
   if(WIN32)
 
     message(STATUS "  ${CONAN_COMPILER_RUNTIME}")
-
+    
     execute_process(
       COMMAND_ECHO STDOUT
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       COMMAND
-      conan install ${CONAN_FILE_PATH} --output-folder=${CMAKE_BINARY_DIR}/conan_build
+      conan install ${CONAN_FILE_PATH} --output-folder=${CMAKE_BINARY_DIR}/_conan_build
       -s build_type=${CMAKE_BUILD_TYPE}
       -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
       -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing)
+      
+    message(STATUS "Cloning private freexl dependency")
+    set(FREEXL_VERSION "2.1.0-dev")
+    FetchContent_Declare(
+      freexl
+      GIT_REPOSITORY   https://github.com/shun2wang/conan-recipes.git
+      GIT_TAG          f014849188bddd01b9ca3ddf63dde8d2e3a45314
+    )
+    FetchContent_MakeAvailable(freexl)
+
+    if(NOT freexl_FOUND)
+        if(freexl_POPULATED)
+
+            message(STATUS "Compiling freexl dependency")
+            execute_process(
+                COMMAND_ECHO STDOUT
+                WORKING_DIRECTORY ${freexl_SOURCE_DIR}/freexl
+                COMMAND
+                conan create . --version=${FREEXL_VERSION}
+                -s build_type=${CMAKE_BUILD_TYPE}
+                -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
+                -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing
+                #--test-missing
+            )
+        else()
+          message(CHECK_FAIL "build freexl failed")
+        endif()
+    endif()
 
   elseif(APPLE)
 
@@ -61,7 +89,7 @@ if(USE_CONAN)
 
   endif()
 
-  if(EXISTS ${CMAKE_BINARY_DIR}/conan_build/${CONAN_RESULT_FILE})
+  if(EXISTS ${CMAKE_BINARY_DIR}/_conan_build/${CONAN_RESULT_FILE})
     message(CHECK_PASS "successful")
   else()
     message(CHECK_FAIL "unsuccessful")
@@ -71,7 +99,8 @@ if(USE_CONAN)
     )
   endif()
 
-  include(${CMAKE_BINARY_DIR}/conan_build/conan_toolchain.cmake)
+  include(${CMAKE_BINARY_DIR}/_conan_build/conan_toolchain.cmake)
+  include(${freexl_SOURCE_DIR}/freexl/test_package/build/msvc-194-x86_64-17-${CMAKE_BUILD_TYPE}/generators/conan_toolchain.cmake)
 
 endif()
 

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -42,7 +42,7 @@ if(USE_CONAN)
     set(FREEXL_VERSION "2.1.0-dev")
     FetchContent_Declare(
       freexl
-      GIT_REPOSITORY   https://github.com/shun2wang/conan-recipes.git
+      GIT_REPOSITORY   https://github.com/jasp-stats/conan-recipes.git
       GIT_TAG          f014849188bddd01b9ca3ddf63dde8d2e3a45314
     )
     FetchContent_MakeAvailable(freexl)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -18,7 +18,6 @@ brotli/1.0.9
 sqlite3/3.46.0
 gmp/6.3.0
 mpfr/4.2.1
-freexl/2.0.0
 
 [generators]
 CMakeDeps

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -15,7 +15,7 @@ jsoncpp/1.9.5
 openssl/3.0.10
 bison/3.7.6
 brotli/1.0.9
-sqlite3/3.46.0
+sqlite3/3.47.2
 gmp/6.3.0
 mpfr/4.2.1
 


### PR DESCRIPTION
This is a bit hacky but conan has no built-in local patching solution.

@boutinb @JorisGoosen Please clone my [repo](https://github.com/shun2wang/conan-recipes.git) as a JASP organization repo and then we can maintain our own patched version of freexl.

TODO:

- [x] Build on Windows
- [ ] Build on MacOS (help needs)
- [x] Build on Linux