### PR TITLE
Check if jaspBase is available before calling registerFonts

### DIFF
--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -366,11 +366,16 @@ void STDCALL jaspRCPP_setFontAndPlotSettings(const char * resultFont, const int 
 {
 	auto rEnvironment = Rcpp::Environment::global_env();
 
-	rEnvironment[".resultFont"]			= resultFont;
+	rEnvironment[".resultFont"]				= resultFont;
 	rEnvironment[".imageBackground"]		= imageBackground;
 	rEnvironment[".ppi"]					= ppi;
-    // sometimes jaspBase is not available
-    jaspRCPP_parseEvalQNT("try(jaspBase:::registerFonts())");
+
+	// sometimes jaspBase is not available, check this using https://stackoverflow.com/a/38082613
+	std::string result = jaspRCPP_parseEvalStringReturn("if (nzchar(system.file(package = \"jaspBase\"))) \"ok\" else \"not ok\"");
+	if (result == "ok")
+		jaspRCPP_parseEvalQNT("jaspBase:::registerFonts()");
+	else
+		jaspRCPP_logString("jaspBase unavailable, did not call jaspBase:::registerFonts()\n");
 }
 
 const char* STDCALL jaspRCPP_runModuleCall(const char* name, const char* title, const char* moduleCall, const char* dataKey, const char* options,


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3382

Suppresses the error message ` Error in loadNamespace(x) : there is no package called ‘jaspBase’` by checking if jaspBase is available. jaspBase is not available when jasp is started and no modules have been loaded yet. It's probably better not to call `jaspRCPP_setFontAndPlotSettings` at this point at all, but that would require adjusting more logic.