### PR TITLE
Tweak drag n drop and column type icons and tooltips

### DIFF
--- a/Desktop/components/JASP/Theme/Theme.qml
+++ b/Desktop/components/JASP/Theme/Theme.qml
@@ -70,6 +70,7 @@ JaspTheme
 
 	//Scales:
 	ribbonScaleHovered:					1.1
+	columnTypeScaleHovered:				1.2
 
 	//Color definitions:
 	white:								"white"

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -51,7 +51,7 @@ MouseArea
 	property var oldParent: null
 
 	hoverEnabled: true
-	cursorShape: (containsMouse && shownChild.shouldDrag(mouseX, mouseY)) || drag.active  ? Qt.PointingHandCursor : Qt.ArrowCursor
+	cursorShape: (containsMouse && shownChild.shouldDrag(mouseX, mouseY)) || drag.active  ? Qt.OpenHandCursor : Qt.ArrowCursor
 	acceptedButtons: Qt.LeftButton | Qt.RightButton
 
 	property bool shouldShowHoverOutline:	false

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -11,7 +11,6 @@ DropArea {
 	property string __debugName: "DropSpot " + (parent !== undefined && parent.__debugName !== undefined ? parent.__debugName : "???")
 
 	property var dropKeys: [ "number", "boolean", "string", "variable" ]
-	property alias dropProxy: dragTarget
 
 	width:  implicitWidth
 	height: implicitHeight
@@ -23,7 +22,7 @@ DropArea {
 	property bool shouldShowX: false
 	property bool iWasChecked: false
 
-	implicitWidth: dropText.contentWidth
+	implicitWidth:	Math.max(dropText.contentWidth, acceptsDrops ? filterConstructor.blockDim * 5 : 0)
 	implicitHeight: filterConstructor.blockDim
 
 	property bool beingDragHovered: false

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -15,29 +15,36 @@ DropArea {
 	width:  implicitWidth
 	height: implicitHeight
 	keys: ["all"]
-	property real originalWidth: defaultText.length * filterConstructor.blockDim * 0.4
-	property bool acceptsDrops: true
+	property real	originalWidth: defaultText.length * filterConstructor.blockDim * 0.4
+	property bool	acceptsDrops: true
 	property string defaultText: acceptsDrops ? "..." : shouldShowX ? "y" : ""
-	property bool droppedShouldBeNested: false
-	property bool shouldShowX: false
-	property bool iWasChecked: false
+	property bool	droppedShouldBeNested: false
+	property bool	shouldShowX: false
+	property bool	iWasChecked: false
 
 	implicitWidth:	Math.max(dropText.contentWidth, acceptsDrops ? filterConstructor.blockDim * 5 : 0)
 	implicitHeight: filterConstructor.blockDim
 
-	property bool beingDragHovered: false
-	property color dragHoverColor: jaspTheme.blue
+	property bool	beingDragHovered: false
+	property color	dragHoverColor: jaspTheme.blue
 
 	Rectangle
 	{
-		id: dragMarker
-		z: -3
-		visible: containsDrag || beingDragHovered
-		radius: width
-		anchors.fill: parent
-		border.color: dragTarget.dragHoverColor
-		border.width: 3
-		color: "transparent"
+		id:				dragMarker
+		z:				-3
+		visible:		containsDrag || beingDragHovered
+		radius:			width
+		anchors.fill:	parent
+		border.color:	dragTarget.dragHoverColor
+		border.width:	3
+		color:			"transparent"
+	}
+	
+	MouseArea
+	{
+		anchors.fill:	parent	
+		z:				-100
+		onClicked:		if(dropTextInput.visible) dropTextInput.forceActiveFocus()
 	}
 
 	function checkCompletenessFormulas()
@@ -87,7 +94,7 @@ DropArea {
 		dragHoverColor = foundOneValidDragKey ? jaspTheme.green : jaspTheme.red
 
 		originalWidth = width
-		width = drag.source.width
+		width = Math.max(drag.source.width, originalWidth)
 	}
 
 	onExited:

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -115,7 +115,7 @@ DropArea {
 		//console.log(__debugName," onContainsItemChanged to " + (containsItem !== null ? containsItem.__debugName : "null"))
 
 		if(containsItem === null)
-			width = Qt.binding(function(){ return dropText.contentWidth })
+			width = Qt.binding(function(){ return dragTarget.implicitWidth })
 		iWasChecked = false
 
 	}

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -46,6 +46,7 @@ Item
 		id:				colIcon
 		source:			filterConstructor.forceColumnInputs === "" ? columnIcon : computedColumnsInterface.computeColumnIconSource
 		width:			height
+		scale:			iconMouseArea.containsMouse ? jaspTheme.columnTypeScaleHovered : 1
 		sourceSize
 		{
 			width:		width * 2
@@ -60,8 +61,10 @@ Item
 		
 		MouseArea
 		{
+			id:					iconMouseArea
 			enabled:			changeTypeAllowed
 			anchors.fill:		parent
+			hoverEnabled:		true
 			onClicked:
 			{
 				var functionCall      = function (index)

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -11,9 +11,8 @@ Item
 	property int	columnType:			columnsModel.getColumnType(columnName)
 	property int	columnTypeUser:		-1
 	property int	columnTypeHere:		columnTypeUser != -1 ? columnTypeUser : columnType
-	property string toolTip:			qsTr("Click icon to change column type") + 
-											(columnType == columnTypeUser || columnTypeUser == -1 ? "" : ("\n\n%1:\n\n").arg(qsTr("Transformed to")) + columnsModel.getColumnTransformedToolTip(columnName, columnTypeUser))
-
+	property string preview:			(columnType == columnTypeUser || columnTypeUser == -1 ? "" : columnsModel.getColumnTransformedToolTip(columnName, columnTypeUser))
+	property string toolTip:			formatToolTip(changeTypeAllowed, colName.contentWidth > colName.width, columnsModel.getColumnDescription(columnName), preview)
 	property real	maxSize:			baseFontSize * 10 * preferencesModel.uiScale
 					height:				filterConstructor.blockDim
 					implicitWidth:		colName.x + colName.width
@@ -23,6 +22,29 @@ Item
 	property bool	changeTypeAllowed:	true
 	property var	dragKeys:			isNumerical ? ["number"]	: isOrdinal ? ["string", "ordered"] : ["string"]
 	property string typeString:			isNumerical ? "scale"		: isOrdinal ? "ordinal"				: "nominal"
+					
+					
+	//colName can elide
+	function formatToolTip(typeChangeAble, colNameTrunc, descriptionV, previewV)
+	{
+		var stringList = []
+		
+		if(colNameTrunc)
+			stringList.push(columnName)
+		
+		if(typeChangeAble)
+			stringList.push(qsTr("Click icon to change column type"))
+		
+		if(descriptionV !== "")
+			stringList.push(qsTr("Column description: ") + descriptionV)
+
+		if(previewV !== "")
+			stringList.push(previewV)
+		
+		return stringList.join("\n\n");
+		
+	}
+					
 					
 	Connections
 	{
@@ -88,7 +110,7 @@ Item
 				customMenu.menuMinIsMin	= true
 			}
 
-			cursorShape:		enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+			cursorShape:		enabled ? Qt.PointingHandCursor : Qt.OpenHandCursor
 		}
 	}
 

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -56,6 +56,11 @@ QString ColumnsModel::getColumnIcon(columnType colType) const
 	return VariableInfo::getIconFile(colType, VariableInfo::DefaultIconType);
 }
 
+QString ColumnsModel::getColumnDescription(const QString &name) const
+{
+	return provideInfo(VariableInfo::ColumnDescription, name).toString().trimmed();
+}
+
 QString ColumnsModel::getColumnIconTransform(int colType) const
 {
 	return getColumnIconTransform(columnType(colType));

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -169,6 +169,7 @@ QVariant ColumnsModel::provideInfo(VariableInfo::InfoType info, const QString& c
 		case VariableInfo::PreviewScale:				return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::previewScale));
 		case VariableInfo::PreviewOrdinal:				return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::previewOrdinal));
 		case VariableInfo::PreviewNominal:				return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::previewNominal));
