### PR TITLE
Loading a data file should set automatically synchronization on

### DIFF
--- a/Desktop/data/asyncloader.cpp
+++ b/Desktop/data/asyncloader.cpp
@@ -238,12 +238,12 @@ void AsyncLoader::loadPackage(QString id)
 			if(!pkg->dataSet())
 				pkg->createDataSet();
 
-			if(_currentEvent->operation() != FileEvent::FileSyncData && _currentEvent->type() != Utils::FileType::jasp && !_currentEvent->isReadOnly())
-				pkg->setSynchingExternally(true);
-
 			if (_currentEvent->operation() == FileEvent::FileSyncData)
 					_loader.syncPackage(path, extension, boost::bind(&AsyncLoader::progressHandler, this, _1));
 			else	_loader.loadPackage(path, extension, boost::bind(&AsyncLoader::progressHandler, this, _1));
+
+			if(_currentEvent->operation() != FileEvent::FileSyncData && _currentEvent->type() != Utils::FileType::jasp && !_currentEvent->isReadOnly())
+				pkg->setSynchingExternally(true);
 
 			QString calcMD5 = fileChecksum(tq(path), QCryptographicHash::Md5);
 


### PR DESCRIPTION
If you load a data file, the Synchronization is off: it should be by default on.

In the AsyncLoader::loadPackage, before loading the dataset, a DataSet object is created (line 239) if it does not exists: I'm not sure whether it is necessary to create this object here, because a new one is created in the Importer loadDataSet anyway.
So the Synchronization flag should be set after importer loadDataSet has been called, so that it is set to the right DataSet object.
