### PR TITLE
QML testing

### DIFF
--- a/Desktop/html/js/utils.js
+++ b/Desktop/html/js/utils.js
@@ -352,7 +352,7 @@ function formatColumn(column, type, format, alignNumbers, combine, modelFootnote
 					else 
 					{
 						if(isP)						formatted["content"] = fixDecimals || window.globSet.pExact ? toExponential(content, (isFinite(dp) ? dp : sf-1), 0, html)	: formatPrecisionWithRespectForFixedDecimals(content, sf, dp, noZeroLead, thousands)
-						else						formatted["content"] = alignNumbers || fixDecimals			? formatFixed(content, -minLSD, false, thousands)				: formatPrecisionWithRespectForFixedDecimals(content, sf, dp, noZeroLead, thousands)
+						else						formatted["content"] = fixDecimals							? formatFixed(content, -minLSD, false, thousands)				: formatPrecisionWithRespectForFixedDecimals(content, sf, dp, noZeroLead, thousands)
 						
 						if(html)
 							formatted["content"] = formatted["content"].replace(/-/g, "&minus;")

--- a/QMLComponents/ALTNavigation/altnavscope.cpp
+++ b/QMLComponents/ALTNavigation/altnavscope.cpp
@@ -1,9 +1,9 @@
-﻿#include "altnavscope.h"
-#include "altnavpostfixassignmentstrategy.h"
+﻿#include "altnavpostfixassignmentstrategy.h"
 #include "altnavcontrol.h"
-
+#include "altnavscope.h"
 #include <QQmlProperty>
 #include <QMetaObject>
+#include <iostream>
 
 ALTNavScope::ALTNavScope(QObject* attachee)
 	: QObject{attachee}
@@ -17,13 +17,21 @@ ALTNavScope::ALTNavScope(QObject* attachee)
 			//create a visual tag
 			QQmlComponent component(qmlEngine(_attachee), QUrl("qrc:/jasp-stats.org/imports/JASP/Controls/components/JASP/Controls/ALTNavTag.qml"), _attachee);
 			_attachedTag = qobject_cast<ALTNavTagBase*>(component.create());
-			_attachedTag->setParentItem(_attachee);
-			_attachedTag->setParent(_attachee);
 
-			//Find parent when attachee parent changes or component is completed (this is when registration of any parent is guaranteed)
-			QObject* attached_component = qmlAttachedPropertiesObject<QQmlComponent>(_attachee);
-			connect(attached_component, SIGNAL(completed()), this, SLOT(init()));
-			connect(_attachee, &QQuickItem::parentChanged, this, &ALTNavScope::registerWithParent);
+			if(!_attachedTag)
+			{
+				std::cerr << "Could not make ALTNavTag.qml, but if you are testing this is ok." << std::endl;
+			}
+			else
+			{
+				_attachedTag->setParentItem(_attachee);
+				_attachedTag->setParent(_attachee);
+
+				//Find parent when attachee parent changes or component is completed (this is when registration of any parent is guaranteed)
+				QObject* attached_component = qmlAttachedPropertiesObject<QQmlComponent>(_attachee);
+				connect(attached_component, SIGNAL(completed()), this, SLOT(init()));
+				connect(_attachee, &QQuickItem::parentChanged, this, &ALTNavScope::registerWithParent);
+			}
 		}
 	}
 }
@@ -171,6 +179,10 @@ void ALTNavScope::setChildrenPrefix()
 void ALTNavScope::setScopeActive(bool value)
 {
 	_scopeActive = value;
+
+	if(!_attachedTag)
+		return; // Should really only occur during testing
+
 	if (!_scopeOnly)
 		_attachedTag->setActive(value);
 	if (_propagateActivity)

--- a/QMLComponents/boundcontrols/boundcontrolbase.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolbase.cpp
@@ -46,6 +46,7 @@ Json::Value BoundControlBase::createMeta()  const
 	return meta;
 }
 
