### PR TITLE
Options not set when loading analysis with TabViews

### DIFF
--- a/QMLComponents/controls/rowcontrols.cpp
+++ b/QMLComponents/controls/rowcontrols.cpp
@@ -27,15 +27,14 @@
 #include <QQmlContext>
 
 RowControls::RowControls(ListModel* parent
-						 , QQmlComponent* component
-						 , const QMap<QString, Json::Value>& rowValues)
- : QObject(parent), _parentModel(parent), _rowComponent(component), _initialValues(rowValues)
+						 , QQmlComponent* component)
+ : QObject(parent), _parentModel(parent), _rowComponent(component)
 {
 }
 
 // Cannot do this code in the constructor: the Component create function (comp->create(context)) will call the addJASPControl method in JASPControl (or ListView),
 // So this RowControls instance needs to exist already.
-void RowControls::init(int row, const Term& key, bool isNew)
+void RowControls::initValues(int row, const Term& key, const QMap<QString, Json::Value>& rowValues)
 {
 	JASPListControl* listView = _parentModel->listView();
 
@@ -43,7 +42,7 @@ void RowControls::init(int row, const Term& key, bool isNew)
 	context->setContextProperty("isDynamic", true);
 	context->setContextProperty("form", listView->form());
 	context->setContextProperty("listView", listView);
-	context->setContextProperty("isNew", isNew);
+	context->setContextProperty("isNew", rowValues.empty());
 	context->setContextProperty("rowIndex",	row);
 	context->setContextProperty("rowLabel", key.label());
 	context->setContextProperty("rowValue", key.value());
@@ -51,25 +50,45 @@ void RowControls::init(int row, const Term& key, bool isNew)
 
 
 	_rowObject = qobject_cast<QQuickItem*>(_rowComponent->create(context)); // The _rowJASPControlMap will be filled during this step
+	assert(_rowObject);
+	if (!_rowObject)
+	{
+		Log::log() << "Could not create control in " << listView->name() << std::endl;
+		return;
+	}
+
 	_rowObject->setParent(_parentModel);
 	_context = context;
+
+	QList<JASPControl*> controls = _rowJASPControlMap.values();
+	for (JASPControl* control : controls)
+		control->setUp();
 
 	_initialized = true;
 	emit initializedChanged();
 
-	if (_rowObject)	_initializeControls();
-	else			Log::log() << "Could not create control in ListView " << listView->name() << std::endl;
+	_setValues(rowValues);
 }
 
-void RowControls::_initializeControls(bool useInitialValue)
+void RowControls::resetValues(int row, const Term &key, const QMap<QString, Json::Value>& rowValues)
+{
+	// Cannot use qmlContext(item) : setContextProperty would generate: 'Cannot set property on internal context.' error
+	_context->setContextProperty("rowIndex", row);
+	_context->setContextProperty("rowLabel", key.label());
+	_context->setContextProperty("rowValue", key.value());
+	_context->setContextProperty("rowType", columnTypeToQString(key.type()));
+	_context->setContextProperty("isNew", false);
+
+	_setValues(rowValues);
+}
+
+void RowControls::_setValues(const QMap<QString, Json::Value>& rowValues)
 {
 	// The controls (when created or reused) need to be initialized
 	QList<JASPControl*> controls = _rowJASPControlMap.values();
 	JASPListControl* parentControl = _parentModel->listView();
 	AnalysisForm* form = parentControl->form();
 
-	for (JASPControl* control : controls)
-		control->setUp();
 
 	if (form)
 		form->sortControls(controls);
@@ -83,8 +102,8 @@ void RowControls::_initializeControls(bool useInitialValue)
 
 		Json::Value optionValue = Json::nullValue;
 
-		if (useInitialValue && _initialValues.contains(control->name()))
-			optionValue = _initialValues[control->name()];
+		if (rowValues.contains(control->name()))
+			optionValue = rowValues[control->name()];
 		else
 		{
 			// It it exists, reuse the current value.
@@ -99,18 +118,6 @@ void RowControls::_initializeControls(bool useInitialValue)
 	if (form)
 		// setInitialized binds value to the control, but does not signal the change. So we have to manually emit the signal
 		emit parentControl->boundValueChanged(parentControl);
-}
-
-void RowControls::setContext(int row, const Term &key)
-{
-	// Cannot use qmlContext(item) : setContextProperty would generate: 'Cannot set property on internal context.' error
-	_context->setContextProperty("rowIndex", row);
-	_context->setContextProperty("rowLabel", key.label());
-	_context->setContextProperty("rowValue", key.value());
-	_context->setContextProperty("rowType", columnTypeToQString(key.type()));
-	_context->setContextProperty("isNew", false);
-
-	_initializeControls(false);
 }
 
 bool RowControls::addJASPControl(JASPControl *control)

--- a/QMLComponents/controls/rowcontrols.h
+++ b/QMLComponents/controls/rowcontrols.h
@@ -38,11 +38,10 @@ public:
 	
 	RowControls(
 			ListModel* parent
-			, QQmlComponent* components
-			, const QMap<QString, Json::Value>& rowValues);
+            , QQmlComponent* components);
 
