### PR TITLE
Open file by drag-and-dropping to JASP Window

### DIFF
--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -87,6 +87,14 @@ Window
 		return (a + n) % n;
 	}
 
+	DropArea
+	{
+		id: drop
+		enabled: true
+		anchors.fill: parent
+		onDropped: (drop) => mainWindow.openURLFile(drop.text)
+	}
+
 	Item
 	{
 		anchors.fill:	parent

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -869,7 +869,7 @@ void MainWindow::openURLFile(QString fileURLPath)
 		return;
 	}
 
-	if (!FileTypeBaseValidName(fileInfo.suffix().toStdString()))
+	if (!FileTypeBaseValidName(fileInfo.suffix().toLower().toStdString()))
 	{
 		MessageForwarder::showWarning(tr("Open file"), tr("JASP does not support this file type %1.").arg(filePath));
 		return;

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -853,7 +853,7 @@ void MainWindow::showLogFolder() const
 
 void MainWindow::openURLFile(QString fileURLPath)
 {
-	QUrl fileUrl = QUrl::fromLocalFile(fileURLPath);
+	QUrl fileUrl = fileURLPath.startsWith("file:") ? QUrl(fileURLPath) : QUrl::fromLocalFile(fileURLPath);
 	if (!fileUrl.isLocalFile())
 	{
 		MessageForwarder::showWarning(tr("Open file"), tr("Cannot access file %1").arg(fileURLPath));

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -853,7 +853,7 @@ void MainWindow::showLogFolder() const
 
 void MainWindow::openURLFile(QString fileURLPath)
 {
-	QUrl fileUrl(fileURLPath);
+	QUrl fileUrl = QUrl::fromLocalFile(fileURLPath);
 	if (!fileUrl.isLocalFile())
 	{
 		MessageForwarder::showWarning(tr("Open file"), tr("Cannot access file %1").arg(fileURLPath));

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -851,6 +851,32 @@ void MainWindow::showLogFolder() const
 	openFolderExternally(AppDirs::logDir());
 }
 
+void MainWindow::openURLFile(QString fileURLPath)
+{
+	QUrl fileUrl(fileURLPath);
+	if (!fileUrl.isLocalFile())
+	{
+		MessageForwarder::showWarning(tr("Open file"), tr("Cannot access file %1").arg(fileURLPath));
+		return;
+	}
+
+	QString filePath = fileUrl.toLocalFile();
+	QFileInfo fileInfo(filePath);
+
+	if (!fileInfo.exists())
+	{
+		MessageForwarder::showWarning(tr("Open file"), tr("File %1 is not found.").arg(filePath));
+		return;
+	}
+
+	if (!FileTypeBaseValidName(fileInfo.suffix().toStdString()))
+	{
+		MessageForwarder::showWarning(tr("Open file"), tr("JASP does not support this file type %1.").arg(filePath));
+		return;
+	}
+
+	open(filePath);
+}
 
 void MainWindow::open(QString filepath)
 {

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -167,6 +167,7 @@ public slots:
 	void zoomResetKeyPressed();	
 	void undo();
 	void redo();
+	void openURLFile(QString fileURLPath);
 
 	QObject * loadQmlData(QString data, QUrl url);
 


### PR DESCRIPTION
From a file explorer, drag and drop a file to a JASP window: the file is opened either in this JASP instance if no file was not loaded yet, or start another JASP instance with this file.