+		case VariableInfo::ColumnDescription:			return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::description));
 		case VariableInfo::DataSetPointer:				return	QVariant::fromValue<void*>(DataSetPackage::pkg()->dataSet());
 		}
 	}

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -28,6 +28,7 @@ ColumnsModel::ColumnsModel(DataSetTableModel *tableModel)
 	connect(this, &ColumnsModel::labelsReordered,						info, &VariableInfo::labelsReordered	);
 	connect(this, &ColumnsModel::filterChanged,							info, &VariableInfo::filterChanged		);
 	connect(this, &ColumnsModel::dataSetChanged,						info, &VariableInfo::dataSetChanged		);
+	connect(this, &ColumnsModel::modelReset,							info, &VariableInfo::refresh			);
 	connect(this, &QTransposeProxyModel::columnsInserted,				info, &VariableInfo::rowCountChanged	);
 	connect(this, &QTransposeProxyModel::columnsRemoved,				info, &VariableInfo::rowCountChanged	);
 	connect(this, &QTransposeProxyModel::modelReset,					info, &VariableInfo::rowCountChanged	);

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -28,7 +28,6 @@ ColumnsModel::ColumnsModel(DataSetTableModel *tableModel)
 	connect(this, &ColumnsModel::labelsReordered,						info, &VariableInfo::labelsReordered	);
 	connect(this, &ColumnsModel::filterChanged,							info, &VariableInfo::filterChanged		);
 	connect(this, &ColumnsModel::dataSetChanged,						info, &VariableInfo::dataSetChanged		);
