### PR TITLE
Fix some loading related problems

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -494,16 +494,6 @@ stringset Column::mergeOldMissingDataMap(const Json::Value &missingData)
 	return foundEmpty;
 }
 
-void Column::updateLabelsPostLocaleChange()
-{
-	beginBatchedLabelsDB();
-	
-	for(Label * label : _labels)
-		label->updateDoubleLabelsPostLocaleChange();
-	
-	endBatchedLabelsDB(true);	
-}
-
 columnType Column::setValues(const stringvec & values, const stringvec & labels, int thresholdScale, bool * aChange, bool useLocale)
 {
 	assert(values.size() == labels.size() || labels.size() == 0);
@@ -1337,7 +1327,7 @@ void Column::_labelMapUpdates(Label * label, const std::string & previousDisplay
 	bool	valueChanged	= previousOriginal		!= label->originalValueAsString(),
 			displayChanged	= previousDisplay		!= label->label(),
 			previousSame	= previousOriginal		== previousDisplay,
-			newSame			= label->label()	== label->originalValueAsString();
+			newSame			= label->label()		== label->originalValueAsString();
 
 	if(valueChanged)
 	{

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1,10 +1,10 @@
 ﻿#include "log.h"
+#include <cassert>
 #include "column.h"
 #include "timers.h"
 #include "dataset.h"
 #include "columnutils.h"
 #include "databaseinterface.h"
-#include <cassert>
 
 bool Column::_autoSortByValuesByDefault = true;
 

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -229,8 +229,7 @@ public:
 			size_t					getMaximumWidthInCharacters(bool shortenAndFancyEmptyValue, bool valuesPlease, size_t	extraPad	= 4); ///< Tries to take into consideration that utf-8 can have more characters than codepoints and compensates for it
 			columnType				resetValues(int thresholdScale); ///< "Reimport" the values it already has with a possibly different threshold of values 
 			stringset				mergeOldMissingDataMap(const Json::Value & missingData); ///< <0.19 JASP collected the removed empty values values in a map in a json object... We need to be able to read at least 0.18.3 so here this function that absorbs such a map and adds any required labels. It does not add the empty values itself though!
-			void					updateLabelsPostLocaleChange();
-			
+
 	static	void					setAutoSortByValuesByDefault(bool autoSort);
 	static	bool					autoSortByValuesByDefault();
 	

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -1643,7 +1643,7 @@ void DatabaseInterface::labelsWrite(const Columns & columns, std::function<void(
 		 bindParametersType _bindParams =  [&](sqlite3_stmt *stmt)
 		 {
 			 const Label			*	label			= *labelIter;
-			 const std::string			labelDisplay	= label->label(),
+			 const std::string			labelDisplay	= label->label(false),
 										origValJson		= label->originalValue().toStyledString();
 			 
 			 Column					*	column			= static_cast<Column*>(label->parent());

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -661,12 +661,6 @@ void DataSet::setDescription(const std::string &desc)
 	dbUpdate();
 }
 
-void DataSet::updateLabelsPostLocaleChange()
-{
-	for(Column * column : _columns)
-		column->updateLabelsPostLocaleChange();
-}
-
 DatabaseInterface &DataSet::db()	
 { 
 	return *DatabaseInterface::singleton(); 

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -322,7 +322,18 @@ void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, Ver
 	//Log::log() << "colCount: " << colCount << ", " << "rowCount: " << rowCount() << std::endl;
 
 	float colProgressMult = 1.0 / colCount;
-			
+
+	Json::Value emptyValsJson;
+	Json::Reader().parse(emptyVals, emptyValsJson);
+
+	bool	do019Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.19",
+			do095Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.95";
+
+	//Ideally we have the emptyvalues before loading the columns, so we get the right labels in the labeleditor, butr for older than 0.19 stuff is complicated so we do that later.
+
+	if(!do019Fix)
+		_emptyValues->fromJson(emptyValsJson);
+
 	for(size_t i=0; i<colCount; i++)
 	{
 		if(_columns.size() == i)
@@ -340,18 +351,13 @@ void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, Ver
 
 	db().dataSetBatchedValuesLoad(this, [&](float p){ progressCallback(0.50 + (p * 0.25)); });
 	db().dataSetBatchedLabelsLoad(this, [&](float p){ progressCallback(0.75 + (p * 0.25)); });
-	
-	Json::Value emptyValsJson;
-	Json::Reader().parse(emptyVals, emptyValsJson);
-	
-	bool	do019Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.19",
-			do095Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.95";
+
+
 	
 	if(do095Fix)
 		beginBatchedToDB();
 	
 	if(do019Fix)	upgradeTo019(emptyValsJson);
-	else			_emptyValues->fromJson(emptyValsJson);
 	
 	if(do095Fix)
 	{

--- a/CommonData/dataset.h
+++ b/CommonData/dataset.h
@@ -87,7 +87,6 @@ public:
 			void					setWorkspaceEmptyValues(	const stringset& values);
 	const	std::string			&	description()																	const	{ return _description; }
 			void					setDescription(				const std::string& desc);
-			void					updateLabelsPostLocaleChange();
 			Json::Value				jsonForCompare() const;
 			
 private:

--- a/CommonData/label.cpp
+++ b/CommonData/label.cpp
@@ -10,14 +10,8 @@ const int Label::NO_LABEL			= -1;
 Label::Label(Column * column, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue, int order, int id)
 : DataSetBaseNode(dataSetBaseNodeType::label, column), _column(column)
 {
-	_label			= label;
-	_intsId			= value;
-	_filterAllows	= filterAllows;
-	_description	= description;//description != "" || label.size() < MAX_LABEL_DISPLAY_LENGTH ? description : label; //Use description given if filled otherwise use label if the label won't be displayed entirely
-	_order			= order;
+	setInformation(column, id, order, label, value, filterAllows, description, originalValue);
 
-	_setOriginalValue(originalValue);
-	
 	if(id == -1)	dbCreate();
 	else			_dbId = id;
 }
@@ -82,28 +76,16 @@ void Label::dbUpdate()
 void Label::setInformation(Column * column, int id, int order, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue)
 {
 	assert(_column == column);
-	_dbId			= id;
-	_order			= order;
-	_label			= label;
-	_intsId			= value;	
+
+	_setOriginalValue(originalValue);
+
+	_intsId			= value;
 	_filterAllows	= filterAllows;
 	_description	= description;
-	
-	_setOriginalValue(originalValue);
-}
+	_order			= order;
 
-void Label::updateDoubleLabelsPostLocaleChange()
-{
-	if(_originalValue.isDouble() && originalValueAsString() != _label)
-	{
-		//Maybe they really arent the same, but its also possible a languagechange just changed the way the decimal separator is written...
-		double labelDouble;
-		if(ColumnUtils::getDoubleValue(_label, labelDouble) && ColumnUtils::doubleToString(labelDouble) == originalValueAsString())
-		{
-			_label = originalValueAsString();
-			dbUpdate();
-		}
-	}
+	std::string oriStr = originalValueAsString();
+	_label			= std::isnan(originalValueAsDouble()) || label != oriStr ? label : ""; // dont store a label if its simply the double
 }
 
 Json::Value Label::serialize() const
@@ -140,7 +122,7 @@ bool Label::setLabel(const std::string & label)
 	if(_label != label)
 	{
 		std::string oldLabel = _label;
-		_label = label.empty() ? originalValueAsString() : label;
+		_label = label;
 		
 		_column->labelDisplayChanged(this, oldLabel);
 
@@ -179,7 +161,7 @@ bool Label::setOriginalValue(const Json::Value & originalValue)
 bool Label::setOrigValLabel(const Json::Value &originalValue)
 {
 	std::string oldLabel	= _label,
-				newLabel	= !originalValue.isDouble() ? originalValue.asString() : _column->doubleToDisplayString(originalValue.asDouble(), false, false);
+				newLabel	= !originalValue.isDouble() ? originalValue.asString() : "";
 	Json::Value previous	= _originalValue;
 	bool		labelChange = _label			!= newLabel,
 				valChange	= _originalValue	!= originalValue,
@@ -257,6 +239,13 @@ Label &Label::operator=(const Label &label)
 	this->_column			= label._column;
 	
 	return *this;
+}
+
+std::string Label::label(bool showOriDblInstead) const
+{
+	if(!showOriDblInstead || _label != "" || std::isnan(originalValueAsDouble()))
+		return _label;
+	return ColumnUtils::doubleToString(originalValueAsDouble());
 }
 
 std::string Label::labelDisplay() const

--- a/CommonData/label.h
+++ b/CommonData/label.h
@@ -36,7 +36,7 @@ public:
 			int					dbId()						const	{ return _dbId;				}
 			bool				userAdded()					const	{ return _userAdded;		}
 	const	std::string		&	description()				const	{ return _description;		}
-			std::string			label()						const	{ return _label;			}
+			std::string			label(bool lie=true)		const;
 			std::string			labelDisplay()				const;
 			int					intsId()					const	{ return _intsId;			}
 			bool				isEmptyValue()				const;
@@ -61,8 +61,6 @@ public:
 			bool				setFilterAllows(	bool allowFilter);
 			void				setUserAdded(		bool userAddedIt);
 			void				setInformation(Column * column, int id, int order, const std::string &label, int value, bool filterAllows, const std::string & description, const Json::Value & originalValue);
-			
-			void				updateDoubleLabelsPostLocaleChange();
 
 			Json::Value			serialize()	const;
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1493,7 +1493,8 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 	_db->load();		
 	_db->upgradeDBFromVersion(_jaspVersion);
 	
-	bool do019Upgrade = _jaspVersion < "0.19";
+	bool 	do019Upgrade  = _jaspVersion < "0.19",
+			do0953Upgrade = _jaspVersion < "0.95.3";
 	
 	_dataSet = new DataSet(0);
 	_dataSet->dbLoad(1, progressCallback, _jaspVersion); //Right now there can only be a dataSet with ID==1 so lets keep it simple

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1266,10 +1266,7 @@ void DataSetPackage::prepareForLanguageChange()
 void DataSetPackage::languageChangeDone()
 {
 	_waitingForLanguageChange = false; //Dont accept changes while the interface changes
-	
-	if(_dataSet)
-		_dataSet->updateLabelsPostLocaleChange();
-	
+
 	refresh();
 }
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1490,8 +1490,7 @@ void DataSetPackage::loadDataSet(std::function<void(float)> progressCallback)
 	_db->load();		
 	_db->upgradeDBFromVersion(_jaspVersion);
 	
-	bool 	do019Upgrade  = _jaspVersion < "0.19",
-			do0953Upgrade = _jaspVersion < "0.95.3";
+	bool 	do019Upgrade  = _jaspVersion < "0.19";
 	
 	_dataSet = new DataSet(0);
 	_dataSet->dbLoad(1, progressCallback, _jaspVersion); //Right now there can only be a dataSet with ID==1 so lets keep it simple


### PR DESCRIPTION
move the intialization of empty values up to avoid them showing up in the labelsview
fixes jasp-stats/INTERNAL-jasp#2955

Also loading a file made with a different locale can mess up the labels.
This is easily fixed though by simply not storing the double as a string.

Fairly sure this is all good but needs to be tested!