### PR TITLE
Still a problem when Radiobuttons are created and deleted dynamically

### DIFF
--- a/QMLComponents/components/JASP/Controls/AssignButton.qml
+++ b/QMLComponents/components/JASP/Controls/AssignButton.qml
@@ -34,7 +34,7 @@ Button
 	readonly	property string iconToRight:	jaspTheme.iconPath + "arrow-right.png"
 	
 	text:			""
-	visible:		sourceM.visible && targetM.visible
+	visible:		sourceM && targetM && sourceM.visible && targetM.visible
 
 	iconSource:		leftToRight ? iconToRight : iconToLeft
 

--- a/QMLComponents/controls/factorsformbase.h
+++ b/QMLComponents/controls/factorsformbase.h
@@ -55,7 +55,7 @@ public:
 	Q_INVOKABLE void	factorAdded(int index, QVariant item);
 
 	int					initNumberFactors()						const				{ return _initNumberFactors;						}
-	int					countVariables()						const				{ return _initialized ? _factorsModel->countVariables() : 0; }
+	int					countVariables()						const				{ return initialized() ? _factorsModel->countVariables() : 0; }
 	JASPListControl*	availableVariablesList()				const				{ return _availableVariablesListItem;				}
 	QString				baseName()								const				{ return _baseName;			}
 	QString				baseTitle()								const				{ return _baseTitle;		}

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -859,6 +859,12 @@ void JASPControl::setInitialized(const Json::Value &value)
 	}
 }
 
+void JASPControl::setUnitialized()
+{
+	_initialized = false;
+	_initializedWithValue = Json::nullValue;
+}
+
 void JASPControl::_setInitialized(const Json::Value &value)
 {
 	BoundControl* bControl = boundControl();

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -164,6 +164,7 @@ public:
 
 	virtual void					setUp()										{}
 	void							setInitialized(const Json::Value& value = Json::nullValue);
+	void							setUnitialized();
 	virtual void					cleanUp()									{ disconnect(); }
 	virtual BoundControl		*	boundControl();
 	virtual bool					encodeValue()						const	{ return false; }

--- a/QMLComponents/controls/radiobuttonsgroupbase.cpp
+++ b/QMLComponents/controls/radiobuttonsgroupbase.cpp
@@ -118,7 +118,7 @@ void RadioButtonsGroupBase::unregisterRadioButton(RadioButtonBase* button)
 {
 	if (_buttons.remove(button))
 	{
-		if (button == _selectedButton && _buttons.size() > 0)
+		if (button == _selectedButton && _buttons.size() > 0 && initialized())
 			_setCheckedButton(*_buttons.begin());
 		emit buttonsChanged();
 	}
@@ -152,6 +152,7 @@ void RadioButtonsGroupBase::setDefaultValue(const QString &defaultValue)
 
 void RadioButtonsGroupBase::unregisterAll()
 {
+	setUnitialized();
 	auto buttonsTmp = _buttons;
 	for(auto* button : buttonsTmp) {
 		button->unregisterRadioButton();

--- a/QMLComponents/controls/rowcontrols.cpp
+++ b/QMLComponents/controls/rowcontrols.cpp
@@ -131,7 +131,7 @@ bool RowControls::addJASPControl(JASPControl *control)
 	return success;
 }
 
-void RowControls::disconnectControls()
+void RowControls::disconnectAndDeleteControls()
 {
 	// If a control depends on a source, disconnect this source with this control.
 	JASPListControl* parentControl = _parentModel->listView();
@@ -142,6 +142,7 @@ void RowControls::disconnectControls()
 			for (SourceItem* source : listControl->sourceItems())
 				source->disconnectModels();
 		control->setParent(nullptr);
+		control->setUnitialized();
 		control->blockSignals(true);
 		control->deleteLater();
 	}

--- a/QMLComponents/controls/rowcontrols.h
+++ b/QMLComponents/controls/rowcontrols.h
@@ -48,7 +48,7 @@ public:
 	const QMap<QString, JASPControl*>&			getJASPControlsMap()						const	{ return _rowJASPControlMap;	}
 	JASPControl*								getJASPControl(const QString& name)					{ return _rowJASPControlMap.contains(name) ? _rowJASPControlMap[name] : nullptr; }
 	bool										addJASPControl(JASPControl* control);
-	void										disconnectControls();
+	void										disconnectAndDeleteControls();
 	bool										initialized()								const	{ return _initialized; }
 
 signals:

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -442,7 +442,7 @@ void TextInputBase::setValue(QVariant value, bool useLocale)
 	{
 		emit valueChanged();
 
-		if (_initialized)
+		if (initialized())
 			_setBoundValue();
 	}
 }

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -209,7 +209,7 @@ void ListModel::setUpRowControls()
 		{
 			// If some row controls are not used anymore, if they use some sources, they must be disconnected from these sources
 			// If a source changes and emits a signal, these controls should not be activated (cf. https://github.com/jasp-stats/jasp-test-release/issues/1786)
-			_rowControlsMap[key]->disconnectControls();
+			_rowControlsMap[key]->disconnectAndDeleteControls();
 			removedKeys.append(key);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2911

The RadioButtons are in a TabView. If one tab is removed, the radio buttons are removed: if a radio button is removed before the radio button group is removed, this could provoke an update of the options (the Tab which is deleted, gets a signal to update its option). To tackle this, in the rowControl which contains the controls of the Tab, we call all its controls to be unitialized before deleting them (the blockSignals is not enough since the Radio button can call the Radio Button group without having to use signals).

