### PR TITLE
Issues with computed columns in JASP file

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1468,7 +1468,8 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 	_dataSubModel->selectNode(_dataSet->dataNode());
 	_filterSubModel->selectNode(_dataSet->filtersNode());
 
-	//DataSetPackage::pkg()->initializeComputedColumns();
+	// Do not compute computed columns when loading a JASP file!
+	// DataSetPackage::pkg()->initializeComputedColumns();
 
 	emit synchingExternallyChanged(synchingExternally());
 	restartEngines();

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1468,7 +1468,7 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 	_dataSubModel->selectNode(_dataSet->dataNode());
 	_filterSubModel->selectNode(_dataSet->filtersNode());
 
-	DataSetPackage::pkg()->initializeComputedColumns();
+	//DataSetPackage::pkg()->initializeComputedColumns();
 
 	emit synchingExternallyChanged(synchingExternally());
 	restartEngines();

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -449,7 +449,7 @@ void EngineSync::process()
 	
 	int			wantThisManyEngines			=	notEnoughIdlesSet.size();
 
-	if (notEnoughIdlesForCompCol)
+	if (notEnoughIdlesForCompCol) // Need an angine for a computed column: create one!
 		wantThisManyEngines++;
 
 	if(notEnoughIdles)

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -432,16 +432,6 @@ void EngineSync::process()
 		
 	processLogCfgRequests();
 
-	if(_stopProcessing || _dataMode || _filterRunning)
-	{
-		bool needEngine = processComputedColumnQueue();
-		
-		if(needEngine)
-			createNewEngine();
-		
-		return;
-	}
-
 	//if(_engines.size() == 0)
 	//	startExtraEngines();
 	
@@ -458,6 +448,9 @@ void EngineSync::process()
 	notEnoughIdlesSet.merge(notEnoughIdlesForScript);
 	
 	int			wantThisManyEngines			=	notEnoughIdlesSet.size();
+
+	if (notEnoughIdlesForCompCol)
+		wantThisManyEngines++;
 
 	if(notEnoughIdles)
 		Log::log() << "Not enough idle engines! Need " << (notEnoughIdlesForScript.size() ? " one for script" : "") << (notEnoughIdlesForCompCol ? " one for compcol" : "") << (notEnoughIdlesForModule.size() ? std::to_string(notEnoughIdlesForModule.size()) + " for installing modules" : "") <<  (notEnoughIdlesForAnalysis.size() ? std::to_string(notEnoughIdlesForAnalysis.size()) + " for analysis" : "") << ", one will " << ( !anEngineIdleSoon() ? "NOT " : "")  << "be idle soon..." << std::endl;


### PR DESCRIPTION
- The computed columns should not be computed again when a JASP file is loaded. 
- If a computed column has to be computed, if no engine is available, a new engine should be started.
