### PR TITLE
Keep "R Syntax in result" setting in JASP file

### DIFF
--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -81,6 +81,12 @@ void DatabaseInterface::upgradeDBFromVersion(Version originalVersion)
 		runStatements(_dbIndexesSql);
 	}
 
+	if(originalVersion <= "0.95.4")
+	{
+		if(!tableHasColumn("DataSets", "showRSyntax"))
+			runStatements("ALTER TABLE DataSets  ADD COLUMN showRSyntax	INT;");
+	}
+
 	transactionWriteEnd();
 }
 
@@ -102,7 +108,7 @@ DatabaseInterface::~DatabaseInterface()
 }
 
 
-int DatabaseInterface::dataSetInsert(const std::string & dataFilePath, long dataFileTimestamp, const std::string & description, const std::string & databaseJson, const std::string & emptyValuesJson, bool dataSynch)
+int DatabaseInterface::dataSetInsert(const std::string & dataFilePath, long dataFileTimestamp, const std::string & description, const std::string & databaseJson, const std::string & emptyValuesJson, bool dataSynch, bool showRSyntax)
 {
 	JASPTIMER_SCOPE(DatabaseInterface::dataSetInsert);
 	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
@@ -113,17 +119,18 @@ int DatabaseInterface::dataSetInsert(const std::string & dataFilePath, long data
 		sqlite3_bind_text(stmt, 4, databaseJson.c_str(),	databaseJson.length(),		SQLITE_TRANSIENT);
 		sqlite3_bind_text(stmt, 5, emptyValuesJson.c_str(), emptyValuesJson.length(),	SQLITE_TRANSIENT);
 		sqlite3_bind_int(stmt,	6, dataSynch);
+		sqlite3_bind_int(stmt,	7, showRSyntax);
 	};
 
 	transactionWriteBegin();
-	int id = runStatementsId("INSERT OR REPLACE INTO DataSets (dataFilePath, dataFileTimestamp, description, databaseJson, emptyValuesJson, dataFileSynch, id) VALUES (?, ?, ?, ?, ?, ?, 1) RETURNING id;", prepare);
+	int id = runStatementsId("INSERT OR REPLACE INTO DataSets (dataFilePath, dataFileTimestamp, description, databaseJson, emptyValuesJson, dataFileSynch, showRSyntax, id) VALUES (?, ?, ?, ?, ?, ?, ?, 1) RETURNING id;", prepare);
 	runStatements("CREATE TABLE " + dataSetName(id) + " (rowNumber INTEGER PRIMARY KEY);"); // Can be overwritten through dataSetCreateTable
 	transactionWriteEnd();
 
 	return id;
 }
 
-void DatabaseInterface::dataSetUpdate(int dataSetId,	const std::string & dataFilePath, long dataFileTimestamp, const std::string & description, const std::string & databaseJson, const std::string & emptyValuesJson, bool dataSynch)
+void DatabaseInterface::dataSetUpdate(int dataSetId,	const std::string & dataFilePath, long dataFileTimestamp, const std::string & description, const std::string & databaseJson, const std::string & emptyValuesJson, bool dataSynch, bool showRSyntax)
 {
 	JASPTIMER_SCOPE(DatabaseInterface::dataSetUpdate);
 	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
@@ -134,15 +141,16 @@ void DatabaseInterface::dataSetUpdate(int dataSetId,	const std::string & dataFil
 		sqlite3_bind_text(stmt, 4, databaseJson.c_str(),	databaseJson.length(),		SQLITE_TRANSIENT);
 		sqlite3_bind_text(stmt, 5, emptyValuesJson.c_str(), emptyValuesJson.length(),	SQLITE_TRANSIENT);
 		sqlite3_bind_int(stmt,	6, dataSynch);
-		sqlite3_bind_int(stmt,	7, dataSetId);
+		sqlite3_bind_int(stmt,	7, showRSyntax);
+		sqlite3_bind_int(stmt,	8, dataSetId);
 	};
 
 	//Log::log() << "UPDATE DataSet " << dataSetId << " with Empty Values: " << emptyValuesJson << std::endl;
 
-	runStatements("UPDATE DataSets SET dataFilePath=?, dataFileTimestamp=?, description=?, databaseJson=?, emptyValuesJson=?, dataFileSynch=?, revision=revision+1 WHERE id = ?;", prepare);
+	runStatements("UPDATE DataSets SET dataFilePath=?, dataFileTimestamp=?, description=?, databaseJson=?, emptyValuesJson=?, dataFileSynch=?, showRSyntax=?, revision=revision+1 WHERE id = ?;", prepare);
 }
 
