### PR TITLE
Powerdev module building via jaspModuleTools

### DIFF
--- a/Desktop/CMakeLists.txt
+++ b/Desktop/CMakeLists.txt
@@ -87,6 +87,10 @@ if(INSTALL_R_MODULES AND NOT FLATPAK_USED)
   endif()
 endif()
 
+if(LOCAL_MODULES_BUILD)
+  add_dependencies(JASP ModulesBuild)
+endif()
+
 if(APPLE)
   add_dependencies(JASP readstat)
 endif()

--- a/Tools/CMake/JASP.cmake
+++ b/Tools/CMake/JASP.cmake
@@ -73,6 +73,19 @@ set(MSIX_SIGN_CERT_PASSWORD
   CACHE STRING "Password selfsign cert for Nightlies")
 
 
+
+#power Dev stuff 
+option(LOCAL_MODULES_BUILD "Should local modules be bundled while building?" OFF)
+
+set(LOCAL_MODULES_ROOT
+    ""
+    CACHE PATH "Path to your local clones of jasp modules")
+
+set(LOCAL_MODULES_TO_BUILD
+    ""
+    CACHE STRING "Semi-colon (;) separated list of local modules to bundle")
+
+
 # TODO:
 # - [ ] Rename all JASP related variables to `JASP_*`. This way,
 #       Qt Creator can categorize them nicely in its CMake configurator

--- a/Tools/CMake/Modules.cmake
+++ b/Tools/CMake/Modules.cmake
@@ -27,5 +27,29 @@ add_custom_target(
   COMMENT "------ Installing Modules"
 )
 
+
+
+
+
+if(LOCAL_MODULES_BUILD) 
+#configure modules build script
+configure_file(${PROJECT_SOURCE_DIR}/Tools/local-build-modules.R.in
+		           ${SCRIPT_DIRECTORY}/local-build-modules.R @ONLY)
+
+add_custom_target(
+  ModulesBuild
+  USES_TERMINAL
+  WORKING_DIRECTORY ${R_HOME_PATH}
+  DEPENDS ${SCRIPT_DIRECTORY}/local-build-modules.R
+  COMMAND ${CMAKE_COMMAND}  -E env ${R_EXECUTABLE} --slave --no-restore --no-save
+        --file=${SCRIPT_DIRECTORY}/local-build-modules.R
+  BYPRODUCTS  ${MODULES_BINARY_PATH}/local-builds.txt
+  COMMENT "------ Building Modules"
+)
+
+
+
+endif()
+
 endif()
 list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/Tools/local-build-modules.R.in
+++ b/Tools/local-build-modules.R.in
@@ -16,8 +16,8 @@ dir.create(toolLibpath, recursive=TRUE)
 .libPaths(toolLibpath)
 
 
-install.packages("remotes")
-library('remotes')
+if (!require("remotes", quietly=TRUE))
+  install.packages("remotes")
 remotes::install_github("jasp-stats/jaspModuleTools")
 
 f <- function(mod) {

--- a/Tools/local-build-modules.R.in
+++ b/Tools/local-build-modules.R.in
@@ -1,0 +1,40 @@
+options(repos='https://cran.r-project.org')
+options(jaspRemoteCellarRedownload=FALSE)
+Sys.setenv(GITHUB_PAT="@GITHUB_PAT@")
+
+
+MODULES_DIR <- file.path("@PROJECT_BINARY_DIR@", "Modules")
+MODULES_SOURCE_ROOT <- file.path("@LOCAL_MODULES_ROOT@")
+MODULES <- "@LOCAL_MODULES_TO_BUILD@"
+
+modules <- sapply(strsplit(MODULES, ';'), trimws)
+modules <- file.path(MODULES_SOURCE_ROOT, modules)
+
+workdir <- file.path(MODULES_DIR, 'jaspLocalBuildWorkdir')
+toolLibpath <- file.path(workdir, 'toolLibpath')
+dir.create(toolLibpath, recursive=TRUE)
+.libPaths(toolLibpath)
+
+
+install.packages("remotes")
+library('remotes')
+remotes::install_github("jasp-stats/jaspModuleTools")
+
+f <- function(mod) {
+    jaspModuleTools::compile(mod, workdir=workdir, createBundle=FALSE)
+    modlib <- file.path(workdir, basename(mod))
+    module_libs <- file.path(MODULES_DIR, 'module_libs')
+    target <- file.path(module_libs, basename(mod))
+
+    if(dir.exists(target)) unlink(target, recursive=TRUE)
+    dir.create(target, recursive = TRUE)
+    file.copy(modlib, module_libs, recursive=TRUE)
+
+    if (Sys.info()[['sysname']] == 'Darwin') {  
+        print("Patching and Signing all Module binaries")
+        jaspEngineLocation <- file.path("@CMAKE_BINARY_DIR@", "Desktop" , "JASPEngine")
+        jaspEngineCall     <- paste0(jaspEngineLocation, ' "', target ,'"')
+        system(jaspEngineCall)
+    }
+}
+sapply(modules, f)

--- a/Tools/windows/msix/AppxManifest-store.xml.in
+++ b/Tools/windows/msix/AppxManifest-store.xml.in
@@ -46,6 +46,9 @@
       <uap:SplashScreen Image="Assets\SplashScreen.png" />
     </uap:VisualElements>
 
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
 
     <Extensions>
       <uap:Extension Category="windows.fileTypeAssociation">

--- a/Tools/windows/msix/makelongpathaware.reg
+++ b/Tools/windows/msix/makelongpathaware.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem]
+"LongPathsEnabled"=dword:00000001


### PR DESCRIPTION
Before perhaps padding this out with some detection of changes,  @vandenman  does this generally serve your needs?

This feature is made for devs able to compile jasp-desktop who work on/review so many different modules that our devModule system or external bundle generation becomes too cumbersome.
It allows one to build Modules using jaspModuleTools and directly inject them into the module_libs folder. (thus skipping bundle packing & unpacking) 
Workdir with renv-cache is kept so allows for incremental development as well.

@JorisGoosen  My initial reluctance to implement this wavered when don explained just how many different modules he must review.  

Since the module list is external to jasp-desktop this should be tenable even when we move to module store.