-	void										init(int row, const Term& key, bool isNew);
-	void										setContext(int row, const Term& key);
+    void										initValues(int row, const Term& key, const QMap<QString, Json::Value>& rowValues);
+    void										resetValues(int row, const Term& key, const QMap<QString, Json::Value>& rowValues);
 	QQmlComponent*								getComponent()								const	{ return _rowComponent; }
 	QQuickItem*									getRowObject()								const	{ return _rowObject;			}
 	const QMap<QString, JASPControl*>&			getJASPControlsMap()						const	{ return _rowJASPControlMap;	}
@@ -56,14 +55,13 @@ signals:
 
 private:
 
-	void										_initializeControls(bool useInitialValue = true);
+    void                                        _setValues(const QMap<QString, Json::Value>& rowValues);
 
 	ListModel*								_parentModel;
 	QQmlComponent*							_rowComponent	= nullptr;
 	QQuickItem*								_rowObject		= nullptr;
 	QMap<QString, JASPControl*>				_rowJASPControlMap;
 	QQmlContext*							_context;
-	QMap<QString, Json::Value>				_initialValues;
 	bool									_initialized	= false;
 };
 

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -85,15 +85,9 @@ void ListModel::_initTerms(const Terms &terms, const Terms::RelatedValuesPerTerm
 {
 	beginResetModel();
 	if (initRowControls)
-	{
-		for(auto & k : _rowControlsMap.keys())
-		{
-			_rowControlsMap[k]->disconnectAndDeleteControls();
-			_rowControlsMap[k]->deleteLater();
-		}
-		_rowControlsMap.clear();
+		// If some row controls are not used anymore, they will be removed during setUpRowControls
 		_rowControlsValues = allValuesMap;
-	}
+
 	_setTerms(terms);
 	endResetModel();
 
@@ -206,23 +200,21 @@ void ListModel::setUpRowControls()
 	{
 		if (!_rowControlsMap.contains(term.value()))
 		{
-			
-			bool hasOptions = _rowControlsValues.contains(term.value());
-			RowControls* rowControls = new RowControls(this, _rowComponent, _rowControlsValues[term.value()]);
+			RowControls* rowControls = new RowControls(this, _rowComponent);
 			_rowControlsMap[term.value()] = rowControls;
-			rowControls->init(row, term, !hasOptions);
+			rowControls->initValues(row, term, _rowControlsValues[term.value()]);
 		}
 		else
-			_rowControlsMap[term.value()]->setContext(row, term);
+			_rowControlsMap[term.value()]->resetValues(row, term, _rowControlsValues[term.value()]);
+
 		row++;
 	}
 	
+	// Disconnect and delete all controls that are not used anymore
 	QStringList removedKeys;
 	for (const QString& key : _rowControlsMap.keys())
 		if (!terms().containsValue(key))
 		{
-			// If some row controls are not used anymore, if they use some sources, they must be disconnected from these sources
-			// If a source changes and emits a signal, these controls should not be activated (cf. https://github.com/jasp-stats/jasp-test-release/issues/1786)
 			_rowControlsMap[key]->disconnectAndDeleteControls();
 			removedKeys.append(key);
 		}


### PR DESCRIPTION
When testing the TabView test analysis in the jaspTestModule, when duplicating the analysis, the TabViews did not get the right values, and sometimes it even crashed.
The problem was that the controls in a Row Control are setup sometimes several times. The controls in the Row Control should be set up only once: if the Row Control is reused, only the values (and the context properties) should be reset.