-	connect(this, &ColumnsModel::modelReset,							info, &VariableInfo::refresh			);
 	connect(this, &QTransposeProxyModel::columnsInserted,				info, &VariableInfo::rowCountChanged	);
 	connect(this, &QTransposeProxyModel::columnsRemoved,				info, &VariableInfo::rowCountChanged	);
 	connect(this, &QTransposeProxyModel::modelReset,					info, &VariableInfo::rowCountChanged	);

--- a/Desktop/data/columnsmodel.h
+++ b/Desktop/data/columnsmodel.h
@@ -33,6 +33,7 @@ public:
 	Q_INVOKABLE	QString						getColumnIcon(int columnType)														const;
 	Q_INVOKABLE	QString						getColumnIcon(int columnType, bool isTransformed)									const;
 				QString						getColumnIcon(columnType colType)													const;
+	Q_INVOKABLE QString						getColumnDescription(const QString & name)											const;
 	Q_INVOKABLE	QString						getColumnIconTransform(int columnType)												const;
 				QString						getColumnIconTransform(columnType colType)											const;
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -636,21 +636,16 @@ QVariant DataSetPackage::headerData(int section, Qt::Orientation orientation, in
 					: columnType::scale;
 			
 			stringvec	preview		= !col ? stringvec()	: col->previewTransform(colTypeWanted);
-			QString		description = !col ? ""				: tq(col->description()).trimmed();
 			
-			if(!description.isEmpty())
-				description = tr("Column description:") + " " + description;
-
 			if(preview.size() != 4)
-				return description; //Its either "" or something useful
+				return "";
 			
 			QString	levelsTotal		= tq(preview[0]),
 					levelsNums		= tq(preview[1]),
 					vals			= tq(preview[2]),
 					empties			= tq(preview[3]);
 			
-			return (description != "" ? description + "\n" : "") +
-					(colTypeWanted == columnType::scale 
+			return 	(colTypeWanted == columnType::scale 
 					?	tr("There are %1 total levels, of which %2 have a numeric value.\nAs a '%3' it looks like: %4\n%5")
 						.arg(levelsTotal)
 						.arg(levelsNums)

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -635,18 +635,23 @@ QVariant DataSetPackage::headerData(int section, Qt::Orientation orientation, in
 					? columnType::ordinal
 					: columnType::scale;
 			
-			stringvec preview = !col ? stringvec() : col->previewTransform(colTypeWanted);
+			stringvec	preview		= !col ? stringvec()	: col->previewTransform(colTypeWanted);
+			QString		description = !col ? ""				: tq(col->description()).trimmed();
 			
+			if(!description.isEmpty())
+				description = tr("Column description:") + " " + description;
+
 			if(preview.size() != 4)
-				return QVariant();
+				return description; //Its either "" or something useful
 			
 			QString	levelsTotal		= tq(preview[0]),
 					levelsNums		= tq(preview[1]),
 					vals			= tq(preview[2]),
 					empties			= tq(preview[3]);
 			
-			if(colTypeWanted == columnType::scale)
-				return	tr("There are %1 total levels, of which %2 have a numeric value.\nAs a '%3' it looks like: %4\n%5")
+			return (description != "" ? description + "\n" : "") +
+					(colTypeWanted == columnType::scale 
+					?	tr("There are %1 total levels, of which %2 have a numeric value.\nAs a '%3' it looks like: %4\n%5")
 						.arg(levelsTotal)
 						.arg(levelsNums)
 						.arg(VariableInfo::getTypeFriendly(colTypeWanted))
@@ -655,12 +660,12 @@ QVariant DataSetPackage::headerData(int section, Qt::Orientation orientation, in
 							empties == "" 
 							? "" 
 							: tr("Implicit missing values: %1").arg(empties)
-						);
-			else
-				return tr("There are %1 total levels.\nAs a '%2' it looks like: %3")
+						)
+						
+					:	tr("There are %1 total levels.\nAs a '%2' it looks like: %3")
 					.arg(levelsTotal)
 					.arg(VariableInfo::getTypeFriendly(colTypeWanted))
-					.arg(vals);
+					.arg(vals));
 		}
 		}
 	}
