### PR TITLE
bugfix: fix to add notes for figures

### DIFF
--- a/Desktop/html/js/image.js
+++ b/Desktop/html/js/image.js
@@ -37,7 +37,7 @@ JASPWidgets.imageView = JASPWidgets.objectView.extend({
 	},
 
 
-	hasNotes:					function() {	return this.$el.hasClass('jasp-collection-item')	=== false;	},
+	hasNotes:					function() {	return this.$el.hasClass('jasp-collection-item') === false || this.$el.hasClass('jasp-image');	},
 	hasCopy:					function() {	return this.model.get("error") === null;						},
 	isEditable:					function() {	return this.model.get("error") === null;						},
 	isConvertible:				function() {	return this.model.get("error") === null && this.model.get("convertible") ===  true;	},


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/2786

The menu option to add a note just doesn't pop up on the image, so that's a bug for a long time.