### PR TITLE
Recovery

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/AutoSaves.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/AutoSaves.qml
@@ -1,0 +1,91 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import JASP.Controls
+import JASP.Widgets
+
+Item
+{
+	id:						rect
+	focus:					true
+	onActiveFocusChanged:	if(activeFocus)
+							{
+								autoSavesList.forceActiveFocus()
+
+								if(fileMenuModel.autoSaves.listModel)
+									fileMenuModel.autoSaves.listModel.refresh();
+							}
+
+	MenuHeader
+	{
+		id:					menuHeader
+		headertext:			qsTr("Recovery")
+	}
+
+
+	ScrollMoreIndicator
+	{
+		anchors
+		{
+			top:			autoSavesList.top
+			left:			autoSavesList.left
+			right:			autoSavesList.right
+		}
+
+		upsideDown:	true
+		extraSpace:	autoSavesList.contentY
+	}
+
+	ScrollMoreIndicator
+	{
+		anchors
+		{
+			left:			 autoSavesList.left
+			right:			 autoSavesList.right
+			bottom:			 autoSavesList.bottom
+		}
+
+		upsideDown:	false
+		extraSpace:	autoSavesList.contentHeight - (autoSavesList.contentY + autoSavesList.height)
+	}
+
+	FileList
+	{
+		id:					autoSavesList
+		cppModel:			fileMenuModel.autoSaves.listModel
+		tabbingEscapes:		true
+
+
+		anchors
+		{
+			top:			menuHeader.bottom
+			left:			menuHeader.left
+			right:			menuHeader.right
+			bottom:			deletionWarning.top
+			topMargin:		jaspTheme.generalMenuMargin
+			bottomMargin:	jaspTheme.generalMenuMargin
+		}
+	}
+
+	Label
+	{
+		text:				qsTr("No recovery files found")
+		font:				jaspTheme.font
+		color:				jaspTheme.black
+		visible:			autoSavesList.count == 0
+		anchors.top:		autoSavesList.top
+		anchors.left:		autoSavesList.left
+	}
+
+	Label
+	{
+		id:					deletionWarning
+		text:				"<i>" + qsTr("Recovery files are deleted after a month") + "</i>"
+		font:				jaspTheme.font
+		color:				jaspTheme.black
+		anchors.bottom:		parent.bottom
+		anchors.margins:	jaspTheme.generalMenuMargin
+		anchors.left:		parent.left
+	}
+
+}

--- a/Desktop/components/JASP/Widgets/FileMenu/MenuHeader.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/MenuHeader.qml
@@ -71,6 +71,7 @@ Item
 
 		orientation:	Qt.Horizontal
 		visible:		toolseparator
+		padding:		0
 	}
 	
 	property real separatorHalve:	firstSeparator.height / 2

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -104,7 +104,7 @@ PrefsScrollView
 							onTextChanged:		preferencesModel.customEditor = text
 							color:				jaspTheme.textEnabled
 
-							KeyNavigation.tab:      thresholdScale
+							KeyNavigation.tab:      autoSave
 
 							anchors
 							{
@@ -123,6 +123,37 @@ PrefsScrollView
 					}
 				}
 			}
+		}
+		
+		PrefsGroupRect
+		{
+			id:				savingRect
+			title:			qsTr("Save settings")
+
+			CheckBox
+			{
+				id:					autoSave
+				label:				qsTr("Automatically save a backup of your workspace")
+				checked:			preferencesModel.autoSaveAtAll
+				onCheckedChanged:	preferencesModel.autoSaveAtAll = checked
+				toolTip:			qsTr("When enabled this will save a copy of your workspace in a folder next to the logs. If JASP crashes with otherwise unsaved changes this backup will make sure you don't lose all your work.")
+	
+				KeyNavigation.tab:	autoSaveInterval
+			}
+			
+			SpinBox
+			{
+				id:					autoSaveInterval
+				text:				qsTr("Autosave interval in minutes")
+				value:				preferencesModel.autoSaveIntervalSec / 60
+				onValueChanged:		preferencesModel.autoSaveIntervalSec = (value  * 60)
+				from:				1
+
+				KeyNavigation.tab:	orderByDefault
+
+				toolTip:	qsTr("Interval in minutes between autosaves.")
+			}
+			
 		}
 
 		

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -33,6 +33,7 @@
 #include "filtermodel.h"
 #include <ranges>
 #include "variableinfo.h"
+#include "fileevent.h"
 
 //Im having problems getting the proxy models to play nicely with beginRemoveRows etc
 //So just reset the whole thing as that is what happens in datasetview
@@ -51,13 +52,17 @@ DataSetPackage::DataSetPackage(QObject * parent) : QAbstractItemModel(parent)
 	_dataSet	= new DataSet(); //We create one here to make sure filter() etc can actually work
 	setDefaultWorkspaceEmptyValues();
 	
-	connect(this, &DataSetPackage::isModifiedChanged,		this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::loadedChanged,			this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::currentFileChanged,		this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::folderChanged,			this, &DataSetPackage::windowTitleChanged);
-	connect(this, &DataSetPackage::currentFileChanged,		this, &DataSetPackage::nameChanged);
-	connect(this, &DataSetPackage::dataModeChanged,			this, &DataSetPackage::onDataModeChanged);
-	connect(this, &DataSetPackage::columnDataTypeChanged,	this, [this]() {ColumnEncoder::setCurrentColumnNames(getColumnTypesMap());}	);
+	connect(this, &DataSetPackage::isModifiedChanged,					this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::loadedChanged,						this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::currentFileChanged,					this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::folderChanged,						this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::isModifiedAfterAutoSaveChanged,		this, &DataSetPackage::windowTitleChanged);
+	connect(this, &DataSetPackage::currentFileChanged,					this, &DataSetPackage::nameChanged);
+	connect(this, &DataSetPackage::dataModeChanged,						this, &DataSetPackage::onDataModeChanged);
+	connect(this, &DataSetPackage::columnDataTypeChanged,				this, [this]() {ColumnEncoder::setCurrentColumnNames(getColumnTypesMap());}	);
+	
+	connect(PreferencesModel::prefs(), &PreferencesModel::autoSaveAtAllChanged,			this, &DataSetPackage::handleAutoSavePrefChange);
+	connect(PreferencesModel::prefs(), &PreferencesModel::autoSaveIntervalSecChanged,	this, &DataSetPackage::handleAutoSavePrefChange);
 
 	_dataSubModel	= new SubNodeModel("data",		_dataSet->dataNode());
 	_filterSubModel = new SubNodeModel("filters",	_dataSet->filtersNode());
@@ -66,12 +71,17 @@ DataSetPackage::DataSetPackage(QObject * parent) : QAbstractItemModel(parent)
 	connect(&_databaseIntervalSyncher,	&QTimer::timeout, this, &DataSetPackage::synchingIntervalPassed);
 	connect(&_delayedRefreshTimer,		&QTimer::timeout, this, &DataSetPackage::delayedRefresh);
 	connect(&_doWalCheckPointTimer,		&QTimer::timeout, this, &DataSetPackage::doWalCheckPoint);
+	connect(&_autoSaveTimer,			&QTimer::timeout, this, &DataSetPackage::handleAutoSave);
 	
 	_undoStack = new UndoStack(this);
 	
-	_doWalCheckPointTimer.setInterval(5*60*1000);
-	_doWalCheckPointTimer.setSingleShot(false);
-	_doWalCheckPointTimer.start();
+	_doWalCheckPointTimer	.setInterval(5*60*1000);
+	_doWalCheckPointTimer	.setSingleShot(false);
+	_doWalCheckPointTimer	.start();
+	
+	
+	_autoSaveTimer			.setSingleShot(false);
+	handleAutoSavePrefChange();
 }
 
 DataSetPackage::~DataSetPackage() 
@@ -1081,7 +1091,29 @@ void DataSetPackage::setModified(bool value)
 		_isModified = value;
 		emit isModifiedChanged();
 	}
+	
+	setModifiedAfterAutoSave(_isModified);
 }
