### PR TITLE
Variety of QoL stuff

### DIFF
--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -29,7 +29,7 @@ Window
 	width:				1280
 	height:				720
 	flags:				Qt.Window | Qt.WindowFullscreenButtonHint
-	color:				jaspTheme.white
+	color:				mainwWindow.hadFatalError ? jaspTheme.red : jaspTheme.white
 	minimumWidth:		jaspTheme.formWidth + 2 * jaspTheme.splitHandleWidth + jaspTheme.scrollbarBoxWidthBig + 3
 	minimumHeight:		400 * jaspTheme.uiScale
 	visibility:			!preferencesModel.startMaximized ? Window.Windowed : Window.Maximized
@@ -90,6 +90,15 @@ Window
 	Item
 	{
 		anchors.fill:	parent
+		
+		Rectangle
+		{
+			z:				1
+			visible:		mainWindow.hadFatalError
+			color:			jaspTheme.red
+			opacity:		0.75
+			anchors.fill:	parent
+		}
 
 		Shortcut { onActivated: mainWindow.showEnginesWindow();					sequences: ["Ctrl+Alt+Shift+E"];								context: Qt.ApplicationShortcut; }
 		Shortcut { onActivated: mainWindow.saveKeyPressed();					sequences: ["Ctrl+S", Qt.Key_Save];								context: Qt.ApplicationShortcut; }

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -932,22 +932,7 @@ void EngineSync::startExtraEngines(size_t num)
 }
 
 
-#ifdef _WIN32 
-///Overwrites the PATH with a simple clean one
-void EngineSync::fixPATHForWindows(QProcessEnvironment & env)
-{
-	const QString R_ARCH =
-#ifdef _WIN64
-		"x64";
-#else
-		"i386";
-#endif
-	
-	env.insert("PATH", AppDirs::programDir().absolutePath() + ";" + QDir(AppDirs::rHome()).absoluteFilePath("bin") + ";" + QDir(AppDirs::rHome()).absoluteFilePath("bin/" + R_ARCH)); // + rtoolsInPath); 
 
-	Log::log() << "Windows PATH was changed to: '" << env.value("PATH", "???") << "'" << std::endl;
-}
-#endif 
 
 
 //Should this function go to EngineRepresentation?
@@ -965,7 +950,7 @@ QProcess * EngineSync::startSlaveProcess(int channel)
 	QProcessEnvironment env = ProcessHelper::getProcessEnvironmentForJaspEngine();
 
 #ifdef _WIN32
