### PR TITLE
Tweaks

### DIFF
--- a/Common/tempfiles.cpp
+++ b/Common/tempfiles.cpp
@@ -165,6 +165,8 @@ void TempFiles::deleteOrphans()
 
 					if (now - modTime > outOfDateDelta)
 					{
+						Log::log() << "Removing folder because status indicates it is out of date: " << statusFile.string() << std::endl;
+						
 						std::filesystem::remove_all(p, error);
 						if (error)
 							Log::log() << "Error when deleting directory: " << error.message() << std::endl;

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -2290,15 +2290,13 @@ void DatabaseInterface::transactionWriteEnd(bool rollback)
 {
 	JASPTIMER_SCOPE(DatabaseInterface::transactionWriteEnd);
 	
-	assert(_transactionWriteDepth > 0);
-	
 	if(rollback)	
 	{
 		runStatements("ROLLBACK");
 		_transactionWriteDepth = 0;
 		throw std::runtime_error("Rollback!"); //Might be better to use a subclass of std::runtime_error but for now this isnt even used anyway.
 	}	
-	else if(--_transactionWriteDepth == 0)
+	else if(_transactionWriteDepth == 0 || --_transactionWriteDepth == 0)
 		runStatements("COMMIT", true);
 	
 }
@@ -2307,9 +2305,7 @@ void DatabaseInterface::transactionReadEnd()
 {
 	JASPTIMER_SCOPE(DatabaseInterface::transactionReadEnd);
 	
-	assert(_transactionReadDepth > 0);
-	
-	if(--_transactionReadDepth == 0)
+	if(_transactionReadDepth == 0 || --_transactionReadDepth == 0)
 		runStatements("COMMIT", true); //ignore fails cause it fails sometimes, probably because no statements was done and so nothing to commit. this is ok
 }
 

--- a/CommonData/ipcchannel.cpp
+++ b/CommonData/ipcchannel.cpp
@@ -44,9 +44,7 @@ using namespace std;
 using namespace boost;
 using namespace boost::posix_time;
 
-#ifdef _WIN32
-std::thread IPCChannel::heartbeatThread;
-#endif
+std::thread IPCChannel::_heartbeatThread;
 
 IPCChannel::IPCChannel(std::string name, size_t channelNumber, bool isSlave)
 	:
@@ -60,7 +58,7 @@ IPCChannel::IPCChannel(std::string name, size_t channelNumber, bool isSlave)
 
 	Log::log() << "IPCChannel(" << name << ", " << channelNumber << ", " << (isSlave ? "slave" : "master") << ");" << std::endl;
 
-	Log::log() << (!_isSlave ? "Creating control memory" : "Opening control memory") << std::endl;
+	//Log::log() << (!_isSlave ? "Creating control memory" : "Opening control memory") << std::endl;
 
 	_memoryControl			= !isSlave ? new interprocess::managed_shared_memory(interprocess::open_or_create,	_baseName.c_str(), 4096)
 									   : new interprocess::managed_shared_memory(interprocess::open_only,		_baseName.c_str());
@@ -88,20 +86,15 @@ IPCChannel::IPCChannel(std::string name, size_t channelNumber, bool isSlave)
 
 	if(!_isSlave)
 	{
-		Log::log() << "Creating communication memory" << std::endl;
 		_memoryMasterToSlave	= new interprocess::managed_shared_memory(interprocess::open_or_create, _nameMtS.c_str(), *_sizeMtoS);
 		_memorySlaveToMaster	= new interprocess::managed_shared_memory(interprocess::open_or_create, _nameStM.c_str(), *_sizeStoM);
 	}
 	else
 		catchAndRepeat("Opening communications memory", [&]()
 		{
-
-			Log::log() << "Opening M->S" << std::endl;
 			_memoryMasterToSlave	= new interprocess::managed_shared_memory(interprocess::open_only, _nameMtS.c_str());
-			Log::log() << "Opening S->M" << std::endl;
 			_memorySlaveToMaster	= new interprocess::managed_shared_memory(interprocess::open_only, _nameStM.c_str());
 		});
-
 
 	generateNames();
 
@@ -151,52 +144,18 @@ IPCChannel::IPCChannel(std::string name, size_t channelNumber, bool isSlave)
 				Log::log() << "More than 1 (in: " << foundDataIn.second << " out: " << foundDataOut.second << ") data String found in IPCChannel startup on engine." << std::endl;
 		});
 
-#ifdef __APPLE__
-	_semaphoreIn  = sem_open(_mutexInName.c_str(),  O_CREAT, S_IWUSR | S_IRGRP | S_IROTH, 0);
-	_semaphoreOut = sem_open(_mutexOutName.c_str(), O_CREAT, S_IWUSR | S_IRGRP | S_IROTH, 0);
-
-	if (isSlave == false)
-	{
-		// cleanse the semaphores; they don't seem to reliably initalise to zero.
-
-		while (sem_trywait(_semaphoreIn) == 0) ; // do nothing
-		while (sem_trywait(_semaphoreOut) == 0); // do nothing
-
-	}
-
-#elif !defined(_WIN32)
-
-	if (_isSlave == false)
-	{
-		interprocess::named_semaphore::remove(_mutexInName.c_str());
-		interprocess::named_semaphore::remove(_mutexOutName.c_str());
-
-		_semaphoreIn  = new interprocess::named_semaphore(interprocess::create_only, _mutexInName.c_str(), 0);
-		_semaphoreOut = new interprocess::named_semaphore(interprocess::create_only, _mutexOutName.c_str(), 0);
-	}
-	else
-	{
-		_semaphoreIn  = new interprocess::named_semaphore(interprocess::open_only, _mutexInName.c_str());
-		_semaphoreOut = new interprocess::named_semaphore(interprocess::open_only, _mutexOutName.c_str());
-	}
-
-
-#endif
-
-#ifdef _WIN32
 	_jaspHeartBeatPath = (std::filesystem::path(Dirs::tempDir()) /  (name + "_heartbeat")).string();
 	