+
+void DataSetPackage::setModifiedAfterAutoSave(bool value)
+{
+	if (value != _isModifiedAfterAutoSave)
+	{
+		_isModifiedAfterAutoSave = value;
+		emit isModifiedAfterAutoSaveChanged();
+	}
+}
+
+
+void DataSetPackage::handleAutoSave()
+{
+	if(_isModifiedAfterAutoSave)				
+		emit makeAnAutoSave();
+	
+	else if(FileEvent::autoSaveExists() && _isModified)
+			Utils::touch(fq(FileEvent::pathTmp()));
+}
+
 
 void DataSetPackage::setLoaded(bool loaded)
 {
@@ -1241,6 +1273,19 @@ void DataSetPackage::languageChangeDone()
 	refresh();
 }
 
+void DataSetPackage::handleAutoSavePrefChange()
+{
+	_autoSaveTimer.setInterval(1000 * PreferencesModel::prefs()->autoSaveIntervalSec());
+	
+	if(_autoSaveTimer.isActive() != PreferencesModel::prefs()->autoSaveAtAll())
+	{
+		if(!PreferencesModel::prefs()->autoSaveAtAll())		
+			_autoSaveTimer.stop();
+		else
+			_autoSaveTimer.start();
+	}
+}
+
 
 
 void DataSetPackage::resetAllFilters()
@@ -1308,7 +1353,6 @@ void DataSetPackage::doWalCheckPoint()
 	if(DatabaseInterface::singleton())
 		DatabaseInterface::singleton()->doWalCheckPoint();
 }
-
 
 
 void DataSetPackage::refreshColumn(QString columnName)
@@ -2469,12 +2513,40 @@ QString DataSetPackage::windowTitle() const
 
 	folder = folder == "" ? "" : "      (" + folder + ")";
 
-	return name + (isModified() ? "*" : "") + folder;
+	return name + (isModified() ? isModifiedAfterAutoSave() ? "*" : "* (autosaved)"  : "") + folder;
 }
 
-bool DataSetPackage::currentFileIsExample() const
+
+bool DataSetPackage::currentJaspFileIsNonSaveable() const
 {
-	return currentFile().startsWith(AppDirs::examples());
+	return filePathIsNonSaveable(currentFile());
+}
+
+bool DataSetPackage::filePathIsNonSaveable(const QString & path) const
+{
+	QFileInfo fileDir(path);
+
+	return fileDir.dir() == QDir(AppDirs::examples()) || fileDir.dir() == QDir(AppDirs::autoSaveDir());
+}
+
+void DataSetPackage::setAnalysesData(const Json::Value &analysesData)
+{
+	QString		previousASF					= analysesData.type() != Json::objectValue ? "" : tq(analysesData.get("autoSaveFileName", "").asString());
+				_analysesData				= analysesData;
+	QFileInfo	dataFile					( tq(_dataSet->dataFilePath()) ),
+				curFileI					( currentFile() );
+	QString		dataFileName				= dataFile.fileName(),
+				curFile						= currentFile(),
+				autoSaveString				= curFile != "JASP" ? tr("%1 autosaved").arg(curFileI.fileName()) + "<br>" + tr("Full path: %1").arg("<code>"+curFileI.absoluteFilePath()+"</code>") : dataFileName == "" ? tr("Unsaved workspace") : tr("Unsaved workspace of datafile %1").arg(dataFileName);
+
+	_analysesData["autoSaveDescription"]	= fq(autoSaveString);
+	_analysesData["autoSaveFileName"]		= fq(curFileI.exists() ? curFileI.fileName() : previousASF != "" ? previousASF : curFile != "" ? curFile : tr("Autosave"));
+}
+
+
+QString DataSetPackage::autoSavedFileName() const
+{
+	return tq(_analysesData.get("autoSaveFileName", fq(currentFile())).asString());
 }
 
 void DataSetPackage::setDataFilePath(std::string filePath, long timestamp)

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -45,15 +45,16 @@ class DataSetPackageSubNodeModel;
 class DataSetPackage : public QAbstractItemModel //Not QAbstractTableModel because of: https://stackoverflow.com/a/38999940 (And this being a tree model)
 {
 	Q_OBJECT
-	Q_PROPERTY(int			columnsFilteredCount	READ columnsFilteredCount								NOTIFY columnsFilteredCountChanged	)
-	Q_PROPERTY(QString		folder					READ folder					WRITE setFolder				NOTIFY folderChanged				)
-	Q_PROPERTY(QString		windowTitle				READ windowTitle										NOTIFY windowTitleChanged			)
-	Q_PROPERTY(bool			modified				READ isModified				WRITE setModified			NOTIFY isModifiedChanged			)
-	Q_PROPERTY(bool			loaded					READ isLoaded				WRITE setLoaded				NOTIFY loadedChanged				)
-	Q_PROPERTY(QString		currentFile				READ currentFile			WRITE setCurrentFile		NOTIFY currentFileChanged			)
-	Q_PROPERTY(bool			dataMode				READ dataMode											NOTIFY dataModeChanged				)
-	Q_PROPERTY(bool			synchingExternally		READ synchingExternally		WRITE setSynchingExternally NOTIFY synchingExternallyChanged	) //might have to be moved to dataset when we have multiple datasets, alse CurrentDataFile in FileMenu will need to be looked at...
-	Q_PROPERTY(bool			manualEdits				READ manualEdits			WRITE setManualEdits		NOTIFY manualEditsChanged			) ///< Did the user change something in the data in such a way that external synching should be disabled if enabled?
+	Q_PROPERTY(int			columnsFilteredCount	READ columnsFilteredCount										NOTIFY columnsFilteredCountChanged	)
+	Q_PROPERTY(QString		folder					READ folder						WRITE setFolder					NOTIFY folderChanged				)
+	Q_PROPERTY(QString		windowTitle				READ windowTitle												NOTIFY windowTitleChanged			)
+	Q_PROPERTY(bool			modified				READ isModified					WRITE setModified				NOTIFY isModifiedChanged			)
+	Q_PROPERTY(bool			modifiedAfterAutoSave	READ isModifiedAfterAutoSave	WRITE setModifiedAfterAutoSave	NOTIFY isModifiedAfterAutoSaveChanged			)
+	Q_PROPERTY(bool			loaded					READ isLoaded					WRITE setLoaded					NOTIFY loadedChanged				)
+	Q_PROPERTY(QString		currentFile				READ currentFile				WRITE setCurrentFile			NOTIFY currentFileChanged			)
+	Q_PROPERTY(bool			dataMode				READ dataMode													NOTIFY dataModeChanged				)
+	Q_PROPERTY(bool			synchingExternally		READ synchingExternally			WRITE setSynchingExternally		NOTIFY synchingExternallyChanged	) //might have to be moved to dataset when we have multiple datasets, alse CurrentDataFile in FileMenu will need to be looked at...
+	Q_PROPERTY(bool			manualEdits				READ manualEdits				WRITE setManualEdits			NOTIFY manualEditsChanged			) ///< Did the user change something in the data in such a way that external synching should be disabled if enabled?
 
 	typedef DataSetPackageSubNodeModel							SubNodeModel;
 
@@ -141,12 +142,14 @@ public:
 				bool				isLoaded()							const	{ return _isLoaded;						 }
 				bool				isJaspFile()						const	{ return _isJaspFile;					  } ///< for readability
 				bool				isModified()						const	{ return _isModified;					   }
-				bool				hasAnalysesWithoutData()			const	{ return _hasAnalysesWithoutData;			}
+				bool				isModifiedAfterAutoSave()			const	{ return _isModifiedAfterAutoSave;	 	    }
+				bool				hasAnalysesWithoutData()			const	{ return _hasAnalysesWithoutData;			 }
 				std::string			initialMD5()						const	{ return _initialMD5;						 }
 				bool				manualEdits()						const;
 				QString				windowTitle()						const;
 				QString				description()						const;
 				QString				currentFile()						const	{ return _currentFile;						 }
+				QString				autoSavedFileName()					const;
 				bool				hasAnalyses()						const	{ return _analysesData.size() > 0;				}
 				bool				synchingData()						const	{ return _synchingData;								}
 				std::string			dataFilePath()						const	{ return _dataSet ? _dataSet->dataFilePath() : "";  }
@@ -161,14 +164,15 @@ public:
 
 				// The data file might be read-only if it comes from the examples or read from an external database
 				bool				dataFileReadOnly()					const	{ return _dataFileReadOnly;						}
-				bool				currentFileIsExample()				const;
+				bool				currentJaspFileIsNonSaveable()		const;
+				bool				filePathIsNonSaveable(const QString &path) const;
 				long				dataFileTimestamp()					const	{ return _dataSet ? _dataSet->dataFileTimestamp() : 0;	}
 				bool				isDatabaseSynching()				const	{ return _databaseIntervalSyncher.isActive();	}
 				bool				filterShouldRunInit()				const	{ return _filterShouldRunInit && isLoaded();					}
 
 
 				void				setFilterShouldRunInit(bool shouldIt)				{ _filterShouldRunInit			= shouldIt;			}
-				void				setAnalysesData(const Json::Value & analysesData)	{ _analysesData					= analysesData;		}
+				void				setAnalysesData(const Json::Value & analysesData);
 				void				setArchiveVersion(Version archiveVersion)			{ _archiveVersion				= archiveVersion;	}
 				void				setJaspVersion(Version jaspVersion)					{ _jaspVersion					= jaspVersion;		}
 				void				updateDbToCurrentVersion();							///< Should be ran immediately after loading the jasp file
@@ -180,6 +184,7 @@ public:
 				void				setAnalysesHTML(const QString & html)				{ _analysesHTML					= html;				}
 				void				setIsJaspFile(bool isJaspFile)						{ _isJaspFile					= isJaspFile;		}
 				void				setHasAnalysesWithoutData()							{ _hasAnalysesWithoutData		= true;				}
+				void				setModifiedAfterAutoSave(bool value);
 				void				setModified(bool value);
 				void				setAnalysesHTMLReady()								{ _analysesHTMLReady			= true;				}
 				void				setId(std::string id)								{ _id							= id;				}
@@ -279,6 +284,8 @@ public:
 				void						emitColumnChanged(const QString &colName); //temporary until ColumnQ exists
 				
 				
+
+				
 				
 				
 signals:
@@ -298,6 +305,7 @@ signals:
 				void				columnAddedManually(	QString columnName);
 				void				chooseColumn(			int		colId);
 				void				isModifiedChanged();
+				void				isModifiedAfterAutoSaveChanged();
 				void				enginesPrepareForDataSignal();
 				void				enginesReceiveNewDataSignal();
 				bool				enginesInitializingSignal();
@@ -323,6 +331,7 @@ signals:
 				void				refreshAllAnalyses();
 				void				refreshAllCompCols();
 				void				setDataMode(bool mode);
+				void				makeAnAutoSave();
 
 public slots:
 				void				refresh()							{ beginResetModel(); endResetModel(); }
@@ -343,9 +352,11 @@ public slots:
 				void				checkDataSetForUpdates();
 				void				delayedRefresh();
 				void				doWalCheckPoint();
+				void				handleAutoSave();
 				void				resetFilterCounters();
 				void				prepareForLanguageChange();
 				void				languageChangeDone();
+				void				handleAutoSavePrefChange();
 				
 private:
 				bool				isThisTheSameThreadAsEngineSync();
@@ -374,6 +385,7 @@ private:
 	bool						_isJaspFile					= false,
 								_dataFileReadOnly,
 								_isModified					= false,
+								_isModifiedAfterAutoSave	= false,
 								_isLoaded					= false,
 								_hasAnalysesWithoutData		= false,
 								_analysesHTMLReady			= false,
@@ -396,7 +408,8 @@ private:
 	
 	QTimer						_databaseIntervalSyncher,
 								_delayedRefreshTimer,
-								_doWalCheckPointTimer;
+								_doWalCheckPointTimer,
+								_autoSaveTimer;
 	UndoStack				*	_undoStack					= nullptr;
 	
 };