-	fixPATHForWindows(env);
+	ProcessHelper::fixPATHForWindows(env);
 #endif
 	
 	env.insert("GITHUB_PAT", PreferencesModel::prefs()->githubPatResolved());

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -121,19 +121,21 @@ bool runJaspEngineJunctionFixer(int argc, char *argv[], bool removeJunctions = f
 #endif
 
 
-void parseArguments(int argc, char *argv[], std::string & filePath, bool & newData, bool & unitTest, bool & dirTest, int & timeOut, bool & save, bool & logToFile, bool & hideJASP, bool & safeGraphics, Json::Value & dbJson, QString & reportingDir)
+void parseArguments(int argc, char *argv[], std::string & filePath, bool & newData, bool & unitTest, bool & dirTest, int & timeOut, bool & save, bool & logToFile, bool & hideJASP, bool & safeGraphics, bool & containerSettingForced, bool & container, Json::Value & dbJson, QString & reportingDir)
 {
-	filePath		= "";
-	unitTest		= false;
-	dirTest			= false;
-	save			= false;
-	logToFile		= false;
-	hideJASP		= false;
-	safeGraphics	= false;
-	newData			= false;
-	reportingDir	= "";
-	timeOut			= 10;
-	dbJson			= Json::nullValue;
+	filePath				= "";
+	unitTest				= false;
+	dirTest					= false;
+	save					= false;
+	logToFile				= false;
+	hideJASP				= false;
+	safeGraphics			= false;
+	newData					= false;
+	containerSettingForced	= false;
+	container				= false;
+	reportingDir			= "";
+	timeOut					= 10;
+	dbJson					= Json::nullValue;
 
 	bool letsExplainSomeThings = false;
 
@@ -148,6 +150,8 @@ void parseArguments(int argc, char *argv[], std::string & filePath, bool & newDa
 		else if(args[arg] == "--safeGraphics")					safeGraphics			= true;
 		else if(args[arg] == "--newData")						newData					= true;
 #ifdef _WIN32
+		else if(args[arg] == "--sandbox")			{			containerSettingForced	= true;		container = true; }
+		else if(args[arg] == "--noSandbox")			{			containerSettingForced	= true;		container = false; }
 		else if(args[arg] == junctionArg)						runJaspEngineJunctionFixer(argc, argv, false); //Run the junctionfixer, it will exit the application btw!
 		else if(args[arg] == removeJunctionsArg)				runJaspEngineJunctionFixer(argc, argv, true);  //Remove the junctions
 #endif
@@ -319,6 +323,7 @@ void parseArguments(int argc, char *argv[], std::string & filePath, bool & newDa
 					<< "If --report is specified then JASP will be started in reporting mode, which requires a path to where you would like to store the results. This is usually used in conjunction with a service/daemon and in that case it might make sense to also pass --hide. Don't forget to also pass a jasp filename otherwise it won't have anything to run...\n"
 			   #ifdef _WIN32
 					<< "If --junctions is specified JASP will recreate the junctions in Modules/ to renv-cache/, this needs to be done at least once after install, but is usually triggered automatically."
+					<< "In case one really wants the engines to be sandboxed specify --sandbox, otherwise use --noSandbox."
 			   #endif
 					<< "This text will be shown when either --help or -h is specified or something else that JASP does not understand is given as argument.\n"
 					<< std::flush;
@@ -432,6 +437,8 @@ int main(int argc, char *argv[])
 				logToFile,
 				hideJASP,
 				safeGraphics,
+				containForce,
+				contain,
 				newData;
 	int			timeOut;
 	Json::Value	dbJson;
@@ -442,10 +449,13 @@ int main(int argc, char *argv[])
 	QCoreApplication::setOrganizationDomain("jasp-stats.org");
 	QCoreApplication::setApplicationName("JASP");
 
-	parseArguments(argc, argv, filePath, newData, unitTest, dirTest, timeOut, save, logToFile, hideJASP, safeGraphics, dbJson, reportingDir);
+	parseArguments(argc, argv, filePath, newData, unitTest, dirTest, timeOut, save, logToFile, hideJASP, safeGraphics, containForce, contain, dbJson, reportingDir);
 
 	if(safeGraphics)		Settings::setValue(Settings::SAFE_GRAPHICS_MODE, true);
 	else					safeGraphics = Settings::value(Settings::SAFE_GRAPHICS_MODE).toBool();
+	
+	if(containForce)		Settings::setValue(Settings::ENGINE_SANDBOX,	contain);
+	else					contain = Settings::value(Settings::ENGINE_SANDBOX).toBool();
 
 	if(reportingDir!="")	Settings::setValue(Settings::REPORT_SHOW, true);
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1559,6 +1559,8 @@ void MainWindow::openGitHubBugReport() const
 	{
 		MessageForwarder::showWarning(tr("GitHub couldn't be openend for you"), tr("Something went wrong with leading you to GitHub..\nYou can still report the bug by going to https://github.com/jasp-stats/jasp-issues/issues"));
 	}
+	
+	emit exitSignal(1);
 }
 
 void MainWindow::fatalError()
@@ -1568,9 +1570,29 @@ void MainWindow::fatalError()
 	if (exiting == false)
 	{
 		exiting = true;
-		if(MessageForwarder::showYesNo(tr("Error"), tr("JASP has experienced an unexpected internal error:\n%1").arg(_fatalError) + "\n\n" +
-			tr("JASP had a serious error and cannot calculate anymore.\n\nWe would be grateful if you could report this error to the JASP team."), tr("Report"), tr("Exit")))
+		MessageForwarder::DialogResponse response = MessageForwarder::showYesNoCancel(
+					tr("Error"), 
+					tr("JASP has experienced an unexpected internal error:\n%1").arg(_fatalError) + "\n\n" +
+					tr("JASP had a serious error and cannot calculate anymore.\n\nWe would be grateful if you could report this error to the JASP team."), 
+					tr("Report"), tr("Salvage"), tr("Exit"));
+		
+		switch(response)
+		{
+		case MessageForwarder::DialogResponse::Yes:
 			openGitHubBugReport();
+			break;
+			
+		case MessageForwarder::DialogResponse::Cancel:
+			exit(2);
+			break;
+			
+		default:
+			break;
+		}
+		
+		
+		_hadFatalError = true;
+		emit hadFatalErrorChanged();
 	}
 }
 
@@ -2164,3 +2186,8 @@ void MainWindow::loadModulesFromUserConfiguration(configState state)
 	}
 }
 
