### PR TITLE
bugfix: trim and remove leading and trailing escapes from excel

### DIFF
--- a/Desktop/data/importers/excel/excel.cpp
+++ b/Desktop/data/importers/excel/excel.cpp
@@ -89,7 +89,7 @@ void Excel::getCellValue(uint32_t &row, uint16_t &col, std::string &cellValue)
 	case FREEXL_CELL_DATETIME:
 	case FREEXL_CELL_TIME:
 		cellValue = cell.value.text_value;
-		cellValue = stringUtils::replaceBy(cellValue, "\n", "_");
+		cellValue = stringUtils::trimAndRemoveEscapes(cellValue);
 		break;
 	case FREEXL_CELL_INT:
 		cellValue = std::to_string(cell.value.int_value);


### PR DESCRIPTION
fix: https://github.com/jasp-stats/jasp-issues/issues/3523

`trimAndRemoveEscapes` was also handled the `\n` replace.
Perhaps centralizing handle these cell imports for all data formats is the wise choice, but I imagine this would require some refactoring, perhaps left for later to do.