### PR TITLE
Fixes markdown help with Tab View

### DIFF
--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -246,7 +246,7 @@ void AnalysisForm::sortControls(QList<JASPControl*>& controls)
 	for (JASPControl* control : controls)
 	{
 		control->addExplicitDependency();
-		std::vector<JASPControl*> depends(control->depends().begin(), control->depends().end());
+		JASPControls depends(control->depends().begin(), control->depends().end());
 
 		// By adding at the end of the vector new dependencies, this makes sure that these dependencies of these new dependencies are
 		// added and so on recursively, so that the 'depends' set of each control gets all (direct or indirect) controls it depends on.

--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -417,7 +417,7 @@ QString ComponentsListBase::_changeLastNumber(const QString &val) const
 		return result.append(QString::number(2));
 }
 
-std::vector<JASPControl *> ComponentsListBase::getMDSubItems(const QQuickItem*) const
+JASPControls ComponentsListBase::getMDSubItems(const QQuickItem*) const
 {
 	const Terms& terms = model()->terms();
 

--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -417,6 +417,18 @@ QString ComponentsListBase::_changeLastNumber(const QString &val) const
 		return result.append(QString::number(2));
 }
 
+std::vector<JASPControl *> ComponentsListBase::getMDSubItems(const QQuickItem*) const
+{
+	const Terms& terms = model()->terms();
+
+	// In case of a ComponentsList (or TabView), use only the items of the first row (if exists) to generate the help.
+	const ListModel::RowControlMap & map = model()->getAllRowControls();
+	if (map.size() > 0)
+		return JASPControl::getMDSubItems(map.first()->getRowObject());
+
+	return {};
+}
+
 QString ComponentsListBase::_makeUnique(const QString &val, int index) const
 {
 	return _makeUnique(val, _termsModel->terms().values(), index);

--- a/QMLComponents/controls/componentslistbase.h
+++ b/QMLComponents/controls/componentslistbase.h
@@ -94,8 +94,9 @@ protected slots:
 
 protected:
 	QString				_makeUnique(const QString& val, int index = -1)	const;
-	QString				_makeUnique(const QString& val, const QList<QString>& values, int index = -1) const;
+	QString				_makeUnique(const QString& val, const QList<QString>& values, int index = -1)	const;
 	QString				_changeLastNumber(const QString& val) const;
+	std::vector<JASPControl*> getMDSubItems(const QQuickItem* parentItem = nullptr)						const override;
 
 private:
 	ListModelTermsAssigned*		_termsModel				= nullptr;

--- a/QMLComponents/controls/componentslistbase.h
+++ b/QMLComponents/controls/componentslistbase.h
@@ -96,7 +96,7 @@ protected:
 	QString				_makeUnique(const QString& val, int index = -1)	const;
 	QString				_makeUnique(const QString& val, const QList<QString>& values, int index = -1)	const;
 	QString				_changeLastNumber(const QString& val) const;
-	std::vector<JASPControl*> getMDSubItems(const QQuickItem* parentItem = nullptr)						const override;
+	JASPControls		getMDSubItems(const QQuickItem* parentItem = nullptr)						const override;
 
 private:
 	ListModelTermsAssigned*		_termsModel				= nullptr;

--- a/QMLComponents/controls/expanderbuttonbase.cpp
+++ b/QMLComponents/controls/expanderbuttonbase.cpp
@@ -35,33 +35,10 @@ void ExpanderButtonBase::setUp()
 
 QString ExpanderButtonBase::generateMDHelp(int depth) const
 {
-	if (!hasInfoSomewhere())
-		return QString();
-
-	QStringList markdown;
-
-	if (!useCollapsibleSection(depth))
-		// For sub-section, draw first a line, and reset the depth to 0.
-		markdown <<  "\n---\n\n";
-
-	markdown << JASPControl::generateMDHelp(0);
-
-	if (useCollapsibleSection(depth))
-		markdown << "\n</details>";
-
-	return markdown.join("");
+	return JASPControl::generateMDHelp(depth) + "\n" + (QString{depth * 2, ' '}) + "</details>\n";
 }
 
 QString ExpanderButtonBase::printLabelMD(int depth) const
 {
-	if (useCollapsibleSection(depth))
-		// Use collapsible section
-		return "<details>\n<summary><b>" + fullLabel() + "</b></summary>\n";
-	else
-		return JASPControl::printLabelMD(depth);
-}
-
-bool ExpanderButtonBase::useCollapsibleSection(int depth) const
-{
-	return depth == 0 && !fullLabel().isEmpty();
+	return "<details><summary><b>" + fullLabel() + "</b></summary>";
 }

--- a/QMLComponents/controls/expanderbuttonbase.h
+++ b/QMLComponents/controls/expanderbuttonbase.h
@@ -36,8 +36,6 @@ public:
 	QString		printLabelMD(int depth)									const	override;
 	bool		infoLabelIsHeader()										const	override	{ return true; }
 
-private:
-	bool useCollapsibleSection(int depth)								const;
 };
 
 #endif // EXPANDERBUTTONBASE_H

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -602,9 +602,9 @@ bool JASPControl::hasLabelOrInfo() const
 	return !fullLabel().isEmpty() || !info().isEmpty();
 }
 
