### PR TITLE
Use Group inside Checkbox in order to align sub-controls

### DIFF
--- a/QMLComponents/components/JASP/Controls/CheckBox.qml
+++ b/QMLComponents/components/JASP/Controls/CheckBox.qml
@@ -25,17 +25,17 @@ CheckBoxBase
 {
 	id:					checkBox
 	implicitWidth:		childrenOnSameRow
-							? control.implicitWidth + (childControlsArea.children.length > 0 ? jaspTheme.columnGroupSpacing + childControlsArea.implicitWidth : 0)
-							: Math.max(control.implicitWidth, control.padding + checkIndicator.width + control.spacing + childControlsArea.implicitWidth)
+							? control.implicitWidth + (childControlsArea.hasChildren ? jaspTheme.columnGroupSpacing + childControlsArea.implicitWidth : 0)
+							: Math.max(control.implicitWidth, control.padding + checkIndicator.width + (childControlsArea.hasChildren ? control.spacing + childControlsArea.implicitWidth : 0))
 	implicitHeight:		childrenOnSameRow
 							? Math.max(control.implicitHeight, childControlsArea.implicitHeight)
-							: control.implicitHeight + (childControlsArea.children.length > 0 ? jaspTheme.rowGroupSpacing + childControlsArea.implicitHeight : 0)
+							: control.implicitHeight + (childControlsArea.hasChildren ? jaspTheme.rowGroupSpacing + childControlsArea.implicitHeight : 0)
 	focusIndicator:		focusIndicator
 	childControlsArea:	childControlsArea
 	innerControl:		control
 	title:				text
 
-	default property alias	content:				childControlsArea.children
+	default property alias	content:				childControlsArea.content
 			property alias	control:				control
 			property alias	childrenArea:			childControlsArea
 			property alias	text:					control.text
@@ -120,7 +120,7 @@ CheckBoxBase
 		}
 	}
 
-	GridLayout
+	Group // Use Group instead of GridLayout so that the label / control fields can be aligned.
 	{
 		id:				childControlsArea
 		anchors
@@ -131,15 +131,14 @@ CheckBoxBase
 			leftMargin: childrenOnSameRow ? jaspTheme.columnGroupSpacing : control.padding + checkIndicator.width + control.spacing
 		}
 		enabled:		enableChildrenOnChecked ? control.checked : true
-		visible:		children.length > 0
-		columns:		childrenOnSameRow ? children.length : 1
-		rowSpacing:		jaspTheme.rowGroupSpacing
+		visible:		hasChildren
+		columns:		childrenOnSameRow ? childControlsArea.content.length : 1
 		columnSpacing:	jaspTheme.columnGridSpacing
 	}
 
 	Component.onCompleted:
 	{
-		if (childControlsArea.children.length > 0)
+		if (childControlsArea.hasChildren)
 		{
 			if (childrenOnSameRow)
 			{

--- a/QMLComponents/components/JASP/Controls/Group.qml
+++ b/QMLComponents/components/JASP/Controls/Group.qml
@@ -24,8 +24,8 @@ import JASP
 GroupBoxBase
 {
 	id						: groupBox
-	implicitWidth			: Math.max(label.realWidth, contentArea.x + contentArea.implicitWidth)
-	implicitHeight			: label.realHeight + jaspTheme.titleBottomMargin + contentArea.implicitHeight
+	implicitWidth			: hasChildren ? Math.max(label.realWidth, contentArea.x + contentArea.implicitWidth) : 0
+	implicitHeight			: hasChildren ? ((label.visible ? (label.realHeight + jaspTheme.titleBottomMargin) : 0) + contentArea.implicitHeight) : 0
 	L.Layout.leftMargin		: indent ? jaspTheme.indentationLength : 0
 	isBound					: false
 	childControlsArea		: contentArea
@@ -43,6 +43,7 @@ GroupBoxBase
 			property alias	label:				label
 			property alias	preferredWidth:		contentArea.width
 			property int	textFormat:			Text.AutoText
+			property bool	hasChildren:		contentArea.count > 0
 
 			property var	_allAlignableFields:		[]
 			property bool	_childrenConnected:	false


### PR DESCRIPTION
If you have controls inside a Checkbox, these controls should be automatically aligned as if they were in a Group, that is that. the label and the field control (of TextFields and Dropdowns) should be aligned.