### PR TITLE
Save changed TextField when adding a new row

### DIFF
--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -190,7 +190,7 @@ void ListModel::setRowComponent(QQmlComponent* rowComponent)
 	_rowComponent = rowComponent;
 }
 
-void ListModel::setUpRowControls()
+void ListModel::setUpRowControls(int startRow)
 {
 	if (_rowComponent == nullptr)
 		return;
@@ -198,14 +198,17 @@ void ListModel::setUpRowControls()
 	int row = 0;
 	for (const Term& term : terms())
 	{
-		if (!_rowControlsMap.contains(term.value()))
+		if (startRow <= row)
 		{
-			RowControls* rowControls = new RowControls(this, _rowComponent);
-			_rowControlsMap[term.value()] = rowControls;
-			rowControls->initValues(row, term, _rowControlsValues[term.value()]);
+			if (!_rowControlsMap.contains(term.value()))
+			{
+				RowControls* rowControls = new RowControls(this, _rowComponent);
+				_rowControlsMap[term.value()] = rowControls;
+				rowControls->initValues(row, term, _rowControlsValues[term.value()]);
+			}
+			else
+				_rowControlsMap[term.value()]->resetValues(row, term, _rowControlsValues[term.value()]);
 		}
-		else
-			_rowControlsMap[term.value()]->resetValues(row, term, _rowControlsValues[term.value()]);
 
 		row++;
 	}
@@ -808,14 +811,16 @@ void ListModel::_removeLastTerm()
 
 void ListModel::_addTerms(const Terms &terms)
 {
+	int i = _terms.size();
 	_terms.add(checkTermsTypes(terms));
-	setUpRowControls();
+	setUpRowControls(i);
 }
 
 void ListModel::_addTerm(const Term &term, bool isUnique)
 {
+	int i = _terms.size();
 	_terms.add(_checkTermType(term), isUnique);
-	setUpRowControls();
+	setUpRowControls(i);
 }
 
 void ListModel::_replaceTerm(int index, const Term &term)

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -190,27 +190,30 @@ void ListModel::setRowComponent(QQmlComponent* rowComponent)
 	_rowComponent = rowComponent;
 }
 
-void ListModel::setUpRowControls(int startRow)
+void ListModel::setUpRowControls(int startRow, bool onlyRemove)
 {
 	if (_rowComponent == nullptr)
 		return;
 
-	int row = 0;
-	for (const Term& term : terms())
+	if (!onlyRemove)
 	{
-		if (startRow <= row)
+		int row = 0;
+		for (const Term& term : terms())
 		{
-			if (!_rowControlsMap.contains(term.value()))
+			if (startRow <= row)
 			{
-				RowControls* rowControls = new RowControls(this, _rowComponent);
-				_rowControlsMap[term.value()] = rowControls;
-				rowControls->initValues(row, term, _rowControlsValues[term.value()]);
+				if (!_rowControlsMap.contains(term.value()))
+				{
+					RowControls* rowControls = new RowControls(this, _rowComponent);
+					_rowControlsMap[term.value()] = rowControls;
+					rowControls->initValues(row, term, _rowControlsValues[term.value()]);
+				}
+				else
+					_rowControlsMap[term.value()]->resetValues(row, term, _rowControlsValues[term.value()]);
 			}
-			else
-				_rowControlsMap[term.value()]->resetValues(row, term, _rowControlsValues[term.value()]);
-		}
 
-		row++;
+			row++;
+		}
 	}
 	
 	// Disconnect and delete all controls that are not used anymore
@@ -788,25 +791,26 @@ void ListModel::_setTerms(const Terms &terms)
 void ListModel::_removeTerms(const Terms &terms)
 {
 	_terms.remove(terms);
-	setUpRowControls();
+	setUpRowControls(0, true);
 }
 
 void ListModel::_removeTerm(int index)
 {
 	_terms.remove(size_t(index));
-	setUpRowControls();
+	setUpRowControls(0, true);
 }
 
 void ListModel::_removeTerm(const Term &term)
 {
 	_terms.remove(term);
-	setUpRowControls();
+	setUpRowControls(0, true);
 }
 
 void ListModel::_removeLastTerm()
 {
 	if (_terms.size() > 0)
 		_terms.remove(_terms.size() - 1);
+	setUpRowControls(0, true);
 }
 
 void ListModel::_addTerms(const Terms &terms)

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -76,7 +76,7 @@ public:
 			Terms					getSourceTerms();
 			void					setColumnsUsedForLabels(const QStringList& columns)						{ _columnsUsedForLabels = columns; }
 			void					setRowComponent(QQmlComponent* rowComponents);
