### PR TITLE
Generated help should not show control with a debug flag

### DIFF
--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -41,16 +41,19 @@ AnalysisForm::AnalysisForm(QQuickItem *parent) : QQuickItem(parent)
 	setObjectName("AnalysisForm");
 
 	_rSyntax = new RSyntax(this);
+
 	// _startRSyntaxTimer is used to call setRSyntaxText only once in a event loop.
-	connect(this,									&AnalysisForm::infoChanged,					this, &AnalysisForm::helpMDChanged			);
-	connect(this,									&AnalysisForm::infoBottomChanged,			this, &AnalysisForm::helpMDChanged			);
-	connect(this,									&AnalysisForm::formCompletedSignal,			this, &AnalysisForm::formCompletedHandler,	Qt::QueuedConnection);
-	connect(this,									&AnalysisForm::analysisChanged,				this, &AnalysisForm::knownIssuesUpdated,	Qt::QueuedConnection);
-	connect(KnownIssues::issues(),					&KnownIssues::knownIssuesUpdated,			this, &AnalysisForm::knownIssuesUpdated,	Qt::QueuedConnection);
-	connect(this,									&AnalysisForm::showAllROptionsChanged,		this, &AnalysisForm::rSyntaxTextChanged,	Qt::QueuedConnection);
-	connect(PreferencesModelBase::preferences(),	&PreferencesModelBase::showRSyntaxChanged,	this, &AnalysisForm::rSyntaxTextChanged,	Qt::QueuedConnection);
-	connect(PreferencesModelBase::preferences(),	&PreferencesModelBase::showAllROptionsChanged,	this, &AnalysisForm::showAllROptionsChanged, Qt::QueuedConnection	);
-	connect(this,									&AnalysisForm::analysisChanged,				this, &AnalysisForm::rSyntaxTextChanged,	Qt::QueuedConnection);
+
+	connect(this,									&AnalysisForm::infoChanged,						this, &AnalysisForm::helpMDChanged									);
+	connect(this,									&AnalysisForm::infoBottomChanged,				this, &AnalysisForm::helpMDChanged									);
+	connect(this,									&AnalysisForm::formCompletedSignal,				this, &AnalysisForm::formCompletedHandler,		Qt::QueuedConnection);
+	connect(this,									&AnalysisForm::analysisChanged,					this, &AnalysisForm::knownIssuesUpdated,		Qt::QueuedConnection);
+	connect(KnownIssues::issues(),					&KnownIssues::knownIssuesUpdated,				this, &AnalysisForm::knownIssuesUpdated,		Qt::QueuedConnection);
+	connect(this,									&AnalysisForm::showAllROptionsChanged,			this, &AnalysisForm::rSyntaxTextChanged,		Qt::QueuedConnection);
+	connect(PreferencesModelBase::preferences(),	&PreferencesModelBase::showRSyntaxChanged,		this, &AnalysisForm::rSyntaxTextChanged,		Qt::QueuedConnection);
+	connect(PreferencesModelBase::preferences(),	&PreferencesModelBase::showAllROptionsChanged,	this, &AnalysisForm::showAllROptionsChanged,	Qt::QueuedConnection);
+	connect(PreferencesModelBase::preferences(),	&PreferencesModelBase::developerModeChanged,	this, &AnalysisForm::helpMDChanged,				Qt::QueuedConnection);
+	connect(this,									&AnalysisForm::analysisChanged,					this, &AnalysisForm::rSyntaxTextChanged,		Qt::QueuedConnection);
 }
 
 AnalysisForm::~AnalysisForm()

--- a/QMLComponents/controls/componentslistbase.cpp
+++ b/QMLComponents/controls/componentslistbase.cpp
@@ -417,18 +417,6 @@ QString ComponentsListBase::_changeLastNumber(const QString &val) const
 		return result.append(QString::number(2));
 }
 
