### PR TITLE
Replace starts_with function

### DIFF
--- a/Desktop/data/importers/readstatimporter.cpp
+++ b/Desktop/data/importers/readstatimporter.cpp
@@ -72,7 +72,7 @@ int handle_note(int note_index, const char *note, void *ctx)
 
 bool ReadStatImporter::extSupported(const std::string & ext)
 {
-	return extsSupported().count(stringUtils::toLower(ext.starts_with(".") ? ext.substr(1) : ext)) > 0;
+	return extsSupported().count(stringUtils::toLower(ext.length() > 0 && ext.substr(0, 1) == "." ? ext.substr(1) : ext)) > 0;
 }
 
 stringset ReadStatImporter::extsSupported()


### PR DESCRIPTION
This is only available in c++20, and the default version of clang is c++20 (the newest Xcode should solve this).

