### PR TITLE
Try to make MD generation robust

### DIFF
--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -468,8 +468,9 @@ DropArea
 										{
 											if(formParent.myForm && helpModel.markdown !== formParent.myForm.helpMD)
 											{
+												helpModel.visible  = true;
 												helpModel.analysis	= formParent.myAnalysis;
-												helpModel.markdown  = Qt.binding(function(){ return formParent.myForm.helpMD; });
+												helpModel.markdown  = Qt.binding(function(){ return formParent.myForm ? formParent.myForm.helpMD : ""; });
 											}
 											else
 											{

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -968,10 +968,7 @@ QString AnalysisForm::helpMD() const
 	for(JASPControl * control : orderedControls)
 	{
 		if (control->hasInfoSomewhere())
-		{
-			control->setMDSubItems();
 			markdown << control->generateMDHelp() << "\n";
-		}
 	}
 
 	markdown << metaHelpMD();

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -961,14 +961,17 @@ QString AnalysisForm::helpMD() const
 
 
 	QList<JASPControl*> orderedControls = JASPControl::getChildJASPControls(this);
-	orderedControls.removeIf([](JASPControl* c) { return c->generateMDHelp().isEmpty(); });
 
 	if (orderedControls.length() > 0 && orderedControls[0]->controlType() != JASPControl::ControlType::Expander)
 		// If the first control is an Section, then it adds already a line
 		markdown << "\n---\n";
 
 	for(JASPControl * control : orderedControls)
-		markdown << control->generateMDHelp() << "\n";
+	{
+		JASPControl::MDItem mdItem = control->generateMDItems();
+		if (!mdItem.isEmpty())
+			markdown << mdItem.print() << "\n";
+	}
 
 	markdown << metaHelpMD();
 

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -959,7 +959,6 @@ QString AnalysisForm::helpMD() const
 		_info, "\n"
 	};
 
-
 	QList<JASPControl*> orderedControls = JASPControl::getChildJASPControls(this);
 
 	if (orderedControls.length() > 0 && orderedControls[0]->controlType() != JASPControl::ControlType::Expander)
@@ -968,9 +967,11 @@ QString AnalysisForm::helpMD() const
 
 	for(JASPControl * control : orderedControls)
 	{
-		JASPControl::MDItem mdItem = control->generateMDItems();
-		if (!mdItem.isEmpty())
-			markdown << mdItem.print() << "\n";
+		if (control->hasInfoSomewhere())
+		{
+			control->setMDSubItems();
+			markdown << control->generateMDHelp() << "\n";
+		}
 	}
 
 	markdown << metaHelpMD();

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -303,11 +303,11 @@ void ComboBoxBase::_setCurrentProperties(int index, bool bindValue)
 }
 
 
-QString	ComboBoxBase::generateMDHelp(int depth) const
+JASPControl::MDItem	ComboBoxBase::generateMDItems(int depth) const
 {
 	QStringList markdown;
 
-	printLabelMD(markdown, depth);
+	markdown << printLabelMD(depth);
 	markdown << info();
 
 	// If one of the option has an info property, then display the options as an unordered list
@@ -330,8 +330,9 @@ QString	ComboBoxBase::generateMDHelp(int depth) const
 		markdown << model()->terms().labels().join(", ");
 	}
 
+	markdown << "\n";
 
-	return markdown.join("") + "\n";
+	return markdown.join("");;
 }
 
 QString ComboBoxBase::generateDoxygenHelp() const

--- a/QMLComponents/controls/comboboxbase.cpp
+++ b/QMLComponents/controls/comboboxbase.cpp
@@ -303,7 +303,7 @@ void ComboBoxBase::_setCurrentProperties(int index, bool bindValue)
 }
 
 
