### PR TITLE
fix row highlight width in LabelEditorWindow

### DIFF
--- a/Desktop/components/JASP/Widgets/LabelEditorWindow.qml
+++ b/Desktop/components/JASP/Widgets/LabelEditorWindow.qml
@@ -564,7 +564,7 @@ FocusScope
 					{
 						id:					selectionRectangle
 						color:				itemSelected ? jaspTheme.itemHighlight : "transparent"
-						width:				levelsTableView.width
+						width:				columnModel.rowWidth
 						anchors
 						{
 							top:			parent.top


### PR DESCRIPTION
This is minor but if label editor window with about 2 rows the highlight color width is not correct.