### PR TITLE
Read doubles in DoubleField

### DIFF
--- a/CommonData/columnutils.cpp
+++ b/CommonData/columnutils.cpp
@@ -79,7 +79,7 @@ bool ColumnUtils::getIntValue(const double &value, int &intValue)
 	return false;
 }
 
-bool ColumnUtils::getDoubleValue(const string &value, double &doubleValue)
+bool ColumnUtils::getDoubleValue(const string &value, double &doubleValue, bool useLocale)
 {
 	JASPTIMER_SCOPE(ColumnUtils::getDoubleValue);
 
@@ -91,7 +91,7 @@ bool ColumnUtils::getDoubleValue(const string &value, double &doubleValue)
 		return true;
 	}
 
-	if(_extraStringToDouble && _extraStringToDouble(value, doubleValue))
+	if(useLocale && _extraStringToDouble && _extraStringToDouble(value, doubleValue))
 		return true;
 	
 	try

--- a/CommonData/columnutils.h
+++ b/CommonData/columnutils.h
@@ -18,7 +18,7 @@ public:
 
 	static bool					getIntValue(	const std::string	& value, int	& intValue);
 	static bool					getIntValue(	const double		& value, int	& intValue);
-	static bool					getDoubleValue(	const std::string	& value, double	& doubleValue);
+	static bool					getDoubleValue(	const std::string	& value, double	& doubleValue,	bool useLocale = true);
 	static doubleset			getDoubleValues(const stringset		& values, bool stripNAN = true);
 
 	static bool					isIntValue(		const std::string	& value);

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -203,21 +203,27 @@ void TextInputBase::setUp()
 		connect(form(), &AnalysisForm::languageChanged, this, &TextInputBase::setDisplayValue);
 
 	if (_value.isNull()) // If the value is not directly set, use the default value.
-		setValue(_defaultValue);
+		setValue(_defaultValue, false);
 
 	JASPControl::setUp(); // It might need the _inputType, so call it after it is set.
 }
 
 void TextInputBase::setDisplayValue()
 {
-
 	int		valueInt;
 	double	valueDbl;
-	bool	isInt,
-			isDbl;
-	
-	isInt = QColumnUtils::getIntValue(		_value.toString(), valueInt);
-	isDbl = QColumnUtils::getDoubleValue(	_value.toString(), valueDbl);
+	bool	isInt = (_value.typeId() == QMetaType::Int),
+			isDbl = (_value.typeId() == QMetaType::Double);
+
+	if (isInt)
+		valueInt = _value.toInt();
+	else if (isDbl)
+		valueDbl = _value.toDouble();
+	else
+	{
+		isInt = QColumnUtils::getIntValue(	_value.toString(), valueInt);
+		isDbl = QColumnUtils::getDoubleValue(	_value.toString(), valueDbl);
+	}
 	
 	QString showThis = _value.toString();
 	
@@ -418,10 +424,10 @@ void TextInputBase::valueChangedSlot()
 	setValue(prop);
 }
 
-void TextInputBase::setValue(QVariant value)
+void TextInputBase::setValue(QVariant value, bool useLocale)
 {
 	double valueDbl;
-	if(QColumnUtils::getDoubleValue(value.toString(), valueDbl))
+	if(QColumnUtils::getDoubleValue(value.toString(), valueDbl, useLocale))
 		value = valueDbl;	
 	
 	bool hasChanged = _value != value;
@@ -444,7 +450,7 @@ void TextInputBase::setValue(QVariant value)
 void TextInputBase::setDefaultValue(QVariant value)
 {
 	double valueDbl;
-	if(QColumnUtils::getDoubleValue(value.toString(), valueDbl))
+	if(QColumnUtils::getDoubleValue(value.toString(), valueDbl, false)) // Don't use locale with default value: they are set by the analysis, not by the user.
 		value = valueDbl;
 		
 	bool	hasChanged	= _defaultValue !=  value,
@@ -456,7 +462,7 @@ void TextInputBase::setDefaultValue(QVariant value)
 		emit defaultValueChanged();
 	
 	if(curValIsDef)
-		setValue(_defaultValue);
+		setValue(_defaultValue, false);
 }
 
 void TextInputBase::_setBoundValue()

--- a/QMLComponents/controls/textinputbase.h
+++ b/QMLComponents/controls/textinputbase.h
@@ -70,7 +70,7 @@ public slots:
 	
 	GENERIC_SET_FUNCTION(Label,				_label,				labelChanged,			QString		)
 	GENERIC_SET_FUNCTION(AfterLabel,		_afterLabel,		afterLabelChanged,		QString		)
-	void setValue(			QVariant value);
+	void setValue(			QVariant value, bool useLocale = true);
 	void setDefaultValue(	QVariant value);
 
 private slots:

--- a/QMLComponents/utilities/qutils.cpp
+++ b/QMLComponents/utilities/qutils.cpp
@@ -325,9 +325,9 @@ bool QColumnUtils::getIntValue(const QString &value, int &intValue)
 	return ColumnUtils::getIntValue(fq(value), intValue);
 }
 
-bool QColumnUtils::getDoubleValue(const QString &value, double &doubleValue)
+bool QColumnUtils::getDoubleValue(const QString &value, double &doubleValue, bool useLocale)
 {
-	return ColumnUtils::getDoubleValue(fq(value), doubleValue);
+	return ColumnUtils::getDoubleValue(fq(value), doubleValue, useLocale);
 }
 
 doubleset QColumnUtils::getDoubleValues(const QStringList &values, bool stripNAN)

--- a/QMLComponents/utilities/qutils.h
+++ b/QMLComponents/utilities/qutils.h
@@ -100,7 +100,7 @@ class QColumnUtils
 {
 public:	
 	static bool					getIntValue(	const QString		& value, int	& intValue);
-	static bool					getDoubleValue(	const QString		& value, double	& doubleValue);
+	static bool					getDoubleValue(	const QString		& value, double	& doubleValue, bool useLocale = true);
 	static doubleset			getDoubleValues(const QStringList	& values, bool stripNAN = true);
 
 	static bool					isIntValue(		const QString		& value);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/3032

Default values (or values) set in QML are set in english format. So the locale chosen by the user should not be used when reading these numbers.