@@ -1666,6 +1671,7 @@ void DataSetPackage::setColumnDescription(size_t columnIndex, const std::string 
 		return;
 
 	column->setDescription(newDescription);
+	
 	refresh();
 }
 

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -406,6 +406,12 @@ VariablesListBase
 				property bool	isVirtual:				(typeof model.type !== "undefined") && model.type.includes("virtual")
 				property bool	isVariable:				(typeof model.type !== "undefined") && model.type.includes("variable")
 				property string	preview:				!isVariable || (typeof model.preview === "undefined") ? "" : model.preview
+				property string	toolTip:				(!itemRectangle.typeChangeable							? "" : qsTr("Click icon to change column type")) +
+														(!(itemRectangle.typeChangeable && colName.truncated)	? "" : "\n\n" ) +
+														(!colName.truncated										? "" : model.name ) + 
+														(!(preview != "" && 
+														(itemRectangle.typeChangeable || colName.truncated)) ? "" : "\n\n" ) +
+														preview
 				property bool	isLayer:				(typeof model.type !== "undefined") && model.type.includes("layer")
 				property bool	draggable:				variablesList.draggable && model.selectable
 				property string	columnType:				isVariable && (typeof model.columnType !== "undefined") ? model.columnType : ""
@@ -438,10 +444,10 @@ VariablesListBase
 				Drag.hotSpot.y:	itemRectangle.height / 2
 				
 				// Use the ToolTip Attached property to avoid creating ToolTip object for each item
