### PR TITLE
Interaction in Factors Form should be kept

### DIFF
--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -74,7 +74,7 @@ void VariablesListBase::_setInitialized(const Json::Value &value)
 		// If addAvailableVariablesToAssigned is true and this is initialized without value,
 		// maybe the availableAssignedList has some default values that must be assigned to this VariablesList
 		ListModelAssignedInterface* assignedModel = qobject_cast<ListModelAssignedInterface*>(_draggableModel);
-		if (assignedModel && assignedModel->availableModel())
+		if (assignedModel && assignedModel->availableModel() && isBound())
 			assignedModel->initTerms(assignedModel->availableModel()->terms());
 	}
 
@@ -115,17 +115,20 @@ void VariablesListBase::setUpModel()
 	case ListViewType::Layers:
 	{
 		auto *	layersModel		= new ListModelLayersAssigned(this);
-				_boundControl	= new BoundControlLayers(layersModel);
-				_draggableModel = layersModel;
-				_useTermsInRSyntax = false;
+		if (isBound())
+			_boundControl		= new BoundControlLayers(layersModel);
+		_draggableModel			= layersModel;
+		_useTermsInRSyntax		= false;
+
 		break;
 	}
 		
 	case ListViewType::RepeatedMeasures:
 	{
 		 auto * measuresCellsModel	= new ListModelMeasuresCellsAssigned(this);
-				_boundControl		= new BoundControlMeasuresCells(measuresCellsModel);
-				_draggableModel		= measuresCellsModel;
+		if (isBound())
+			_boundControl			= new BoundControlMeasuresCells(measuresCellsModel);
+		_draggableModel				= measuresCellsModel;
 		break;
 	}
 		
@@ -136,14 +139,16 @@ void VariablesListBase::setUpModel()
 		if (columns() > 1)
 		{
 			auto *	multiTermsModel = new ListModelMultiTermsAssigned(this, columns());
-					_boundControl	= new BoundControlMultiTerms(multiTermsModel);
-					_draggableModel = multiTermsModel;
+			if (isBound())
+				_boundControl		= new BoundControlMultiTerms(multiTermsModel);
+			_draggableModel			= multiTermsModel;
 		}
 		else
 		{
-			termsModel		= new ListModelTermsAssigned(this);
-			_boundControl	= new BoundControlTerms(termsModel, _maxRows == 1);
-			_draggableModel = termsModel;
+			termsModel			= new ListModelTermsAssigned(this);
+			if (isBound())
+				_boundControl	= new BoundControlTerms(termsModel, _maxRows == 1);
+			_draggableModel		= termsModel;
 		}
 		break;
 	}
@@ -151,8 +156,9 @@ void VariablesListBase::setUpModel()
 	case ListViewType::Interaction:
 	{
 		auto *	termsModel		= new ListModelInteractionAssigned(this);
-				_boundControl	= new BoundControlTerms(termsModel);
-				_draggableModel = termsModel;
+		if (isBound())
+			_boundControl		= new BoundControlTerms(termsModel);
+		_draggableModel			= termsModel;
 		break;
 	}
 		

--- a/QMLComponents/controls/variableslistbase.cpp
+++ b/QMLComponents/controls/variableslistbase.cpp
@@ -69,12 +69,13 @@ void VariablesListBase::setUp()
 
 void VariablesListBase::_setInitialized(const Json::Value &value)
 {
-	if (value == Json::nullValue && addAvailableVariablesToAssigned())
+	if (value == Json::nullValue && isBound() && addAvailableVariablesToAssigned())
 	{
-		// If addAvailableVariablesToAssigned is true and this is initialized without value,
-		// maybe the availableAssignedList has some default values that must be assigned to this VariablesList
+		// A bound control should have a value when it is initialized from a JASP file. So here is the case when a new analysis is created.
+		// If it is an Assigned VariablesList with addAvailableVariablesToAssigned set to true, if there is some terms in the correspondig Available VariablesList,
+		// these terms must be used to initialize this VariablesList
 		ListModelAssignedInterface* assignedModel = qobject_cast<ListModelAssignedInterface*>(_draggableModel);
-		if (assignedModel && assignedModel->availableModel() && isBound())
+		if (assignedModel && assignedModel->availableModel())
 			assignedModel->initTerms(assignedModel->availableModel()->terms());
 	}
 


### PR DESCRIPTION
In Linear Regression, if you add an interaction between 2 variables in one model, If you duplicate this analysis (or save the analysis in a JASP file, and reload this JASP file), then this interaction disappears.

A FactorsForm is a control that has itself an Available VariablesList and 1 or more Assigned VariablesLists. But only the FactorsForm has an option value (is bound), the others Assigned VariablesList do not have their proper option value: their values contribute to the value of the FactorsForm option. Each control that is bound to an option value has a BoundControl object (some controls like Available VariablesList do not have a BoundControl, as their value is not set in an option).

The error was that the Assigned VariablesList inside a FactorsForm had still a BoundControl object, and this lead to some confusion in the code.

What happened in Linear Regression is a bit tricky: the "model 1" VariablesList in the FactorsForm has the assignAvailableVariablesToList property set to true, which means that when new variables are set in the Available VariablesList, these variables should be automatically set in the "model 1" VariablesList. 
When an analysis is loaded (either by duplicating the analysis, or by loading a JASP file), all controls are initialized when they are created with an input value (from the original analysis or from the JASP file). But as the "model 1" VariablesList does not have its own value, its input value is null (it got its value directly from the FactorsForm control).

When a new analysis is created, no input value is given, and the controls get their own default values (Available VariablesList get their values from their sources). One particular case is for a VariablesList that has assignAvailableVariablesToList set to true: as there might be already some values in the Available VariablesList (this is for example the case in the ModelTerms of the Repeated Measures ANOVA, where default value "RM Factor 1" is already in the available VariablesList when an empty analysis is created), these values must also be set in the Assigned VariablesList (line 77 of VariablesListBase.cpp). This action is done automatically when a new value is set to the Available VariablesList, but as during the intiialization of the controls, the Assigned VariablesList is initialized after the Available VariablesList (due to dependency), this action must be also done when the Assigned VariablesList is initialized.
But when the "Model 1" VariablesList in the FactorsForm is initialized, it has also no input value and assignAvailableVariablesToList is true, and this action just overwrites the values given by the FactorsForm: all interaction values which were added in the original analysis, are removed.

As no value should be set directly to a control that has no bound value (because its value is set by another control), the problem is solved by just checking (in this line 77) whether the control has a bound value.
Also the BoundControl objects should not be created when the control has no bound value.

