### PR TITLE
check if analysis needs to be refreshed before opening ploteditor

### DIFF
--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -38,11 +38,23 @@ void PlotEditorModel::showPlotEditor(int id, QString options)
 	//maybe the following checks are a bit extreme but whatever
 	if(!_analysis || !_imgOptions.isMember("type") || _imgOptions["type"].type() != Json::stringValue || _imgOptions["type"] != "interactive")
 		return;
+	
+	if (_analysis->needsRefresh())
+	{
+		if (	_analysis->storedWithoutState() 
+			?	MessageForwarder::showYesNo(tr("Stored without state"),		tr("This analysis was stored without state, to edit the plot it must be refreshed first.\n\nRefresh the analysis?"))
+			:	MessageForwarder::showYesNo(tr("Version incompatibility"),	tr("This analysis was created in an older version of JASP, to edit the plot it must be refreshed first.\n\nRefresh the analysis?"))
+			)
+			_analysis->refresh();
+	}
+	else
+	{
 
-	setup();
-
-	if (_validOptions)
-		setVisible(true);
+		setup();
+	
+		if (_validOptions)
+			setVisible(true);
+	}
 	setLoading(false);
 }
 

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -114,7 +114,7 @@ const Settings::Setting Settings::Values[] = {
 	{"localConfigurationPath",		""		},
 	{"useConfigurationFile",		true	},
 	{"startMaximized",				false	},
-	{"storeStateEtc",				false	},
+	{"storeStateEtc",				true	},
 	{"autoSaveOn",					true	},
 	{"autoSaveInterval",			5*60	},
 };	
@@ -122,7 +122,11 @@ const Settings::Setting Settings::Values[] = {
 QVariant Settings::value(Settings::Type key)
 {
 	if(resultXmlCompare::compareResults::theOne()->testMode())
-		return defaultValue(key);
+		switch(key)
+		{
+		default:						return defaultValue(key);
+		case Type::STORE_STATE_ETC:		return false; //Dont store state in the data library
+		}
 	
 	return getSettings()->value(Settings::Values[key].type, defaultValue(key));
 }


### PR DESCRIPTION
fixes jasp-stats/jasp-issues#3755

Also store state etc again by default, except for for the data library