-JASPControls ComponentsListBase::getMDSubItems(const QQuickItem*) const
-{
-	const Terms& terms = model()->terms();
-
-	// In case of a ComponentsList (or TabView), use only the items of the first row (if exists) to generate the help.
-	const ListModel::RowControlMap & map = model()->getAllRowControls();
-	if (map.size() > 0)
-		return JASPControl::getMDSubItems(map.first()->getRowObject());
-
-	return {};
-}
-
 QString ComponentsListBase::_makeUnique(const QString &val, int index) const
 {
 	return _makeUnique(val, _termsModel->terms().values(), index);

--- a/QMLComponents/controls/componentslistbase.h
+++ b/QMLComponents/controls/componentslistbase.h
@@ -96,7 +96,6 @@ protected:
 	QString				_makeUnique(const QString& val, int index = -1)	const;
 	QString				_makeUnique(const QString& val, const QList<QString>& values, int index = -1)	const;
 	QString				_changeLastNumber(const QString& val) const;
-	JASPControls		getMDSubItems(const QQuickItem* parentItem = nullptr)						const override;
 
 private:
 	ListModelTermsAssigned*		_termsModel				= nullptr;

--- a/QMLComponents/controls/expanderbuttonbase.h
+++ b/QMLComponents/controls/expanderbuttonbase.h
@@ -34,7 +34,6 @@ public:
 	void		setUp()															override;
 	QString		generateMDHelp(int depth = 0)							const	override;
 	QString		printLabelMD(int depth)									const	override;
-	bool		infoLabelIsHeader()										const	override	{ return true; }
 
 };
 

--- a/QMLComponents/controls/groupboxbase.cpp
+++ b/QMLComponents/controls/groupboxbase.cpp
@@ -5,8 +5,3 @@ GroupBoxBase::GroupBoxBase(QQuickItem* parent)
 { 
 	_controlType = JASPControl::ControlType::GroupBox; 
 }
-
-bool GroupBoxBase::infoLabelIsHeader() const
-{ 
-	return true; 
-}

--- a/QMLComponents/controls/groupboxbase.h
+++ b/QMLComponents/controls/groupboxbase.h
@@ -29,8 +29,6 @@ class GroupBoxBase : public JASPControl
 public:
 	GroupBoxBase(QQuickItem* parent = nullptr);
 
-	bool infoLabelIsHeader()	const	override;
-
 };
 
 #endif // GROUPBOXBASE_H

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -62,6 +62,11 @@ JASPControl::JASPControl(QQuickItem *parent) : QQuickItem(parent)
 	connect(this, &JASPControl::boundValueChanged,		this, &JASPControl::_resetBindingValue);
 	connect(this, &JASPControl::activeFocusChanged,		this, &JASPControl::_setFocus);
 	connect(this, &JASPControl::activeFocusChanged,		this, &JASPControl::_notifyFormOfActiveFocus);
+								 
+	PreferencesModelBase* pref = PreferencesModelBase::preferences();
+								 
+	if(pref)
+		connect(pref, &PreferencesModelBase::developerModeChanged, this, [this](){ _setVisible(); });
 }
 
 JASPControl::~JASPControl()
@@ -139,6 +144,9 @@ void JASPControl::_setVisible()
 
 	if (!isDeveloperMode && (debug() || parentDebug()))
 		setVisible(false);
+								 
+	if(isDeveloperMode && (debug() || parentDebug()))
+		setVisible(true);
 }
 
 void JASPControl::_resetBindingValue()

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -3,6 +3,7 @@
 #include "log.h"
 #include "analysisform.h"
 #include "jasptheme.h"
+#include "preferencesmodelbase.h"
 #include <QQmlProperty>
 #include <QQmlContext>
 #include <QTimer>
