### PR TITLE
Use sourceID and name in R Sources in the right way

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -1097,7 +1097,8 @@ void Analysis::checkForRSources()
 	}
 
 	//First check meta for qmlSources and collections
-	std::set<std::string> sourceIDs, isCollection;
+	QMap<std::string, std::string> sourceNamesMap; // Map source name to source ID
+	std::set<std::string> isCollection;
 
 	std::function<void(Json::Value & meta)> findNewSource = [&](Json::Value & meta) -> void
 	{
@@ -1109,8 +1110,8 @@ void Analysis::checkForRSources()
 			//Here we collect the meta's names for collections and qmlSources
 			if(meta.isMember("type"))
 			{
-					if(		meta["type"].asString() == "qmlSource")		sourceIDs.insert(	meta["name"].asString());
-					else if(meta["type"].asString() == "collection")	isCollection.insert(meta["name"].asString());
+				if(		meta["type"].asString() == "qmlSource")		sourceNamesMap[meta["name"].asString()] = meta.isMember("sourceID") ? meta["sourceID"].asString() : meta["name"].asString();
+				else if(meta["type"].asString() == "collection")	isCollection.insert(meta["name"].asString());
 			}
 
 			if(meta.isMember("meta")) //means there is an array of more meta below there
@@ -1131,11 +1132,11 @@ void Analysis::checkForRSources()
 
 		else if(results.isObject())
 		{
-			if(results.isMember("name") && sourceIDs.count(results["name"].asString()) > 0)
+			if(results.isMember("name") && sourceNamesMap.count(results["name"].asString()) > 0)
 				newSources[results["sourceID"].asString()] = results["json"]; //We take the json from this qmlSource as that is the value we want
 
 			for(const std::string & memberName : results.getMemberNames())
-				if(sourceIDs.count(memberName) > 0)
+				if(sourceNamesMap.count(memberName) > 0)
 					newSources[results[memberName]["sourceID"].asString()] = results[memberName]["json"];
 
 				else if(isCollection.count(memberName) > 0 && results[memberName].isMember("collection")) //Checking for "collection" is to avoid stupid crashes but shouldnt really be necessary anyhow
@@ -1147,6 +1148,7 @@ void Analysis::checkForRSources()
 	//And then calculate the delta
 	std::set<std::string> removeAfterwards;
 
+	QList<std::string> sourceIDs = sourceNamesMap.values();
 	for(auto & sourceJson : _rSources)
 		// The sourceIDs come from the meta values, newSources from the results
 		// If a result of a source does not change, only its meta value is send, not its result.


### PR DESCRIPTION
During the development of the "Moderated Non-LInear Factor" analysis of the SEM module, @juliuspfadt came accross a strange bug: this analysis uses a R source, and it gives another value for the name of the R source and the sourceID.
The handling of R source could not cope with this. What happens is that in the meta part of the result, only the name of the R source was used. and only in the value part of the result the sourceID is given.
The sources are kept in the analysis with the _rSources property which is a map from the sourceID to its json value (the sourceID is what is used in QML to specify a R source).
The value of the R sources is given in the result, only if it is new or has another value.
But to detect whether a R source still exists, it searches in the _rSources the ones that do not exist anymore in the meta. As the _rSources uses the sourceID and the meta uses the source name, if they are not the same, the R source was then removed, and the controls depending of this R source in the QML form was removed.

In https://github.com/jasp-stats/jaspBase/pull/179, the jaspBase is changed so that the user does not have to specify a sourceID to define a R source (this is quite confusing), it takes per default the name of the source. Moreover the meta gets also the sourceID as property.
In this PR, the confusion in the code between sourceID and source name is fixed.

The "Test R source" analysis of jaspTestModule will be also changed to test different possibilities. But as jaspTestModule depends on jaspBase, the renv.lock must be changed to load the new version of jaspBase: so the changes in jaspBase must be first merged, before new tests on R sources can be added in jaspTestModule.