+
 void BoundControlBase::handleComputedColumn(const Json::Value& value)
 {
 	if (_isColumn && value.isString())

--- a/QMLComponents/components/JASP/Controls/Group.qml
+++ b/QMLComponents/components/JASP/Controls/Group.qml
@@ -19,7 +19,7 @@
 import QtQuick
 import QtQuick.Layouts		as L
 import JASP.Controls
-import JASP
+//import JASP
 
 GroupBoxBase
 {

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -286,36 +286,51 @@ void JASPControl::addControlError(QString message)
 {
 	if (_form && message.size())
 		_form->addControlError(this, message, false);
+	else
+		setHasError(true);
 }
 
 void JASPControl::addControlErrorTemporary(QString message)
 {
 	if (_form && message.size())
 		_form->addControlError(this, message, true);
+	else
+		setHasError(true);
 }
 
 void JASPControl::addControlErrorPermanent(QString message)
 {
 	if (_form && message.size())
 		_form->addControlError(this, message, false, false, false);
+	else
+		setHasError(true);
 }
 
 void JASPControl::addControlWarning(QString message)
 {
 	if (_form && message.size())
 		_form->addControlError(this, message, false, true);
+	else
+		setHasWarning(true);
 }
 
 void JASPControl::addControlWarningTemporary(QString message)
 {
 	if (_form && message.size())
 		_form->addControlError(this, message, true, true);
+	else
+		setHasWarning(true);
 }
 
 void JASPControl::clearControlError()
 {
 	if (_form)
 		_form->clearControlError(this);
+	else
+	{
+		setHasError(false);
+		setHasWarning(false);
+	}
 }
 
 QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, bool collapseStructuralControls)

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -3,6 +3,7 @@
 #include "log.h"
 #include "analysisform.h"
 #include "jasptheme.h"
+#include "utilities/qutils.h"
 #include "preferencesmodelbase.h"
 #include <QQmlProperty>
 #include <QQmlContext>
@@ -359,8 +360,12 @@ QList<JASPControl*> JASPControl::getChildJASPControls(const QQuickItem * item, b
 
 BoundControl *JASPControl::boundControl()
 {
-	if (isBound())	return dynamic_cast<BoundControl*>(this);
-	return nullptr;
+	return isBound() ? dynamic_cast<BoundControl*>(this) : nullptr;
+}
+
+const BoundControl *JASPControl::boundControl() const
+{
+	return isBound() ? dynamic_cast<const BoundControl*>(this) : nullptr;
 }
 
 bool JASPControl::addDependency(JASPControl *item)
@@ -608,6 +613,11 @@ QString JASPControl::printLabelMD(int depth) const
 bool JASPControl::hasLabelOrInfo() const
 {
 	return !fullLabel().isEmpty() || !info().isEmpty();
+}
+
+QJSValue JASPControl::boundJson() const
+{
+	return boundControl() ? tqj(boundControl()->createJson(), this) : QJSValue();
 }
 
 JASPControls JASPControl::getMDSubItems(const QQuickItem* parentItem) const

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -3,7 +3,6 @@
 
 #include <QQuickItem>
 #include <QPropertyAnimation>
-
 #include "utilities/qutils.h"
 #include "columntype.h"
 
@@ -150,10 +149,10 @@ public:
 	int					preferredWidth()			const	{ return _preferredWidth;			}
 	int					cursorShape()				const	{ return _cursorShape;				}
 	bool				hovered()					const;
-	int					alignment()					const	{ return _alignment;				}
-	Qt::FocusReason		getFocusReason()			const	{ return _focusReason;				}
-	bool				dependsOnDynamicComponents() const	{ return _dependsOnDynamicComponents; }
-	const QVariant&		explicitDepends()			const	{ return _explicitDepends;			}
+	int					alignment()					const	{ return _alignment;					}
+	Qt::FocusReason		getFocusReason()			const	{ return _focusReason;					}
+	bool				dependsOnDynamicComponents() const	{ return _dependsOnDynamicComponents;	}
+	const QVariant&		explicitDepends()			const	{ return _explicitDepends;				}
 
 	QString				humanFriendlyLabel()		const;
 
@@ -167,6 +166,7 @@ public:
 	void							setUnitialized();
 	virtual void					cleanUp();
 	virtual BoundControl		*	boundControl();
+	virtual const BoundControl	*	boundControl() const;
 	virtual bool					encodeValue()						const	{ return false; }
 
 	const Set					&	depends()							const	{ return _depends; }
@@ -181,6 +181,9 @@ public:
 	virtual QString					friendlyName() const;
 	void							addExplicitDependency();
 	bool							hasLabelOrInfo() const;
+
+
+	Q_INVOKABLE	QJSValue			boundJson() const;
 
 public slots:
 	void	setControlType(			ControlType			controlType)		{ _controlType = controlType; }

--- a/QMLComponents/controls/textareabase.h
+++ b/QMLComponents/controls/textareabase.h
@@ -65,6 +65,7 @@ public:
 
 	void						rScriptDoneHandler(const QString &result)			override;
 	BoundControl			*	boundControl()										override	{ return isBound() ? _boundControl : nullptr;			}
+	const BoundControl		*	boundControl()								const	override	{ return isBound() ? _boundControl : nullptr;			}
 
 	TextType					textType()									const				{ return _textType;										}
 	bool						hasScriptError()							const				{ return _hasScriptError;								}

--- a/QMLComponents/controls/variableslistbase.h
+++ b/QMLComponents/controls/variableslistbase.h
@@ -60,6 +60,7 @@ public:
 
 	ListViewType				listViewType()																			const				{ return _listViewType;								}
 	BoundControl			*	boundControl()																					override	{ return _boundControl;								}
+	const BoundControl		*	boundControl()																			const	override	{ return _boundControl;								}
 	int							columns()																				const				{ return _columns;									}
 	const QStringList		&	dropKeys()																				const				{ return _dropKeys;									}
 	const QString			&	interactionHighOrderCheckBox()															const				{ return _interactionHighOrderCheckBox;				}

--- a/QMLComponents/preferencesmodelbase.cpp
+++ b/QMLComponents/preferencesmodelbase.cpp
@@ -10,6 +10,12 @@ PreferencesModelBase::PreferencesModelBase(QObject *parent)
 	_singleton = this;
 }
 
+PreferencesModelBase::~PreferencesModelBase()
+{
+	assert(_singleton == nullptr || _singleton == this);
+	_singleton = nullptr;
+}
+
 PreferencesModelBase *PreferencesModelBase::preferences()
 {
 	if (_singleton == nullptr)

--- a/QMLComponents/preferencesmodelbase.h
+++ b/QMLComponents/preferencesmodelbase.h
@@ -13,7 +13,7 @@ class PreferencesModelBase : public QObject
 
 public:
 	explicit PreferencesModelBase(QObject *parent = nullptr);
-	~PreferencesModelBase() { _singleton = nullptr; }
+	~PreferencesModelBase();
 
 	virtual double	uiScale()						{ return 1;		}
 	virtual int		maxFlickVelocity()		const	{ return 808;	}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(BUILD_TESTS)
 
-find_package(Qt6 REQUIRED COMPONENTS Test)
+find_package(Qt6 REQUIRED COMPONENTS Test QuickTest Qml Core)
 
 qt_add_executable(
   JASPTest
@@ -28,10 +28,30 @@ qt_add_executable(
   testengine.h testengine.cpp
 )
 
+qt_add_executable(
+  JASPQuickTest
+  ${SYSTEM_TYPE}
+  testqml.h
+  testqml.cpp
+  $<$<PLATFORM_ID:Darwin>:${_R_Framework}>
+  $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/Desktop/JASP.exe.manifest>
+)
+
+qt_add_executable(
+  JASPFormTest
+  ${SYSTEM_TYPE}
+  testqmlform.h
+  testqmlform.cpp
+  $<$<PLATFORM_ID:Darwin>:${_R_Framework}>
+  $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/Desktop/JASP.exe.manifest>
+)
+
+
 add_dependencies(JASPTest           JASPDesktopLib)
 add_dependencies(JASPTestDebugData  JASPDesktopLib)
 add_dependencies(JASPTestEngine     JASPDesktopLib)
-
+add_dependencies(JASPFormTest       JASPDesktopLib)
+add_dependencies(JASPQuickTest      JASPDesktopLib)
 
 target_include_directories(
   JASPTest
@@ -39,9 +59,77 @@ target_include_directories(
   JASPDesktopLib
 )
 
+target_include_directories(
+  JASPTestDebugData
+  PUBLIC
+  JASPDesktopLib
+
+  PRIVATE
+  Qt6::Core
+)
+
+target_include_directories(
+  JASPTestEngine
+  PUBLIC
+  JASPDesktopLib
+)
+
+target_include_directories(
+  JASPQuickTest
+  PUBLIC
+  JASPDesktopLib
+)
+
+target_include_directories(
+  JASPFormTest
+  PUBLIC
+  JASPDesktopLib
+)
 
 target_link_libraries(
   JASPTest
+  PUBLIC
+  JASPDesktopLib
+  Qt::Test
+
+  PRIVATE
+  Qt6::Core
+)
+
+target_link_libraries(
+  JASPTestDebugData
+  PUBLIC
+  JASPDesktopLib
+  Qt::Test
+
+  PRIVATE
+  Qt6::Core
+)
+
+target_link_libraries(
+  JASPQuickTest
+  PUBLIC
+  JASPDesktopLib
+  Qt::QuickTest
+
+  PRIVATE
+  Qt6::Core
+  Qt6::Qml
+)
+
+target_link_libraries(
+  JASPFormTest
+  PUBLIC
+  JASPDesktopLib
+  Qt::QuickTest
+
+  PRIVATE
+  Qt6::Core
+  Qt6::Qml
+)
+
+target_link_libraries(
+  JASPTestEngine
   PUBLIC
   JASPDesktopLib
   Qt::Test
@@ -52,19 +140,9 @@ target_compile_definitions(
   PUBLIC TESTLIBRARY_DIR=${CMAKE_SOURCE_DIR}/Tests/TestLibrary
 )
 
-
-target_include_directories(
-  JASPTestDebugData
-  PUBLIC
-  JASPDesktopLib
-)
-
-
-target_link_libraries(
-  JASPTestDebugData
-  PUBLIC
-  JASPDesktopLib
-  Qt::Test
+target_compile_definitions(
+  JASPTest
+  PUBLIC TESTLIBRARY_DIR=${CMAKE_SOURCE_DIR}/Tests/TestLibrary
 )
 
 target_compile_definitions(
@@ -72,23 +150,22 @@ target_compile_definitions(
   PUBLIC TESTLIBRARY_DIR=${CMAKE_SOURCE_DIR}/Tests/TestLibrary
 )
 
-target_include_directories(
-  JASPTestEngine
-  PUBLIC
-  JASPDesktopLib
-)
-
-
-target_link_libraries(
-  JASPTestEngine
-  PUBLIC
-  JASPDesktopLib
-  Qt::Test
-)
-
 target_compile_definitions(
   JASPTestEngine
   PUBLIC TESTLIBRARY_DIR=${CMAKE_SOURCE_DIR}/Tests/TestLibrary
+)
+
+target_compile_definitions(
+  JASPQuickTest
+  PUBLIC 
+  TESTLIBRARY_DIR=${CMAKE_SOURCE_DIR}/Tests/TestLibrary
+  -DQUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qmlTests/"
+)
+
+target_compile_definitions(
+  JASPFormTest
+  PUBLIC TESTLIBRARY_DIR=${CMAKE_SOURCE_DIR}/Tests/TestLibrary
+  -DQUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/formTests/"
 )
 
 enable_testing(true)
@@ -96,7 +173,7 @@ enable_testing(true)
 add_test(NAME testDataImport  COMMAND JASPTest)
 add_test(NAME testDebugData   COMMAND JASPTestDebugData)
 add_test(NAME testEngine      COMMAND JASPTestEngine)
-
-
+add_test(NAME testQuick       COMMAND JASPQuickTest)
+add_test(NAME testForms       COMMAND JASPFormTest)
 
 endif()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -126,6 +126,9 @@ target_link_libraries(
   PRIVATE
   Qt6::Core
   Qt6::Qml
+  Qt::WebEngineQuick
+  Qt::WebChannel
+  Qt::WebChannelQuick
 )
 
 target_link_libraries(

--- a/Tests/formTests/tst_webengine.qml
+++ b/Tests/formTests/tst_webengine.qml
@@ -63,11 +63,18 @@ TestCase
 								  function(result) { resultsView.jsDone(result); });
 		spy.wait(1000);
 		compare(spy.count, 1);
-		console.log(spy.signalArguments[0][0])
 		compare(spy.signalArguments[0][0], "1.2");
 		
 		
-		//compare(control.boundJson(),  2);
+		spy.clear()
+		resultsView.runJavaScript(	"result = formatColumn(column=column, type='number', format='sf:4', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		//console.log(spy.signalArguments[0][0])
+		compare(spy.signalArguments[0][0], "1.234");
 	}
 }
 

--- a/Tests/formTests/tst_webengine.qml
+++ b/Tests/formTests/tst_webengine.qml
@@ -149,6 +149,38 @@ TestCase
 		spy.wait(1000);
 		compare(spy.count, 1);
 		compare(spy.signalArguments[0][0], "€1,000,234");
+		
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 1.01}];" +
+									"result = formatColumn(column=column, type='number', format='pc', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "101.00&thinsp;%");
+		
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 0.01}];" +
+									"result = formatColumn(column=column, type='number', format='pc', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "1.00&thinsp;%");
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 0.9999}];" +
+									"result = formatColumn(column=column, type='number', format='pc', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "99.99&thinsp;%");
 	}
 }
 

