### PR TITLE
enh: log more msg from Qt runtime

### DIFF
--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -401,6 +401,28 @@ void recursiveFileOpener(QFileInfo file, int & failures, int & total, int & time
 	}
 }
 
+void qtMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+	QByteArray localMsg = msg.toLocal8Bit();
+	const char *file	= context.file ? context.file : "";
+	const char *function = context.function ? context.function : "";
+
+	switch (type) {
+	case QtWarningMsg:
+		Log::log() << "Msg from Qt Warning: " << localMsg.constData() << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
+		break;
+	case QtCriticalMsg:
+		Log::log() << "Msg from Qt Critical: " << localMsg.constData() << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
+		break;
+	case QtFatalMsg:
+		Log::log() << "Msg from Qt Fatal: " << localMsg.constData() << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
+		break;
+	case QtDebugMsg:
+	case QtInfoMsg:
+		break;
+	}
+}
+
 int main(int argc, char *argv[])
 {
 	std::string filePath;
@@ -415,6 +437,8 @@ int main(int argc, char *argv[])
 	int			timeOut;
 	Json::Value	dbJson;
 
+	qInstallMessageHandler(qtMessageHandler);
+	
 	QCoreApplication::setOrganizationName("JASP");
 	QCoreApplication::setOrganizationDomain("jasp-stats.org");
 	QCoreApplication::setApplicationName("JASP");

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -403,19 +403,18 @@ void recursiveFileOpener(QFileInfo file, int & failures, int & total, int & time
 
 void qtMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-	QByteArray localMsg = msg.toLocal8Bit();
 	const char *file	= context.file ? context.file : "";
 	const char *function = context.function ? context.function : "";
 
 	switch (type) {
 	case QtWarningMsg:
-		Log::log() << "Msg from Qt Warning: " << localMsg.constData() << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
+		Log::log() << "Msg from Qt Warning: " << msg << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
 		break;
 	case QtCriticalMsg:
-		Log::log() << "Msg from Qt Critical: " << localMsg.constData() << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
+		Log::log() << "Msg from Qt Critical: " << msg << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
 		break;
 	case QtFatalMsg:
-		Log::log() << "Msg from Qt Fatal: " << localMsg.constData() << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
+		Log::log() << "Msg from Qt Fatal: " << msg << " [" << file << ":" << context.line << ", " << function << "]" << std::endl;
 		break;
 	case QtDebugMsg:
 	case QtInfoMsg:


### PR DESCRIPTION
To log more infomation from Qt runtime while running JASP. this may help us locate the error more.

This will of course increase the size of the log file, as there are warnings of partial duplicate writes, is this a burden on performance?