### PR TITLE
Get factor levels

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolmeasurescells.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolmeasurescells.cpp
@@ -20,7 +20,6 @@
 #include "models/listmodelmeasurescellsassigned.h"
 #include "models/listmodelfactorlevels.h"
 #include "controls/jasplistcontrol.h"
-#include "analysisform.h"
 #include "utilities/qutils.h"
 
 #include <QTimer>
@@ -44,11 +43,11 @@ void BoundControlMeasuresCells::bindTo(const Json::Value &value)
 	_measuresCellsModel->initLevels(getLevels(), variables, true);
 }
 
-Terms BoundControlMeasuresCells::getLevels() const
+QList<QStringList> BoundControlMeasuresCells::getLevels() const
 {
-	Terms levels;
+	QList<QStringList> levels;
 	for (ListModelFactorLevels* factorsModel : _sourceFactorsModels)
-		levels.add(factorsModel->getLevels());
+		levels.append(factorsModel->getCombinedLevels());
 	
 	return levels;
 }

--- a/QMLComponents/boundcontrols/boundcontrolmeasurescells.h
+++ b/QMLComponents/boundcontrols/boundcontrolmeasurescells.h
@@ -30,13 +30,13 @@ class BoundControlMeasuresCells : public BoundControlBase
 public:
 	BoundControlMeasuresCells(ListModelMeasuresCellsAssigned* model);
 	
-	bool		isJsonValid(const Json::Value& optionValue) const	override;
-	Json::Value	createJson()								const	override;
-	void		bindTo(const Json::Value &value)					override;
-	void		resetBoundValue()									override;
+	bool				isJsonValid(const Json::Value& optionValue) const	override;
+	Json::Value			createJson()								const	override;
+	void				bindTo(const Json::Value &value)					override;
+	void				resetBoundValue()									override;
 
-	void		addFactorModel(ListModelFactorLevels* factorModel);
-	Terms		getLevels()									const;
+	void				addFactorModel(ListModelFactorLevels* factorModel);
+	QList<QStringList>	getLevels()									const;
 	
 private:
 	ListModelMeasuresCellsAssigned*	_measuresCellsModel;

--- a/QMLComponents/controls/factorlevellistbase.cpp
+++ b/QMLComponents/controls/factorlevellistbase.cpp
@@ -38,6 +38,32 @@ void FactorLevelListBase::setUp()
 
 	connect(this, &FactorLevelListBase::itemChanged, _factorLevelsModel, &ListModelFactorLevels::itemChanged);
 	connect(this, &FactorLevelListBase::itemRemoved, _factorLevelsModel, &ListModelFactorLevels::itemRemoved);
+	connect(_factorLevelsModel, &ListModelFactorLevels::termsChanged, this, &FactorLevelListBase::factorsChanged);
+	connect(_factorLevelsModel, &ListModelFactorLevels::termsChanged, this, &FactorLevelListBase::factorLevelMapChanged);
+	connect(_factorLevelsModel, &ListModelFactorLevels::termsChanged, this, &FactorLevelListBase::nbFactorsChanged);
+}
+
+QStringList FactorLevelListBase::factors() const
+{
+	return _factorLevelsModel ? _factorLevelsModel->terms().labels() : QStringList();
+}
+
+int FactorLevelListBase::nbFactors() const
+{
+	return _factorLevelsModel ? _factorLevelsModel->terms().size() : 0;
+}
+
+QVariantMap FactorLevelListBase::factorLevelMap() const
+{
+	QVariantMap map;
+
+	if (_factorLevelsModel)
+	{
+		for (const Term& term : _factorLevelsModel->terms())
+			map[term.label()] = _factorLevelsModel->getLevels(term.value());
+	}
+
+	return map;
 }
 
 void FactorLevelListBase::bindTo(const Json::Value& value)
