### PR TITLE
Make database connection thread-safe

### DIFF
--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -12,6 +12,10 @@
 
 DatabaseInterface * DatabaseInterface::_singleton	= nullptr;
 
+thread_local 	int			_transactionWriteDepth	= 0,
+							_transactionReadDepth	= 0;
+
+
 //#define SIR_LOG_A_LOT
 
 const std::string DatabaseInterface::_dbConstructionSql =
@@ -2050,10 +2054,7 @@ sqlite3 * DatabaseInterface::_db()
 	if(_dbCreated && _dbCreator == id)
 		return _dbCreated;
 
-	if(!_dbs.count(id))
-		load();
-
-	return _dbs.at(id);
+	return load();
 }
 
 void DatabaseInterface::create()
@@ -2132,40 +2133,41 @@ void DatabaseInterface::preloadInterfaceForThread()
     _db();
 }
 
-void DatabaseInterface::load()
+sqlite3* DatabaseInterface::load()
 {
     JASPTIMER_SCOPE(DatabaseInterface::load);
-	assert(!_dbCreated || std::this_thread::get_id() != _dbCreator);
+    assert(!_dbCreated || std::this_thread::get_id() != _dbCreator);
 
     _loadMutex.lock();
     if(_dbs.count(std::this_thread::get_id()))
     {
+        sqlite3* connection = _dbs.at(std::this_thread::get_id());
         _loadMutex.unlock();
-        return;
+        return connection;
     }
 
-	
-	if(!std::filesystem::exists(dbFile()))
-		throw std::runtime_error("Trying to load '" + dbFile() + "' but it doesn't exist!");
+    if(!std::filesystem::exists(dbFile()))
+        throw std::runtime_error("Trying to load '" + dbFile() + "' but it doesn't exist!");
 
     bool        loadingWorked	= false;
     size_t      loadingAttempt	= 0;
     sqlite3 *   db              = nullptr;
 
+	int ret = sqlite3_open_v2(dbFile().c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOMUTEX, NULL);
+
+	if(ret != SQLITE_OK)
+	{
+		Log::log() << "Couldnt open sqlite internal db, because of: " << (db ? sqlite3_errmsg(db) : "not even a broken sqlite3 obj was returned..." ) << std::endl;
+		throw std::runtime_error("JASP cannot run without an internal database and it cannot be created. Contact the JASP team for help.");
+	}
+	else
+		Log::log() << "Opened internal sqlite database for loading at '" << dbFile() << "'. This is for thread " << std::this_thread::get_id() << std::endl;
+
+	_dbs[std::this_thread::get_id()] = db;
+	_loadMutex.unlock();
+
     for(bool loadingWorked = false; !loadingWorked; )
     {
-        int ret = sqlite3_open_v2(dbFile().c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOMUTEX, NULL);
-
-        if(ret != SQLITE_OK)
-        {
-            Log::log() << "Couldnt open sqlite internal db, because of: " << (db ? sqlite3_errmsg(db) : "not even a broken sqlite3 obj was returned..." ) << std::endl;
-            throw std::runtime_error("JASP cannot run without an internal database and it cannot be created. Contact the JASP team for help.");
-        }
-        else
-            Log::log() << "Opened internal sqlite database for loading at '" << dbFile() << "'. This is for thread " << std::this_thread::get_id() << std::endl;
-
-        _dbs[std::this_thread::get_id()] = db;
-		
 		sqlite3_busy_timeout(db, 100);
 
         try
@@ -2187,17 +2189,14 @@ void DatabaseInterface::load()
         if(!loadingWorked)
         {
 			if(loadingAttempt > 10 * 60) //Timeout is 0.1 sec, so this lets the db try for 1 minute to connect...
-            {
-                _loadMutex.unlock();
                 throw dbMalformedException();
-            }
 
             Log::log() << "There was a problem loading the database, retrying for the #" << loadingAttempt << " time" << std::endl;
 			std::this_thread::sleep_for(std::chrono::nanoseconds(100000000));
         }
     }
 
-    _loadMutex.unlock();
+	return db;
 }
 
 void DatabaseInterface::close()
@@ -2254,6 +2253,16 @@ bool DatabaseInterface::tableExists(const std::string &name)
 	return runStatementsId("SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='" + name + "';") > 0;
 }
 
+int DatabaseInterface::transactionWriteDepth()
+{
+	return _transactionWriteDepth;
+}
+
+int DatabaseInterface::transactionReadDepth()
+{
+	return _transactionReadDepth;
+}
+
 void DatabaseInterface::transactionWriteBegin()
 {
 	JASPTIMER_SCOPE(DatabaseInterface::transactionWriteBegin);
@@ -2294,7 +2303,7 @@ void DatabaseInterface::transactionWriteEnd(bool rollback)
 	}	
 	else if(_transactionWriteDepth == 0 || --_transactionWriteDepth == 0)
 		runStatements("COMMIT", true);
