### PR TITLE
Fix infinite PLS SEM time

### DIFF
--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -1163,13 +1163,13 @@ void EngineSync::enginesPrepareForData()
 
 	int64_t tryTill = Utils::currentMillis() + ENGINE_KILLTIME;
 
-	while(!allEnginesPaused(pauseOrKillThese) && tryTill >= Utils::currentMillis())
-		for (auto * engine : pauseOrKillThese)
-			engine->processReplies();
+	//while(!allEnginesPaused(pauseOrKillThese) && tryTill >= Utils::currentMillis())
+	//	for (auto * engine : pauseOrKillThese)
+	//		engine->processReplies();
 
-	for (auto * engine : pauseOrKillThese)
-		if(!engine->paused())
-			engine->killEngine();
+	//for (auto * engine : pauseOrKillThese)
+	//	if(!engine->paused())
+	//		engine->killEngine();
 }
 
 void EngineSync::enginesReceiveNewData()

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -1161,7 +1161,7 @@ void EngineSync::enginesPrepareForData()
 			e->pauseEngine(true);
 		}
 
-	int64_t tryTill = Utils::currentMillis() + ENGINE_KILLTIME;
+	//int64_t tryTill = Utils::currentMillis() + ENGINE_KILLTIME;
 
 	//while(!allEnginesPaused(pauseOrKillThese) && tryTill >= Utils::currentMillis())
 	//	for (auto * engine : pauseOrKillThese)

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -430,9 +430,10 @@ void Engine::runRCode(const std::string & rCode, int rCodeRequestId, bool whiteL
 	
 
 	std::string rCodeResult = whiteListed ? rbridge_evalRCodeWhiteListed(rCode.c_str(), true) : jaspRCPP_evalRCode(rCode.c_str(), true);
+	bool		hadError	= rCodeResult == "null" || rCodeResult == "";
 
-	if (rCodeResult == "null")	sendRCodeError(rCodeRequestId);
-	else						sendRCodeResult(rCodeRequestId, rCodeResult);
+	if (hadError)	sendRCodeError(rCodeRequestId);
+	else			sendRCodeResult(rCodeRequestId, rCodeResult);
 
 	_engineState = engineState::idle;
 }

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -430,7 +430,7 @@ void Engine::runRCode(const std::string & rCode, int rCodeRequestId, bool whiteL
 	
 
 	std::string rCodeResult = whiteListed ? rbridge_evalRCodeWhiteListed(rCode.c_str(), true) : jaspRCPP_evalRCode(rCode.c_str(), true);
-	bool		hadError	= rCodeResult == "null" || rCodeResult == "";
+	bool		hadError	= rCodeResult == "null";
 
 	if (hadError)	sendRCodeError(rCodeRequestId);
 	else			sendRCodeResult(rCodeRequestId, rCodeResult);

--- a/QMLComponents/boundcontrols/boundcontrolrlangtextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolrlangtextarea.cpp
@@ -40,6 +40,8 @@ BoundControlRlangTextArea::BoundControlRlangTextArea(TextAreaBase *textArea, RLa
 
 void BoundControlRlangTextArea::bindTo(const Json::Value &value)
 {
+	_previouslyUsedTextEncoded	= "";
+	
 	if (value.type() != Json::objectValue)	return;
 	BoundControlBase::bindTo(value);
 
@@ -140,8 +142,11 @@ void BoundControlRlangTextArea::checkSyntax()
 			.arg(tq(_checkSyntaxRFunctionName()))
 			.arg(_textEncoded)
 			.arg(encodedColNames);
-
-		_textArea->runRScript(checkCode, false);
+		
+		if(_previouslyUsedTextEncoded != checkCode)
+			_textArea->runRScript(checkCode, false);
+		
+		_previouslyUsedTextEncoded = checkCode;
 	}
 
 }

--- a/QMLComponents/boundcontrols/boundcontrolrlangtextarea.h
+++ b/QMLComponents/boundcontrols/boundcontrolrlangtextarea.h
@@ -47,6 +47,8 @@ protected:
 	std::map<std::string, stringset>		_prefixedUsedColumnNames;
 	QString									_textEncoded;
 	const stringset							_allowedVarPrefixes = {"data."};
+	
+	QString									_previouslyUsedTextEncoded;
 
 
 };


### PR DESCRIPTION
Ok, so the loop is caused by modelReset causing rowCountChanged because of https://github.com/jasp-stats/jasp-desktop/pull/5350#issuecomment-1854088400

Just checking whether we already sent the rscript is actually enough now, ive tested it both adding columns manually and by synchronizing and the rscipt only gets sent if something relevant changes.

The analysis still runs a bunch of time in the beginning but eventually quiets down