-	if(!_isSlave && heartbeatThread.get_id() == std::thread::id()) {  //doki doki
+	if(!_isSlave && _heartbeatThread.get_id() == std::thread::id()) {  //doki doki
 		//Create the file
 		std::fstream f;
 		f.open(_jaspHeartBeatPath.c_str(), ios_base::out);
 		f.close();
 		
 		//start the thread		
-		heartbeatThread = std::thread(IPCChannel::heartbeat, _jaspHeartBeatPath, _heatbeatDelayS);
-		heartbeatThread.detach();
+		_heartbeatThread = std::thread(IPCChannel::heartbeat, _jaspHeartBeatPath, _heatbeatDelayS);
+		_heartbeatThread.detach();
 	}
-#endif
 
 	//Log::log() << "IPCChannel init done" << std::endl;
 }
@@ -233,18 +192,17 @@ void IPCChannel::findConstructAllAgain()
 	findConstructDataStrings();
 }
 
-#ifdef _WIN32
 
 bool IPCChannel::heartbeat(string path, unsigned int delayS)
 {
-	while(true) {
+	while(true)
+	{
 		Utils::touch(path);
 		std::this_thread::sleep_for(std::chrono::seconds(delayS));
 	}
 
 	return false;
 }
-
 
 bool IPCChannel::jaspAlive()
 {
@@ -272,7 +230,6 @@ bool IPCChannel::jaspAlive()
 
 	return true;
 }
-#endif
 
 void IPCChannel::catchAndRepeat(const std::string & taskDescription, std::function<void()> doThis)
 {
@@ -283,7 +240,6 @@ void IPCChannel::catchAndRepeat(const std::string & taskDescription, std::functi
 	bool worked = false;
 
 	Log::log() << taskDescription << " for at least " << wait << "ms" << std::endl;
-
 
 	while(!worked && Utils::currentMillis() < now + wait)
 		try
@@ -404,13 +360,11 @@ void IPCChannel::send(string &data, bool alreadyLockedMutex)
 	{
 		if(!alreadyLockedMutex)
 			_mutexOut->lock();
-#ifdef _WIN32
-			_dataOut->assign(std::to_string(_msgIDSend % 10).c_str()); // prefix a one character msg ID
-			_msgIDSend++;
-			_dataOut->append(data.c_str(), data.length());
-#else
-			_dataOut->assign(data.begin(), data.end());
-#endif
+
+		_dataOut->assign(std::to_string(_msgIDSend % 10).c_str()); // prefix a one character msg ID
+		_msgIDSend++;
+		_dataOut->append(data.c_str(), data.length());
+
 	}
 	catch (boost::interprocess::bad_alloc &e)	{ goto retryAfterDoublingMemory; }
 	catch (std::length_error &e)				{ goto retryAfterDoublingMemory; }
@@ -425,13 +379,6 @@ void IPCChannel::send(string &data, bool alreadyLockedMutex)
 		Log::log() << "IPCChannel::send encountered an exception: " << e.what() << std::endl;
 		throw e; //no need to unlock because this will crash stuff
 	}
-
-#ifdef __APPLE__
-	sem_post(_semaphoreOut);
-#elif !defined (_WIN32 )
-	_semaphoreOut->post();
-#endif
-
 
 	_mutexOut->unlock();
 	return; // return here to avoid going to retryAfterDoublingMemory
@@ -450,18 +397,13 @@ bool IPCChannel::receive(string &data, int timeout)
 	{
 		_mutexIn->lock();
 
-#ifndef _WIN32
+
 		while (tryWait()); // clear it completely
-#endif
+
 		try
 		{
 			rebindMemoryInIfSizeChanged();
-			#ifdef _WIN32
 			data.assign(_dataIn->c_str() + 1, _dataIn->size() - 1); // remove message id prefix
-			#else
-			data.assign(_dataIn->c_str(), _dataIn->size());
-			#endif
-
 		}
 		catch(std::exception & e)
 		{
@@ -482,18 +424,7 @@ bool IPCChannel::tryWait(int timeout)
 {
 	bool messageWaiting = false;
 
-#ifdef __APPLE__
 
-	messageWaiting = sem_trywait(_semaphoreIn) == 0;
-
-	while (timeout > 0 && messageWaiting == false)
-	{
-		usleep(100000);
-		timeout -= 10;
-		messageWaiting = sem_trywait(_semaphoreIn) == 0;
-	}
-
-#elif defined _WIN32
 	std::this_thread::sleep_for(std::chrono::milliseconds(timeout));
 	if(_dataIn->length()) {
 		try{
@@ -504,20 +435,6 @@ bool IPCChannel::tryWait(int timeout)
 			}
 		} catch(std::exception& e) {Log::log()<< "Failure getting msgID: " << e.what() << std::endl;}
 	}
-#else
-
-	if (timeout > 0)
-	{
-		ptime now(microsec_clock::universal_time());
-		ptime then = now + microseconds(1000 * timeout);
-
-		messageWaiting = _semaphoreIn->timed_wait(then);
-	}
-	else
-	{
-		messageWaiting = _semaphoreIn->try_wait();
-	}
-#endif
 
 	return messageWaiting;
 

--- a/CommonData/ipcchannel.h
+++ b/CommonData/ipcchannel.h
@@ -22,16 +22,10 @@
  * and sometimes under windows too. hence, there are platform specific
  * implementations below */
 
-#ifdef __APPLE__
-#include <semaphore.h>
-#elif defined _WIN32
-
+#ifdef  _WIN32
 #undef Realloc
 #undef Free
-
 #include <windows.h>
-#else
-#include <boost/interprocess/sync/named_semaphore.hpp>
 #endif
 
 #include <boost/interprocess/managed_shared_memory.hpp>
@@ -65,9 +59,7 @@ public:
 
 	void findConstructAllAgain();
 
-#ifdef _WIN32
 	bool jaspAlive();
-#endif
 
 private:
 	bool tryWait(int timeout = 0);
@@ -81,14 +73,13 @@ private:
 	void findConstructDataStrings();
 	void findConstructMutexes();
 
-#ifdef _WIN32
-	static bool heartbeat(std::string path, unsigned int delayMs);
+	static bool										heartbeat(std::string path, unsigned int delayMs);
+	static std::thread								_heartbeatThread;
+
 	int64_t											_lastHeartBeatTimestamp = 0;
 	std::string										_jaspHeartBeatPath;
 	unsigned int									_heatbeatDelayS = 5;
 	unsigned int									_maxHeartbeatDiffS = 100;
-	static std::thread heartbeatThread;
-#endif
 
 	std::string										_baseName,
 													_nameControl,
@@ -117,16 +108,8 @@ private:
 													_dataOutName,
 													_semaphoreInName,
 													_semaphoreOutName;
-#ifdef __APPLE__
-	sem_t										*	_semaphoreOut			= nullptr,
-												*	_semaphoreIn			= nullptr;
-#elif defined _WIN32
-	uint64_t										_msgIDSend				= 0;
-	uint64_t										_msgIDRecv				= 1;
-#else
-	boost::interprocess::named_semaphore		*	_semaphoreOut			= nullptr,
-												*	_semaphoreIn			= nullptr;
-#endif
+	uint64_t										_msgIDSend				= 0,
+													_msgIDRecv				= 1;
 };
 
 #endif // IPCCHANNEL_H

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -163,6 +163,7 @@ void Analyses::storeAnalysis(Analysis* analysis, size_t id, bool notifyAll)
 
 void Analyses::bindAnalysisHandler(Analysis* analysis)
 {
+	connect(analysis,	&Analysis::userModifiedSomething,				this, [](){ DataSetPackage::pkg()->setModified(true); });
 	connect(analysis,	&Analysis::statusChanged,						this, &Analyses::analysisStatusChanged				);
 	connect(analysis,	&Analysis::sendRScriptSignal,					this, &Analyses::sendRScriptHandler					);
 	connect(analysis,	&Analysis::sendFilterSignal,					this, &Analyses::sendFilterHandler					);

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -489,6 +489,7 @@ void Analysis::setStatus(Analysis::Status status)
 
 void Analysis::boundValueChangedHandler()
 {
+	emit userModifiedSomething();
 	incrementRevision(); // To make sure we always process all changed options we increment the revision whenever anything changes
 
 	Log::log() << "Option changed for analysis '" << name() << "' and id " << id() << ", revision incremented to: " << _revision << std::endl;

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -172,7 +172,6 @@ signals:
 	void					userDataChangedSignal(	Analysis * analysis);
 	void					imageChanged();
 	void					rSourceChanged(QString optionName);
-	void					optionsChanged();
 
 	Column				*	requestComputedColumnCreation(		const std::string & columnName, Analysis * analysis);
 	bool					requestColumnCreation(				const std::string & columnName, Analysis * source, columnType type);
@@ -184,7 +183,7 @@ signals:
 
 	void					createFormWhenYouHaveAMoment(QQuickItem* parent = nullptr);
 	void					analysisInitialized();
-	
+	void					userModifiedSomething();
 
 public slots:
 	void					setDynamicModule(	Modules::DynamicModule * module);

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -197,6 +197,9 @@ void DataSetPackage::onDataModeChanged(bool dataMode)
 	beginResetModel();
 	endResetModel();
 	
+	if(false)
+		enginesReceiveNewData();
+	
 	/*if(dataSet())
 	{
 		if(_dataMode)	dataSet()->beginBatchedToDB();

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1432,7 +1432,7 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 	if(_dataSet)
 		deleteDataSet(); //no dbDelete necessary cause we just copied an old sqlite file here from the JASP file
 	
-	//_db->close();
+	_db->close();
 	_db->load();		
 	_db->upgradeDBFromVersion(_jaspVersion);
 	

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1429,7 +1429,7 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 	if(_dataSet)
 		deleteDataSet(); //no dbDelete necessary cause we just copied an old sqlite file here from the JASP file
 	
-	_db->close();
+	//_db->close();
 	_db->load();		
 	_db->upgradeDBFromVersion(_jaspVersion);
 	

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -139,6 +139,7 @@ public:
 				bool				isLoaded()							const	{ return _isLoaded;						 }
 				bool				isJaspFile()						const	{ return _isJaspFile;					  } ///< for readability
 				bool				isModified()						const	{ return _isModified;					   }
+				bool				hasAnalysesWithoutData()			const	{ return _hasAnalysesWithoutData;			}
 				std::string			initialMD5()						const	{ return _initialMD5;						 }
 				bool				manualEdits()						const;
 				QString				windowTitle()						const;

--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -143,7 +143,8 @@ void EngineRepresentation::handleEngineCrash()
 		return; //It will be resumed by EngineSync::restartKilledEngines()
 
 	default: //If not one of the above then let the engine crash and burn (https://www.youtube.com/watch?v=UtUpXPiSJEg)
-		emit  engineTerminated();
+		Log::log() << "emit  engineTerminated();" << std::endl;
+		emit engineTerminated();
 		return;
 	}
 

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -260,7 +260,7 @@ EngineRepresentation * EngineSync::createNewEngine(bool addToEngines, int overri
 		connect(engine,						&EngineRepresentation::moduleLoadingFailed,				this,					&EngineSync::moduleLoadingFailed										);
 		connect(engine,						&EngineRepresentation::logCfgReplyReceived,				this,					&EngineSync::logCfgReplyReceived										);
 		connect(engine,						&EngineRepresentation::plotEditorRefresh,				this,					&EngineSync::plotEditorRefresh											);
-		connect(engine,						&EngineRepresentation::requestEngineRestartAfterCrash,	this,					&EngineSync::restartEngineAfterCrash									);
+		connect(engine,						&EngineRepresentation::requestEngineRestartAfterCrash,	this,					&EngineSync::restartEngineAfterCrash,			Qt::QueuedConnection	);
 		connect(engine,						&EngineRepresentation::registerForModule,				this,					&EngineSync::registerEngineForModule									);
 		connect(engine,						&EngineRepresentation::unregisterForModule,				this,					&EngineSync::unregisterEngineForModule									);
 		connect(engine,						&EngineRepresentation::moduleHasEngine,					this,					&EngineSync::moduleHasEngine											);
@@ -335,6 +335,8 @@ void EngineSync::restartEngines()
 
 void EngineSync::restartEngineAfterCrash(EngineRepresentation * engine)
 {
+	Log::log() << "restartEngineAfterCrash(" << engine->channelNumber() << ")" << std::endl;
+	
 	engine->restartEngine(startSlaveProcess(engine->channelNumber()));
 	logCfgRequest();
 }
@@ -1069,8 +1071,12 @@ void EngineSync::resumeEngines()
 
 	_stopProcessing = false;
 	
-	for(EngineRepresentation * engine : _engines)
-		engine->processReplies(); //Try it once but dont block everything for it
+	while(!allEnginesResumed())
+		for(EngineRepresentation * engine : _engines)
+		{
+			engine->processReplies();
+			startStoppedEngine(engine);
+		}
 }
 
 bool EngineSync::allEnginesStopped(std::set<EngineRepresentation *> these)

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -1069,9 +1069,8 @@ void EngineSync::resumeEngines()
 
 	_stopProcessing = false;
 	
-	while(!allEnginesResumed())
-		for (auto * engine : _engines)
-			engine->processReplies();
+	for(EngineRepresentation * engine : _engines)
+		engine->processReplies(); //Try it once but dont block everything for it
 }
 
 bool EngineSync::allEnginesStopped(std::set<EngineRepresentation *> these)

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -309,14 +309,19 @@ void EngineSync::start(int )
 	//Once it is assigned to a module it won't be possible to use it for another module until it is restarted.
 	createNewEngine();
 
-	QTimer	*timerProcess	= new QTimer(this),
-			*timerBeat		= new QTimer(this);
+	_timerProcess	= new QTimer(this);
+	_timerBeat		= new QTimer(this);
 
-	connect(timerProcess,	&QTimer::timeout, this, &EngineSync::process,				Qt::QueuedConnection);
-	connect(timerBeat,		&QTimer::timeout, this, &EngineSync::heartbeatTempFiles,	Qt::QueuedConnection);
+	connect(_timerProcess,	&QTimer::timeout, this, &EngineSync::process,				Qt::QueuedConnection);
+	connect(_timerBeat,		&QTimer::timeout, this, &EngineSync::heartbeatTempFiles,	Qt::QueuedConnection);
 
-	timerProcess->start(50);
-	timerBeat->start(50);
+	_timerProcess->start(100);
+	_timerBeat->start(50);
+}
+
+void EngineSync::killProcessTimer()
+{
+	_timerProcess->stop();
 }
 
 void EngineSync::restartEngines()

--- a/Desktop/engine/enginesync.h
+++ b/Desktop/engine/enginesync.h
@@ -39,6 +39,7 @@ public:
 	~EngineSync();
 
 	void start(int ppi);
+	void killProcessTimer();
 	bool allEnginesInitializing(std::set<EngineRepresentation *> these = {}); ///< If `these` isn't filled all engines are checked
 
 	static EngineSync * singleton() { return _singleton; }
@@ -164,7 +165,9 @@ private:
 
 private:
 	static EngineSync				*	_singleton;
-	QTimer							*	_filterRunningResetTimer		= nullptr;
+	QTimer							*	_filterRunningResetTimer		= nullptr,
+									*	_timerProcess					= nullptr,
+									*	_timerBeat						= nullptr;
 	RFilterStore					*	_waitingFilter					= nullptr;
 	bool								_stopProcessing					= false,
 										_dataMode						= false,

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1148,6 +1148,10 @@ bool MainWindow::startDetached(const QString & applicationPath, const QStringLis
 #ifdef __unix__
 	detachMe.setUnixProcessParameters(QProcess::UnixProcessFlag::IgnoreSigPipe | QProcess::UnixProcessFlag::CreateNewSession | QProcess::UnixProcessFlag::ResetSignalHandlers | QProcess::UnixProcessFlag::DisconnectControllingTerminal);
 #endif
+	detachMe.setStandardErrorFile(QProcess::nullDevice());
+	detachMe.setStandardInputFile(QProcess::nullDevice());
+	detachMe.setStandardOutputFile(QProcess::nullDevice());
+
 	qint64 pidResult;
 	bool worked = detachMe.startDetached(&pidResult);
 

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1013,7 +1013,11 @@ void MainWindow::refreshPlotsHandler(bool askUserForRefresh)
 void MainWindow::checkEmptyWorkspace()
 {
 	if (!analysesAvailable() && !dataAvailable())
-		_fileMenu->close();
+	{
+		if(DataSetPackage::pkg()->hasAnalysesWithoutData())
+			_fileMenu->close();
+
+	}
 }
 
 void MainWindow::analysisResultsChangedHandler(Analysis *analysis)

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -406,7 +406,7 @@ void MainWindow::makeConnections()
 	connect(_engineSync,			&EngineSync::computeColumnSucceeded,				_computedColumnsModel,	&ComputedColumnModel::computeColumnSucceeded				);
 	connect(_engineSync,			&EngineSync::computeColumnRemoved,					_computedColumnsModel,	&ComputedColumnModel::computeColumnRemoved					);
 	connect(_engineSync,			&EngineSync::computeColumnFailed,					_computedColumnsModel,	&ComputedColumnModel::computeColumnFailed					);
-	connect(_engineSync,			&EngineSync::engineTerminated,						this,					&MainWindow::fatalError,									Qt::QueuedConnection); //To give the process some time to realize it has crashed or something
+	connect(_engineSync,			&EngineSync::engineTerminated,						this,					&MainWindow::fatalError										);
 	connect(_engineSync,			&EngineSync::columnDataTypeChanged,					_columnsModel,			&ColumnsModel::columnTypeChanged							);
 	connect(_engineSync,			&EngineSync::refreshAllPlotsExcept,					_analyses,				&Analyses::refreshAllPlots									);
 	connect(_engineSync,			&EngineSync::processNewFilterResult,				_filterModel,			&FilterModel::processFilterResult							);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -391,6 +391,7 @@ void MainWindow::makeConnections()
 	connect(_package,				&DataSetPackage::checkForDependentColumnsToBeSent,	_computedColumnsModel,	&ComputedColumnModel::checkForDependentColumnsToBeSentSlot	);
 	connect(_package,				&DataSetPackage::datasetChanged,					_columnsModel,			&ColumnsModel::datasetChanged								);
 	connect(_package,				&DataSetPackage::isModifiedChanged,					this,					&MainWindow::packageChanged									);
+	connect(_package,				&DataSetPackage::isModifiedChanged,					_fileMenu,				&FileMenu::workspaceModified								);
 	connect(_package,				&DataSetPackage::windowTitleChanged,				this,					&MainWindow::windowTitleChanged								);
 	connect(_package,				&DataSetPackage::columnDataTypeChanged,				_computedColumnsModel,	&ComputedColumnModel::recomputeColumn						);
 	connect(_package,				&DataSetPackage::checkDoSync,						_loader,				&AsyncLoader::checkDoSync,									Qt::DirectConnection); //Force DirectConnection because the signal is called from Importer which means it is running in AsyncLoaderThread...
@@ -1404,6 +1405,7 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 			_package->dbDelete();
 			_package->reset(false);
 			_ribbonModel->showStatistics();
+			_fileMenu->buttonsForEmptyWorkspace();
 
 			if(!_applicationExiting)
 				_engineSync->cleanRestart();

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1576,7 +1576,7 @@ void MainWindow::fatalError()
 					tr("Error"), 
 					tr("JASP has experienced an unexpected internal error:\n%1").arg(_fatalError) + "\n\n" +
 					tr("JASP had a serious error and cannot calculate anymore.\n\nWe would be grateful if you could report this error to the JASP team."), 
-					tr("Report"), tr("Salvage"), tr("Exit"));
+					tr("Report"), tr("Salvage"), tr("Exit"), QMessageBox::Icon::Critical);
 		
 		switch(response)
 		{

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1225,6 +1225,8 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 	}
 	else if (event->operation() == FileEvent::FileClose)
 	{
+		connectFileEventCompleted(event);
+
 		if (_package->isModified() && (dataAvailable() || analysesAvailable()))
 		{
 			QString title = windowTitle();
@@ -1235,24 +1237,20 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 			default:
 			case MessageForwarder::DialogResponse::Cancel:
 				event->setComplete(false);
-				dataSetIOCompleted(event);
 				return;
 
 			case MessageForwarder::DialogResponse::Save:
 				event->chain(_fileMenu->save());
-				connectFileEventCompleted(event);
 				break;
 
 			case MessageForwarder::DialogResponse::Discard:
 				event->setComplete(true);
-				dataSetIOCompleted(event);
 				break;
 			}
 		}
 		else
 		{
 			event->setComplete();
-			dataSetIOCompleted(event);
 		}
 	}
 }

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1139,12 +1139,30 @@ void MainWindow::connectFileEventCompleted(FileEvent * event)
 	connect(event, &FileEvent::completed, this, &MainWindow::dataSetIOCompleted, Qt::QueuedConnection);
 }
 
+bool MainWindow::startDetached(const QString & applicationPath, const QStringList & args) const
+{
+	QProcess detachMe;
+
+	detachMe.setProgram(applicationPath);
+	detachMe.setArguments(args);
+#ifdef __unix__
+	detachMe.setUnixProcessParameters(QProcess::UnixProcessFlag::IgnoreSigPipe | QProcess::UnixProcessFlag::CreateNewSession | QProcess::UnixProcessFlag::ResetSignalHandlers | QProcess::UnixProcessFlag::DisconnectControllingTerminal);
+#endif
+	qint64 pidResult;
+	bool worked = detachMe.startDetached(&pidResult);
+
+
+	Log::log() << (worked ? "Started" : "Failed to start" ) << " application " << applicationPath << " with args: (" << args.join(", ") << ") and got pid: " << pidResult << std::endl;
+
+	return worked;
+}
+
 void MainWindow::dataSetIORequestHandler(FileEvent *event)
 {
 	if (event->operation() == FileEvent::FileNew)
 	{
 		if (_package->isLoaded())
-			QProcess::startDetached(QCoreApplication::applicationFilePath(), QStringList("--newData"));
+			MainWindow::startDetached(QCoreApplication::applicationFilePath(), QStringList("--newData"));
 		else
 			showNewData();
 	}
@@ -1157,8 +1175,8 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 
 			// begin new instance
 			
-			if(event->isDatabase())		QProcess::startDetached(QCoreApplication::applicationFilePath(), QStringList(tq(event->databaseStr())));
-			else						QProcess::startDetached(QCoreApplication::applicationFilePath(), QStringList(event->path()));
+			if(event->isDatabase())		MainWindow::startDetached(QCoreApplication::applicationFilePath(), QStringList(tq(event->databaseStr())));
+			else						MainWindow::startDetached(QCoreApplication::applicationFilePath(), QStringList(event->path()));
 		}
 		else
 		{
@@ -1789,7 +1807,7 @@ void MainWindow::clearModulesFoldersUser()
 /* the following does not seem to work: the new process crashes immediately... 
 void MainWindow::restartJASP()
 {
-	QProcess::startDetached(QCoreApplication::applicationFilePath());
+	MainWindow::startDetached(QCoreApplication::applicationFilePath());
 	QApplication::quit();
 }*/
 
@@ -1845,7 +1863,7 @@ void MainWindow::startDataEditor(QString path)
 #else
 		args = {path};
 #endif
-		if (!QProcess::startDetached(appname, args))
+		if (!MainWindow::startDetached(appname, args))
 			MessageForwarder::showWarning(tr("Start Editor"), tr("Unable to start the editor : %1. Please check your editor settings in the preference menu.").arg(appname));
 	}
 	else

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -205,10 +205,20 @@ This setting can always be changed in the Interface Preferences.)MultiLine"),
 MainWindow::~MainWindow()
 {
 	Log::log() << "MainWindow::~MainWindow()" << std::endl;
+	
+	_engineSync->killProcessTimer();
 
-	DatabaseInterface::closeInterfaces();
+	try
+	{
+		DatabaseInterface::closeInterfaces();
+	}
+	catch(...) {}
 
-	_analyses->destroyAllForms();
+	try
+	{
+		_analyses->destroyAllForms();
+	}
+	catch(...) {}
 
 	_singleton = nullptr;
 
@@ -229,11 +239,6 @@ MainWindow::~MainWindow()
 		_odm->clearAuthenticationOnExit(OnlineDataManager::OSF);
 
 		delete _resultsJsInterface;
-
-		if (_package->hasDataSet())
-			_package->reset(false);
-
-		//delete _engineSync; it will be deleted by Qt!
 	}
 	catch(...)	{}
 }

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1378,8 +1378,7 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 
 			if(!_applicationExiting)
 				_engineSync->cleanRestart();
-
-			if (_applicationExiting)	
+			else
 				emit exitSignal();
 		}
 		else
@@ -1572,6 +1571,9 @@ void MainWindow::fatalError()
 	if (exiting == false)
 	{
 		exiting = true;
+		
+		_engineSync->killProcessTimer();
+		
 		MessageForwarder::DialogResponse response = MessageForwarder::showYesNoCancel(
 					tr("Error"), 
 					tr("JASP has experienced an unexpected internal error:\n%1").arg(_fatalError) + "\n\n" +

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -129,8 +129,8 @@ public:
 	const QString 		contactUrlBugs()		const;
 	const QString 		contactText()			const;
 	const QString		questionsUrl()			const { return "https://forum.cogsci.nl/index.php?p=/categories/jasp-bayesfactor"; }
-
-	bool hadFatalError() const;
+	bool				startDetached(const QString & applicationPath, const QStringList & args) const; ///< Makes sure no pipes are connected
+	bool				hadFatalError() const;
 	
 public slots:
 	void setImageBackgroundHandler(QString value);

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -128,23 +128,15 @@ FileEvent *FileMenu::newData()
 
 FileEvent *FileMenu::save()
 {
-	FileEvent *event = nullptr;
-
 	if (_currentFileType != Utils::FileType::jasp || DataSetPackage::pkg()->currentFileIsExample())
+		return saveAs();
+
+	FileEvent *event = new FileEvent(this, FileEvent::FileSave);
+	if (!event->setPath(_currentFilePath))
 	{
-		event = saveAs();
-		if (event->isCompleted())
-			return event;
-	}
-	else
-	{
-		event = new FileEvent(this, FileEvent::FileSave);
-		if (!event->setPath(_currentFilePath))
-		{
-			MessageForwarder::showWarning(tr("File Types"), event->getLastError());
-			event->setComplete(false, tr("Failed to open file from OSF"));
-			return event;
-		}
+		MessageForwarder::showWarning(tr("File Types"), event->getLastError());
+		event->setComplete(false, tr("Failed to open file from OSF"));
+		return event;
 	}
 
 	dataSetIORequestHandler(event);

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -252,6 +252,16 @@ void FileMenu::enableButtonsForOpenedWorkspace(bool enableSaveButton)
 	_actionButtons->setEnabled(ActionButtons::Close,			true);
 }
 
+void FileMenu::buttonsForEmptyWorkspace()
+{
+	_actionButtons->setEnabled(ActionButtons::Save,				false);
+	_actionButtons->setEnabled(ActionButtons::SaveAs,			false);
+	_actionButtons->setEnabled(ActionButtons::ExportResults,	false);
+	_actionButtons->setEnabled(ActionButtons::ExportData,		false);
+	_actionButtons->setEnabled(ActionButtons::SyncData,			false);
+	_actionButtons->setEnabled(ActionButtons::Close,			false);
+}
+
 void FileMenu::dataSetIOCompleted(FileEvent *event)
 {
 	if (event->operation() == FileEvent::FileSave || event->operation() == FileEvent::FileOpen)
@@ -281,7 +291,7 @@ void FileMenu::dataSetIOCompleted(FileEvent *event)
 				)
 					DataSetPackage::pkg()->setSynchingExternally(true);
 			}
-			
+
 			// all this stuff is a hack
 			QFileInfo info(event->path());
 			_computer->setFileName(info.completeBaseName());
@@ -313,16 +323,11 @@ void FileMenu::dataSetIOCompleted(FileEvent *event)
 		{
 		case FileEvent::FileOpen:
 		case FileEvent::FileSave:
-			enableButtonsForOpenedWorkspace((!event->isReadOnly() && event->type() == Utils::FileType::jasp) || event->operation() == FileEvent::FileSave);
+			enableButtonsForOpenedWorkspace((!event->isReadOnly() && event->type() == Utils::FileType::jasp) && (event->operation() == FileEvent::FileOpen && DataSetPackage::pkg()->currentFileIsExample() ));
 			break;
 
 		case FileEvent::FileClose:
-			_actionButtons->setEnabled(ActionButtons::Save,				false);
-			_actionButtons->setEnabled(ActionButtons::SaveAs,			false);
-			_actionButtons->setEnabled(ActionButtons::ExportResults,	false);
-			_actionButtons->setEnabled(ActionButtons::ExportData,		false);
-			_actionButtons->setEnabled(ActionButtons::SyncData,			false);
-			_actionButtons->setEnabled(ActionButtons::Close,			false);
+			buttonsForEmptyWorkspace();
 			setMode(FileEvent::FileOpen);
 			break;
 
@@ -368,6 +373,12 @@ void FileMenu::analysisAdded(Analysis *analysis)
 	_actionButtons->setEnabled(ActionButtons::Close,			true);
 	_actionButtons->setEnabled(ActionButtons::SaveAs,			true);
 	_actionButtons->setEnabled(ActionButtons::ExportResults,	true);
+}
+
+void FileMenu::workspaceModified()
+{
+	if(DataSetPackage::pkg()->isLoaded())
+		_actionButtons->setEnabled(ActionButtons::Save, DataSetPackage::pkg()->isModified());
 }
 
 void FileMenu::setSyncFile(FileEvent *event)

--- a/Desktop/widgets/filemenu/filemenu.h
+++ b/Desktop/widgets/filemenu/filemenu.h
@@ -119,6 +119,7 @@ signals:
 
 public slots:
 	void analysisAdded(Analysis *analysis);
+	void workspaceModified();
 	void setSyncFile(FileEvent *event);
 	void dataAutoSynchronizationChanged(bool on) { setDataFileWatcher(on); }
 	void dataSetIOCompleted(FileEvent *event);
@@ -135,7 +136,7 @@ public slots:
 	void refresh();
 	void close();
 	void enableButtonsForOpenedWorkspace(bool enableSaveButton = false);
-
+	void buttonsForEmptyWorkspace();
 
 
 private slots:

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -99,11 +99,7 @@ Engine::~Engine()
 
 bool Engine::parentAlive()
 {
-#ifdef _WIN32
 	return _channel->jaspAlive();
-#else 
-	return ProcessInfo::isParentRunning(); //ProcessInfo::parentPID() == _parentPID;
-#endif
 }
 
 void Engine::run()
@@ -202,7 +198,7 @@ bool Engine::receiveMessages(int timeout)
 			printData["GITHUB_PAT"] = "********";
 		}
 		
-		Log::log() << "Received: '" << printData.toStyledString() << "' so now clearing my send buffer" << std::endl;
+		//Log::log() << "Received: '" << printData.toStyledString() << "' so now clearing my send buffer" << std::endl;
 
 		sendString("");
 

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -97,14 +97,18 @@ Engine::~Engine()
 	_channel = nullptr;
 }
 
