### PR TITLE
Expose used varaibles in text area

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolrlangtextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolrlangtextarea.cpp
@@ -90,6 +90,13 @@ void BoundControlRlangTextArea::checkSyntax()
 		Log::log() << "Warning: no non prefixed entries returned from column encoder?";
 
 
+	if (!_textArea->initialized())
+	{
+		// Do not run the engine to check the script if the control in not yet initialized
+		_setBoundValues();
+		return;
+	}
+
 	// Create R code string
 	QString encodedColNames = "c(";
 	for (const std::string& column : _noPrefixUsedColumnNames)
@@ -124,15 +131,27 @@ QString BoundControlRlangTextArea::rScriptDoneHandler(const QString & result)
 	if (!result.isEmpty())
 		return result;
 
+	_setBoundValues();
+	return QString();
+}
+
+void BoundControlRlangTextArea::_setBoundValues()
+{
 	Json::Value boundValue(Json::objectValue);
 
 	boundValue["modelOriginal"] = _textArea->text().toStdString();
 	boundValue["model"]			= _textEncoded.toStdString();
 
 	Json::Value columns(Json::arrayValue);
-	for (const std::string& column : _noPrefixUsedColumnNames)
-		columns.append(ColumnEncoder::columnEncoder()->encode(column));
+	Terms	terms;
 
+	for (const std::string& column : _noPrefixUsedColumnNames)
+	{
+		terms.add(Term(column, _textArea->getVariableType(tq(column))));
+		columns.append(ColumnEncoder::columnEncoder()->encode(column));
+	}
+
+	_textArea->model()->initTerms(terms);
 	boundValue["columns"] = columns;
 
 	Json::Value prefixedColumns(Json::objectValue);
@@ -145,7 +164,4 @@ QString BoundControlRlangTextArea::rScriptDoneHandler(const QString & result)
 	boundValue["prefixedColumns"] = prefixedColumns;
 
 	setBoundValue(boundValue, !_control->form()->wasUpgraded());
-
-	return QString();
-
 }

--- a/QMLComponents/boundcontrols/boundcontrolrlangtextarea.h
+++ b/QMLComponents/boundcontrols/boundcontrolrlangtextarea.h
@@ -36,9 +36,9 @@ public:
 
 protected:
 	virtual const char *					_checkSyntaxRFunctionName() { return "jaspSem:::checkLavaanModel"; }
+	void									_setBoundValues();
 
-protected:
-    RSyntaxHighlighter*	_rLangHighlighter		= nullptr;
+	RSyntaxHighlighter*						_rLangHighlighter		= nullptr;
 
 	stringset								_noPrefixUsedColumnNames;
 	std::map<std::string, stringset>		_prefixedUsedColumnNames;

--- a/QMLComponents/components/JASP/Controls/TabView.qml
+++ b/QMLComponents/components/JASP/Controls/TabView.qml
@@ -280,6 +280,8 @@ ComponentsListBase
 			topMargin	: 2 * preferencesModel.uiScale
 			left		: parent.left
 			right		: parent.right
+			leftMargin	: 1 // Remove border line
+			rightMargin	: 1
 		}
 
 		currentIndex		: itemTabBar.currentIndex
@@ -294,10 +296,14 @@ ComponentsListBase
 				id:	tabViewWrapper
 				property var rowComponentItem: model.rowComponent
 
-				width	: rowComponentItem ? rowComponentItem.width : 0
+				width	: itemStack.width
 				height	: rowComponentItem ? rowComponentItem.height : 0
 
-				Component.onCompleted: rowComponentItem.parent = tabViewWrapper
+				Component.onCompleted:
+				{
+					rowComponentItem.parent = tabViewWrapper
+					rowComponentItem.width = Qt.binding(function() {return itemStack.width})
+				}
 			}
 		}
 	}

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -141,7 +141,8 @@ Json::Value ComboBoxBase::createJson() const
 
 bool ComboBoxBase::isJsonValid(const Json::Value &optionValue) const
 {
-	return optionValue.type() == Json::stringValue || optionValue.type() == Json::objectValue;
+	return optionValue.type() == Json::stringValue ||
+		(optionValue.type() == Json::objectValue && optionValue.isMember("value") && optionValue["value"].isString());
 }
 
 void ComboBoxBase::setUp()

--- a/QMLComponents/controls/factorsformbase.cpp
+++ b/QMLComponents/controls/factorsformbase.cpp
@@ -28,7 +28,6 @@ FactorsFormBase::FactorsFormBase(QQuickItem *parent)
 {
 	_controlType			= ControlType::FactorsForm;
 	_useControlMouseArea	= false;
-	_containsVariables		= true;
 	_mayUseFormula			= false;
 	_useTermsInRSyntax		= false;
 }

