### PR TITLE
[Do-Not-Merge] allow window activation from JavaScript

### DIFF
--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -313,6 +313,9 @@ Item
 
 			url:					resultsJsInterface.resultsPageUrl
 
+			settings.allowWindowActivationFromJavaScript: false
+			settings.javascriptCanOpenWindows: false
+
 			onContextMenuRequested: (request) => request.accepted = true
 
 			backgroundColor:		jaspTheme.uiBackground


### PR DESCRIPTION
Could some one trigger a build for this PR and I want to know why upload image from jasp note in not work(does not have a file dialog window) on all official build but only works on my locally build...

locally build: Windows with Qt 6.8.2