### PR TITLE
Update encoding when type change

### DIFF
--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -23,7 +23,12 @@ ColumnsModel::ColumnsModel(DataSetTableModel *tableModel)
 
 	connect(this, &ColumnsModel::columnNamesChanged,					info, &VariableInfo::variableNamesChanged	);
 	connect(this, &ColumnsModel::columnsChanged,						info, &VariableInfo::variablesChanged		);
-	connect(this, &ColumnsModel::columnTypeChanged,						info, &VariableInfo::variableTypeChanged	);
+	connect(this, &ColumnsModel::columnTypeChanged,						this, [this] (QString colName)
+		{
+			Term term(colName, columnType(data(index(getColumnIndex(fq(colName)), 0), ColumnsModel::ColumnTypeRole).toInt()));
+			emit VariableInfo::info()->variableTypeChanged(term);
+		} );
+
 	connect(this, &ColumnsModel::labelsChanged,							info, &VariableInfo::labelsChanged			);
 	connect(this, &ColumnsModel::labelsReordered,						info, &VariableInfo::labelsReordered		);
 	connect(this, &ColumnsModel::filterChanged,							info, &VariableInfo::filterChanged			);
@@ -152,12 +157,11 @@ QVariant ColumnsModel::provideInfo(VariableInfo::InfoType info, const QString& c
 		QModelIndex qColIndex = index(colIndex, 0),
 					qValIndex = index(colIndex, row);
 
-		int			colTypeInt	= data(qColIndex, ColumnsModel::ColumnTypeRole).toInt();
 		//columnType	colTypeHere	= static_cast<columnType>(colTypeInt);
 
 		switch(info)
 		{
-		case VariableInfo::VariableType:				return	colTypeInt;
+		case VariableInfo::VariableType:				return	data(qColIndex, ColumnsModel::ColumnTypeRole).toInt();
 		case VariableInfo::DoubleValues:				return	QTransposeProxyModel::data(qColIndex,						int(DataSetPackage::specialRoles::valuesDblList));
 		case VariableInfo::TotalNumericValues:			return	QTransposeProxyModel::data(qColIndex,						int(DataSetPackage::specialRoles::nonFilteredNumericValuesCount));
 		case VariableInfo::TotalLevels:					return	QTransposeProxyModel::data(qColIndex,						int(DataSetPackage::specialRoles::nonFilteredLevels)).toStringList().length();

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -51,12 +51,13 @@ DataSetPackage::DataSetPackage(QObject * parent) : QAbstractItemModel(parent)
 	_dataSet	= new DataSet(); //We create one here to make sure filter() etc can actually work
 	setDefaultWorkspaceEmptyValues();
 	
-	connect(this, &DataSetPackage::isModifiedChanged,	this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::loadedChanged,		this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::currentFileChanged,	this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::folderChanged,		this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::currentFileChanged,	this, &DataSetPackage::nameChanged);
-	connect(this, &DataSetPackage::dataModeChanged,		this, &DataSetPackage::onDataModeChanged);
+	connect(this, &DataSetPackage::isModifiedChanged,		this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::loadedChanged,			this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::currentFileChanged,		this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::folderChanged,			this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::currentFileChanged,		this, &DataSetPackage::nameChanged);
+	connect(this, &DataSetPackage::dataModeChanged,			this, &DataSetPackage::onDataModeChanged);
+	connect(this, &DataSetPackage::columnDataTypeChanged,	this, [this]() {ColumnEncoder::setCurrentColumnNames(getColumnTypesMap());}	);
 
 	_dataSubModel	= new SubNodeModel("data",		_dataSet->dataNode());
 	_filterSubModel = new SubNodeModel("filters",	_dataSet->filtersNode());
@@ -1405,20 +1406,6 @@ void DataSetPackage::dbDelete()
 	JASPTIMER_SCOPE(DataSetPackage::dbDelete);
 	if(_dataSet && _dataSet->id() != -1)
 		_dataSet->dbDelete();
-}
-
-void DataSetPackage::resetVariableTypes()
-{
-	for (Column * col : _dataSet->columns())
-	{
-		columnType guessedType = col->resetValues(PreferencesModel::prefs()->thresholdScale());
-		
-		if(guessedType != col->type() && col->changeType(guessedType) == columnTypeChangeResult::changed)
-		{
-			emit columnDataTypeChanged(tq(col->name()));
-			refreshWithDelay();
-		}
-	}
 }
 
 void DataSetPackage::createDataSet()

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -272,7 +272,6 @@ public:
 				stringset					columnsCreatedByAnalysis(					Analysis * analysis);
 				std::string					freeNewColumnName(size_t startHere);
 				void						dbDelete();
-				void						resetVariableTypes();
 				void						emitColumnChanged(const QString &colName); //temporary until ColumnQ exists
 				
 				

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -2157,11 +2157,6 @@ void MainWindow::setDefaultWorkspaceEmptyValues()
 	DataSetPackage::pkg()->setDefaultWorkspaceEmptyValues();
 }
 
