### PR TITLE
Fix Integer or double in a TextField

### DIFF
--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -125,8 +125,12 @@ void TextInputBase::bindTo(const Json::Value& value)
 	}
 		
 	default:
-		if (value.isString())	
+		if (value.isString())
 			_value = tq(value.asString());
+		else if (value.isInt())
+			_value = value.asInt();
+		else if (value.isDouble())
+			_value = value.asDouble();
 		break;
 	}
 


### PR DESCRIPTION
If a value is seen as an integer or a double, it is saved in the option as (json) integer or double. So it must be read as integer or double when reading a JASP file.