### PR TITLE
Check variables types when allowed types are changed

### DIFF
--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -169,6 +169,7 @@ void JASPListControl::setUp()
 	connect(listModel,							&ListModelDraggable::termsChanged,				this,	&JASPListControl::levelsChanged				);
 	connect(listModel,							&ListModelDraggable::filterChanged,				this,	&JASPListControl::levelsChanged				);
 	connect(listModel,							&ListModelDraggable::filterChanged,				this,	&JASPListControl::checkLevelsConstraints, Qt::QueuedConnection	);
+	connect(_allowedTypesModel,					&ColumnTypesModel::typesChanged,				this,	&JASPListControl::checkTermsTypes				);
 }
 
 void JASPListControl::cleanUp()
@@ -408,6 +409,15 @@ bool JASPListControl::checkLevelsConstraints()
 		clearControlError();
 
 	return checked;
+}
+
+void JASPListControl::checkTermsTypes()
+{
+	if (model())
+	{
+		model()->checkTermsTypes();
+		checkLevelsConstraints();
+	}
 }
 
 QStringList JASPListControl::levels() const

--- a/QMLComponents/controls/jasplistcontrol.h
+++ b/QMLComponents/controls/jasplistcontrol.h
@@ -162,6 +162,7 @@ protected slots:
 			void					setOptionKeyValue(const QString& optionKeyValue)		{ _optionKeyValue = optionKeyValue; }
 			void					setOptionKeyLabel(const QString& optionKeyLabel)		{ _optionKeyLabel = optionKeyLabel; }
 			bool					checkLevelsConstraints();
+			void					checkTermsTypes();
 
 protected:
 	void							_setInitialized(const Json::Value& value = Json::nullValue)				override;

--- a/QMLComponents/models/columntypesmodel.cpp
+++ b/QMLComponents/models/columntypesmodel.cpp
@@ -46,6 +46,8 @@ void ColumnTypesModel::setTypes(columnTypeVec types)
 	_defaultType = _types.size() > 0 ? _types[0] : columnType::unknown;
 	std::sort(_types.begin(), _types.end());
 	endResetModel();
+
+	emit typesChanged();
 }
 
 QVariant ColumnTypesModel::data(const QModelIndex &index, int role) const

--- a/QMLComponents/models/columntypesmodel.h
+++ b/QMLComponents/models/columntypesmodel.h
@@ -54,6 +54,9 @@ public:
 	columnType								defaultType()												const			{ return _defaultType;	}
 	QStringList								iconList()													const;
 
+signals:
+	void									typesChanged();
+
 private:
 	static columnTypeVec					_allTypes;
 

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -132,6 +132,12 @@ Terms ListModel::checkTermsTypes(const std::vector<Term>& terms) const
 	return checkedTerms;
 }
 
+void ListModel::checkTermsTypes()
+{
+	_terms.set(checkTermsTypes(_terms));
+	setUpRowControls();
+}
+
 
 Terms ListModel::checkTermsTypes(const Terms& terms) const
 {

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -94,6 +94,7 @@ public:
 
 			Terms					checkTermsTypes(const Terms& terms)								const;
 			Terms					checkTermsTypes(const std::vector<Term>& terms)					const;
+			void					checkTermsTypes();
 	virtual Terms					termsFromIndexes(	const QList<int>& indexes)					const;
 	virtual QList<int>				indexesFromTerms(	const Terms		& terms)					const;
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3681#issuecomment-3289465808

The Variables Form test in the jaspTestModule has been modified to test the change of allowed types (https://github.com/jasp-stats/jasp-desktop/pull/6019)