@@ -81,19 +107,14 @@ Json::Value FactorLevelListBase::createJson() const
 Json::Value FactorLevelListBase::createMeta() const
 {
 	Json::Value meta(BoundControlBase::createMeta()); //Work from parent to get everything it defines
-	
-	auto factors = _factorLevelsModel->getFactors();
-	
-	if(factors.size() == 0)
-		return meta;
-	
-	meta["encodeThis"] = Json::arrayValue;
-	for (const auto & factor : factors)
-	{
-		meta["encodeThis"].append(factor.first);
 		
-		for(const auto & level : factor.second)
-			meta["encodeThis"].append(level);
+	meta["encodeThis"] = Json::arrayValue;
+	for (const QString & factor : factors())
+	{
+		meta["encodeThis"].append(fq(factor));
+		
+		for(const QString & level : _factorLevelsModel->getLevels(factor))
+			meta["encodeThis"].append(fq(level));
 	}
 	
 	return meta;
@@ -120,21 +141,19 @@ void FactorLevelListBase::termsChangedHandler()
 	JASPListControl::termsChangedHandler();
 
 	Json::Value boundValue(Json::arrayValue);
-	const vector<pair<string, vector<string> > > &factors = _factorLevelsModel->getFactors();
 	
-	for (const auto &factor : factors)
+	for (const QString &factor : factors())
 	{
 		Json::Value row(Json::objectValue);
-		row["name"] = factor.first;
+		row["name"] = fq(factor);
 
 		Json::Value levels(Json::arrayValue);
-		for (const string &level : factor.second)
-			levels.append(level);
+		for (const QString &level : _factorLevelsModel->getLevels(factor))
+			levels.append(fq(level));
 
 		row["levels"] = levels;
 		boundValue.append(row);
 	}
 	
-	setNbFactors(factors.size());
 	setBoundValue(boundValue);
 }

--- a/QMLComponents/controls/factorlevellistbase.h
+++ b/QMLComponents/controls/factorlevellistbase.h
@@ -35,6 +35,8 @@ class FactorLevelListBase :  public JASPListControl, public BoundControlBase
 	Q_PROPERTY( int				minFactors			READ minFactors				WRITE setMinFactors				NOTIFY minFactorsChanged			)
 	Q_PROPERTY( int				minLevels			READ minLevels				WRITE setMinLevels				NOTIFY minLevelsChanged				)
 	Q_PROPERTY( int				nbFactors			READ nbFactors												NOTIFY nbFactorsChanged				)
+	Q_PROPERTY( QStringList		factors				READ factors												NOTIFY factorsChanged				)
+	Q_PROPERTY( QVariantMap		factorLevelMap		READ factorLevelMap											NOTIFY factorLevelMapChanged		)
 
 public:
 	FactorLevelListBase(QQuickItem* parent = nullptr);
@@ -54,10 +56,13 @@ public:
 	QString			levelPlaceHolder()							const				{ return _levelPlaceHolder;		}
 	int				minFactors()								const				{ return _minFactors;			}
 	int				minLevels()									const				{ return _minLevels;			}
-	int				nbFactors()									const				{ return _nbFactors;			}
+	int				nbFactors()									const;
 
 	QString			getFactorName(int i)						const				{ return QStringLiteral("%1 %2").arg(_factorName).arg(i);	}
 	QString			getLevelName(int i)							const				{ return QStringLiteral("%1 %2").arg(_levelName).arg(i);	}
+
+	QStringList		factors()									const;
+	QVariantMap		factorLevelMap()							const;
 
 signals:
 	void			itemChanged(int index, QString name);
@@ -70,6 +75,8 @@ signals:
 	void			minFactorsChanged();
 	void			minLevelsChanged();
 	void			nbFactorsChanged();
+	void			factorsChanged();
+	void			factorLevelMapChanged();
 
 protected slots:
 	void			termsChangedHandler() override;
@@ -81,7 +88,6 @@ protected:
 	GENERIC_SET_FUNCTION(LevelPlaceHolder,		_levelPlaceHolder,		levelPlaceHolderChanged,	QString		)
 	GENERIC_SET_FUNCTION(MinFactors,			_minFactors,			minFactorsChanged,			int			)
 	GENERIC_SET_FUNCTION(MinLevels,				_minLevels,				minLevelsChanged,			int			)
-	GENERIC_SET_FUNCTION(NbFactors,				_nbFactors,				nbFactorsChanged,			int			)
 
 private:
 	ListModelFactorLevels*				_factorLevelsModel	= nullptr;

--- a/QMLComponents/models/listmodelcustomcontrasts.cpp
+++ b/QMLComponents/models/listmodelcustomcontrasts.cpp
@@ -327,13 +327,12 @@ void ListModelCustomContrasts::_setFactors()
 
 	if (_factorsSourceModel)
 	{
-		std::vector<std::pair<std::string, std::vector<std::string> > > factors = _factorsSourceModel->getFactors();
-		for (const auto& factor : factors)
+		for (const Term& factor : _factorsSourceModel->terms())
 		{
 			QList<QString> levels;
-			for (const std::string& level : factor.second)
-				levels.push_back(QString::fromStdString(level));
-			_factors[QString::fromStdString(factor.first)] = levels;
+			for (const QString& level : _factorsSourceModel->getLevels(factor.value()))
+				levels.push_back(level);
+			_factors[factor.value()] = levels;
 		}
 	}
 

--- a/QMLComponents/models/listmodelfactorlevels.cpp
+++ b/QMLComponents/models/listmodelfactorlevels.cpp
@@ -62,6 +62,23 @@ QVariant ListModelFactorLevels::data(const QModelIndex &index, int role) const
 	return ListModel::data(index, role);
 }
 