--- a/Desktop/data/fileevent.cpp
+++ b/Desktop/data/fileevent.cpp
@@ -16,13 +16,14 @@
 // <http://www.gnu.org/licenses/>.
 //
 
-#include "fileevent.h"
-#include "exporters/dataexporter.h"
-#include "exporters/resultexporter.h"
-#include "exporters/jaspexporter.h"
-
 #include <QTimer>
+#include "fileevent.h"
+#include "processinfo.h"
 #include "utilities/appdirs.h"
+#include "exporters/dataexporter.h"
+#include "exporters/jaspexporter.h"
+#include "exporters/resultexporter.h"
+
 
 FileEvent::FileEvent(QObject *parent, FileEvent::FileMode fileMode)
 	: QObject(parent), _operation(fileMode)
@@ -112,6 +113,51 @@ bool FileEvent::isExample() const
 	return path().startsWith(AppDirs::examples());
 }
 
+bool FileEvent::autoSaveExists()
+{
+	return QFileInfo::exists(pathTmp());
+}
+
+void FileEvent::removeAutoSaveIfItExists()
+{
+	if(!autoSaveExists())
+		return;
+	
+	QFile autoSaveFile(pathTmp());
+	
+	autoSaveFile.remove();
+}
+
+QString FileEvent::pathTmp()
+{
+	static QString tmpFile = []()
+	{
+		QDir autoSaveFolder(AppDirs::autoSaveDir());
+		
+		QFileInfoList files = autoSaveFolder.entryInfoList(QDir::Filter::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks);
+		
+		std::set<QString> usedNames;
+		
+		for(QFileInfo & fi : files)
+			usedNames.insert(fi.fileName());
+		
+		auto aNamePlease = [](){
+			static int num = 0;
+			return "autosave-" + QString::number(ProcessInfo::currentPID()) + "-" + QString::number(num++) + ".jasp";
+		};
+		
+		QString newFileName;
+		
+		do		{ newFileName = aNamePlease();	}
+		while	( usedNames.count(newFileName)	);
+		
+		return autoSaveFolder.absoluteFilePath(newFileName);
+		
+	}();
+	
+	return tmpFile;
+}
+
 const std::string FileEvent::databaseStr() const 
 { 
 	return _database.toStyledString();
@@ -145,7 +191,7 @@ QString FileEvent::getProgressMsg() const
 		}
 		break;
 
-	case FileEvent::FileSave:			return tr("Saving JASP File");
+	case FileEvent::FileSave:			return !_tmp ? tr("Saving JASP File") : tr("Saving autosave JASP File");
 	case FileEvent::FileExportResults:	return tr("Exporting Results");
 	case FileEvent::FileExportData:
 	case FileEvent::FileGenerateData:	return tr("Exporting Data");

--- a/Desktop/data/fileevent.h
+++ b/Desktop/data/fileevent.h
@@ -43,6 +43,7 @@ public:
 	void				setOsfPath(		const QString & path)			{ _osfPath = path; }
 	void				setDatabase(	const Json::Value & dbInfo);
 	void				setFileType(	Utils::FileType	type)			{ _type = type; }
+	void				setTmp(			bool saveTmp)					{ _tmp  = saveTmp; }
 
 	void				setComplete(bool success = true, const QString &message = "");
 	void				chain(FileEvent *event);
@@ -53,12 +54,16 @@ public:
 	bool				isReadOnly()	const { return isExample() || isDatabase();		}
 	bool				isCompleted()	const { return _completed;						}
 	bool				isSuccessful()	const { return _success;						}
+	bool				isTmp()			const { return _tmp; }
+	static bool			autoSaveExists();
+	static void			removeAutoSaveIfItExists();
 
 	Exporter *			exporter()		const { return _exporter;		}
 	FileMode			operation()		const { return _operation;		}
 	Utils::FileType		type()			const { return _type;			}
 
-	const QString &		path()			const { return _path;			}
+	QString				path()			const { return !_tmp ? _path : pathTmp();	}
+	static QString		pathTmp();
 	const std::string	databaseStr()	const;
 	const Json::Value &	database()		const { return _database;		}
 	const QString &		osfPath()		const { return _osfPath;		}
@@ -83,7 +88,8 @@ private:
 						_last_error		= "Unknown error",
 						_message;
 	bool				_completed		= false,
-						_success		= false;
+						_success		= false,
+						_tmp			= false;
 	FileEvent		*	_chainedTo		= nullptr;
 	Exporter		*	_exporter		= nullptr;
 	Json::Value			_database		= Json::nullValue;