-void DatabaseInterface::dataSetLoad(int dataSetId, std::string & dataFilePath, long & dataFileTimestamp, std::string & description, std::string & databaseJson, std::string & emptyValuesJson, int & revision, bool & dataSynch)
+void DatabaseInterface::dataSetLoad(int dataSetId, std::string & dataFilePath, long & dataFileTimestamp, std::string & description, std::string & databaseJson, std::string & emptyValuesJson, int & revision, bool & dataSynch, bool & showRSyntax)
 {
 	JASPTIMER_SCOPE(DatabaseInterface::dataSetLoad);
 	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
@@ -154,7 +162,7 @@ void DatabaseInterface::dataSetLoad(int dataSetId, std::string & dataFilePath, l
 	{
 		int colCount = sqlite3_column_count(stmt);
 
-		assert(colCount == 7);
+		assert(colCount == 8);
 
 		dataFilePath	= _wrap_sqlite3_column_text(stmt, 0);
 		dataFileTimestamp	= sqlite3_column_int(	stmt, 1);
@@ -163,11 +171,12 @@ void DatabaseInterface::dataSetLoad(int dataSetId, std::string & dataFilePath, l
 		emptyValuesJson = _wrap_sqlite3_column_text(stmt, 4);
 		revision		= sqlite3_column_int(		stmt, 5);
 		dataSynch		= sqlite3_column_int(		stmt, 6);
+		showRSyntax		= sqlite3_column_int(		stmt, 7);
 
 		//Log::log() << "Output loadDataset(dataSetId="<<dataSetId<<") had (dataFilePath='"<<dataFilePath<<"', databaseJson='"<<databaseJson<<"', emptyValuesJson='"<<emptyValuesJson<<"')" << std::endl;
 	};
 
-	runStatements("SELECT dataFilePath, dataFileTimestamp, description, databaseJson, emptyValuesJson, revision, dataFileSynch FROM DataSets WHERE id = ?;", prepare, processRow);
+	runStatements("SELECT dataFilePath, dataFileTimestamp, description, databaseJson, emptyValuesJson, revision, dataFileSynch, showRSyntax FROM DataSets WHERE id = ?;", prepare, processRow);
 }
 
 int DatabaseInterface::dataSetColCount(int dataSetId)

--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -89,9 +89,9 @@ public:
 	int			dataSetGetId();
 	bool		dataSetExists(			int dataSetId);
 	void		dataSetDelete(			int dataSetId);
-	int			dataSetInsert(							const std::string & dataFilePath = "", long dataFileTimestamp = 0, const std::string & description = "", const std::string & databaseJson = "", const std::string & emptyValuesJson = "", bool dataSynch = false);		///< Inserts a new DataSet row into DataSets and creates an empty DataSet_#id. returns id
-	void		dataSetUpdate(			int dataSetId,	const std::string & dataFilePath = "", long dataFileTimestamp = 0, const std::string & description = "", const std::string & databaseJson = "", const std::string & emptyValuesJson = "", bool dataSynch = false);		///< Updates an existing DataSet row in DataSets
-	void		dataSetLoad(			int dataSetId,		  std::string & dataFilePath,	long & dataFileTimestamp,		 std::string & description,			   std::string & databaseJson,			  std::string & emptyValuesJson, int & revision, bool & dataSynch);	///< Loads an existing DataSet row into arguments
+	int			dataSetInsert(							const std::string & dataFilePath = "", long dataFileTimestamp = 0, const std::string & description = "", const std::string & databaseJson = "", const std::string & emptyValuesJson = "", bool dataSynch = false, bool showRSyntax = false);		///< Inserts a new DataSet row into DataSets and creates an empty DataSet_#id. returns id
+	void		dataSetUpdate(			int dataSetId,	const std::string & dataFilePath = "", long dataFileTimestamp = 0, const std::string & description = "", const std::string & databaseJson = "", const std::string & emptyValuesJson = "", bool dataSynch = false, bool showRSyntax = false);		///< Updates an existing DataSet row in DataSets
+	void		dataSetLoad(			int dataSetId,		  std::string & dataFilePath,	long & dataFileTimestamp,		 std::string & description,			   std::string & databaseJson,			  std::string & emptyValuesJson, int & revision, bool & dataSynch, bool & showRSyntax);	///< Loads an existing DataSet row into arguments
 	static int	dataSetColCount(		int dataSetId);
 	static int	dataSetRowCount(		int dataSetId);
 	void		dataSetSetRowCount(		int dataSetId, size_t rowCount);

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -267,7 +267,7 @@ void DataSet::dbCreate()
 	db().transactionWriteBegin();
 
 	//The variables are probably empty though:
-	_dataSetID	= db().dataSetInsert(_dataFilePath, _dataFileTimestamp, _description, _databaseJson, _emptyValues->toJson().toStyledString(), _dataFileSynch);
+	_dataSetID	= db().dataSetInsert(_dataFilePath, _dataFileTimestamp, _description, _databaseJson, _emptyValues->toJson().toStyledString(), _dataFileSynch, _showRSyntax);
 	
 	assert(_dataSetID == 1);
 	
@@ -283,7 +283,7 @@ void DataSet::dbCreate()
 void DataSet::dbUpdate()
 {
 	assert(_dataSetID > 0);
-	db().dataSetUpdate(_dataSetID, _dataFilePath, _dataFileTimestamp, _description, _databaseJson, _emptyValues->toJson().toStyledString(), _dataFileSynch);
+	db().dataSetUpdate(_dataSetID, _dataFilePath, _dataFileTimestamp, _description, _databaseJson, _emptyValues->toJson().toStyledString(), _dataFileSynch, _showRSyntax);
 	incRevision();
 }
 
@@ -309,7 +309,7 @@ void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, Ver
 
 	std::string emptyVals;
 
-	db().dataSetLoad(_dataSetID, _dataFilePath, _dataFileTimestamp, _description, _databaseJson, emptyVals, _revision, _dataFileSynch);
+	db().dataSetLoad(_dataSetID, _dataFilePath, _dataFileTimestamp, _description, _databaseJson, emptyVals, _revision, _dataFileSynch, _showRSyntax);
 	progressCallback(0.1);
 
 	if(!_filter)

--- a/CommonData/dataset.h
+++ b/CommonData/dataset.h
@@ -30,6 +30,7 @@ public:
 			int				columnCount()			const ;
 			int				rowCount()				const ;
 			bool			dataFileSynch()			const { return _dataFileSynch;			}
+			bool			showRSyntax()			const { return _showRSyntax;			}
 	const	std::string &	dataFilePath()			const { return _dataFilePath;			}
 			int				dataFileTimestamp()		const { return _dataFileTimestamp;		}
 	const	std::string &	databaseJson()			const { return _databaseJson;			}
@@ -63,6 +64,7 @@ public:
 			void			setDataFile( const std::string & dataFilePath, long timestamp)	{ _dataFilePath	= dataFilePath;	_dataFileTimestamp = timestamp; dbUpdate(); }
 			void			setDatabaseJson(	const std::string & databaseJson)	{ _databaseJson		= databaseJson;			dbUpdate(); }
 			void			setDataFileSynch(	bool synchronizing)					{ _dataFileSynch	= synchronizing;		dbUpdate(); }
+			void			setShowRSyntax(		bool showRSyntax)					{ _showRSyntax		= showRSyntax;			dbUpdate(); }
 
 			void			setColumnCount(	size_t colCount);
 			void			setRowCount(	size_t rowCount, bool alsoLoadData = true);
@@ -109,7 +111,8 @@ private:
 	std::string					_dataFilePath,
 								_databaseJson;
 	
-	bool						_dataFileSynch			= false;
+	bool						_dataFileSynch			= false,
+								_showRSyntax			= false;
 	static stringset			_defaultEmptyvalues;	// Default empty values if workspace do not have its own empty values (used for backward compatibility)
 	std::string					_description;
 };

--- a/CommonData/internalDbDefinition.sql
+++ b/CommonData/internalDbDefinition.sql
@@ -8,7 +8,8 @@ CREATE TABLE DataSets (
 	databaseJson	TEXT, 
 	emptyValuesJson TEXT, 
 	revision		INT DEFAULT 0, 
-	dataFileSynch	INT
+	dataFileSynch	INT,
+	showRSyntax		INT DEFAULT 0
 );
 
 CREATE TABLE Filters ( 

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -747,11 +747,11 @@ void Analyses::moveAnalysesResults(Analysis* fromAnalysis, int index)
 
 void Analyses::showRSyntaxInResults(bool show)
 {
-	Settings::setValue(Settings::SHOW_RSYNTAX_IN_RESULTS, show);
+	DataSetPackage::pkg()->setWorkspaceShowRSyntax(show);
 
 	applyToAll([&](Analysis * a)
 	{
-		a->setRSyntaxTextInResult();
+		a->setRSyntaxTextInResult(show);
 	});
 }
 

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -225,6 +225,8 @@ void Analysis::setResults(const Json::Value & results, Status status, const Json
 
 	_wasUpgraded		= false;
 	_storedWithoutState = false;
+
+	setRSyntaxTextInResult(DataSetPackage::pkg()->workspaceShowRSyntax()); // At this point, we are sure that the analysis exists in the results
 }
 
 void Analysis::exportResults()
@@ -358,9 +360,7 @@ void Analysis::createForm(QQuickItem* parentItem)
 		connect(this, 					&Analysis::titleChanged,			_analysisForm,	&AnalysisForm::titleChanged					);
 		connect(this,					&Analysis::needsRefreshChanged,		_analysisForm,	&AnalysisForm::needsRefreshChanged			);
 		connect(this,					&Analysis::needsRefreshChanged,		_analysisForm,	&AnalysisForm::rSyntaxTextChanged			);
-		connect(this,					&Analysis::boundValuesChanged,		this,			&Analysis::setRSyntaxTextInResult,		Qt::QueuedConnection	);
 
-		setRSyntaxTextInResult();
 		_analysisForm->setShowRButton(_moduleData->hasWrapper());
 		_analysisForm->setDeveloperMode(_dynamicModule->isDevMod());
 
@@ -1075,12 +1075,11 @@ void Analysis::analysisQMLFileChanged()
 		Log::log() << "Form (" << form() << ") wasn't complete " << ( form() ? std::to_string(form()->formCompleted()) : " because there was no form...") << " yet, and also did not have a QML error set yet, so ignoring it." << std::endl;
 }
 
-void Analysis::setRSyntaxTextInResult()
+void Analysis::setRSyntaxTextInResult(bool show)
 {
 	if (!form() || !_moduleData->hasWrapper() || !form()->initialized()) return;
 
-	bool generateRSyntax = Settings::value(Settings::SHOW_RSYNTAX_IN_RESULTS).toBool();
-	ResultsJsInterface::singleton()->setRSyntax(id(), generateRSyntax ? form()->generateRSyntax(true) : "");
+	ResultsJsInterface::singleton()->setRSyntax(id(), show ? form()->generateRSyntax(true) : "");
 }
 
 void Analysis::onUsedVariablesChanged()

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -196,7 +196,7 @@ public slots:
 	void					requestColumnCreationHandler(			const std::string & columnName, columnType colType)	override;
 	void					requestComputedColumnDestructionHandler(const std::string & columnName)						override;
 	void					analysisQMLFileChanged();
-	void					setRSyntaxTextInResult();
+	void					setRSyntaxTextInResult(bool show);
 	void					filterByNameDone(const QString &name, const QString &error);
 	void					onUsedVariablesChanged()																	override;
 

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -50,7 +50,7 @@ DataSetPackage::DataSetPackage(QObject * parent) : QAbstractItemModel(parent)
 	_db			= new DatabaseInterface(true);
 
 	_dataSet	= new DataSet(); //We create one here to make sure filter() etc can actually work
-	setDefaultWorkspaceEmptyValues();
+	setDefaultWorkspaceValues();
 	
 	connect(this, &DataSetPackage::isModifiedChanged,					this, &DataSetPackage::windowTitleChanged);
 	connect(this, &DataSetPackage::loadedChanged,						this, &DataSetPackage::windowTitleChanged);
@@ -1473,7 +1473,7 @@ void DataSetPackage::createDataSet()
 	dbDelete();
 	deleteDataSet();
 	_dataSet = new DataSet();
-	setDefaultWorkspaceEmptyValues();
+	setDefaultWorkspaceValues();
 	_dataSubModel->selectNode(_dataSet->dataNode());
 	_filterSubModel->selectNode(_dataSet->filtersNode());
 	
@@ -2031,21 +2031,37 @@ const stringset& DataSetPackage::workspaceEmptyValues() const
 	return _dataSet ? _dataSet->workspaceEmptyValues() : emptyVec;
 }
 
