### PR TITLE
bugfix: fix to cell value vertical-align in tables

### DIFF
--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -114,6 +114,7 @@ td.symbol {
 
 td {
 	text-align: right ;
+	vertical-align: middle ;
 }
 
 thead tr:nth-child(2) th:not(.separator) {

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -114,7 +114,6 @@ td.symbol {
 
 td {
 	text-align: right ;
-	vertical-align: top ;
 }
 
 thead tr:nth-child(2) th:not(.separator) {

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -114,8 +114,8 @@ td.symbol {
 
 /* Customed superscripts and subscripts to maintain consistent vertical alignment and line height */
 td sub, td sup {
-	font-size: 75%;
-	line-height: 0;
+	font-size: 70%;
+	line-height: 1em;
 	position: relative;
 	vertical-align: baseline;
 }
@@ -131,6 +131,8 @@ td sub {
 td {
 	text-align: right ;
 	vertical-align: middle ;
+	padding-top: .1em;
+	padding-bottom: .1em;
 }
 
 thead tr:nth-child(2) th:not(.separator) {

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -112,6 +112,22 @@ td.symbol {
 	padding-left: 0 ;
 }
 
+/* Customed superscripts and subscripts to maintain consistent vertical alignment and line height */
+td sub, td sup {
+	font-size: 75%;
+	line-height: 0;
+	position: relative;
+	vertical-align: baseline;
+}
+
+td sup {
+	top: -0.5em;
+}
+
+td sub {
+	bottom: -0.25em;
+}
+
 td {
 	text-align: right ;
 	vertical-align: middle ;

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -36,8 +36,10 @@ class SvgToPng {
 		if (svgs.length > 0) {
 			svgs.forEach(svg => {
 				const canvas = document.createElement('canvas');
-				const svgWidth = svg.width ? svg.width.baseVal.value : svg.getAttribute("width")
-				const svgHeight = svg.height ? svg.height.baseVal.value : svg.getAttribute("Height")
+				const svgWidth = svg.width ? svg.width.baseVal.value : svg.getAttribute("width");
+				const svgHeight = svg.height ? svg.height.baseVal.value : svg.getAttribute("height");
+				const svgDisplay = window.getComputedStyle(svg, null).display;
+				const svgVerticalAlign = window.getComputedStyle(svg, null).verticalAlign;
 				canvas.width = parseFloat(svgWidth) * 1.5;
 				canvas.height = parseFloat(svgHeight) * 1.5;
 				const img = new Image();
@@ -49,6 +51,8 @@ class SvgToPng {
 					newImg.src = pngDataUrl;
 					newImg.width = svgWidth;
 					newImg.height = svgHeight;
+					newImg.style.display = svgDisplay ? svgDisplay : "inline-block";
+					newImg.style.verticalAlign = svgVerticalAlign ? svgVerticalAlign : "middle";
 					if (svg.parentNode)
 						svg.parentNode.replaceChild(newImg, svg);
 				};


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/2794

Not sure why we set to 'top', the browser user agent stylesheet auto set to middle/inherit by default so we just remove it.
Or we can specify it to be fixed to center alignment, any preference?

Note: Maybe the unit test .jasp files also need to be updated because the CSS style string will be changed.