--- a/Desktop/gui/preferencesmodel.cpp
+++ b/Desktop/gui/preferencesmodel.cpp
@@ -193,6 +193,9 @@ GET_PREF_FUNC_BOOL(	useConfigurationFile,		Settings::USE_CONFIGURATION_FILE					
 GET_PREF_FUNC_BOOL(	startMaximized,				Settings::START_MAXIMIZED							)
 GET_PREF_FUNC_BOOL(	storeStateEtc,				Settings::STORE_STATE_ETC							)
 
+GET_PREF_FUNC_BOOL(	autoSaveAtAll,				Settings::AUTOSAVE_ON								)
+GET_PREF_FUNC_INT(	autoSaveIntervalSec,		Settings::AUTOSAVE_INTERVAL_SEC						)
+
 bool PreferencesModel::engineSandbox() const
 {
 #ifdef _WIN32
@@ -399,6 +402,9 @@ SET_PREF_FUNCTION(				QString,	setRemoteConfigurationURL,	remoteConfigurationURL
 SET_PREF_FUNCTION(				bool,   	setUseConfigurationFile, 	useConfigurationFile,		useConfigurationFileChanged,    Settings::USE_CONFIGURATION_FILE  					)
 SET_PREF_FUNCTION(				bool,   	setStartMaximized,			startMaximized,				startMaximizedChanged,			Settings::START_MAXIMIZED		  					)
 SET_PREF_FUNCTION(				bool,   	setStoreStateEtc,			storeStateEtc,				storeStateEtcChanged,			Settings::STORE_STATE_ETC		  					)
+SET_PREF_FUNCTION(				bool,   	setAutoSaveAtAll,			autoSaveAtAll,				autoSaveAtAllChanged,			Settings::AUTOSAVE_ON			  					)
+SET_PREF_FUNCTION(				int,		setAutoSaveIntervalSec,		autoSaveIntervalSec,		autoSaveIntervalSecChanged,		Settings::AUTOSAVE_INTERVAL_SEC	  					)
+
 
 void PreferencesModel::setGithubPatCustom(QString newPat)
 {

--- a/Desktop/gui/preferencesmodel.h
+++ b/Desktop/gui/preferencesmodel.h
@@ -84,6 +84,10 @@ class PreferencesModel : public PreferencesModelBase
 	Q_PROPERTY(bool			startMaximized			READ startMaximized				WRITE setStartMaximized				NOTIFY startMaximizedChanged			)
 	Q_PROPERTY(bool			storeStateEtc			READ storeStateEtc				WRITE setStoreStateEtc				NOTIFY storeStateEtcChanged				)
 	
+	Q_PROPERTY(int			autoSaveIntervalSec		READ autoSaveIntervalSec		WRITE setAutoSaveIntervalSec		NOTIFY autoSaveIntervalSecChanged		)
+	Q_PROPERTY(bool			autoSaveAtAll			READ autoSaveAtAll				WRITE setAutoSaveAtAll				NOTIFY autoSaveAtAllChanged				)
+	
+
 
 public:
 	explicit	 PreferencesModel(QObject *parent = 0);
@@ -163,16 +167,17 @@ public:
 	QString			remoteConfigurationURL()				const;
 	bool			remoteConfiguration()					const;
 	bool			useConfigurationFile()					const;
-
+	bool			checkUpdates()							const;
+	bool			startMaximized()						const;
+	int				autoSaveIntervalSec()					const;
+	bool			autoSaveAtAll()							const;
+	bool			checkUpdatesAskUser()					const;
 	
-	bool checkUpdatesAskUser() const;
-	void setCheckUpdatesAskUser(bool newCheckUpdatesAskUser);
-	
-	bool checkUpdates() const;
-	void setCheckUpdates(bool newCheckUpdates);
-	
-	bool startMaximized() const;
-	void setStartMaximized(bool newStartMaximized);
+	void			setCheckUpdatesAskUser(	bool	newCheckUpdatesAskUser);
+	void			setCheckUpdates(		bool	newCheckUpdates);
+	void			setStartMaximized(		bool	newStartMaximized);
+	void			setAutoSaveIntervalSec(	int		newAutoSaveIntervalSec);
+	void			setAutoSaveAtAll(		bool	newAutoSaveAtAll);
 	
 	bool storeStateEtc() const;
 	void setStoreStateEtc(bool newStoreStateEtc);
@@ -312,6 +317,8 @@ signals:
 	void useConfigurationFileChanged(	bool		enabled);
 	void startMaximizedChanged(			bool		startMaximized);
 	void storeStateEtcChanged(			bool		state);
+	void autoSaveIntervalSecChanged(	int			interval);
+	void autoSaveAtAllChanged(			bool		autoSave);
 	
 private slots:
 	void dataLabelNAChangedSlot(QString label);
@@ -330,6 +337,8 @@ private:
 	QString			_checkFontList(QString fonts)					const;
 	QStringList		_splitValues(const QString& values)				const;
 	void			_setEmptyValues(const QStringList& values);
+	bool _autoSaveIntervalSec;
+	bool _autoSaveAtAll;
 };
 
 #endif // PREFERENCESDIALOG_H

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -402,6 +402,8 @@ void MainWindow::makeConnections()
 	connect(_package,				&DataSetPackage::dataModeChanged,					_engineSync,			&EngineSync::dataModeChanged								);
 	connect(_package,				&DataSetPackage::dataModeChanged,					this,					&MainWindow::onDataModeChanged								);
 	connect(_package,				&DataSetPackage::askUserForExternalDataFile,		this,					&MainWindow::startDataEditorHandler							);
+	connect(_package,				&DataSetPackage::makeAnAutoSave,					this,					&MainWindow::saveTmpFileHandler								);
+	
 	connect(_package,				&DataSetPackage::runFilter,							_filterModel,			&FilterModel::sendGeneratedAndRFilter						);
 	connect(_package,				&DataSetPackage::showWarning,						_msgForwarder,			&MessageForwarder::showWarningQML,							Qt::QueuedConnection);
 	connect(_package,				&DataSetPackage::synchingExternallyChanged,			_fileMenu,				&FileMenu::dataAutoSynchronizationChanged					);
@@ -1281,6 +1283,7 @@ void MainWindow::dataSetIORequestHandler(FileEvent *event)
 				break;
 
 			case MessageForwarder::DialogResponse::Discard:
+				FileEvent::removeAutoSaveIfItExists();
 				event->setComplete(true);
 				break;
 			}
@@ -1318,7 +1321,11 @@ bool MainWindow::checkPackageModifiedBeforeClosing()
 	case MessageForwarder::DialogResponse::Cancel:			return false;
 
 	default:												[[fallthrough]];
-	case MessageForwarder::DialogResponse::Discard:			return true;
+	case MessageForwarder::DialogResponse::Discard:			
+	{
+		FileEvent::removeAutoSaveIfItExists();	
+		return true;
+	}
 	}
 }
 
