### PR TITLE
Initialization of row component fails sometimes

### DIFF
--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -76,10 +76,9 @@ void ListModel::addControlError(const QString &error) const
 	_listView->addControlError(error);
 }
 
-void ListModel::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap, bool reInit)
+void ListModel::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap)
 {
-
-	_initTerms(terms, allValuesMap, reInit);
+    _initTerms(terms, allValuesMap, true);
 }
 
 void ListModel::_initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap, bool initRowControls)

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -72,7 +72,7 @@ public:
 			void					setNeedsSource(bool needs)												{ _needsSource = needs;			}
 			void					addControlError(const QString& error)						const;
 	virtual void					refresh();
-			virtual void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap = {}, bool reInit = false);
+            virtual void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap = {});
 			Terms					getSourceTerms();
 			void					setColumnsUsedForLabels(const QStringList& columns)						{ _columnsUsedForLabels = columns; }
 			void					setRowComponent(QQmlComponent* rowComponents);

--- a/QMLComponents/models/listmodelfactorsform.cpp
+++ b/QMLComponents/models/listmodelfactorsform.cpp
@@ -234,7 +234,7 @@ void ListModelFactorsForm::ensureNesting()
 		{
 			// By changing the current model, avoid calling again the ensureNesting slot
 			_ensuringNesting = true;
-			currentModel->initTerms(newTerms, {}, true);
+            currentModel->initTerms(newTerms);
 			_ensuringNesting = false;
 		}
 	}
@@ -244,7 +244,7 @@ void ListModelFactorsForm::ensureNesting()
 		Terms newTerms = onderModel->terms();
 		newTerms.setUndraggableTerms(currentModel->terms());
 		if (!newTerms.strictlyEquals(onderModel->terms()))
-			onderModel->initTerms(newTerms, {}, true);
+            onderModel->initTerms(newTerms);
 	}
 
 }
@@ -265,7 +265,7 @@ void ListModelFactorsForm::nestedChangedHandler()
 			Terms newTerms = onderModel->terms();
 			newTerms.setUndraggableTerms(currentModel->terms());
 			if (!newTerms.strictlyEquals(onderModel->terms()))
-				onderModel->initTerms(newTerms, {}, true);
+                onderModel->initTerms(newTerms);
 		}
 	}
 	else
@@ -277,7 +277,7 @@ void ListModelFactorsForm::nestedChangedHandler()
 			Terms draggableTerms = currentModel->terms();
 			draggableTerms.setDraggable(true);
 			if (!draggableTerms.strictlyEquals(currentModel->terms()))
-				currentModel->initTerms(draggableTerms, {}, true);
+                currentModel->initTerms(draggableTerms, {});
 		}
 	}
 }

--- a/QMLComponents/models/listmodelinteractionassigned.cpp
+++ b/QMLComponents/models/listmodelinteractionassigned.cpp
@@ -33,32 +33,29 @@ ListModelInteractionAssigned::ListModelInteractionAssigned(JASPListControl* list
 	_variablesList = qobject_cast<VariablesListBase*>(listView);
 }
 
-void ListModelInteractionAssigned::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap, bool reInit)
+void ListModelInteractionAssigned::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap)
 {
 	// Initialization of the terms can be a re-initialization: in this case the interaction terms can be lost
 	// So the interaction terms must be kept, and if their components are in the new terms, then add this interaction.
 	Terms newTerms = terms;
 
-	if (reInit)
-	{
-		Terms oldInteractions = this->terms();
-		for (const Term& oldInteraction : oldInteractions)
-		{
-			if (oldInteraction.size() > 1)
-			{
-				bool add = true;
-				for (const QString& comp : oldInteraction.components())
-				{
-					if (!terms.containsValue(comp))
-						add = false;
-				}
-				if (add)
-					newTerms.add(oldInteraction);
-			}
-		}
-	}
+    Terms oldInteractions = this->terms();
+    for (const Term& oldInteraction : oldInteractions)
+    {
+        if (oldInteraction.size() > 1)
+        {
+            bool add = true;
+            for (const QString& comp : oldInteraction.components())
+            {
+                if (!terms.containsValue(comp))
+                    add = false;
+            }
+            if (add)
+                newTerms.add(oldInteraction);
+        }
+    }
 	_setTerms(newTerms);
-	ListModelAssignedInterface::initTerms(this->terms(), allValuesMap, reInit);
+    ListModelAssignedInterface::initTerms(this->terms(), allValuesMap);
 }
 
 void ListModelInteractionAssigned::removeTerms(const QList<int> &indices)

--- a/QMLComponents/models/listmodelinteractionassigned.h
+++ b/QMLComponents/models/listmodelinteractionassigned.h
@@ -30,7 +30,7 @@ class ListModelInteractionAssigned : public ListModelAssignedInterface
 public:
 	ListModelInteractionAssigned(JASPListControl* listView);
 
-	void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& = {}, bool reInit = false)	override;
+    void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& = {})          override;
 	Terms			addTerms(const Terms& terms, int dropItemIndex = -1, const Terms::RelatedValuesPerTerm& rowValues = {})	override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)					override;
 	void			removeTerms(const QList<int> &indices)											override;

--- a/QMLComponents/models/listmodelmeasurescellsassigned.cpp
+++ b/QMLComponents/models/listmodelmeasurescellsassigned.cpp
@@ -96,9 +96,9 @@ QList<int> ListModelMeasuresCellsAssigned::indexesFromTerms(const Terms &terms) 
 	return indexes;
 }
 
