### PR TITLE
Add the R functions strftime and strptime to the whitelist

### DIFF
--- a/Common/r_functionwhitelist.cpp
+++ b/Common/r_functionwhitelist.cpp
@@ -191,6 +191,8 @@ const std::set<std::string> R_FunctionWhiteList::functionWhiteList {
 	"sqrt",
 	"stack",
 	"str",
+	"strftime",
+	"strptime",
 	"strsplit",
 	"sub",
 	"subset",


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3768

these are for converting from/ to POSIX/ character objects (see e.g., https://www.statology.org/strptime-strftime-r/) 