### PR TITLE
Always resume engine

### DIFF
--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -1069,9 +1069,6 @@ void EngineSync::startStoppedEngine(EngineRepresentation * engine)
 
 void EngineSync::resumeEngines()
 {
-	if(_dataMode)
-		return;
-	
 	JASPTIMER_SCOPE(EngineSync::resumeEngines);
 
 	Log::log() << "EngineSync::resumeEngines()" << std::endl;


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2920

When a new dataset is created, the engines are restarted. But as the dataMode is true, the resumeEmgines function does not resume the engine, and especially the _stopProcessing is not reset to false. As _stopProcessing stays false, no engine is called to process the analysis.
The resumeEngines is called either with

- processFilterScript
- file is closed (it calls cleanRestart that calls resumeEngines( 
- when a new language is chosen.

In this 3 cases , there is no reason why the resumeEngines should be blocked in data mode.
So just remove the condition `if (_dataMode) return` in this function.