-JASPControl::MDItem	ComboBoxBase::generateMDItems(int depth) const
+QString	ComboBoxBase::generateMDHelp(int depth) const
 {
 	QStringList markdown;
 
@@ -327,12 +327,12 @@ JASPControl::MDItem	ComboBoxBase::generateMDItems(int depth) const
 	{
 		markdown << "\n" << QString{depth * 2, ' '};
 		// Display the options in one line separated by a comma.
-		markdown << model()->terms().labels().join(", ");
+		markdown << tr("Possible values are: %1").arg(model()->terms().labels().join(", "));
 	}
 
 	markdown << "\n";
 
-	return markdown.join("");;
+	return markdown.join("");
 }
 
 QString ComboBoxBase::generateDoxygenHelp() const
@@ -373,9 +373,9 @@ bool ComboBoxBase::_hasOptionInfo() const
 	return false;
 }
 
-bool ComboBoxBase::hasInfo() const
+bool ComboBoxBase::hasInfoSomewhere() const
 {
-	return JASPControl::hasInfo() || _hasOptionInfo();
+	return JASPControl::hasInfoSomewhere() || _hasOptionInfo();
 }
 
 std::string ComboBoxBase::_findType(std::string value) const

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -47,7 +47,7 @@ public:
 	void				setUp()												override;
 	ListModel*			model()										const	override	{ return _model;				}
 	void				setUpModel()										override;
-	QString				generateMDHelp(int depth = 0)				const	override;
+	MDItem				generateMDItems(int depth = 0)				const	override;
 	QString				generateDoxygenHelp()						const	override;
 	bool				hasInfo()									const	override;
 	void				setBoundValue(const Json::Value &value, bool emitChanges = true)	override;

--- a/QMLComponents/controls/comboboxbase.h
+++ b/QMLComponents/controls/comboboxbase.h
@@ -47,9 +47,9 @@ public:
 	void				setUp()												override;
 	ListModel*			model()										const	override	{ return _model;				}
 	void				setUpModel()										override;
-	MDItem				generateMDItems(int depth = 0)				const	override;
+	QString				generateMDHelp(int depth = 0)				const	override;
 	QString				generateDoxygenHelp()						const	override;
-	bool				hasInfo()									const	override;
+	bool				hasInfoSomewhere()									const	override;
 	void				setBoundValue(const Json::Value &value, bool emitChanges = true)	override;
 
 	const QString&		currentLabel()								const				{ return _currentLabel;			}

--- a/QMLComponents/controls/expanderbuttonbase.cpp
+++ b/QMLComponents/controls/expanderbuttonbase.cpp
@@ -33,26 +33,35 @@ void ExpanderButtonBase::setUp()
 	setInitialized();
 }
 
-JASPControl::MDItem ExpanderButtonBase::generateMDItems(int depth) const
+QString ExpanderButtonBase::generateMDHelp(int depth) const
 {
-	if (!hasInfo())
+	if (!hasInfoSomewhere())
 		return QString();
 
-	MDItem mdItem = JASPControl::generateMDItems(0);
+	QStringList markdown;
 
-	// For sub-section, draw first a line, and reset the depth to 0.
-	if ((mdItem.label.isEmpty()) || depth > 0)
-		mdItem.label = "\n---\n\n" + mdItem.label;
-	else
-		mdItem.isSection = true;
+	if (!useCollapsibleSection(depth))
+		// For sub-section, draw first a line, and reset the depth to 0.
+		markdown <<  "\n---\n\n";
 
-	return mdItem;
+	markdown << JASPControl::generateMDHelp(0);
+
+	if (useCollapsibleSection(depth))
+		markdown << "\n</details>";
+
+	return markdown.join("");
 }
 
 QString ExpanderButtonBase::printLabelMD(int depth) const
 {
-	if (depth == 0)
-		return (infoLabel().isEmpty() ? title() : infoLabel()).trimmed();
+	if (useCollapsibleSection(depth))
+		// Use collapsible section
+		return "<details>\n<summary><b>" + fullLabel() + "</b></summary>\n";
 	else
 		return JASPControl::printLabelMD(depth);
+}
+
+bool ExpanderButtonBase::useCollapsibleSection(int depth) const
+{
+	return depth == 0 && !fullLabel().isEmpty();
 }