-				QTCONTROLS.ToolTip.visible: mouseArea.containsMouse && !itemRectangle.containsDragItem && (preview != "" ||  (model.name && colName.truncated))
-				QTCONTROLS.ToolTip.delay: 300
-				QTCONTROLS.ToolTip.text: colName.truncated ? (model.name + (preview != "" ? "\n\n" + preview : "")) : preview
-				
+				QTCONTROLS.ToolTip.visible:		mouseArea.containsMouse && !itemRectangle.containsDragItem && toolTip.trim() !== ""
+				QTCONTROLS.ToolTip.timeout:		jaspTheme.toolTipTimeout
+				QTCONTROLS.ToolTip.delay:		jaspTheme.toolTipDelay
+				QTCONTROLS.ToolTip.text:		toolTip
 				Component.onCompleted:
 				{
 					if (extraItem)
@@ -464,7 +470,7 @@ VariablesListBase
 					visible:				sourceVar !== ""
 					mipmap:					true
 					smooth:					true
-					scale:					itemRectangle.typeChangeable && mouseArea.containsMouse && mouseArea.mouseX < icon.width ? 1.2 : 1
+					scale:					itemRectangle.typeChangeable && mouseArea.containsMouse && mouseArea.mouseX < icon.width ? jaspTheme.columnTypeScaleHovered : 1
 
 					//So Im pushing this through a property because it seems to results in "undefined" during loading and this adds a ton of warnings to the output which is not helpful. I tried less heavyhanded approaches first but this works perfectly fine.
 					property var sourceVar:	variablesList.showVariableTypeIcon && itemRectangle.isVariable ? (enabled ? model.columnTypeIcon : model.columnTypeDisabledIcon) : ""

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -405,13 +405,8 @@ VariablesListBase
 				property bool	containsDragItem:		variablesList.itemContainingDrag === itemRectangle
 				property bool	isVirtual:				(typeof model.type !== "undefined") && model.type.includes("virtual")
 				property bool	isVariable:				(typeof model.type !== "undefined") && model.type.includes("variable")
-				property string	preview:				!isVariable || (typeof model.preview === "undefined") ? "" : model.preview
-				property string	toolTip:				(!itemRectangle.typeChangeable							? "" : qsTr("Click icon to change column type")) +
-														(!(itemRectangle.typeChangeable && colName.truncated)	? "" : "\n\n" ) +
-														(!colName.truncated										? "" : model.name ) + 
-														(!(preview != "" && 
-														(itemRectangle.typeChangeable || colName.truncated)) ? "" : "\n\n" ) +
-														preview
+				property string	preview:				!isVariable || (typeof model.preview     === "undefined") ? "" : model.preview.trim()
+				property string	toolTip:				formatToolTip(itemRectangle.typeChangeable, colName.truncated, model.description.trim(), preview)
 				property bool	isLayer:				(typeof model.type !== "undefined") && model.type.includes("layer")
 				property bool	draggable:				variablesList.draggable && model.selectable
 				property string	columnType:				isVariable && (typeof model.columnType !== "undefined") ? model.columnType : ""
@@ -419,6 +414,26 @@ VariablesListBase
 				property bool	typeChangeable:			variablesList.allowTypeChange && (allowedTypeIcons.count === 0 || allowedTypeIcons.count > 1) && icon.visible
 
 				enabled: !variablesList.draggable || model.selectable
+				
+				function formatToolTip(typeChangeAble, colNameTrunc, descriptionV, previewV)
+				{
+					var stringList = []
+					
+					if(colNameTrunc)
+						stringList.push(model.name)
+					
+					if(typeChangeAble)
+						stringList.push(qsTr("Click icon to change column type"))
+					
+					if(descriptionV !== "")
+						stringList.push(qsTr("Column description: ") + descriptionV)
+
+					if(previewV !== "")
+						stringList.push(previewV)
+					
+					return stringList.join("\n\n");
+					
+				}
 
 				function setRelative(draggedRect)
 				{
@@ -543,7 +558,7 @@ VariablesListBase
 
 					drag.target:	itemRectangle.draggable ? parent : null
 					hoverEnabled:	true
-					cursorShape:	Qt.PointingHandCursor
+					cursorShape:	itemRectangle.typeChangeable && mouseX < icon.width ? Qt.PointingHandCursor : Qt.OpenHandCursor
 
 					onDoubleClicked: (mouse)=>
 					{

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -285,7 +285,7 @@ protected:
 	bool					_isBound					= true,
 							_indent						= false,
 							_initialized				= false,
-							_initializedWithValue	= false,
+							_initializedWithValue		= false,
 							_debug						= false,
 							_parentDebug				= false,
 							_hasError					= false,

--- a/QMLComponents/controls/sourceitem.cpp
+++ b/QMLComponents/controls/sourceitem.cpp
@@ -133,6 +133,7 @@ void SourceItem::connectModels()
 		connect(variableInfo,	&VariableInfo::labelsReordered,		controlModel, &ListModel::sourceLabelsReordered );
 		connect(variableInfo,	&VariableInfo::filterChanged,		controlModel, &ListModel::filterChanged );
 		connect(variableInfo,	&VariableInfo::columnsChanged,		controlModel, &ListModel::sourceColumnsChanged );
+		connect(variableInfo,	&VariableInfo::refresh,				controlModel, &ListModel::refresh );
 	}
 
 	if (_sourceListModel)

--- a/QMLComponents/controls/variablesformbase.cpp
+++ b/QMLComponents/controls/variablesformbase.cpp
@@ -22,7 +22,8 @@
 
 VariablesFormBase::VariablesFormBase(QQuickItem* parent) : JASPControl(parent)
 {
-	_controlType = ControlType::VariablesForm;
+	_controlType			= ControlType::VariablesForm;
+	_useControlMouseArea	= false;
 }
 
 void VariablesFormBase::componentComplete()

--- a/QMLComponents/jasptheme.cpp
+++ b/QMLComponents/jasptheme.cpp
@@ -1318,3 +1318,16 @@ void JaspTheme::updateFontMetrics()
 	if(currentTheme())
 		_fontMetrics = QFontMetricsF(currentTheme()->font());
 }
+
+float JaspTheme::columnTypeScaleHovered() const
+{
+	return _columnTypeScaleHovered;
+}
+
+void JaspTheme::setColumnTypeScaleHovered(float newColumnTypeScaleHovered)
+{
+	if (qFuzzyCompare(_columnTypeScaleHovered, newColumnTypeScaleHovered))
+		return;
+	_columnTypeScaleHovered = newColumnTypeScaleHovered;
+	emit columnTypeScaleHoveredChanged();
+}

--- a/QMLComponents/jasptheme.h
+++ b/QMLComponents/jasptheme.h
@@ -18,6 +18,8 @@ class JaspTheme : public QQuickItem
 
 	Q_PROPERTY(float              uiScale                         READ uiScale                                                                  NOTIFY uiScaleChanged                         )
 	Q_PROPERTY(float              ribbonScaleHovered              READ ribbonScaleHovered              WRITE setRibbonScaleHovered              NOTIFY ribbonScaleHoveredChanged              )
+	Q_PROPERTY(float              columnTypeScaleHovered          READ columnTypeScaleHovered          WRITE setColumnTypeScaleHovered          NOTIFY columnTypeScaleHoveredChanged          )
+	
 
 	//Colors (base):
 	Q_PROPERTY(QColor             white                           READ white                           WRITE setWhite                           NOTIFY whiteChanged                           )
@@ -321,7 +323,10 @@ public:
 	QString				themeName()							const	{ return _themeName;					}
 	static QString		currentIconPath();
 	bool				isDark()							const	{ return _isDark;						}
-
+	
+	float columnTypeScaleHovered() const;
+	void setColumnTypeScaleHovered(float newColumnTypeScaleHovered);
+	
 signals:
 	void currentThemeReady(JaspTheme * newTheme);
 	void uiScaleChanged(float uiScale);
@@ -456,7 +461,9 @@ signals:
 	void themeNameChanged(QString themeName);
 	void currentThemeNameChanged();
 	void isDarkChanged(bool isDark);
-
+	
+	void columnTypeScaleHoveredChanged();
+	
 public slots:
 	void setRibbonScaleHovered(float ribbonScaleHovered);
 	void setWhite(QColor white);
@@ -599,6 +606,7 @@ private:
 	static JaspTheme		* _currentTheme;
 
 	float				_ribbonScaleHovered,
+						_columnTypeScaleHovered,
 						_uiScale				= 1,	///< default for when in R, otherwise ignored
 						_maximumFlickVelocity	= 801;	///< default for when in R, otherwise ignored
 

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -664,7 +664,7 @@ bool ListModel::sourceColumnTypeChanged(Term sourceTerm)
 			term.setTypes(types);
 			QModelIndex ind = index(i, 0);
 
-			emit dataChanged(ind, ind, {ListModel::ColumnTypeRole, ListModel::ColumnTypeIconRole, ListModel::ColumnTypeDisabledIconRole});
+			emit dataChanged(ind, ind, {ListModel::ColumnTypeRole, ListModel::ColumnTypeIconRole, ListModel::ColumnTypeDisabledIconRole, ListModel::ColumnPreviewRole});
 			emit columnTypeChanged(term);
 
 			change = true;

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -51,6 +51,7 @@ QHash<int, QByteArray> ListModel::roleNames() const
 		roles[SelectableRole]				= "selectable";
 		roles[ColumnTypeRole]				= "columnType";
 		roles[ColumnPreviewRole]			= "preview";
+		roles[ColumnDescriptionRole]		= "description";
 		roles[ColumnRealTypeRole]			= "columnRealType";
 		roles[ColumnTypeIconRole]			= "columnTypeIcon";
 		roles[ColumnTypeDisabledIconRole]	= "columnTypeDisabledIcon";
@@ -312,6 +313,11 @@ columnType ListModel::getVariableType(const QString& name) const
 	return (columnType)requestInfo(VariableInfo::VariableType, name).toInt();
 }
 