--- a/Tests/formTests/tst_webengine.qml
+++ b/Tests/formTests/tst_webengine.qml
@@ -76,9 +76,20 @@ TestCase
 		compare(spy.signalArguments[0][0], "1.234");
 		
 		spy.clear()
-		resultsView.runJavaScript(	"result = formatColumn(column=column, type='number', format='dp:3', alignNumbers=true, combine=false, modelFootnotes='');" +
+		resultsView.runJavaScript(	"column=[{content: 123456789}];" +
+									"result = formatColumn(column=column, type='number', format='sf:3', alignNumbers=true, combine=false, modelFootnotes='');" +
 									"result[0].content",
-								  function(result) { resultsView.jsDone(result); });
+									function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "1.23&times;10<sup>+8</sup>");
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 1.234}];" +
+									"result = formatColumn(column=column, type='number', format='dp:3', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+									function(result) { resultsView.jsDone(result); });
 		
 		spy.wait(1000);
 		compare(spy.count, 1);

--- a/Tests/formTests/tst_webengine.qml
+++ b/Tests/formTests/tst_webengine.qml
@@ -1,0 +1,88 @@
+import QtTest
+import QtQuick
+import QtWebEngine
+import QtWebChannel
+import QtQuick.Controls
+//import JASP.Controls		as JC
+
+
+TestCase
+{
+		
+	WebEngineView
+	{
+		id:						resultsView
+
+		url:					"qrc:///html/index-jasp.html"
+		
+		signal jsDone(result: var);
+		signal resultsLoaded();
+		
+		onLoadingChanged: (loadRequest)=>
+		{
+			if(loadRequest.status === WebEngineView.LoadSucceededStatus)
+				resultsLoaded();
+		}
+		
+	}
+	
+	SignalSpy
+	{
+		id:				spyLoader
+		target:			resultsView
+		signalName:		"resultsLoaded"
+	}
+	
+	SignalSpy
+	{
+		id:				spy
+		target:			resultsView
+		signalName:		"jsDone"
+	}
+
+	function test_format()
+	{
+		//Make sure the resultspage loads
+		spyLoader.wait(1000);
+		compare(spyLoader.count, 1);
+		
+		
+		resultsView.runJavaScript(	"let column=[{content: 1.234}];" +
+									"let result = formatColumn(column=column, type='number', format='sf:4', alignNumbers=false, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		//console.log(spy.signalArguments[0][0])
+		compare(spy.signalArguments[0][0], "1.234");
+		
+		spy.clear();
+		resultsView.runJavaScript(	"result = formatColumn(column=column, type='number', format='sf:2', alignNumbers=false, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		spy.wait(1000);
+		compare(spy.count, 1);
+		console.log(spy.signalArguments[0][0])
+		compare(spy.signalArguments[0][0], "1.2");
+		
+		
+		//compare(control.boundJson(),  2);
+	}
+}
+
+
+
+
+//function formatColumn(column, type, format, alignNumbers, combine, modelFootnotes, html = true, errorOnMixed = false) {
+	/**
+	 * Prepares the columns of a table to the required format
+	 * @param column
+	 * @param type           column type - string, number, pvalue, integer, ...
+	 * @param format         decimal format, p-value format
+	 * @param alignNumbers
+	 * @param combine
+	 * @param modelFootnotes
+	 * @param html           html render or latex code. Default is true
+	 * @param errorOnMixed   internal, used to avoid infinite loops
+	 */

--- a/Tests/formTests/tst_webengine.qml
+++ b/Tests/formTests/tst_webengine.qml
@@ -115,6 +115,40 @@ TestCase
 		spy.wait(1000);
 		compare(spy.count, 1);
 		compare(spy.signalArguments[0][0], ".900");
+		
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 1000234}];" +
+									"setCurrentLocaleID('en', false);"+
+									"result = formatColumn(column=column, type='number', format='monetary:EUR;thousands', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "€1,000,234");
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 1000234}];" +
+									"setCurrentLocaleID('en', false);"+
+									"result = formatColumn(column=column, type='number', format='monetary:EUR', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "€1000234");
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 1000234}];" +
+									"setCurrentLocaleID('en', true);"+
+									"result = formatColumn(column=column, type='number', format='monetary:EUR', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "€1,000,234");
 	}
 }
 

