### PR TITLE
Do not resume engine if it is resuming or has just resumed

### DIFF
--- a/Desktop/engine/enginerepresentation.cpp
+++ b/Desktop/engine/enginerepresentation.cpp
@@ -848,6 +848,9 @@ void EngineRepresentation::sendPauseEngine()
 
 void EngineRepresentation::resumeEngine(bool setResuming)
 {
+	if (_engineState == engineState::resuming || _engineState == engineState::idle )
+		return;
+
 	if(_engineState != engineState::paused && _engineState != engineState::stopped && _engineState != engineState::initializing)
 		throw unexpectedEngineReply("Attempt to resume engine #" + std::to_string(channelNumber()) + " made but it isn't paused, initializing or stopped");
 


### PR DESCRIPTION
Load a data file in JASP
Change some data in the data file
-> crash

After the https://github.com/jasp-stats/jasp-desktop/commit/a67eff523e0667de4bf6b3bd009060bb7c575021 commit, JASP tries to resume the engines a. bit too frenetically. This must be adjusted.