### PR TITLE
0.19 files dont always have labels for all doubles we need to add them

### DIFF
--- a/Common/version.h
+++ b/Common/version.h
@@ -34,9 +34,9 @@ public:
 		const char* what() const noexcept override;
 	};
 
-	Version(const char * version);
-	Version(const std::string & version);
-	Version(unsigned int major = 0, unsigned int minor = 0, unsigned int release = 0, unsigned int fourth = 0) : _major(major), _minor(minor), _release(release), _fourth(fourth) {}
+				Version(const char * version);
+				Version(const std::string & version);
+	explicit	Version(unsigned int major = 0, unsigned int minor = 0, unsigned int release = 0, unsigned int fourth = 0) : _major(major), _minor(minor), _release(release), _fourth(fourth) {}
 
 	///By default this tries to minimize the string, so all trailing zeroes + dots are removed. Unless versionNumbersToInclude is set to something >1. If 2 then major and minor are always shown, etc.
 	std::string asString(size_t versionNumbersToInclude = 0) const;

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1932,8 +1932,27 @@ bool Column::isColumnDifferentFromStringLookUps(const std::string & title, size_
 void Column::upgradeSetDoubleLabelsInInts()
 {
 	_ints = intvec(_dbls.size(), Label::NO_LABEL);
+}
+
+void Column::upgradeDoublesToLabels()
+{
+	doubleset dbls(_dbls.begin(), _dbls.end());
 	
-	dbUpdateValues();
+	std::map<double, int> dblToIntsId;
+	
+	beginBatchedLabelsDB();
+	
+	for(double dbl : dbls)
+		if(!dblToIntsId.count(dbl))
+		{
+			std::string		dblStr	= Column::doubleToDisplayString(dbl);
+			Label		*	label	= labelByValue(dblStr);
+			dblToIntsId		[dbl]	= label ? label->intsId() : labelsAdd(dblStr);
+		}
+	
+	for(size_t row=0; row<_dbls.size(); row++)
+		if(_ints[row] == Label::NO_LABEL && dblToIntsId.count(_dbls[row]))
+			_ints[row] = dblToIntsId[_dbls[row]];
 }
 
 void Column::upgradeExtractDoublesIntsFromLabels()
@@ -1946,8 +1965,6 @@ void Column::upgradeExtractDoublesIntsFromLabels()
 		
 		_dbls [r] = ! label || !label->originalValue().isDouble() ? EmptyValues::missingValueDouble : label->originalValue().asDouble();
 	}
-	
-	dbUpdateValues();
 }
 
 void Column::checkForLoopInDependencies(std::string code)

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -116,6 +116,7 @@ public:
 			
 			void					upgradeSetDoubleLabelsInInts();			///< Used by upgrade 0.18.* -> 0.19
 			void					upgradeExtractDoublesIntsFromLabels();	///< Used by upgrade 0.18.* -> 0.19
+			void					upgradeDoublesToLabels();				///< 0.19.* -> 0.95
 
 			void					labelsClear(bool doIncRevision=true);
 			int						labelsAdd(			int display);

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -284,7 +284,7 @@ void DataSet::dbUpdate()
 	incRevision();
 }
 
-void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, bool do019Fix)
+void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, Version doUpgradeFrom)
 {
 	//Log::log() << "loadDataSet(index=" << index << "), _dataSetID="<< _dataSetID <<";" << std::endl;
 
@@ -341,8 +341,22 @@ void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, boo
 	Json::Value emptyValsJson;
 	Json::Reader().parse(emptyVals, emptyValsJson);
 	
+	bool	do019Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.19",
+			do095Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.95";
+	
+	if(do095Fix)
+		beginBatchedToDB();
+	
 	if(do019Fix)	upgradeTo019(emptyValsJson);
 	else			_emptyValues->fromJson(emptyValsJson);
+	
+	if(do095Fix)
+	{
+		upgrade019To095();
+		endBatchedToDB();
+	}
+	
+	
 }
 
 void DataSet::upgradeTo019(const Json::Value & emptyVals)
@@ -409,6 +423,15 @@ void DataSet::upgradeTo019(const Json::Value & emptyVals)
 	
 	_emptyValues->setEmptyValues(workspaceEmpty);
 	incRevision();
+}
+
+void DataSet::upgrade019To095()
+{
+	// 0.19.* versions attempted to speedup scalar columns by not making labels for double-only columns. This in the end required so many caches that it slowed it down and made it complicated.
+	// Now we just make labels for everything, however, they are missing for 0.19.* files. 
+	
+	for(Column * col : _columns)
+		col->upgradeDoublesToLabels();
 }
 
 int DataSet::columnCount() const

--- a/CommonData/dataset.h
+++ b/CommonData/dataset.h
@@ -5,6 +5,7 @@
 #include "column.h"
 #include "filter.h"
 #include "emptyvalues.h"
+#include "version.h"
 
 class DataSet : public DataSetBaseNode
 {
@@ -37,7 +38,7 @@ public:
 
 			void			dbCreate();
 			void			dbUpdate();
-			void			dbLoad(int index = -1, std::function<void(float)> progressCallback = [](float){}, bool do019Fix = false);
+			void			dbLoad(int index = -1, std::function<void(float)> progressCallback = [](float){}, Version doUpgradeFrom = Version());
 			void			dbDelete();
 
 			void			beginBatchedToDB();
@@ -90,6 +91,7 @@ public:
 			
 private:			
 			void					upgradeTo019(const Json::Value & emptyVals);
+			void					upgrade019To095();
 			void					setEmptyValuesJsonOldStuff(	const Json::Value & emptyValues);
 			
 			

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1433,10 +1433,11 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 	_db->load();		
 	_db->upgradeDBFromVersion(_jaspVersion);
 	
-	bool do019Upgrade = _jaspVersion < "0.19"; // A tweak needs to be made to the data as its loaded, see https://github.com/jasp-stats/jasp-desktop/pull/5367
+	bool do019Upgrade = _jaspVersion < "0.19";
 	
 	_dataSet = new DataSet(0);
-	_dataSet->dbLoad(1, progressCallback, do019Upgrade); //Right now there can only be a dataSet with ID==1 so lets keep it simple
+	_dataSet->dbLoad(1, progressCallback, _jaspVersion); //Right now there can only be a dataSet with ID==1 so lets keep it simple
+	
 	if (do019Upgrade)
 	{
 		// In 0.18.3 and before, there was a bug with the order of dataFilePath and description in the database.


### PR DESCRIPTION
For instance to load the last two columns in the testfile in https://github.com/jasp-stats/jasp-issues/issues/3282

updates now work and use the same batched writing as the normal database writes for dataset

Without this fix, loading that file will show you no labels whatsoever for the last two columns at least.
With this fix they have a label for each double.

I can only build this on macos by rebasing it first on https://github.com/jasp-stats/jasp-desktop/pull/5904