+
+bool MainWindow::hadFatalError() const
+{
+	return _hadFatalError;
+}

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1554,13 +1554,10 @@ void MainWindow::openGitHubBugReport() const
 
 		if(openBrowseFolder)
 			showLogFolder();
-
-		emit exitSignal(1);
 	}
 	catch(...)
 	{
 		MessageForwarder::showWarning(tr("GitHub couldn't be openend for you"), tr("Something went wrong with leading you to GitHub..\nYou can still report the bug by going to https://github.com/jasp-stats/jasp-issues/issues"));
-		emit exitSignal(1);
 	}
 }
 
@@ -1572,10 +1569,8 @@ void MainWindow::fatalError()
 	{
 		exiting = true;
 		if(MessageForwarder::showYesNo(tr("Error"), tr("JASP has experienced an unexpected internal error:\n%1").arg(_fatalError) + "\n\n" +
-			tr("JASP cannot continue and will close.\n\nWe would be grateful if you could report this error to the JASP team."), tr("Report"), tr("Exit")))
+			tr("JASP had a serious error and cannot calculate anymore.\n\nWe would be grateful if you could report this error to the JASP team."), tr("Report"), tr("Exit")))
 			openGitHubBugReport();
-		else
-			emit exitSignal(2);
 	}
 }
 

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -91,6 +91,7 @@ class MainWindow : public QObject
 	Q_PROPERTY(QString		contactUrlBugs		READ contactUrlBugs											CONSTANT							)
 	Q_PROPERTY(QString		contactText			READ contactText											NOTIFY contactTextChanged			)
 	Q_PROPERTY(QString		questionsUrl		READ questionsUrl											CONSTANT							)
+	Q_PROPERTY(bool			hadFatalError		READ hadFatalError											NOTIFY hadFatalErrorChanged			)
 
 	friend class FileMenu;
 public:
@@ -129,6 +130,8 @@ public:
 	const QString 		contactText()			const;
 	const QString		questionsUrl()			const { return "https://forum.cogsci.nl/index.php?p=/categories/jasp-bayesfactor"; }
 
+	bool hadFatalError() const;
+	
 public slots:
 	void setImageBackgroundHandler(QString value);
 	void plotPPIChangedHandler(int ppi, bool wasUserAction);
@@ -249,6 +252,8 @@ signals:
 	void resizeData(int row, int col);
 	void qmlLoadedChanged();
 
+	void hadFatalErrorChanged();
+	
 private slots:
 	void resultsPageLoaded();
 	void analysisResultsChangedHandler(Analysis* analysis);
@@ -353,7 +358,8 @@ private:
 									_welcomePageVisible		= true,
 									_checkAutomaticSync		= false,
 									_contactVisible			= false,
-									_communityVisible		= false;
+									_communityVisible		= false,
+									_hadFatalError			= false;
 									
 	QFont							_defaultFont;
 };

--- a/Desktop/utilities/processhelper.cpp
+++ b/Desktop/utilities/processhelper.cpp
@@ -115,3 +115,20 @@ QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool bootS
 
 	return(env);	
 }
