### PR TITLE
Load labels from database in the ordered way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,9 +83,6 @@ Modules/renv-root/
 Desktop/utilities/simplecryptkey.h
 Common/appinfo.cpp
 QMLComponents/utilities/appdirs.h
-CommonData/jaspBase_distributionSamplers.h
-CommonData/jaspBase_friendlyConstructorFunctions.h
-CommonData/jaspBase_transformFunctions.h
 
 # Bundle related
 Tools/ModuleBundleBuildDir

--- a/CommonData/.gitignore
+++ b/CommonData/.gitignore
@@ -1,1 +1,5 @@
 internalDbDefinition.h
+createIndexes.h
+jaspBase_distributionSamplers.h
+jaspBase_friendlyConstructorFunctions.h
+jaspBase_transformFunctions.h

--- a/CommonData/CMakeLists.txt
+++ b/CommonData/CMakeLists.txt
@@ -8,7 +8,8 @@
 #
 list(APPEND CMAKE_MESSAGE_CONTEXT CommonData)
 
-make_includable(internalDbDefinition.sql internalDbDefinition.h)
+make_includable(internalDbDefinition.sql  internalDbDefinition.h)
+make_includable(createIndexes.sql		  createIndexes.h)
 
 make_includable(../Engine/jaspBase/R/distributionSamplers.R				jaspBase_distributionSamplers.h)
 make_includable(../Engine/jaspBase/R/friendlyConstructorFunctions.R		jaspBase_friendlyConstructorFunctions.h)

--- a/CommonData/createIndexes.sql
+++ b/CommonData/createIndexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS ColumnOrderIdx			ON Columns	(id, dataSet,	colIdx);
+CREATE INDEX IF NOT EXISTS LabelOrderPerColumnIdx	ON Labels	(id, columnId,	ordering DESC);

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -72,6 +72,9 @@ void DatabaseInterface::upgradeDBFromVersion(Version originalVersion)
 		
 		if(!tableHasColumn("Labels", "userAdded"))
 			runStatements("ALTER TABLE Labels  ADD COLUMN userAdded	INT DEFAULT 0;");
+		
+		//Create indexes cause they dont exist yet
+		runStatements(_dbIndexesSql);
 	}
 
 	transactionWriteEnd();
@@ -2093,6 +2096,7 @@ isItReallyALabel:
 	{
 		transactionWriteBegin();
 		runStatements(_dbConstructionSql);
+		runStatements(_dbIndexesSql);
 		transactionWriteEnd();
 		
 		constructionWorked = true;

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -19,6 +19,10 @@ const std::string DatabaseInterface::_dbConstructionSql =
 #include "internalDbDefinition.h"
 ;
 
+const std::string DatabaseInterface::_dbIndexesSql =
+#include "createIndexes.h"
+;
+
 void DatabaseInterface::upgradeDBFromVersion(Version originalVersion)
 {
 	transactionWriteBegin();

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -1471,9 +1471,8 @@ void DatabaseInterface::labelsLoad(Column * column)
 		column->labelsSet(row,	value, label, filterAllows, description, originalValueJson, order, id);
 	};
 
-	runStatements("SELECT id, value, label, ordering, filterAllows, description, originalValueJson FROM Labels WHERE columnId = ?;", prepare, processRow);
+	runStatements("SELECT id, value, label, ordering, filterAllows, description, originalValueJson FROM Labels WHERE columnId = ? ORDER BY ordering;", prepare, processRow);
 
-	column->_sortLabelsByOrder();
 	column->labelsRemoveBeyond(labelsSize);
 	 
 	column->endBatchedLabelsDB(false);
@@ -1505,7 +1504,7 @@ void DatabaseInterface::labelsLoad(const Columns &columns)//, std::function<void
 		labelsPerCol[column->id()] = 0;
 	}
 	
-	statement << ");";
+	statement << ") ORDER BY columnId, ordering;";
 	
 
 	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
@@ -1549,7 +1548,6 @@ void DatabaseInterface::labelsLoad(const Columns &columns)//, std::function<void
 
 	for(Column * column : columns)
 	{
-		column->_sortLabelsByOrder();
 		column->labelsRemoveBeyond(labelsPerCol[column->id()]);
 		column->endBatchedLabelsDB(false);
 	}

--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -212,8 +212,8 @@ private:
 
 	static			std::string _wrap_sqlite3_column_text(sqlite3_stmt * stmt, int iCol);
 	static const	std::string _dbConstructionSql;
-
-
+	static const	std::string _dbIndexesSql;
+	
 	static DatabaseInterface * _singleton;
 
 	friend class DataSetPackage;

--- a/CommonData/internalDbDefinition.sql
+++ b/CommonData/internalDbDefinition.sql
@@ -63,3 +63,5 @@ CREATE TABLE Labels
 	
 	FOREIGN KEY(columnId) REFERENCES Columns(id)
 );
+
+


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2842

The row order of the labels in the database should not be trusted.
When loading the labels from the database the Column::labelsSet is called, but it is with the assumption that the row of the labels in the database is the same as the index in the _labels property.
Just add an "ORDER BY ordering" in the SQL statement to ensure that the selection is ordered as the _labels.
The call to _sortLabelsByOrder is then not needed anymore.

I find a bit weird that the labels were not querying in the database with an ORDER BY: @JorisGoosen is there any reason why the SELECT statement was done without ORDER BY, and afterwards ordering the labels with _sortLabelsByOrder?

I have found another issue: if you change manually (in the Label view) the order of the labels of a computed column, then recomputing the column sets also some wrong labels... This issue exists also in development, but this fix does not solve this issue.

