### PR TITLE
Rowwise functions added to Drag N Drop and auxiliary improvements

### DIFF
--- a/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
+++ b/Desktop/components/JASP/Widgets/ComputeColumnWindow.qml
@@ -185,6 +185,15 @@ FocusScope
 					ListElement	{ type: "function";	friendlyFunctionName:	"";						functionName: "round";	functionParameters: "y,n";		functionParamTypes: "number,number";			toolTip: qsTr("rounds y to n decimals") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";						functionName: "length";	functionParameters: "y";		functionParamTypes: "string:number:boolean";	toolTip: qsTr("returns number of elements in y") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";						functionName: "median";	functionParameters: "values";	functionParamTypes: "number";					toolTip: qsTr("median") }
+					
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";	functionName: "rowMean";		toolTip: qsTr("Rowwise mean") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";	functionName: "rowSum";			toolTip: qsTr("Rowwise sum") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";	functionName: "rowSD";			toolTip: qsTr("Rowwise standard deviation") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";	functionName: "rowVariance";	toolTip: qsTr("Rowwise variance") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";	functionName: "rowMedian";		toolTip: qsTr("Rowwise median") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";	functionName: "rowMin";			toolTip: qsTr("Rowwise minimum") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";	functionName: "rowMax";			toolTip: qsTr("Rowwise maximum") }
+					
 
 					ListElement	{ type: "separator" }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";						functionName: "log";			functionParameters: "y";				functionParamTypes: "number";						toolTip: qsTr("natural logarithm") }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ColumnDrag.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ColumnDrag.qml
@@ -2,9 +2,9 @@ import QtQuick
 
 DragGeneric 
 {
-	property string columnName:		"?"
-	property int    columnTypeUser:	-1
-
+	property alias columnName:		showMe.columnName
+	property alias  columnTypeUser:	showMe.columnTypeUser
+	property alias  columnTypeDrop:	showMe.columnTypeDrop
 					shownChild:		showMe
 					dragKeys:		showMe.dragKeys
     property bool	acceptsDrops:	true
@@ -15,8 +15,6 @@ DragGeneric
 	JASPColumn
 	{
 		id:						showMe
-		columnName:				parent.columnName
-		columnTypeUser:			parent.columnTypeUser
 		changeTypeAllowed:		parent.acceptsDrops
 
 		x:						parent.dragX

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
@@ -240,6 +240,7 @@ FocusScope
 				anchors.right: parent.right
 
 				height: Math.min(60, scrollScriptColumn.height)
+				z:		1000
 			}
 
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ComputedColumnsConstructor.qml
@@ -377,16 +377,16 @@ FocusScope
 	function jsonChanged()
 	{
 		//.replace(/\s/g,'')
-		//console.log("last: ",jsonConverterComputedColumns.lastProperlyconstructorJson.replace(/\s/g,''))
+		//console.log("last: ",jsonConverter.lastProperlyconstructorJson.replace(/\s/g,''))
 		//console.log("new:  ",JSON.stringify(returnFilterJSON()).replace(/\s/g,''))
 
-		return jsonConverterComputedColumns.lastProperlyconstructorJson !== JSON.stringify(returnFilterJSON())
+		return jsonConverter.lastProperlyconstructorJson !== JSON.stringify(returnFilterJSON())
 	}
 
 	JSONtoFormulas
 	{
-		id: jsonConverterComputedColumns
-		objectName: "jsonConverterComputedColumns"
+		id: jsonConverter
+		objectName: "jsonConverter"
 
 		visible: false
 	}
@@ -400,7 +400,7 @@ FocusScope
 		trashCan.destroyAll();
 		if(jsonString !== "")
 		{
-			jsonConverterComputedColumns.convertJSONtoFormulas(jsonString)
+			jsonConverter.convertJSONtoFormulas(jsonString)
 			checkAndApplyFilter()
 		}
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -58,6 +58,7 @@ MouseArea
 	property bool showHighlight:			shownChild !== null ? !shownChild.acceptsDrops : false
 	
 	signal wasDroppedOn();
+	signal jsonChanged();
 
 	Rectangle
 	{
@@ -172,7 +173,7 @@ MouseArea
 				return
 			}
 
-            if(leftDropSpot !== null && this.tryLeftApplication(dropTarget)) //maybe gobble something up instead of the other way 'round?
+            if(this.tryLeftApplication(dropTarget)) //maybe gobble something up instead of the other way 'round?
                return
 		}
 
@@ -230,7 +231,10 @@ MouseArea
 				this.removeAncestorsHoverOutlines()
 			
 			if(parent != scriptColumn)
+			{
 				parent.somethingDropped();
+				filterConstructor.somethingChanged = true;
+			}
 			
 			this.wasDroppedOn()
 
@@ -260,7 +264,7 @@ MouseArea
 			}
 		}
 
-		return lastScriptScrap.returnEmptyRightMostDropSpot(true)
+		return lastScriptScrap.returnEmptyRightMostDropSpot()
 	}
 
 	//onParentChanged: { console.log(__debugName," onParentChanged parent == ", parent === null ? "null" : parent === undefined ? "undefined" : parent.__debugName, " alternativeDropFunction == ", alternativeDropFunction === null ? "null" : alternativeDropFunction === undefined ? "undefined" : alternativeDropFunction)	}

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -144,14 +144,23 @@ MouseArea
 	
 	function dropTargetIsOK(dropTarget)
 	{
-		var foundAtLeastOneMatchingKey = false;
-		
-		if(dropTarget !== null && dropTarget.objectName === "DropSpot")
-			for(var dragI=0; dragI<dragKeys.length; dragI++)
-				if(dropTarget.dropKeys.indexOf(dragKeys[dragI]) >= 0)
-					foundAtLeastOneMatchingKey = true
+		if(dropTarget === null)
+			return false;
 
-		return foundAtLeastOneMatchingKey
+		switch(dropTarget.objectName)
+		{
+			case "DropTrash":	
+				return true;
+				
+			case "DropSpot":	
+			{
+				for(var dragI=0; dragI<dragKeys.length; dragI++)
+					if(dropTarget.dropKeys.indexOf(dragKeys[dragI]) >= 0)
+						return true;
+			}
+		}
+		
+		return false;
 	}
 
 	function releaseHere(dropTarget)
@@ -179,7 +188,7 @@ MouseArea
 
 		//console.log("Second half of release here")
 
-		if(dropTarget != scriptColumn && dropTarget !== null && !dropTargetIsOK(dropTarget))
+		if(dropTarget != scriptColumn && !dropTargetIsOK(dropTarget))
 		{
 			this.releaseHere(scriptColumn)
 			return

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -225,7 +225,10 @@ MouseArea
 			parent.containsItem = this
 
 			shouldShowHoverOutline = false
-			this.removeAncestorsHoverOutlines()
+			
+			if(this.removeAncestorsHoverOutlines != undefined)
+				this.removeAncestorsHoverOutlines()
+			
 			if(parent != scriptColumn)
 				parent.somethingDropped();
 			

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -224,7 +224,6 @@ MouseArea
 
 			shouldShowHoverOutline = false
 			this.removeAncestorsHoverOutlines()
-
 		}
 
 		scriptColumn.focus = true

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -56,6 +56,8 @@ MouseArea
 
 	property bool shouldShowHoverOutline:	false
 	property bool showHighlight:			shownChild !== null ? !shownChild.acceptsDrops : false
+	
+	signal wasDroppedOn();
 
 	Rectangle
 	{
@@ -226,6 +228,8 @@ MouseArea
 			this.removeAncestorsHoverOutlines()
 			if(parent != scriptColumn)
 				parent.somethingDropped();
+			
+			this.wasDroppedOn()
 
 		}
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -224,7 +224,8 @@ MouseArea
 
 			shouldShowHoverOutline = false
 			this.removeAncestorsHoverOutlines()
-			parent.somethingDropped();
+			if(parent != scriptColumn)
+				parent.somethingDropped();
 
 		}
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -107,6 +107,7 @@ MouseArea
 		if(mouse.buttons === Qt.RightButton)
 		{
 			//delete me!
+			filterConstructor.somethingChanged = true
 			if(alternativeDropFunction === null)
 				this.destroy();
 		}
@@ -137,7 +138,18 @@ MouseArea
 		else
 			mouseArea.releaseHere(dragMe.Drag.target)
 	}
