### PR TITLE
Set the add column + sign correctly

### DIFF
--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -299,9 +299,10 @@ FocusScope
 				JaspControls.RectangularButton
 				{
 					id:				addColumnButton
-					x:				2.5
+					x:				1 * preferencesModel.uiScale
 					y:				-1
-					width:			visible ? height + 2 : 0
+					height:			dataTableView.headerHeight + 1.8
+					width:			visible ? height : 0
 					toolTip:		qsTr("Add computed column")
 					iconSource:		jaspTheme.iconPath + "/addition-sign.svg"
 					onClicked:		createComputeDialog.open()


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2906

I see that there is a horizontal line under the + sign, but I cannot see in the code where this line comes from. I just tried my best to make the rectangle big enough so that this extra line stays hidden, but sometimes with some zoom scale, you can still see it. Maybe @JorisGoosen knows better where this line comes from and can remove it.