-void MainWindow::resetVariableTypes()
-{
-	DataSetPackage::pkg()->resetVariableTypes();
-}
-
 void MainWindow::loadModulesFromUserConfiguration(configState state)
 {
 	if(state == configState::FAIL)

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -142,7 +142,6 @@ public slots:
 	void setContactVisible(bool newContactVisible);
 	void setCommunityVisible(bool newCommunityVisible);
 	void setDefaultWorkspaceEmptyValues();
-	void resetVariableTypes();
 
 	void showRCommander();
 

--- a/QMLComponents/controls/sourceitem.cpp
+++ b/QMLComponents/controls/sourceitem.cpp
@@ -203,11 +203,7 @@ void SourceItem::connectModels()
 	{
 		VariableInfo* variableInfo = VariableInfo::info();
 		connect(variableInfo,	&VariableInfo::variableNamesChanged,	controlModel, &ListModel::sourceVariableNamesChanged );
-		connect(variableInfo,	&VariableInfo::variableTypeChanged,		controlModel, [this, controlModel] (QString colName)
-		{
-			Term term(colName, (columnType)requestInfo(VariableInfo::VariableType, colName).toInt());
-			controlModel->sourceVariableTypeChanged(term);
-		} );
+		connect(variableInfo,	&VariableInfo::variableTypeChanged,		controlModel, &ListModel::sourceVariableTypeChanged );
 		connect(variableInfo,	&VariableInfo::labelsChanged,		controlModel, &ListModel::sourceLabelsChanged );
 		connect(variableInfo,	&VariableInfo::labelsReordered,		controlModel, &ListModel::sourceLabelsReordered );
 		connect(variableInfo,	&VariableInfo::filterChanged,		controlModel, &ListModel::filterChanged );

--- a/QMLComponents/controls/textareabase.cpp
+++ b/QMLComponents/controls/textareabase.cpp
@@ -43,6 +43,14 @@ void TextAreaBase::setUpModel()
 		_model = new ListModelTermsAvailable(this);
 		_model->setNeedsSource(_textType == TextType::TextTypeCSem || _textType == JASPControl::TextType::TextTypeMetaSem);
 
+		if (_textType == TextType::TextTypeLavaan)
+		{
+			// Lavaan TextArea does not have a source, but the script contains variables: so it the variables types or names change, the model must be updated.
+			VariableInfo* variableInfo = VariableInfo::info();
+			connect(variableInfo,	&VariableInfo::variableNamesChanged,	_model, &ListModel::sourceVariableNamesChanged	);
+			connect(variableInfo,	&VariableInfo::variableTypeChanged,		_model, &ListModel::sourceVariableTypeChanged	);
+		}
+
 		JASPListControl::setUpModel();
 	}
 }

--- a/QMLComponents/variableinfo.h
+++ b/QMLComponents/variableinfo.h
@@ -24,6 +24,7 @@
 #include <QAbstractItemModel>
 #include <QQmlContext>
 #include "columntype.h"
+#include "models/term.h"
 
 class VariableInfoProvider;
 class DataSet;
@@ -66,7 +67,7 @@ signals:
 	void dataSetChanged();
 	void rowCountChanged();
 	void labelsReordered(	QString columnName);
-	void variableTypeChanged(	QString colName);
+	void variableTypeChanged(Term variable);
 	void dataAvailableChanged();
 
 private:	


### PR DESCRIPTION
In a R Script a column names are encoded with the encoding as the type-qualified column names (contNormal and contNormal.scale have the same enconding). But if the type of column is changed, the encoding should be changed also.