-std::vector<JASPControl*> JASPControl::getMDSubItems(const QQuickItem* parentItem) const
+JASPControls JASPControl::getMDSubItems(const QQuickItem* parentItem) const
 {
-	std::vector<JASPControl*> MDSubItems;
+	JASPControls MDSubItems;
 
 	if (!parentItem)
 		parentItem = _childControlsArea ? _childControlsArea : this;
@@ -614,7 +614,7 @@ std::vector<JASPControl*> JASPControl::getMDSubItems(const QQuickItem* parentIte
 		// In case of RadioButtonGroup, if at least one of the RadioButton has info, then all RadioButtons should be listed even if they don't have any info
 		if (childControl->hasInfoSomewhere() || (controlType() == ControlType::RadioButtonGroup && childControl->controlType() == ControlType::RadioButton))
 		{
-			std::vector<JASPControl*> MDGrandChilren = childControl->getMDSubItems();
+			JASPControls MDGrandChilren = childControl->getMDSubItems();
 
 			if (!childControl->hasLabelOrInfo())
 				// The child does not have label nor info: just add its own children to the parent
@@ -629,7 +629,7 @@ std::vector<JASPControl*> JASPControl::getMDSubItems(const QQuickItem* parentIte
 
 QString JASPControl::generateMDHelp(int depth) const
 {
-	std::vector<JASPControl*> MDSubItems = getMDSubItems();
+	JASPControls MDSubItems = getMDSubItems();
 	QStringList markdown;
 	markdown << printLabelMD(depth) << info() << "\n";
 

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -602,11 +602,14 @@ bool JASPControl::hasLabelOrInfo() const
 	return !fullLabel().isEmpty() || !info().isEmpty();
 }
 
-std::vector<JASPControl*> JASPControl::getMDSubItems() const
+std::vector<JASPControl*> JASPControl::getMDSubItems(const QQuickItem* parentItem) const
 {
 	std::vector<JASPControl*> MDSubItems;
 
-	for (JASPControl* childControl : getChildJASPControls(_childControlsArea ? _childControlsArea : this, true))
+	if (!parentItem)
+		parentItem = _childControlsArea ? _childControlsArea : this;
+
+	for (JASPControl* childControl : getChildJASPControls(parentItem, true))
 	{
 		// In case of RadioButtonGroup, if at least one of the RadioButton has info, then all RadioButtons should be listed even if they don't have any info
 		if (childControl->hasInfoSomewhere() || (controlType() == ControlType::RadioButtonGroup && childControl->controlType() == ControlType::RadioButton))

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -53,7 +53,8 @@ class JASPControl : public QQuickItem
 protected:
 	typedef std::set<JASPControl*>			Set;
 	typedef std::set<const JASPControl*>	SetConst;
-
+	typedef std::vector<JASPControl*>		JASPControls;
+	
 public:
 	struct ParentKey
 	{
@@ -259,22 +260,22 @@ signals:
 	void	usedVariablesChanged();
 	void	explicitDependsChanged();
 
-	void				requestColumnCreation(std::string columnName, columnType columnType);
-	void				requestComputedColumnCreation(std::string columnName);
-	void				requestComputedColumnDestruction(std::string columnName);
+	void					requestColumnCreation(std::string columnName, columnType columnType);
+	void					requestComputedColumnCreation(std::string columnName);
+	void					requestComputedColumnDestruction(std::string columnName);
 
 protected:
-	void				componentComplete()									override;
-	void				setCursorShape(int shape);
-	void				setParentDebugToChildren(bool debug);
-	void				focusInEvent(QFocusEvent* event)					override;
-	bool				eventFilter(QObject *watched, QEvent *event)		override;
-	bool				checkOptionName(const QString& name);
-	void				_addExplicitDependency(const QVariant& depends);
-	bool				dependingControlsAreInitialized();
-	virtual void		_setInitialized(const Json::Value &value);
-	virtual QString		printLabelMD(int depth)												const;
-	virtual std::vector<JASPControl*> getMDSubItems(const QQuickItem* parentItem = nullptr)	const;
+	void					componentComplete()									override;
+	void					setCursorShape(int shape);
+	void					setParentDebugToChildren(bool debug);
+	void					focusInEvent(QFocusEvent* event)					override;
+	bool					eventFilter(QObject *watched, QEvent *event)		override;
+	bool					checkOptionName(const QString& name);
+	void					_addExplicitDependency(const QVariant& depends);
+	bool					dependingControlsAreInitialized();
+	virtual void			_setInitialized(const Json::Value &value);
+	virtual QString			printLabelMD(int depth)												const;
+	virtual JASPControls	getMDSubItems(const QQuickItem* parentItem = nullptr)	const;
 
 protected:
 	Set						_depends;
@@ -327,5 +328,6 @@ protected:
 	static const QStringList						_optionReservedNames;
 };
 
+typedef std::vector<JASPControl*> JASPControls;
 
 #endif // JASPCONTROL_H

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -119,7 +119,6 @@ public:
 	virtual bool		infoLabelItalic()			const	{ return  false;					}
 
 	QString				toolTip()					const	{ return _toolTip;					}
-	std::vector<JASPControl*> getMDSubItems()		const;
 	virtual QString		generateMDHelp(int depth = 0) const;
 	virtual QString		generateDoxygenHelp()		const;
 	virtual bool		hasInfoSomewhere()					const;
@@ -274,7 +273,8 @@ protected:
 	void				_addExplicitDependency(const QVariant& depends);
 	bool				dependingControlsAreInitialized();
 	virtual void		_setInitialized(const Json::Value &value);
-	virtual QString		printLabelMD(int depth)								const;
+	virtual QString		printLabelMD(int depth)												const;
+	virtual std::vector<JASPControl*> getMDSubItems(const QQuickItem* parentItem = nullptr)	const;
 
 protected:
 	Set						_depends;


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2955

In a TabView (and any ComponentList), the generated markdown should only take into account the controls made by the first Tab (or Row), if not it will duplicate the help for each new tab.

Also markdown generated by Section should also work if the Section is inside a TabView (or a ComponentList).