-	virtual void					setUpRowControls(int startRow = 0);
+	virtual void					setUpRowControls(int startRow = 0, bool onlyRemove = false);
 	const RowControlMap	&			getAllRowControls()												const		{ return _rowControlsMap;				}
 	Terms::RelatedValuesPerTerm		getTermsWithComponentValues()									const;
 	RowControls*					getRowControls(const QString& key)								const		{ return _rowControlsMap.value(key);	}

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -76,7 +76,7 @@ public:
 			Terms					getSourceTerms();
 			void					setColumnsUsedForLabels(const QStringList& columns)						{ _columnsUsedForLabels = columns; }
 			void					setRowComponent(QQmlComponent* rowComponents);
-	virtual void					setUpRowControls();
+	virtual void					setUpRowControls(int startRow = 0);
 	const RowControlMap	&			getAllRowControls()												const		{ return _rowControlsMap;				}
 	Terms::RelatedValuesPerTerm		getTermsWithComponentValues()									const;
 	RowControls*					getRowControls(const QString& key)								const		{ return _rowControlsMap.value(key);	}

--- a/QMLComponents/models/listmodeltermsassigned.cpp
+++ b/QMLComponents/models/listmodeltermsassigned.cpp
@@ -141,7 +141,7 @@ void ListModelTermsAssigned::removeTerm(int index)
 {
 	if (index < 0 || index >= rowCount()) return;
 
-	beginResetModel();
+	beginRemoveRows(QModelIndex(), index, index);
 
 	const Term& term = terms().at(size_t(index));
 
@@ -158,7 +158,7 @@ void ListModelTermsAssigned::removeTerm(int index)
 	}
 	_removeTerm(term);
 
-	endResetModel();
+	endRemoveRows();
 }
 
 void ListModelTermsAssigned::changeTerm(int index, const Term& term)

--- a/QMLComponents/models/listmodeltermsassigned.cpp
+++ b/QMLComponents/models/listmodeltermsassigned.cpp
@@ -102,17 +102,22 @@ Terms ListModelTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemInde
 		// in a TabView, if the user changes the title of a Tab and clicks direclty the '+' button to add another tab, adding a new tab will be done first, and will add a new
 		// term to the model: if the model of the TabView is reset, the TextField controls that handle the titles of the Tabs are destroyed and recreated. As the TextField control
 		// that was used to change the title is destroyed, the signal that changes this title is not received, and the title gets back its old value.
-		newTerms = terms();
-		if (dropItemIndex >= 0 && dropItemIndex < terms().size())
-			newTerms.insert(dropItemIndex, termsToAdd);
-		else
-		{
+		if (dropItemIndex < 0 || dropItemIndex > terms().size())
 			dropItemIndex = terms().size();
-			newTerms.add(termsToAdd);
-		}
 
 		beginInsertRows(QModelIndex(), dropItemIndex, dropItemIndex + termsToAdd.size() - 1);
-		_setTerms(newTerms);
+		newTerms = terms();
+		if (dropItemIndex < terms().size())
+		{
+			newTerms.insert(dropItemIndex, termsToAdd);
+			_setTerms(newTerms);
+		}
+		else
+		{
+			newTerms.add(termsToAdd);
+			_addTerms(termsToAdd);
+		}
+
 		endInsertRows();
 
 		if (maxRows > 0 && newTerms.size() > maxRows)


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3812

In a ComponentsList with TextField's, if you change a value in a TextField and click 'Add row', then your change in the TextField is lost.
When a TextField loses the focus, the changes should be saved. But when adding a new row this action takes place first, and this sets the Row controls for each row (term) of the components list. Of course it reuses the existing Row controls, but it resets the values of each control. As the internal value of the TextField was not changed yet, it uses the old value and resets the display value of the TextField, which discards the changed value.

But when adding a new row, it should not set the Row controls of the previous rows: this fixes this issue.