--- a/QMLComponents/controls/factorsformbase.h
+++ b/QMLComponents/controls/factorsformbase.h
@@ -45,6 +45,7 @@ public:
 	void			bindTo(const Json::Value& value)					override;
 	ListModel*		model()										const	override	{ return _factorsModel; }
 	void			setUpModel()										override;
+	bool			containsVariables()							const	override	{ return true; };
 
 	Q_INVOKABLE	void	addFactor()													{ _factorsModel->addFactor();						}
 	Q_INVOKABLE void	removeFactor()												{ _factorsModel->removeFactor();					}

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -211,36 +211,40 @@ void JASPControl::componentComplete()
 		// The control is created dynamically, this is the case for row components.
 		// They are created either from a ListView (or a TableView): when all terms of the ListView are set, the row components are created, and then initialized (via rhe ListModel::setUpRowControls function).
 		// Here the parent ListView and the key for this control is stored.
-		setUp();
-
-		JASPListControl* listView = nullptr;
+		JASPListControl* parentlistView = nullptr;
 
 		QVariant listViewVar = context->contextProperty("listView");
 		if (!listViewVar.isNull())
-			listView = listViewVar.value<JASPListControl*>();
+			parentlistView = listViewVar.value<JASPListControl*>();
 		else
 		{
 			QVariant tableViewVar = context->contextProperty("tableView");
 			if (!tableViewVar.isNull())
-				listView = tableViewVar.value<JASPListControl*>();
+				parentlistView = tableViewVar.value<JASPListControl*>();
 		}
 
-		if (listView && listView != this)
+		if (parentlistView && parentlistView != this)
 		{
-			_parentListView = listView;
+			_parentListView = parentlistView;
+			emit parentListViewChanged();
 
 			if (!listViewVar.isNull())
 			{
 				_parentListViewKey = context->contextProperty("rowValue").toString();
-				connect(listView->model(), &ListModel::oneTermChanged, this, &JASPControl::parentListViewKeyChanged);
+				connect(parentlistView->model(), &ListModel::oneTermChanged, this, &JASPControl::parentListViewKeyChanged);
 			}
 			else
 				_parentListViewKey = context->contextProperty("rowIndex").toString();
-
-			listView->addRowControl(_parentListViewKey, this);
-
-			emit parentListViewChanged();
 		}
+
+		JASPListControl* listControl = qobject_cast<JASPListControl*>(this);
+		if (listControl)
+			listControl->setUpModel();
+		if (parentlistView)
+			parentlistView->addRowControl(_parentListViewKey, this);
+
+		// Setup must be done after _parentListView & _parentListViewKey are set (if they exist), so that if the control has a source, the right source is found.
+		setUp();
 	}
 
 	if (_background == nullptr && _innerControl != nullptr)
@@ -702,12 +706,6 @@ bool JASPControl::childHasWarning() const
 	return _hasWarning;
 }
 
-// This method is just for the parentListView property that needs a JASPControl (JASPListControl is unknown in QML).
-JASPControl *JASPControl::parentListViewEx() const
-{
-	return _parentListView;
-}
-
 bool JASPControl::hovered() const
 {
 	if (_mouseAreaObj)
@@ -715,8 +713,6 @@ bool JASPControl::hovered() const
 	else
 		return false;
 }
