### PR TITLE
Add access to factors form variables lists and their titles

### DIFF
--- a/QMLComponents/controls/factorsformbase.cpp
+++ b/QMLComponents/controls/factorsformbase.cpp
@@ -43,13 +43,10 @@ void FactorsFormBase::setUpModel()
 	_availableVariablesListItem = qobject_cast<JASPListControl *>(availableListVariant.value<QObject *>());
 
 	connect(this, &FactorsFormBase::initializedChanged, this, &FactorsFormBase::countVariablesChanged);
-	connect(_factorsModel, &ListModelFactorsForm::modelReset, this, &FactorsFormBase::factorsNamesChanged);
 	connect(_factorsModel, &ListModelFactorsForm::modelReset, this, &FactorsFormBase::factorsTitlesChanged);
 	connect(_factorsModel, &ListModelFactorsForm::modelReset, this, &FactorsFormBase::factorsItemsChanged);
-	connect(_factorsModel, &ListModelFactorsForm::rowsInserted, this, &FactorsFormBase::factorsNamesChanged);
 	connect(_factorsModel, &ListModelFactorsForm::rowsInserted, this, &FactorsFormBase::factorsTitlesChanged);
 	connect(_factorsModel, &ListModelFactorsForm::rowsInserted, this, &FactorsFormBase::factorsItemsChanged);
-	connect(_factorsModel, &ListModelFactorsForm::rowsRemoved, this, &FactorsFormBase::factorsNamesChanged);
 	connect(_factorsModel, &ListModelFactorsForm::rowsRemoved, this, &FactorsFormBase::factorsTitlesChanged);
 	connect(_factorsModel, &ListModelFactorsForm::rowsRemoved, this, &FactorsFormBase::factorsItemsChanged);
 }
@@ -207,28 +204,21 @@ void FactorsFormBase::factorAdded(int index, QVariant item)
 	listView->setInitialized();
 }
 
-QStringList FactorsFormBase::factorsNames() const
+
+QVariantList FactorsFormBase::factorsTitles() const
 {
-	QStringList names;
-
-	if (!_factorsModel)
-		return names;
-
-	for (auto factorModel : _factorsModel->getFactors())
-		names.append(factorModel.name);
-
-	return names;
-}
-
-QStringList FactorsFormBase::factorsTitles() const
-{
-	QStringList titles;
+	QVariantList titles;
 
 	if (!_factorsModel)
 		return titles;
 
 	for (auto factorModel : _factorsModel->getFactors())
-		titles.append(factorModel.title);
+	{
+		QMap<QString, QVariant> map;
+		map["label"] = factorModel.title;
+		map["value"] = factorModel.name;
+		titles.append(map);
+	}
 
 	return titles;
 }

--- a/QMLComponents/controls/factorsformbase.cpp
+++ b/QMLComponents/controls/factorsformbase.cpp
@@ -43,6 +43,15 @@ void FactorsFormBase::setUpModel()
 	_availableVariablesListItem = qobject_cast<JASPListControl *>(availableListVariant.value<QObject *>());
 
 	connect(this, &FactorsFormBase::initializedChanged, this, &FactorsFormBase::countVariablesChanged);
+	connect(_factorsModel, &ListModelFactorsForm::modelReset, this, &FactorsFormBase::factorsNamesChanged);
+	connect(_factorsModel, &ListModelFactorsForm::modelReset, this, &FactorsFormBase::factorsTitlesChanged);
+	connect(_factorsModel, &ListModelFactorsForm::modelReset, this, &FactorsFormBase::factorsItemsChanged);
+	connect(_factorsModel, &ListModelFactorsForm::rowsInserted, this, &FactorsFormBase::factorsNamesChanged);
+	connect(_factorsModel, &ListModelFactorsForm::rowsInserted, this, &FactorsFormBase::factorsTitlesChanged);
+	connect(_factorsModel, &ListModelFactorsForm::rowsInserted, this, &FactorsFormBase::factorsItemsChanged);
+	connect(_factorsModel, &ListModelFactorsForm::rowsRemoved, this, &FactorsFormBase::factorsNamesChanged);
+	connect(_factorsModel, &ListModelFactorsForm::rowsRemoved, this, &FactorsFormBase::factorsTitlesChanged);
+	connect(_factorsModel, &ListModelFactorsForm::rowsRemoved, this, &FactorsFormBase::factorsItemsChanged);
 }
 
 void FactorsFormBase::bindTo(const Json::Value& value)