--- a/Tests/formTests/tst_webengine.qml
+++ b/Tests/formTests/tst_webengine.qml
@@ -73,8 +73,48 @@ TestCase
 		
 		spy.wait(1000);
 		compare(spy.count, 1);
-		//console.log(spy.signalArguments[0][0])
 		compare(spy.signalArguments[0][0], "1.234");
+		
+		spy.clear()
+		resultsView.runJavaScript(	"result = formatColumn(column=column, type='number', format='dp:3', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "1.234");
+		
+		
+		spy.clear()
+		resultsView.runJavaScript(	"result = formatColumn(column=column, type='number', format='dp:1', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "1.2");
+		
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 0.9999}];" +
+									"result = formatColumn(column=column, type='number', format='p:0.01;dp:3', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], "1.000");
+		
+		
+		spy.clear()
+		resultsView.runJavaScript(	"column=[{content: 0.9}];" +
+									"result = formatColumn(column=column, type='number', format='p:0.01;dp:3', alignNumbers=true, combine=false, modelFootnotes='');" +
+									"result[0].content",
+								  function(result) { resultsView.jsDone(result); });
+		
+		spy.wait(1000);
+		compare(spy.count, 1);
+		compare(spy.signalArguments[0][0], ".900");
 	}
 }
 

--- a/Tests/qmlTests/tst_checkbox.qml
+++ b/Tests/qmlTests/tst_checkbox.qml
@@ -1,0 +1,26 @@
+import QtQuick
+import QtTest
+import JASP.Controls
+
+TestCase
+{
+	name:		"TestCheckbox"
+
+	CheckBox
+	{
+
+		id:						control
+	}
+
+	function test_checked()
+	{
+		control.checked = true
+		compare(control.boundJson(), true);
+	}
+
+	function test_otherValue()
+	{
+		control.checked = false
+		compare(control.boundJson(), false);
+	}
+}

