### PR TITLE
make sure to load the relevant properties from DESCRIPTION instead of Description.qml

### DIFF
--- a/Desktop/modules/description/description.cpp
+++ b/Desktop/modules/description/description.cpp
@@ -33,7 +33,7 @@ void Description::setUpDelayedUpdate()
 	_timer.setInterval(300); //Some interval? Could be shorter too. Lets see how it works out
 	_timer.callOnTimeout([=]()
 	{
-		Log::log() << "Description delay timer done, update!" << std::endl;
+		//Log::log() << "Description delay timer done, update!" << std::endl;
 		try { desc->iShouldBeUpdated(desc); }
 		catch (std::exception e) { Log::log() << "iShouldBeUpdated had exception " << e.what() << std::endl; }
 	});

--- a/Desktop/modules/description/description.h
+++ b/Desktop/modules/description/description.h
@@ -24,15 +24,15 @@ class AnalysisEntry;
 class Description : public QQuickItem
 {
 	Q_OBJECT
-	Q_PROPERTY(QString					name			READ name				WRITE setName				NOTIFY nameChanged				)
-	Q_PROPERTY(QString					title			READ title				WRITE setTitle				NOTIFY titleChanged				)
+	Q_PROPERTY(QString					name			READ name				WRITE setDummy						NOTIFY nameChanged				)
+	Q_PROPERTY(QString					title			READ title				WRITE setDummy				NOTIFY titleChanged				)
 	Q_PROPERTY(QString					icon			READ icon				WRITE setIcon				NOTIFY iconChanged				)
-	Q_PROPERTY(QString					description		READ description		WRITE setDescription		NOTIFY descriptionChanged		)
-	Q_PROPERTY(QString					version			READ version			WRITE setVersion			NOTIFY versionChanged			)
-	Q_PROPERTY(QString					author			READ author				WRITE setAuthor				NOTIFY authorChanged			)
-	Q_PROPERTY(QString					maintainer		READ maintainer			WRITE setMaintainer			NOTIFY maintainerChanged		)
-	Q_PROPERTY(QUrl						website			READ website			WRITE setWebsite			NOTIFY websiteChanged			)
-	Q_PROPERTY(QString					license			READ license			WRITE setLicense			NOTIFY licenseChanged			)
+	Q_PROPERTY(QString					description		READ description		WRITE setDummy				NOTIFY descriptionChanged		)
+	Q_PROPERTY(QString					version			READ version			WRITE setDummy				NOTIFY versionChanged			)
+	Q_PROPERTY(QString					author			READ author				WRITE setDummy				NOTIFY authorChanged			)
+	Q_PROPERTY(QString					maintainer		READ maintainer			WRITE setDummy				NOTIFY maintainerChanged		)
+	Q_PROPERTY(QUrl						website			READ website			WRITE setDummyUrl			NOTIFY websiteChanged			)
+	Q_PROPERTY(QString					license			READ license			WRITE setDummy				NOTIFY licenseChanged			)
 	///requiresData should really be called defaultRequiresData or something. Because that is what it does. But it would be a lot of work to change all the qmls...
 	Q_PROPERTY(bool						requiresData	READ requiresDataDef	WRITE setRequiresDataDef	NOTIFY requiresDataDefChanged	)
 	Q_PROPERTY(bool						preloadData		READ preloadData		WRITE setPreloadData		NOTIFY preloadDataChanged		)
@@ -43,6 +43,9 @@ public:
 	Description(QQuickItem *parent = nullptr);
 	~Description();
 
+	void			setDummy(QString ) {}; // Temporary placeholder to make existing entries in Description.qml not stop it from loading, can be removed once all modules are updated
+	void			setDummyUrl(QUrl ) {}; // Temporary placeholder to make existing entries in Description.qml not stop it from loading, can be removed once all modules are updated
+	
 	QString			name()				const { return _name;						}
 	QString			title()				const { return _title;						}
 	QString			icon()				const { return _icon;						}

--- a/Desktop/modules/description/description.h
+++ b/Desktop/modules/description/description.h
@@ -115,7 +115,7 @@ private:
 	QUrl					_website;
 	Version					_version;
 	bool					_requiresDataDef	= true,
-							_hasWrappers		= true,
+							_hasWrappers		= false,
 							_preloadData		= true;
 	DynamicModule		*	_dynMod				= nullptr;
 	QList<EntryBase*>		_entries;

--- a/Desktop/modules/description/description.h
+++ b/Desktop/modules/description/description.h
@@ -24,10 +24,10 @@ class AnalysisEntry;
 class Description : public QQuickItem
 {
 	Q_OBJECT
-	Q_PROPERTY(QString					name			READ name				WRITE setDummy						NOTIFY nameChanged				)
-	Q_PROPERTY(QString					title			READ title				WRITE setDummy				NOTIFY titleChanged				)
+	Q_PROPERTY(QString					name			READ name				WRITE setDummy				NOTIFY nameChanged				)
+	Q_PROPERTY(QString					title			READ title				WRITE setTitle				NOTIFY titleChanged				)
 	Q_PROPERTY(QString					icon			READ icon				WRITE setIcon				NOTIFY iconChanged				)
-	Q_PROPERTY(QString					description		READ description		WRITE setDummy				NOTIFY descriptionChanged		)
+	Q_PROPERTY(QString					description		READ description		WRITE setDescription		NOTIFY descriptionChanged		)
 	Q_PROPERTY(QString					version			READ version			WRITE setDummy				NOTIFY versionChanged			)
 	Q_PROPERTY(QString					author			READ author				WRITE setDummy				NOTIFY authorChanged			)
 	Q_PROPERTY(QString					maintainer		READ maintainer			WRITE setDummy				NOTIFY maintainerChanged		)
@@ -115,8 +115,8 @@ private:
 	QUrl					_website;
 	Version					_version;
 	bool					_requiresDataDef	= true,
-							_hasWrappers		= false,
-							_preloadData		= false;
+							_hasWrappers		= true,
+							_preloadData		= true;
 	DynamicModule		*	_dynMod				= nullptr;
 	QList<EntryBase*>		_entries;
 	QTimer					_timer;

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -314,9 +314,6 @@ void DynamicModule::loadDESCRIPTION(const QString &descriptionText)
 		entries[entryName] = entryText;
 	}
 	
-	
-	_description->setTitle(			entries["Title"]);
-	_description->setDescription(	entries["Description"]);
 	_description->setVersion(		entries["Version"]);
 	_description->setAuthor(		entries["Author"]);
 	_description->setMaintainer(	entries["Maintainer"]);

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -36,6 +36,7 @@
 #include "description/description.h"
 #include "utilities/extractarchive.h"
 #include "utilities/qmlutils.h"
+#include "utilities/qutils.h"
 #include "mainwindow.h"
 
 #ifdef __APPLE__
@@ -74,6 +75,7 @@ DynamicModule::DynamicModule(std::string modulePackageFile, QObject *parent, boo
 	_moduleFolder	= QFileInfo(AppDirs::userModulesDir() + QString::fromStdString(_name) + "/");
 
 	loadDescriptionFromArchive(_modulePackage);
+	loadDESCRIPTION(tq(getDESCRIPTIONFromArchive(_modulePackage)));
 }
 
 QFileInfo DynamicModule::developmentModuleFolder()
@@ -102,6 +104,7 @@ DynamicModule::DynamicModule(QObject * parent) : QObject(parent), _isDeveloperMo
 	_developmentModuleName = _name;
 
 	loadDescriptionFromFolder(_modulePackage);
+	loadDESCRIPTION(tq(getDESCRIPTIONFromFolder(_modulePackage)));
 }
 
 
