### PR TITLE
fix to build on MSVC due to implicitly capture

### DIFF
--- a/Desktop/gui/jaspConfiguration/jaspconfiguration.cpp
+++ b/Desktop/gui/jaspConfiguration/jaspconfiguration.cpp
@@ -75,7 +75,7 @@ void JASPConfiguration::processConfiguration()
 		if(Settings::value(Settings::REMOTE_CONFIGURATION).toBool())
 		{
 			auto conn = std::make_shared<QMetaObject::Connection>();
-			*conn = connect(&_networkManager, &QNetworkAccessManager::finished, this, [=, this](QNetworkReply* reply) {
+			*conn = connect(&_networkManager, &QNetworkAccessManager::finished, this, [this, conn, localOK](QNetworkReply* reply) {
 				QObject::disconnect(*conn);
 				reply->deleteLater();
 


### PR DESCRIPTION
I cannot build on MSVC without this change. because implicitly capture was not allowed on MSVC Windows.