-void Engine::run()
+bool Engine::parentAlive()
 {
 #ifdef _WIN32
-	bool jaspAlive = true;
-	while(_engineState != engineState::stopped && jaspAlive)
+	return _channel->jaspAlive();
 #else 
-	while(_engineState != engineState::stopped && ProcessInfo::isParentRunning())
+	return ProcessInfo::parentPID() == _parentPID;
 #endif
+}
+
+void Engine::run()
+{
+	do
 	{
 		static bool initDone = false;
 		if(!initDone && _engineState == engineState::initializing) //Do this first, otherwise receiveMessages possibly triggers some other functions
@@ -127,11 +131,8 @@ void Engine::run()
 		default:
 			Log::log() << "Engine got stuck in engineState " << engineStateToString(_engineState) << " which is not supposed to happen..." << std::endl;
 		}
-
-#ifdef _WIN32
-		jaspAlive = _channel->jaspAlive();
-#endif
 	}
+	while(_engineState != engineState::stopped && parentAlive());
 
 	if(_engineState == engineState::stopped)
 		Log::log() << "Engine leaving mainloop after having been asked to stop." << std::endl;

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -102,7 +102,7 @@ bool Engine::parentAlive()
 #ifdef _WIN32
 	return _channel->jaspAlive();
 #else 