-
-
 
 QString JASPControl::humanFriendlyLabel() const
 {

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -38,7 +38,7 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( bool								initialized				READ initialized											NOTIFY initializedChanged			)
 	Q_PROPERTY( bool								shouldStealHover		READ shouldStealHover		WRITE setShouldStealHover		NOTIFY shouldStealHoverChanged		)
 	Q_PROPERTY( QQuickItem						*	childControlsArea		READ childControlsArea		WRITE setChildControlsArea											)
-	Q_PROPERTY( JASPControl						*	parentListView			READ parentListViewEx										NOTIFY parentListViewChanged		)
+	Q_PROPERTY( JASPListControl					*	parentListView			READ parentListView											NOTIFY parentListViewChanged		)
 	Q_PROPERTY( QQuickItem						*	innerControl			READ innerControl			WRITE setInnerControl			NOTIFY innerControlChanged			)
 	Q_PROPERTY( QQuickItem						*	background				READ background				WRITE setBackground				NOTIFY backgroundChanged			)
 	Q_PROPERTY( QQuickItem						*	focusIndicator			READ focusIndicator			WRITE setFocusIndicator			NOTIFY focusIndicatorChanged		)
@@ -140,7 +140,6 @@ public:
 	AnalysisForm	*	form()						const	{ return _form;						}
 	QQuickItem		*	childControlsArea()			const	{ return _childControlsArea;		}
 	JASPListControl	*	parentListView()			const	{ return _parentListView;			}
-	JASPControl		*	parentListViewEx()			const;
 	QString				parentListViewKey()			const	{ return _parentListViewKey;		}
 	QQuickItem		*	innerControl()				const	{ return _innerControl;				}
 	QQuickItem		*	background()				const	{ return _background;				}

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -44,7 +44,7 @@ JASPListControl::JASPListControl(QQuickItem *parent)
 
 void JASPListControl::setUpModel()
 {
-	if (model() && form())	form()->addModel(model());
+	if (model() && form() && !_parentListView)	form()->addModel(model());
 
 	emit modelChanged();
 }
@@ -52,93 +52,50 @@ void JASPListControl::setUpModel()
 void JASPListControl::_setupSources()
 {
 	for (SourceItem* sourceItem : _sourceItems)
-	{
-		if (sourceItem->sourceListModel())
-		{
-			JASPListControl* sourceControl = sourceItem->sourceListModel()->listView();
-			disconnect(sourceControl, &JASPListControl::containsVariablesChanged,		this, &JASPListControl::setContainsVariables);
-			disconnect(sourceControl, &JASPListControl::containsInteractionsChanged,	this, &JASPListControl::setContainsInteractions);
-		}
 		delete sourceItem;
-	}
-	_sourceItems.clear();
 
 	_sourceItems = SourceItem::readAllSources(this);
+}
+
+bool JASPListControl::containsVariables() const
+{
+	// If it is an assigned variablesList, check whether the available variablesList contains variables
+	ListModelAssignedInterface* assignedModel = qobject_cast<ListModelAssignedInterface*>(model());
+	if (assignedModel && assignedModel->availableModel() && assignedModel->availableModel()->listView()->containsVariables())
+		return true;
+
+	// If not check the sources: if one is the DataSet, or one contains variables (and the source is neither a control of this source, or the levels of this source), then return true
+	for (SourceItem* sourceItem : _sourceItems)
+	{
+		if (sourceItem->isAnalysisDataSet())
+			return true;
+		else if (sourceItem->sourceListModel() && sourceItem->sourceListModel()->listView() != this)
+		{
+			if (sourceItem->sourceListModel()->listView()->containsVariables() && sourceItem->rowControlName().isEmpty() && !sourceItem->sourceFilter().contains("levels"))
+				return true;
+		}
+	}
+
+	return false;
+}
+
+bool JASPListControl::containsInteractions() const
+{
+	ListModelAssignedInterface* assignedModel = qobject_cast<ListModelAssignedInterface*>(model());
+	if (assignedModel && assignedModel->availableModel() && assignedModel->availableModel()->listView()->containsInteractions())
+		return true;
 
 	for (SourceItem* sourceItem : _sourceItems)
 	{
 		if (sourceItem->sourceListModel())
 		{
 			JASPListControl* sourceControl = sourceItem->sourceListModel()->listView();
-			connect(sourceControl, &JASPListControl::containsVariablesChanged,		this, &JASPListControl::setContainsVariables);
-			connect(sourceControl, &JASPListControl::containsInteractionsChanged,	this, &JASPListControl::setContainsInteractions);
+			if (sourceControl != this && (sourceControl->containsInteractions() || sourceItem->generateInteractions()))
+				return true;
 		}
 	}
 
-	setContainsVariables();
-	setContainsInteractions();
-}
-
-void JASPListControl::setContainsVariables()
-{
-	bool containsVariables = _containsVariables;
-
-	ListModelAssignedInterface* assignedModel = qobject_cast<ListModelAssignedInterface*>(model());
-	if (assignedModel && assignedModel->availableModel())
-		containsVariables = assignedModel->availableModel()->listView()->containsVariables();
-
-	if (!containsVariables)
-	{
-		for (SourceItem* sourceItem : _sourceItems)
-		{
-			if (sourceItem->isAnalysisDataSet())	containsVariables = true;
-			else if (sourceItem->sourceListModel())
-			{
-				if (sourceItem->sourceListModel()->listView()->containsVariables() && sourceItem->rowControlName().isEmpty() && !sourceItem->sourceFilter().contains("levels"))
-					containsVariables = true;
-			}
-		}
-	}
-
-	if (_containsVariables != containsVariables)
-	{
-		_containsVariables = containsVariables;
-		emit containsVariablesChanged();
-	}
-}
-
-void JASPListControl::setContainsInteractions()
-{
-	bool containsInteractions = false;
-
-	if (_termsAreInteractions)
-		containsInteractions = true;
-
-	if (!containsInteractions)
-	{
-		ListModelAssignedInterface* assignedModel = qobject_cast<ListModelAssignedInterface*>(model());
-		if (assignedModel && assignedModel->availableModel())
-			containsInteractions = assignedModel->availableModel()->listView()->containsInteractions();
-	}
-
-	if (!containsInteractions)
-	{
-		for (SourceItem* sourceItem : _sourceItems)
-		{
-			if (sourceItem->sourceListModel())
-			{
-				JASPListControl* sourceControl = sourceItem->sourceListModel()->listView();
-				if (sourceControl->containsInteractions() || sourceItem->generateInteractions())
-					containsInteractions = true;
-			}
-		}
-	}
-
-	if (_containsInteractions != containsInteractions)
-	{
-		_containsInteractions = containsInteractions;
-		emit containsInteractionsChanged();
-	}
+	return false;
 }
 
 void JASPListControl::termsChangedHandler()

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -100,8 +100,8 @@ public:
 			int						maxRows()					const			{ return _maxRows;				}
 			bool					addEmptyValue()				const			{ return _addEmptyValue;		}
 			const QString		&	placeholderText()			const			{ return _placeHolderText;		}
-			bool					containsVariables()			const			{ return _containsVariables;	}
-			bool					containsInteractions()		const			{ return _containsInteractions;	}
+	virtual	bool					containsVariables()			const;
+	virtual bool					containsInteractions()		const;
 			bool					encodeValue()				const override	{ return containsVariables() || containsInteractions();	}
 			bool					useSourceLevels()			const			{ return _useSourceLevels;		}
 			void					setUseSourceLevels(bool b)					{ _useSourceLevels = b;			}
@@ -153,10 +153,6 @@ signals:
 			void					allowedColumnsChanged();
 			void					allowedColumnsIconsChanged();
 
-public slots:
-			void					setContainsVariables();
-			void					setContainsInteractions();
-
 protected slots:
 	virtual void					termsChangedHandler();
 			void					_termsChangedHandler();
@@ -201,9 +197,6 @@ protected:
 	QVariant				_rSource;
 	QVariant				_values;
 	bool					_addEmptyValue						= false,
-							_containsVariables					= false,
-							_containsInteractions				= false,
-							_termsAreInteractions				= false,
 							_useSourceLevels					= false,
 							_addAvailableVariablesToAssigned	= false,
 							_allowAnalysisOwnComputedColumns	= true,

--- a/QMLComponents/controls/rowcontrols.cpp
+++ b/QMLComponents/controls/rowcontrols.cpp
@@ -51,6 +51,9 @@ void RowControls::init(int row, const Term& key, bool isNew)
 	_rowObject->setParent(_parentModel);
 	_context = context;
 
+	_initialized = true;
+	emit initializedChanged();
+
 	if (_rowObject)	_initializeControls();
 	else			Log::log() << "Could not create control in ListView " << listView->name() << std::endl;
 }