-void DataSetPackage::setDefaultWorkspaceEmptyValues()
+bool DataSetPackage::workspaceShowRSyntax() const
 {
+	return _dataSet ? _dataSet->showRSyntax() : PreferencesModel::prefs()->showRSyntaxInResults();
+}
+
+void DataSetPackage::setDefaultWorkspaceValues()
+{
+	_dataSet->setShowRSyntax(PreferencesModel::prefs()->showRSyntaxInResults());
+
 	stringvec prefs = fq(PreferencesModel::prefs()->emptyValues());
-	setWorkspaceEmptyValues(stringset(prefs.begin(), prefs.end()));
+	setWorkspaceEmptyValues(stringset(prefs.begin(), prefs.end()));	
 }
 
 void DataSetPackage::setWorkspaceEmptyValues(const stringset &emptyValues, bool reset)
 {
-	if (!_dataSet) return;
+	if (!_dataSet || _dataSet->workspaceEmptyValues() == emptyValues) return;
 	
 	if(reset)	beginResetModel();
 	_dataSet->setWorkspaceEmptyValues(emptyValues);
 	if(reset)	endResetModel();
 	
 	emit workspaceEmptyValuesChanged();
+}
+
+void DataSetPackage::setWorkspaceShowRSyntax(bool show)
+{
+	if (!_dataSet || _dataSet->showRSyntax() == show) return;
+
+	_dataSet->setShowRSyntax(show);
+
+	setModified(true);
 }
 
 void DataSetPackage::pasteSpreadsheet(size_t row, size_t col, const std::vector<std::vector<QString>> & values, const std::vector<std::vector<QString>> &  labels, const intvec & coltypes, const QStringList & colNames, const std::vector<boolvec> & selected)

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -271,8 +271,10 @@ public:
 	static		int							thresholdScale();
 	static		int							orderByValueByDefault();
 				const stringset&			workspaceEmptyValues()										const;
