### PR TITLE
Tweak to reset DevmodulePatch dir for Mac Dev module

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -164,7 +164,7 @@ ScrollView
 			{	
 				id:					cleanModulesFolder
 				text:				qsTr("Clear installed modules and packages")
-				toolTip:			qsTr("This will erase the 'renv' and 'Modules' folders in the appdata.")
+                toolTip:			qsTr("This will erase the 'renv', 'Modules' and development Module folders in the appdata.")
 				onClicked:			mainWindow.clearModulesFoldersUser();
 
 				KeyNavigation.tab:		useRemoteConf

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1753,6 +1753,11 @@ void MainWindow::clearModulesFoldersUser()
 	if(renvroot.exists())	renvroot.removeRecursively();
 	if(usermods.exists())	usermods.removeRecursively();
 
+#ifdef __APPLE__
+	QDir devModPatchDir(AppDirs::devModulePatchDir());
+	if(devModPatchDir.exists())	devModPatchDir.removeRecursively();
+#endif
+
 }
 
 /* the following does not seem to work: the new process crashes immediately... 

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -950,9 +950,9 @@ QString DynamicModule::patchLibPathHelperFunc(QString libpath) {
 
 
 	//remove pkgs no longer present in libpath from our patched libpath
-	auto patchedPath = std::filesystem::temp_directory_path() / devMod;
+	auto patchedPath = std::filesystem::path(AppDirs::devModulePatchDir().toStdString()) / devMod;
 	if(!std::filesystem::exists(patchedPath))
-		std::filesystem::create_directory(patchedPath);
+		std::filesystem::create_directories(patchedPath);
 
 	std::filesystem::path stdLibpath{libpath.toStdString()};
 	for (auto const& pkg : std::filesystem::directory_iterator{patchedPath}) {

--- a/QMLComponents/utilities/appdirs.cpp
+++ b/QMLComponents/utilities/appdirs.cpp
@@ -241,3 +241,13 @@ QString AppDirs::renvCacheLocations()
     return dynamicCache + separator + staticCache;
 	
 }
+
+#ifdef __APPLE__
+QString AppDirs::devModulePatchDir()
+{
+	QString path = appData();
+	path += "/_DevModulePatchDir/";
+
+	return path;
+}
+#endif

--- a/QMLComponents/utilities/appdirs.h.in
+++ b/QMLComponents/utilities/appdirs.h.in
@@ -49,6 +49,11 @@ public:
 	static QDir    programDir();
 	static QString renvRootLocation();
 	static QString renvCacheLocations();
+
+#ifdef __APPLE__
+	static QString devModulePatchDir();
+
+#endif
 	
 private:
 	static QString processPath(const QString & path);


### PR DESCRIPTION
Add an option to reset the patch folder by pressing the button under advanced prefs