--- a/QMLComponents/controls/expanderbuttonbase.cpp
+++ b/QMLComponents/controls/expanderbuttonbase.cpp
@@ -33,21 +33,26 @@ void ExpanderButtonBase::setUp()
 	setInitialized();
 }
 
-QString ExpanderButtonBase::generateMDHelp(int depth) const
+JASPControl::MDItem ExpanderButtonBase::generateMDItems(int depth) const
 {
 	if (!hasInfo())
-		return "";
+		return QString();
 
-	QString label = (infoLabel().isEmpty() ? title() : infoLabel()).trimmed();
+	MDItem mdItem = JASPControl::generateMDItems(0);
+
 	// For sub-section, draw first a line, and reset the depth to 0.
-	if (label.isEmpty() || depth > 0)
-		return "\n---\n\n" + JASPControl::generateMDHelp(0);
+	if ((mdItem.label.isEmpty()) || depth > 0)
+		mdItem.label = "\n---\n\n" + mdItem.label;
+	else
+		mdItem.isSection = true;
 
-	// Use collapsible section
-	return "<details>\n<summary><b>" + label + "</b></summary>\n" + JASPControl::generateMDHelp(0) + "\n</details>";
+	return mdItem;
 }
 
-bool ExpanderButtonBase::printLabelMD(QStringList &md, int depth) const
+QString ExpanderButtonBase::printLabelMD(int depth) const
 {
-	return depth == 0 || JASPControl::printLabelMD(md, depth);
+	if (depth == 0)
+		return (infoLabel().isEmpty() ? title() : infoLabel()).trimmed();
+	else
+		return JASPControl::printLabelMD(depth);
 }

--- a/QMLComponents/controls/expanderbuttonbase.h
+++ b/QMLComponents/controls/expanderbuttonbase.h
@@ -31,9 +31,9 @@ class ExpanderButtonBase : public JASPControl
 public:
 	explicit ExpanderButtonBase(QQuickItem *parent = nullptr);
 
-	void	setUp()												override;
-	QString generateMDHelp(int depth)					const	override;
-	bool	printLabelMD(QStringList& md, int depth)	const	override;
+	void		setUp()															override;
+	MDItem		generateMDItems(int depth = 0)							const	override;
+	QString		printLabelMD(int depth)									const	override;
 	
 
 	bool infoLabelIsHeader()		const	override	{ return true; }

--- a/QMLComponents/controls/expanderbuttonbase.h
+++ b/QMLComponents/controls/expanderbuttonbase.h
@@ -32,11 +32,12 @@ public:
 	explicit ExpanderButtonBase(QQuickItem *parent = nullptr);
 
 	void		setUp()															override;
-	MDItem		generateMDItems(int depth = 0)							const	override;
+	QString		generateMDHelp(int depth = 0)							const	override;
 	QString		printLabelMD(int depth)									const	override;
-	
+	bool		infoLabelIsHeader()										const	override	{ return true; }
 
-	bool infoLabelIsHeader()		const	override	{ return true; }
+private:
+	bool useCollapsibleSection(int depth)								const;
 };
 
 #endif // EXPANDERBUTTONBASE_H

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -44,8 +44,8 @@ JASPControl::JASPControl(QQuickItem *parent) : QQuickItem(parent)
 
 	connect(this, &JASPControl::titleChanged,			this, &JASPControl::helpMDChanged);
 	connect(this, &JASPControl::infoChanged,			this, &JASPControl::helpMDChanged);
