### PR TITLE
bugfix: fix table cell vertical-align table export styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ QMLComponents/utilities/appdirs.h
 # Bundle related
 Tools/ModuleBundleBuildDir
 Modules/local
+
+# User configurations
+.qmlls.ini

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -102,10 +102,12 @@ th[colspan="2"] {
 }
 
 td {
-	padding-left: 2em;
+	text-align: right;
+	vertical-align: bottom;
+	padding-left: 1em;
 	padding-right: 1em;
-	text-align: right ;
-	vertical-align: top ;
+	/* padding-top: .25em;   because algin to buttom then seems visual balanced */
+	padding-bottom: .25em;
 }
 
 thead tr:nth-child(2) th:not(.separator) {
@@ -129,6 +131,8 @@ thead th {
 	white-space: nowrap;
 	padding-top: .25em ;
 	padding-bottom: .25em ;
+	padding-left: 1em;
+	padding-right: 1em;
 }
 
 tbody th {
@@ -189,7 +193,7 @@ tbody tr td.new-sub-group-row {
 
 tbody tr td.new-group-row,
 tbody tr:first-child td {
-
+	vertical-align: top;  /* align to top for first group rows */
 	padding-top: .9em ;
 }
 

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -183,7 +183,7 @@ div.over-title-space:empty {
 tbody tr:last-child th,
 tbody tr:last-child td {
 
-	border-bottom: 2px solid ;
+	border-bottom: thin solid ;
 }
 
 tbody tr td.new-sub-group-row {

--- a/Desktop/html/css/jasp.css
+++ b/Desktop/html/css/jasp.css
@@ -101,18 +101,9 @@ th[colspan="2"] {
 	padding-right: 1em ;
 }
 
-td.value {
-	padding-left : 1em ;
-	padding-right: 0 ;
-}
-
-td.symbol {
-	text-align: left ;
-	padding-right: 1em ;
-	padding-left: 0 ;
-}
-
 td {
+	padding-left: 2em;
+	padding-right: 1em;
 	text-align: right ;
 	vertical-align: top ;
 }
@@ -215,7 +206,7 @@ td.text {
 }
 
 tfoot td {
-
+	padding-left: 0em ;
 	text-align: left;
 }
 

--- a/Desktop/html/js/jaspwidgets.js
+++ b/Desktop/html/js/jaspwidgets.js
@@ -250,7 +250,7 @@ JASPWidgets.Exporter = {
 	},
 
 	getTableContentStyles: function (element, exportParams) {
-			return JASPWidgets.Exporter.getStyles(element, ["border-collapse", "border-top-width", "border-bottom-width", "border-left-width", "border-right-width", "border-color", "border-style", "padding", "text-align", "margin", "display", "float", "font-size", "font-weight", "font", "color"]);
+			return JASPWidgets.Exporter.getStyles(element, ["border-collapse", "border-top-width", "border-bottom-width", "border-left-width", "border-right-width", "border-color", "border-style", "padding", "text-align", "margin", "display", "float", "font-size", "font-weight", "font", "color", "background", "background-color"]);
 	},
 
 	getErrorStyles: function (element, component) {

--- a/Desktop/html/js/table.js
+++ b/Desktop/html/js/table.js
@@ -548,18 +548,15 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 		var chunks = []
 
 		if (optError) {
-
 			chunks.push('<table class="error-state jasp-no-select">')
 		}
 		else {
-
 			chunks.push('<table class="jasp-no-select">')
 		}
 
-
 		chunks.push('<thead>')
 		chunks.push('<tr>')
-		chunks.push('<th colspan="' + 2 * columnCount + '"><div class="toolbar"></div></div>')
+		chunks.push('<th colspan="' + columnCount + '"><div class="toolbar"></div></div>')
 
 		if (optError && optError.errorMessage) {
 
@@ -576,7 +573,7 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 
 		if (optSubtitle) {
 			chunks.push('<tr>')
-			chunks.push('<th colspan="' + 2 * columnCount + '"></th>')
+			chunks.push('<th colspan="' + columnCount + '"></th>')
 			chunks.push('</tr>')
 		}
 
@@ -606,11 +603,10 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 
 			if (hasOvertitles) {
 
-				if (hasAdjacentOvertitles) {
+				if (hasAdjacentOvertitles)
 					chunks.push('<tr class="over-title-space">')
-				} else {
+				else
 					chunks.push('<tr class="over-title">')
-				}
 
 
 				var span = 1;
@@ -627,26 +623,24 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 						newTitle = ""
 
 					if (newTitle == oldTitle) {
-
 						span++
 					}
 					else {
-						if (hasAdjacentOvertitles) {
-							chunks.push('<th colspan="' + (2 * span) + '"><div class="over-title-space">' + oldTitle + '</div></th>');
-						} else {
-							chunks.push('<th colspan="' + (2 * span) + '">' + oldTitle + '</th>');
-						}
+						if (hasAdjacentOvertitles)
+							chunks.push('<th colspan="' + span + '"><div class="over-title-space">' + oldTitle + '</div></th>');
+						else
+							chunks.push('<th colspan="' + span + '">' + oldTitle + '</th>');
+
 						oldTitle = newTitle
 						span = 1
 					}
 				}
 
 				if (newTitle == oldTitle) {
-					if (hasAdjacentOvertitles) {
-						chunks.push('<th colspan="' + (2 * span) + '"><div class="over-title-space">' + newTitle + '</div></th>')
-					} else {
-						chunks.push('<th colspan="' + (2 * span) + '">' + newTitle + '</th>')
-					}
+					if (hasAdjacentOvertitles)
+						chunks.push('<th colspan="' + span + '"><div class="over-title-space">' + newTitle + '</div></th>')
+					else
+						chunks.push('<th colspan="' + span + '">' + newTitle + '</th>')
 				}
 
 
@@ -669,9 +663,6 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 				span = 1
 
 			if (span) {
-
-				span *= 2  // times 2, because of footnote markers
-
 				chunks.push('<th colspan="' + span + '" class="' + cell.type + '">' + cell.content)
 				if (cell.footnotes)
 					chunks.push(cell.footnotes.join(' '))
@@ -709,18 +700,14 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 					cellClass += (cell.span > 1 ? " row-span" : "")
 
 					cellHtml += (cell.header ? '<th' : '<td')
-					cellHtml += ' class="value ' + cellClass + '"'
+					cellHtml += ' class="' + cellClass + '"' 
 					cellHtml += (cell.span ? ' rowspan="' + cell.span + '"' : '')
 					cellHtml += '>'
 					cellHtml += (typeof cell.content != "undefined" ? cell.content : '')
-					cellHtml += (cell.header ? '</th>' : '</td>')
 
-					cellHtml += (cell.header ? '<th' : '<td')
-					cellHtml += ' class="symbol ' + cellClass + '"'
-					cellHtml += (cell.span ? ' rowspan="' + cell.span + '"' : '')
-					cellHtml += '>'
-					if (typeof cell.footnotes != "undefined")
-						cellHtml += cell.footnotes.join(' ')
+					if (typeof cell.footnotes != "undefined" && cell.footnotes.length > 0)
+						cellHtml += '<sup>' + cell.footnotes.join('') + '</sup>' 
+
 					cellHtml += (cell.header ? '</th>' : '</td>')
 
 					tableProgress[colNo].from += 1
@@ -746,7 +733,7 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 			chunks.push('</tr>')
 		}
 
-		chunks.push('<tr><td colspan="' + 2 * columnCount + '"></td></tr>')
+		chunks.push('<tr><td colspan="' + columnCount + '"></td></tr>')
 
 		chunks.push('</tbody>')
 
@@ -758,7 +745,7 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 				if(optFootnotes[i].text !== "")
 				{
 
-					chunks.push('<tr><td colspan="' + 2 * columnCount + '">')
+					chunks.push('<tr><td colspan="' + columnCount + '">')
 
 					var footnote = optFootnotes[i]
 

--- a/Desktop/html/js/table.js
+++ b/Desktop/html/js/table.js
@@ -556,7 +556,7 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 
 		chunks.push('<thead>')
 		chunks.push('<tr>')
-		chunks.push('<th colspan="' + columnCount + '"><div class="toolbar"></div></div>')
+		chunks.push('<th colspan="' + columnCount + '"><div class="toolbar"></div>')
 
 		if (optError && optError.errorMessage) {
 
@@ -705,8 +705,8 @@ JASPWidgets.tablePrimitive = JASPWidgets.View.extend({
 					cellHtml += '>'
 					cellHtml += (typeof cell.content != "undefined" ? cell.content : '')
 
-					if (typeof cell.footnotes != "undefined" && cell.footnotes.length > 0)
-						cellHtml += '<sup>' + cell.footnotes.join('') + '</sup>' 
+					if (typeof cell.footnotes != "undefined")
+						cellHtml += cell.footnotes.join(' ')
 
 					cellHtml += (cell.header ? '</th>' : '</td>')
 


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/jasp-issues/issues/3008
Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/2794
Fix: https://github.com/jasp-stats/jasp-issues/issues/3620

replace: https://github.com/jasp-stats/jasp-desktop/pull/5793

This PR may cause the old comparison table unit test to fail. In this case, you may need to refresh the old JASP files.