### PR TITLE
Loading JASP File without data should not crash

### DIFF
--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -82,9 +82,12 @@ void DataSet::endBatchedToDB(std::function<void(float)> progressCallback, Column
 		_writeBatchedToDBDepth--;
 	}
 	
-	if(_writeBatchedToDBDepth == 0 && columns.size() > 0)
+	if(_writeBatchedToDBDepth == 0)
 	{
-		db().dataSetBatchedValuesUpdate(this, columns, [&progressCallback](float f){ progressCallback(0.75 + (f * 0.25));});
+		if(columns.size())
+			db().dataSetBatchedValuesUpdate(this, columns, [&progressCallback](float f){ progressCallback(0.75 + (f * 0.25));});
+		else
+			progressCallback(1);
 		incRevision(); //Should trigger reload at engine end
 	}
 }

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -82,7 +82,7 @@ void DataSet::endBatchedToDB(std::function<void(float)> progressCallback, Column
 		_writeBatchedToDBDepth--;
 	}
 	
-	if(_writeBatchedToDBDepth == 0)
+	if(_writeBatchedToDBDepth == 0 && columns.size() > 0)
 	{
 		db().dataSetBatchedValuesUpdate(this, columns, [&progressCallback](float f){ progressCallback(0.75 + (f * 0.25));});
 		incRevision(); //Should trigger reload at engine end


### PR DESCRIPTION
Load Data Library/5. Frequnecies/Three-Sided Coin JASP file.
This should not crash.