--- a/Tests/qmlTests/tst_doublefield.qml
+++ b/Tests/qmlTests/tst_doublefield.qml
@@ -1,0 +1,38 @@
+import QtQuick
+import QtTest
+import JASP.Controls
+
+TestCase
+{
+	name:		"TestDoublefield"
+
+	DoubleField
+	{
+
+		id:						control
+	}
+
+	function test_displayValue()
+	{
+		control.value = 0
+		compare(control.boundJson(), 0);
+	}
+
+	function test_otherValue()
+	{
+		control.value = 2;
+		compare(control.boundJson(),  2);
+	}
+
+	function test_anotherValue()
+	{
+		control.value = 12.34;
+		compare(control.boundJson(),  12.34);
+	}
+
+	function test_aString()
+	{
+		control.value = "This isnt a double at all!";
+		compare(control.boundJson(),  0);
+	}
+}

--- a/Tests/qmlTests/tst_doublefieldMinMax.qml
+++ b/Tests/qmlTests/tst_doublefieldMinMax.qml
@@ -1,0 +1,91 @@
+import QtQuick
+import QtTest
+import JASP.Controls
+import JASP
+
+TestCase
+{
+	name:		"TestDoublefieldMinMax"
+
+	DoubleField
+	{
+		id: defaultDoubleLower
+		label: "Default Double Lower Bound"
+		name: "lowerIntegerDefault"
+		value: 0.1
+	}
+
+	DoubleField
+	{
+		id:		doubleLower
+		name:	"doubleLower"
+		label:  "Double Lower Bound"
+		max:	doubleUpper.value
+		defaultValue: defaultDoubleLower.value
+		min:	0
+	}
+
+	DoubleField
+	{
+		id:		doubleUpper
+		name:	"doubleUpper"
+		label:  "Double Upper Bound (Exclusive)"
+		min:	doubleLower.value
+		defaultValue: 0.50
+		max:	1
+		inclusive: JASP.MinOnly
+	}
+
+	function test_1setDefaultValue()
+	{
+		defaultDoubleLower.value = .2
+		compare(doubleLower.boundJson(), .2, "The default value and the current value of doubleLower are both .1, so when changing the default value to .2, the current value also change to .2");
+	}
+
+	function test_2setDefaultValue()
+	{
+		doubleLower.value = .3
+		compare(doubleLower.boundJson(), .3, "The default value and the current value of doubleLower are resp. .2 and .3");
+		defaultDoubleLower.value = .4
+		compare(doubleLower.boundJson(), .3, "As the default value and the current value were different, changing the default value does not change the current value");
+	}
+
+	function test_3minValueError()
+	{
+		doubleLower.value = .1
+		compare(doubleLower.hasError, false);
+		doubleLower.forceActiveFocus()
+		doubleLower.value = -0.1
+		doubleUpper.forceActiveFocus();			// The error will be triggered when the control loses the focus
+		compare(doubleLower.hasError, true, "The value cannot be negative")
+		compare(doubleLower.boundJson(), .1, "The value is set back to the previous valid value")
+	}
+
+	function test_4maxValueError()
+	{
+		doubleLower.forceActiveFocus()
+		doubleLower.value = .5
+		doubleUpper.forceActiveFocus();
+		compare(doubleLower.hasError, false, "The max value is .5 and is inclusive, so .5 is valid");
+		doubleLower.forceActiveFocus()
+		doubleLower.value = .51
+		doubleUpper.forceActiveFocus();
+		compare(doubleLower.hasError, true, "The value is .51 is too high");
+		compare(doubleLower.boundJson(), .5, "The value is set back to the previous valid value");
+	}
+
+	function test_5exclusiveMaxValueError()
+	{
+		doubleUpper.forceActiveFocus();
+		doubleUpper.value = .99
+		doubleLower.forceActiveFocus();
+		compare(doubleUpper.boundJson(), .99, "The max value is 1 and is exclusive, so .99 is valid");
+		compare(doubleUpper.hasError, false);
+		doubleUpper.forceActiveFocus();
+		doubleUpper.value = 1
+		doubleLower.forceActiveFocus();
+		compare(doubleUpper.hasError, true, "The max value is 1 and is exclusive, so 1 is not valid");
+		compare(doubleUpper.boundJson(), .99, "The value is set back to the previous valid value");
+	}
+
+}

