### PR TITLE
fix massive filesizes by not using labelDisplay() as it messes up badly with finding previous labels then.

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -997,13 +997,13 @@ void Column::labelsRemoveByIntsId(std::set<int> valuesToRemove, bool updateOrder
 		_dbUpdateLabelOrder();
 }
 
-void Column::labelsRemoveBeyond(size_t desiredLabelsSize)
+void Column::labelsRemoveBeyond(size_t indexToStartRemoving)
 {
-	for(size_t i=desiredLabelsSize+1; i<_labels.size(); i++)
+	for(size_t i=indexToStartRemoving+1; i<_labels.size(); i++)
 		delete _labels[i];
 	
-	if(desiredLabelsSize+1 < _labels.size())
-		_labels.resize(desiredLabelsSize);
+	if(indexToStartRemoving+1 < _labels.size())
+		_labels.resize(indexToStartRemoving);
 
 	_resetLabelValueMap();
 }

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -901,8 +901,6 @@ int Column::labelsAdd(int value, const std::string & display, bool filterAllows,
 	if(_labelByValDis.count(valDisplay))
 		return _labelByValDis.at(valDisplay)->intsId();
 
-	if(display == ".i")
-		"???";
 
 	Label * label = new Label(this, display, value, filterAllows, description, originalValue, order, id);
 	_labels.push_back(label);
@@ -1523,13 +1521,9 @@ bool Column::setValue(size_t row, std::string value, const std::string & label, 
 	if(itsADouble)
 		value = ColumnUtils::doubleToString(newDoubleToSet);
 
-	if(label == ".i")
-		"???";
 
 	Label	* newLabel		= justAValue ? labelByValue(value) : labelByValueAndDisplay(value, label);
 
-	if(label == ".i")
-		"???";
 
 	if(!newLabel)
 		newLabel = labelByIntsId(labelsAdd((justAValue || labelIsValue) ? value : label, "", itsADouble ? Json::Value(newDoubleToSet) : value));

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -551,6 +551,7 @@ columnType Column::setValues(size_t rows, const std::function<std::string(size_t
 	{
 		const std::string	value = valueLookup(i),
 							label = labelLookup(i);
+
 		if(setValue(i, value, label, false) && aChange)
 			(*aChange) = true;
 				
@@ -877,15 +878,15 @@ int Column::labelsAdd(const std::string & display, const std::string & descripti
 int Column::_labelMapIt(Label * label)
 {
 	_labelByIntsIdMap	[ label->intsId()				] =			label;
-	_labelsByDisplay	[ label->labelDisplay()			].insert(	label);
+	_labelsByDisplay	[ label->label()				].insert(	label);
 	_labelByValDis		[ label->origValDisplay()		] =			label;
 	_labelsByValue		[ label->originalValueAsString()].insert(	label);
 
 	_highestIntsId = std::max(_highestIntsId, label->intsId());
 	_maxWidthValue = std::max(_maxWidthValue, int(stringUtils::approximateVisualLength(label->originalValueAsString(true, false))));
-	_maxWidthLabel = std::max(_maxWidthLabel, int(stringUtils::approximateVisualLength(label->labelDisplay())));
+	_maxWidthLabel = std::max(_maxWidthLabel, int(stringUtils::approximateVisualLength(label->label())));
 
-	if(label->originalValueAsString() != label->labelDisplay())
+	if(label->originalValueAsString() != label->label() && !label->isEmptyValue())
 		_hasShadows = true;
 		
 	return label->intsId();
@@ -899,6 +900,9 @@ int Column::labelsAdd(int value, const std::string & display, bool filterAllows,
 
 	if(_labelByValDis.count(valDisplay))
 		return _labelByValDis.at(valDisplay)->intsId();
+
+	if(display == ".i")
+		"???";
 
 	Label * label = new Label(this, display, value, filterAllows, description, originalValue, order, id);
 	_labels.push_back(label);
@@ -943,14 +947,12 @@ int Column::labelsSet(int labelIndex, int value, const std::string &display, boo
 	}
 	else
 	{
-		if(_labels.size() != labelIndex)
-			Log::log() << "Labels are not being set in a sensible order it seems." << std::endl;
-
 		if(id == -1)
 			Log::log() << "This functions expects a label to be set from the DB, so why is dbId -1?" << std::endl;
 
 		if(_labels.size() < labelIndex+1)
 			_labels			. resize(labelIndex+1);
+
 		_labels[labelIndex]	= new Label(this, display, value, filterAllows, description, originalValue, order, id);
 		label				= _labels[labelIndex];
 	}
@@ -975,7 +977,7 @@ void Column::labelsRemoveByIntsId(std::set<int> valuesToRemove, bool updateOrder
 				{
 					_labelByIntsIdMap.erase(label->intsId());
 					
-					auto valDis = std::make_pair(label->originalValueAsString(), label->labelDisplay());
+					auto valDis = std::make_pair(label->originalValueAsString(), label->label());
 					if(_labelByValDis.count(valDis) && _labelByValDis.at(valDis) == label)
 						_labelByValDis.erase(valDis);
 						
@@ -999,10 +1001,10 @@ void Column::labelsRemoveByIntsId(std::set<int> valuesToRemove, bool updateOrder
 
 void Column::labelsRemoveBeyond(size_t desiredLabelsSize)
 {
-	for(size_t i=desiredLabelsSize; i<_labels.size(); i++)
+	for(size_t i=desiredLabelsSize+1; i<_labels.size(); i++)
 		delete _labels[i];
 	
-	if(desiredLabelsSize < _labels.size())
+	if(desiredLabelsSize+1 < _labels.size())
 		_labels.resize(desiredLabelsSize);
 
 	_resetLabelValueMap();
@@ -1093,7 +1095,7 @@ std::string Column::_getLabelDisplayStringByValue(int key, bool ignoreEmptyValue
 	if(_labelByIntsIdMap.count(key))
 	{
 		return	ignoreEmptyValue 
-			?	_labelByIntsIdMap.at(key)->labelIgnoreEmpty()
+			?	_labelByIntsIdMap.at(key)->label()
 			:	_labelByIntsIdMap.at(key)->labelDisplay();
 	}
 
@@ -1237,12 +1239,10 @@ stringvec Column::dataAsRLevels(intvec & values, const boolvec & filter, bool us
 	for(Label * label : _labels)
 		if(usedIds.count(label->intsId()) || !shouldDropLevels())
 		{
-			levels.push_back(useLabels ? label->labelDisplay() : label->originalValueAsString(false));
+			levels.push_back(useLabels ? label->label() : label->originalValueAsString(false));
 			idToLevel[label->intsId()] = levels.size();
 		}
 		
-			
-
 	values.resize(valuesSize);
 
 	for(size_t row=0, valueRow=0; row<rowCount() && valueRow < valuesSize; row++)
@@ -1282,7 +1282,7 @@ doublevec Column::dataAsRDoubles(const boolvec &filter) const
 void Column::labelValueChanged(Label *label, const Json::Value & previousOriginal)
 {
 	auto prevOrigV	= Label::originalValueAsString(this, previousOriginal);
-	auto oldValDis	= std::make_pair(prevOrigV, label->labelDisplay());
+	auto oldValDis	= std::make_pair(prevOrigV, label->label());
 	bool merged		= _labelByValDis.count(label->origValDisplay()) != 0;
 	
 	if(merged)
@@ -1299,7 +1299,7 @@ void Column::labelValueChanged(Label *label, const Json::Value & previousOrigina
 		if(_ints[r] == label->intsId())
 			_dbls[r] = theDouble;
 
-	_labelMapUpdates(label, label->labelDisplay(), prevOrigV);
+	_labelMapUpdates(label, label->label(), prevOrigV);
 
 	if(merged)
 		_dbUpdateLabelOrder();
@@ -1315,9 +1315,9 @@ void Column::_labelMapUpdates(Label * label, const std::string & previousDisplay
 	_labelByValDis[label->origValDisplay()] = label;
 
 	bool	valueChanged	= previousOriginal		!= label->originalValueAsString(),
-			displayChanged	= previousDisplay		!= label->labelDisplay(),
+			displayChanged	= previousDisplay		!= label->label(),
 			previousSame	= previousOriginal		== previousDisplay,
-			newSame			= label->labelDisplay()	== label->originalValueAsString();
+			newSame			= label->label()	== label->originalValueAsString();
 
 	if(valueChanged)
 	{
@@ -1354,11 +1354,12 @@ void Column::_labelMapUpdates(Label * label, const std::string & previousDisplay
 
 	if(displayChanged)
 	{
-		_labelsByDisplay[previousDisplay]				.erase(label);
-		_labelsByDisplay[label->labelDisplay()]			.insert(label);
+		_labelsByDisplay[previousDisplay]	.erase(label);
+		_labelsByDisplay[label->label()]	.insert(label);
 		
 		size_t prevL = stringUtils::approximateVisualLength(previousDisplay),
-				newL = stringUtils::approximateVisualLength(label->labelDisplay());
+				newL = stringUtils::approximateVisualLength(label->label());
+
 		if(newL > _maxWidthLabel)
 			_maxWidthLabel = newL;
 		else if(prevL < newL && prevL == _maxWidthLabel) 
@@ -1393,7 +1394,7 @@ void Column::_labelMapUpdates(Label * label, const std::string & previousDisplay
 		//Do we still have shadows now?
 		_hasShadows = false;
 		for(const Label * label : _labels)
-			if(label->labelDisplay() != label->originalValueAsString())
+			if(label->label() != label->originalValueAsString())
 			{
 				_hasShadows = true;
 				break;
@@ -1435,7 +1436,7 @@ void Column::labelValDisplayChanged(Label *label, const std::string &previousDis
 {
 	auto	oldOrigValS	= Label::originalValueAsString(this, previousOriginal);
 	auto	oldValDis	= std::make_pair(oldOrigValS, previousDisplay),
-			newValDis	= std::make_pair(label->originalValueAsString(), label->labelDisplay());
+			newValDis	= std::make_pair(label->originalValueAsString(), label->label());
 	bool	merged		= _labelByValDis.count(label->origValDisplay()) != 0;
 	
 	if(merged)
@@ -1522,7 +1523,13 @@ bool Column::setValue(size_t row, std::string value, const std::string & label, 
 	if(itsADouble)
 		value = ColumnUtils::doubleToString(newDoubleToSet);
 
+	if(label == ".i")
+		"???";
+
 	Label	* newLabel		= justAValue ? labelByValue(value) : labelByValueAndDisplay(value, label);
+
+	if(label == ".i")
+		"???";
 
 	if(!newLabel)
 		newLabel = labelByIntsId(labelsAdd((justAValue || labelIsValue) ? value : label, "", itsADouble ? Json::Value(newDoubleToSet) : value));
@@ -1718,12 +1725,12 @@ void Column::labelsOrderByValue(bool doDbUpdateEtc)
 
 	doublevec				asc			= valuesNumericOrdered();
 	auto					alpha		= valuesAlphabeticalOffsets();
-	size_t					ascMax		= asc.size()+1;
+	size_t					ascMax		= asc.size();
 	std::map<double, int>	orderMap;
 	
 	for(size_t i=0; i<asc.size(); i++)
 		orderMap[asc[i]] = i;
-	
+
 	//and now to write them back into the data
 	for(Label * label : _labels)
 	{

--- a/CommonData/createIndexes.sql
+++ b/CommonData/createIndexes.sql
@@ -1,2 +1,2 @@
 CREATE INDEX IF NOT EXISTS ColumnOrderIdx			ON Columns	(id, dataSet,	colIdx);
-CREATE INDEX IF NOT EXISTS LabelOrderPerColumnIdx	ON Labels	(id, columnId,	ordering DESC);
+CREATE INDEX IF NOT EXISTS LabelOrderPerColumnIdx	ON Labels	(id, columnId,	ordering);

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -1458,7 +1458,7 @@ void DatabaseInterface::labelsLoad(Column * column)
 		labelsSize = std::max(labelsSize, order);
 	};
 
-	runStatements("SELECT id, value, label, ordering, filterAllows, description, originalValueJson FROM Labels WHERE columnId = ?;", prepare, processRow);
+	runStatements("SELECT id, value, label, ordering, filterAllows, description, originalValueJson FROM Labels WHERE columnId = ? ORDER BY ordering;", prepare, processRow);
 
 	column->labelsRemoveBeyond(labelsSize);
 	 
@@ -1493,7 +1493,7 @@ void DatabaseInterface::labelsLoad(const Columns &columns)//, std::function<void
 		column->_resetLabelValueMap();
 	}
 	
-	statement << ");";
+	statement << ")  ORDER BY columnId, ordering;";
 
 	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
 	{

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -930,30 +930,6 @@ double DatabaseInterface::_doubleTroubleReader(sqlite3_stmt * stmt, int colI)
 	return sqlite3_column_double(stmt, colI);
 }
 
-intvec DatabaseInterface::columnGetLabelIds(int columnId)
-{
-	JASPTIMER_SCOPE(DatabaseInterface::columnGetLabelIds);
-	intvec out;
-
-	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
-	{
-		sqlite3_bind_int(stmt, 1, columnId);
-	};
-
-	std::function<void(size_t row, sqlite3_stmt *stmt)> processRow = [&](size_t row, sqlite3_stmt *stmt)
-	{
-		int colCount = sqlite3_column_count(stmt);
-
-		assert(colCount == 1);
-		out.push_back(sqlite3_column_int(stmt, 0));
-
-	};
-
-	runStatements("SELECT id FROM Labels WHERE columnId = ? ORDER BY ordering;", prepare, processRow);
-
-	return out;
-}
-
 size_t DatabaseInterface::columnGetLabelCount(int columnId)
 {
 	JASPTIMER_SCOPE(DatabaseInterface::columnGetLabelCount);
@@ -1445,7 +1421,9 @@ void DatabaseInterface::labelsLoad(Column * column)
 	
 	column->beginBatchedLabelsDB();
 	
-	size_t labelsSize = columnGetLabelCount(column->id());
+	int labelsSize = 0;
+
+	column->_resetLabelValueMap();
 	
 	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
 	{
@@ -1454,7 +1432,7 @@ void DatabaseInterface::labelsLoad(Column * column)
 	
 	Json::Reader reader;
 
-	std::function<void(size_t row, sqlite3_stmt *stmt)> processRow = [&](size_t row, sqlite3_stmt *stmt)
+	std::function<void(size_t row, sqlite3_stmt *stmt)> processRow = [&](size_t, sqlite3_stmt *stmt)
 	{
 		int colCount = sqlite3_column_count(stmt);
 
@@ -1475,10 +1453,12 @@ void DatabaseInterface::labelsLoad(Column * column)
 		if (originalValueJson.isNull() && !originalValueJsonStr.empty())
 			originalValueJson = originalValueJsonStr; // For backward compatibility: in some JASP files the originalValueJson is not a json string but just the original string.
 
-		column->labelsSet(row,	value, label, filterAllows, description, originalValueJson, order, id);
+		column->labelsSet(order,	value, label, filterAllows, description, originalValueJson, order, id);
+
+		labelsSize = std::max(labelsSize, order);
 	};
 
-	runStatements("SELECT id, value, label, ordering, filterAllows, description, originalValueJson FROM Labels WHERE columnId = ? ORDER BY ordering;", prepare, processRow);
+	runStatements("SELECT id, value, label, ordering, filterAllows, description, originalValueJson FROM Labels WHERE columnId = ?;", prepare, processRow);
 
 	column->labelsRemoveBeyond(labelsSize);
 	 
@@ -1509,10 +1489,11 @@ void DatabaseInterface::labelsLoad(const Columns &columns)//, std::function<void
 		
 		localColMap [column->id()] = column;
 		labelsPerCol[column->id()] = 0;
+
+		column->_resetLabelValueMap();
 	}
 	
-	statement << ") ORDER BY columnId, ordering;";
-	
+	statement << ");";
 
 	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
 	{
@@ -1546,8 +1527,21 @@ void DatabaseInterface::labelsLoad(const Columns &columns)//, std::function<void
 
 		if(localColMap.count(columnId))
 		{
-			localColMap.at(columnId)->labelsSet(labelsPerCol[columnId],	value, label, filterAllows, description, originalValueJson, order, id);
-			labelsPerCol[columnId]++;
+			//std::stringstream str;
+			//str << "labelsLoad for column " << localColMap.at(columnId)->name() << " in thread " << std::this_thread::get_id() << " got "
+			//	<< "labelsSet(row='"		<< order
+			//	<< "', value='"				<< value
+			//	<< "', label='"				<< label
+			//	<< "', filterAllows='"		<< filterAllows
+			//	<< "', description='"		<< description
+			//	<< "', originalValueJson='"	<< originalValueJson
+			//	<< "', order='"				<< order
+			//	<< "', id='"				<< id
+			//	<< "')\n";
+			//Log::log() << str.str() << std::flush;
+
+			localColMap.at(columnId)->labelsSet(order,	value, label, filterAllows, description, originalValueJson, order, id);
+			labelsPerCol[columnId] = std::max(order, labelsPerCol[columnId]);
 		}
 	};
 
@@ -1601,7 +1595,7 @@ void DatabaseInterface::labelsWrite(Column *column)
 			labelIter++;
 		};
 		
-		_runStatementsRepeatedly("INSERT OR REPLACE INTO Labels (columnId, value, label, filterAllows, description, originalValueJson, ordering) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id;", [&](bindParametersType ** bindParams, size_t)
+		_runStatementsRepeatedly("INSERT INTO Labels (columnId, value, label, filterAllows, description, originalValueJson, ordering) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id;", [&](bindParametersType ** bindParams, size_t)
 			{
 				(*bindParams) = &_bindParams;
 				
@@ -1656,7 +1650,7 @@ void DatabaseInterface::labelsWrite(const Columns & columns, std::function<void(
 										origValJson		= label->originalValue().toStyledString();
 			 
 			 Column					*	column			= static_cast<Column*>(label->parent());
-			 
+
 			 sqlite3_bind_int( stmt,	1, column->id());
 			 sqlite3_bind_int( stmt,	2, label->intsId());
 			 sqlite3_bind_text(stmt,	3, labelDisplay.c_str(),			labelDisplay.length(),				SQLITE_TRANSIENT);
@@ -1684,7 +1678,7 @@ void DatabaseInterface::labelsWrite(const Columns & columns, std::function<void(
 			}
 		 };
 		 
-		 _runStatementsRepeatedly("INSERT OR REPLACE INTO Labels (columnId, value, label, filterAllows, description, originalValueJson, ordering) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id;", [&](bindParametersType ** bindParams, size_t)
+		 _runStatementsRepeatedly("INSERT INTO Labels (columnId, value, label, filterAllows, description, originalValueJson, ordering) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id;", [&](bindParametersType ** bindParams, size_t)
 			 {
 				 (*bindParams) = &_bindParams;
 				 

--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -152,7 +152,6 @@ public:
 	void		columnGetComputedInfo(		int columnId, int &analysisId, bool & invalidated, computedColumnType & codeType,		std::string & rCode,		std::string & error,		Json::Value & constructorJson, std::string & computeFilter);
 	void		columnSetValues(			int columnId, const intvec	  & ints, const doublevec & dbls);
 	void		columnSetValue(				int columnId, size_t row, int valueInt, double valueDbl);
-	intvec		columnGetLabelIds(			int columnId);
 	size_t		columnGetLabelCount(		int columnId);
 	void		columnGetValues(			int columnId,	intvec		& ints, doublevec & dbls);
 	std::string columnBaseName(				int columnId) const;

--- a/CommonData/label.cpp
+++ b/CommonData/label.cpp
@@ -264,11 +264,6 @@ std::string Label::labelDisplay() const
 	return isEmptyValue() ? EmptyValues::displayString() : label();
 }
 
-std::string Label::labelIgnoreEmpty() const
-{
-	return label();
-}
-
 bool Label::isEmptyValue() const
 {
 	return _column->isEmptyValue(originalValueAsString(false)) || _column->isEmptyValue(label());

--- a/CommonData/label.h
+++ b/CommonData/label.h
@@ -38,7 +38,6 @@ public:
 	const	std::string		&	description()				const	{ return _description;		}
 			std::string			label()						const	{ return _label;			}
 			std::string			labelDisplay()				const;
-			std::string			labelIgnoreEmpty()			const;
 			int					intsId()					const	{ return _intsId;			}
 			bool				isEmptyValue()				const;
 			int					order()						const	{ return _order;			}
@@ -46,7 +45,7 @@ public:
 	const	Json::Value		&	originalValue()				const	{ return _originalValue;	}
 			double				originalValueAsDouble()		const	{ return _dblValue;			}
 	std::pair<std::string
-		,std::string>			origValDisplay()			const	{ return std::make_pair(originalValueAsString(), labelDisplay()); }
+		,std::string>			origValDisplay()			const	{ return std::make_pair(originalValueAsString(), label()); }
 
 	static	std::string			originalValueAsString(const Column * column, const Json::Value & originalValue, bool fancyEmptyValue = false, bool ignoreEmpty=true);
 			std::string			originalValueAsString(bool fancyEmptyValue = false, bool ignoreEmpty = true)		const;

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -946,7 +946,7 @@ bool DataSetPackage::setLabelValue(const QModelIndex &index, const QString &newL
 		// which means that if this column is a computed column of scale type we are only allowed to change the label and only the value for the other types.
 		// so in this case this means that if it is a computed column, and of type !scale we do *not* also update the label when updating the value. Because otherwise it would override the data from the computed column...
 		
-		bool dontSetLabel = label->originalValueAsString(false) != label->labelDisplay() || (originalValue.isDouble() && !label->originalValue().isDouble());
+		bool dontSetLabel = label->originalValueAsString(false) != label->label() || (originalValue.isDouble() && !label->originalValue().isDouble());
 		
 		if(!dontSetLabel && column->isComputed() && column->type() != columnType::scale)
 			dontSetLabel = true;
@@ -2219,9 +2219,6 @@ bool DataSetPackage::removeRows(int row, int count, const QModelIndex & aparent)
 	for(Column * column : dataSet()->columns())
 	{
 		changed.push_back(column->name());
-		
-		//if(row+count > column->rowCount())
-		//	Log::log() << "???" << std::endl;
 	
 		for(int r=row+count; r>row; r--)
 			column->rowDelete(r-1);

--- a/Desktop/data/importers/jaspimporterold.cpp
+++ b/Desktop/data/importers/jaspimporterold.cpp
@@ -226,7 +226,7 @@ void JASPImporterOld::loadDataArchive_1_00(const std::string &path, std::functio
 				if(label)
 				{
 					values.push_back(label->originalValueAsString());
-					labels.push_back(label->labelIgnoreEmpty());
+					labels.push_back(label->label());
 				}
 				else if (value == EmptyValues::missingValueInteger)
 				{


### PR DESCRIPTION
fixes (probably and to some extent) 	https://github.com/jasp-stats/jasp-issues/issues/2808

a dta of 27mb before this translated to jasp file of 280mb and now to 10mb :o

[zipit.zip](https://github.com/user-attachments/files/20907154/zipit.zip)