-	
+
 }
 
 void DatabaseInterface::transactionReadEnd()

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -2054,7 +2054,10 @@ sqlite3 * DatabaseInterface::_db()
 	if(_dbCreated && _dbCreator == id)
 		return _dbCreated;
 
-	return load();
+	if(!_dbs.count(id))
+		load();
+
+	return _dbs.at(id);
 }
 
 void DatabaseInterface::create()
@@ -2133,7 +2136,7 @@ void DatabaseInterface::preloadInterfaceForThread()
     _db();
 }
 
-sqlite3* DatabaseInterface::load()
+void DatabaseInterface::load()
 {
     JASPTIMER_SCOPE(DatabaseInterface::load);
     assert(!_dbCreated || std::this_thread::get_id() != _dbCreator);
@@ -2143,7 +2146,7 @@ sqlite3* DatabaseInterface::load()
     {
         sqlite3* connection = _dbs.at(std::this_thread::get_id());
         _loadMutex.unlock();
-        return connection;
+		return;
     }
 
     if(!std::filesystem::exists(dbFile()))
@@ -2196,7 +2199,7 @@ sqlite3* DatabaseInterface::load()
         }
     }
 
-	return db;
+	return;
 }
 
 void DatabaseInterface::close()

--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -197,9 +197,7 @@ private:
 	void		_runStatementsRepeatedly(	const std::string & statements, std::function<bool(	std::function<void(sqlite3_stmt *stmt)> **	bindParameters, size_t row)> bindParameterFactory, std::function<void(size_t row, size_t repetition, sqlite3_stmt *stmt)> * processRow = nullptr, bool ignoreFails = false);
 
 	void		create();					///< Creates a new sqlite database in sessiondir and loads it
-	sqlite3*	load();						///< Loads a sqlite database from sessiondir (after loading a jaspfile)
-
-	
+	void		load();						///< Loads a sqlite database from sessiondir (after loading a jaspfile)
 
 	std::map<std::thread::id, sqlite3*>		_dbs;
 	std::thread::id							_dbCreator;

--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -183,8 +183,8 @@ public:
 	void		truncateAllTables();
 	bool		tableHasColumn(const std::string & tableName, const std::string & columnName);
 	bool		tableExists(const std::string & name);
-	int			transactionWriteDepth() { return _transactionWriteDepth; }
-	int			transactionReadDepth()	{ return _transactionReadDepth;  }
+	int			transactionWriteDepth();
+	int			transactionReadDepth();
 
     void        preloadInterfaceForThread();
 	void		close();					///< Closes the loaded database and disconnects
@@ -197,12 +197,9 @@ private:
 	void		_runStatementsRepeatedly(	const std::string & statements, std::function<bool(	std::function<void(sqlite3_stmt *stmt)> **	bindParameters, size_t row)> bindParameterFactory, std::function<void(size_t row, size_t repetition, sqlite3_stmt *stmt)> * processRow = nullptr, bool ignoreFails = false);
 
 	void		create();					///< Creates a new sqlite database in sessiondir and loads it
-	void		load();						///< Loads a sqlite database from sessiondir (after loading a jaspfile)
+	sqlite3*	load();						///< Loads a sqlite database from sessiondir (after loading a jaspfile)
 
 	
-
-	int			_transactionWriteDepth	= 0,
-				_transactionReadDepth	= 0;
 
 	std::map<std::thread::id, sqlite3*>		_dbs;
 	std::thread::id							_dbCreator;

--- a/Desktop/data/datasetloader.cpp
+++ b/Desktop/data/datasetloader.cpp
@@ -89,8 +89,6 @@ void DataSetLoader::loadPackage(const string &locator, const string &extension, 
 
 void DataSetLoader::syncPackage(const string &locator, const string &extension, std::function<void(int)> progress)
 {
-	Utils::sleep(100); // :'(
-
 	Importer* importer = getImporter(locator, extension);
 
 	if (importer)


### PR DESCRIPTION
When working on the new feature to generate reports with feeding jasp files with other datafiles (https://github.com/jasp-stats/jasp-desktop/pull/6025), I came upon an issue that sometimes the synchronization hangs. 
This was due to the fact that after opening a JASP file, the Filter model generates some SQL statements, but the synchronization task was already started: this lead to concurrency issues with the database. Especially the connection object to SQLite is thread dependent, but `_transactionWriteDepth` and `_transactionReadDepth` are not. So one thread could increment _transactionWriteDepth, and another thread checking _transactionWriteDepth would think that a transaction was already started, and then would not execute a 'BEGIN EXCLUSIVE' statement.
So the solution is to make `_transactionWriteDepth` and `_transactionReadDepth` thread dependent.

Also the connection object is stored in a map, but a std map does not use mutex: so setting and querying the map must be done under a mutex to be sure that the manipulation of the map is thread safe.

This fix solves probably some hanging issues that some users report.