### PR TITLE
fixes crash on saving a workspace without data after closing a workspace without data

### DIFF
--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -1465,7 +1465,7 @@ void MainWindow::dataSetIOCompleted(FileEvent *event)
 			_analyses->setVisible(false);
 			_analyses->clear();
 			_package->dbDelete();
-			_package->reset(false);
+			_package->reset(true);
 			_ribbonModel->showStatistics();
 			_fileMenu->buttonsForEmptyWorkspace();
 			_filterModel->reset();


### PR DESCRIPTION
Replaces https://github.com/jasp-stats/jasp-desktop/pull/6051 with one that does a few less changes...