@@ -120,6 +123,7 @@ DynamicModule::DynamicModule(QObject * parent, QString libpath) : QObject(parent
 	_developmentModuleName = _name;
 
 	loadDescriptionFromFolder(_modulePackage);
+	loadDESCRIPTION(tq(getDESCRIPTIONFromFolder(_modulePackage)));
 	setInstalled(true);
 }
 
@@ -218,7 +222,9 @@ void DynamicModule::initialize()
 	
 	QFile DESCRIPTION(checkForExistence("DESCRIPTION", true).absoluteFilePath());
 	DESCRIPTION.open(QFile::ReadOnly);
-	loadRequiredModulesFromDESCRIPTIONTxt(DESCRIPTION.readAll());
+	QString txt = DESCRIPTION.readAll();
+	loadDESCRIPTION(txt);
+	loadRequiredModulesFromDESCRIPTIONTxt(txt);
 }
 
 void DynamicModule::loadDescriptionFromFolder( const std::string & folderPath, bool onlyIfNotLoadedYet)
@@ -258,17 +264,18 @@ void DynamicModule::loadRequiredModulesFromDESCRIPTIONTxt(const QString & DESCRI
 	stringset reqModules;
 	
 	
-	QRegularExpression isItImports("Imports:");
+	static QRegularExpression isItImports("Imports:");
 	
 
-	QRegularExpressionMatch m = isItImports.match(DESCRIPTION);
+	QRegularExpressionMatch m;
+	m = isItImports.match(DESCRIPTION);
 	
 	if(!m.hasMatch()) return;
 	
 	size_t importsEnd = m.capturedEnd();
 
 	//Aka check for stuff like "name (...),", "name (...)", "name," or "name" 
-	QRegularExpression pkgEx("[[:space:]]*([[:alnum:].]+)[[:space:]]*(\\([^)]\\))?(,)?");
+	static QRegularExpression pkgEx("[[:space:]]*([[:alnum:].]+)[[:space:]]*(\\([^)]\\))?(,)?");
 	
 	QRegularExpressionMatchIterator pkgMIt = pkgEx.globalMatch(DESCRIPTION, importsEnd);
 
@@ -289,6 +296,33 @@ void DynamicModule::loadRequiredModulesFromDESCRIPTIONTxt(const QString & DESCRI
 	setImportsR(reqModules);
 }
 
+
+void DynamicModule::loadDESCRIPTION(const QString &descriptionText)
+{
+	assert(_description);
+	
+	std::map<QString, QString> entries;
+	
+	static QRegularExpression entriesRegex("(\\S+):\\s*(.+(\\n\\s.+)*)\\n");
+	
+
+	for(auto & m : entriesRegex.globalMatch(descriptionText))
+	{
+		QString entryName = m.captured(1),
+				entryText = m.captured(2);
+		
+		entries[entryName] = entryText;
+	}
+	
+	
+	_description->setTitle(			entries["Title"]);
+	_description->setDescription(	entries["Description"]);
+	_description->setVersion(		entries["Version"]);
+	_description->setAuthor(		entries["Author"]);
+	_description->setMaintainer(	entries["Maintainer"]);
+	_description->setWebsite(		entries["Website"]);
+	_description->setLicense(		entries["License"]);
+}
 
 
 Description * DynamicModule::instantiateDescriptionQml(const QString & descriptionTxt, const QUrl & url, const std::string & moduleName)
@@ -621,7 +655,9 @@ void DynamicModule::reloadDescription()
 {
 	try
 	{
-		loadDescriptionFromFolder(fq(_moduleFolder.absoluteFilePath() + "/" + nameQ() + "/"), false);
+		std::string folder = fq(_moduleFolder.absoluteFilePath() + "/" + nameQ() + "/");
+		loadDescriptionFromFolder(folder, false);
+		loadDESCRIPTION(tq(getDESCRIPTIONFromFolder(folder)));
 	}
 	catch(std::runtime_error e) { return; } //If it doesnt work then never mind.
 }

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -171,6 +171,7 @@ public:
 
 	void initialize();
 	void loadDescriptionQml(const QString		& descriptionTxt,	const QUrl		& url);
+	void loadDESCRIPTION(	const QString		& descriptionText);
 	void loadUpgradesQML(	const QString		& upgradesTxt,		const QUrl		& url);
 	bool hasUpgradesToApply(const std::string	& function,			const Version	& version);
 	void applyUpgrade(		const std::string	& function,			const Version	& version, Json::Value & analysesJson, UpgradeMsgs & msgs, StepsTaken & stepsTaken);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1251

Will still need to update all the modules to avoid having ridiculous names like "A blabla module for JASP" as titles...
So setting it as draft until then.