+QStringList ListModelFactorLevels::getLevels(const QString &factor) const
+{
+	QStringList levels;
+
+	for (auto item = _items.begin(); item != _items.end(); item++)
+	{
+		if (!item->isLevel && !item->isVirtual && item->value == factor)
+		{
+			item++;
+			for (; item->isLevel && !item->isVirtual && item != _items.end(); item++)
+				levels.push_back(item->value);
+			break;
+		}
+	}
+	return levels;
+}
+
 void ListModelFactorLevels::initFactors(const vector<pair<string, vector<string> > > &factors)
 {
 	beginResetModel();
@@ -85,86 +102,46 @@ void ListModelFactorLevels::initFactors(const vector<pair<string, vector<string>
 	// Append a virtual factor
 	_items.append(FactorLevelItem(_factorLevelList->factorPlaceHolder(), true, false));
 
-	_setAllLevelsCombinations();
+	_setTerms(_getAllFactors()); // _terms get only the factors
 
 	endResetModel();
 	
 }
 
-vector<pair<string, vector<string> > > ListModelFactorLevels::getFactors() const
+QList<QStringList> ListModelFactorLevels::getCombinedLevels() const
 {
-	vector<pair<string, vector<string> > > result;
-	string currentFactorName;
-	vector<string> currentLevels;
-	for (const FactorLevelItem& factor: _items)
-	{
-		if (!factor.isVirtual && !factor.isLevel)
-		{
-			currentFactorName = factor.value.toStdString();
-			currentLevels.clear();
-		} 
-		else if (!factor.isVirtual && factor.isLevel)
-		{
-			currentLevels.push_back(factor.value.toStdString());
-		}	
-		else if (factor.isVirtual && factor.isLevel)
-		{
-			result.push_back(make_pair(currentFactorName, currentLevels));
-			currentLevels.clear();
-		}
-	}
-	
-	return result;
-}
+	QList<QStringList> list;
 
-const Terms &ListModelFactorLevels::getLevels() const
-{
-	return _allLevelsCombinations;
-}
-
-void ListModelFactorLevels::_setAllLevelsCombinations()
-{
-	vector<vector<string> > allLevelsCombinations;
-	_setTerms(_getAllFactors()); // _terms get only the factors
-	
-	vector<vector<string> > allLevels;	
-	vector<string> currentLevels;
-	for (const FactorLevelItem& factor: _items)
+	for (const Term& term : terms())
 	{
-		if (factor.isLevel && !factor.isVirtual)
-			currentLevels.push_back(factor.value.toStdString());
-		else if (!currentLevels.empty())
+		if (list.empty())
 		{
-			allLevels.push_back(currentLevels);
-			currentLevels.clear();
-		}
-	}
-	
-	for (const string& level : allLevels[0])
-	{
-		vector<string> levelVector {level};
-		allLevelsCombinations.push_back(levelVector);
-	}
-	
-	for (uint i = 1; i < allLevels.size(); i++)
-	{
-		const vector<string>& levels = allLevels[i];
-		vector<vector<string> > previousLevelCombinations = allLevelsCombinations; // Copy it
-		allLevelsCombinations.clear();
-		
-		for (uint j = 0; j < previousLevelCombinations.size(); j++)
-		{
-			for (uint k = 0; k < levels.size(); k++)
+			for (const QString& level : getLevels(term.value()))
 			{
-				vector<string> previousLevels = previousLevelCombinations[j];
-				previousLevels.push_back(levels[k]);
-				allLevelsCombinations.push_back(previousLevels);
+				QStringList elt = {level};
+				list.append(elt);
 			}
-		}		
+		}
+		else
+		{
+			QList<QStringList> newList;
+			for (const QStringList& elt : list)
+			{
+				for (const QString& level : getLevels(term.value()))
+				{
+					QStringList newElt = elt;
+					newElt.append(level);
+					newList.append(newElt);
+				}
+			}
+
+			list = newList;
+		}
 	}
-	
-	_allLevelsCombinations.set(allLevelsCombinations, false);
+
+	return list;
 }
+
 
 QStringList ListModelFactorLevels::_getAllFactors() const
 {
@@ -208,6 +185,7 @@ void ListModelFactorLevels::itemChanged(int row, QVariant value)
 				// It the changed item was a virtual level, add after this one a virtual level.
 				beginInsertRows(QModelIndex(), row+1, row+1);
 				_items.insert(row + 1, FactorLevelItem(_factorLevelList->levelPlaceHolder(), true, true));
+				_setTerms(_getAllFactors());
 				endInsertRows();
 			}
 			else
