### PR TITLE
emit containsVariablesChanged at the right moment

### DIFF
--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -55,6 +55,11 @@ void JASPListControl::_setupSources()
 		delete sourceItem;
 
 	_sourceItems = SourceItem::readAllSources(this);
+
+	// Update the containsVariables and containsInteractions property once the sources are set
+	emit containsVariablesChanged();
+	emit containsInteractionsChanged();
+
 }
 
 bool JASPListControl::containsVariables() const

--- a/QMLComponents/controls/sourceitem.cpp
+++ b/QMLComponents/controls/sourceitem.cpp
@@ -213,8 +213,6 @@ void SourceItem::connectModels()
 		connect(variableInfo,	&VariableInfo::filterChanged,		controlModel, &ListModel::filterChanged );
 		connect(variableInfo,	&VariableInfo::columnsChanged,		controlModel, &ListModel::sourceColumnsChanged );
 		connect(variableInfo,	&VariableInfo::refresh,				controlModel, &ListModel::refresh );
-
-		emit _targetListControl->containsVariablesChanged();
 	}
 
 	if (_sourceListModel)
@@ -231,10 +229,6 @@ void SourceItem::connectModels()
 	{
 		connect(_sourceListControl,		&JASPListControl::containsVariablesChanged,		_targetListControl, &JASPListControl::containsVariablesChanged);
 		connect(_sourceListControl,		&JASPListControl::containsInteractionsChanged,	_targetListControl, &JASPListControl::containsInteractionsChanged);
-
-		// Update the containsVariables and containsInteractions property of the target control
-		emit _targetListControl->containsVariablesChanged();
-		emit _targetListControl->containsInteractionsChanged();
 	}
 
 	_connected = true;


### PR DESCRIPTION
Check the containsVariables (or containsInteractions) of a List Control only when the sources are set.

The new analysis 'Moderateed Non-Linear Factor' in SEM (https://github.com/juliuspfadt/jaspSem/blob/newAnalysisMnlfa) crashes (sometimes) when the Square or Cubic Checkboxes effects (in Moderation) are checked or unchecked. This is because the Moderators dropdowns (in the sub-sub-sub Tab View in Plots) have for source 3 different sources that depends on these checkboxes, and the containsVariables should be checked only if all the sources are set.