### PR TITLE
fix analyses without data the easy way

### DIFF
--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -424,9 +424,6 @@ void EngineSync::process()
 
 	processSettingsChanged();
 	
-	if(!DataSetPackage::pkg()->isLoaded())
-		return;
-	
 	if(!anEngineIsLoadingData)
 		processFilterScript();
 		


### PR DESCRIPTION
@RensDofferhoff suggested just removing this line and it sure is an easy way to go back to how it worked before.