@@ -133,11 +134,10 @@ void JASPControl::_setBackgroundColor()
 
 void JASPControl::_setVisible()
 {
-	bool isDebug = false;
-#ifdef JASP_DEBUG
-	isDebug = true;
-#endif
-	if (!isDebug && (debug() || parentDebug()))
+	PreferencesModelBase* pref = PreferencesModelBase::preferences();
+	bool isDeveloperMode = pref ? pref->developerMode() : false;
+
+	if (!isDeveloperMode && (debug() || parentDebug()))
 		setVisible(false);
 }
 
@@ -313,6 +313,7 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 	if (!item)
 		return result;
 
+	PreferencesModelBase* pref = PreferencesModelBase::preferences();
 	QList<QQuickItem*> childItems = item->childItems();
 
 	for (QQuickItem* childItem : childItems)
@@ -321,10 +322,9 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 
 		if (childControl)
 		{
-#ifndef JASP_DEBUG
-			if (childControl->debug())
+			if (!pref->developerMode() && childControl->debug())
 				continue;
-#endif
+
 			if (collapseStructuralControls && childControl->controlType() == ControlType::GroupBox && !childControl->hasLabelOrInfo())
 				// If a Group has no label, title or info, then it is used probably for layout purpose.
 				// Just skip it: this is necessary for generating properly the markdown help

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -321,6 +321,10 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 
 		if (childControl)
 		{
+#ifndef JASP_DEBUG
+			if (childControl->debug())
+				continue;
+#endif
 			if (collapseStructuralControls && childControl->controlType() == ControlType::GroupBox && !childControl->hasLabelOrInfo())
 				// If a Group has no label, title or info, then it is used probably for layout purpose.
 				// Just skip it: this is necessary for generating properly the markdown help
@@ -577,22 +581,15 @@ QString JASPControl::printLabelMD(int depth) const
 
 	QStringList md;
 	// Print the label as a header, in italic or in bold
-	if (infoLabelIsHeader())			md << "<h" << QString::number(depth + 3) << ">";
-	else if	(infoLabelItalic())			md << "*";
+	if	(infoLabelItalic())				md << "*";
 	else								md << "**";
 
 	if (infoAddControlType())			md << (friendlyName() + (!label.isEmpty() ? " - " : ""));
 
-	md << label;
-
-	if (infoLabelIsHeader())			md << "</h" << QString::number(depth + 3) << ">";
-	else
-	{
-		md << (infoLabelItalic() ? "*" : "**");
-		if (!info().isEmpty() && !label.endsWith(":")) // Add ':' when necessary
-			md << ":";
-		md << " ";
-	}
+	md << label << (infoLabelItalic() ? "*" : "**");
+	if (!info().isEmpty() && !label.endsWith(":")) // Add ':' when necessary
+		md << ":";
+	md << " ";
 
 	return md.join("");
 }
@@ -633,13 +630,12 @@ QString JASPControl::generateMDHelp(int depth) const
 	QStringList markdown;
 	markdown << printLabelMD(depth) << info() << "\n";
 
-	if (MDSubItems.size() == 1)
-		markdown << "\n" << QString{depth * 2, ' '} << MDSubItems[0]->generateMDHelp(depth + 1);
-	else if (MDSubItems.size() > 1)
+	if (MDSubItems.size() > 0)
 	{
-		markdown << "\n"; // Before adding bullets, a new line is needed
+		bool addBullet = MDSubItems.size() > 1 || (depth == 0 && MDSubItems[0]->hasLabelOrInfo());
+		markdown << "\n";
 		for (const auto& childMD : MDSubItems)
-			markdown << QString{depth * 2, ' '} << "- " << childMD->generateMDHelp(depth + 1);
+			markdown << QString{depth * 2, ' '} << (addBullet ? "- " : "") << childMD->generateMDHelp(depth + 1);
 	}
 
 	return markdown.join("");

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -116,7 +116,6 @@ public:
 	QString				infoLabel()					const	{ return _infoLabel;				}
 	QString				fullLabel()					const	{ return (infoLabel().isEmpty() ? title() : infoLabel()).trimmed(); }
 	virtual bool		infoAddControlType()		const	{ return  false;					}
-	virtual bool		infoLabelIsHeader()			const	{ return  false;					}
 	virtual bool		infoLabelItalic()			const	{ return  false;					}
 
 	QString				toolTip()					const	{ return _toolTip;					}

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -276,6 +276,26 @@ std::vector<std::string> JASPListControl::usedVariables() const
 	else												return {};
 }
 