@@ -1339,8 +1346,12 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 		if (event->isSuccessful())
 		{
 			populateUIfromDataSet();
-			
+
 			_package->setCurrentFile(event->path());
+			
+
+			if(_package->currentFile().startsWith(AppDirs::autoSaveDir()))
+				_package->setModified(true); //Its autosaved after all
 
 			if(event->osfPath() != "")
 				_package->setFolder("OSF://" + event->osfPath()); //It is also set by setCurrentPath, but then we get some weirdlooking OSF path
@@ -1396,17 +1407,36 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 
 		if (event->isSuccessful())
 		{
-			_package->setCurrentFile(event->path());
-			if(event->osfPath() != "")
-				_package->setFolder("OSF://" + event->osfPath()); //It is also set by setCurrentPath, but then we get some weirdlooking OSF path
+			if(!event->isTmp())
+			{
+				{ //Before changing the currentfile in DataSetPackage we first check this was a recovery file and if so delete it now. The user succesfully saved after all
+					QFileInfo	curFileI	( _package->currentFile());
+					bool		wasRecovery = curFileI.dir() == QDir(AppDirs::autoSaveDir());
 
-			_package->setModified(false);
+					if(wasRecovery && curFileI.exists())
+					{
+						QFile removeRecoveryFile(curFileI.absoluteFilePath());
+						if(!removeRecoveryFile.moveToTrash())
+							removeRecoveryFile.remove();
+					}
+				}
 
-			if(testingAndSaving)
-				std::cerr << "Tested and saved " << event->path().toStdString() << " succesfully!" << std::endl;
-
-			if(_savingForClose)
-				emit exitSignal(0);
+				_package->setCurrentFile(event->path());
+				if(event->osfPath() != "")
+					_package->setFolder("OSF://" + event->osfPath()); //It is also set by setCurrentPath, but then we get some weirdlooking OSF path
+	
+				_package->setModified(false);
+				
+				FileEvent::removeAutoSaveIfItExists();	
+	
+				if(testingAndSaving)
+					std::cerr << "Tested and saved " << event->path().toStdString() << " succesfully!" << std::endl;
+	
+				if(_savingForClose)
+					emit exitSignal(0);
+			}
+			else
+				_package->setModifiedAfterAutoSave(false);
 
 		}
 		else
@@ -2049,6 +2079,15 @@ void MainWindow::saveJaspFileHandler()
 	FileEvent * saveEvent = new FileEvent(this, FileEvent::FileSave);
 
 	saveEvent->setPath(resultXmlCompare::compareResults::theOne()->filePath());
+
+	dataSetIORequestHandler(saveEvent);
+}
+
+void MainWindow::saveTmpFileHandler()
+{
+	FileEvent * saveEvent = new FileEvent(this, FileEvent::FileSave);
+
+	saveEvent->setTmp(true);
 
 	dataSetIORequestHandler(saveEvent);
 }

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -277,6 +277,7 @@ private slots:
 	bool checkDoSync();
 	void unitTestTimeOut();
 	void saveJaspFileHandler();
+	void saveTmpFileHandler();
 	void logToFileChanged(bool logToFile);
 	void logRemoveSuperfluousFiles(int maxFilesToKeep);
 

--- a/Desktop/utilities/application.cpp
+++ b/Desktop/utilities/application.cpp
@@ -39,7 +39,7 @@ void Application::init(QString filePath, bool newData, bool unitTest, int timeOu
 
 	_mainWindow = new MainWindow(this);
 
-	connect(_mainWindow, &MainWindow::qmlLoadedChanged, _mainWindow, [=]() {
+	connect(_mainWindow, &MainWindow::qmlLoadedChanged, _mainWindow, [=,this]() {
 		// The QML files are not yet laoded when MainWindow is just created (loadQML is called via a QTmer::singleShot)
 		// But to correctly work, the following calls need the QML files to be loaded.
 		if (newData)

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -115,6 +115,8 @@ const Settings::Setting Settings::Values[] = {
 	{"useConfigurationFile",		true	},
 	{"startMaximized",				false	},
 	{"storeStateEtc",				false	},
+	{"autoSaveOn",					true	},
+	{"autoSaveInterval",			5*60	},
 };	
 
 QVariant Settings::value(Settings::Type key)

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -116,7 +116,7 @@ const Settings::Setting Settings::Values[] = {
 	{"startMaximized",				false	},
 	{"storeStateEtc",				false	},
 	{"autoSaveOn",					true	},
-	{"autoSaveInterval",			5*60	},
+	{"autoSaveInterval",			60	},
 };	
 
 QVariant Settings::value(Settings::Type key)

--- a/Desktop/utilities/settings.h
+++ b/Desktop/utilities/settings.h
@@ -95,6 +95,8 @@ public:
 		USE_CONFIGURATION_FILE,
 		START_MAXIMIZED,
 		STORE_STATE_ETC,
+		AUTOSAVE_ON,
+		AUTOSAVE_INTERVAL_SEC
 	};
 
 	static QVariant value(Settings::Type key);

--- a/Desktop/widgets/filemenu/actionbuttons.cpp
+++ b/Desktop/widgets/filemenu/actionbuttons.cpp
@@ -23,7 +23,7 @@ void ActionButtons::loadButtonData()
 	_data = 
 	{
 		{FileOperation::New,			tr("New"),				true,	{}																																				},
-		{FileOperation::Open,			tr("Open"),				true,	{ResourceButtons::Computer, ResourceButtons::OSF, ResourceButtons::Database, ResourceButtons::RecentFiles,	ResourceButtons::DataLibrary }		},
+		{FileOperation::Open,			tr("Open"),				true,	{ResourceButtons::Computer, ResourceButtons::AutoSaves, ResourceButtons::OSF, ResourceButtons::Database, ResourceButtons::RecentFiles,	ResourceButtons::DataLibrary }		},
 		{FileOperation::Save,			tr("Save"),				false,	{}																																				},
 		{FileOperation::SaveAs,			tr("Save As"),			false,	{ResourceButtons::Computer, ResourceButtons::OSF }																								},
 		{FileOperation::ExportResults,	tr("Export Results"),	false,	{ResourceButtons::Computer, ResourceButtons::OSF }																								},

--- a/Desktop/widgets/filemenu/autosavefilelistmodel.cpp
+++ b/Desktop/widgets/filemenu/autosavefilelistmodel.cpp
@@ -1,0 +1,26 @@
+#include "autosavefilelistmodel.h"
+#include "autosavefilesystem.h"
+
+AutoSaveFileListModel::AutoSaveFileListModel(QObject *parent)
+	: FileMenuBasicListModel{parent, new AutoSaveFileSystem(parent)}
+{
+
+}
+
+void AutoSaveFileListModel::refresh()
+{
+	beginResetModel();
+	_model->refresh();
+	endResetModel();
+}
+
+void AutoSaveFileListModel::openFile(const QString &path)
+{
+	if (path.isEmpty())
+		return;
+
+	FileEvent *event = new FileEvent(this->parent(), FileEvent::FileOpen);
+	event->setPath(path);
+
+	emit dataSetIORequest(event);
+}

--- a/Desktop/widgets/filemenu/autosavefilelistmodel.h
+++ b/Desktop/widgets/filemenu/autosavefilelistmodel.h
@@ -1,0 +1,19 @@
+#ifndef AUTOSAVEFILELISTMODEL_H
+#define AUTOSAVEFILELISTMODEL_H
+
+#include "filemenubasiclistmodel.h"
+
+class AutoSaveFileListModel : public FileMenuBasicListModel
+{
+	Q_OBJECT
+public:
+	explicit			AutoSaveFileListModel(QObject *parent = nullptr);
+
+	Q_INVOKABLE void	refresh();
+				void	openFile(const QString &path) override;
+
+signals:
+				void	dataSetIORequest(FileEvent *event);
+};
+
+#endif // AUTOSAVEFILELISTMODEL_H

--- a/Desktop/widgets/filemenu/autosavefilesystem.cpp
+++ b/Desktop/widgets/filemenu/autosavefilesystem.cpp
@@ -1,0 +1,55 @@
+#include "json/json.h"
+#include "data/fileevent.h"
+#include "utilities/qutils.h"
+#include "utilities/appdirs.h"
+#include "autosavefilesystem.h"
+#include "gui/preferencesmodel.h"
+#include "utilities/extractarchive.h"
+
+AutoSaveFileSystem::AutoSaveFileSystem(QObject *parent)
+	: FileSystem{parent}
+{
+	AutoSaveFileSystem::refresh();
+}
+
+void AutoSaveFileSystem::refresh()
+{
+	_entries.clear();
+
+	QDir autoSave = AppDirs::autoSaveDir();
+
+	Json::Reader reader;
+
+	QDateTime now = QDateTime::currentDateTime();
+
+	for(const QFileInfo & asf : autoSave.entryInfoList(QDir::Filter::Files | QDir::Filter::NoDotAndDotDot | QDir::Filter::NoSymLinks, QDir::SortFlag::Time))
+	{
+		int daysAgo = asf.lastModified().daysTo(now),
+			secsAgo = asf.lastModified().secsTo(now);
+
+		if(daysAgo > 30)
+		{
+			if(asf.exists())
+			{
+				QFile asfF(asf.absoluteFilePath());
+
+				if(!asfF.moveToTrash())
+					asfF.remove();
+			}
+		}
+		else if(asf.absoluteFilePath() != FileEvent::pathTmp())
+		{
+			//Its not our autosave file and also a file that isnt under active autosave by another jasp instance, so we can show it
+			std::string json	= ExtractArchive::extractSingleTextFileFromArchive(fq(asf.absoluteFilePath()), "analyses.json");
+			Json::Value jObj;
+			bool		alive	= PreferencesModel::prefs()->autoSaveAtAll() && secsAgo <= 60 + PreferencesModel::prefs()->autoSaveIntervalSec();
+			QString		savedAt = !alive ? tr("Saved at %1").arg(asf.lastModified().toString()) : tr("Saved %1 seconds ago, might still be loaded in another JASP.").arg(secsAgo);
+			bool		parsed	= reader.parse(json, jObj) && jObj.isMember("autoSaveDescription") && jObj.isMember("autoSaveFileName");
+
+			_entries.push_back(parsed	? createEntry(asf.absoluteFilePath(), tq(jObj.get("autoSaveFileName", "unknown").asString()),	tq(jObj.get("autoSaveDescription", "").asString()) +"<br>" + savedAt,	FileSystemEntry::JASP)
+										: createEntry(asf.absoluteFilePath(), asf.fileName(),											savedAt,																FileSystemEntry::JASP));
+		}
+	}
+
+	emit entriesChanged();
+}

--- a/Desktop/widgets/filemenu/autosavefilesystem.h
+++ b/Desktop/widgets/filemenu/autosavefilesystem.h
@@ -1,0 +1,15 @@
+#ifndef AUTOSAVEFILESYSTEM_H
+#define AUTOSAVEFILESYSTEM_H
+
+#include "filesystem.h"
+
+class AutoSaveFileSystem : public FileSystem
+{
+	Q_OBJECT
+public:
+	explicit AutoSaveFileSystem(QObject *parent = nullptr);
+
+	void refresh() override;
+};
+
+#endif // AUTOSAVEFILESYSTEM_H

--- a/Desktop/widgets/filemenu/autosaves.cpp
+++ b/Desktop/widgets/filemenu/autosaves.cpp
@@ -1,0 +1,9 @@
+#include "autosaves.h"
+
+
+AutoSaves::AutoSaves(FileMenu *parent)
+	: FileMenuObject(parent)
+	, _listModel(new AutoSaveFileListModel(this))
+{
+	connect(_listModel, &AutoSaveFileListModel::dataSetIORequest, this, &AutoSaves::dataSetIORequest);
+}

--- a/Desktop/widgets/filemenu/autosaves.h
+++ b/Desktop/widgets/filemenu/autosaves.h
@@ -1,0 +1,22 @@
+#ifndef AUTOSAVES_H
+#define AUTOSAVES_H
+
+#include "filemenuobject.h"
+#include "autosavefilelistmodel.h"
+
+class AutoSaves : public FileMenuObject
+{
+	Q_OBJECT
+
+	Q_PROPERTY(AutoSaveFileListModel * listModel READ listModel CONSTANT)
+
+public:
+	AutoSaves(FileMenu *parent);
+
+	AutoSaveFileListModel * listModel() { return _listModel; }
+
+private:
+	AutoSaveFileListModel	*	_listModel = nullptr;
+};
+
+#endif // AUTOSAVES_H

--- a/Desktop/widgets/filemenu/computer.cpp
+++ b/Desktop/widgets/filemenu/computer.cpp
@@ -104,7 +104,8 @@ FileEvent *Computer::browseSave(const QString &path, FileEvent::FileMode mode)
 	case FileEvent::FileSave:
 		caption = tr("Save");
 		filter  = tr("JASP Files") + " (*.jasp)";
-		browsePath += ".jasp";
+		if(!browsePath.endsWith(".jasp"))
+			browsePath += ".jasp";
 		break;
 
 	default:
@@ -125,7 +126,8 @@ FileEvent *Computer::browseSave(const QString &path, FileEvent::FileMode mode)
 															 !finalPath.endsWith(".pdf",  Qt::CaseInsensitive))	)	finalPath.append(QString(".html"));
 		else if	(mode == FileEvent::FileExportData		&&	(!finalPath.endsWith(".csv",  Qt::CaseInsensitive) &&
 															 !finalPath.endsWith(".txt",  Qt::CaseInsensitive) &&
-															 !finalPath.endsWith(".tsv",  Qt::CaseInsensitive))	)	finalPath.append(QString(".csv"));
+															 !finalPath.endsWith(".tsv",  Qt::CaseInsensitive))	)	finalPath.append(QString(".csv"));			
+		
 		event->setPath(finalPath);
 		emit dataSetIORequest(event);
 	}