+	
+	function dropTargetIsOK(dropTarget)
+	{
+		var foundAtLeastOneMatchingKey = false;
+		
+		if(dropTarget !== null && dropTarget.objectName === "DropSpot")
+			for(var dragI=0; dragI<dragKeys.length; dragI++)
+				if(dropTarget.dropKeys.indexOf(dragKeys[dragI]) >= 0)
+					foundAtLeastOneMatchingKey = true
 
+		return foundAtLeastOneMatchingKey
+	}
 
 	function releaseHere(dropTarget)
 	{
@@ -152,34 +164,22 @@ MouseArea
 
 			var newDropTarget = this.determineReasonableInsertionSpot();
 
-			if(newDropTarget !== null)
-			{
-				//console.log("Found a new droptarget: " + newDropTarget.__debugName)
+			if(dropTargetIsOK(newDropTarget) && dropTarget != newDropTarget)
+			{			
 				this.releaseHere(newDropTarget)
 				return
 			}
 
-            if(leftDropSpot !== null && this.tryLeftApplication()) //maybe gobble something up instead of the other way 'round?
+            if(leftDropSpot !== null && this.tryLeftApplication(dropTarget)) //maybe gobble something up instead of the other way 'round?
                return
 		}
 
 		//console.log("Second half of release here")
 
-		if(dropTarget !== null && dropTarget.objectName === "DropSpot")
+		if(dropTarget != scriptColumn && dropTarget !== null && !dropTargetIsOK(dropTarget))
 		{
-			//console.log("it is in fact dropped on a dropspot!");
-
-			var foundAtLeastOneMatchingKey = false
-			for(var dragI=0; dragI<dragKeys.length; dragI++)
-				if(dropTarget.dropKeys.indexOf(dragKeys[dragI]) >= 0)
-					foundAtLeastOneMatchingKey = true
-
-			if(!foundAtLeastOneMatchingKey)
-			{
-				//console.log("Didnt find a matching key...")
-				this.releaseHere(scriptColumn)
-				return
-			}
+			this.releaseHere(scriptColumn)
+			return
 		}
 
 
@@ -263,13 +263,10 @@ MouseArea
 	function checkCompletenessFormulas()		{ wasChecked = true; return shownChild.checkCompletenessFormulas() }
 	function convertToJSON()					{ var obj = shownChild.convertToJSON(); obj.toolTipText = toolTipText; return obj }
 
-	function tryLeftApplication()
+	function tryLeftApplication(lastDropTarget)
 	{
-		//console.log(__debugName," tryLeftApplication")
-
-		this.releaseHere(scriptColumn)
-
-        if(leftDropSpot === null || leftDropSpot.containsItem !== null || scriptColumn.data.length === 1) return false
+        if(leftDropSpot === null || leftDropSpot.containsItem !== null || scriptColumn.data.length === 1) 
+			return false
 
 		for(var i=scriptColumn.data.length - 1; i>=0; i--)
 			if(scriptColumn.data[i] !== this)
@@ -277,17 +274,17 @@ MouseArea
 				var gobbleMeUp = scriptColumn.data[i]
 				var putResultHere = scriptColumn
 
-				while(gobbleMeUp !== null && putResultHere !== null && gobbleMeUp !== undefined)
+				while(gobbleMeUp !== null && putResultHere != null && gobbleMeUp !== undefined)
 				{
 
 					for(var keyI=0; keyI<gobbleMeUp.dragKeys.length; keyI++)
 						if(leftDropSpot.dropKeys.indexOf(gobbleMeUp.dragKeys[keyI])>=0)
 							for(var myDragKeyI=0; myDragKeyI<this.dragKeys.length; myDragKeyI++)
-								if(putResultHere === scriptColumn || putResultHere.dropKeys.indexOf(dragKeys[myDragKeyI]) >= 0) //Make sure we are allowed to drop ourselves there!
+								if(putResultHere == scriptColumn || putResultHere.dropKeys.indexOf(dragKeys[myDragKeyI]) >= 0) //Make sure we are allowed to drop ourselves there!
 								{
-									gobbleMeUp.releaseHere(scriptColumn)
+									//gobbleMeUp.releaseHere(scriptColumn)
 
-									if(putResultHere !== scriptColumn) //we went deeper
+									if(putResultHere != scriptColumn && putResultHere != null && lastDropTarget !== putResultHere) //we went deeper
 										this.releaseHere(putResultHere)
 
 									gobbleMeUp.releaseHere(leftDropSpot)
@@ -300,7 +297,8 @@ MouseArea
 					//Which means we have to place ourselves in the dropSpot under the current gobbleMeUp!
 
 					putResultHere	= gobbleMeUp.returnFilledRightMostDropSpot()
-					if(putResultHere === null) return
+					if(putResultHere == null) 
+						return
 					gobbleMeUp		= putResultHere.containsItem
 
 					//if(gobbleMeUp.objectName !== "DragGeneric")

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -224,6 +224,8 @@ MouseArea
 
 			shouldShowHoverOutline = false
 			this.removeAncestorsHoverOutlines()
+			parent.somethingDropped();
+
 		}
 
 		scriptColumn.focus = true

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DragGeneric.qml
@@ -224,6 +224,7 @@ MouseArea
 
 			shouldShowHoverOutline = false
 			this.removeAncestorsHoverOutlines()
+
 		}
 
 		scriptColumn.focus = true

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -30,6 +30,17 @@ DropArea {
 	property color	dragHoverColor: jaspTheme.blue
 	
 	signal somethingDropped();
+	signal jsonChanged();
+	
+	Connections
+	{
+		target:		containsItem
+		enabled:	containsItem != null
+		function onJsonChanged()
+		{
+			dragTarget.jsonChanged();	
+		}
+	}
 
 	Rectangle
 	{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -21,12 +21,14 @@ DropArea {
 	property bool	droppedShouldBeNested: false
 	property bool	shouldShowX: false
 	property bool	iWasChecked: false
+	property bool	ignoreEmpty: false
 
 	implicitWidth:	Math.max(dropText.contentWidth, acceptsDrops ? filterConstructor.blockDim * 5 : 0)
 	implicitHeight: filterConstructor.blockDim
 
 	property bool	beingDragHovered: false
 	property color	dragHoverColor: jaspTheme.blue
+	
 
 	Rectangle
 	{
@@ -193,8 +195,8 @@ DropArea {
 					createString(text)
 			}
 
-			function createNumber(value)	{ setCreatedObjectUp(numberComp.createObject(dragTarget, { "value": value,  "canBeDragged": true, "acceptsDrops": true } ) ) }
-			function createString(string)	{ setCreatedObjectUp(stringComp.createObject(dragTarget, { "text":  string, "canBeDragged": true, "acceptsDrops": true } ) ) }
+			function createNumber(value)	{ setCreatedObjectUp(numberComp.createObject(dragTarget, { "value": value } ) ) }
+			function createString(string)	{ setCreatedObjectUp(stringComp.createObject(dragTarget, { "text":  string } ) ) }
 
 
 			function setCreatedObjectUp(obj)
@@ -212,7 +214,7 @@ DropArea {
 		{
 			id: errorMarker
 			z: -2
-			visible: (dragTarget.iWasChecked && dragTarget.containsItem === null)
+			visible: (dragTarget.iWasChecked && (dragTarget.containsItem === null && !ignoreEmpty))
 			radius: width
 			anchors.fill: parent
 			color: "#BB0000"

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -29,6 +29,7 @@ DropArea {
 	property bool	beingDragHovered: false
 	property color	dragHoverColor: jaspTheme.blue
 	
+	signal somethingDropped();
 
 	Rectangle
 	{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -118,7 +118,10 @@ DropArea {
 		//console.log(__debugName," onContainsItemChanged to " + (containsItem !== null ? containsItem.__debugName : "null"))
 
 		if(containsItem === null)
-			width = Qt.binding(function(){ return dragTarget.implicitWidth })
+		{
+			width			= Qt.binding(function(){ return dragTarget.implicitWidth		})
+			dropText.text	= Qt.binding(function(){ return dragTarget.defaultText			})
+		}
 		iWasChecked = false
 
 	}
@@ -211,19 +214,21 @@ DropArea {
 			}
 		}
 
-		Rectangle
-		{
-			id: errorMarker
-			z: -2
-			visible: (dragTarget.iWasChecked && (dragTarget.containsItem === null && !ignoreEmpty))
-			radius: width
-			anchors.fill: parent
-			color: "#BB0000"
-		}
+		
 	}
 
 	Component { id: numberComp; NumberDrag {}}
 	Component { id: stringComp; StringDrag {}}
+	
+	Rectangle
+	{
+		id: errorMarker
+		z: -2
+		visible: (dragTarget.iWasChecked && (dragTarget.containsItem === null && !ignoreEmpty))
+		radius: width
+		anchors.fill: parent
+		color: "#BB0000"
+	}
 
 
 }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -87,7 +87,7 @@ DropArea {
 		}
 
 		var ancestry = parent
-		while(ancestry !== null)
+		while(ancestry != null)
 		{
 			if((ancestry.objectName === "DragGeneric" && ancestry.dragChild === drag.source) || ancestry === drag.source)
 			{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropSpot.qml
@@ -62,7 +62,7 @@ DropArea {
 				//console.log("problem! ",parent.objectName," doesnt contain a dragger in dropper")
 			return containsItem.checkCompletenessFormulas()
 		}
-		return false
+		return ignoreEmpty
 	}
 
 	onEntered: (drag)=>

--- a/Desktop/components/JASP/Widgets/FilterConstructor/DropTrash.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/DropTrash.qml
@@ -22,7 +22,7 @@ DropArea
 		anchors.centerIn:	parent
 		height:				sizer * parent.iconPadding
 		width:				(sizer / aspect) * parent.iconPadding
-		source:				somethingHovers ? jaspTheme.iconPath + "/trashcan_open.png" : jaspTheme.iconPath + "/trashcan.png"
+		source:				somethingHovers || trashCan.containsDrag ? jaspTheme.iconPath + "/trashcan_open.png" : jaspTheme.iconPath + "/trashcan.png"
 		sourceSize.width:	160 / aspect
 		sourceSize.height:	160
 		smooth:				true

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
@@ -105,15 +105,15 @@ ListView
 
 		onDoubleClicked: alternativeDropFunctionDef()
 
-		Component { id: operatorComp;		OperatorDrag			{ toolTipText: listToolTip; operator: listOperator;		acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
-		Component { id: operatorvertComp;	OperatorVerticalDrag	{ toolTipText: listToolTip; operator: listOperator;		acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
-		Component { id: functionComp;		FunctionDrag			{ toolTipText: listToolTip; functionName: listFunction;	acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
-		Component { id: rowFunctionComp;	RowFunctionDrag			{ toolTipText: listToolTip; functionName: listFunction;	acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
+		Component { id: operatorComp;		OperatorDrag			{ toolTipText: listToolTip; operator: listOperator;			acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
+		Component { id: operatorvertComp;	OperatorVerticalDrag	{ toolTipText: listToolTip; operator: listOperator;			acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
+		Component { id: functionComp;		FunctionDrag			{ toolTipText: listToolTip; functionName: listFunction;		acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
+		Component { id: rowFunctionComp;	RowFunctionDrag			{ toolTipText: listToolTip; functionName: listRFunction;	acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: numberComp;			NumberDrag				{ toolTipText: listToolTip; value: listNumber;									alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: stringComp;			StringDrag				{ toolTipText: listToolTip; text: listText;										alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: separatorComp;		Item					{ height: filterConstructor.blockDim; width: listWidth - listOfStuff.widthMargin; Rectangle { height: 1; color: jaspTheme.black; width: parent.width ; anchors.centerIn: parent }  } }
 		Component { id: defaultComp;		Text					{ text: "Something wrong!"; color: jaspTheme.red }  }
-		Component {	id: columnComp;			ColumnDrag				{ columnName: listColName;	columnTypeUser:	-1;			acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef; maxSize: listOfStuff.maxWidth } }
+		Component {	id: columnComp;			ColumnDrag				{ columnName: listColName;	columnTypeUser:	-1;				acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef; maxSize: listOfStuff.maxWidth } }
 	}
 
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
@@ -43,6 +43,11 @@ ListView
 					_parameterDropKeys[param] = _parameterDropKeys[param].split(":");
 
 			}
+			else if(type == "rowfunction")
+			{
+				_functionName			= functionName;
+				_friendlyFunctionName	= friendlyFunctionName != "" ? friendlyFunctionName : functionName;
+			}
 			else if(type == "number")		{ _value = number }
 			else if(type == "string")		{ _text = text }
 			else if(type == "column")		{ _columnName = columnName; }
@@ -50,6 +55,7 @@ ListView
 			if(type == "operator")			obj = operatorCompBetterContext.createObject(scriptColumn,		{ "toolTipText": toolTip,	"alternativeDropFunction": null, "operator": _operator,			"acceptsDrops": true})
 			else if(type == "operatorvert")	obj = operatorvertCompBetterContext.createObject(scriptColumn,	{ "toolTipText": toolTip,	"alternativeDropFunction": null, "operator": _operator,			"acceptsDrops": true})
 			else if(type == "function")		obj = functionCompBetterContext.createObject(scriptColumn,		{ "toolTipText": toolTip,	"alternativeDropFunction": null, "functionName": _functionName,	"acceptsDrops": true, "parameterNames": _parameterNames, "parameterDropKeys": _parameterDropKeys, "friendlyFunctionName": _friendlyFunctionName })
+			else if(type == "rowfunction")	obj = rowFunctionCompBetterContext.createObject(scriptColumn,	{ "toolTipText": toolTip,	"alternativeDropFunction": null, "functionName": _functionName,	"acceptsDrops": true, "friendlyFunctionName": _friendlyFunctionName })
 			else if(type == "number")		obj = numberCompBetterContext.createObject(scriptColumn,		{ "toolTipText": toolTip,	"alternativeDropFunction": null, "value": _value,				"acceptsDrops": true})
 			else if(type == "string")		obj = stringCompBetterContext.createObject(scriptColumn,		{ "toolTipText": toolTip,	"alternativeDropFunction": null, "text": _text,					"acceptsDrops": true})
 			else if(type == "column")		obj = columnCompBetterContext.createObject(scriptColumn,		{							"alternativeDropFunction": null, "columnName": _columnName,		"acceptsDrops": true,	"columnTypeUser": -1 })
@@ -63,12 +69,13 @@ ListView
 
 			property bool isColumn:				type === "column"
 			property bool isOperator:			type !== undefined && type.indexOf("operator") >=0
-			property string listOperator:		isOperator			?	operator			: "???"
-			property string listFunction:		type !== "function"	?	"???"				: friendlyFunctionName != "" ? friendlyFunctionName : functionName
-			property real	listNumber:			type === "number"	?	number				: -1
-			property string	listText:			type === "string"	?	text				: "???"
+			property string listOperator:		isOperator				?	operator			: "???"
+			property string listFunction:		type !== "function"		?	"???"				: friendlyFunctionName != "" ? friendlyFunctionName : functionName
+			property string listRFunction:		type !== "rowfunction"	?	"???"				: friendlyFunctionName != "" ? friendlyFunctionName : functionName
+			property real	listNumber:			type === "number"		?	number				: -1
+			property string	listText:			type === "string"		?	text				: "???"
 			property real	listWidth:			parent.width
-			property string	listColName:		isColumn			?	columnName			: "???"
+			property string	listColName:		isColumn				?	columnName			: "???"
 			property string listToolTip:		type !== "separator" && type !== "text" && toolTip !== undefined? toolTip : ""
 
 			//anchors.centerIn: parent
@@ -82,15 +89,17 @@ ListView
 										 operatorvertComp :
 										 type === "function" ?
 											 functionComp :
-											 type === "number" ?
-												 numberComp :
-												 type === "string" ?
-													 stringComp :
-													 type === "column" ?
-														 columnComp :
-														 type === "separator" ?
-															 separatorComp :
-															 defaultComp
+											 type === "rowfunction" ?
+												 rowFunctionComp :
+												 type === "number" ?
+													 numberComp :
+													 type === "string" ?
+														 stringComp :
+														 type === "column" ?
+															 columnComp :
+															 type === "separator" ?
+																 separatorComp :
+																 defaultComp
 
 		}
 
@@ -99,6 +108,7 @@ ListView
 		Component { id: operatorComp;		OperatorDrag			{ toolTipText: listToolTip; operator: listOperator;		acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: operatorvertComp;	OperatorVerticalDrag	{ toolTipText: listToolTip; operator: listOperator;		acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: functionComp;		FunctionDrag			{ toolTipText: listToolTip; functionName: listFunction;	acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
+		Component { id: rowFunctionComp;	RowFunctionDrag			{ toolTipText: listToolTip; functionName: listFunction;	acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: numberComp;			NumberDrag				{ toolTipText: listToolTip; value: listNumber;									alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: stringComp;			StringDrag				{ toolTipText: listToolTip; text: listText;										alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: separatorComp;		Item					{ height: filterConstructor.blockDim; width: listWidth - listOfStuff.widthMargin; Rectangle { height: 1; color: jaspTheme.black; width: parent.width ; anchors.centerIn: parent }  } }
@@ -110,6 +120,7 @@ ListView
 	Component { id: operatorCompBetterContext;		OperatorDrag			{ } }
 	Component { id: operatorvertCompBetterContext;	OperatorVerticalDrag	{ } }
 	Component { id: functionCompBetterContext;		FunctionDrag			{ } }
+	Component { id: rowFunctionCompBetterContext;	RowFunctionDrag			{ } }
 	Component { id: numberCompBetterContext;		NumberDrag				{ } }
 	Component { id: stringCompBetterContext;		StringDrag				{ } }
 	Component { id: separatorCompBetterContext;		Item					{ } }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
@@ -192,7 +192,6 @@ Item
 			Rectangle
 			{
 				id:				rectangularColumnContainer
-				z:				parent.z + 1
 				border.width:	1
 				border.color:	jaspTheme.uiBorder
 				color:			"transparent"

--- a/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/FilterConstructor.qml
@@ -264,6 +264,7 @@ Item
 					anchors.right: parent.right
 
 					height: Math.min(60 * preferencesModel.uiScale, scrollScriptColumn.height)
+					z:		1000
 				}
 
 			}

--- a/Desktop/components/JASP/Widgets/FilterConstructor/Function.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/Function.qml
@@ -221,7 +221,7 @@ Item
 
 				return heightOut
 			}
-
+			
 			///This also goes down the tree
 			property var rightMostEmptyDropSpot: function()
 			{
@@ -229,21 +229,21 @@ Item
 
 				for(var i=funcRoot.parameterNames.length-1; i>=0; i--)
 				{
-					var prevDropSpot = dropSpot
 					dropSpot = dropRepeat.itemAt(i).getDropSpot()
 
 					if(dropSpot.containsItem !== null)
 					{
 						var subResult = dropSpot.containsItem.returnEmptyRightMostDropSpot()
-						if(subResult === null) // cant put anything there but maybe we can return the previous (and thus empty dropspot?)
-							return prevDropSpot //its ok if it is null. we just cant find anything here
-						else
+						if(subResult !== null) // cant put anything there but maybe we can return the previous (and thus empty dropspot?)
 							return subResult
 					}
-					//else dropSpot now contains a DropSpot with space, but lets loop back to the beginning to see if we can go further left
+					else 
+						return dropSpot;
 				}
-				return dropSpot
+				
+				return null
 			}
+			
 
 			//this does not go down the tree
 			property var leftMostFilledDropSpot: function()

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -7,11 +7,12 @@ Item
 					objectName:			"Column"
 	property string __debugName:		"JASPColumn " + columnName
 	property string columnName:			"?"
-	property string columnIcon:			columnsModel.getColumnIcon(columnTypeUser == -1 ? columnType : columnTypeUser, columnTypeUser != -1 && columnTypeUser != columnType)
+	property string columnIcon:			columnsModel.getColumnIcon(columnTypeHere, columnTypeHere != columnType)
 	property int	columnType:			columnsModel.getColumnType(columnName)
 	property int	columnTypeUser:		-1
-	property int	columnTypeHere:		columnTypeUser != -1 ? columnTypeUser : columnType
-	property string preview:			(columnType == columnTypeUser || columnTypeUser == -1 ? "" : columnsModel.getColumnTransformedToolTip(columnName, columnTypeUser))
+	property int	columnTypeDrop:		-1	//If set to anything, it is what is allowed by whatever dropspot this column is in
+	property int	columnTypeHere:		columnTypeDrop != -1 ? columnTypeDrop : columnTypeUser != -1 ? columnTypeUser : columnType
+	property string preview:			(columnType == columnTypeHere ? "" : columnsModel.getColumnTransformedToolTip(columnName, columnTypeUser))
 	property string toolTip:			formatToolTip(changeTypeAllowed, colName.contentWidth > colName.width, columnsModel.getColumnDescription(columnName), preview)
 	property real	maxSize:			baseFontSize * 10 * preferencesModel.uiScale
 					height:				filterConstructor.blockDim
@@ -20,10 +21,52 @@ Item
 	property bool	isNumerical:		columnTypeHere == columnTypeScale
 	property bool	isOrdinal:			columnTypeHere == columnTypeOrdinal
 	property bool	changeTypeAllowed:	true
-	property var	dragKeys:			isNumerical ? ["number"]	: isOrdinal ? ["string", "ordered"] : ["string"]
+	property var	dragKeys:			columnTypeDrop == -1 ? ["number", "string", "ordered"] : isNumerical ? ["number"]	: isOrdinal ? ["string", "ordered"] : ["string"]
 	property string typeString:			isNumerical ? "scale"		: isOrdinal ? "ordinal"				: "nominal"
-					
-					
+	
+	Connections
+	{
+		id:			dropHandler
+		target:		parent
+		enabled:	parent.objectName == "DragGeneric" && parent.parent != undefined && parent.parent.objectName == "DropSpot"
+		function onWasDroppedOn() {
+			columnTypeDrop = -1;
+			
+
+			if(columnTypeUser != -1 && dropAccepts(columnTypeToRelevantString(columnTypeUser)))
+			{
+				columnTypeDrop = columnTypeUser;
+				return;
+			}
+			
+			if(dropAccepts(columnTypeToRelevantString(columnType)))
+			{
+				columnTypeDrop = columnType;
+				return;
+			}
+						
+			var listTypes =  [ columnTypeScale, columnTypeOrdinal, columnTypeNominal ]
+			for(var i=0; i<listTypes.length; i++)
+				if(dropAccepts(columnTypeToRelevantString(listTypes[i])))
+				{
+					columnTypeDrop = listTypes[i];
+					return;
+				}
+		}
+		
+		function dropAccepts(dragKeyToCheck)
+		{
+			var dropSpot = parent.parent;
+			
+			return dropSpot != undefined && dropSpot.objectName == "DropSpot" && dropSpot.dropKeys.indexOf(dragKeyToCheck) >= 0	
+		}
+		
+		function columnTypeToRelevantString(columnType)
+		{
+			// maybe ordinal needs more ?
+			return columnType == columnTypeOrdinal ? "ordered" : columnType != columnTypeScale ? "string" : "number"
+		}
+	}
 	//colName can elide
 	function formatToolTip(typeChangeAble, colNameTrunc, descriptionV, previewV)
 	{
@@ -48,19 +91,22 @@ Item
 					
 	Connections
 	{
-		target:								columnsModel
+		target:		columnsModel
 		function onColumnTypeChanged(name)	
 		{ 
 			if(columnName == name)
 			{
-				columnType = columnsModel.getColumnType(columnName); 
+				columnType = columnsModel.getColumnType(columnName);
 				filterConstructor.somethingChanged = true;
+				
+				if(dropHandler.enabled)
+					dropHandler.onWasDroppedOn()
 			}
 		}
 	}
 	
 	onColumnTypeUserChanged:		filterConstructor.somethingChanged = true;
-	
+	onColumnTypeDropChanged:		filterConstructor.somethingChanged = true;
 	
 
 	Image
@@ -148,7 +194,7 @@ Item
 	function checkCompletenessFormulas()		{ return true }
 	function convertToJSON()
 	{
-		var jsonObj = { "nodeType": "Column", "columnName": columnName, "columnTypeUser": columnTypeUser }
+		var jsonObj = { "nodeType": "Column", "columnName": columnName, "columnTypeUser": columnTypeUser, "columnTypeDrop": columnTypeDrop }
 		return jsonObj
 	}
 }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -25,14 +25,19 @@ Item
 	property string typeString:			isNumerical ? "scale"		: isOrdinal ? "ordinal"				: "nominal"
 					
 	onColumnTypeHereChanged: {
-		filterConstructor.somethingChanged = true	
+		filterConstructor.somethingChanged = true
 	}
+	
+	onColumnTypeUserChanged:		if(dropHandler.enabled) dropHandler.onWasDroppedOn(); else columnTypeDrop = -1;
+	onColumnTypeDropChanged:		filterConstructor.somethingChanged = true;
 	
 	Connections
 	{
 		id:			dropHandler
 		target:		parent
 		enabled:	parent.objectName == "DragGeneric" && parent.parent != undefined && parent.parent.objectName == "DropSpot"
+		
+		function onEnabledChanged() {	if(!enabled) columnTypeDrop = 1; }
 		
 		function	onWasDroppedOn() 
 		{
@@ -42,14 +47,12 @@ Item
 			if(columnTypeUser != -1 && dropAccepts(columnTypeToRelevantString(columnTypeUser)))
 			{
 				columnTypeDrop = columnTypeUser;
-				filterConstructor.somethingChanged = true
 				return;
 			}
 			
 			if(dropAccepts(columnTypeToRelevantString(columnType)))
 			{
 				columnTypeDrop = columnType;
-				filterConstructor.somethingChanged = true
 				return;
 			}
 						
@@ -58,7 +61,6 @@ Item
 				if(dropAccepts(columnTypeToRelevantString(listTypes[i])))
 				{
 					columnTypeDrop = listTypes[i];
-					filterConstructor.somethingChanged = true
 					return;
 				}
 		}
@@ -113,10 +115,7 @@ Item
 			}
 		}
 	}
-	
-	onColumnTypeUserChanged:		filterConstructor.somethingChanged = true;
-	onColumnTypeDropChanged:		filterConstructor.somethingChanged = true;
-	
+
 
 	Image
 	{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -23,25 +23,33 @@ Item
 	property bool	changeTypeAllowed:	true
 	property var	dragKeys:			columnTypeDrop == -1 ? ["number", "string", "ordered"] : isNumerical ? ["number"]	: isOrdinal ? ["string", "ordered"] : ["string"]
 	property string typeString:			isNumerical ? "scale"		: isOrdinal ? "ordinal"				: "nominal"
+					
+	onColumnTypeHereChanged: {
+		filterConstructor.somethingChanged = true	
+	}
 	
 	Connections
 	{
 		id:			dropHandler
 		target:		parent
 		enabled:	parent.objectName == "DragGeneric" && parent.parent != undefined && parent.parent.objectName == "DropSpot"
-		function onWasDroppedOn() {
+		
+		function	onWasDroppedOn() 
+		{
 			columnTypeDrop = -1;
 			
 
 			if(columnTypeUser != -1 && dropAccepts(columnTypeToRelevantString(columnTypeUser)))
 			{
 				columnTypeDrop = columnTypeUser;
+				filterConstructor.somethingChanged = true
 				return;
 			}
 			
 			if(dropAccepts(columnTypeToRelevantString(columnType)))
 			{
 				columnTypeDrop = columnType;
+				filterConstructor.somethingChanged = true
 				return;
 			}
 						
@@ -50,6 +58,7 @@ Item
 				if(dropAccepts(columnTypeToRelevantString(listTypes[i])))
 				{
 					columnTypeDrop = listTypes[i];
+					filterConstructor.somethingChanged = true
 					return;
 				}
 		}
@@ -190,7 +199,7 @@ Item
 	function shouldDrag(mouseX, mouseY)			{ return true }
 	function returnEmptyRightMostDropSpot()		{ return null }
 	function returnFilledRightMostDropSpot()	{ return null }
-	function returnR()							{ return columnTypeUser == -1 ? columnName : columnName + "." + typeString }
+	function returnR()							{ return columnName + "." + typeString }
 	function checkCompletenessFormulas()		{ return true }
 	function convertToJSON()
 	{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
@@ -46,12 +46,8 @@ Item
 		}
 		else if(jsonObj.nodeType === "RowFunction")
 		{
-		
-			var rfuncObj = createRowFunction(jsonObj.functionName, jsonObj.droppedItems,  atoolTip)
+			var rfuncObj = createRowFunction(jsonObj.functionName, jsonObj.droppedItems,  toolTip)
 			rfuncObj.releaseHere(dropItHere)
-
-			for(var i=0; i<jsonObj.arguments.length; i++)
-				convertJSONtoItem(jsonObj.arguments[i].argument, rfuncObj.getParameterDropSpot(jsonObj.arguments[i].name))
 		}
 		else if(jsonObj.nodeType === "Number")
 				createNumber(jsonObj.value, toolTip).releaseHere(dropItHere)
@@ -65,7 +61,8 @@ Item
 	function createOperatorVertical(operator, toolTip)			{ return operatorvertComp.createObject(scriptColumn,	{ "toolTipText": toolTip, "operator": operator } ) }
 	function createFunction(functionName, parameterNames,
 							parameterDropKeys, toolTip)			{ return functionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"parameterNames": parameterNames, "parameterDropKeys": parameterDropKeys } ) }
-	function createRowFunction(functionName,parameters,toolTip)	{ return rowFunctionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"droppedItems": parameters } ) }
+	function createRowFunction(functionName,
+							   droppedItems,toolTip)			{ return rowFunctionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"droppedItems": droppedItems } ) }
 	function createNumber(number, toolTip)						{ return numberComp.createObject(scriptColumn,			{ "toolTipText": toolTip, "value": number } ) }
 	function createString(text, toolTip)						{ return stringComp.createObject(scriptColumn,			{ "toolTipText": toolTip, "text": text } ) }
 	function createColumn(columnName, columnTypeUser, toolTip)	{ return columnComp.createObject(scriptColumn,			{ "columnName": columnName,	"columnTypeUser": columnTypeUser } ) }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
@@ -44,6 +44,15 @@ Item
 			for(var i=0; i<jsonObj.arguments.length; i++)
 				convertJSONtoItem(jsonObj.arguments[i].argument, funcObj.getParameterDropSpot(jsonObj.arguments[i].name))
 		}
+		else if(jsonObj.nodeType === "RowFunction")
+		{
+		
+			var funcObj = createRowFunction(jsonObj.functionName, atoolTip)
+			funcObj.releaseHere(dropItHere)
+
+			for(var i=0; i<jsonObj.arguments.length; i++)
+				convertJSONtoItem(jsonObj.arguments[i].argument, funcObj.getParameterDropSpot(jsonObj.arguments[i].name))
+		}
 		else if(jsonObj.nodeType === "Number")
 				createNumber(jsonObj.value, toolTip).releaseHere(dropItHere)
 		else if(jsonObj.nodeType === "String")
@@ -56,6 +65,7 @@ Item
 	function createOperatorVertical(operator, toolTip)			{ return operatorvertComp.createObject(scriptColumn,	{ "toolTipText": toolTip, "operator": operator } ) }
 	function createFunction(functionName, parameterNames,
 							parameterDropKeys, toolTip)			{ return functionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"parameterNames": parameterNames, "parameterDropKeys": parameterDropKeys } ) }
+	function createRowFunction(functionName,parameters,toolTip)	{ return rowFunctionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"droppedItems": parameters } ) }
 	function createNumber(number, toolTip)						{ return numberComp.createObject(scriptColumn,			{ "toolTipText": toolTip, "value": number } ) }
 	function createString(text, toolTip)						{ return stringComp.createObject(scriptColumn,			{ "toolTipText": toolTip, "text": text } ) }
 	function createColumn(columnName, columnTypeUser, toolTip)	{ return columnComp.createObject(scriptColumn,			{ "columnName": columnName,	"columnTypeUser": columnTypeUser } ) }
@@ -64,6 +74,7 @@ Item
 	Component { id: operatorComp;		OperatorDrag			{ } }
 	Component { id: operatorvertComp;	OperatorVerticalDrag	{ } }
 	Component { id: functionComp;		FunctionDrag			{ } }
+	Component { id: rowFunctionComp;	RowFunctionDrag			{ } }
 	Component { id: numberComp;			NumberDrag				{ } }
 	Component { id: stringComp;			StringDrag				{ } }
 	Component {	id: columnComp;			ColumnDrag				{ } }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
@@ -47,11 +47,11 @@ Item
 		else if(jsonObj.nodeType === "RowFunction")
 		{
 		
-			var funcObj = createRowFunction(jsonObj.functionName, atoolTip)
-			funcObj.releaseHere(dropItHere)
+			var rfuncObj = createRowFunction(jsonObj.functionName, jsonObj.droppedItems,  atoolTip)
+			rfuncObj.releaseHere(dropItHere)
 
 			for(var i=0; i<jsonObj.arguments.length; i++)
-				convertJSONtoItem(jsonObj.arguments[i].argument, funcObj.getParameterDropSpot(jsonObj.arguments[i].name))
+				convertJSONtoItem(jsonObj.arguments[i].argument, rfuncObj.getParameterDropSpot(jsonObj.arguments[i].name))
 		}
 		else if(jsonObj.nodeType === "Number")
 				createNumber(jsonObj.value, toolTip).releaseHere(dropItHere)

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
@@ -46,8 +46,9 @@ Item
 		}
 		else if(jsonObj.nodeType === "RowFunction")
 		{
-			var rfuncObj = createRowFunction(jsonObj.functionName, jsonObj.droppedItems,  toolTip)
+			var rfuncObj = createRowFunction(jsonObj.functionName, ["null"],  toolTip)
 			rfuncObj.releaseHere(dropItHere)
+			rfuncObj.droppedItems = jsonObj.droppedItems
 		}
 		else if(jsonObj.nodeType === "Number")
 				createNumber(jsonObj.value, toolTip).releaseHere(dropItHere)

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
@@ -46,9 +46,10 @@ Item
 		}
 		else if(jsonObj.nodeType === "RowFunction")
 		{
-			var rfuncObj = createRowFunction(jsonObj.functionName, ["null"],  toolTip)
-			rfuncObj.releaseHere(dropItHere)
+			var rfuncObj = createRowFunction(jsonObj.functionName,  toolTip)
 			rfuncObj.droppedItems = jsonObj.droppedItems
+			
+			rfuncObj.releaseHere(dropItHere)
 		}
 		else if(jsonObj.nodeType === "Number")
 				createNumber(jsonObj.value, toolTip).releaseHere(dropItHere)
@@ -62,8 +63,7 @@ Item
 	function createOperatorVertical(operator, toolTip)			{ return operatorvertComp.createObject(scriptColumn,	{ "toolTipText": toolTip, "operator": operator } ) }
 	function createFunction(functionName, parameterNames,
 							parameterDropKeys, toolTip)			{ return functionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"parameterNames": parameterNames, "parameterDropKeys": parameterDropKeys } ) }
-	function createRowFunction(functionName,
-							   droppedItems,toolTip)			{ return rowFunctionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"droppedItems": droppedItems } ) }
+	function createRowFunction(functionName,toolTip)			{ return rowFunctionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"droppedItems": ["null"] } ) }
 	function createNumber(number, toolTip)						{ return numberComp.createObject(scriptColumn,			{ "toolTipText": toolTip, "value": number } ) }
 	function createString(text, toolTip)						{ return stringComp.createObject(scriptColumn,			{ "toolTipText": toolTip, "text": text } ) }
 	function createColumn(columnName, columnTypeUser,

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JSONtoFormulas.qml
@@ -55,7 +55,7 @@ Item
 		else if(jsonObj.nodeType === "String")
 				createString(jsonObj.text, toolTip).releaseHere(dropItHere)
 		else if(jsonObj.nodeType === "Column")
-				createColumn(jsonObj.columnName, jsonObj.columnTypeUser, toolTip).releaseHere(dropItHere)
+				createColumn(jsonObj.columnName, jsonObj.columnTypeUser, jsonObj.columnTypeDrop != undefined ? jsonObj.columnTypeDrop : -1, toolTip).releaseHere(dropItHere)
 	}
 
 	function createOperator(operator, toolTip)					{ return operatorComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "operator": operator } ) }
@@ -66,7 +66,8 @@ Item
 							   droppedItems,toolTip)			{ return rowFunctionComp.createObject(scriptColumn,		{ "toolTipText": toolTip, "functionName": functionName,	"droppedItems": droppedItems } ) }
 	function createNumber(number, toolTip)						{ return numberComp.createObject(scriptColumn,			{ "toolTipText": toolTip, "value": number } ) }
 	function createString(text, toolTip)						{ return stringComp.createObject(scriptColumn,			{ "toolTipText": toolTip, "text": text } ) }
-	function createColumn(columnName, columnTypeUser, toolTip)	{ return columnComp.createObject(scriptColumn,			{ "columnName": columnName,	"columnTypeUser": columnTypeUser } ) }
+	function createColumn(columnName, columnTypeUser,
+						  columnTypeDrop, toolTip)				{ return columnComp.createObject(scriptColumn,			{ "columnName": columnName,	"columnTypeUser": columnTypeUser, "columnTypeDrop": columnTypeDrop } ) }
 
 
 	Component { id: operatorComp;		OperatorDrag			{ } }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/NumberDrag.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/NumberDrag.qml
@@ -7,6 +7,7 @@ DragGeneric {
 	shownChild: showMe
 	property string __debugName: "NumberDrag"
 
+	
 	Number
 	{
 		id: showMe

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -67,9 +67,14 @@ Item
 	{
 		var compounded = functionName + "NaRm("
 
+		var filledEntries = []
+		
 		for(var i=0; i<parameterCount; i++)
-				if(dropRepeat.itemAt(i) !== null && dropRepeat.dropped[i] != "null"  && dropRepeat.dropped[i] != "") 
-					compounded += (i > 0 ? ", " : "") + (dropRepeat.itemAt(i).returnR())
+				if(dropRepeat.itemAt(i) !== null && dropRepeat.dropped[i] != "null"  && dropRepeat.dropped[i] != "")
+					filledEntries.push(dropRepeat.itemAt(i).returnR())
+		
+		for(var i=0; i<filledEntries.length; i++)
+			compounded += (i > 0 ? ", " : "") + filledEntries[i]
 
 		compounded += ")"
 
@@ -195,11 +200,15 @@ Item
 			property var rightMostEmptyDropSpot: function()
 			{
 				var dropSpot = null
+				var prevDropSpot = dropSpot
+				var firstSpot = null
 
 				for(var i=parameterCount-1; i>=0; i--)
 				{
-					var prevDropSpot = dropSpot
+					prevDropSpot = dropSpot
 					dropSpot = dropRepeat.itemAt(i).getDropSpot()
+					if(firstSpot == null)
+						firstSpot = dropSpot
 
 					if(dropSpot.containsItem !== null)
 					{
@@ -211,14 +220,14 @@ Item
 					}
 					//else dropSpot now contains a DropSpot with space, but lets loop back to the beginning to see if we can go further left
 				}
-				return dropSpot
+				return firstSpot
 			}
 
 			//this does not go down the tree
 			property var leftMostFilledDropSpot: function()
 			{
 				var dropSpot = null
-
+				
 				for(var i=0; i<parameterCount; i++)
 				{
 					var prevDropSpot = dropSpot

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -273,7 +273,7 @@ Item
 			onItemAdded:
 			{
 				//rebindSize()
-				messages.log("dropRepeat.dropped is: ")
+				//messages.log("dropRepeat.dropped is: ")
 				for(var i=0; i<parameterCount; i++)
 				{
 					messages.log(dropRepeat.dropped[i])
@@ -282,7 +282,7 @@ Item
 						var dropSpot = dropRepeat.itemAt(i).getDropSpot()
 						if(dropSpot.containsItem == null && dropRepeat.dropped[i] != "" && dropRepeat.dropped[i] != "null")
 						{
-							messages.log("Converting onItemAdded stored json to item: " + dropRepeat.dropped[i] + " to fill " + dropSpot.containsItem)
+							//messages.log("Converting onItemAdded stored json to item: " + dropRepeat.dropped[i] + " to fill " + dropSpot.containsItem)
 							var jsonObjHere = JSON.parse(dropRepeat.dropped[i])
 							jsonConverter.convertJSONtoItem(jsonObjHere, dropSpot) 	
 						}
@@ -324,7 +324,7 @@ Item
 	
 					if(spot.containsItem == null && dropRepeat.dropped[index] != "" && dropRepeat.dropped[index] != "null")
 					{
-						messages.log("Converting onCompleted stored json to item: " + dropRepeat.dropped[index] + " to fill " + spot.containsItem)
+						//messages.log("Converting onCompleted stored json to item: " + dropRepeat.dropped[index] + " to fill " + spot.containsItem)
 						var jsonObjHere = JSON.parse(dropRepeat.dropped[index])
 						jsonConverter.convertJSONtoItem(jsonObjHere, spot) 	
 					}
@@ -352,29 +352,28 @@ Item
 					{
 						if(spot.containsItem != null)
 						{
-							print("containsItem="+(spot.containsItem))
 							//First make the list of what is there now:
 							var itsFull = true;
 							
 							var jsonStr = JSON.stringify(spot.containsItem.convertToJSON())
 							
-							messages.log("Converted dropped thing to '" + jsonStr + "' and it was: " + dropRepeat.dropped[index] + " at index " + index)
+							//messages.log("Converted dropped thing to '" + jsonStr + "' and it was: " + dropRepeat.dropped[index] + " at index " + index)
 							
 							if(dropRepeat.dropped[index] == jsonStr)
 							{
-								messages.log("Already there ")
+								//messages.log("Already there ")
 							}
 							else
 							{
-								messages.log("Before insert dropped is: ")
+								/*messages.log("Before insert dropped is: ")
 								for(var i=0; i<parameterCount; i++)
-									messages.log(dropRepeat.dropped[i])
+									messages.log(dropRepeat.dropped[i])*/
 								
 								dropRepeat.dropped[index] = jsonStr
 								
-								messages.log("After insert dropped is: ")
+								/*messages.log("After insert dropped is: ")
 								for(var i=0; i<parameterCount; i++)
-									messages.log(dropRepeat.dropped[i])
+									messages.log(dropRepeat.dropped[i])*/
 							}
 	
 							for(var i=0; i<parameterCount; i++)

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -14,7 +14,13 @@ Item
 
 	property int parameterCount: droppedItems.length
 	property list<string> droppedItems: ["null"]
+	
+	onDroppedItemsChanged: {
+		filterConstructor.somethingChanged = true
+		funcRoot.jsonChanged()
+	}
 
+	signal jsonChanged();
 
 	property variant functionNameToBaseFunc: {
 	"rowMean":				"mean",
@@ -200,27 +206,23 @@ Item
 			property var rightMostEmptyDropSpot: function()
 			{
 				var dropSpot = null
-				var prevDropSpot = dropSpot
-				var firstSpot = null
 
 				for(var i=parameterCount-1; i>=0; i--)
 				{
-					prevDropSpot = dropSpot
 					dropSpot = dropRepeat.itemAt(i).getDropSpot()
-					if(firstSpot == null)
-						firstSpot = dropSpot
+
 
 					if(dropSpot.containsItem !== null)
 					{
 						var subResult = dropSpot.containsItem.returnEmptyRightMostDropSpot()
-						if(subResult === null) // cant put anything there but maybe we can return the previous (and thus empty dropspot?)
-							return prevDropSpot //its ok if it is null. we just cant find anything here
-						else
+						if(subResult !== null) // cant put anything there but maybe we can return the previous (and thus empty dropspot?)
 							return subResult
 					}
-					//else dropSpot now contains a DropSpot with space, but lets loop back to the beginning to see if we can go further left
+					else 
+						return dropSpot;
 				}
-				return firstSpot
+				
+				return null
 			}
 
 			//this does not go down the tree
@@ -251,7 +253,7 @@ Item
 
 			function convertToJSON()
 			{
-				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "droppedItems": funcRoot.droppedItems }
+				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "droppedItems": funcRoot.droppedItems.length > 0 ?  funcRoot.droppedItems : ["null"] }
 				return jsonObj
 			}
 
@@ -328,8 +330,7 @@ Item
 					}
 				}
 				
-
-
+				
 				DropSpot 
 				{
 					id:					spot
@@ -343,8 +344,9 @@ Item
 					shouldShowX:		false
 					ignoreEmpty:		true
 					
-					onSomethingDropped:		handleContainsItemChange()
-					onContainsItemChanged:	handleContainsItemChange()
+					onSomethingDropped:		spot.handleContainsItemChange()
+					onContainsItemChanged:	if(!containsItem) spot.handleContainsItemChange()
+					onJsonChanged:			spot.handleContainsItemChange()
 						
 					function handleContainsItemChange()
 					{
@@ -356,7 +358,7 @@ Item
 							
 							var jsonStr = JSON.stringify(spot.containsItem.convertToJSON())
 							
-							messages.log("Converted dropped thing to: " + dropRepeat.dropped[index] + " inserting at index " + index)
+							messages.log("Converted dropped thing to '" + jsonStr + "' and it was: " + dropRepeat.dropped[index] + " at index " + index)
 							
 							if(dropRepeat.dropped[index] == jsonStr)
 							{
@@ -369,6 +371,10 @@ Item
 									messages.log(dropRepeat.dropped[i])
 								
 								dropRepeat.dropped[index] = jsonStr
+								
+								messages.log("After insert dropped is: ")
+								for(var i=0; i<parameterCount; i++)
+									messages.log(dropRepeat.dropped[i])
 							}
 	
 							for(var i=0; i<parameterCount; i++)
@@ -377,11 +383,13 @@ Item
 
 							if(itsFull) //Then apparently this one just got filled?
 							{
-								dropRepeat.dropped.push("null")
+								dropRepeat.dropped.push("null")								
 							}
 						}
 						else
+						{
 							dropRepeat.dropped[index] = "null"
+						}
 					}
 				}
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -106,31 +106,27 @@ Item
 		}
 	}
 
-	Item
+	Row
 	{
 		id: functionDef
 		anchors.top: funcRoot.isRoot ? parent.top : meanBar.bottom
 		anchors.bottom: parent.bottom
 
 		x: extraMeanWidth / 2
-		width: functionText.visible ? functionText.width : functionImg.width
 
 		Text
 		{
 			id:						functionText
 
-			anchors.top:			parent.top
-			anchors.bottom:			parent.bottom
+
 			color:					jaspTheme.textEnabled
 
 			verticalAlignment:		Text.AlignVCenter
 			horizontalAlignment:	Text.AlignHCenter
 
-			text:					funcRoot.drawMeanSpecial ? "" : friendlyFunctionName
+			text:					functionImg.visible ? "row" : funcRoot.drawMeanSpecial ? "" : friendlyFunctionName
 			font.pixelSize:			filterConstructor.fontPixelSize
 			font.family:			jaspTheme.font.family
-
-			visible:				!functionImg.visible
 		}
 
 
@@ -138,7 +134,7 @@ Item
 		{
 			id:						functionImg
 
-			visible:				(!funcRoot.acceptsDrops) && functionImageSource !== ""
+			visible:				functionImageSource !== ""
 
 			source:					functionImageSource
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -69,7 +69,7 @@ Item
 		var compounded = functionName + "("
 
 		for(var i=0; i<parameterCount; i++)
-				compounded += (i > 0 ? ", " : "") + (dropRepeat.itemAt(i) === null ? "null" : dropRepeat.itemAt(i).returnR())
+				compounded += (i > 0 ? ", " : "") + (dropRepeat.itemAtIndex(i) === null ? "null" : dropRepeat.itemAtIndex(i).returnR())
 
 		compounded += ")"
 
@@ -180,24 +180,30 @@ Item
 
 		x: haakjesLinks.width + haakjesLinks.x
 
-		width:	0
-		height: 0
+		width:	dropRepeat.implicitWidth
+		height: dropRepeat.implicitHeight
 
 		property real implicitWidthDrops: parent.acceptsDrops ? funcRoot.initialWidth / 4 : 0
 
 
 
-		Repeater
+		ListView
 		{
-			id:		dropRepeat
-			model:	parameterCount
+			id:				dropRepeat
+			model:			funcRoot.parameterCount
+			reuseItems:		false
+			cacheBuffer:	400
 			//anchors.fill: parent
+			
+			width:			contentWidth
+			height:			contentHeight
+			orientation:	Qt.Horizontal
 
 			property var rowWidthCalc: function()
 			{
 				var widthOut = 0
 				for(var i=0; i<parameterCount; i++)
-					widthOut += dropRepeat.itemAt(i).width
+					widthOut += dropRepeat.itemAtIndex(i).width
 				return widthOut
 			}
 
@@ -205,7 +211,7 @@ Item
 			{
 				var heightOut = filterConstructor.blockDim
 				for(var i=0; i<parameterCount; i++)
-					heightOut = Math.max(dropRepeat.itemAt(i).height, heightOut)
+					heightOut = Math.max(dropRepeat.itemAtIndex(i).height, heightOut)
 
 				return heightOut
 			}
@@ -218,7 +224,7 @@ Item
 				for(var i=parameterCount-1; i>=0; i--)
 				{
 					var prevDropSpot = dropSpot
-					dropSpot = dropRepeat.itemAt(i).getDropSpot()
+					dropSpot = dropRepeat.itemAtIndex(i).getDropSpot()
 
 					if(dropSpot.containsItem !== null)
 					{
@@ -241,7 +247,7 @@ Item
 				for(var i=0; i<parameterCount; i++)
 				{
 					var prevDropSpot = dropSpot
-					dropSpot = dropRepeat.itemAt(i).getDropSpot()
+					dropSpot = dropRepeat.itemAtIndex(i).getDropSpot()
 
 					if(dropSpot.containsItem === null)
 						return prevDropSpot //its ok if it is null. we just cant find anything here
@@ -251,12 +257,12 @@ Item
 
 			function checkCompletenessFormulas()
 			{
-				var allComplete = true
+				var thereIsOne = false
 				for(var i=0; i<dropRepeat.count; i++)
-					if(!dropRepeat.itemAt(i).checkCompletenessFormulas())
-						allComplete = false
+					if(dropRepeat.itemAtIndex(i).checkCompletenessFormulas())
+						thereIsOne = true
 
-				return allComplete
+				return thereIsOne
 			}
 
 			function convertToJSON()
@@ -265,9 +271,10 @@ Item
 
 				for(var i=0; i<parameterCount; i++)
 				{
-					var dropSpot = dropRepeat.itemAt(i).getDropSpot()
-					var argJson = dropSpot.containsItem === null ? null : dropSpot.containsItem.convertToJSON()
-					jsonObj.arguments.push({ "name": i, "argument": argJson})
+					var dropSpot = dropRepeat.itemAtIndex(i).getDropSpot()
+					
+					if(dropSpot.containsItem !== null)
+						jsonObj.arguments.push({ "name": i, "argument": dropSpot.containsItem.convertToJSON()})
 				}
 				return jsonObj
 			}
@@ -276,34 +283,18 @@ Item
 			{
 				for(var i=0; i<parameterCount; i++)
 					if(i == param)
-						return dropRepeat.itemAt(i).getDropSpot()
+						return dropRepeat.itemAtIndex(i).getDropSpot()
 
 				return null
 
 			}
 
-			function rebindSize()
+			delegate:	Item
 			{
-				dropRow.width	= Qt.binding(rowWidthCalc)
-				dropRow.height	= Qt.binding(rowHeightCalc)
-			}
-
-			onItemAdded:
-			{
-				rebindSize()
-
-
-				for(var i=0; i<funcRoot.parameterCount; i++)
-					if(funcRoot.droppedItems.length > i)
-						dropRepeat.itemAt(i).getDropSpot().containsItem = funcRoot.droppedItems[i]
-
-			}
-			onItemRemoved:	rebindSize()
-
-			Item
-			{
-				width: spot.width + comma.width
-				height: spot.height
+				implicitWidth:		spot.width + comma.width
+				implicitHeight:		spot.height
+				width:				implicitWidth
+				height:				implicitHeight
 
 				function returnR()
 				{
@@ -322,19 +313,16 @@ Item
 
 
 
-				DropSpot {
-					id: spot
+				DropSpot 
+				{
+					id:					spot
 
-					height: implicitHeight
-					implicitWidth: originalWidth
-					implicitHeight: filterConstructor.blockDim
+					acceptsDrops:		funcRoot.acceptsDrops
 
-					acceptsDrops: funcRoot.acceptsDrops
+					defaultText:		"..."
+					dropKeys:			["number"]
 
-					defaultText: "..."
-					dropKeys: ["number"]
-
-					droppedShouldBeNested: parameterCount === 1 && !funcRoot.drawMeanSpecial
+					droppedShouldBeNested: funcRoot.parameterCount === 1 && !funcRoot.drawMeanSpecial
 					shouldShowX: false
 
 					onContainsItemChanged:
@@ -344,15 +332,15 @@ Item
 						funcRoot.droppedItems = []
 
 						for(var i=0; i<parameterCount; i++)
-							if(dropRepeat.itemAt(i).getDropSpot().containsItem != null)
-								funcRoot.droppedItems.push(dropRepeat.itemAt(i).getDropSpot().containsItem)
+							if(dropRepeat.itemAtIndex(i).getDropSpot().containsItem != null)
+								funcRoot.droppedItems.push(dropRepeat.itemAtIndex(i).getDropSpot().containsItem)
 							else
 								itsFull = false;
 
 						if(itsFull) //Then apparently this one just got filled?
 						{
 							for(var i=0; i<funcRoot.parameterCount; i++)
-								dropRepeat.itemAt(i).getDropSpot().containsItem = null;
+								dropRepeat.itemAtIndex(i).getDropSpot().containsItem = null;
 
 							funcRoot.parameterCount++; //Is this enough to trigger the creation of new dropSpots?
 						}

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -251,15 +251,7 @@ Item
 
 			function convertToJSON()
 			{
-				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "arguments":[], "droppedItems": droppedItems }
-
-				for(var i=0; i<parameterCount; i++)
-				{
-					var dropSpot = dropRepeat.itemAt(i).getDropSpot()
-
-					if(dropSpot.containsItem !== null)
-						jsonObj.arguments.push({ "name": i, "argument": dropSpot.containsItem.convertToJSON()})
-				}
+				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "droppedItems": funcRoot.droppedItems }
 				return jsonObj
 			}
 
@@ -268,6 +260,9 @@ Item
 				for(var i=0; i<parameterCount; i++)
 					if(i == param)
 						return dropRepeat.itemAt(i).getDropSpot()
+				
+				if(param > 0 && param < parameterCount)
+					return dropRepeat.itemAt(param).getDropSpot()
 
 				return null
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -1,5 +1,5 @@
+import JASP
 import QtQuick
-
 
 Item
 {
@@ -12,9 +12,8 @@ Item
 	property string friendlyFunctionName: functionName.endsWith("NaRm") ? functionName.substring(0, functionName.length-4) : functionName //By default exactly the same unless we need to add some fancy unicode
 	property bool acceptsDrops: true
 
-	property int parameterCount: 1
-	property list<Item> droppedItems: []
-
+	property int parameterCount: droppedItems.length
+	property alias droppedItems: dropRepeat.dropped
 
 
 	property variant functionNameToBaseFunc: {
@@ -66,10 +65,11 @@ Item
 
 	function returnR()
 	{
-		var compounded = functionName + "("
+		var compounded = functionName + "NaRm("
 
 		for(var i=0; i<parameterCount; i++)
-				compounded += (i > 0 ? ", " : "") + (dropRepeat.itemAtIndex(i) === null ? "null" : dropRepeat.itemAtIndex(i).returnR())
+				if(dropRepeat.itemAt(i) !== null && dropRepeat.dropped[i] != "null"  && dropRepeat.dropped[i] != "") 
+					compounded += (i > 0 ? ", " : "") + (dropRepeat.itemAt(i).returnR())
 
 		compounded += ")"
 
@@ -180,41 +180,26 @@ Item
 
 		x: haakjesLinks.width + haakjesLinks.x
 
-		width:	dropRepeat.implicitWidth
-		height: dropRepeat.implicitHeight
-
+	
 		property real implicitWidthDrops: parent.acceptsDrops ? funcRoot.initialWidth / 4 : 0
+		
+		JSONtoFormulas
+		{
+			id:			jsonConverterRow
+			objectName: "jsonConverterRow"
+			
+			visible: false
+		}
 
-
-
-		ListView
+		Repeater
 		{
 			id:				dropRepeat
-			model:			funcRoot.parameterCount
-			reuseItems:		false
-			cacheBuffer:	400
+			model:			parameterCount
 			//anchors.fill: parent
+					
+			property list<string> dropped: ["null"]
 			
-			width:			contentWidth
-			height:			contentHeight
-			orientation:	Qt.Horizontal
 
-			property var rowWidthCalc: function()
-			{
-				var widthOut = 0
-				for(var i=0; i<parameterCount; i++)
-					widthOut += dropRepeat.itemAtIndex(i).width
-				return widthOut
-			}
-
-			property var rowHeightCalc: function()
-			{
-				var heightOut = filterConstructor.blockDim
-				for(var i=0; i<parameterCount; i++)
-					heightOut = Math.max(dropRepeat.itemAtIndex(i).height, heightOut)
-
-				return heightOut
-			}
 
 			///This also goes down the tree
 			property var rightMostEmptyDropSpot: function()
@@ -224,7 +209,7 @@ Item
 				for(var i=parameterCount-1; i>=0; i--)
 				{
 					var prevDropSpot = dropSpot
-					dropSpot = dropRepeat.itemAtIndex(i).getDropSpot()
+					dropSpot = dropRepeat.itemAt(i).getDropSpot()
 
 					if(dropSpot.containsItem !== null)
 					{
@@ -247,7 +232,7 @@ Item
 				for(var i=0; i<parameterCount; i++)
 				{
 					var prevDropSpot = dropSpot
-					dropSpot = dropRepeat.itemAtIndex(i).getDropSpot()
+					dropSpot = dropRepeat.itemAt(i).getDropSpot()
 
 					if(dropSpot.containsItem === null)
 						return prevDropSpot //its ok if it is null. we just cant find anything here
@@ -259,7 +244,7 @@ Item
 			{
 				var thereIsOne = false
 				for(var i=0; i<dropRepeat.count; i++)
-					if(dropRepeat.itemAtIndex(i).checkCompletenessFormulas())
+					if(dropRepeat.itemAt(i).checkCompletenessFormulas(true))
 						thereIsOne = true
 
 				return thereIsOne
@@ -267,12 +252,12 @@ Item
 
 			function convertToJSON()
 			{
-				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "arguments":[], "parameterCount": parameterCount }
+				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "arguments":[], "droppedItems": parameters }
 
 				for(var i=0; i<parameterCount; i++)
 				{
-					var dropSpot = dropRepeat.itemAtIndex(i).getDropSpot()
-					
+					var dropSpot = dropRepeat.itemAt(i).getDropSpot()
+
 					if(dropSpot.containsItem !== null)
 						jsonObj.arguments.push({ "name": i, "argument": dropSpot.containsItem.convertToJSON()})
 				}
@@ -283,13 +268,40 @@ Item
 			{
 				for(var i=0; i<parameterCount; i++)
 					if(i == param)
-						return dropRepeat.itemAtIndex(i).getDropSpot()
+						return dropRepeat.itemAt(i).getDropSpot()
 
 				return null
 
 			}
+			
+			onItemAdded:
+			{
+				//rebindSize()
+				messages.log("dropRepeat.dropped is: ")
+				for(var i=0; i<parameterCount; i++)
+				{
+					messages.log(dropRepeat.dropped[i])
+					if(dropRepeat.itemAt(i) != null)
+					{
+						var dropSpot = dropRepeat.itemAt(i).getDropSpot()
+						if(dropSpot.containsItem == null && dropRepeat.dropped[i] != "" && dropRepeat.dropped[i] != "null")
+						{
+							messages.log("Converting onItemAdded stored json to item: " + dropRepeat.dropped[i] + " to fill " + dropSpot.containsItem)
+							var jsonObjHere = JSON.parse(dropRepeat.dropped[i])
+							jsonConverterRow.convertJSONtoItem(jsonObjHere, dropSpot) 	
+						}
+					}
+				}
+			
+			
+			}
+			//onItemRemoved:  rebindSize()
+			
+		
+			
 
-			delegate:	Item
+
+			Item
 			{
 				implicitWidth:		spot.width + comma.width
 				implicitHeight:		spot.height
@@ -301,7 +313,7 @@ Item
 					if(spot.containsItem != null)
 						return spot.containsItem.returnR();
 					else
-						return "null"
+						return ""
 				}
 
 				function getDropSpot() { return spot }
@@ -310,7 +322,18 @@ Item
 				{
 					return spot.checkCompletenessFormulas()
 				}
-
+				
+				Component.onCompleted: 
+				{
+	
+					if(spot.containsItem == null && dropRepeat.dropped[index] != "" && dropRepeat.dropped[index] != "null")
+					{
+						messages.log("Converting onCompleted stored json to item: " + dropRepeat.dropped[index] + " to fill " + spot.containsItem)
+						var jsonObjHere = JSON.parse(dropRepeat.dropped[index])
+						jsonConverterRow.convertJSONtoItem(jsonObjHere, spot) 	
+					}
+				}
+				
 
 
 				DropSpot 
@@ -323,27 +346,45 @@ Item
 					dropKeys:			["number"]
 
 					droppedShouldBeNested: funcRoot.parameterCount === 1 && !funcRoot.drawMeanSpecial
-					shouldShowX: false
-
-					onContainsItemChanged:
+					shouldShowX:		false
+					ignoreEmpty:		true
+					
+					onSomethingDropped:
 					{
-						//First make the list of what is there now:
-						var itsFull = true;
-						funcRoot.droppedItems = []
-
-						for(var i=0; i<parameterCount; i++)
-							if(dropRepeat.itemAtIndex(i).getDropSpot().containsItem != null)
-								funcRoot.droppedItems.push(dropRepeat.itemAtIndex(i).getDropSpot().containsItem)
-							else
-								itsFull = false;
-
-						if(itsFull) //Then apparently this one just got filled?
+						if(spot.containsItem != null)
 						{
-							for(var i=0; i<funcRoot.parameterCount; i++)
-								dropRepeat.itemAtIndex(i).getDropSpot().containsItem = null;
+							print("containsItem="+(spot.containsItem))
+							//First make the list of what is there now:
+							var itsFull = true;
+							
+							var jsonStr = JSON.stringify(spot.containsItem.convertToJSON())
+							
+							messages.log("Converted dropped thing to: " + dropRepeat.dropped[index] + " inserting at index " + index)
+							
+							if(dropRepeat.dropped[index] == jsonStr)
+							{
+								messages.log("Already there ")
+							}
+							else
+							{
+								messages.log("Before insert dropped is: ")
+								for(var i=0; i<parameterCount; i++)
+									messages.log(dropRepeat.dropped[i])
+								
+								dropRepeat.dropped[index] = jsonStr
+							}
+	
+							for(var i=0; i<parameterCount; i++)
+								if(dropRepeat.dropped[i] == "null")
+									itsFull = false;
 
-							funcRoot.parameterCount++; //Is this enough to trigger the creation of new dropSpots?
+							if(itsFull) //Then apparently this one just got filled?
+							{
+								dropRepeat.dropped.push("null")
+							}
 						}
+						else
+							dropRepeat.dropped[index] = "null"
 					}
 				}
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -13,7 +13,7 @@ Item
 	property bool acceptsDrops: true
 
 	property int parameterCount: droppedItems.length
-	property alias droppedItems: dropRepeat.dropped
+	property list<string> droppedItems: ["null"]
 
 
 	property variant functionNameToBaseFunc: {
@@ -183,13 +183,7 @@ Item
 	
 		property real implicitWidthDrops: parent.acceptsDrops ? funcRoot.initialWidth / 4 : 0
 		
-		JSONtoFormulas
-		{
-			id:			jsonConverterRow
-			objectName: "jsonConverterRow"
-			
-			visible: false
-		}
+
 
 		Repeater
 		{
@@ -197,7 +191,7 @@ Item
 			model:			parameterCount
 			//anchors.fill: parent
 					
-			property list<string> dropped: ["null"]
+			property alias dropped: funcRoot.droppedItems
 			
 
 
@@ -252,7 +246,7 @@ Item
 
 			function convertToJSON()
 			{
-				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "arguments":[], "droppedItems": parameters }
+				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "arguments":[], "droppedItems": droppedItems }
 
 				for(var i=0; i<parameterCount; i++)
 				{
@@ -288,7 +282,7 @@ Item
 						{
 							messages.log("Converting onItemAdded stored json to item: " + dropRepeat.dropped[i] + " to fill " + dropSpot.containsItem)
 							var jsonObjHere = JSON.parse(dropRepeat.dropped[i])
-							jsonConverterRow.convertJSONtoItem(jsonObjHere, dropSpot) 	
+							jsonConverter.convertJSONtoItem(jsonObjHere, dropSpot) 	
 						}
 					}
 				}
@@ -330,7 +324,7 @@ Item
 					{
 						messages.log("Converting onCompleted stored json to item: " + dropRepeat.dropped[index] + " to fill " + spot.containsItem)
 						var jsonObjHere = JSON.parse(dropRepeat.dropped[index])
-						jsonConverterRow.convertJSONtoItem(jsonObjHere, spot) 	
+						jsonConverter.convertJSONtoItem(jsonObjHere, spot) 	
 					}
 				}
 				

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -343,7 +343,10 @@ Item
 					shouldShowX:		false
 					ignoreEmpty:		true
 					
-					onSomethingDropped:
+					onSomethingDropped:		handleContainsItemChange()
+					onContainsItemChanged:	handleContainsItemChange()
+						
+					function handleContainsItemChange()
 					{
 						if(spot.containsItem != null)
 						{

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunction.qml
@@ -4,39 +4,56 @@ import QtQuick
 Item
 {
 	id: funcRoot
-	objectName: "Function"
-	property string __debugName: "Function " + functionName
+	objectName: "RowFunction"
+	property string __debugName: "RowFunction " + functionName
 
-	property int initialWidth: filterConstructor.blockDim * 3
-	property string functionName: "sum"
-	property string friendlyFunctionName: functionName //By default exactly the same unless we need to add some fancy unicode
+	property int initialWidth: filterConstructor.blockDim * 6
+	property string functionName: "rowSum"
+	property string friendlyFunctionName: functionName.endsWith("NaRm") ? functionName.substring(0, functionName.length-4) : functionName //By default exactly the same unless we need to add some fancy unicode
 	property bool acceptsDrops: true
 
-	property var parameterNames: []
-	property var parameterDropKeys: [[]]
+	property int parameterCount: 1
+	property list<Item> droppedItems: []
+
+
+
+	property variant functionNameToBaseFunc: {
+	"rowMean":				"mean",
+	"rowMeanNaRm":			"mean",
+	"rowSum":				"sum",
+	"rowSumNaRm":			"sum",
+	"rowSD":				"sd",
+	"rowSDNaRm":			"sd",
+	"rowVariance":			"variance",
+	"rowVarianceNaRm":		"variance",
+	"rowMedian":			"median",
+	"rowMedianNaRm":		"median",
+	"rowMin":				"min",
+	"rowMinNaRm":			"min",
+	"rowMax":				"max",
+	"rowMaxNaRm":			"max"
+	}
+
 
 	property variant functionNameToImageSource: { "sum": jaspTheme.iconPath + "/sum.png", "prod": jaspTheme.iconPath + "/product.png", "sd": jaspTheme.iconPath + "/sigma.png", "var": jaspTheme.iconPath + "/variance.png", "!": jaspTheme.iconPath + "/negative.png", "sqrt":jaspTheme.iconPath + "/rootHead.png"}
-	property string functionImageSource: functionNameToImageSource[functionName] !== undefined ? functionNameToImageSource[functionName] : ""
+	property string functionImageSource: functionNameToBaseFunc[functionName] !== undefined && functionNameToImageSource[functionNameToBaseFunc[functionName]] !== undefined ? functionNameToImageSource[functionNameToBaseFunc[functionName]] : ""
 	property bool isNested: false
-	property var booleanReturningFunctions: ["!", "hasSubstring", "is.na"]
 
-	readonly property bool isIfElse: functionName === "ifelse"
-	property var ifElseReturn: ["string", "number", "boolean"]
-	property var dragKeys: isIfElse ? ifElseReturn : booleanReturningFunctions.indexOf(functionName) >= 0 ? ["boolean"] : [ "number" ]
+
+	property var dragKeys: [ "number" ]
+
 
 	readonly property bool isMean: functionName === "mean"
-	readonly property bool isAbs:  functionName === "abs"
-	readonly property bool isRoot: functionName === "sqrt"
 	readonly property bool drawMeanSpecial: false
-	readonly property bool showParentheses: !drawMeanSpecial && (parameterNames.length > 1 || isAbs || functionImageSource === "")
+	readonly property bool showParentheses: !drawMeanSpecial && (parameterCount > 1 || functionImageSource === "")
 
 	property real extraMeanWidth: (drawMeanSpecial ? 10 * preferencesModel.uiScale : 0)
 
-	property var addNARMFunctions: ["mean", "sd", "var", "sum", "prod", "min", "max", "mean", "median"]
-	property string extraParameterCode: addNARMFunctions.indexOf(functionName) >= 0 ? ", na.rm=TRUE" : ""
+	//property var addNARMFunctions: ["mean", "sd", "var", "sum", "prod", "min", "max", "mean", "median"]
+	//property string extraParameterCode: addNARMFunctions.indexOf(functionName) >= 0 ? ", na.rm=TRUE" : ""
+	//I guess we just only do the NaRm version here.
 
-	height: funcRoot.isRoot && !funcRoot.acceptsDrops ? filterConstructor.blockDim  //If in the operatorselector bar then force same height as other operators
-													  : meanBar.height + Math.max(dropRow.height, filterConstructor.blockDim)
+	height: meanBar.height + Math.max(dropRow.height, filterConstructor.blockDim)
 	width: functionDef.width + haakjesLinks.width + dropRow.width + haakjesRechts.width + extraMeanWidth
 
 	function shouldDrag(mouseX, mouseY)
@@ -51,10 +68,10 @@ Item
 	{
 		var compounded = functionName + "("
 
-		for(var i=0; i<funcRoot.parameterNames.length; i++)
+		for(var i=0; i<parameterCount; i++)
 				compounded += (i > 0 ? ", " : "") + (dropRepeat.itemAt(i) === null ? "null" : dropRepeat.itemAt(i).returnR())
 
-		compounded += extraParameterCode + ")"
+		compounded += ")"
 
 		return compounded
 	}
@@ -68,10 +85,10 @@ Item
 	Item
 	{
 		id: meanBar
-		visible: funcRoot.drawMeanSpecial || funcRoot.isRoot
+		visible: funcRoot.drawMeanSpecial
 		height: visible ? 6 * preferencesModel.uiScale : 0
 
-		anchors.left: funcRoot.isRoot ? functionDef.right : parent.left
+		anchors.left: parent.left
 		anchors.right: parent.right
 		anchors.top: parent.top
 
@@ -83,7 +100,7 @@ Item
 			anchors.left: parent.left
 			anchors.right: parent.right
 			anchors.top: parent.top
-			anchors.topMargin: funcRoot.isRoot ? 0 : Math.max(1, 3 * preferencesModel.uiScale)
+			anchors.topMargin: Math.max(1, 3 * preferencesModel.uiScale)
 
 			height: Math.max(1, 3 * preferencesModel.uiScale)
 		}
@@ -96,7 +113,7 @@ Item
 		anchors.bottom: parent.bottom
 
 		x: extraMeanWidth / 2
-		width: functionImgRoot.visible ? functionImgRoot.width : functionText.visible ? functionText.width : functionImg.width
+		width: functionText.visible ? functionText.width : functionImg.width
 
 		Text
 		{
@@ -109,7 +126,7 @@ Item
 			verticalAlignment:		Text.AlignVCenter
 			horizontalAlignment:	Text.AlignHCenter
 
-			text:					funcRoot.drawMeanSpecial || funcRoot.isAbs || funcRoot.isRoot ? "" : friendlyFunctionName
+			text:					funcRoot.drawMeanSpecial ? "" : friendlyFunctionName
 			font.pixelSize:			filterConstructor.fontPixelSize
 			font.family:			jaspTheme.font.family
 
@@ -121,9 +138,9 @@ Item
 		{
 			id:						functionImg
 
-			visible:				(!funcRoot.isRoot || !funcRoot.acceptsDrops) && functionImageSource !== ""
+			visible:				(!funcRoot.acceptsDrops) && functionImageSource !== ""
 
-			source:					funcRoot.isRoot && !funcRoot.acceptsDrops ? jaspTheme.iconPath + "/sqrtSelector.png" : functionImageSource //workaround for operatorselector bar
+			source:					functionImageSource
 
 
 			height:					filterConstructor.blockDim
@@ -133,21 +150,6 @@ Item
 
 			anchors.verticalCenter: parent.verticalCenter
 
-		}
-
-		Image
-		{
-			id:					functionImgRoot
-
-			visible:			funcRoot.isRoot &&  funcRoot.acceptsDrops
-
-			source:				functionImageSource
-			anchors.top:		parent.top
-			anchors.bottom:		parent.bottom
-			width:				filterConstructor.blockDim
-			sourceSize.width:	filterConstructor.blockDim * 2
-			sourceSize.height:	filterConstructor.blockDim * 3
-			smooth:				true
 		}
 	}
 
@@ -163,24 +165,10 @@ Item
 		horizontalAlignment:	Text.AlignHCenter
 
 		width:					showParentheses ? filterConstructor.blockDim / 3 : 0
-		text:					! showParentheses || funcRoot.isAbs || funcRoot.isRoot ? "" : "("
+		text:					! showParentheses ? "" : "("
 		font.pixelSize:			filterConstructor.fontPixelSize
 		font.family:			jaspTheme.font.family
 		color:					jaspTheme.textEnabled
-
-		Rectangle
-		{
-			anchors.top: parent.top
-			anchors.bottom: parent.bottom
-			anchors.margins: 2
-			anchors.horizontalCenter: parent.horizontalCenter
-
-			color: jaspTheme.black
-			width: 2
-
-			visible: funcRoot.isAbs
-		}
-
 	}
 
 
@@ -202,13 +190,13 @@ Item
 		Repeater
 		{
 			id:		dropRepeat
-			model:	funcRoot.parameterNames
+			model:	parameterCount
 			//anchors.fill: parent
 
 			property var rowWidthCalc: function()
 			{
 				var widthOut = 0
-				for(var i=0; i<funcRoot.parameterNames.length; i++)
+				for(var i=0; i<parameterCount; i++)
 					widthOut += dropRepeat.itemAt(i).width
 				return widthOut
 			}
@@ -216,7 +204,7 @@ Item
 			property var rowHeightCalc: function()
 			{
 				var heightOut = filterConstructor.blockDim
-				for(var i=0; i<funcRoot.parameterNames.length; i++)
+				for(var i=0; i<parameterCount; i++)
 					heightOut = Math.max(dropRepeat.itemAt(i).height, heightOut)
 
 				return heightOut
@@ -227,7 +215,7 @@ Item
 			{
 				var dropSpot = null
 
-				for(var i=funcRoot.parameterNames.length-1; i>=0; i--)
+				for(var i=parameterCount-1; i>=0; i--)
 				{
 					var prevDropSpot = dropSpot
 					dropSpot = dropRepeat.itemAt(i).getDropSpot()
@@ -250,7 +238,7 @@ Item
 			{
 				var dropSpot = null
 
-				for(var i=0; i<funcRoot.parameterNames.length; i++)
+				for(var i=0; i<parameterCount; i++)
 				{
 					var prevDropSpot = dropSpot
 					dropSpot = dropRepeat.itemAt(i).getDropSpot()
@@ -273,21 +261,21 @@ Item
 
 			function convertToJSON()
 			{
-				var jsonObj = { "nodeType":"Function", "functionName": functionName, "arguments":[] }
+				var jsonObj = { "nodeType":"RowFunction", "functionName": functionName, "arguments":[], "parameterCount": parameterCount }
 
-				for(var i=0; i<funcRoot.parameterNames.length; i++)
+				for(var i=0; i<parameterCount; i++)
 				{
 					var dropSpot = dropRepeat.itemAt(i).getDropSpot()
 					var argJson = dropSpot.containsItem === null ? null : dropSpot.containsItem.convertToJSON()
-					jsonObj.arguments.push({ "name": funcRoot.parameterNames[i], "dropKeys": funcRoot.parameterDropKeys[i], "argument": argJson})
+					jsonObj.arguments.push({ "name": i, "argument": argJson})
 				}
 				return jsonObj
 			}
 
 			function getParameterDropSpot(param)
 			{
-				for(var i=0; i<funcRoot.parameterNames.length; i++)
-					if(funcRoot.parameterNames[i] === param)
+				for(var i=0; i<parameterCount; i++)
+					if(i == param)
 						return dropRepeat.itemAt(i).getDropSpot()
 
 				return null
@@ -300,7 +288,16 @@ Item
 				dropRow.height	= Qt.binding(rowHeightCalc)
 			}
 
-			onItemAdded:	rebindSize()
+			onItemAdded:
+			{
+				rebindSize()
+
+
+				for(var i=0; i<funcRoot.parameterCount; i++)
+					if(funcRoot.droppedItems.length > i)
+						dropRepeat.itemAt(i).getDropSpot().containsItem = funcRoot.droppedItems[i]
+
+			}
 			onItemRemoved:	rebindSize()
 
 			Item
@@ -334,17 +331,38 @@ Item
 
 					acceptsDrops: funcRoot.acceptsDrops
 
-					defaultText: funcRoot.parameterNames[index]
-					dropKeys: funcRoot.parameterDropKeys[index]
+					defaultText: "..."
+					dropKeys: ["number"]
 
-					droppedShouldBeNested: funcRoot.parameterNames.length === 1 && !funcRoot.isAbs && !funcRoot.drawMeanSpecial
-					shouldShowX: funcRoot.parameterNames <= 1
+					droppedShouldBeNested: parameterCount === 1 && !funcRoot.drawMeanSpecial
+					shouldShowX: false
+
+					onContainsItemChanged:
+					{
+						//First make the list of what is there now:
+						var itsFull = true;
+						funcRoot.droppedItems = []
+
+						for(var i=0; i<parameterCount; i++)
+							if(dropRepeat.itemAt(i).getDropSpot().containsItem != null)
+								funcRoot.droppedItems.push(dropRepeat.itemAt(i).getDropSpot().containsItem)
+							else
+								itsFull = false;
+
+						if(itsFull) //Then apparently this one just got filled?
+						{
+							for(var i=0; i<funcRoot.parameterCount; i++)
+								dropRepeat.itemAt(i).getDropSpot().containsItem = null;
+
+							funcRoot.parameterCount++; //Is this enough to trigger the creation of new dropSpots?
+						}
+					}
 				}
 
 				Text
 				{
 					id:					comma
-					text:				index < funcRoot.parameterNames.length - 1 ? ", " : ""
+					text:				index < parameterCount - 1 ? ", " : ""
 
 					font.pixelSize:		filterConstructor.fontPixelSize
 					font.family:		jaspTheme.font.family
@@ -369,22 +387,10 @@ Item
 		horizontalAlignment:	Text.AlignHCenter
 
 		width:					 showParentheses ? filterConstructor.blockDim / 3 : 0
-		text:					!showParentheses || funcRoot.isAbs || funcRoot.isRoot ? "" : ")"
+		text:					!showParentheses ? "" : ")"
 		font.pixelSize:			filterConstructor.fontPixelSize
 		font.family:			jaspTheme.font.family
 		color:					jaspTheme.textEnabled
 
-		Rectangle
-		{
-			anchors.top: parent.top
-			anchors.bottom: parent.bottom
-			anchors.margins: 2
-			anchors.horizontalCenter: parent.horizontalCenter
-
-			color: jaspTheme.black
-			width: 2
-
-			visible: funcRoot.isAbs
-		}
 	}
 }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunctionDrag.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunctionDrag.qml
@@ -4,19 +4,20 @@ DragGeneric {
 	shownChild: showMe
 	property string __debugName: "RowFunctionDrag"
 
-	property string functionName: "rowSum"
-	property string friendlyFunctionName: functionName
+	property alias functionName:			showMe.functionName
+	property alias friendlyFunctionName:	showMe.friendlyFunctionName
+	property alias droppedItems:			showMe.droppedItems
 
-	property bool acceptsDrops: true
-	dragKeys: showMe.dragKeys
+	property bool acceptsDrops:				true
+	dragKeys:								showMe.dragKeys
 
 	function getParameterDropSpot(param)		{ return showMe.getParameterDropSpot(param) }
 
 	RowFunction
 	{
 		id:						showMe
-		functionName:			parent.functionName
-		friendlyFunctionName:	parent.friendlyFunctionName
+		//functionName:			parent.functionName
+		//friendlyFunctionName:	parent.friendlyFunctionName
 
 		x:						parent.dragX
 		y:						parent.dragY

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunctionDrag.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunctionDrag.qml
@@ -1,7 +1,8 @@
 import QtQuick
 
-DragGeneric {
-	shownChild: showMe
+DragGeneric 
+{
+	shownChild:			showMe
 	property string __debugName: "RowFunctionDrag"
 
 	property alias functionName:			showMe.functionName

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunctionDrag.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunctionDrag.qml
@@ -1,0 +1,27 @@
+import QtQuick
+
+DragGeneric {
+	shownChild: showMe
+	property string __debugName: "RowFunctionDrag"
+
+	property string functionName: "rowSum"
+	property string friendlyFunctionName: functionName
+
+	property bool acceptsDrops: true
+	dragKeys: showMe.dragKeys
+
+	function getParameterDropSpot(param)		{ return showMe.getParameterDropSpot(param) }
+
+	RowFunction
+	{
+		id:						showMe
+		functionName:			parent.functionName
+		friendlyFunctionName:	parent.friendlyFunctionName
+
+		x:						parent.dragX
+		y:						parent.dragY
+
+		isNested:				parent.nested
+		acceptsDrops:			parent.acceptsDrops
+	}
+}

--- a/Desktop/components/JASP/Widgets/FilterConstructor/RowFunctionDrag.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/RowFunctionDrag.qml
@@ -2,6 +2,7 @@ import QtQuick
 
 DragGeneric 
 {
+	id:					dragMe
 	shownChild:			showMe
 	property string __debugName: "RowFunctionDrag"
 
@@ -13,6 +14,16 @@ DragGeneric
 	dragKeys:								showMe.dragKeys
 
 	function getParameterDropSpot(param)		{ return showMe.getParameterDropSpot(param) }
+	
+	Connections
+	{
+		target:		showMe
+		enabled:	showMe != undefined
+		function onJsonChanged()
+		{
+			dragMe.jsonChanged();	
+		}
+	}
 
 	RowFunction
 	{

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -129,6 +129,9 @@ FocusScope
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "prod";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("product of values") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "zScores";		functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("Standardizes the variable") }
 
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";			functionName: "rowMean";		toolTip: qsTr("rowwise mean") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";			functionName: "rowSum";			toolTip: qsTr("rowwise sum") }
+
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "min";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("returns minimum of values") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "max";			functionParameters: "values";			functionParamTypes: "number";							toolTip: qsTr("returns maximum of values") }
 					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "mean";			functionParameters: "values";			functionParamTypes: "number";								toolTip: qsTr("mean") }

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -122,26 +122,33 @@ FocusScope
 				functionModel: ListModel
 				{
 
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "abs";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("absolute value") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "sd";				functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("standard deviation") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "var";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("variance") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "sum";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("summation") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "prod";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("product of values") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "zScores";		functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("Standardizes the variable") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Abs");					*/ functionName: "abs";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("absolute value") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Standard deviation");	*/ 	functionName: "sd";				functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("standard deviation") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Variance");			*/ 	functionName: "var";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("variance") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Sum");					*/ functionName: "sum";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("summation") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Product");				*/ functionName: "prod";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("product of values") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("ZScores");				*/ functionName: "zScores";		functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("Standardizes the variable") }
 
-					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";			functionName: "rowMean";		toolTip: qsTr("rowwise mean") }
-					ListElement	{ type: "rowfunction";	friendlyFunctionName:	"";			functionName: "rowSum";			toolTip: qsTr("rowwise sum") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	""; /* qsTr("Rowwise mean") ;				*/	functionName: "rowMean";		toolTip: qsTr("Rowwise mean") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	""; /* qsTr("Rowwise sum") ;				*/	functionName: "rowSum";			toolTip: qsTr("Rowwise sum") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	""; /* qsTr("Rowwise standard deviation");	*/	functionName: "rowSD";			toolTip: qsTr("Rowwise standard deviation") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	""; /* qsTr("Rowwise variance") ;			*/	functionName: "rowVariance";	toolTip: qsTr("Rowwise variance") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	""; /* qsTr("Rowwise median") ;				*/	functionName: "rowMedian";		toolTip: qsTr("Rowwise median") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	""; /* qsTr("Rowwise minimum") ;			*/	functionName: "rowMin";			toolTip: qsTr("Rowwise minimum") }
+					ListElement	{ type: "rowfunction";	friendlyFunctionName:	""; /* qsTr("Rowwise maximum") ;			*/	functionName: "rowMax";			toolTip: qsTr("Rowwise maximum") }
+					
+					
 
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "min";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("returns minimum of values") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "max";			functionParameters: "values";			functionParamTypes: "number";							toolTip: qsTr("returns maximum of values") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "mean";			functionParameters: "values";			functionParamTypes: "number";								toolTip: qsTr("mean") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "sign";			functionParameters: "values";			functionParamTypes: "number";									toolTip: qsTr("returns the sign of values") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "round";			functionParameters: "y,n";				functionParamTypes: "number,number";								toolTip: qsTr("rounds y to n decimals") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "length";			functionParameters: "y";				functionParamTypes: "string:number";									toolTip: qsTr("returns number of elements in y") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "median";			functionParameters: "values";			functionParamTypes: "number";												toolTip: qsTr("median") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "ifelse";			functionParameters: "test,then,else";	functionParamTypes: "boolean,boolean:string:number,boolean:string:number";		toolTip: qsTr("if-else statement") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "hasSubstring";	functionParameters: "string,substring";	functionParamTypes: "string,string";											toolTip: qsTr("returns true if string contains substring at least once") }
-					ListElement	{ type: "function";	friendlyFunctionName:	"";				functionName: "is.na";			functionParameters: "y";				functionParamTypes: "string:number:boolean";									toolTip: qsTr("Combine with not-operator to filter out rows with missing values (NA) for a column.") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("Min");			*/	functionName: "min";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("returns minimum of values") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("Max");			*/	functionName: "max";			functionParameters: "values";			functionParamTypes: "number";							toolTip: qsTr("returns maximum of values") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("Mean");			*/	functionName: "mean";			functionParameters: "values";			functionParamTypes: "number";								toolTip: qsTr("mean") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("Sign");			*/	functionName: "sign";			functionParameters: "values";			functionParamTypes: "number";									toolTip: qsTr("returns the sign of values") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("Round");		*/		functionName: "round";			functionParameters: "y,n";				functionParamTypes: "number,number";								toolTip: qsTr("rounds y to n decimals") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("Length");		*/		functionName: "length";			functionParameters: "y";				functionParamTypes: "string:number";									toolTip: qsTr("returns number of elements in y") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("Median");		*/		functionName: "median";			functionParameters: "values";			functionParamTypes: "number";												toolTip: qsTr("median") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("IfElse");		*/		functionName: "ifelse";			functionParameters: "test,then,else";	functionParamTypes: "boolean,boolean:string:number,boolean:string:number";		toolTip: qsTr("if-else statement") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("HasSubstring");	*/	functionName: "hasSubstring";	functionParameters: "string,substring";	functionParamTypes: "string,string";											toolTip: qsTr("returns true if string contains substring at least once") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /*qsTr("Is.NA");		*/		functionName: "is.na";			functionParameters: "y";				functionParamTypes: "string:number:boolean";									toolTip: qsTr("Combine with not-operator to filter out rows with missing values (NA) for a column.") }
 				}
 
 				function askIfChanged(closeFunc)

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -28,7 +28,7 @@
 #include <QtWebEngineQuick/qtwebenginequickglobal.h>
 #include <QAction>
 #include <QMenuBar>
-
+#include <exception>
 #include <iostream>
 
 #include "log.h"
@@ -653,6 +653,8 @@ void MainWindow::loadQML()
 	Log::log() << "Loading CommunityWindow"		<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/CommunityWindow.qml"));
 	Log::log() << "Loading MainWindow"			<< std::endl; _qml->load(QUrl("qrc:///components/JASP/Widgets/MainWindow.qml"));
 
+	if(!DataSetView::mainDataViewer())
+		throw std::runtime_error("The main data viewer did not load, without which JASP cannot run.");
 	
 	//To make sure we connect to the "main datasetview":
 	connect(_preferences, &PreferencesModel::uiScaleChanged,			DataSetView::mainDataViewer(),	&DataSetView::viewportChangedDelayed);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2616 and also adds row SD vriance etc

Also tried to improve the behaviour of dropping stuff into the drag n drop and inserting stuff at the right (or left) place.
If a column wouldnt be accepted into something with its natural type it will use either the user selected type or whatever works.

This all mostly works as intended.

Although the `row*` functions in JASP will need some love.
Right now they work great for columns, but sadly columns only.
They cant handle getting single string/number inputs, so I guess some R-programmer should have a look?
@JohnnyDoorn  for instance?

Ill also trigger some builds.