### PR TITLE
feat: showing column descriptions also on variable list while hovered

### DIFF
--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -559,6 +559,11 @@ VariablesListBase
 					hoverEnabled:	true
 					cursorShape:	itemRectangle.typeChangeable && mouseX < icon.width ? Qt.PointingHandCursor : Qt.OpenHandCursor
 
+					onEntered:
+					{
+						itemRectangle.formatToolTip()
+					}
+
 					onDoubleClicked: (mouse)=>
 					{
 						if (itemRectangle.draggable)


### PR DESCRIPTION
part of: https://github.com/jasp-stats/jasp-issues/issues/3524

It is a quick request from users they have many short name cols and want to know description quickly before drag it, minor but improves the user experience.