--- a/Desktop/widgets/filemenu/computerfilesystem.h
+++ b/Desktop/widgets/filemenu/computerfilesystem.h
@@ -27,7 +27,7 @@ class ComputerFileSystem : public FileSystem
 public:
 	explicit ComputerFileSystem(QObject *parent = NULL);
 
-	void refresh() OVERRIDE;
+	void refresh() override;
 
 	QString mostRecent() const;
 

--- a/Desktop/widgets/filemenu/computerlistmodel.cpp
+++ b/Desktop/widgets/filemenu/computerlistmodel.cpp
@@ -1,5 +1,5 @@
 #include "computerlistmodel.h"
-#include "filesystementry.h"
+#include "utilities/appdirs.h"
 #include <QFileInfo>
 #include <QDir>
 
@@ -18,6 +18,13 @@ QString ComputerListModel::getMostRecent()
 
 void ComputerListModel::addRecentFolder(const QString &newpath)
 {
+	QFileInfo	path		( newpath );
+	QDir		autoSaveDir = AppDirs::autoSaveDir();
+
+
+	if(path.dir() == autoSaveDir)
+		return;
+
 	beginResetModel();
 	
 	_fsbmRecentFolders->addRecent(newpath);

--- a/Desktop/widgets/filemenu/currentfilefilesystem.h
+++ b/Desktop/widgets/filemenu/currentfilefilesystem.h
@@ -27,7 +27,7 @@ class CurrentFileFileSystem : public FileSystem
 public:
 	CurrentFileFileSystem(QObject *parent = NULL);
 
-	void refresh() OVERRIDE;
+	void refresh() override;
 
 	void setCurrent(const QString &path);
 	QString getCurrent() const;

--- a/Desktop/widgets/filemenu/filemenu.cpp
+++ b/Desktop/widgets/filemenu/filemenu.cpp
@@ -31,9 +31,10 @@ FileMenu::FileMenu(QObject *parent) : QObject(parent)
 	_mainWindow				= qobject_cast<MainWindow*>(parent);
 	_recentFiles			= new RecentFiles			(this);
 	_currentDataFile		= new CurrentDataFile		(this);
+	_autoSaves				= new AutoSaves				(this);
 	_computer				= new Computer				(this);
 	_OSF					= new OSF					(this);
-	_database				= new DatabaseFileMenu				(this);
+	_database				= new DatabaseFileMenu		(this);
 	_dataLibrary			= new DataLibrary			(this);
 	_actionButtons			= new ActionButtons			(this);
 	_resourceButtons		= new ResourceButtons		(this);
@@ -128,7 +129,7 @@ FileEvent *FileMenu::newData()
 
 FileEvent *FileMenu::save()
 {
-	if (_currentFileType != Utils::FileType::jasp || DataSetPackage::pkg()->currentFileIsExample())
+	if (_currentFileType != Utils::FileType::jasp || DataSetPackage::pkg()->currentJaspFileIsNonSaveable())
 		return saveAs();
 
 	FileEvent *event = new FileEvent(this, FileEvent::FileSave);
@@ -146,7 +147,6 @@ FileEvent *FileMenu::save()
 
 void FileMenu::sync()
 {
-	
 	if(DataSetPackage::pkg()->databaseJson() != Json::nullValue)
 	{
 		FileEvent *event = new FileEvent(this, FileEvent::FileSyncData);
@@ -266,7 +266,7 @@ void FileMenu::dataSetIOCompleted(FileEvent *event)
 {
 	if (event->operation() == FileEvent::FileSave || event->operation() == FileEvent::FileOpen)
 	{
-		if (event->isSuccessful())
+		if (event->isSuccessful() && !event->isTmp())
 		{
 			//  don't add database to the recent list
 			if (!event->isDatabase())
@@ -285,19 +285,21 @@ void FileMenu::dataSetIOCompleted(FileEvent *event)
 
 				if	(	event->operation() == FileEvent::FileOpen
 					&& !event->isReadOnly()
-					&& event->type() == FileTypeBase::jasp
+					&&	event->type() == FileTypeBase::jasp
 					&& !DataSetPackage::pkg()->dataFileReadOnly()
-					&& DataSetPackage::pkg()->dataSet()->dataFileSynch()
+					&&	DataSetPackage::pkg()->dataSet()->dataFileSynch()
 				)
 					DataSetPackage::pkg()->setSynchingExternally(true);
 			}
 
 			// all this stuff is a hack
 			QFileInfo info(event->path());
-			_computer->setFileName(info.completeBaseName());
+
+			_computer->setFileName(info.dir() != QDir(AppDirs::autoSaveDir()) ? info.completeBaseName() : DataSetPackage::pkg()->autoSavedFileName());
 
 			_currentFilePath		= event->path();
 			_currentFileType		= event->type();
+
 			_OSF->setProcessing(false);
 		}
 	}
@@ -317,13 +319,16 @@ void FileMenu::dataSetIOCompleted(FileEvent *event)
 
 	_resourceButtons->setButtonEnabled(ResourceButtons::CurrentFile, !_currentDataFile->getCurrentFilePath().isEmpty());
 
-	if (event->isSuccessful())
+	if (event->isSuccessful() && !event->isTmp())
 	{
 		switch(event->operation())
 		{
 		case FileEvent::FileOpen:
 		case FileEvent::FileSave:
-			enableButtonsForOpenedWorkspace((!event->isReadOnly() && event->type() == Utils::FileType::jasp) && (event->operation() == FileEvent::FileOpen && DataSetPackage::pkg()->currentFileIsExample() ));
+			enableButtonsForOpenedWorkspace(
+						(!event->isReadOnly() && event->type() == Utils::FileType::jasp)
+						&&
+						(event->operation() == FileEvent::FileOpen && !DataSetPackage::pkg()->filePathIsNonSaveable(event->path()) ));
 			break;
 
 		case FileEvent::FileClose:
@@ -377,7 +382,7 @@ void FileMenu::analysisAdded(Analysis *analysis)
 
 void FileMenu::workspaceModified()
 {
-	if(DataSetPackage::pkg()->isLoaded() && !DataSetPackage::pkg()->dataFileReadOnly() && getCurrentFileType() == Utils::FileType::jasp)
+	if(DataSetPackage::pkg()->isLoaded() && !DataSetPackage::pkg()->dataFileReadOnly() && getCurrentFileType() == Utils::FileType::jasp && !DataSetPackage::pkg()->currentJaspFileIsNonSaveable())
 		_actionButtons->setEnabled(ActionButtons::Save, DataSetPackage::pkg()->isModified());
 }
 
@@ -418,7 +423,7 @@ void FileMenu::actionButtonClicked(const ActionButtons::FileOperation action)
 	case ActionButtons::FileOperation::SyncData:			setMode(FileEvent::FileSyncData);		break;
 	case ActionButtons::FileOperation::Close:				close();								break;
 	case ActionButtons::FileOperation::Save:
-		if (getCurrentFileType() == Utils::FileType::jasp && ! DataSetPackage::pkg()->currentFileIsExample())
+		if (getCurrentFileType() == Utils::FileType::jasp && !DataSetPackage::pkg()->currentJaspFileIsNonSaveable())
 			save();
 		else
 			setMode(FileEvent::FileSave);			
@@ -450,8 +455,17 @@ void FileMenu::actionButtonClicked(const ActionButtons::FileOperation action)
 
 void FileMenu::resourceButtonClicked(const int buttonType)
 {
-	if (buttonType == ResourceButtons::OSF)
+	switch(buttonType)
+	{
+	case ResourceButtons::OSF:
 		_OSF->attemptToConnect();
+		break;
+
+	case ResourceButtons::AutoSaves:
+		_autoSaves->listModel()->refresh();
+		break;
+	}
+
 }
 
 void FileMenu::showAboutRequest()

--- a/Desktop/widgets/filemenu/filemenu.h
+++ b/Desktop/widgets/filemenu/filemenu.h
@@ -26,6 +26,7 @@
 
 #include "widgets/filemenu/recentfiles.h"
 #include "widgets/filemenu/currentdatafile.h"
+#include "widgets/filemenu/autosaves.h"
 #include "widgets/filemenu/computer.h"
 #include "widgets/filemenu/osf.h"
 #include "widgets/filemenu/databasefilemenu.h"
@@ -47,20 +48,21 @@ class FileMenu : public QObject
 	Q_OBJECT
 
 	Q_PROPERTY(FileOperation				fileoperation			READ fileoperation				WRITE setFileoperation				NOTIFY fileoperationChanged		)
-	Q_PROPERTY(DataLibrary				*	datalibrary				READ datalibrary													NOTIFY dummyChangedNotifier		)
-	Q_PROPERTY(CurrentDataFile			*	currentFile				READ currentFile													NOTIFY dummyChangedNotifier		)
-	Q_PROPERTY(RecentFiles				*	recentFiles				READ recentFiles													NOTIFY dummyChangedNotifier		)
-	Q_PROPERTY(Computer					*	computer				READ computer														NOTIFY dummyChangedNotifier		)
-	Q_PROPERTY(OSF						*	osf						READ osf															NOTIFY dummyChangedNotifier		)
-	Q_PROPERTY(DatabaseFileMenu			*	database				READ database														NOTIFY dummyChangedNotifier		)
+	Q_PROPERTY(DataLibrary				*	datalibrary				READ datalibrary													CONSTANT						)
+	Q_PROPERTY(CurrentDataFile			*	currentFile				READ currentFile													CONSTANT						)
+	Q_PROPERTY(RecentFiles				*	recentFiles				READ recentFiles													CONSTANT						)
+	Q_PROPERTY(AutoSaves				*	autoSaves				READ autoSaves														CONSTANT						)
+	Q_PROPERTY(Computer					*	computer				READ computer														CONSTANT						)
+	Q_PROPERTY(OSF						*	osf						READ osf															CONSTANT						)
+	Q_PROPERTY(DatabaseFileMenu			*	database				READ database														CONSTANT						)
+	Q_PROPERTY(ActionButtons			*	actionButtons			READ actionButtons													CONSTANT						)
+	Q_PROPERTY(ResourceButtons			*	resourceButtons			READ resourceButtons												CONSTANT						)
+	Q_PROPERTY(ResourceButtonsVisible	*	resourceButtonsVisible	READ resourceButtonsVisible											CONSTANT						)
 	Q_PROPERTY(bool							visible					READ visible					WRITE setVisible					NOTIFY visibleChanged			)
-	Q_PROPERTY(ActionButtons			*	actionButtons			READ actionButtons													NOTIFY dummyChangedNotifier		)
-	Q_PROPERTY(ResourceButtons			*	resourceButtons			READ resourceButtons												NOTIFY dummyChangedNotifier		)
-	Q_PROPERTY(ResourceButtonsVisible	*	resourceButtonsVisible	READ resourceButtonsVisible											NOTIFY dummyChangedNotifier		) 
 
 public:
 
-	enum FileLocation { Recent = 0, Current, ThisComputer, Osf, Examples, CountLocations };
+	enum FileLocation { Recent = 0, Current, ThisComputer, Osf, Examples, AutoSavesLoc, CountLocations };
 
 	Q_ENUM(FileMenuListItemType)
 
@@ -95,6 +97,7 @@ public:
 	DataLibrary						*	datalibrary()				const	{ return _dataLibrary;				}
 	CurrentDataFile					*	currentFile()				const	{ return _currentDataFile;			}
 	RecentFiles						*	recentFiles()				const	{ return _recentFiles;				}
+	AutoSaves						*	autoSaves()					const	{ return _autoSaves;				}
 	Computer						*	computer()					const	{ return _computer;					}
 	OSF								*	osf()						const	{ return _OSF;						}
 	DatabaseFileMenu				*	database()					const	{ return _database;					}
@@ -153,6 +156,7 @@ private:
 	OnlineDataManager			*	_odm						= nullptr;
 	CurrentDataFile				*	_currentDataFile			= nullptr;
 	RecentFiles					*	_recentFiles				= nullptr;
+	AutoSaves					*	_autoSaves					= nullptr;
 	Computer					*	_computer					= nullptr;
 	OSF							*	_OSF						= nullptr;
 	DatabaseFileMenu			*	_database					= nullptr;
@@ -167,7 +171,7 @@ private:
 	Utils::FileType					_currentFileType			= Utils::FileType::unknown;
 	bool							_visible					= false;
 	FileOperation					_fileoperation				= ActionButtons::None;
-	MainWindow*						_mainWindow					= nullptr;
+	MainWindow					*	_mainWindow					= nullptr;
 };
 
 #endif // FILEMENU_H

--- a/Desktop/widgets/filemenu/filemenubasiclistmodel.cpp
+++ b/Desktop/widgets/filemenu/filemenubasiclistmodel.cpp
@@ -102,22 +102,22 @@ Qt::ItemFlags FileMenuBasicListModel::flags(const QModelIndex &index) const
 
 void FileMenuBasicListModel::changePath(const QString& name, const QString& path)
 {
-	Log::log() << "Override basicListModel::changePath!" << std::endl;
+	assert(false);
 }
 
 void FileMenuBasicListModel::changePathCrumbIndex(const int& index)
 {
-	Log::log() << "Override basicListModel::changePathCrumbIndex!" << std::endl;
+	assert(false);
 }
 
 void FileMenuBasicListModel::openFile(const QString& path)
 {
-	Log::log() << "Override basicListModel::openFile!" << std::endl;
+	assert(false);
 }
 
 void FileMenuBasicListModel::saveFile(const QString& path)
 {
-	Log::log() << "Override basicListModel::saveFile!" << std::endl;
+	assert(false);
 }
 
 QMutex FileMenuBasicListModel::_opening;

--- a/Desktop/widgets/filemenu/filemenubasiclistmodel.cpp
+++ b/Desktop/widgets/filemenu/filemenubasiclistmodel.cpp
@@ -49,8 +49,15 @@ QVariant FileMenuBasicListModel::data(const QModelIndex &index, int role) const
 		else
 		{
 			QString location = QDir::toNativeSeparators(QFileInfo (item.path).path()) ;
-			if (role == DisplayedPathRole && location.startsWith(AppDirs::examples()))
-				location = location.mid(AppDirs::examples().length() + 1);
+			if (role == DisplayedPathRole)
+			{
+				if(location.startsWith(AppDirs::examples()))
+					location = location.mid(AppDirs::examples().length() + 1);
+				else if(QFileInfo (item.path).dir() == QDir(AppDirs::autoSaveDir()))
+					return "";
+			}
+
+
 			while (location.endsWith(QDir::separator())) location.chop(1);
 			return location + QDir::separator();
 		}

--- a/Desktop/widgets/filemenu/filemenubasiclistmodel.h
+++ b/Desktop/widgets/filemenu/filemenubasiclistmodel.h
@@ -34,7 +34,7 @@ public slots:
 	bool mayOpen();
 
 protected:
-	FileSystem *_model = nullptr;
+	FileSystem	*	_model = nullptr;
 	bool			_openFileWhenClicked = true;
 	static QMutex	_opening;
 	void			resetOpening();

--- a/Desktop/widgets/filemenu/recentfileslistmodel.cpp
+++ b/Desktop/widgets/filemenu/recentfileslistmodel.cpp
@@ -1,8 +1,8 @@
 #include "recentfileslistmodel.h"
-#include "filesystementry.h"
+#include "utilities/appdirs.h"
+#include "recentfiles.h"
 #include <QFileInfo>
 #include <QDir>
-#include "recentfiles.h"
 
 RecentFilesListModel::RecentFilesListModel(QObject *parent)	: FileMenuBasicListModel(parent, new RecentFilesFileSystem(parent))
 {
@@ -14,14 +14,19 @@ RecentFilesListModel::RecentFilesListModel(QObject *parent)	: FileMenuBasicListM
 
 void RecentFilesListModel::addRecentFilePath(const QString &newpath)
 {
+	QFileInfo	path		( newpath );
+	QDir		autoSaveDir = AppDirs::autoSaveDir();
 	
+
+	if(path.dir() == autoSaveDir)
+		return;
+
 	beginResetModel();
 	
 	_fsbmRecentFiles->addRecent(newpath);
 	_fsbmRecentFiles->refresh();
 	
 	endResetModel();
-	
 }
 
 //Slots

--- a/Desktop/widgets/filemenu/resourcebuttons.cpp
+++ b/Desktop/widgets/filemenu/resourcebuttons.cpp
@@ -16,6 +16,7 @@ void ResourceButtons::loadButtonData()
 		{ButtonType::RecentFiles,	tr("Recent Files"),	false,	"./RecentFiles.qml"		, true},
 		{ButtonType::CurrentFile,	tr("Current File"),	false,	"./CurrentFile.qml"		, false},
 		{ButtonType::Computer,		tr("Computer"),		false,	"./Computer.qml"		, true},
+		{ButtonType::AutoSaves,		tr("Recovery"),		false,	"./AutoSaves.qml"		, true},
 		{ButtonType::OSF,			tr("OSF"),			false,	"./OSF.qml"				, true},
 		{ButtonType::Database,		tr("Database"),		false,	"./Database.qml"		, true},
 		{ButtonType::DataLibrary,	tr("Data Library"),	false,	"./DataLibrary.qml"		, true},

--- a/Desktop/widgets/filemenu/resourcebuttons.h
+++ b/Desktop/widgets/filemenu/resourcebuttons.h
@@ -16,7 +16,7 @@ class ResourceButtons : public QAbstractListModel
 
 public:
 	//["Recent Files", "Current File", "Computer", "OSF", "Data Library"]
-	enum ButtonType {None, RecentFiles, CurrentFile, Computer, OSF, Database, DataLibrary, PrefsData, PrefsResults, PrefsUI, PrefsAdvanced};
+	enum ButtonType {None, RecentFiles, CurrentFile, Computer, AutoSaves, OSF, Database, DataLibrary, PrefsData, PrefsResults, PrefsUI, PrefsAdvanced};
 	Q_ENUM(ButtonType)
 
 	struct DataRow { ButtonType button; QString name; bool visible; QString qml; bool enabled; };

--- a/QMLComponents/utilities/appdirs.cpp
+++ b/QMLComponents/utilities/appdirs.cpp
@@ -136,6 +136,19 @@ QString AppDirs::logDir()
 	return path;
 }
 
+QString AppDirs::autoSaveDir()
+{
+	QString path = appData();
+	path += "/AutoSaves/";
+
+	QDir autoSave(path);
+
+	if(!autoSave.exists())
+		autoSave.mkpath(".");
+
+	return path;
+}
+
 QString AppDirs::appData(bool roaming)
 {
 	if(roaming)

--- a/QMLComponents/utilities/appdirs.h.in
+++ b/QMLComponents/utilities/appdirs.h.in
@@ -43,6 +43,7 @@ public:
 	static QString bundledModulesDir();
 	static QString bundledModulesLibDir();
 	static QString documents();
+	static QString autoSaveDir();
  	static QString sandboxedDocuments();
 	static QString logDir();
 	static QString appData(bool roaming = true);


### PR DESCRIPTION
Implements [feature request of having autosave and a recovery mode](https://github.com/jasp-stats/INTERNAL-jasp/issues/2953)

How?
=====

It adds a preference to data preferences where (default enabled) autosave and its interval in minutes can be specified.
If enabled it will make an autosavefile if there are active unsaved changes, and if there already is an autosave it is "touched" so it will still look fresh. This file is stored in a folder next to "Logs" called "AutoSaves" and all files get a similar name like "autosave-*pid*-0. To allow the user to get some insight in what the file could be 2 extra fields are added to "analyses.json" in each jaspfile, with a name and some description. 


Recovering
====
Loading is then done through the added file open menu of "Recovery", where all recovery files are shown of the user, excluding the recoveryfile of the current jasp process (if any). This is ordered on last modified time and will, as a  side-effect, also delete autosaves older than a month.

<img width="948" height="520" alt="image" src="https://github.com/user-attachments/assets/fd082516-93fb-48e1-82f1-59cbd731f207" />
<img width="948" height="520" alt="image" src="https://github.com/user-attachments/assets/aa7c9e1d-659b-4765-a63f-d755044a7fc7" />

If a recovery file is then saved the file is considered "recovered" and the autosave file is moved to the trash or, if that fails, removed.