### PR TITLE
Fix typo in platform name output

### DIFF
--- a/Desktop/gui/aboutmodel.cpp
+++ b/Desktop/gui/aboutmodel.cpp
@@ -82,7 +82,7 @@ QString AboutModel::systemInfo()
 		info += "Kernel Version: "   + QSysInfo::kernelVersion() + "\n";
 		info += "Architecture: "     + QSysInfo::currentCpuArchitecture() + "\n";
 		info += "Install Path: "     + QCoreApplication::applicationDirPath() + "\n";
-		info += "Platfotm Name: "    + QGuiApplication::platformName() + "\n";
+		info += "Platform Name: "    + QGuiApplication::platformName() + "\n";
 		info += "System Local: "     + QLocale::system().name() + "\n\n";
 
 		process.start(command, arguments);


### PR DESCRIPTION
`Platfotm` -> `Platform`