-	connect(this, &JASPControl::visibleChanged,			this, &JASPControl::helpMDChanged);
-	connect(this, &JASPControl::visibleChildrenChanged,	this, &JASPControl::helpMDChanged);
+	//connect(this, &JASPControl::visibleChanged,			this, &JASPControl::helpMDChanged);
+	//connect(this, &JASPControl::visibleChildrenChanged,	this, &JASPControl::helpMDChanged);
 	connect(this, &JASPControl::backgroundChanged,		[this] () { if (!_focusIndicator)		setFocusIndicator(_background); });
 	connect(this, &JASPControl::infoChanged,			[this] () { if (_toolTip.isEmpty())	setToolTip(info());					});
 	connect(this, &JASPControl::toolTipChanged,			[this] () { setShouldStealHover(!_toolTip.isEmpty());					});
@@ -322,9 +322,9 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 		if (childControl)
 		{
 			if (removeUnecessaryGroups && childControl->controlType() == ControlType::GroupBox && childControl->title().isEmpty() && childControl->infoLabel().isEmpty() && childControl->info().isEmpty())
-				// If a Group has no label, title or info, then it is used probably for layout purpose, but to structure the controls is sub elements.
+				// If a Group has no label, title or info, then it is used probably for layout purpose.
 				// Just skip it: this is necessary for generating properly the markdown help
-				result.append(getChildJASPControls(childControl));
+				result.append(getChildJASPControls(childControl, removeUnecessaryGroups));
 			else
 				result.push_back(childControl);
 		}
@@ -336,7 +336,7 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 			result.push_back(expanderButton);
 		}
 		else
-			result.append(getChildJASPControls(childItem));
+			result.append(getChildJASPControls(childItem, removeUnecessaryGroups));
 	}
 
 	return result;
@@ -569,12 +569,13 @@ bool JASPControl::hasInfo() const
 	return false;
 }
 
-bool JASPControl::printLabelMD(QStringList& md, int depth) const
+QString JASPControl::printLabelMD(int depth) const
 {
 	QString label = (infoLabel().isEmpty() ? title() : infoLabel()).trimmed();
 	if(label.isEmpty() && !infoAddControlType())
-		return false;
+		return QString();
 
+	QStringList md;
 	// Print the label as a header, in italic or in bold
 	if (infoLabelIsHeader())			md << "<h" << QString::number(depth + 3) << ">";
 	else if	(infoLabelItalic())			md << "*";
@@ -593,44 +594,56 @@ bool JASPControl::printLabelMD(QStringList& md, int depth) const
 		md << " ";
 	}
 
-	return true;
+	return md.join("");
 }
 
-QString JASPControl::generateMDHelp(int depth) const
+JASPControl::MDItem JASPControl::generateMDItems(int depth) const
 {
-	if (!hasInfo()) return "";
-		
-	QStringList childMDs, markdown;
+	MDItem mdItem;
+
+	if (!hasInfo()) return mdItem;
+
+	mdItem.label = printLabelMD(depth);
+	mdItem.info = info();
 
 	for (JASPControl* childControl : getChildJASPControls(_childControlsArea ? _childControlsArea : this, true))
 	{
-		QString childMD = childControl->generateMDHelp(depth + 1);
-		if (!childMD.isEmpty())
-			childMDs.push_back(childMD);
+		MDItem childMD = childControl->generateMDItems(depth + 1);
+		if (!childMD.hasHeader())
+			// The child does not have label nor info: just add its own children to the parent
+			mdItem.children.insert(mdItem.children.end(), childMD.children.begin(), childMD.children.end());
+		else if (!childMD.isEmpty())
+			mdItem.children.push_back(childMD);
 	}
 
-	bool hasLabel = printLabelMD(markdown, depth);
-	markdown << info() << "\n";
+	return mdItem;
+}
 
