### PR TITLE
fixes weird order loading of filterwindow by using more filtermodel properties in addition to a loader 

### DIFF
--- a/Desktop/components/JASP/Widgets/DataPanel.qml
+++ b/Desktop/components/JASP/Widgets/DataPanel.qml
@@ -17,14 +17,27 @@ Rectangle
 		anchors.leftMargin: rootDataset.leftHandSpace
 		orientation:		Qt.Vertical
 		
-		FilterWindow
+		Loader
 		{
-			id:							filterWindow
-			objectName:					"filterWindow"
-			SplitView.minimumHeight:	desiredMinimumHeight
-			SplitView.preferredHeight:	desiredHeight
+			SplitView.minimumHeight:	preferencesModel.uiScale * 200
+			SplitView.preferredHeight:	Screen.desktopAvailableHeight / 3
 			SplitView.maximumHeight:	splitViewData.height
-
+			
+			sourceComponent:			filterComponent
+			active:						filterModel.filterVisible
+			visible:					filterModel.filterVisible
+		}
+		
+		Component
+		{
+			id:	filterComponent
+			
+			FilterWindow
+			{
+				id:							filterWindow
+				objectName:					"filterWindow"
+	
+			}
 		}
 
 		VariablesWindow

--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -277,9 +277,9 @@ FocusScope
 					{
 						id:				filterToggleButton
 						
-						toolTip:		filterWindow.opened ? qsTr("Hide filter") : qsTr("Show filter")
+						toolTip:		filterModel.filterVisible ? qsTr("Hide filter") : qsTr("Show filter")
 						iconSource:		jaspTheme.iconPath + "filter.png"
-						onClicked:		filterWindow.toggle()
+						onClicked:		filterModel.filterVisible = !filterModel.filterVisible
 						border.width:	1
 						
 						anchors

--- a/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
@@ -183,8 +183,8 @@ Rectangle
 
 				if(dataSetModel.columnUsedInEasyFilter(columnIndex))
 				{
-					filterWindow.showEasyFilter = true
-					filterWindow.open()
+					filterModel.showEasyFilter = true
+					filterModel.filterVisible = true
 				}
 				
 				//A button in VariablesWindow will do this? in any case, it is kind of annoying to have the analysis always pop up instead of variableswindow...

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -7,51 +7,11 @@ import JASP
 FocusScope
 {
 	id:							filterContainer
-	visible:					opened
 
-	property bool	opened:					false
-	property int	minimumHeightTextBoxes: 50 * preferencesModel.uiScale
-	property bool	showEasyFilter:			true
-	property int	desiredMinimumHeight:	easyFilterConstructor.desiredMinimumHeight
-	property int	desiredHeight:			easyFilterConstructor.desiredHeight
-	
-	onShowEasyFilterChanged:	if(!showEasyFilter) absorbModelRFilter()
-	onVisibleChanged:			if(!visible) filterWindow.close()
-
-	Connections
-	{
-		target:	 filterModel
-		function onRFilterChanged()			{ absorbModelRFilter();				}
-		function onFilterErrorMsgChanged()	
-		{ 
-			if (filterModel.filterErrorMsg.length > 0 && !visible) 
-			{
-				open();	
-				
-				//Now this might be caused by some labelfilter, or something. However, the filterwindow by default does not show the generatedFilter
-				//Maybe its better to open it on the R display then?
-				if(filterModel.isJustGeneratedFilter())
-					filterContainer.showEasyFilter = false
-			}
-		}
-	}
-
-	function toggle()
-	{
-		opened = !opened
-		absorbModelRFilter()
-	}
-
-	function open()
-	{
-		if(!opened)
-			toggle();
-	}
 
 	function close()
 	{
-		if(opened)
-			toggle();
+		filterModel.filterVisible = false
 	}
 
 
@@ -66,12 +26,6 @@ FocusScope
 		filterModel.resetRFilter()
 		absorbModelRFilter()
 	}
-
-	function absorbModelRFilter()
-	{
-		filterEdit.text = filterModel.rFilter
-	}
-
 	signal rCodeChanged(string rScript)
 
 	Rectangle
@@ -101,7 +55,7 @@ FocusScope
 		{
 			anchors.fill:		parent
 			anchors.margins:	1
-			visible:			filterContainer.showEasyFilter
+			visible:			filterModel.showEasyFilter
 
 
 			FilterConstructor
@@ -198,7 +152,7 @@ FocusScope
 				width:				height
 				radius:				height
 				iconSource:			jaspTheme.iconPath + "close-button.png"
-				onClicked:			easyFilterConstructor.askIfChanged(function() { filterWindow.toggle() } )
+				onClicked:			easyFilterConstructor.askIfChanged(function() { filterWindow.close() } )
 				toolTip:			qsTr("Close filter window")
 				anchors
 				{
@@ -212,7 +166,7 @@ FocusScope
 			{
 				id:			rRectangularButton
 				iconSource: jaspTheme.iconPath + "/R.png"
-				onClicked:	easyFilterConstructor.askIfChanged(function() { filterContainer.showEasyFilter = false } )
+				onClicked:	easyFilterConstructor.askIfChanged(function() { filterModel.showEasyFilter = false } )
 				width:		height
 				toolTip:	qsTr("Switch to the R filter")
 				anchors
@@ -260,7 +214,7 @@ FocusScope
 		Item
 		{
 							id:						rFilterFields
-							visible:				!filterContainer.showEasyFilter
+							visible:				!filterModel.showEasyFilter
 							anchors.fill:			parent
 							anchors.margins:		1
 			property real	desiredMinimumHeight:	filterButtons.height + (filterErrorScroll.visible ? filterErrorScroll.height : 0 ) + filterEditRectangle.desiredMinimumHeight
@@ -331,7 +285,7 @@ FocusScope
 							anchors.top:			filterGeneratedBox.top
 							anchors.left:			resetAllGeneratedFilters.right
 							anchors.right:			filterGeneratedBox.right
-							text:					filterModel.generatedFilter +"\n"
+							text:					filterModel.generatedFilter + "\n"
 							height:					contentHeight
 							readOnly:				true
 							color:					jaspTheme.grayDarker
@@ -385,6 +339,7 @@ FocusScope
 							font.pixelSize:         baseFontSize * preferencesModel.uiScale
 							wrapMode:				TextArea.WrapAtWordBoundaryOrAnywhere
 							color:					jaspTheme.textEnabled
+							text:					filterModel.rFilter
 
 							property bool changedSinceLastApply: text !== filterModel.rFilter
 
@@ -489,7 +444,7 @@ FocusScope
 				{
 					id:				easyRectangularButton
 					iconSource:		jaspTheme.iconPath + "/NotR.png"
-					onClicked:		filterEditRectangle.askIfChanged(function (){ filterContainer.showEasyFilter = true })
+					onClicked:		filterEditRectangle.askIfChanged(function (){ filterModel.showEasyFilter = true })
 					width:			visible ? height : 0
 					toolTip:		qsTr("Switch to the drag and drop filter")
 					anchors
@@ -570,7 +525,7 @@ FocusScope
 					anchors.right:	parent.right
 					anchors.bottom: parent.bottom
 
-					onClicked:		filterEditRectangle.askIfChanged(function (){ filterWindow.toggle() })
+					onClicked:		filterEditRectangle.askIfChanged(function (){ filterWindow.close() })
 					toolTip:		qsTr("Hide filter")
 				}
 			}

--- a/Desktop/data/filtermodel.cpp
+++ b/Desktop/data/filtermodel.cpp
@@ -46,6 +46,9 @@ bool FilterModel::isJustGeneratedFilter() const
 
 void FilterModel::reset()
 {
+	setFilterVisible(false);
+	setShowEasyFilter(true);
+	
 	_setGeneratedFilter(DEFAULT_FILTER_GEN	);
 	setConstructorJson(	DEFAULT_FILTER_JSON	);
 	_setRFilter(		defaultRFilter()		);
@@ -58,6 +61,9 @@ void FilterModel::reset()
 
 void FilterModel::dataSetPackageResetDone()
 {
+	setFilterVisible(false);
+	setShowEasyFilter(true);
+	
 	if(DataSetPackage::pkg()->isLoaded())
 	{
 		_setGeneratedFilter(tq(_labelFilterGenerator->generateFilter())		);
@@ -110,6 +116,16 @@ void FilterModel::setFilterErrorMsg(	QString newFilterErrorMsg)
 			DataSetPackage::filter()->setErrorMsg(fq(newFilterErrorMsg));
 		
 		emit filterErrorMsgChanged();
+		if(filterErrorMsg() != "")
+		{
+			setFilterVisible(true);
+			
+			//Now this might be caused by some labelfilter, or something. However, the filterwindow by default does not show the generatedFilter
+			//Maybe its better to open it on the R display then?
+			if(isJustGeneratedFilter())
+				setShowEasyFilter(false);
+				
+		}
 	}
 }
 
@@ -330,4 +346,34 @@ QVariantList FilterModel::filterDropDownList() const
 		out.append(localMap{std::make_pair("value", tq(DataSetPackage::filter()->name())), std::make_pair("label", QObject::tr("Use filter"))});
 	
 	return out;
+}
+
+bool FilterModel::filterVisible() const
+{
+	return _filterVisible;
+}
+
+void FilterModel::setFilterVisible(bool newFilterVisible)
+{
+	if (_filterVisible == newFilterVisible)
+		return;
+	_filterVisible = newFilterVisible;
+		
+	emit filterVisibleChanged();
+	
+	if(_filterVisible)
+		setGeneratedFilter(tq(_labelFilterGenerator->generateFilter()));
+}
+
+bool FilterModel::showEasyFilter() const
+{
+	return _showEasyFilter;
+}
+
+void FilterModel::setShowEasyFilter(bool newShowEasyFilter)
+{
+	if (_showEasyFilter == newShowEasyFilter)
+		return;
+	_showEasyFilter = newShowEasyFilter;
+	emit showEasyFilterChanged();
 }

--- a/Desktop/data/filtermodel.cpp
+++ b/Desktop/data/filtermodel.cpp
@@ -61,9 +61,6 @@ void FilterModel::reset()
 
 void FilterModel::dataSetPackageResetDone()
 {
-	setFilterVisible(false);
-	setShowEasyFilter(true);
-	
 	if(DataSetPackage::pkg()->isLoaded())
 	{
 		_setGeneratedFilter(tq(_labelFilterGenerator->generateFilter())		);

--- a/Desktop/data/filtermodel.h
+++ b/Desktop/data/filtermodel.h
@@ -20,7 +20,9 @@ class FilterModel : public QObject
 	Q_PROPERTY( bool			hasFilter			READ hasFilter										NOTIFY hasFilterChanged				)
 	Q_PROPERTY( QString			defaultRFilter		READ defaultRFilter									NOTIFY defaultRFilterChanged		)
 	Q_PROPERTY( QVariantList	filterDropDownList	READ filterDropDownList								NOTIFY filterDropDownListChanged	)
-
+	Q_PROPERTY( bool			filterVisible		READ filterVisible		WRITE setFilterVisible		NOTIFY filterVisibleChanged			)
+	Q_PROPERTY( bool			showEasyFilter		READ showEasyFilter		WRITE setShowEasyFilter		NOTIFY showEasyFilterChanged		)
+	
 public:
 	explicit					FilterModel(labelFilterGenerator * labelfilterGenerator);
 	
@@ -44,6 +46,12 @@ public:
 				void			reset();
 				void			modelInit();
 				
+				
+				bool filterVisible() const;
+				void setFilterVisible(bool newFilterVisible);
+				
+				bool showEasyFilter() const;
+				void setShowEasyFilter(bool newShowEasyFilter);
 				
 public slots:
 	GENERIC_SET_FUNCTION(StatusBarText,			_statusBarText,			statusBarTextChanged,		QString)
@@ -90,6 +98,10 @@ signals:
 
 	void defaultRFilterChanged(); //Will never be called
 
+	void filterVisibleChanged();
+	
+	void showEasyFilterChanged();
+	
 private:
 	bool _setGeneratedFilter(const QString& newGeneratedFilter);
 	bool _setRFilter(const QString& newRFilter);
@@ -104,6 +116,8 @@ private:
 	int							_lastSentRequestId		= 0;
 
 	UndoStack*					_undoStack				= nullptr;
+	bool						_filterVisible,
+								_showEasyFilter			= true;
 };
 
 #endif // FILTERMODEL_H

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1468,6 +1468,7 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 			_package->reset(false);
 			_ribbonModel->showStatistics();
 			_fileMenu->buttonsForEmptyWorkspace();
+			_filterModel->reset();
 
 			if(!_applicationExiting)
 				_engineSync->cleanRestart();


### PR DESCRIPTION
prevents:
<img width="1920" height="854" alt="image" src="https://github.com/user-attachments/assets/4373873c-b720-45e5-a476-753846a2627c" />