-	return ProcessInfo::parentPID() == _parentPID;
+	return ProcessInfo::isParentRunning(); //ProcessInfo::parentPID() == _parentPID;
 #endif
 }
 

--- a/Engine/engine.h
+++ b/Engine/engine.h
@@ -42,7 +42,7 @@ public:
 	int						engineNum() const { return _engineNum; }
 	void					sendString(std::string message);
 
-	
+	bool					parentAlive();
 
 	Status					getAnalysisStatus() { return _analysisStatus; }
 	analysisResultStatus	getStatusToAnalysisStatus();

--- a/QMLComponents/utilities/messageforwarder.cpp
+++ b/QMLComponents/utilities/messageforwarder.cpp
@@ -103,7 +103,7 @@ void MessageForwarder::showWarning(QString title, QString message)
 	box.exec();
 }
 
-bool MessageForwarder::showYesNo(QString title, QString message, QString YesButtonText, QString NoButtonText)
+bool MessageForwarder::showYesNo(QString title, QString message, QString YesButtonText, QString NoButtonText, QMessageBox::Icon icon)
 {
 	if(YesButtonText == "")		YesButtonText	= tr("Yes");
 	if(NoButtonText == "")		NoButtonText	= tr("No");
@@ -123,7 +123,7 @@ bool MessageForwarder::showYesNo(QString title, QString message, QString YesButt
 	return box.clickedButton() == yesButton;
 }
 
-MessageForwarder::DialogResponse MessageForwarder::showYesNoCancel(QString title, QString message, QString YesButtonText, QString NoButtonText, QString CancelButtonText)
+MessageForwarder::DialogResponse MessageForwarder::showYesNoCancel(QString title, QString message, QString YesButtonText, QString NoButtonText, QString CancelButtonText, QMessageBox::Icon icon)
 {
 	if(YesButtonText == "")		YesButtonText		= tr("Yes");
 	if(NoButtonText == "")		NoButtonText		= tr("No");
@@ -133,7 +133,7 @@ MessageForwarder::DialogResponse MessageForwarder::showYesNoCancel(QString title
 
 	box.setText(title);
 	box.setInformativeText(message);
-	box.setIcon(QMessageBox::Question);
+	box.setIcon(icon);
 
 	QPushButton* yesButton =	box.addButton(YesButtonText,		QMessageBox::ButtonRole::YesRole);
 	QPushButton* noButton =		box.addButton(NoButtonText,			QMessageBox::ButtonRole::NoRole);

--- a/QMLComponents/utilities/messageforwarder.h
+++ b/QMLComponents/utilities/messageforwarder.h
@@ -32,13 +32,13 @@ public:
 	static void showWarning(std::string message)						{ showWarning(QString::fromStdString(message));								}
 	static void showWarning(const char * message)						{ showWarning(QString(message));											}
 
-	static bool showYesNo(QString title,		QString message,		QString YesButtonText		= "",	QString NoButtonText = "");
-	static bool showYesNo(std::string title,	std::string message,	std::string YesButtonText	= "",	std::string NoButtonText = "")	{ return showYesNo(QString::fromStdString(title), QString::fromStdString(message), QString::fromStdString(YesButtonText), QString::fromStdString(NoButtonText)); }
-	static bool showYesNo(const char * title,	const char * message,	const char * YesButtonText	= "",	const char * NoButtonText = "")	{ return showYesNo(QString(title), QString(message), QString(YesButtonText), QString(NoButtonText)); }
+	static bool showYesNo(QString title,		QString message,		QString YesButtonText		= "",	QString NoButtonText = "",			QMessageBox::Icon icon = QMessageBox::Question);
+	static bool showYesNo(std::string title,	std::string message,	std::string YesButtonText	= "",	std::string NoButtonText = "",		QMessageBox::Icon icon = QMessageBox::Question)	{ return showYesNo(QString::fromStdString(title), QString::fromStdString(message), QString::fromStdString(YesButtonText), QString::fromStdString(NoButtonText), icon); }
+	static bool showYesNo(const char * title,	const char * message,	const char * YesButtonText	= "",	const char * NoButtonText = "",		QMessageBox::Icon icon = QMessageBox::Question)	{ return showYesNo(QString(title), QString(message), QString(YesButtonText), QString(NoButtonText), icon); }
 
 
 	static DialogResponse showSaveDiscardCancel(QString title, QString message, QString saveTxt = "",		QString discardText = "",	QString cancelText = "");
-	static DialogResponse showYesNoCancel(		QString title, QString message, QString YesButtonText = "", QString NoButtonText = "",	QString CancelButtonText = "");
+	static DialogResponse showYesNoCancel(		QString title, QString message, QString YesButtonText = "", QString NoButtonText = "",	QString CancelButtonText = "",	QMessageBox::Icon icon = QMessageBox::Question);
 
 	static QString browseOpenFile(			QString caption, QString browsePath,	QString filter, bool multiple = false);
 	static QString browseSaveFile(			QString caption, QString browsePath,	QString filter, QString * selectedExtension = nullptr);


### PR DESCRIPTION
Add a critical icon to crash msgbox and change loop a bit.

Also try to make JASP a bit less prone to crashing or getting stuck.

now uses same communication protocol on all three oses.

Stop calling "EngineSync::process" once exit is chosen or a fatal error occurs.

Set stdout/cerr etc to null for newly started detached JASPs. (to avoid weird crashes in secondary jasp's engines after closing the prime jasp).