### PR TITLE
add nighly version notice to welcome page

### DIFF
--- a/Desktop/components/JASP/Widgets/WelcomePage.qml
+++ b/Desktop/components/JASP/Widgets/WelcomePage.qml
@@ -105,6 +105,48 @@ FocusScope
 				}
 			}
 
+			Rectangle
+			{
+				id:					nightlyNoticeButton
+				color:				jaspTheme.rose
+				radius:				height / 2
+				height:				unstableNotice.height * 1.5
+				width:				unstableNotice.width  * 1.2
+				visible:			aboutModel.branch !== "stable"
+				z: 					2
+
+				anchors
+				{
+					top:					freshAndFunky.bottom
+					topMargin:				(freshAndFunky.height * 3) - (height)
+					horizontalCenter:		freshAndFunky.horizontalCenter
+				}
+
+				Text
+				{
+					id:						unstableNotice
+					anchors.centerIn:		parent
+					text:					"⚠️ " + qsTr("Notice: This is a preview version for testing purposes only!")
+					font.family:			jaspTheme.font.family
+					font.pixelSize:			openADataFile.font.pixelSize + (unstableNoticeTooltip.containsMouse ? 4 * welcomeRoot.scaler : 0)
+					color:					jaspTheme.black
+					horizontalAlignment:	Text.AlignHCenter
+					verticalAlignment:		Text.AlignVCenter
+					renderType:				Text.QtRendering
+					textFormat:				Text.StyledText
+				}
+
+				JASPMouseAreaToolTipped
+				{
+					id:						unstableNoticeTooltip
+					anchors.fill:			parent
+					hoverEnabled:			true
+					cursorShape:			Qt.PointingHandCursor
+					onClicked:				Qt.openUrlExternally("https://www.jasp-stats.org/download");
+					toolTipText:			qsTr("Click to get final release version")
+				}
+			}
+
 			Component
 			{
 				id:					orangeDot


### PR DESCRIPTION
Reopened https://github.com/jasp-stats/jasp-desktop/pull/5797 which was closed by accidently force push...

Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/2739

We using a branch name to detecting if it is a nightly build. before merge this we should fix [Git detached HEAD](https://kodekloud.com/blog/git-detached-head/) of this repo.

Now in the welcom page for both developers and users convenient to know whether they are working with a nightly under testing. because we did see in the issue that some users "accidentally" used the test version in the production environment.