### PR TITLE
Wait for all controls to be created before setting them up

### DIFF
--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -251,8 +251,6 @@ void JASPControl::componentComplete()
 		if (parentlistView)
 			parentlistView->addRowControl(_parentListViewKey, this);
 
-		// Setup must be done after _parentListView & _parentListViewKey are set (if they exist), so that if the control has a source, the right source is found.
-		setUp();
 	}
 
 	if (_background == nullptr && _innerControl != nullptr)

--- a/QMLComponents/controls/rowcontrols.cpp
+++ b/QMLComponents/controls/rowcontrols.cpp
@@ -68,6 +68,9 @@ void RowControls::_initializeControls(bool useInitialValue)
 	JASPListControl* parentControl = _parentModel->listView();
 	AnalysisForm* form = parentControl->form();
 
+	for (JASPControl* control : controls)
+		control->setUp();
+
 	if (form)
 		form->sortControls(controls);
 

--- a/QMLComponents/models/listmodelfactorsform.cpp
+++ b/QMLComponents/models/listmodelfactorsform.cpp
@@ -204,7 +204,7 @@ void ListModelFactorsForm::factorAdded(int index, VariablesListBase* listView)
 
 void ListModelFactorsForm::ensureNesting()
 {
-	if (_ensuringNesting || !_factorsForm->nested()) return;
+	if (_ensuringNesting || !_factorsForm->nested() || !_factorsForm->initialized()) return;
 
 	ListModelDraggable	*currentModel	= qobject_cast<ListModelDraggable*>(sender()),
 						*onderModel		= nullptr,
@@ -216,7 +216,7 @@ void ListModelFactorsForm::ensureNesting()
 		{
 			if (currentModel == _factors[i].listView->model())
 			{
-				if (i > 0)
+				if (i > 0 )
 					upperModel = qobject_cast<ListModelDraggable*>(_factors[i-1].listView->model());
 				if (i + 1 < _factors.size())
 					onderModel = qobject_cast<ListModelDraggable*>(_factors[i+1].listView->model());

--- a/QMLComponents/models/listmodelfactorsform.cpp
+++ b/QMLComponents/models/listmodelfactorsform.cpp
@@ -216,7 +216,7 @@ void ListModelFactorsForm::ensureNesting()
 		{
 			if (currentModel == _factors[i].listView->model())
 			{
-				if (i > 0 )
+				if (i > 0)
 					upperModel = qobject_cast<ListModelDraggable*>(_factors[i-1].listView->model());
 				if (i + 1 < _factors.size())
 					onderModel = qobject_cast<ListModelDraggable*>(_factors[i+1].listView->model());


### PR DESCRIPTION
When controls are created dynamically, wait first for all controls to be created before calling their setup function: the setup links the controls together (with their sources), so it needs all controls to be created first.