### PR TITLE
Infinite value in formula

### DIFF
--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -655,7 +655,7 @@ void AnalysisForm::setAnalysisUp()
 	bindTo(defaultOptions);
 	lockOptions();
 
-	blockValueChangeSignal(false, true);
+	blockValueChangeSignal(false, false);
 
 	_initialized = true;
 

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -655,7 +655,7 @@ void AnalysisForm::setAnalysisUp()
 	bindTo(defaultOptions);
 	lockOptions();
 
-	blockValueChangeSignal(false, false);
+	blockValueChangeSignal(false, true);
 
 	_initialized = true;
 

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -88,20 +88,31 @@ void TextInputBase::bindTo(const Json::Value& value)
 	}
 	case TextInputType::FormulaType:
 	{
-		_value = value.isString() ? tq(value.asString()) : value.isNumeric() ? value.asDouble() : QVariant();
-
 		// If it is already numeric, no need to parse it.
 		// This also avoid parsing infinite value: a QVariant with an infinite value gives "inf" as string value,
 		// which gives an error when parsed by R.
-		if (value.isNumeric())
-			setProperty("realValue", _value);
-		else
-		{
-			setIsRCode();
+		bool setRealValue = true;
 
-			if (!_value.isNull())
+		if (value.isNumeric())
+			_value = value.asDouble();
+		else if (value.isString())
+		{
+			double dblVal = 0;
+			QString strValue = tq(value.asString());
+			if (!strValue.isEmpty() && !QColumnUtils::getDoubleValue(strValue, dblVal))
+			{
+				setIsRCode();
 				runRScript("as.character(" + _value.toString() + ")", true);
+				setRealValue = false;
+			}
+			else
+				_value = dblVal;
 		}
+		else
+			_value = QVariant();
+
+		if (setRealValue)
+			setProperty("realValue", _value);
 
 		break;
 	}
@@ -446,7 +457,10 @@ void TextInputBase::_setBoundValue()
 {
 	if (_inputType == TextInputType::FormulaType)
 	{
-		if (_value.metaType().id() == QMetaType::Double)
+		double valueDbl = 0;
+		bool isDbl = QColumnUtils::getDoubleValue(_value.toString(), valueDbl);
+
+		if (isDbl)
 		{
 			setProperty("realValue", _value);
 			setBoundValue(_getJsonValue(_value));

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -253,6 +253,12 @@ void TextInputBase::rScriptDoneHandler(const QString &result)
 			setHasScriptError(true);
 			break;
 		}
+		else
+		{
+			clearControlError();
+			setHasScriptError(false);
+		}
+
 
 		if (!_formulaResultInBounds(val))
 		{
@@ -464,6 +470,9 @@ void TextInputBase::_setBoundValue()
 		{
 			setProperty("realValue", _value);
 			setBoundValue(_getJsonValue(_value));
+			clearControlError();
+			setHasScriptError(false);
+			emit formulaCheckSucceeded();
 		}
 		else
 		{

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -89,10 +89,19 @@ void TextInputBase::bindTo(const Json::Value& value)
 	case TextInputType::FormulaType:
 	{
 		_value = value.isString() ? tq(value.asString()) : value.isNumeric() ? value.asDouble() : QVariant();
-		setIsRCode();
 
-		if (!_value.isNull())
-			runRScript("as.character(" + _value.toString() + ")", true);
+		// If it is already numeric, no need to parse it.
+		// This also avoid parsing infinite value: a QVariant with an infinite value gives "inf" as string value,
+		// which gives an error when parsed by R.
+		if (value.isNumeric())
+			setProperty("realValue", _value);
+		else
+		{
+			setIsRCode();
+
+			if (!_value.isNull())
+				runRScript("as.character(" + _value.toString() + ")", true);
+		}
 
 		break;
 	}
@@ -437,19 +446,24 @@ void TextInputBase::_setBoundValue()
 {
 	if (_inputType == TextInputType::FormulaType)
 	{
-		QString strValue = _value.toString();
-
-		// _formula might be empty (in TableView the FormulaType is not directly bound, and has its own model).
-		if (boundValue().asString() != fq(strValue))
+		if (_value.metaType().id() == QMetaType::Double)
+			setProperty("realValue", _value);
+		else
 		{
-			if (!_parseDefaultValue && _defaultValue == _value)
+			QString strValue = _value.toString();
+
+			// _formula might be empty (in TableView the FormulaType is not directly bound, and has its own model).
+			if (boundValue().asString() != fq(strValue))
 			{
-				// The value is the same as the default value and this default value should not be parsed (this might be just a string like '...')
-				// So just set this value and emit that the formula is succesfully checked without running the R script.
-				setBoundValue(fq(strValue));
-				emit formulaCheckSucceeded();
+				if (!_parseDefaultValue && _defaultValue == _value)
+				{
+					// The value is the same as the default value and this default value should not be parsed (this might be just a string like '...')
+					// So just set this value and emit that the formula is succesfully checked without running the R script.
+					setBoundValue(fq(strValue));
+					emit formulaCheckSucceeded();
+				}
+				runRScript("as.character(" + strValue + ")", true);
 			}
-			runRScript("as.character(" + strValue + ")", true);
 		}
 	}
 	else setBoundValue(_getJsonValue(_value));

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -447,7 +447,10 @@ void TextInputBase::_setBoundValue()
 	if (_inputType == TextInputType::FormulaType)
 	{
 		if (_value.metaType().id() == QMetaType::Double)
+		{
 			setProperty("realValue", _value);
+			setBoundValue(_getJsonValue(_value));
+		}
 		else
 		{
 			QString strValue = _value.toString();


### PR DESCRIPTION
Cannot set infinity value in FormulaField
If you set per default an infinity value in a formula field, or if you set manually an inifinity value, you get an error, because it cannot be parsed by R.
But as the parsing in unnecessary when the value is already a double, just skip this parsing.
A new test (Test Input Field) is added in the jaspTestModule