+QString ListModel::getVariableDescription(const QString &name) const
+{
+	return requestInfo(VariableInfo::ColumnDescription, name).toString();
+}
+
 columnType ListModel::getVariableRealType(const QString& name) const
 {
 	return (columnType)requestInfo(VariableInfo::VariableType, name).toInt();
@@ -507,6 +513,9 @@ QVariant ListModel::data(const QModelIndex &index, int role) const
 		
 	case ListModel::ColumnPreviewRole:
 		return (!listView()->containsVariables() || term.size() != 1) ? "" : getVariablePreview(term.asQString());
+		
+	case ListModel::ColumnDescriptionRole:
+		return (!listView()->containsVariables() || term.size() != 1) ? "" : getVariableDescription(term.asQString());
 	
 	case ListModel::ColumnTypeRole:
 	case ListModel::ColumnRealTypeRole:

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -48,6 +48,7 @@ public:
 		ColumnPreviewRole,
 		ColumnRealTypeRole,
 		ColumnTypeIconRole,
+		ColumnDescriptionRole,
 		ColumnTypeDisabledIconRole,
 		RowComponentRole,
 		ValueRole,
@@ -82,24 +83,25 @@ public:
 			void					setColumnsUsedForLabels(const QStringList& columns)						{ _columnsUsedForLabels = columns; }
 			void					setRowComponent(QQmlComponent* rowComponents);
 	virtual void					setUpRowControls();
-	const RowControlMap	&			getAllRowControls()											const		{ return _rowControlsMap;				}
-	RowControlsValues				getTermsWithComponentValues()								const;
-	RowControls*					getRowControls(const QString& key)							const		{ return _rowControlsMap.value(key);	}
-	virtual JASPControl	*			getRowControl(const QString& key, const QString& name)		const;
+	const RowControlMap	&			getAllRowControls()												const		{ return _rowControlsMap;				}
+	RowControlsValues				getTermsWithComponentValues()									const;
+	RowControls*					getRowControls(const QString& key)								const		{ return _rowControlsMap.value(key);	}
+	virtual JASPControl	*			getRowControl(const QString& key, const QString& name)			const;
 	virtual bool					addRowControl(const QString& key, JASPControl* control);
-			QStringList				allLevels(const Terms& terms)								const;
+			QStringList				allLevels(const Terms& terms)									const;
 			void					setVariableType(int index, columnType type);
-			columnType				getVariableType(	const QString& name)					const;
-			Json::Value				getVariableTypes(bool onlyChanged = false)					const;
+			columnType				getVariableType(	const QString& name)						const;
+			QString					getVariableDescription(	const QString& name)					const;
+			Json::Value				getVariableTypes(bool onlyChanged = false)						const;
 			Json::Value				getVariableTypes(const Terms& terms, bool onlyChanged = false)	const;
-			columnType				getVariableRealType(const QString& name)					const;
-			QString					getVariablePreview(	const QString& name)					const;
-			QStringList				getUsedTypes()												const;
+			columnType				getVariableRealType(const QString& name)						const;
+			QString					getVariablePreview(	const QString& name)						const;
+			QStringList				getUsedTypes()													const;
 
-			Terms					checkTermsTypes(const Terms& terms)							const;
-			Terms					checkTermsTypes(const std::vector<Term>& terms)				const;
-	virtual Terms					termsFromIndexes(	const QList<int>& indexes)				const;
-	virtual QList<int>				indexesFromTerms(	const Terms		& terms)				const;
+			Terms					checkTermsTypes(const Terms& terms)								const;
+			Terms					checkTermsTypes(const std::vector<Term>& terms)					const;
+	virtual Terms					termsFromIndexes(	const QList<int>& indexes)					const;
+	virtual QList<int>				indexesFromTerms(	const Terms		& terms)					const;
 
 
 	Q_INVOKABLE int					searchTermWith(QString searchString);

--- a/QMLComponents/variableinfo.h
+++ b/QMLComponents/variableinfo.h
@@ -38,7 +38,7 @@ class VariableInfo : public QObject
 {
 	Q_OBJECT
 public:
-	enum InfoType { VariableType, VariableNames, DataSetRowCount, Labels, DoubleValues, NameRole, DataSetValue, DataSetValues, MaxWidth, SignalsBlocked, DataAvailable, TotalNumericValues, TotalLevels, PreviewScale, PreviewOrdinal, PreviewNominal, DataSetPointer };
+	enum InfoType { VariableType, VariableNames, DataSetRowCount, Labels, DoubleValues, NameRole, DataSetValue, DataSetValues, MaxWidth, SignalsBlocked, DataAvailable, TotalNumericValues, TotalLevels, PreviewScale, PreviewOrdinal, PreviewNominal, DataSetPointer, ColumnDescription };
 	enum IconType { DefaultIconType, DisabledIconType, InactiveIconType, TransformedIconType };
 
 public:

--- a/QMLComponents/variableinfo.h
+++ b/QMLComponents/variableinfo.h
@@ -58,14 +58,15 @@ public:
 	DataSet					*	dataSet();
 
 signals:
+	void refresh();
 	void namesChanged(		QMap<QString, QString> changedNames);
-	void columnsChanged(	QStringList changedColumns);
-	void columnTypeChanged(	QString colName);
-	void labelsChanged(		QString columnName, QMap<QString, QString> changedLabels);
-	void labelsReordered(	QString columnName);
-	void dataSetChanged();
 	void filterChanged();
+	void labelsChanged(		QString columnName, QMap<QString, QString> changedLabels);
+	void columnsChanged(	QStringList changedColumns);
+	void dataSetChanged();
 	void rowCountChanged();
+	void labelsReordered(	QString columnName);
+	void columnTypeChanged(	QString colName);
 	void dataAvailableChanged();
 
 private:	


### PR DESCRIPTION
bigger capture zones and easier clicking to edit the "..." in dragndrop.

also add description in tooltip of columns in variablelist and JASPColumn for https://github.com/jasp-stats/jasp-issues/issues/1190