--- a/Tests/qmlTests/tst_integerfield.qml
+++ b/Tests/qmlTests/tst_integerfield.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import QtTest
+import JASP.Controls
+
+TestCase
+{
+	name:		"TestIntegerfield"
+
+	IntegerField
+	{
+		id:						control
+	}
+
+	function test_displayValue()
+	{
+		control.value = 0
+		compare(control.boundJson(), 0);
+	}
+
+	function test_otherValue()
+	{
+		control.value = 2;
+		compare(control.boundJson(),  2);
+	}
+
+	function test_anotherValue()
+	{
+		control.value = 12.34;
+		compare(control.boundJson(),  12);
+	}
+
+	function test_aString()
+	{
+		control.value = "This isnt an integer at all!";
+		compare(control.boundJson(),  0);
+	}
+}

--- a/Tests/qmlTests/tst_integerfieldMinMax.qml
+++ b/Tests/qmlTests/tst_integerfieldMinMax.qml
@@ -1,0 +1,91 @@
+import QtQuick
+import QtTest
+import JASP.Controls
+import JASP
+
+TestCase
+{
+	name:		"TestIntegerfieldMinMax"
+
+	IntegerField
+	{
+		id: defaultIntegerLower
+		label: "Default Integer Lower Bound"
+		name: "lowerDefault"
+		value: 1
+	}
+
+	IntegerField
+	{
+		id:		integerLower
+		name:	"integerLower"
+		label:  "Integer Lower Bound"
+		max:	integerUpper.value
+		defaultValue: defaultIntegerLower.value
+		min:	0
+	}
+
+	IntegerField
+	{
+		id:		integerUpper
+		name:	"integerUpper"
+		label:  "Integer Upper Bound (Exclusive)"
+		min:	integerLower.value
+		defaultValue: 5
+		max:	10
+		inclusive: JASP.MinOnly
+	}
+
+	function test_1setDefaultValue()
+	{
+		defaultIntegerLower.value = 2
+		compare(integerLower.boundJson(), 2, "The default value and the current value of integerLower are both 1, so when changing the default value to 2, the current value also change to 2")
+	}
+
+	function test_2displayValue()
+	{
+		integerLower.value = 3
+		compare(integerLower.boundJson(), 3, "The default value and the current value of integerLower are resp. 2 and 3")
+		defaultIntegerLower.value = 4
+		compare(integerLower.boundJson(), 3, "As the default value and the current value were different, changing the default value does not change the current value")
+	}
+
+	function test_3minValueError()
+	{
+		integerLower.value = 1
+		compare(integerLower.hasError, false);
+		integerLower.forceActiveFocus()
+		integerLower.value = -1
+		integerUpper.forceActiveFocus();		// The error will be triggered when the control loses the focus
+		compare(integerLower.hasError, true, "The value cannot be negative")
+		compare(integerLower.boundJson(), 1, "The value is set back to the previous valid value")
+	}
+
+	function test_4maxValueError()
+	{
+		integerLower.forceActiveFocus()
+		integerLower.value = 5
+		integerUpper.forceActiveFocus();
+		compare(integerLower.hasError, false, "The max value is 5 and is inclusive, so 5 is valid");
+		integerLower.forceActiveFocus()
+		integerLower.value = 6
+		integerUpper.forceActiveFocus();
+		compare(integerLower.hasError, true, "The value is 6 is too high")
+		compare(integerLower.boundJson(), 5, "The value is set back to the previous valid value")
+	}
+
+	function test_5exclusiveMaxValueError()
+	{
+		integerUpper.forceActiveFocus();
+		integerUpper.value = 9
+		integerLower.forceActiveFocus();
+		compare(integerUpper.boundJson(), 9, "The max value is 10 and is exclusive, so 9 is valid");
+		compare(integerUpper.hasError, false);
+		integerUpper.forceActiveFocus();
+		integerUpper.value = 10
+		integerLower.forceActiveFocus();
+		compare(integerUpper.hasError, true, "The max value is 10 and is exclusive, so 10 is not valie");
+		compare(integerUpper.boundJson(), 9, "The value is set back to the previous valid value");
+	}
+
+}

