### PR TITLE
Display p-values properly and generic formatting fixes

### DIFF
--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -159,7 +159,7 @@ public:
 	bool			directLibpathEnabled()					const;
 	QString			directLibpathFolder()					const;
 	QString			directDevModName()						const;
-	bool			engineSandbox()							const;
+	
 	QString			localConfigurationPATH()				const;
 	QString			remoteConfigurationURL()				const;
 	bool			remoteConfiguration()					const;
@@ -176,7 +176,8 @@ public:
 	void setStartMaximized(bool newStartMaximized);
 	
 public slots:
-	bool useNativeFileDialog()					const;
+	bool engineSandbox()							const;
+	bool useNativeFileDialog()						const;
 	void setUiScale(					double		uiScale);
 	void setCustomPPI(					int			customPPI);
 	void setDefaultPPI(					int			defaultPPI);

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -156,7 +156,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 			if (window.globSet.pExact) {
 				sf = 4;
 			} else {
-				p = Number(f.substring(2));
+				p = fixDecimals ? 1/Math.pow(10,dp) : Number(f.substring(2));
 				noZeroLead = true;
 			}
 		}

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -51,6 +51,9 @@ function formatPrecision(number, precision, noZeroLead=false) {
 }
 
 function formatPrecisionWithRespectForFixedDecimals(number, sf, dp, noZeroLead=false) {
+	if(isNan(dp))
+		return formatPrecision(number, sf, noZeroLead);
+	
 	const formatter = new Intl.NumberFormat(currentLocaleId, { 
 		minimumSignificantDigits:	sf, maximumSignificantDigits:	sf, 
 		minimumFractionDigits:		dp, maximumFractionDigits:		dp, 
@@ -323,7 +326,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else if (content < p) 
 					{
-						formatted["content"] 	= (html ? "<&nbsp;" : "< ") + formatPrecision(p, sf, noZeroLead)
+						formatted["content"] 	= (html ? "<&nbsp;" : "< ") + formatPrecisionWithRespectForFixedDecimals(p, sf, noZeroLead)
 						formatted["class"]		= "p-value"
 						isNumber = false
 					}
@@ -339,8 +342,8 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else 
 					{
-						if(isP)						formatted["content"] = fixDecimals && window.globSet.pExact ? toExponential(content, (isFinite(dp) ? dp : sf-1), 0, html) : formatPrecision(content, sf, dp, noZeroLead)
-						else						formatted["content"] = alignNumbers || fixDecimals ? formatFixed(content, -minLSD) : formatPrecisionWithRespectForFixedDecimals(content, sf, dp, noZeroLead)
+						if(isP)						formatted["content"] = fixDecimals || window.globSet.pExact ? toExponential(content, (isFinite(dp) ? dp : sf-1), 0, html)	: formatPrecisionWithRespectForFixedDecimals(content, sf, dp, noZeroLead)
+						else						formatted["content"] = alignNumbers || fixDecimals			? formatFixed(content, -minLSD)									: formatPrecisionWithRespectForFixedDecimals(content, sf, dp, noZeroLead)
 						
 						if(html)
 							formatted["content"] = formatted["content"].replace(/-/g, "&minus;")

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -250,7 +250,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 		minLSD = Math.max(-20, minLSD)
 	}
 	
-	format = currency != "" ? "monetary" : pc ? "percentage" : isFinite(dp) ? "decimalPoints" : isFinite(sf) ? "significance" : "other"
+	format = currency != "" ? "monetary" : pc ? "percentage" : isFinite(sf) ? "significance" : isFinite(dp) ? "decimalPoints" : "other"
 	
 	//Now that thats been determined we can format our cells
 	for (var rowNo = 0; rowNo < column.length; rowNo++) 

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -789,7 +789,7 @@ function formatCellforLaTeX (toFormat) {
 function camelize (str) {
 	return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
 		if (+match === 0) return "";
-		return index == 0 ? match.toLowerCase() : match.toUpperCase();
+		return index === 0 ? match.toLowerCase() : match.toUpperCase();
 	});
 }
 
@@ -800,7 +800,7 @@ function getDecimalSeparator()
 {
     const numberWithDecimalSeparator = 1.1;
 	
-    return Intl.NumberFormat(currentLocaleId)        
+    return (new Intl.NumberFormat(currentLocaleId))
 		.formatToParts(numberWithDecimalSeparator)
         .find(part => part.type === 'decimal')
         .value;

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -27,18 +27,27 @@ function formatMoney(_currency='EUR', amount) {
 	return amount == "." ? amount : formatter.format(amount)
 }
 
-function formatFixed(number, digitsFrac) {
+function formatFixed(number, digitsFrac, noZeroLead=false) {
 	if(isNaN(digitsFrac))
 		digitsFrac = 0
 	const formatter = new Intl.NumberFormat(currentLocaleId, { minimumFractionDigits: digitsFrac, maximumFractionDigits: digitsFrac, useGrouping: useThousandsSeparators});
 	
-	return formatter.format(number)
+	var result = formatter.format(number)
+	
+	if(number >= 0 && number < 1 && noZeroLead)
+		return result.substring(1);
+	
+	return result;
 }
 
-function formatPrecision(number, precision) {
+function formatPrecision(number, precision, noZeroLead=false) {
 	const formatter = new Intl.NumberFormat(currentLocaleId, { minimumSignificantDigits: precision, maximumSignificantDigits: precision, useGrouping: useThousandsSeparators });
 	
-	return formatter.format(number)
+	var result = formatter.format(number)
+	
+	if(number >= 0 && number < 1 && noZeroLead)
+		return result.substring(1);
+	return result;
 }
 
 function formatNumber(number) {
@@ -136,7 +145,8 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 	let approx		= false;
 	let fixDecimals = typeof dp === 'number' && dp >= 0;
 	let currency	= ""
-	let moneyFmt	= "monetary" 
+	let moneyFmt	= "monetary"
+	let noZeroLead	= false;
 	
 	for (let i = 0; i < formats.length; i++) 
 	{
@@ -147,6 +157,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 				sf = 4;
 			} else {
 				p = Number(f.substring(2));
+				noZeroLead = true;
 			}
 		}
 		
@@ -294,13 +305,13 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else if (content < p) 
 					{
-						formatted["content"] 	= (html ? "<&nbsp;" : "< ") + p
+						formatted["content"] 	= (html ? "<&nbsp;" : "< ") + formatPrecision(p, sf, noZeroLead)
 						formatted["class"]		= "p-value"
 						isNumber = false
 					}
 					else if (content == 0)
 					{
-						formatted["content"] = isFinite(dp) ? formatFixed(content, dp) : formatPrecision(content, sf)
+						formatted["content"] = isFinite(dp) ? formatFixed(content, dp, noZeroLead) : formatPrecision(content, sf, noZeroLead)
 					}
 					else if (Math.abs(content) >= upperLimit || Math.abs(content) < Math.pow(10, -dp))
 					{
@@ -310,7 +321,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else 
 					{
-						formatted["content"] = alignNumbers || fixDecimals ? formatFixed(content, -minLSD) : formatPrecision(content, sf)
+						formatted["content"] = alignNumbers || fixDecimals ? formatFixed(content, -minLSD) : formatPrecision(content, sf, noZeroLead)
 						if(html)
 							formatted["content"] = formatted["content"].replace(/-/g, "&minus;")
 					}
@@ -327,7 +338,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else if (content < p) 
 					{
-						formatted["content"] 	= (html ? "<&nbsp;" : "< ") + p
+						formatted["content"] 	= (html ? "<&nbsp;" : "< ") + formatFixed(p, dp, noZeroLead)
 						formatted["class"]		= "p-value"
 						isNumber = false
 					}
@@ -339,7 +350,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 							strContent = toExponential(content, dp, 0, html)
 						else 
 						{
-							strContent = formatFixed(content, dp)
+							strContent = formatFixed(content, dp, noZeroLead)
 							if(html)
 								strContent = strContent.replace(/-/g, "&minus;")
 						}

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -250,7 +250,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 		minLSD = Math.max(-20, minLSD)
 	}
 	
-	format = currency != "" ? "monetary" : pc ? "percentage" : isFinite(sf) ? "significance" : isFinite(dp) ? "decimalPoints" : "other"
+	format = currency != "" ? "monetary" : pc ? "percentage" : isFinite(dp) ? "decimalPoints" : isFinite(sf) ? "significance" : "other"
 	
 	//Now that thats been determined we can format our cells
 	for (var rowNo = 0; rowNo < column.length; rowNo++) 
@@ -338,7 +338,9 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else if (content < p) 
 					{
-						formatted["content"] 	= (html ? "<&nbsp;" : "< ") + formatFixed(p, dp, noZeroLead)
+						let dpP					= 1/Math.pow(10,dp)
+						let specialP			= dpP < p ? ("~" + formatFixed(dpP, dp, noZeroLead)) : formatFixed(p, dp, noZeroLead);
+						formatted["content"] 	= (html ? "<&nbsp;" : "< ") + specialP
 						formatted["class"]		= "p-value"
 						isNumber = false
 					}

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -51,7 +51,7 @@ function formatPrecision(number, precision, noZeroLead=false) {
 }
 
 function formatPrecisionWithRespectForFixedDecimals(number, sf, dp, noZeroLead=false) {
-	if(isNan(dp))
+	if(isNaN(dp))
 		return formatPrecision(number, sf, noZeroLead);
 	
 	const formatter = new Intl.NumberFormat(currentLocaleId, { 

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -139,6 +139,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 	
 	let formats		= format.split(";");
 	let p			= NaN;
+	let isP			= false;
 	let dp			= parseInt(window.globSet.decimals);
 	let sf			= NaN;
 	let pc			= false;
@@ -159,6 +160,8 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 				p = fixDecimals ? 1/Math.pow(10,dp) : Number(f.substring(2));
 				noZeroLead = true;
 			}
+			
+			isP = true;
 		}
 		
 		if(f.startsWith(moneyFmt))
@@ -321,7 +324,9 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else 
 					{
-						formatted["content"] = alignNumbers || fixDecimals ? formatFixed(content, -minLSD) : formatPrecision(content, sf, noZeroLead)
+						if(isP)						formatted["content"] = fixDecimals && window.globSet.pExact ? toExponential(content, (isFinite(dp) ? dp : sf-1), 0, html) : formatPrecision(content, sf, noZeroLead)
+						else						formatted["content"] = alignNumbers || fixDecimals ? formatFixed(content, -minLSD) : formatPrecision(content, sf, noZeroLead)
+						
 						if(html)
 							formatted["content"] = formatted["content"].replace(/-/g, "&minus;")
 					}

--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -50,6 +50,21 @@ function formatPrecision(number, precision, noZeroLead=false) {
 	return result;
 }
 
+function formatPrecisionWithRespectForFixedDecimals(number, sf, dp, noZeroLead=false) {
+	const formatter = new Intl.NumberFormat(currentLocaleId, { 
+		minimumSignificantDigits:	sf, maximumSignificantDigits:	sf, 
+		minimumFractionDigits:		dp, maximumFractionDigits:		dp, 
+		roundingPriority:			"lessPrecision", 
+		useGrouping:				useThousandsSeparators 
+	});
+	
+	var result = formatter.format(number)
+	
+	if(number >= 0 && number < 1 && noZeroLead)
+		return result.substring(1);
+	return result;
+}
+
 function formatNumber(number) {
 	const formatter = new Intl.NumberFormat(currentLocaleId, { useGrouping: useThousandsSeparators });
 	
@@ -314,7 +329,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else if (content == 0)
 					{
-						formatted["content"] = isFinite(dp) ? formatFixed(content, dp, noZeroLead) : formatPrecision(content, sf, noZeroLead)
+						formatted["content"] = isFinite(dp) ? formatFixed(content, dp, noZeroLead) : formatPrecisionWithRespectForFixedDecimals(content, sf, 0, noZeroLead)
 					}
 					else if (Math.abs(content) >= upperLimit || Math.abs(content) < Math.pow(10, -dp))
 					{
@@ -324,8 +339,8 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					}
 					else 
 					{
-						if(isP)						formatted["content"] = fixDecimals && window.globSet.pExact ? toExponential(content, (isFinite(dp) ? dp : sf-1), 0, html) : formatPrecision(content, sf, noZeroLead)
-						else						formatted["content"] = alignNumbers || fixDecimals ? formatFixed(content, -minLSD) : formatPrecision(content, sf, noZeroLead)
+						if(isP)						formatted["content"] = fixDecimals && window.globSet.pExact ? toExponential(content, (isFinite(dp) ? dp : sf-1), 0, html) : formatPrecision(content, sf, dp, noZeroLead)
+						else						formatted["content"] = alignNumbers || fixDecimals ? formatFixed(content, -minLSD) : formatPrecisionWithRespectForFixedDecimals(content, sf, dp, noZeroLead)
 						
 						if(html)
 							formatted["content"] = formatted["content"].replace(/-/g, "&minus;")

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -501,14 +501,13 @@ void MainWindow::makeConnections()
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_resultsJsInterface,	&ResultsJsInterface::setFontFamily							);
 	connect(_preferences,			&PreferencesModel::resultFontChanged,				_engineSync,			&EngineSync::refreshAllPlots								);
 	connect(_preferences,			&PreferencesModel::restartAllEngines,				_engineSync,			&EngineSync::haveYouTriedTurningItOffAndOnAgain				);
-	connect(_preferences,			&PreferencesModel::normalizedNotationChanged,		_resultsJsInterface,	&ResultsJsInterface::setNormalizedNotationHandler			);
 	connect(_preferences,			&PreferencesModel::developerFolderChanged,			_dynamicModules,		&DynamicModules::uninstallJASPDeveloperModule				);
 	connect(_preferences,			&PreferencesModel::showRSyntaxInResultsChanged,		_analyses,				&Analyses::showRSyntaxInResults								);
 	connect(_preferences,			&PreferencesModel::ALTNavModeActiveChanged,			ALTNavControl::ctrl(),	&ALTNavControl::enableAlTNavigation							);
-	connect(_preferences,			&PreferencesModel::orderByValueByDefaultChanged,	[&](){	Column::setAutoSortByValuesByDefault(PreferencesModel::prefs()->orderByValueByDefault()); });
 	connect(_preferences,			&PreferencesModel::remoteConfigurationChanged,		_jaspConfiguration,		&JASPConfiguration::remoteChanged							);
 	connect(_preferences,			&PreferencesModel::remoteConfigurationURLChanged,	_jaspConfiguration,		&JASPConfiguration::remoteChanged							);
-	connect(_preferences,			&PreferencesModel::useConfigurationFileChanged,	_jaspConfiguration,		&JASPConfiguration::processConfiguration					);
+	connect(_preferences,			&PreferencesModel::useConfigurationFileChanged,		_jaspConfiguration,		&JASPConfiguration::processConfiguration					);
+	connect(_preferences,			&PreferencesModel::orderByValueByDefaultChanged,	[&](){	Column::setAutoSortByValuesByDefault(PreferencesModel::prefs()->orderByValueByDefault()); });
 
 
 	Column::setAutoSortByValuesByDefault(PreferencesModel::prefs()->orderByValueByDefault());

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -490,6 +490,7 @@ void MainWindow::makeConnections()
 	connect(_preferences,			&PreferencesModel::plotBackgroundChanged,			this,					&MainWindow::setImageBackgroundHandler						);
 	connect(_preferences,			&PreferencesModel::plotPPIChanged,					this,					&MainWindow::plotPPIChangedHandler							);
 	connect(_preferences,			&PreferencesModel::exactPValuesChanged,				_resultsJsInterface,	&ResultsJsInterface::setExactPValuesHandler					);
+	connect(_preferences,			&PreferencesModel::normalizedNotationChanged,		_resultsJsInterface,	&ResultsJsInterface::setNormalizedNotationHandler			);
 	connect(_preferences,			&PreferencesModel::fixedDecimalsChangedString,		_resultsJsInterface,	&ResultsJsInterface::setFixDecimalsHandler					);
 	connect(_preferences,			&PreferencesModel::uiScaleChanged,					_resultsJsInterface,	&ResultsJsInterface::uiScaleChangedHandler					);
 	connect(_preferences,			&PreferencesModel::developerModeChanged,			_analyses,				&Analyses::refreshAllAnalyses								);


### PR DESCRIPTION
Aims to have the formatting of numbers in the result be more like before, by giving some precedence to decimal points requested over significant figures. This helps interpret the jasp unittests a bit better.

Also changes the way p values are displayed according to https://github.com/jasp-stats/jasp-issues/issues/3374
And some general fixes to disply of p values.

They will now look as follows (in french, so a comma):
<img width="838" alt="image" src="https://github.com/user-attachments/assets/5f82bb84-958b-466e-b14a-48aa8892cd06" />
<img width="858" alt="image" src="https://github.com/user-attachments/assets/a0be343c-0942-47d8-8598-606675bf816c" />
<img width="851" alt="image" src="https://github.com/user-attachments/assets/1cb4be6a-51f8-4a83-953d-2f120292f7ca" />
<img width="842" alt="image" src="https://github.com/user-attachments/assets/3de01ecb-f358-4644-8317-c9a5d5f2eaf3" />
<img width="894" alt="image" src="https://github.com/user-attachments/assets/fd818c92-1fc7-4e76-83d7-5937b0c41bb5" />
<img width="836" alt="image" src="https://github.com/user-attachments/assets/57cdb6a6-58e6-437c-8873-82760a66592b" />
<img width="865" alt="image" src="https://github.com/user-attachments/assets/c17966cd-2423-44c7-808a-e75ebb14b84d" />
<img width="834" alt="image" src="https://github.com/user-attachments/assets/ad114d72-bc0d-464f-a912-b3a0e5d3ad73" />

