### PR TITLE
use find_library for locating libreadstat.so

### DIFF
--- a/Tools/CMake/Libraries.cmake
+++ b/Tools/CMake/Libraries.cmake
@@ -185,7 +185,7 @@ if(LINUX)
   endif()
 
   message(CHECK_START "Looking for libreadstat.so")
-  find_file(LIBREADSTAT_LIBRARIES libreadstat.so
+  find_library(LIBREADSTAT_LIBRARIES libreadstat.so
             HINTS ${LIBREADSTAT_LIBRARY_DIRS} REQUIRED)
 
   if(EXISTS ${LIBREADSTAT_LIBRARIES})


### PR DESCRIPTION
Using `find_library` makes it so that even if the readstat shared library is not in any of the paths specified in HINTS, it can still be found via cmake's search path mechanism (e.g. `CMAKE_LIBRARY_PATH`).

This patch is already used as a part of the [nixpkgs patchset for jasp-desktop](https://github.com/NixOS/nixpkgs/blob/85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054/pkgs/by-name/ja/jasp-desktop/cmake.patch#L44-L51)

Note: seems like the logic for finding `librdata.so` is already also `find_library` instead of `find_file`.