-	if (infoLabelIsHeader() && !info().isEmpty())
-		markdown << "\n"; // Special case when a header has no info (a Section without info eg).
-
-	if (childMDs.length() == 1)
-		markdown << QString{depth * 2, ' '} << childMDs[0];
+QString JASPControl::MDItem::print(int depth) const
+{
+	QStringList markdown;
+	if (depth == 0 && isSection)
+		// Use collapsible section
+		markdown << "<details>\n<summary><b>" << label << "</b></summary>\n";
 	else
+		markdown << label;
+
+	markdown << info << "\n";
+
+	if (children.size() == 1)
+		markdown << "\n" << QString{depth * 2, ' '} << children[0].print(depth + 1);
+	else if (children.size() > 1)
 	{
-		for (const QString& childMD : childMDs)
-		{
-			markdown << QString{depth * 2, ' '};
-			if (hasLabel)
-				markdown << "- "; // Add bullet list
-			markdown << childMD;
-			if (!hasLabel)
-				markdown << "\n"; // If no bullet list is used, markdown needs an extra '\n' to display a new line
-		}
+		markdown << "\n"; // Before adding bullets, a new line is needed
+		for (const auto& childMD : children)
+			markdown << QString{depth * 2, ' '} << "- " << childMD.print(depth + 1);
 	}
 
-	return markdown.join("");;
+	if (depth == 0 && isSection)
+		markdown << "\n</details>";
+
+
+	return markdown.join("");
 }
 
 QString JASPControl::generateDoxygenHelp() const
@@ -858,4 +871,4 @@ void JASPControl::_setInitialized(const Json::Value &value)
 	_initialized = true;
 	_initializedWithValue = (value != Json::nullValue);
 	emit initializedChanged();
-}		
+}

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -602,37 +602,40 @@ bool JASPControl::hasLabelOrInfo() const
 	return !fullLabel().isEmpty() || !info().isEmpty();
 }
 
-void JASPControl::setMDSubItems()
+std::vector<JASPControl*> JASPControl::getMDSubItems() const
 {
-	_MDSubItems.clear();
+	std::vector<JASPControl*> MDSubItems;
 
 	for (JASPControl* childControl : getChildJASPControls(_childControlsArea ? _childControlsArea : this, true))
 	{
 		// In case of RadioButtonGroup, if at least one of the RadioButton has info, then all RadioButtons should be listed even if they don't have any info
 		if (childControl->hasInfoSomewhere() || (controlType() == ControlType::RadioButtonGroup && childControl->controlType() == ControlType::RadioButton))
 		{
-			childControl->setMDSubItems();
+			std::vector<JASPControl*> MDGrandChilren = childControl->getMDSubItems();
 
 			if (!childControl->hasLabelOrInfo())
 				// The child does not have label nor info: just add its own children to the parent
-				_MDSubItems.insert(_MDSubItems.end(), childControl->MDSubItems().begin(), childControl->MDSubItems().end());
+				MDSubItems.insert(MDSubItems.end(), MDGrandChilren.begin(), MDGrandChilren.end());
 			else
-				_MDSubItems.push_back(childControl);
+				MDSubItems.push_back(childControl);
 		}
 	}
+
+	return MDSubItems;
 }
 
 QString JASPControl::generateMDHelp(int depth) const
 {
+	std::vector<JASPControl*> MDSubItems = getMDSubItems();
 	QStringList markdown;
 	markdown << printLabelMD(depth) << info() << "\n";
 
-	if (_MDSubItems.size() == 1)
-		markdown << "\n" << QString{depth * 2, ' '} << _MDSubItems[0]->generateMDHelp(depth + 1);
-	else if (_MDSubItems.size() > 1)
+	if (MDSubItems.size() == 1)
+		markdown << "\n" << QString{depth * 2, ' '} << MDSubItems[0]->generateMDHelp(depth + 1);
+	else if (MDSubItems.size() > 1)
 	{
 		markdown << "\n"; // Before adding bullets, a new line is needed
-		for (const auto& childMD : _MDSubItems)
+		for (const auto& childMD : MDSubItems)
 			markdown << QString{depth * 2, ' '} << "- " << childMD->generateMDHelp(depth + 1);
 	}
 

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -321,7 +321,7 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 
 		if (childControl)
 		{
-			if (removeUnecessaryGroups && childControl->controlType() == ControlType::GroupBox && childControl->title().isEmpty() && childControl->infoLabel().isEmpty() && childControl->info().isEmpty())
+			if (removeUnecessaryGroups && childControl->controlType() == ControlType::GroupBox && !childControl->hasLabelOrInfo())
 				// If a Group has no label, title or info, then it is used probably for layout purpose.
 				// Just skip it: this is necessary for generating properly the markdown help
 				result.append(getChildJASPControls(childControl, removeUnecessaryGroups));
@@ -559,19 +559,19 @@ QString JASPControl::ControlTypeToFriendlyString(ControlType controlType)
 	}
 }
 