-void ListModelMeasuresCellsAssigned::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm &allValuesMap, bool reInit)
+void ListModelMeasuresCellsAssigned::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm &allValuesMap)
 {
-	ListModelAssignedInterface::initTerms(terms, allValuesMap, reInit);
+    ListModelAssignedInterface::initTerms(terms, allValuesMap);
 	_fitTermsWithLevels();
 }
 

--- a/QMLComponents/models/listmodelmeasurescellsassigned.h
+++ b/QMLComponents/models/listmodelmeasurescellsassigned.h
@@ -33,7 +33,7 @@ public:
 	QVariant		data(const QModelIndex &index, int role = Qt::DisplayRole)										const	override;
 	Terms			termsFromIndexes(const QList<int> &indexes)														const	override;
 	QList<int>		indexesFromTerms(const Terms &terms)															const	override;
-	void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap = {}, bool reInit = false)		override;
+    void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap = {})                     override;
 	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, const Terms::RelatedValuesPerTerm& rowValues = {}) override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)											override;
 	void			removeTerms(const QList<int>& indexes) override;

--- a/QMLComponents/models/listmodelmultitermsassigned.cpp
+++ b/QMLComponents/models/listmodelmultitermsassigned.cpp
@@ -30,7 +30,7 @@ ListModelMultiTermsAssigned::ListModelMultiTermsAssigned(JASPListControl* listVi
 	_allowDuplicatesInMultipleColumns = listView->property("allowDuplicatesInMultipleColumns").toBool();
 }
 
-void ListModelMultiTermsAssigned::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap, bool)
+void ListModelMultiTermsAssigned::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap)
 {
 	beginResetModel();
 

--- a/QMLComponents/models/listmodelmultitermsassigned.h
+++ b/QMLComponents/models/listmodelmultitermsassigned.h
@@ -27,7 +27,7 @@ class ListModelMultiTermsAssigned: public ListModelAssignedInterface
 public:
 	ListModelMultiTermsAssigned(JASPListControl* listView, int columns = 2);
 
-	void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap = {}, bool reInit = false)			override;
+    void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap = {})                         		override;
 	Terms			canAddTerms(const Terms& terms)																				const	override;
 	Terms			addTerms(const Terms &terms, int dropItemIndex = -1, const Terms::RelatedValuesPerTerm& rowValues = {})				override;
 	void			moveTerms(const QList<int>& indexes, int dropItemIndex = -1)														override;

--- a/QMLComponents/models/listmodeltermsassigned.cpp
+++ b/QMLComponents/models/listmodeltermsassigned.cpp
@@ -31,9 +31,9 @@ ListModelTermsAssigned::ListModelTermsAssigned(JASPListControl* listView)
 {
 }
 
-void ListModelTermsAssigned::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap, bool reInit)
+void ListModelTermsAssigned::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap)
 {
-	ListModelAssignedInterface::initTerms(terms, allValuesMap, reInit);
+    ListModelAssignedInterface::initTerms(terms, allValuesMap);
 
 	if (availableModel())
 		availableModel()->removeTermsInAssignedList();

--- a/QMLComponents/models/listmodeltermsassigned.h
+++ b/QMLComponents/models/listmodeltermsassigned.h
@@ -29,9 +29,9 @@ class ListModelTermsAssigned : public ListModelAssignedInterface
 public:
 	ListModelTermsAssigned(JASPListControl* listView);
 	
-	void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap = {}, bool reInit = false)		override;
+    void			initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& allValuesMap = {})                                 override;
 	Terms			canAddTerms(const Terms& terms)																				const	override;
-	Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, const Terms::RelatedValuesPerTerm& rowValues = {})	override;
+    Terms			addTerms(const Terms& termsToAdd, int dropItemIndex = -1, const Terms::RelatedValuesPerTerm& rowValues = {})        override;
 	void			removeTerm(int index);
 
 	virtual void	changeTerm(int index, const Term& term);

--- a/QMLComponents/models/listmodeltermsavailable.cpp
+++ b/QMLComponents/models/listmodeltermsavailable.cpp
@@ -29,7 +29,7 @@ ListModelTermsAvailable::ListModelTermsAvailable(JASPListControl *listView, cons
 	_setTerms(terms);
 }
 
-void ListModelTermsAvailable::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm&, bool)
+void ListModelTermsAvailable::initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm&)
 {
 	beginResetModel();
 	
@@ -224,7 +224,7 @@ void ListModelTermsAvailable::removeTermsInAssignedList()
 	{
 		Terms assignedTerms = modelAssign->terms();
 		if (assignedTerms.discardWhatIsntTheseTerms(_allSortedTerms))
-			modelAssign->initTerms(assignedTerms, {}, true); // initTerms call removeTermsInAssignedList
+            modelAssign->initTerms(assignedTerms); // initTerms call removeTermsInAssignedList
 		newTerms.remove(assignedTerms);
 	}
 

--- a/QMLComponents/models/listmodeltermsavailable.h
+++ b/QMLComponents/models/listmodeltermsavailable.h
@@ -33,7 +33,7 @@ public:
 	ListModelTermsAvailable(JASPListControl* listView, const Terms& terms = Terms());
 
 	virtual const Terms& allTerms()																											const { return _allSortedTerms; }
-	void initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& _rowControlsValues = {}, bool reInit = false)	override;
+    void initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm& _rowControlsValues = {})                          override;
 	virtual void removeTermsInAssignedList();
 	
 			void sortItems(SortType sortType)											override;


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jaspProcess/pull/166#issuecomment-3381081725

The `reInit` argument of the `initTerms` function was confusing, and was in fact unnecessary.
It was used as `initRowControls` argument of `_initTerms` and this was misleading, because the row controls must be always set when `initTerms` is called.

A extra test is added in Tab View test of the jaspTestModule