### PR TITLE
add pageup and pagedown to datatableview

### DIFF
--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -222,7 +222,40 @@ FocusScope
 						event.accepted = true;
 						mainWindowRoot.changeFocusToFileMenu();
 						break;
-
+									
+				
+				case Qt.Key_PageUp:
+					event.accepted = true;
+					if(shiftPressed)	contentX = Math.max(0, contentX - width)
+					else				contentY = Math.max(0, contentY - height)
+					break;
+								
+				case Qt.Key_PageDown:
+					event.accepted = true; 
+					if(shiftPressed)	contentX = Math.min(contentWidth  - width,  contentX + width)
+					else				contentY = Math.min(contentHeight - height, contentY + height)
+					break;
+				
+				case Qt.Key_Down:
+					event.accepted = true;
+					budgeDown();
+					break;
+				
+				case Qt.Key_Up:
+					event.accepted = true;
+					budgeUp();
+					break;
+				
+				case Qt.Key_Left:
+					event.accepted = true;
+					budgeLeft();
+					break;
+				
+				case Qt.Key_Right:
+					event.accepted = true;
+					budgeRight();
+					break;
+									
 				default:
 					event.accepted = false;
 					break;

--- a/Desktop/components/JASP/Widgets/DataTableViewEdit.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewEdit.qml
@@ -38,6 +38,10 @@ Item
 			var shiftPressed	= Boolean(event.modifiers & Qt.ShiftModifier  );
 			var arrowPressed	= false;
 			var arrowIndex;
+							
+			if(!itemEditable && (event.key == Qt.Key_Up || event.key == Qt.Key_Left || event.key == Qt.Key_Right || event.key == Qt.Key_Down))
+				return;
+					
 	
 			switch(event.key)
 			{

--- a/Desktop/components/JASP/Widgets/JASPDataView.qml
+++ b/Desktop/components/JASP/Widgets/JASPDataView.qml
@@ -32,8 +32,8 @@ FocusScope
 	readonly	property alias rowNumberWidth:			theView.rowNumberWidth
 	readonly	property alias headerHeight:			theView.headerHeight
 
-	readonly	property alias contentX:				myFlickable.contentX
-	readonly	property alias contentY:				myFlickable.contentY
+				property alias contentX:				myFlickable.contentX
+				property alias contentY:				myFlickable.contentY
 	readonly	property alias contentWidth:			myFlickable.contentWidth
 	readonly	property alias contentHeight:			myFlickable.contentHeight
 	readonly	property alias contentX0:				myFlickable.contentX
@@ -60,11 +60,16 @@ FocusScope
 	Keys.onDownPressed: 	(event) => { budgeDown();	event.accepted = true; }
 	Keys.onRightPressed:	(event) => { budgeRight();	event.accepted = true; }
 	
+	
+	
 	function budgeUp()		{ if(myFlickable.contentY0 > 0)							myFlickable.contentY = Math.max(0,												myFlickable.contentY - contentFlickSize) }
 	function budgeDown()	{ if(myFlickable.contentY1 < myFlickable.contentHeight)	myFlickable.contentY = Math.min(myFlickable.contentHeight - myFlickable.height,	myFlickable.contentY + contentFlickSize) }
 	function budgeLeft()	{ if(myFlickable.contentX0 > 0)							myFlickable.contentX = Math.max(0,												myFlickable.contentX - contentFlickSize) }
 	function budgeRight()	{ if(myFlickable.contentX1 < myFlickable.contentWidth)	myFlickable.contentX = Math.min(myFlickable.contentWidth  - myFlickable.width,	myFlickable.contentX + contentFlickSize) }
 	
+	
+	function budgePageUp()		{ if(myFlickable.contentY0 > 0)							myFlickable.contentY = Math.max(0,												myFlickable.contentY0 - myFlickable.height) }
+	function budgePageDown()	{ if(myFlickable.contentY1 < myFlickable.contentHeight)	myFlickable.contentY = Math.min(myFlickable.contentHeight - myFlickable.height,	myFlickable.contentY0 + myFlickable.height) }
 
 	function moveItemIntoView(item)
 	{
@@ -120,8 +125,11 @@ FocusScope
 		anchors.right:		vertiScroller.left
 		anchors.bottom:		horiScroller.top
 		
-		contentHeight:	theView.height
-		contentWidth:	theView.width
+		contentHeight:		theView.height
+		contentWidth:		theView.width
+		
+		onFlickStarted:		if(!__JASPDataViewRoot.activeFocus) 
+								__JASPDataViewRoot.forceActiveFocus()
 
 
 		DataSetView
@@ -159,6 +167,12 @@ FocusScope
 		cursorShape:		Qt.PointingHandCursor
         z:					-1000
         onDoubleClicked:    __JASPDataViewRoot.doubleClicked()
+		onPressed:			(event) => {
+			if(!__JASPDataViewRoot.activeFocus) 
+				__JASPDataViewRoot.forceActiveFocus()
+			
+			event.accepted = false;
+		} 
 	}
 
 	JASPScrollBar

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -321,8 +321,8 @@ Item
 			{
 				switch(event)
 				{
-				case Qt.Key_PageDown:	resultsView.runJavaScript("windows.pageDown();");	break;
-				case Qt.Key_PageUp:		resultsView.runJavaScript("windows.pageUp();");		break;
+				case Qt.Key_PageDown:	resultsView.runJavaScript("windows.pageDown();");	event.accepted=true; break;
+				case Qt.Key_PageUp:		resultsView.runJavaScript("windows.pageUp();");		event.accepted=true; break;
 				}
 			}
 


### PR DESCRIPTION
also force active focus on dataviewer on a press or a flick

this does however work after youve scrolled even a tiny bit so I guess this counts as a: fix for https://github.com/jasp-stats/jasp-issues/issues/3388

You can now use page up and down in the dataviewer(s) and pressing shift with it makes it scrolls horizontally

If you wonder where this button is on a mac: fn+option+up/down