-bool JASPControl::hasInfo() const
+bool JASPControl::hasInfoSomewhere() const
 {
 	if(!info().isEmpty()) return true;
 
 	for (JASPControl* control : getChildJASPControls(_childControlsArea ? _childControlsArea : this))
-		if (control->hasInfo()) return true;
+		if (control->hasInfoSomewhere()) return true;
 
 	return false;
 }
 
 QString JASPControl::printLabelMD(int depth) const
 {
-	QString label = (infoLabel().isEmpty() ? title() : infoLabel()).trimmed();
+	QString label = fullLabel();
 	if(label.isEmpty() && !infoAddControlType())
 		return QString();
 
@@ -597,51 +597,44 @@ QString JASPControl::printLabelMD(int depth) const
 	return md.join("");
 }
 
-JASPControl::MDItem JASPControl::generateMDItems(int depth) const
+bool JASPControl::hasLabelOrInfo() const
 {
-	MDItem mdItem;
+	return !fullLabel().isEmpty() || !info().isEmpty();
+}
 
-	if (!hasInfo()) return mdItem;
-
-	mdItem.label = printLabelMD(depth);
-	mdItem.info = info();
+void JASPControl::setMDSubItems()
+{
+	_MDSubItems.clear();
 
 	for (JASPControl* childControl : getChildJASPControls(_childControlsArea ? _childControlsArea : this, true))
 	{
-		MDItem childMD = childControl->generateMDItems(depth + 1);
-		if (!childMD.hasHeader())
-			// The child does not have label nor info: just add its own children to the parent
-			mdItem.children.insert(mdItem.children.end(), childMD.children.begin(), childMD.children.end());
-		else if (!childMD.isEmpty())
-			mdItem.children.push_back(childMD);
-	}
+		// In case of RadioButtonGroup, if at least one of the RadioButton has info, then all RadioButtons should be listed even if they don't have any info
+		if (childControl->hasInfoSomewhere() || (controlType() == ControlType::RadioButtonGroup && childControl->controlType() == ControlType::RadioButton))
+		{
+			childControl->setMDSubItems();
 
-	return mdItem;
+			if (!childControl->hasLabelOrInfo())
+				// The child does not have label nor info: just add its own children to the parent
+				_MDSubItems.insert(_MDSubItems.end(), childControl->MDSubItems().begin(), childControl->MDSubItems().end());
+			else
+				_MDSubItems.push_back(childControl);
+		}
+	}
 }
 
-QString JASPControl::MDItem::print(int depth) const
+QString JASPControl::generateMDHelp(int depth) const
 {
 	QStringList markdown;
-	if (depth == 0 && isSection)
-		// Use collapsible section
-		markdown << "<details>\n<summary><b>" << label << "</b></summary>\n";
-	else
-		markdown << label;
+	markdown << printLabelMD(depth) << info() << "\n";
 
-	markdown << info << "\n";
-
-	if (children.size() == 1)
-		markdown << "\n" << QString{depth * 2, ' '} << children[0].print(depth + 1);
-	else if (children.size() > 1)
+	if (_MDSubItems.size() == 1)
+		markdown << "\n" << QString{depth * 2, ' '} << _MDSubItems[0]->generateMDHelp(depth + 1);
+	else if (_MDSubItems.size() > 1)
 	{
 		markdown << "\n"; // Before adding bullets, a new line is needed
-		for (const auto& childMD : children)
-			markdown << QString{depth * 2, ' '} << "- " << childMD.print(depth + 1);
+		for (const auto& childMD : _MDSubItems)
+			markdown << QString{depth * 2, ' '} << "- " << childMD->generateMDHelp(depth + 1);
 	}
-
-	if (depth == 0 && isSection)
-		markdown << "\n</details>";
-
 
 	return markdown.join("");
 }

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -306,7 +306,7 @@ void JASPControl::clearControlError()
 		_form->clearControlError(this);
 }
 
-QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, bool removeUnecessaryGroups)
+QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, bool collapseStructuralControls)
 {
 	QList<JASPControl*> result;
 
@@ -321,10 +321,10 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 
 		if (childControl)
 		{
-			if (removeUnecessaryGroups && childControl->controlType() == ControlType::GroupBox && !childControl->hasLabelOrInfo())
+			if (collapseStructuralControls && childControl->controlType() == ControlType::GroupBox && !childControl->hasLabelOrInfo())
 				// If a Group has no label, title or info, then it is used probably for layout purpose.
 				// Just skip it: this is necessary for generating properly the markdown help
-				result.append(getChildJASPControls(childControl, removeUnecessaryGroups));
+				result.append(getChildJASPControls(childControl, collapseStructuralControls));
 			else
 				result.push_back(childControl);
 		}
@@ -336,7 +336,7 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 			result.push_back(expanderButton);
 		}
 		else
-			result.append(getChildJASPControls(childItem, removeUnecessaryGroups));
+			result.append(getChildJASPControls(childItem, collapseStructuralControls));
 	}
 
 	return result;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -161,7 +161,7 @@ public:
 	QVector<JASPControl::ParentKey>	getParentKeys();
 
 	static QString					ControlTypeToFriendlyString(ControlType controlType);
-	static QList<JASPControl*>		getChildJASPControls(const QQuickItem* item, bool removeUnecessaryGroups = false);
+	static QList<JASPControl*>		getChildJASPControls(const QQuickItem* item, bool collapseStructuralControls = false);
 
 	virtual void					setUp()										{}
 	void							setInitialized(const Json::Value& value = Json::nullValue);

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -63,24 +63,6 @@ public:
 			: name(_name), key(_key), value(_value) {}
 	};
 
-	typedef struct MDItem
-	{
-		bool						isSection = false;
-		QString						label,
-									info;
-		std::vector<struct MDItem>	children;
-
-		MDItem() {}
-		MDItem(const QString& _label) : label{_label} {}
-
-		bool	isEmpty()	{ return label.isEmpty() && info.isEmpty() && children.size() == 0; }
-		bool	hasHeader()	{ return !label.isEmpty() || !info.isEmpty(); }
-
-		QString print(int depth = 0) const;
-
-
-	} MDItem;
-
 	// Any addition here should also be added manually to ControlTypeToFriendlyString... I couldnt get this to work with DECLARE_ENUM...
 	enum class ControlType {
 		  DefaultControl
@@ -131,14 +113,16 @@ public:
 	QString				title()						const	{ return _title;					}
 	QString				info()						const	{ return _info;						}
 	QString				infoLabel()					const	{ return _infoLabel;				}
+	QString				fullLabel()					const	{ return (infoLabel().isEmpty() ? title() : infoLabel()).trimmed(); }
 	virtual bool		infoAddControlType()		const	{ return  false;					}
 	virtual bool		infoLabelIsHeader()			const	{ return  false;					}
 	virtual bool		infoLabelItalic()			const	{ return  false;					}
 
 	QString				toolTip()					const	{ return _toolTip;					}
-	virtual MDItem		generateMDItems(int depth = 0) const;
+	void				setMDSubItems();
+	virtual QString		generateMDHelp(int depth = 0) const;
 	virtual QString		generateDoxygenHelp()		const;
-	virtual bool		hasInfo()					const;
+	virtual bool		hasInfoSomewhere()					const;
 	bool				isBound()					const	{ return _isBound;					}
 	bool				nameIsOptionValue()			const	{ return _nameIsOptionValue;		}
 	bool				indent()					const	{ return _indent;					}
@@ -196,6 +180,8 @@ public:
 
 	virtual QString					friendlyName() const;
 	void							addExplicitDependency();
+	const std::vector<JASPControl*>& MDSubItems() const { return _MDSubItems; }
+	bool							hasLabelOrInfo() const;
 
 public slots:
 	void	setControlType(			ControlType			controlType)		{ _controlType = controlType; }
@@ -335,6 +321,7 @@ protected:
 	QVariant				_explicitDepends;
 	QString					_info,
 							_infoLabel;
+	std::vector<JASPControl*>	_MDSubItems;
 
 
 	static QMap<QQmlEngine*, QQmlComponent*>		_mouseAreaComponentMap;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -63,6 +63,24 @@ public:
 			: name(_name), key(_key), value(_value) {}
 	};
 
