### PR TITLE
Try to speed up adding computed columns to big datasets

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -713,6 +713,7 @@ bool Column::overwriteDataAndType(stringvec colData, columnType colType)
 	nonFilteredCountersReset();
 	labelsHandleAutoSort();
 	
+	
 	return changes;
 }
 
@@ -1107,11 +1108,15 @@ void Column::_resetLabelValueMap()
 {
 	_labelByIntsIdMap.clear();
 	_labelByValDis.clear();
+	_labelsByValue.clear();
+	_labelsByDisplay.clear();
 
 	for(Label * label : _labels)
 	{
-		_labelByIntsIdMap[label->intsId()]														= label;
-		_labelByValDis[std::make_pair(label->originalValueAsString(), label->labelDisplay())]	= label;
+		_labelByIntsIdMap[				label->intsId()											] = label;
+		_labelByValDis[std::make_pair(	label->originalValueAsString(),	label->labelDisplay())	] = label;
+		_labelsByValue[					label->originalValueAsString()							] . insert(label);
+		_labelsByDisplay[												label->labelDisplay()	] . insert(label);
 	}
 }
 

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -787,6 +787,26 @@ void Column::labelsClear(bool doIncRevision)
 		incRevision();
 }
 
+
+void Column::_resetLabelValueMap()
+{
+
+	_labelByIntsIdMap.clear();
+	_labelByValDis.clear();
+	_labelsByValue.clear();
+	_labelsByDisplay.clear();
+	
+	_maxWidthLabel	= -1;
+	_maxWidthValue	= -1;
+	_hasShadows		= false;
+	
+	_highestIntsId = 0;
+	
+	for(Label * label : _labels)
+		_labelMapIt(label);
+}
+
+
 void Column::beginBatchedLabelsDB()
 {
 	_batchedLabelDepth++;
@@ -984,37 +1004,6 @@ void Column::labelsRemoveByIntsId(std::set<int> valuesToRemove, bool updateOrder
 		_dbUpdateLabelOrder();
 }
 
-strintmap Column::labelsResetValues(int & maxValue)
-{
-	JASPTIMER_SCOPE(Column::labelsResetValues);
-
-	beginBatchedLabelsDB();
-
-	strintmap result;
-	int labelValue = 0;
-	_labelByIntsIdMap.clear();
-
-	for (Label * label : _labels)
-	{
-		if (label->intsId() != labelValue)
-			label->setIntsId(labelValue);
-
-		result[label->label()] = labelValue;
-
-		_labelByIntsIdMap[labelValue] = label;
-
-		labelValue++;
-	}
-
-	maxValue = labelValue;
-
-	_highestIntsId = maxValue;
-
-	endBatchedLabelsDB();
-
-	return result;
-}
-
 void Column::labelsRemoveBeyond(size_t desiredLabelsSize)
 {
 	for(size_t i=desiredLabelsSize; i<_labels.size(); i++)
@@ -1101,23 +1090,6 @@ Label * Column::labelByIndexNotEmpty(int index) const
 size_t Column::labelsNonEmptyCount() const
 {
 	return _labelNonEmptyIndexByLabel.size();
-}
-
-
-void Column::_resetLabelValueMap()
-{
-	_labelByIntsIdMap.clear();
-	_labelByValDis.clear();
-	_labelsByValue.clear();
-	_labelsByDisplay.clear();
-
-	for(Label * label : _labels)
-	{
-		_labelByIntsIdMap[				label->intsId()											] = label;
-		_labelByValDis[std::make_pair(	label->originalValueAsString(),	label->labelDisplay())	] = label;
-		_labelsByValue[					label->originalValueAsString()							] . insert(label);
-		_labelsByDisplay[												label->labelDisplay()	] . insert(label);
-	}
 }
 
 std::string Column::_getLabelDisplayStringByValue(int key, bool ignoreEmptyValue) const

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -761,9 +761,13 @@ void Column::_sortLabelsByOrder()
 
 void Column::labelsClear(bool doIncRevision)
 {
+	bool hadLabels = _labels.size() > 0;
 	for (Label* label : _labels)
 		delete label;
-	db().labelsClear(_id);
+	
+	if(hadLabels)
+		db().labelsClear(_id);
+	
 	_labelNonEmptyIndexByLabel.clear();
 	_labelByNonEmptyIndex.clear();
 	_labelByIntsIdMap.clear();

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -127,7 +127,6 @@ public:
 			void					labelsRemove(		int labelIndex);
 			int						labelsSet(int lbId,	int value, const std::string & display, bool filterAllows, const std::string & description, const Json::Value & originalValue, int order=-1, int id=-1);
 			void					labelsRemoveByIntsId(	intset valuesToRemove, bool updateOrder = true);
-			strintmap				labelsResetValues(	int & maxValue);
 			void					labelsRemoveBeyond( size_t indexToStartRemoving);
 			
 			int						nonFilteredNumericsCount();

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -1882,6 +1882,7 @@ void DatabaseInterface::_runStatements(const std::string & statements, bindParam
 				{
 					std::string errorMsg = "Running ```\n"+statements.substr(current - start)+"\n``` had unchecked status "+std::to_string(ret)+" because of: `" + sqlite3_errmsg(_db());
 					Log::log() << errorMsg << std::endl;
+					break;
 				}
 			   }
 				

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1373,7 +1373,7 @@ void DataSetPackage::emitColumnChanged(const QString & colName)
 }
 
 
-void DataSetPackage::beginLoadingData(bool informEngines)
+void DataSetPackage::beginLoadingData(bool)
 {
 	JASPTIMER_SCOPE(DataSetPackage::beginLoadingData);
 
@@ -1382,7 +1382,7 @@ void DataSetPackage::beginLoadingData(bool informEngines)
 	beginResetModel();
 }
 
-void DataSetPackage::endLoadingData(bool informEngines)
+void DataSetPackage::endLoadingData(bool)
 {
 	JASPTIMER_SCOPE(DataSetPackage::endLoadingData);
 
@@ -2049,7 +2049,10 @@ QString DataSetPackage::insertColumnSpecial(int columnIndex, const QMap<QString,
 
 	if(setManualEditsPar)
 		setManualEdits(true); //Don't synch with external file after editing
-
+	
+	//So, we are inserting a column here, but maybe there are engines running, doing whatever (maybe loading a really big datafile)
+	//Instead of waiting for this, and then inserting the column, and then waiting for it again, we can also simply stop those engines.
+	enginesPrepareForData();
 	beginResetModel();
 
 	_dataSet->insertColumn(columnIndex);
@@ -2071,6 +2074,8 @@ QString DataSetPackage::insertColumnSpecial(int columnIndex, const QMap<QString,
 	
 	if(column->codeType() == computedColumnType::constructorCode || column->codeType() == computedColumnType::rCode)
 		emit columnAddedManually(tq(column->name())); //Will trigger setChosenColumn and setVisible(true) on ColumnModel, showing it to the user
+	
+	enginesReceiveNewData();
 
 	return QString::fromStdString(column->name());
 }

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -1139,8 +1139,9 @@ void EngineSync::dataModeChanged(bool dataMode)
 
 void EngineSync::enginesPrepareForData()
 {
-	/*JASPTIMER_SCOPE(EngineSync::enginesPrepareForData);
+	JASPTIMER_SCOPE(EngineSync::enginesPrepareForData);
 
+	Log::log() << "EngineSync::enginesPrepareForData!" << std::endl;
 	
 	//make sure we process any received messages first.
 	for(auto * engine : _engines)
@@ -1149,7 +1150,7 @@ void EngineSync::enginesPrepareForData()
 	std::set<EngineRepresentation *> pauseOrKillThese;
 
 	for(EngineRepresentation * e : _engines)
-		if(e->busyWithData())
+		if(!e->idle())
 		{
 			pauseOrKillThese.insert(e);
 			e->pauseEngine(true);
@@ -1163,11 +1164,13 @@ void EngineSync::enginesPrepareForData()
 
 	for (auto * engine : pauseOrKillThese)
 		if(!engine->paused())
-			engine->killEngine();*/
+			engine->killEngine();
 }
 
 void EngineSync::enginesReceiveNewData()
 {
+	Log::log() << "EngineSync::enginesReceiveNewData!" << std::endl;
+	
 	emit reloadData();
 }
 

--- a/QMLComponents/datasetviewbase.cpp
+++ b/QMLComponents/datasetviewbase.cpp
@@ -342,11 +342,15 @@ void DataSetViewBase::viewportChanged()
 
 	determineCurrentViewPortIndices();
     storeOutOfViewItems();
-	buildNewLinesAndCreateNewItems();
-
-	JASPTIMER_RESUME(DataSetViewBase::updateCalledForRender);
-	update();
-	JASPTIMER_STOP(DataSetViewBase::updateCalledForRender);
+	
+	if(_viewportW > 0 && _viewportH > 0)
+	{
+		buildNewLinesAndCreateNewItems();
+	
+		JASPTIMER_RESUME(DataSetViewBase::updateCalledForRender);
+		update();
+		JASPTIMER_STOP(DataSetViewBase::updateCalledForRender);
+	}
 
 	_previousViewportColMin = _currentViewportColMin;
 	_previousViewportColMax = _currentViewportColMax;


### PR DESCRIPTION
Some problems with loading a long file (2000000 rows) were:
- the filtereddataentry was trying to make show all the cells at once, despite the viewport width being -1
- it was deleting all labels from the database for a just created column... Just wasted time after all
- and if an engine started loading the data already, or an analysis and that analysis adds a computed column... It first waits, the does the computed column and then reloads.

Given that sampling added 3 computed columns and als has the filtereddataentry does indeed make things pretty slow...

Ive made all of this much quicker. The only thing now remaining is that the filtered data entry component still is a bit slow but its not obvious to the user that something is happening:
- first it tries to run the filter before the computed columns are filled, so a bunch of time waited for nothing. (Well, showing a warning that "everything was filtered out" 
- computed columns are then filled by running the analysis, this takes a while all on its own
- then it runs the filter by name again and actually selects the rows for filtereddataentry
- and it finally shows them.

It does work and with some patience it isnt so bad.
However, for user friendlieness I would love to have feedback in the component/analysis. But there is really no time for this now.

If a manual for auditing/sampling is created maybe it could mention opening the engineswindow to keep an eye on whats going on:
Ctrl+Shift+Alt+E
Cmd+Shift+Option+E
Opening it from the button in advanced preferences.

This PR probably fixes https://github.com/jasp-stats/jasp-test-release/issues/2998 as far as I can now