### PR TITLE
Stop engines after destroying old db and restart them later

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1382,6 +1382,18 @@ void DataSetPackage::beginLoadingData(bool)
 	beginResetModel();
 }
 
+void DataSetPackage::stopEngines()
+{
+	EngineSync::singleton()->stopEngines();
+}
+
+void DataSetPackage::restartEngines()
+{
+	EngineSync::singleton()->restartEngines();
+}
+
+
+
 void DataSetPackage::endLoadingData(bool)
 {
 	JASPTIMER_SCOPE(DataSetPackage::endLoadingData);
@@ -1433,6 +1445,7 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 		deleteDataSet(); //no dbDelete necessary cause we just copied an old sqlite file here from the JASP file
 	
 	_db->close();
+	stopEngines();
 	_db->load();		
 	_db->upgradeDBFromVersion(_jaspVersion);
 	
@@ -1458,6 +1471,7 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 	DataSetPackage::pkg()->initializeComputedColumns();
 
 	emit synchingExternallyChanged(synchingExternally());
+	restartEngines();
 }
 
 void DataSetPackage::deleteDataSet()

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -94,6 +94,8 @@ public:
 		void				waitForExportResultsReady();
 
 		void				beginLoadingData(	bool informEngines = true);
+		void				stopEngines();
+		void				restartEngines();
 		void				endLoadingData(		bool informEngines = true);
 		void				beginSynchingData(	bool informEngines = true);
 		void				endSynchingDataChangedColumns(stringvec	&	changedColumns,		bool hasNewColumns = false, bool informEngines = true);

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -305,10 +305,6 @@ void EngineSync::start(int )
 	for(size_t s=0;s < _engineStopTimes.size(); s++)
 		_engineStopTimes[s] = -1;
 
-	//We start with a single engine. Later we can start more if necessary and allowed by the user. This one engine can run filters etc and it can be assigned to a particular module.
-	//Once it is assigned to a module it won't be possible to use it for another module until it is restarted.
-	createNewEngine();
-
 	_timerProcess	= new QTimer(this);
 	_timerBeat		= new QTimer(this);
 


### PR DESCRIPTION
So after the potentially replaced internal.sqlite is available again.

Fixes https://github.com/jasp-stats/jasp-test-release/issues/3035

