### PR TITLE
Allow read sqlite database of more than 2GB

### DIFF
--- a/CommonData/archivereader.cpp
+++ b/CommonData/archivereader.cpp
@@ -113,7 +113,7 @@ void ArchiveReader::writeEntryToTempFiles(std::function<void(float)> progressCal
     file.rdbuf()->pubsetbuf(streamBuff, sizeof(streamBuff)); //Set the buffer manually to make it much faster our issue https://github.com/jasp-stats/INTERNAL-jasp/issues/436 and solution from:  https://stackoverflow.com/a/15177770
 
     static char copyBuff[8192 * 4];
-    long		bytes		= 0;
+    int64_t		bytes		= 0;
     int         errorCode	= 0;
     float       tallyBytes  = 0;
     do
@@ -159,18 +159,18 @@ string ArchiveReader::extension() const
 }
 
 
-long ArchiveReader::readData(char *data, long maxSize, int &errorCode)
+int64_t ArchiveReader::readData(char *data, int64_t maxSize, int &errorCode)
 {
 	if (!_exists)
 		return 0;
 
-    long    bytesAvailable	= _size - _currentRead,
-            toRead			= std::min(maxSize, bytesAvailable);
+    int64_t    bytesAvailable	= _size - _currentRead,
+                toRead			= std::min(maxSize, bytesAvailable);
 
 	if (toRead <= 0)
 		return 0;
 
-    long count = archive_read_data(_archive, data, toRead);
+    int64_t count = archive_read_data(_archive, data, toRead);
 
 	if (count > 0)
 	{
@@ -188,7 +188,7 @@ long ArchiveReader::readData(char *data, long maxSize, int &errorCode)
 
 std::string ArchiveReader::readAllData(int blockSize, int &errorCode)
 {
-    long size = bytesAvailable();
+    int64_t size = bytesAvailable();
 	if (size == 0)
 		return NULL;
 
@@ -197,7 +197,7 @@ std::string ArchiveReader::readAllData(int blockSize, int &errorCode)
 	char *data = new char[size];
 	data[size - 1] = '\0';
 
-    long startOffset = _currentRead;
+    int64_t startOffset = _currentRead;
 
 	errorCode = 0;
 	while (readData(&data[_currentRead - startOffset], blockSize, errorCode) > 0 && errorCode == 0);

--- a/CommonData/archivereader.cpp
+++ b/CommonData/archivereader.cpp
@@ -113,8 +113,8 @@ void ArchiveReader::writeEntryToTempFiles(std::function<void(float)> progressCal
     file.rdbuf()->pubsetbuf(streamBuff, sizeof(streamBuff)); //Set the buffer manually to make it much faster our issue https://github.com/jasp-stats/INTERNAL-jasp/issues/436 and solution from:  https://stackoverflow.com/a/15177770
 
     static char copyBuff[8192 * 4];
-    int			bytes		= 0,
-                errorCode	= 0;
+    long		bytes		= 0;
+    int         errorCode	= 0;
     float       tallyBytes  = 0;
     do
     {
@@ -159,18 +159,18 @@ string ArchiveReader::extension() const
 }
 
 
-int ArchiveReader::readData(char *data, int maxSize, int &errorCode)
+long ArchiveReader::readData(char *data, long maxSize, int &errorCode)
 {
 	if (!_exists)
 		return 0;
 
-	int bytesAvailable	= _size - _currentRead,
-		toRead			= std::min(maxSize, bytesAvailable);
+    long    bytesAvailable	= _size - _currentRead,
+            toRead			= std::min(maxSize, bytesAvailable);
 
 	if (toRead <= 0)
 		return 0;
 
-	int count = archive_read_data(_archive, data, toRead);
+    long count = archive_read_data(_archive, data, toRead);
 
 	if (count > 0)
 	{
@@ -188,7 +188,7 @@ int ArchiveReader::readData(char *data, int maxSize, int &errorCode)
 
 std::string ArchiveReader::readAllData(int blockSize, int &errorCode)
 {
-	int size = bytesAvailable();
+    long size = bytesAvailable();
 	if (size == 0)
 		return NULL;
 
@@ -197,7 +197,7 @@ std::string ArchiveReader::readAllData(int blockSize, int &errorCode)
 	char *data = new char[size];
 	data[size - 1] = '\0';
 
-	int startOffset = _currentRead;
+    long startOffset = _currentRead;
 
 	errorCode = 0;
 	while (readData(&data[_currentRead - startOffset], blockSize, errorCode) > 0 && errorCode == 0);

--- a/CommonData/archivereader.h
+++ b/CommonData/archivereader.h
@@ -45,20 +45,20 @@ public:
 	 * @brief size Sizeof archive, or entry.
 	 * @return size found.
 	 */
-    long size() const { return _exists ? _size : 0;
+    int64_t size() const { return _exists ? _size : 0;
 	}
 
 	/**
 	 * @brief pos The current position in the file.
 	 * @return Bytes from start of file.
 	 */
-    long pos() const { return _currentRead; }
+    int64_t	 pos() const { return _currentRead; }
 
 	/**
 	 * @brief bytes Available Bytes in the file or entry.
 	 * @return Number bytes still to be read.
 	 */
-    long bytesAvailable() const { return _exists ? _size - _currentRead : 0;	}
+    int64_t bytesAvailable() const { return _exists ? _size - _currentRead : 0;	}
 
 
 	/**
@@ -68,7 +68,7 @@ public:
 	 * @param errorCode On success = 0, On Error < 0
 	 * @return Number bytes read.
 	 */
-    long readData(char * data, long maxSize, int &errorCode);
+    int64_t readData(char * data, int64_t maxSize, int &errorCode);
 
 	/**
 	 * @brief readAllData Read all file data from current postion.
@@ -136,7 +136,7 @@ private:
 	bool						_isOpen			= false,
 								_exists			= false,
 								_archiveExists	= false;
-    long						_size			= 0,
+    int64_t						_size			= 0,
 								_currentRead	= 0;
 	std::string					_archivePath,
 								_entryPath;

--- a/CommonData/archivereader.h
+++ b/CommonData/archivereader.h
@@ -45,20 +45,20 @@ public:
 	 * @brief size Sizeof archive, or entry.
 	 * @return size found.
 	 */
-	int size() const { return _exists ? _size : 0;
+    long size() const { return _exists ? _size : 0;
 	}
 
 	/**
 	 * @brief pos The current position in the file.
 	 * @return Bytes from start of file.
 	 */
-	int pos() const { return _currentRead; }
+    long pos() const { return _currentRead; }
 
 	/**
 	 * @brief bytes Available Bytes in the file or entry.
 	 * @return Number bytes still to be read.
 	 */
-	int bytesAvailable() const { return _exists ? _size - _currentRead : 0;	}
+    long bytesAvailable() const { return _exists ? _size - _currentRead : 0;	}
 
 
 	/**
@@ -68,7 +68,7 @@ public:
 	 * @param errorCode On success = 0, On Error < 0
 	 * @return Number bytes read.
 	 */
-	int readData(char * data, int maxSize, int &errorCode);
+    long readData(char * data, long maxSize, int &errorCode);
 
 	/**
 	 * @brief readAllData Read all file data from current postion.
@@ -136,7 +136,7 @@ private:
 	bool						_isOpen			= false,
 								_exists			= false,
 								_archiveExists	= false;
-	int							_size			= 0,
+    long						_size			= 0,
 								_currentRead	= 0;
 	std::string					_archivePath,
 								_entryPath;

--- a/Desktop/data/importers/jaspimporter.cpp
+++ b/Desktop/data/importers/jaspimporter.cpp
@@ -145,7 +145,7 @@ void JASPImporter::readManifest(const std::string &path)
 	std::string     manifestName		= "manifest.json";
 	ArchiveReader	manifestReader;
 	manifestReader.openEntry(path, manifestName); //separate from constructor to avoid a failed close (because an exception in constructor messes up destructor)
-    long            size				= manifestReader.bytesAvailable();
+    int64_t         size				= manifestReader.bytesAvailable();
     int             errorCode;
 
 	if (size > 0)
@@ -203,11 +203,11 @@ bool JASPImporter::parseJsonEntry(Json::Value &root, const std::string &path,  c
 		return false;
 	}
 
-    long size = dataEntry->bytesAvailable();
+    int64_t size = dataEntry->bytesAvailable();
 	if (size > 0)
 	{
 		char *data = new char[size];
-        long startOffset = dataEntry->pos();
+        int64_t startOffset = dataEntry->pos();
 		int errorCode = 0;
 		while (dataEntry->readData(&data[dataEntry->pos() - startOffset], 8016, errorCode) > 0 && errorCode == 0) ;
 

--- a/Desktop/data/importers/jaspimporter.cpp
+++ b/Desktop/data/importers/jaspimporter.cpp
@@ -145,8 +145,8 @@ void JASPImporter::readManifest(const std::string &path)
 	std::string     manifestName		= "manifest.json";
 	ArchiveReader	manifestReader;
 	manifestReader.openEntry(path, manifestName); //separate from constructor to avoid a failed close (because an exception in constructor messes up destructor)
-	int             size				= manifestReader.bytesAvailable(),
-					errorCode;
+    long            size				= manifestReader.bytesAvailable();
+    int             errorCode;
 
 	if (size > 0)
 	{
@@ -203,11 +203,11 @@ bool JASPImporter::parseJsonEntry(Json::Value &root, const std::string &path,  c
 		return false;
 	}
 
-	int size = dataEntry->bytesAvailable();
+    long size = dataEntry->bytesAvailable();
 	if (size > 0)
 	{
 		char *data = new char[size];
-		int startOffset = dataEntry->pos();
+        long startOffset = dataEntry->pos();
 		int errorCode = 0;
 		while (dataEntry->readData(&data[dataEntry->pos() - startOffset], 8016, errorCode) > 0 && errorCode == 0) ;
 

--- a/Desktop/data/importers/jaspimporterold.cpp
+++ b/Desktop/data/importers/jaspimporterold.cpp
@@ -440,7 +440,7 @@ bool JASPImporterOld::parseJsonEntry(Json::Value &root, const std::string &path,
 	if (size > 0)
 	{
 		char *data = new char[size];
-		int startOffset = dataEntry->pos();
+        long startOffset = dataEntry->pos();
 		int errorCode = 0;
 		while (dataEntry->readData(&data[dataEntry->pos() - startOffset], 8016, errorCode) > 0 && errorCode == 0) ;
 

--- a/Desktop/data/importers/jaspimporterold.cpp
+++ b/Desktop/data/importers/jaspimporterold.cpp
@@ -440,7 +440,7 @@ bool JASPImporterOld::parseJsonEntry(Json::Value &root, const std::string &path,
 	if (size > 0)
 	{
 		char *data = new char[size];
-        long startOffset = dataEntry->pos();
+        int64_t startOffset = dataEntry->pos();
 		int errorCode = 0;
 		while (dataEntry->readData(&data[dataEntry->pos() - startOffset], 8016, errorCode) > 0 && errorCode == 0) ;
 


### PR DESCRIPTION
When reading the JASP file, it reads the number of bytes with an 'int' type, which means that if a file is bigger than 2GB, it fails. But the archive library we use, uses the 'long' type, and can handle much larger file.

Fixes https://github.com/jasp-stats/jasp-issues/issues/3725