+
+#ifdef _WIN32 
+///Overwrites the PATH with a simple clean one
+void ProcessHelper::fixPATHForWindows(QProcessEnvironment & env)
+{
+	const QString R_ARCH =
+#ifdef _WIN64
+		"x64";
+#else
+		"i386";
+#endif
+	
+	env.insert("PATH", AppDirs::programDir().absolutePath() + ";" + QDir(AppDirs::rHome()).absoluteFilePath("bin") + ";" + QDir(AppDirs::rHome()).absoluteFilePath("bin/" + R_ARCH)); // + rtoolsInPath); 
+
+	Log::log() << "Windows PATH was changed to: '" << env.value("PATH", "???") << "'" << std::endl;
+}
+#endif 

--- a/Desktop/utilities/processhelper.cpp
+++ b/Desktop/utilities/processhelper.cpp
@@ -106,9 +106,11 @@ QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool bootS
 	env.insert("R_LIBS_USER", (AppDirs::programDir().absolutePath().toStdString() + "/../R/library").c_str());
 #endif
 
-	Log::log() <<	"R_LIBS:"			<< env.value("R_LIBS")			<< "\n" <<
-					"R_LIBS_USER:"		<< env.value("R_LIBS_USER")		<< "\n" <<
-					"LD_LIBRARY_PATH:"	<< env.value("LD_LIBRARY_PATH") << "\n" <<
+	Log::log() <<	"PATH:            "	<< env.value("PATH")			<< "\n" <<
+					"R_HOME:          "	<< env.value("R_HOME")			<< "\n" <<
+					"R_LIBS:          "	<< env.value("R_LIBS")			<< "\n" <<
+					"R_LIBS_USER:     "	<< env.value("R_LIBS_USER")		<< "\n" <<
+					"LD_LIBRARY_PATH: "	<< env.value("LD_LIBRARY_PATH") << "\n" <<
 					std::endl;
 
 	return(env);	

