### PR TITLE
Do not use source when initialROwCount is used for a Simple TableView

### DIFF
--- a/QMLComponents/controls/tableviewbase.cpp
+++ b/QMLComponents/controls/tableviewbase.cpp
@@ -49,6 +49,10 @@ void TableViewBase::setUpModel()
 	case ModelType::Simple					: _tableModel = new ListModelTableViewBase(			this );	break;
 	}
 
+	if (modelType() == ModelType::Simple &&_initialRowCount > 0)
+		// Per default the rows are set by the source, and if no source is specified, it sets automatically the dataset as source.
+		// But if initialRowCount is used, it means that this table sets its own rows, so no source is needed.
+		_tableModel->setNeedsSource(false);
 	JASPListControl::setUpModel();
 
 	connect(_tableModel, &ListModelTableViewBase::columnCountChanged,	this, &TableViewBase::columnCountChanged);


### PR DESCRIPTION
This solves an issue in the "Create Factorial Worksheet" analysis in Quality Control: the Table View of the Factors show per default as many rows as the number of variables. It should use the default Number of factors (3).