+				bool						workspaceShowRSyntax()										const;
 				void						setWorkspaceEmptyValues(const stringset& emptyValues, bool resetModel = true);
-				void						setDefaultWorkspaceEmptyValues();
+				void						setWorkspaceShowRSyntax(bool show);
+				void						setDefaultWorkspaceValues();
 
 				void						databaseStartSynching(bool syncImmediately);
 				void						databaseStopSynching();

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -2282,11 +2282,6 @@ void MainWindow::setCommunityVisible(bool newCommunityVisible)
 	emit communityVisibleChanged();
 }
 
-void MainWindow::setDefaultWorkspaceEmptyValues()
-{
-	DataSetPackage::pkg()->setDefaultWorkspaceEmptyValues();
-}
-
 void MainWindow::loadModulesFromUserConfiguration(configState state)
 {
 	if(state == configState::FAIL)

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -147,7 +147,6 @@ public slots:
 	void setScreenPPI(int screenPPI);
 	void setContactVisible(bool newContactVisible);
 	void setCommunityVisible(bool newCommunityVisible);
-	void setDefaultWorkspaceEmptyValues();
 
 	void showRCommander();
 

--- a/Desktop/results/resultmenumodel.cpp
+++ b/Desktop/results/resultmenumodel.cpp
@@ -21,6 +21,8 @@
 #include "utilities/settings.h"
 #include "jasptheme.h"
 #include "gui/preferencesmodel.h"
+#include "data/datasetpackage.h"
+
 
 ResultMenuModel::ResultMenuModel(QObject *parent) : QAbstractListModel(parent),
 	_entriesOrder({"hasCollapse", "hasEditTitle", "hasCopy", "hasLaTeXCode", "hasCite", "hasSaveImg", "hasExportResults",
@@ -137,7 +139,7 @@ void ResultMenuModel::setOptions(QString options, QStringList selected)
 		else if (key == "hasShowRSyntax")
 		{
 			entries.push_back(separator);
-			bool shown = Settings::value(Settings::SHOW_RSYNTAX_IN_RESULTS).toBool();
+			bool shown = DataSetPackage::pkg()->workspaceShowRSyntax();
 
 			QString jsFunction = QString("window.showRSyntaxClicked(%1);").arg(shown ? "false" : "true");
 			entry.setJSFunction(jsFunction);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3846

When creating a new JASP file, the R syntax in results will be displayed according to the user setting in Preferences/Results. This setting is then loaded in the JASP file.
It can be changed in the 'Show R Syntax' in the main menu of the results.
When loading a JASP file, "Show R Syntax in Result" setting of the JASP file is used.
If the user changes its own setting in Preferences/Results, it overwrites the setting of the JASP file.