### PR TITLE
Colorblind friendlier palettes

### DIFF
--- a/QMLComponents/components/JASP/Controls/ColorPalette.qml
+++ b/QMLComponents/components/JASP/Controls/ColorPalette.qml
@@ -27,15 +27,17 @@ DropDown
 	indexDefaultValue: 0
 	values:
 	[
-		{ label: qsTr("Colorblind"),		value: "colorblind"		},
-		{ label: qsTr("Colorblind #2"),		value: "colorblind2"	},
-		{ label: qsTr("Colorblind #3"),		value: "colorblind3"	},
-		{ label: qsTr("JASP"),				value: "jaspPalette"			},
-		{ label: qsTr("Viridis"),			value: "viridis"		},
-		{ label: qsTr("ggplot2"),			value: "ggplot2"		},
-		{ label: qsTr("Gray"),				value: "gray"			},
-		{ label: qsTr("Blue"),				value: "blue"			},
-		{ label: qsTr("Sports teams: NBA"),	value: "sportsTeamsNBA"	},
-		{ label: qsTr("Grand Budapest"),	value: "grandBudapest"	}
+		{ label: qsTr("Colorblind #3"),			   value: "colorblind3"	   },
+		{ label: qsTr("Colorblind #4"),			   value: "colorblind4"	   },
+		{ label: qsTr("Viridis"),				   value: "viridis"		   },
+		{ label: qsTr("Inferno"),				   value: "inferno"		   },
+		{ label: qsTr("JASP"),					   value: "jaspPalette"	   },
+		{ label: qsTr("ggplot2"),				   value: "ggplot2"		   },
+		{ label: qsTr("Gray"),					   value: "gray"		   },
+		{ label: qsTr("Blue"),					   value: "blue"		   },
+		{ label: qsTr("Sports teams: NBA"),		   value: "sportsTeamsNBA" },
+		{ label: qsTr("Grand Budapest"),		   value: "grandBudapest"  },
+		{ label: qsTr("deprecated Colorblind"),	   value: "colorblind"	   },
+		{ label: qsTr("deprecated Colorblind #2"), value: "colorblind2"	   }
 	]
 }


### PR DESCRIPTION
Context: https://github.com/jasp-stats/jaspGraphs/pull/118

I want users to switch to colorblind friendlier palettes.
This is why I would like to make Colorblind #3 the new default at the very top.

To ensure backwards compatibility, I kept Colorblind and Colorblind #1
Yet, they are marked as deprecated and moved to the very bottom.

Maybe this is not the optimal solution yet, so feel free to fix/build on my current proposal.