--- a/QMLComponents/controls/rowcontrols.h
+++ b/QMLComponents/controls/rowcontrols.h
@@ -49,6 +49,10 @@ public:
 	JASPControl*								getJASPControl(const QString& name)					{ return _rowJASPControlMap.contains(name) ? _rowJASPControlMap[name] : nullptr; }
 	bool										addJASPControl(JASPControl* control);
 	void										disconnectControls();
+	bool										initialized()								const	{ return _initialized; }
+
+signals:
+	void										initializedChanged();
 
 private:
 
@@ -60,6 +64,7 @@ private:
 	QMap<QString, JASPControl*>				_rowJASPControlMap;
 	QQmlContext*							_context;
 	QMap<QString, Json::Value>				_initialValues;
+	bool									_initialized	= false;
 };
 
 #endif // ROWCOMPONENTS_H

--- a/QMLComponents/controls/sourceitem.cpp
+++ b/QMLComponents/controls/sourceitem.cpp
@@ -43,7 +43,7 @@ SourceItem::SourceItem(
 	QString modelUse			= map["use"].toString().trimmed();
 
 	_sourceName					= map["name"].toString();
-	_rowControlName				= map["controlName"].toString();
+	_rowControlName				= map["rowControlName"].toString();
 	_sourceFilter				= !modelUse.isEmpty() ? modelUse.split(",") : QStringList();
 	_conditionExpression		= map["condition"].toString();
 	_values						= values;
@@ -51,11 +51,12 @@ SourceItem::SourceItem(
 	_discardSources				= discardSources;
 	_rSources					= rSources;
 
-	_isValuesSource				= map.contains("isValuesSource")			? map["isValuesSource"].toBool()			: false;
-	_isDataSetVariables			= map.contains("isDataSetVariables")		? map["isDataSetVariables"].toBool()		: false;
-	_combineWithOtherModels		= map.contains("combineWithOtherModels")	? map["combineWithOtherModels"].toBool()	: false;
-	_noInteractions				= map.contains("noInteraction")				? map["noInteraction"].toBool()				: false;
-	_nativeModelRole			= map.contains("nativeModelRole")			? map["nativeModelRole"].toInt()			: Qt::DisplayRole;
+	_sourceListControl			= map.contains("listControl")				? map["listControl"].value<JASPListControl*>()	: nullptr;
+	_isValuesSource				= map.contains("isValuesSource")			? map["isValuesSource"].toBool()				: false;
+	_isDataSetVariables			= map.contains("isDataSetVariables")		? map["isDataSetVariables"].toBool()			: false;
+	_combineWithOtherModels		= map.contains("combineWithOtherModels")	? map["combineWithOtherModels"].toBool()		: false;
+	_noInteractions				= map.contains("noInteraction")				? map["noInteraction"].toBool()					: false;
+	_nativeModelRole			= map.contains("nativeModelRole")			? map["nativeModelRole"].toInt()				: Qt::DisplayRole;
 	_combineTerms				= map.contains("combineTerms")				? JASPControl::CombinationType(map["combineTerms"].toInt())	: JASPControl::CombinationType::NoCombination;
 	if (isInfoProviderModel(_sourceNativeModel))									_isDataSetVariables = true;
 	if (_sourceFilter.contains("levels"))											_targetListControl->setUseSourceLevels(true);
@@ -93,9 +94,87 @@ SourceItem::SourceItem(JASPListControl *listControl)
 	_setUp();
 }
 
+void SourceItem::_setUp()
+{
+	if (_isValuesSource)
+		// Add a ListModelLabelValueTerms to contain the values given in the source
+		_sourceNativeModel = new ListModelLabelValueTerms(_targetListControl, _values);
+	else if (_isDataSetVariables)
+	{
+		_sourceNativeModel	= infoProviderModel();
+		_nativeModelRole	= requestInfo(VariableInfo::NameRole).toInt();
+	}
+	else if (_targetListControl->form() && !_sourceName.isEmpty())
+	{
+		// If we are in a form and we have the name of the source, search for the source model in the form
+		_sourceNativeModel = _sourceListModel = _targetListControl->form()->getModel(_sourceName);
+		if (!_sourceListModel && _targetListControl->parentListView())
+		{
+			// If no model is found, but we are in a control created dynamically by its parent, the source control might be another control created dynamicatlly by this parent.
+			// If all controls are not yet created, we have to wait for the initialization of the rowControls
+			RowControls* rowControls = _targetListControl->parentListView()->model()->getRowControls(_targetListControl->parentListViewKey());
+			if (rowControls && !rowControls->initialized())
+			{
+				connect(rowControls, &RowControls::initializedChanged, this, &SourceItem::_findModelAndControl);
+				return;
+			}
+		}
+	}
+
+	_findModelAndControl();
+}
+
+void SourceItem::_findModelAndControl()
+{
+	if (_targetListControl->form() && !_sourceName.isEmpty() && !_sourceListModel && _targetListControl->parentListView())
+	{
+		// Case when we are in a form, we have source name, but not yet the corresponding control. The rowControls should be here initialized
+		RowControls* rowControls = _targetListControl->parentListView()->model()->getRowControls(_targetListControl->parentListViewKey());
+		if (rowControls)
+			_sourceListControl = qobject_cast<JASPListControl*>(rowControls->getJASPControl(_sourceName));
+	}
+
+	if (_sourceNativeModel || _isRSource || _sourceListControl)
+	{
+		if (_sourceNativeModel)
+		{
+			_sourceListModel = qobject_cast<ListModel*>(_sourceNativeModel);
+			if (_sourceListModel)
+				_sourceListControl = _sourceListModel->listView();
+		}
+		else if (_sourceListControl)
+			_sourceNativeModel = _sourceListModel = _sourceListControl->model();
+
+		if (_sourceListControl) _targetListControl->addDependency(_sourceListControl);
+
+		// Do not connect before this control (and the controls of the source) are completely initialized
+		// The source could send some data to this control before it is completely ready for it.
+		if (_targetListControl->initialized()) connectModels();
+		else connect(_targetListControl, &JASPControl::initializedChanged, this, &SourceItem::connectModels);
+	}
+	else if (_rSources.length() == 0)
+	{
+		// Could not find the source control: add an error
+		if (_sourceName.isEmpty())
+		{
+			if (_targetListControl->form())	_targetListControl->addControlError(QObject::tr("No name given for the source of %1").arg(_targetListControl->name()));
+			else							_targetListControl->addControlError(QObject::tr("No source given for %1").arg(_targetListControl->name()));
+		}
+		else								_targetListControl->addControlError(QObject::tr("Cannot find component %1 for the source of %2").arg(_sourceName).arg(_targetListControl->name()));
+	}
+
+}
+
 void SourceItem::connectModels()
 {
 	if (!_targetListControl->initialized() || _connected) return;
+
+	if (!_sourceNativeModel && _sourceListControl)
+	{
+		// The source model was maybe not yet made. But as the source control is now initialized, we should find it.
+		_sourceName = _sourceListControl->name();
+		_sourceNativeModel = _sourceListModel = _sourceListControl->model();
+	}
 
 	ListModel *controlModel = _targetListControl->model();
 	AnalysisForm* form		= _targetListControl->form();
@@ -134,6 +213,8 @@ void SourceItem::connectModels()
 		connect(variableInfo,	&VariableInfo::filterChanged,		controlModel, &ListModel::filterChanged );
 		connect(variableInfo,	&VariableInfo::columnsChanged,		controlModel, &ListModel::sourceColumnsChanged );
 		connect(variableInfo,	&VariableInfo::refresh,				controlModel, &ListModel::refresh );
+
+		emit _targetListControl->containsVariablesChanged();
 	}
 
 	if (_sourceListModel)
@@ -144,6 +225,16 @@ void SourceItem::connectModels()
 		connect(_sourceListModel,		&ListModel::labelsReordered,		controlModel, &ListModel::sourceLabelsReordered );
 		connect(_sourceListModel,		&ListModel::filterChanged,			controlModel, &ListModel::filterChanged );
 		connect(_sourceListModel,		&ListModel::columnsChanged,			controlModel, &ListModel::sourceColumnsChanged );
+	}
+
+	if (_sourceListControl && _sourceListControl != _targetListControl)
+	{
+		connect(_sourceListControl,		&JASPListControl::containsVariablesChanged,		_targetListControl, &JASPListControl::containsVariablesChanged);
+		connect(_sourceListControl,		&JASPListControl::containsInteractionsChanged,	_targetListControl, &JASPListControl::containsInteractionsChanged);
+
+		// Update the containsVariables and containsInteractions property of the target control
+		emit _targetListControl->containsVariablesChanged();
+		emit _targetListControl->containsInteractionsChanged();
 	}
 
 	_connected = true;
