### PR TITLE
chore: fix workflow on Linux with latest R version

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,11 +19,13 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
+      - name: Get Installed R Version
+        run: echo "R_VERSION=$(R --version | head -n 1 | awk '{print $3}')" >> $GITHUB_ENV
       
       - name: Install Qt6
         uses: jurplel/install-qt-action@v3
         with:
-            version: 6.7.0
+            version: 6.8.*
             aqtversion: '==3.1.*'
             host: 'linux'
             target: 'desktop'
@@ -36,11 +38,9 @@ jobs:
         run: |     
             sudo apt install libboost-dev libjsoncpp25 libjsoncpp-dev libarchive13 libarchive-dev
             sudo apt install libxcb-xkb-dev libxcb-xkb1 libxcb-xinerama0 libxkbcommon-dev libxkbcommon-x11-dev autoconf zlib1g zlib1g-dev cmake
-            sudo apt install gfortran build-essential flex libssl-dev libgl1-mesa-dev libsqlite3-dev r-base
+            sudo apt install gfortran build-essential flex libssl-dev libgl1-mesa-dev libsqlite3-dev
             sudo apt install libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev #required by some r packgaes
-            sudo apt install libcurl4-openssl-dev #required by curl R packages
-            sudo apt install libmpfr-dev #required by rmpfr packages
-            sudo apt install libglpk-dev #required by igraph packages
+            sudo apt install libglpk-dev libcurl4-openssl-dev libmpfr-dev libfontconfig1-dev libcairo2-dev #required by some r packages
             sudo apt install jags
             sudo apt install libminizip-dev # required by freexl
             git clone https://github.com/jasp-stats/freexl.git
@@ -72,6 +72,7 @@ jobs:
             BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
             Boost_INCLUDE_DIR: "${{steps.install-boost.outputs.BOOST_ROOT}}/include"
             Boost_LIBRARY_DIRS: "${{steps.install-boost.outputs.BOOST_ROOT}}/lib"
+            R_HOME: "/opt/R/${{ env.R_VERSION }}/lib/R"
 
       - name: Build JASP desktop
         run: |


### PR DESCRIPTION
legacy old R version break build in workflows so we make sure to use latest R installation.