@@ -220,14 +198,17 @@ void ListModelFactorLevels::itemChanged(int row, QVariant value)
 
 				_items.push_back(FactorLevelItem(_factorLevelList->levelPlaceHolder(), true, true)); // Virtual level
 				_items.push_back(FactorLevelItem(_factorLevelList->factorPlaceHolder(), true, false)); // Virtual factor
+				_setTerms(_getAllFactors());
 
 				endInsertRows();
 			}
 		}
 		else
+		{
+			_setTerms(_getAllFactors());
 			emit variableNamesChanged({ {oldVal, item.value} });
+		}
 
-		_setAllLevelsCombinations();
 	}
 
 	if (updateRow)
@@ -258,7 +239,8 @@ bool ListModelFactorLevels::_removeItem(int row)
 	beginRemoveRows(QModelIndex(), row, row + nbRowsToRemove - 1);
 	for (int i = 0; i < nbRowsToRemove; i++)
 		_items.removeAt(row);
-	_setAllLevelsCombinations();
+
+	_setTerms(_getAllFactors());
 	endRemoveRows();
 
 	return true;

--- a/QMLComponents/models/listmodelfactorlevels.h
+++ b/QMLComponents/models/listmodelfactorlevels.h
@@ -30,14 +30,13 @@ public:
 	
 	ListModelFactorLevels(JASPListControl* listView);
 	
-	int rowCount(const QModelIndex &parent = QModelIndex())						const override;
-	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole)			const override;
+	int					rowCount(const QModelIndex &parent = QModelIndex())												const override;
+	QVariant			data(const QModelIndex &index, int role = Qt::DisplayRole)										const override;
 	
-	void initFactors(const std::vector<std::pair<std::string, std::vector<std::string> > > &factors);
-	std::vector<std::pair<std::string, std::vector<std::string> > > getFactors() const;
-	const Terms& getLevels() const;
+	void				initFactors(const std::vector<std::pair<std::string, std::vector<std::string> > > &factors);
+	QStringList			getLevels(const QString& factor)																const;
+	QList<QStringList>	getCombinedLevels()																				const;
 
-	
 public slots:
 	void itemChanged(int row, QVariant value);
 	void itemRemoved(int row);
@@ -71,7 +70,6 @@ protected:
 	};
 
 	QList<FactorLevelItem>	_items;
-	Terms					_allLevelsCombinations;
 
 	QStringList			_getAllFactors()													const;
 	QString				_giveUniqueValue(const FactorLevelItem& item, const QString value)	const;

--- a/QMLComponents/models/listmodelmeasurescellsassigned.cpp
+++ b/QMLComponents/models/listmodelmeasurescellsassigned.cpp
@@ -30,21 +30,13 @@ ListModelMeasuresCellsAssigned::ListModelMeasuresCellsAssigned(JASPListControl* 
 {
 }
 
-void ListModelMeasuresCellsAssigned::initLevels(const Terms &levels, const Terms &variables, bool initVariables)
+void ListModelMeasuresCellsAssigned::initLevels(const QList<QStringList> &combinedLevels, const Terms &variables, bool initVariables)
 {
 	beginResetModel();
 	_levels.clear();
-	vector<vector<string> > allLevels = levels.asVectorOfVectors();
 
-	for (const vector<string>& levels : allLevels)
-	{
-		string concatLevels;
-		if (levels.size() > 0)
-			concatLevels = levels[0];
-		for (uint i = 1; i < levels.size(); i++)
-			concatLevels += "," + levels[i];
-		_levels.push_back(QString::fromStdString(concatLevels));
-	}
+	for (const QStringList& levels : combinedLevels)
+		_levels.push_back(levels.join(","));
 	
 	if (initVariables)
 		_setTerms(variables);

--- a/QMLComponents/models/listmodelmeasurescellsassigned.h
+++ b/QMLComponents/models/listmodelmeasurescellsassigned.h
@@ -38,7 +38,7 @@ public:
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)											override;
 	void			removeTerms(const QList<int>& indexes) override;
 
-	void			initLevels(const Terms& levels, const Terms &variables = Terms(), bool initVariables = false);
+	void			initLevels(const QList<QStringList>& levels, const Terms &variables = Terms(), bool initVariables = false);
 
 public slots:	
 	void			sourceTermsReset()																					override;


### PR DESCRIPTION
Add 2 properties to the FactorLevelList control :
. factors that gives all the factor names.
. factorLevelMap that gives all the levels for a given factor.

Also take advantage of this PR to remove _allLevelsCombinations member that caches the level combination needed by the Repeated Measures Cell control.

A test has been added in the Tab View analysis of the jaspTestModule