+JASPControls JASPListControl::getMDSubItems(const QQuickItem*) const
+{
+	const Terms& terms = model()->terms();
+
+	// If row components are used, use only the items of the first row (if exists) to generate the help.
+	const ListModel::RowControlMap & map = model()->getAllRowControls();
+	if (map.size() > 0)
+	{
+		QQuickItem* rowItem = map.first()->getRowObject();
+		JASPControl* rowControl = qobject_cast<JASPControl*>(rowItem);
+		if (rowControl)
+			return {rowControl};
+		else
+			return JASPControl::getMDSubItems(map.first()->getRowObject());
+	}
+
+	return {};
+}
+
+
 void JASPListControl::sourceChangedHandler()
 {
 	if (!model())	return;

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -70,13 +70,13 @@ class JASPListControl : public JASPControl
 
 
 public:
-    JASPListControl(QQuickItem* parent = nullptr);
+	JASPListControl(QQuickItem* parent = nullptr);
 
 	virtual ListModel			*	model()						const	{ return nullptr; } // Cannot be a pure virtual function: JASPListControl would not be a default constructible object, and could not be a QML Type
 	virtual void					setUpModel();
 			void					setUp()						override;
 			void					cleanUp()					override;
-	
+
 	const QVector<SourceItem*>	&	sourceItems()				const			{ return _sourceItems; }
 			void					applyToAllSources(std::function<void(SourceItem *sourceItem, const Terms& terms)> applyThis);
 
@@ -165,10 +165,11 @@ protected slots:
 			bool					checkLevelsConstraints();
 
 protected:
-	void							_setInitialized(const Json::Value& value = Json::nullValue)	override;
+	void							_setInitialized(const Json::Value& value = Json::nullValue)				override;
 	void							_setAllowedVariables();
 	virtual bool					_checkLevelsConstraints();
 	bool							_checkLevelsConstraintsForVariable(const QString& variable);
+	JASPControls					getMDSubItems(const QQuickItem* parentItem = nullptr)			const	override;
 
 	GENERIC_SET_FUNCTION(Source,							_source,							sourceChanged,							QVariant		)
 	GENERIC_SET_FUNCTION(RSource,							_rSource,							sourceChanged,							QVariant		)
@@ -193,7 +194,7 @@ private:
 	void					_setupSources();
 	Terms					_getCombinedTerms(SourceItem* sourceToCombine);
 	void					_checkAllSourcesAreConnected(bool addConnect = true);
-			
+
 protected:
 	QVector<SourceItem*>	_sourceItems;
 	QString					_optionKeyValue						= "value",

--- a/QMLComponents/controls/variablesformbase.h
+++ b/QMLComponents/controls/variablesformbase.h
@@ -37,7 +37,6 @@ class VariablesFormBase : public JASPControl
 public:
 	VariablesFormBase(QQuickItem* parent = nullptr);
 
-	bool					infoLabelIsHeader()				const	override	{ return true; }
 	JASPControl*			availableVariablesList()		const;
 	QList<JASPControl*>		allAssignedVariablesList()		const	{ return _allAssignedVariablesList;		}
 	QList<JASPControl*>		allJASPControls()				const	{ return _allJASPControls;				}


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/3017
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2901

Also if a row component in a VariablesList with has an info property, the generated help should be generated only once (and not for every occurence of the row component).

Replace also '<hx></hx>' HTML tags by markdown bold tag '**'. These HTML tags render sometimes badly.