--- a/Desktop/utilities/processhelper.cpp
+++ b/Desktop/utilities/processhelper.cpp
@@ -43,7 +43,7 @@ QProcessEnvironment ProcessHelper::getProcessEnvironmentForJaspEngine(bool bootS
 #endif
 	
 			TZDIR		= shortenWinPaths(TZDIR);
-	QString PATH		= shortenWinPaths(programDir.absoluteFilePath("R/library/RInside/libs/" ARCH_SUBPATH)) + ";" + shortenWinPaths(programDir.absoluteFilePath("R/library/Rcpp/libs/" ARCH_SUBPATH)) + ";" + shortenWinPaths(programDir.absoluteFilePath("R/bin/" ARCH_SUBPATH)) + ";" + shortenWinPaths(env.value("PATH")),
+	QString PATH		= shortenWinPaths(programDir.absolutePath()) + ";" + shortenWinPaths(programDir.absoluteFilePath("R/library/RInside/libs/" ARCH_SUBPATH)) + ";" + shortenWinPaths(programDir.absoluteFilePath("R/library/Rcpp/libs/" ARCH_SUBPATH)) + ";" + shortenWinPaths(programDir.absoluteFilePath("R/bin/" ARCH_SUBPATH)) + ";" + shortenWinPaths(env.value("PATH")),
 			_R_HOME		= shortenWinPaths(rHome.absolutePath()),
 			JAGS_HOME	= shortenWinPaths(programDir.absoluteFilePath("R/opt/jags/"));
 			// JAGS_LIBDIR	= shortenWinPaths(programDir.absoluteFilePath("R/opt/jags/lib/"));

--- a/Desktop/utilities/processhelper.h
+++ b/Desktop/utilities/processhelper.h
@@ -10,7 +10,10 @@ class ProcessHelper
 {
 public:
 	
-    static QProcessEnvironment getProcessEnvironmentForJaspEngine(bool bootStrap = false);
+    static QProcessEnvironment	getProcessEnvironmentForJaspEngine(bool bootStrap = false);
+#ifdef _WIN32 
+	static void					fixPATHForWindows(QProcessEnvironment & env);
+#endif
 	
 private:
 	ProcessHelper(){}

--- a/Desktop/utilities/wincontainermanager.cpp
+++ b/Desktop/utilities/wincontainermanager.cpp
@@ -91,7 +91,10 @@ bool checkIfAccessible(STARTUPINFOEX si, const std::vector<std::string>& paths)
 {
 	QDir programDir					= AppDirs::programDir();
 	QString checkerExecutable		= programDir.absoluteFilePath("ContainerFilePermissionChecker");
-	QProcess* checkProc = new QProcess();
+	QProcess* checkProc				= new QProcess();
+	QProcessEnvironment env			= QProcessEnvironment::systemEnvironment();
+	ProcessHelper::fixPATHForWindows(env);
+	checkProc->setProcessEnvironment(env);
 
 	QStringList args;
 	for(const std::string& path : paths)

--- a/Desktop/utilities/wincontainermanager.cpp
+++ b/Desktop/utilities/wincontainermanager.cpp
@@ -8,6 +8,7 @@
 #include "utilities/appdirs.h"
 #include "utilities/messageforwarder.h"
 #include "gui/preferencesmodel.h"
+#include "processhelper.h"
 
 std::wstring toWString(const std::string& in) {
 	return std::wstring(in.begin(), in.end());
@@ -41,7 +42,7 @@ bool AllowNamedObjectAccess(PSID appContainerSid, PWSTR name, SE_OBJECT_TYPE typ
 	} while (false);
 
 	if (newAcl)
-		::LocalFree(newAcl);
+		::LocaslFree(newAcl);
 
 	return status == ERROR_SUCCESS;
 }

--- a/Desktop/utilities/wincontainermanager.cpp
+++ b/Desktop/utilities/wincontainermanager.cpp
@@ -42,7 +42,7 @@ bool AllowNamedObjectAccess(PSID appContainerSid, PWSTR name, SE_OBJECT_TYPE typ
 	} while (false);
 
 	if (newAcl)
-		::LocaslFree(newAcl);
+		::LocalFree(newAcl);
 
 	return status == ERROR_SUCCESS;
 }

--- a/QMLComponents/utilities/appdirs.cpp
+++ b/QMLComponents/utilities/appdirs.cpp
@@ -101,11 +101,7 @@ QString AppDirs::bundledModulesLibDir()
 
 QString AppDirs::processPath(const QString & path)
 {
-#ifdef _WIN32
-	return QString::fromStdWString(Utils::getShortPathWin(path.toStdWString()));
-#else
 	return path;
-#endif
 }
 
 

--- a/QMLComponents/utilities/qutils.cpp
+++ b/QMLComponents/utilities/qutils.cpp
@@ -229,11 +229,7 @@ QString QJSErrorToString(QJSValue::ErrorType errorType)
 
 QString shortenWinPaths(QString in)
 {
-#ifdef _WIN32
-	return QString::fromStdWString(Utils::getShortPathWin(in.toStdWString()));
-#else
 	return in;
-#endif
 }
 
 void copyQDirRecursively(QDir copyThis, QDir toHere)

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -77,9 +77,9 @@ extern char * R_TempDir;
 // Code from RInside.cpp
 int __parseEval(const std::string & line, SEXP & ans)
 {
-#ifdef PRINT_ENGINE_MESSAGES
-	jaspRCPP_logString("parseEval: " + line + "\n");
-#endif
+//#ifdef PRINT_ENGINE_MESSAGES
+	//jaspRCPP_logString("parseEval: " + line + "\n");
+//#endif
 	ParseStatus status;
 	SEXP cmdSexp, cmdexpr = R_NilValue;
 	int i, errorOccurred;


### PR DESCRIPTION
Short paths should really not be necessary anymore given that we now use utf-8.

You can now tell JASP to specifically use or not use sandboxing on windows through `--sandbox` and `--noSandbox`.

And last but not least, if engines (keep) crash(ing) at the wrong times JASP now offers the option between a github report, exiting, or "salvage". Where the last one means: keep going so you can change preferences, or even try to save your data.
But because I dont want people complaining the engine doesnt run after skipping the msgbox Ive also made the data/welcome/analyses/results all red, so people cant possibly ignore that something is very much wrong indeed.