--- a/Tests/qmlTests/tst_percentfield.qml
+++ b/Tests/qmlTests/tst_percentfield.qml
@@ -1,0 +1,44 @@
+import QtQuick
+import QtTest
+import JASP.Controls
+
+TestCase
+{
+	name:		"TestPercentfield"
+
+	PercentField
+	{
+
+		id:						control
+	}
+
+	function test_displayValue()
+	{
+		control.value = 0
+		compare(control.boundJson(), 0);
+	}
+
+	function test_otherValue()
+	{
+		control.value = 2;
+		compare(control.boundJson(),  0.02);
+	}
+
+	function test_anotherValue()
+	{
+		control.value = 12.34;
+		compare(control.boundJson(),  0.1234);
+	}
+
+	function test_aValueAbove100()
+	{
+		control.value = 122.34;
+		compare(control.boundJson(),  1);
+	}
+
+	function test_aString()
+	{
+		control.value = "This isnt a percentage at all!";
+		compare(control.boundJson(),  0);
+	}
+}

--- a/Tests/qmlTests/tst_textfield.qml
+++ b/Tests/qmlTests/tst_textfield.qml
@@ -1,0 +1,26 @@
+import QtQuick
+import QtTest
+import JASP.Controls
+
+TestCase
+{
+	name:		"TestTextfield"
+
+	TextField
+	{
+
+		id:						textField
+	}
+
+	function test_displayValue()
+	{
+		textField.value =					"Hallo wereld!"
+		compare(textField.boundJson(),	"Hallo wereld!");
+	}
+
+	function test_otherValue()
+	{
+		textField.value =				"Iets anders!";
+		compare(textField.boundJson(),  "Iets anders!");
+	}
+}

--- a/Tests/testall.cpp
+++ b/Tests/testall.cpp
@@ -13,10 +13,10 @@
 #include "data/importers/jaspimporterold.h"
 #include "data/importers/readstatimporter.h"
 
+
 void TestAll::initTestCase()
 {
 	TempFiles::init(ProcessInfo::currentPID()); // needed here so that the LRNAM can be passed the session directory
-
 }
 
 void TestAll::init()
@@ -58,7 +58,6 @@ void TestAll::testDataImport_data()
 				QTest::newRow(i.fileName().toUtf8()) << folder << i.absoluteFilePath();
 	}
 }
-
 
 void TestAll::testDataImport()
 {
@@ -112,7 +111,6 @@ void TestAll::testDataImport()
 		jsonFile.open(QFile::OpenModeFlag::WriteOnly);
 		jsonFile.write(stringUtils::replaceBy(compareMe.toStyledString(), "\n", " ").c_str());
 		jsonFile.close();
-
 	}
 
 	QVERIFY(jsonFileIn.exists());
@@ -238,6 +236,5 @@ void TestAll::testJaspDataImport()
 	DataSet loadMe(dataSet->id());
 	QVERIFY2(dataSet->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
 }
-
 
 QTEST_MAIN(TestAll)

--- a/Tests/testall.h
+++ b/Tests/testall.h
@@ -10,7 +10,7 @@ private slots:
     void    initTestCase();
     void    init();
 	void	cleanup();
-    void    testDataImport();
+	void    testDataImport();
 	void	testDataImport_data();
 	void	testJaspDataImport();
 	void	testJaspDataImport_data();

--- a/Tests/testqml.cpp
+++ b/Tests/testqml.cpp
@@ -3,6 +3,7 @@
 #include <QQmlContext>
 #include "jasptheme.h"
 #include "preferencesmodelbase.h"
+#include "utilities/qmlutils.h"
 
 TestQml::TestQml(QObject *parent)
 	: QObject{parent}