@@ -192,36 +283,7 @@ void SourceItem::_rSourceChanged(const QString& name)
 		_targetListControl->model()->sourceTermsReset();
 }
 
-void SourceItem::_setUp()
-{
-	if (_isValuesSource)											_sourceNativeModel = new ListModelLabelValueTerms(_targetListControl, _values);
-	else if (_targetListControl->form() && !_sourceName.isEmpty())	_sourceNativeModel = _targetListControl->form()->getModel(_sourceName);
-	else if (_isDataSetVariables)
-	{
-		_sourceNativeModel		= infoProviderModel();
-		_nativeModelRole	= requestInfo(VariableInfo::NameRole).toInt();
-	}
 
-	if (_sourceNativeModel || _isRSource)
-	{
-		_sourceListModel = qobject_cast<ListModel*>(_sourceNativeModel);
-		if (_sourceListModel)	_targetListControl->addDependency(_sourceListModel->listView());
-
-		// Do not connect before this control (and the controls of the source) are completely initialized
-		// The source could sent some data to this control before it is completely ready for it.
-		if (_targetListControl->initialized()) connectModels();
-		else connect(_targetListControl, &JASPControl::initializedChanged, this, &SourceItem::connectModels);
-	}
-	else if (_rSources.length() == 0)
-	{
-		if (_sourceName.isEmpty())
-		{
-			if (_targetListControl->form())		_targetListControl->addControlError(QObject::tr("No name given for the source of %1").arg(_targetListControl->name()));
-			else							_targetListControl->addControlError(QObject::tr("No source given for %1").arg(_targetListControl->name()));
-		}
-		else								_targetListControl->addControlError(QObject::tr("Cannot find component %1 for the source of %2").arg(_sourceName).arg(_targetListControl->name()));
-	}
-}
 
 QList<QVariant> SourceItem::getListVariant(QVariant var)
 {
@@ -284,22 +346,22 @@ QString SourceItem::_readRSourceName(const QString& sourceNameExt, QString& sour
 QMap<QString, QVariant> SourceItem::_readSource(JASPListControl* listControl, const QVariant& source, SourceItem::SourceValuesType& sourceValues, QVector<SourceItem*>& rSources, QAbstractItemModel*& nativeModel)
 {
 	QMap<QString, QVariant> map;
-	QString sourceName, sourceControl, sourceUse;
+	QString sourceName, sourceControlName, sourceUse;
 
 	JASPControl* sourceItem = source.value<JASPControl*>();
-	if (sourceItem)										sourceName = sourceItem->name();
-	else if (source.typeId() == QMetaType::QString)	sourceName = _readSourceName(source.toString(), sourceControl, sourceUse);
+	if (sourceItem)									sourceName = sourceItem->name();
+	else if (source.typeId() == QMetaType::QString)	sourceName = _readSourceName(source.toString(), sourceControlName, sourceUse);
 	else if (source.canConvert<QMap<QString, QVariant> >())
 	{
 		map = source.toMap();
 		if (map.contains("id"))
 		{
-			JASPControl* sourceItem2 = map["id"].value<JASPControl*>();
-			if (sourceItem2)	sourceName = sourceItem2->name();
+			sourceItem = map["id"].value<JASPControl*>();
+			if (sourceItem)	sourceName = sourceItem->name();
 		}
 
 		if (map.contains("name"))
-			sourceName = _readSourceName(map["name"].toString(), sourceControl, sourceUse);
+			sourceName = _readSourceName(map["name"].toString(), sourceControlName, sourceUse);
 
 		if (map.contains("use"))
 		{
@@ -354,9 +416,10 @@ QMap<QString, QVariant> SourceItem::_readSource(JASPListControl* listControl, co
 			}
 		}
 	}
-	map["name"]			= sourceName;
-	map["controlName"]	= sourceControl;
-	map["use"]			= sourceUse;
+	map["name"]				= sourceName;
+	map["rowControlName"]	= sourceControlName;
+	map["use"]				= sourceUse;
+	map["listControl"]		= QVariant::fromValue(qobject_cast<JASPListControl*>(sourceItem));
 	return map;
 }
 

--- a/QMLComponents/controls/sourceitem.h
+++ b/QMLComponents/controls/sourceitem.h
@@ -101,6 +101,7 @@ private:
 	static SourceValuesType					_readValues(JASPListControl* _listControl, const QVariant& _values);
 
 	void									_setUp();
+	void									_findModelAndControl();
 	Terms									_readAllTerms();
 
 private slots:
@@ -109,7 +110,8 @@ private slots:
 	void									_rSourceChanged(const QString& name);
 
 private:
-	JASPListControl		*			_targetListControl			= nullptr;
+	JASPListControl		*			_targetListControl			= nullptr,
+						*			_sourceListControl			= nullptr;
 	QString							_sourceName,
 									_rowControlName;
 	QStringList						_sourceFilter;

--- a/QMLComponents/controls/textareabase.cpp
+++ b/QMLComponents/controls/textareabase.cpp
@@ -42,10 +42,18 @@ void TextAreaBase::setUpModel()
 	if (_textType == TextType::TextTypeSource || _textType == TextType::TextTypeJAGSmodel || _textType == TextType::TextTypeLavaan || _textType == TextType::TextTypeCSem)
 	{
 		_model = new ListModelTermsAvailable(this);
-		_model->setNeedsSource(_textType == TextType::TextTypeLavaan || _textType == TextType::TextTypeCSem);
+		_model->setNeedsSource(_textType == TextType::TextTypeCSem);
 
 		JASPListControl::setUpModel();
 	}
+}
+
+bool TextAreaBase::containsVariables() const
+{
+	if (_textType == TextType::TextTypeLavaan)
+		return true;
+
+	return JASPListControl::containsVariables();
 }
 
 void TextAreaBase::setUp()
@@ -53,7 +61,7 @@ void TextAreaBase::setUp()
 	switch (_textType)
 	{
 	case TextType::TextTypeSource:		_boundControl = new BoundControlSourceTextArea(this);	break;
-    case TextType::TextTypeLavaan:		_boundControl = new BoundControlRlangTextArea(this);	break;
+	case TextType::TextTypeLavaan:		_boundControl = new BoundControlRlangTextArea(this);	break;
     case TextType::TextTypeRcode:		_boundControl = new BoundControlRlangTextArea(this);	break;
 	case TextType::TextTypeJAGSmodel:	_boundControl = new BoundControlJAGSTextArea(this);		break;
 	case TextType::TextTypeCSem:		_boundControl = new BoundControlCSemTextArea(this);		break;

--- a/QMLComponents/controls/textareabase.h
+++ b/QMLComponents/controls/textareabase.h
@@ -60,8 +60,11 @@ public:
 	ListModelTermsAvailable*	availableModel()							const				{ return _model;										}
 	void						setUp()												override;
 	void						setUpModel()										override;
+	bool						containsVariables()							const	override;
+
 
 	void						rScriptDoneHandler(const QString &result)			override;
+	BoundControl			*	boundControl()										override	{ return isBound() ? _boundControl : nullptr;			}
 
 	TextType					textType()									const				{ return _textType;										}
 	bool						hasScriptError()							const				{ return _hasScriptError;								}
@@ -71,6 +74,7 @@ public:
 
 	bool autoCheckSyntax()								const	{	return _autoCheckSyntax;	}
 	bool checkSyntax()									const	{	return _checkSyntax;		}
+
 
 public slots:
 	GENERIC_SET_FUNCTION(TextType,			_textType,			textTypeChanged,		TextType	)
@@ -91,7 +95,7 @@ signals:
 
 protected slots:
 	void	termsChangedHandler()		override;
-    
+
 protected:
 	void						_setInitialized(const Json::Value& value = Json::nullValue)	override;
 

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -117,7 +117,6 @@ void VariablesListBase::setUpModel()
 
 	case ListViewType::AvailableInteraction:
 		_isBound				= false;
-		_termsAreInteractions	= true;
 		_draggableModel			= new ListModelInteractionAvailable(this);
 		break;
 
@@ -159,8 +158,6 @@ void VariablesListBase::setUpModel()
 		
 	case ListViewType::Interaction:
 	{
-		_termsAreInteractions = true;
-
 		bool	interactionContainLowerTerms	= property("interactionContainLowerTerms").toBool(),
 				addInteractionsByDefault		= property("addInteractionsByDefault").toBool();
 
@@ -272,9 +269,16 @@ void VariablesListBase::moveItems(QList<int> &indexes, ListModelDraggable* targe
 	if (form()) form()->blockValueChangeSignal(false);
 }
 
+bool VariablesListBase::containsInteractions() const
+{
+	if (_listViewType == ListViewType::AvailableInteraction || _listViewType == ListViewType::Interaction)
+		return true;
+
+	return JASPListControl::containsInteractions();
+}
+
 void VariablesListBase::setDropKeys(const QStringList &dropKeys)
 {
-	Log::log() << "LOG setDropKeys " << name() << ": " << dropKeys.join('/') << std::endl;
 	if (dropKeys != _dropKeys)
 	{
 		_dropKeys = dropKeys;
@@ -331,8 +335,8 @@ void VariablesListBase::_setRelations()
 				assignedModel->setAvailableModel(availableModel);
 				availableModel->addAssignedModel(assignedModel);
 				addDependency(availableModel->listView());
-				setContainsVariables();
-				setContainsInteractions();
+				emit containsVariablesChanged();
+				emit containsInteractionsChanged();
 
 				// When the assigned model is of type interaction or it has multiple columns, then the available model should keep its terms when they are moved to the assigned model
 				if (_listViewType == ListViewType::Interaction || (columns() > 1 && _listViewType != ListViewType::RepeatedMeasures))

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -63,6 +63,7 @@ public:
 	bool						addRowControl(const QString& key, JASPControl* control)											override;
 	void						moveItems(QList<int> &indexes, ListModelDraggable* dropModel, int dropItemIndex = -1);
 	bool						keepVariablesWhenMoved()																const				{ return _keepVariablesWhenMoved;					}
+	bool						containsInteractions()																	const	override;
 
 signals:
 	void listViewTypeChanged();

--- a/QMLComponents/models/listmodelavailableinterface.cpp
+++ b/QMLComponents/models/listmodelavailableinterface.cpp
@@ -217,8 +217,8 @@ void ListModelAvailableInterface::addAssignedModel(ListModelAssignedInterface *a
 	connect(this,			&ListModelAvailableInterface::labelsChanged,		assignedModel,				&ListModelAssignedInterface::sourceLabelsChanged		);
 	connect(this,			&ListModelAvailableInterface::labelsReordered,		assignedModel,				&ListModelAssignedInterface::sourceLabelsReordered		);
 	connect(this,			&ListModelAvailableInterface::filterChanged,		assignedModel,				&ListModelAssignedInterface::filterChanged				);
-	connect(listView(),		&JASPListControl::containsVariablesChanged,			assignedModel->listView(),	&JASPListControl::setContainsVariables					);
-	connect(listView(),		&JASPListControl::containsInteractionsChanged,		assignedModel->listView(),	&JASPListControl::setContainsInteractions				);
+	connect(listView(),		&JASPListControl::containsVariablesChanged,			assignedModel->listView(),	&JASPListControl::containsVariablesChanged				);
+	connect(listView(),		&JASPListControl::containsInteractionsChanged,		assignedModel->listView(),	&JASPListControl::containsInteractionsChanged			);
 }
 
 void ListModelAvailableInterface::removeAssignedModel(ListModelAssignedInterface *assignedModel)


### PR DESCRIPTION
Lavaan code in TextArea can use variables from the DataSet. These columns should be exposed, so that they can be used as source of other controls.

When adding this feature, I had to solve some issues:

- The resolution of the sources was not working properly when the source and target controls were created dynamically. The new test (Test TextArea) in the TestModule checks this with a TabView containing a TextArea wih Lavaan code which is source of a VariablesList (or a DropDown).
- The containsVariables and containsInteraction properties in List Controls (live VariablesList) were cached in each control. This was cumbersome and unneeded. The _containVariabels, _containInteraction and _termsAreInteractions are removed from the JASPListControl, and containsVariables and containsInteraction are functions that check each time the sources to see whether they contain variables or interactions.
- Also the width of TabView was not correctly set

@FBartos When this PR is merged, there is an example in jaspTestModule (Test Text Area) how to use the variables in a Lavaan TextArea as source for other controls. It gives also an example with a TabView with 2 columns.