@@ -194,4 +203,47 @@ void FactorsFormBase::factorAdded(int index, QVariant item)
 	connect(listView->model(), &ListModel::termsChanged, _factorsModel, &ListModelFactorsForm::resetModelTerms, Qt::QueuedConnection);
 	connect(listView->model(), &ListModel::termsChanged, this, &FactorsFormBase::countVariablesChanged);
 	connect(listView->model(), &ListModel::termsChanged, _factorsModel, &ListModelFactorsForm::ensureNesting);
+
+	listView->setInitialized();
 }
+
+QStringList FactorsFormBase::factorsNames() const
+{
+	QStringList names;
+
+	if (!_factorsModel)
+		return names;
+
+	for (auto factorModel : _factorsModel->getFactors())
+		names.append(factorModel.name);
+
+	return names;
+}
+
+QStringList FactorsFormBase::factorsTitles() const
+{
+	QStringList titles;
+
+	if (!_factorsModel)
+		return titles;
+
+	for (auto factorModel : _factorsModel->getFactors())
+		titles.append(factorModel.title);
+
+	return titles;
+}
+
+QVariantList FactorsFormBase::factorsItems() const
+{
+	QVariantList items;
+
+	if (!_factorsModel)
+		return items;
+
+	for (auto factorModel : _factorsModel->getFactors())
+		items.append(QVariant::fromValue(factorModel.listView));
+
+	return items;
+}
+
+

--- a/QMLComponents/controls/factorsformbase.h
+++ b/QMLComponents/controls/factorsformbase.h
@@ -29,13 +29,16 @@ class FactorsFormBase :  public JASPListControl, public BoundControlBase
 	Q_OBJECT
 	QML_ELEMENT
 
-	Q_PROPERTY( int		initNumberFactors		READ initNumberFactors		WRITE setInitNumberFactors	NOTIFY initNumberFactorsChanged	)
-	Q_PROPERTY( int		countVariables			READ countVariables										NOTIFY countVariablesChanged	)
-	Q_PROPERTY(QString	baseName				READ baseName				WRITE setBaseName			NOTIFY baseNameChanged			)
-	Q_PROPERTY(QString	baseTitle				READ baseTitle				WRITE setBaseTitle			NOTIFY baseTitleChanged			)
-	Q_PROPERTY(int		startIndex				READ startIndex				WRITE setStartIndex			NOTIFY startIndexChanged		)
-	Q_PROPERTY(bool		nested					READ nested					WRITE setNested				NOTIFY nestedChanged			)
-	Q_PROPERTY(bool		allowInteraction		READ allowInteraction		WRITE setAllowInteraction	NOTIFY allowInteractionChanged	)
+	Q_PROPERTY( int			initNumberFactors		READ initNumberFactors		WRITE setInitNumberFactors	NOTIFY initNumberFactorsChanged	)
+	Q_PROPERTY( int			countVariables			READ countVariables										NOTIFY countVariablesChanged	)
+	Q_PROPERTY(QString		baseName				READ baseName				WRITE setBaseName			NOTIFY baseNameChanged			)
+	Q_PROPERTY(QString		baseTitle				READ baseTitle				WRITE setBaseTitle			NOTIFY baseTitleChanged			)
+	Q_PROPERTY(int			startIndex				READ startIndex				WRITE setStartIndex			NOTIFY startIndexChanged		)
+	Q_PROPERTY(bool			nested					READ nested					WRITE setNested				NOTIFY nestedChanged			)
+	Q_PROPERTY(bool			allowInteraction		READ allowInteraction		WRITE setAllowInteraction	NOTIFY allowInteractionChanged	)
+	Q_PROPERTY(QStringList	factorsNames			READ factorsNames										NOTIFY factorsNamesChanged		)
+	Q_PROPERTY(QStringList	factorsTitles			READ factorsTitles										NOTIFY factorsTitlesChanged		)
+	Q_PROPERTY(QVariantList	factorsItems			READ factorsItems										NOTIFY factorsItemsChanged		)
 
 public:
 	FactorsFormBase(QQuickItem* parent = nullptr);
@@ -55,11 +58,14 @@ public:
 	int					initNumberFactors()						const				{ return _initNumberFactors;						}
 	int					countVariables()						const				{ return _initialized ? _factorsModel->countVariables() : 0; }
 	JASPListControl*	availableVariablesList()				const				{ return _availableVariablesListItem;				}