+	typedef struct MDItem
+	{
+		bool						isSection = false;
+		QString						label,
+									info;
+		std::vector<struct MDItem>	children;
+
+		MDItem() {}
+		MDItem(const QString& _label) : label{_label} {}
+
+		bool	isEmpty()	{ return label.isEmpty() && info.isEmpty() && children.size() == 0; }
+		bool	hasHeader()	{ return !label.isEmpty() || !info.isEmpty(); }
+
+		QString print(int depth = 0) const;
+
+
+	} MDItem;
+
 	// Any addition here should also be added manually to ControlTypeToFriendlyString... I couldnt get this to work with DECLARE_ENUM...
 	enum class ControlType {
 		  DefaultControl
@@ -118,7 +136,7 @@ public:
 	virtual bool		infoLabelItalic()			const	{ return  false;					}
 
 	QString				toolTip()					const	{ return _toolTip;					}
-	virtual QString		generateMDHelp(int depth = 0)	const;
+	virtual MDItem		generateMDItems(int depth = 0) const;
 	virtual QString		generateDoxygenHelp()		const;
 	virtual bool		hasInfo()					const;
 	bool				isBound()					const	{ return _isBound;					}
@@ -271,7 +289,7 @@ protected:
 	void				_addExplicitDependency(const QVariant& depends);
 	bool				dependingControlsAreInitialized();
 	virtual void		_setInitialized(const Json::Value &value);
-	virtual bool		printLabelMD(QStringList& md, int depth)			const;
+	virtual QString		printLabelMD(int depth)								const;
 
 protected:
 	Set						_depends;

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -119,7 +119,7 @@ public:
 	virtual bool		infoLabelItalic()			const	{ return  false;					}
 
 	QString				toolTip()					const	{ return _toolTip;					}
-	void				setMDSubItems();
+	std::vector<JASPControl*> getMDSubItems()		const;
 	virtual QString		generateMDHelp(int depth = 0) const;
 	virtual QString		generateDoxygenHelp()		const;
 	virtual bool		hasInfoSomewhere()					const;
@@ -180,7 +180,6 @@ public:
 
 	virtual QString					friendlyName() const;
 	void							addExplicitDependency();
-	const std::vector<JASPControl*>& MDSubItems() const { return _MDSubItems; }
 	bool							hasLabelOrInfo() const;
 
 public slots:
@@ -321,8 +320,6 @@ protected:
 	QVariant				_explicitDepends;
 	QString					_info,
 							_infoLabel;
-	std::vector<JASPControl*>	_MDSubItems;
-
 
 	static QMap<QQmlEngine*, QQmlComponent*>		_mouseAreaComponentMap;
 	static QByteArray								_mouseAreaDef;


### PR DESCRIPTION
Sub items that do not have labels or info, should be set at the same level as their parents. For this, the hierarchy of the items should be kept, before generating the MD string.