@@ -21,6 +22,8 @@ void TestQml::qmlEngineAvailable(QQmlEngine *engine)
 	engine->rootContext()->setContextProperty("myContextProperty", QVariant(true));
 
 	static QStringList originalImportPaths = engine->importPathList();
+
+	QmlUtils::setGlobalPropertiesInQMLContext(engine->rootContext());
 
 	QStringList newImportPaths = originalImportPaths;
 

--- a/Tests/testqml.cpp
+++ b/Tests/testqml.cpp
@@ -1,0 +1,47 @@
+#include "testqml.h"
+#include <QQmlEngine>
+#include <QQmlContext>
+#include "jasptheme.h"
+#include "preferencesmodelbase.h"
+
+TestQml::TestQml(QObject *parent)
+	: QObject{parent}
+{
+
+}
+
+void TestQml::applicationAvailable()
+{
+	// Initialization that only requires the QGuiApplication object to be available
+}
+
+void TestQml::qmlEngineAvailable(QQmlEngine *engine)
+{
+	// Initialization requiring the QQmlEngine to be constructed
+	engine->rootContext()->setContextProperty("myContextProperty", QVariant(true));
+
+	static QStringList originalImportPaths = engine->importPathList();
+
+	QStringList newImportPaths = originalImportPaths;
+
+	newImportPaths.append(":/jasp-stats.org/imports");
+	newImportPaths.append("qrc:///components");
+
+	engine->setImportPathList(newImportPaths);
+
+	_theme = new JaspTheme();
+	_prefs = new PreferencesModelBase(engine);
+
+	engine->rootContext()->setContextProperty("jaspTheme",			_theme);
+	engine->rootContext()->setContextProperty("preferencesModel",	_prefs);
+
+}
+
+void TestQml::cleanupTestCase()
+{
+}
+
+
+QUICK_TEST_MAIN_WITH_SETUP(qmltest, TestQml);
+
+#include "testqml.moc"

--- a/Tests/testqml.h
+++ b/Tests/testqml.h
@@ -1,0 +1,28 @@
+#ifndef TESTQML_H
+#define TESTQML_H
+
+#include <QtQuickTest>
+
+class PreferencesModelBase;
+class QQmlEngine;
+class JaspTheme;
+
+class TestQml : public QObject
+{
+	Q_OBJECT
+public:
+	explicit TestQml(QObject *parent = nullptr);
+
+public slots:
+	void applicationAvailable();
+
+	void qmlEngineAvailable(QQmlEngine *engine);
+
+	void cleanupTestCase();
+
+private:
+	JaspTheme				* _theme = nullptr;
+	PreferencesModelBase	* _prefs = nullptr;
+};
+
+#endif // TESTQML_H

--- a/Tests/testqmlform.cpp
+++ b/Tests/testqmlform.cpp
@@ -1,0 +1,47 @@
+#include "testqmlform.h"
+#include <QQmlEngine>
+#include <QQmlContext>
+#include "jasptheme.h"
+#include "preferencesmodelbase.h"
+
+TestForm::TestForm(QObject *parent)
+	: QObject{parent}
+{
+
+}
+
+void TestForm::applicationAvailable()
+{
+	// Initialization that only requires the QGuiApplication object to be available
+}
+
+void TestForm::qmlEngineAvailable(QQmlEngine *engine)
+{
+	// Initialization requiring the QQmlEngine to be constructed
+	engine->rootContext()->setContextProperty("myContextProperty", QVariant(true));
+
+	static QStringList originalImportPaths = engine->importPathList();
+
+	QStringList newImportPaths = originalImportPaths;
+
+	newImportPaths.append(":/jasp-stats.org/imports");
+	newImportPaths.append("qrc:///components");
+
+	engine->setImportPathList(newImportPaths);
+
+	_theme = new JaspTheme();
+	_prefs = new PreferencesModelBase(engine);
+
+	engine->rootContext()->setContextProperty("jaspTheme",			_theme);
+	engine->rootContext()->setContextProperty("preferencesModel",	_prefs);
+
+}
+
+void TestForm::cleanupTestCase()
+{
+}
+
+
+QUICK_TEST_MAIN_WITH_SETUP(qmlformtest, TestForm);
+
+#include "testqmlform.moc"

--- a/Tests/testqmlform.h
+++ b/Tests/testqmlform.h
@@ -1,0 +1,28 @@
+#ifndef TESTQML_H
+#define TESTQML_H
+
+#include <QtQuickTest>
+
+class PreferencesModelBase;
+class QQmlEngine;
+class JaspTheme;
+
+class TestForm : public QObject
+{
+	Q_OBJECT
+public:
+	explicit TestForm(QObject *parent = nullptr);
+
+public slots:
+	void applicationAvailable();
+
+	void qmlEngineAvailable(QQmlEngine *engine);
+
+	void cleanupTestCase();
+
+private:
+	JaspTheme				* _theme = nullptr;
+	PreferencesModelBase	* _prefs = nullptr;
+};
+
+#endif // TESTQML_H


### PR DESCRIPTION
This adds some relatively simple qmltests to verify the validators of the textfields etc.
It also adds a webengine/resultspage test, where (for now) we can test the output of the number formatting independent of analyses and other settings.