-	QString				baseName()								const				{ return _baseName;		}
-	QString				baseTitle()								const				{ return _baseTitle;	}
-	int					startIndex()							const				{ return _startIndex;	}
-	bool				nested()								const				{ return _nested;		}
-	bool				allowInteraction()						const				{ return _allowInteraction;		}
+	QString				baseName()								const				{ return _baseName;			}
+	QString				baseTitle()								const				{ return _baseTitle;		}
+	int					startIndex()							const				{ return _startIndex;		}
+	bool				nested()								const				{ return _nested;			}
+	bool				allowInteraction()						const				{ return _allowInteraction;	}
+	QStringList			factorsNames()							const;
+	QStringList			factorsTitles()							const;
+	QVariantList		factorsItems()							const;
 
 	GENERIC_SET_FUNCTION(BaseName			, _baseName			, baseNameChanged			, QString		)
 	GENERIC_SET_FUNCTION(BaseTitle			, _baseTitle		, baseTitleChanged			, QString		)
@@ -75,6 +81,9 @@ signals:
 	void startIndexChanged();
 	void nestedChanged();
 	void allowInteractionChanged();
+	void factorsNamesChanged();
+	void factorsTitlesChanged();
+	void factorsItemsChanged();
 
 protected slots:
 	void			termsChangedHandler() override;

--- a/QMLComponents/controls/factorsformbase.h
+++ b/QMLComponents/controls/factorsformbase.h
@@ -36,8 +36,7 @@ class FactorsFormBase :  public JASPListControl, public BoundControlBase
 	Q_PROPERTY(int			startIndex				READ startIndex				WRITE setStartIndex			NOTIFY startIndexChanged		)
 	Q_PROPERTY(bool			nested					READ nested					WRITE setNested				NOTIFY nestedChanged			)
 	Q_PROPERTY(bool			allowInteraction		READ allowInteraction		WRITE setAllowInteraction	NOTIFY allowInteractionChanged	)
-	Q_PROPERTY(QStringList	factorsNames			READ factorsNames										NOTIFY factorsNamesChanged		)
-	Q_PROPERTY(QStringList	factorsTitles			READ factorsTitles										NOTIFY factorsTitlesChanged		)
+	Q_PROPERTY(QVariantList	factorsTitles			READ factorsTitles										NOTIFY factorsTitlesChanged		)
 	Q_PROPERTY(QVariantList	factorsItems			READ factorsItems										NOTIFY factorsItemsChanged		)
 
 public:
@@ -63,8 +62,7 @@ public:
 	int					startIndex()							const				{ return _startIndex;		}
 	bool				nested()								const				{ return _nested;			}
 	bool				allowInteraction()						const				{ return _allowInteraction;	}
-	QStringList			factorsNames()							const;
-	QStringList			factorsTitles()							const;
+	QVariantList		factorsTitles()							const;
 	QVariantList		factorsItems()							const;
 
 	GENERIC_SET_FUNCTION(BaseName			, _baseName			, baseNameChanged			, QString		)
@@ -81,7 +79,6 @@ signals:
 	void startIndexChanged();
 	void nestedChanged();
 	void allowInteractionChanged();
-	void factorsNamesChanged();
 	void factorsTitlesChanged();
 	void factorsItemsChanged();
 

--- a/QMLComponents/controls/rowcontrols.cpp
+++ b/QMLComponents/controls/rowcontrols.cpp
@@ -133,5 +133,8 @@ void RowControls::disconnectControls()
 		if (listControl)
 			for (SourceItem* source : listControl->sourceItems())
 				source->disconnectModels();
+		control->setParent(nullptr);
+		control->blockSignals(true);
+		control->deleteLater();
 	}
 }

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -221,11 +221,18 @@ void ListModel::setUpRowControls()
 		row++;
 	}
 
+	QStringList removedKeys;
 	for (const QString& key : _rowControlsMap.keys())
 		if (!keys.contains(key))
+		{
 			// If some row controls are not used anymore, if they use some sources, they must be disconnected from these sources
 			// If a source changes and emits a signal, these controls should not be activated (cf. https://github.com/jasp-stats/jasp-test-release/issues/1786)
 			_rowControlsMap[key]->disconnectControls();
+			removedKeys.append(key);
+		}
+
+	for (const QString& key : removedKeys)
+		_rowControlsMap.remove(key);
 }
 
 ListModel::RowControlsValues ListModel::getTermsWithComponentValues() const

--- a/QMLComponents/models/listmodelfactorsform.cpp
+++ b/QMLComponents/models/listmodelfactorsform.cpp
@@ -165,6 +165,7 @@ void ListModelFactorsForm::titleChangedSlot(int row, QString title)
 	_factors[row].title = title;
 
 	emit dataChanged(index(row, 0), index(row,0));
+	emit _factorsForm->factorsTitlesChanged();
 }
 
 void ListModelFactorsForm::resetModelTerms()


### PR DESCRIPTION
The Variables Lists (and their titles) inside a Factors Form, should be accessible to act as a source of other components.

See the Test Factors Form in the Test Module (Simple Factors Form Section)

This feature will be used by @juliuspfadt