### PR TITLE
Add a "computed" argument to creating columns from R

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -258,7 +258,7 @@ void Column::setCodeType(computedColumnType codeType)
 		_constructorJson["formulas"] = Json::arrayValue;
 	}
 
-	if(_codeType == computedColumnType::analysisNotComputed)
+	if(_codeType == computedColumnType::analysisNotComputed && codeType != computedColumnType::analysis)
 		_analysisId = -1;
 
 	_codeType	= codeType;
@@ -658,7 +658,7 @@ bool Column::setDescriptions(strstrmap labelToDescriptionMap)
 }
 
 
-bool Column::overwriteDataAndType(stringvec colData, columnType colType)
+bool Column::overwriteDataAndType(stringvec colData, columnType colType, bool computed)
 {
 	JASPTIMER_SCOPE(Column::overwriteDataAndType);
 	
@@ -709,6 +709,8 @@ bool Column::overwriteDataAndType(stringvec colData, columnType colType)
 	// In this case, the locale used is just UTF-8/C, so the locale chosen by the user should not be used to convert the values.
 	beginBatchedLabelsDB();
 	setValues(values, labels, 0, &changes, false);
+	if(computed && _codeType == computedColumnType::analysisNotComputed)
+		setCodeType(computedColumnType::analysis);
 	setType(colType);
 	nonFilteredCountersReset();
 	labelsHandleAutoSort();

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -82,7 +82,7 @@ public:
 			bool					setAsNominalOrOrdinal(	const intvec	& values, intstrmap uniqueValues,			bool	is_ordinal = false);
 
 			bool					initFromLookups(const std::string & newName, size_t rows, const std::function<std::string(size_t)> valueLookup, const std::function<std::string(size_t)> labelLookup, const std::string & title, columnType desiredType, const stringset & emptyValues, int threshold, bool orderLabelsByValue, bool leaveBatchedUnfinished = false);
-			bool					overwriteDataAndType(	stringvec		data, columnType colType);
+			bool					overwriteDataAndType(	stringvec		data, columnType colType, bool computed);
 			
 			bool					allLabelsPassFilter()	const;
 			bool					hasFilter()				const;

--- a/CommonData/databridge.cpp
+++ b/CommonData/databridge.cpp
@@ -138,12 +138,12 @@ bool DataBridge::deleteColumn(const std::string &columnName)
 	return true;
 }
 
-bool DataBridge::setColumnDataAndType(const std::string &columnName, const std::vector<std::string> &data, columnType colType)
+bool DataBridge::setColumnDataAndType(const std::string &columnName, const std::vector<std::string> &data, columnType colType, bool computed)
 {
 	if(!isColumnNameOk(columnName))
 		return false;
 
-	return provideAndUpdateDataSet()->column(columnName)->overwriteDataAndType(data, colType);
+	return provideAndUpdateDataSet()->column(columnName)->overwriteDataAndType(data, colType, computed);
 }
 
 void DataBridge::reloadColumnNames()

--- a/CommonData/databridge.h
+++ b/CommonData/databridge.h
@@ -28,7 +28,7 @@ public:
 
 	std::string				createColumn(				const std::string & columnName); ///< Returns encoded columnname on success or "" on failure (cause it already exists)
 	bool					deleteColumn(				const std::string & columnName);
-	bool					setColumnDataAndType(		const std::string & columnName, const	std::vector<std::string>	& nominalData, columnType colType); ///< return true for any changes
+	bool					setColumnDataAndType(		const std::string & columnName, const	std::vector<std::string>	& nominalData, columnType colType, bool computed); ///< return true for any changes
 	int						getColumnType(				const std::string & columnName);
 	int						getColumnAnalysisId(		const std::string & columnName);
 	int						getColumnOriginalIndex(		const std::string & columnName);

--- a/CommonData/rbridge.cpp
+++ b/CommonData/rbridge.cpp
@@ -616,13 +616,13 @@ extern "C" bool STDCALL rbridge_deleteColumn(const char * columnName)
 	return data_bridge->deleteColumn(columnName);
 }
 
-extern "C" bool STDCALL rbridge_setColumnDataAndType(const char* columnName, const char ** nominalData, size_t length, int _columnType)
+extern "C" bool STDCALL rbridge_setColumnDataAndType(const char* columnName, const char ** nominalData, size_t length, int _columnType, bool computed)
 {
 	JASP_COLUMN_DECODE_HERE_STORED_colName;
 
 	std::vector<std::string> nominals(nominalData, nominalData + length);
 
-	return data_bridge->setColumnDataAndType(colName, nominals, columnType(_columnType));
+	return data_bridge->setColumnDataAndType(colName, nominals, columnType(_columnType), computed);
 }
 
 extern "C" int	STDCALL rbridge_dataSetRowCount()

--- a/CommonData/rbridge.h
+++ b/CommonData/rbridge.h
@@ -63,7 +63,7 @@ extern "C" {
 	int							STDCALL rbridge_getColumnOriginalIndex	(const char * columnName);
 	const char *				STDCALL rbridge_createColumn			(const char * columnName);
 	bool						STDCALL rbridge_deleteColumn			(const char * columnName);
-	bool						STDCALL rbridge_setColumnDataAndType	(const char* columnName, const char **	nominalData,	size_t length,	int columnType);
+	bool						STDCALL rbridge_setColumnDataAndType	(const char* columnName, const char **	nominalData,	size_t length,	int columnType, bool computed);
 	int							STDCALL rbridge_dataSetRowCount();
 	const char *				STDCALL rbridge_encodeColumnName(		const char * in);
 	const char *				STDCALL rbridge_decodeColumnName(		const char * in);

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -102,11 +102,14 @@ Analysis::~Analysis()
 
 	if(DataSetPackage::pkg() && DataSetPackage::pkg()->hasDataSet())
 	{
-		for(const std::string & col : computedColumns())
-			if(DataSetPackage::pkg()->isColumnAnalysisNotComputed(col))
-				DataSetPackage::pkg()->setColumnComputedType(col, computedColumnType::notComputed);
-			else
-				emit requestComputedColumnDestruction(col, this);
+		for(Column * col : DataSetPackage::pkg()->dataSet()->columns())
+			if(col->analysisId() == id())
+			{
+				if(col->codeType() == computedColumnType::analysisNotComputed)
+					DataSetPackage::pkg()->setColumnComputedType(DataSetPackage::pkg()->dataSet()->columnIndex(col), computedColumnType::notComputed);
+				else
+					emit requestComputedColumnDestruction(col->name(), this);
+			}
 	}
 }
 
@@ -508,24 +511,17 @@ void Analysis::boundValueChangedHandler()
 
 void Analysis::requestComputedColumnCreationHandler(const std::string& columnName)
 {
-	Column *result = requestComputedColumnCreation(columnName, this);
-
-	if (result)
-		addOwnComputedColumn(columnName);
+	emit requestComputedColumnCreation(columnName, this);
 }
 
 void Analysis::requestColumnCreationHandler(const std::string & columnName, columnType colType)
 {
 	emit requestColumnCreation(columnName, this, colType);
-
-	addOwnComputedColumn(columnName);
 }
 
 void Analysis::requestComputedColumnDestructionHandler(const std::string& columnName)
 {
 	emit requestComputedColumnDestruction(columnName, this);
-	//We could check whether it worked or not, but if this column wasnt owned by analysis and it dfailed the next will be noop anyway:
-	removeOwnComputedColumn(columnName);
 }
 
 performType Analysis::desiredPerformTypeFromAnalysisStatus() const
@@ -788,6 +784,13 @@ Json::Value Analysis::rSources() const
 		result[pair.first] = pair.second;
 
 	return result;
+}
+
+bool Analysis::isOwnComputedColumn(const std::string & colName) const
+{
+	Column * col = DataSetPackage::pkg()->dataSet() ? DataSetPackage::pkg()->dataSet()->column(colName) : nullptr;
+	
+	return col->analysisId() == id();
 }
 
 void Analysis::storeUserDataEtc()

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -156,10 +156,9 @@ public:
 
 	const stringvec &		upgradeMsgsForOption(const std::string & name)		const	override;
 
-	const QList<std::string>	&	computedColumns()							const				{ return _computedColumns; }
 	const Json::Value			&	getRSource(const std::string & name)		const	override	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }
 	Json::Value						rSources()									const;
-	bool							isOwnComputedColumn(const std::string& col)	const	override	{ return _computedColumns.contains(col); }
+	bool							isOwnComputedColumn(const std::string& col)	const	override;
 	void							preprocessMarkdownHelp(QString & md)		const				{ if (_dynamicModule) _dynamicModule->preprocessMarkdownHelp(md);}
 
 signals:
@@ -202,8 +201,6 @@ public slots:
 
 protected:
 	void					abort();
-	void					addOwnComputedColumn(	const std::string & col)	{ _computedColumns.push_back(col); }
-	void					removeOwnComputedColumn(const std::string & col)	{ _computedColumns.removeAll(col); }
 	void					watchQmlForm();
 
 private:
@@ -254,7 +251,6 @@ private:
 
 	Modules::AnalysisEntry	*	_moduleData						= nullptr;
 	Modules::DynamicModule	*	_dynamicModule					= nullptr;
-	QList<std::string>			_computedColumns;
 	QFileSystemWatcher			_QMLFileWatcher;
 
 	QString						_helpFile;

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -894,24 +894,24 @@ bool jaspRCPP_columnIsScale(		const std::string & columnName) { return jaspRCPP_
 bool jaspRCPP_columnIsOrdinal(		const std::string & columnName) { return jaspRCPP_getColumnType(columnName) == columnType::ordinal;		}
 bool jaspRCPP_columnIsNominal(		const std::string & columnName) { return jaspRCPP_getColumnType(columnName) == columnType::nominal;		}
 
-bool jaspRCPP_setColumnDataAsScale(const std::string & columnName, Rcpp::RObject scalarData)
+bool jaspRCPP_setColumnDataAsScale(const std::string & columnName, Rcpp::RObject scalarData, bool computed)
 {
-	return _jaspRCPP_setColumnDataAndType(columnName, scalarData, columnType::scale);
+	return _jaspRCPP_setColumnDataAndType(columnName, scalarData, columnType::scale, computed);
 }
 
 
-bool jaspRCPP_setColumnDataAsOrdinal(const std::string & columnName, Rcpp::RObject ordinalData)
+bool jaspRCPP_setColumnDataAsOrdinal(const std::string & columnName, Rcpp::RObject ordinalData, bool computed)
 {
-	return _jaspRCPP_setColumnDataAndType(columnName, ordinalData, columnType::ordinal);
+	return _jaspRCPP_setColumnDataAndType(columnName, ordinalData, columnType::ordinal, computed);
 }
 
 
-bool jaspRCPP_setColumnDataAsNominal(const std::string & columnName, Rcpp::RObject nominalData)
+bool jaspRCPP_setColumnDataAsNominal(const std::string & columnName, Rcpp::RObject nominalData, bool computed)
 {
-	return _jaspRCPP_setColumnDataAndType(columnName, nominalData, columnType::nominal);
+	return _jaspRCPP_setColumnDataAndType(columnName, nominalData, columnType::nominal, computed);
 }
 
-bool _jaspRCPP_setColumnDataAndType(const std::string & columnName, Rcpp::RObject data, columnType colType)
+bool _jaspRCPP_setColumnDataAndType(const std::string & columnName, Rcpp::RObject data, columnType colType, bool computed)
 {
 	static Rcpp::Function asNumeric("as.numeric");
 	static Rcpp::Function asCharacter("as.character");
@@ -933,7 +933,7 @@ bool _jaspRCPP_setColumnDataAndType(const std::string & columnName, Rcpp::RObjec
 					: (!isLgl	? convertedStrings[i].c_str() : convertedStrings[i] == "TRUE" ? "1" : "0"); //Also getting TRUE or FALSE is not ideal
 	}
 
-	return dataSetColumnDataAndType(columnName.c_str(), nominals, static_cast<size_t>(strData.size()), int(colType));
+	return dataSetColumnDataAndType(columnName.c_str(), nominals, static_cast<size_t>(strData.size()), int(colType), computed);
 }
 
 

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -894,21 +894,21 @@ bool jaspRCPP_columnIsScale(		const std::string & columnName) { return jaspRCPP_
 bool jaspRCPP_columnIsOrdinal(		const std::string & columnName) { return jaspRCPP_getColumnType(columnName) == columnType::ordinal;		}
 bool jaspRCPP_columnIsNominal(		const std::string & columnName) { return jaspRCPP_getColumnType(columnName) == columnType::nominal;		}
 
-bool jaspRCPP_setColumnDataAsScale(const std::string & columnName, Rcpp::RObject scalarData, bool computed)
+bool jaspRCPP_setColumnDataAsScale(const std::string & columnName, Rcpp::RObject scalarData, int computed)
 {
-	return _jaspRCPP_setColumnDataAndType(columnName, scalarData, columnType::scale, computed);
+	return _jaspRCPP_setColumnDataAndType(columnName, scalarData, columnType::scale, computed==1);
 }
 
 
-bool jaspRCPP_setColumnDataAsOrdinal(const std::string & columnName, Rcpp::RObject ordinalData, bool computed)
+bool jaspRCPP_setColumnDataAsOrdinal(const std::string & columnName, Rcpp::RObject ordinalData, int computed)
 {
-	return _jaspRCPP_setColumnDataAndType(columnName, ordinalData, columnType::ordinal, computed);
+	return _jaspRCPP_setColumnDataAndType(columnName, ordinalData, columnType::ordinal, computed==1);
 }
 
 
-bool jaspRCPP_setColumnDataAsNominal(const std::string & columnName, Rcpp::RObject nominalData, bool computed)
+bool jaspRCPP_setColumnDataAsNominal(const std::string & columnName, Rcpp::RObject nominalData, int computed)
 {
-	return _jaspRCPP_setColumnDataAndType(columnName, nominalData, columnType::nominal, computed);
+	return _jaspRCPP_setColumnDataAndType(columnName, nominalData, columnType::nominal, computed==1);
 }
 
 bool _jaspRCPP_setColumnDataAndType(const std::string & columnName, Rcpp::RObject data, columnType colType, bool computed)

--- a/R-Interface/jasprcpp.h
+++ b/R-Interface/jasprcpp.h
@@ -78,10 +78,10 @@ bool jaspRCPP_columnIsScale(				const std::string & columnName	);
 bool jaspRCPP_columnIsOrdinal(				const std::string & columnName		  );
 bool jaspRCPP_columnIsNominal(				const std::string & columnName				 );
 
-bool jaspRCPP_setColumnDataAsScale(			const std::string & columnName,	Rcpp::RObject scalarData,               bool computed = true);
-bool jaspRCPP_setColumnDataAsOrdinal(		const std::string & columnName,	Rcpp::RObject ordinalData,              bool computed = true);
-bool jaspRCPP_setColumnDataAsNominal(		const std::string & columnName,	Rcpp::RObject nominalData,              bool computed = true);
-bool _jaspRCPP_setColumnDataAndType(		const std::string & columnName, Rcpp::RObject data, columnType colType, bool computed = true);
+bool jaspRCPP_setColumnDataAsScale(			const std::string & columnName,	Rcpp::RObject scalarData,               int computed = 0);
+bool jaspRCPP_setColumnDataAsOrdinal(		const std::string & columnName,	Rcpp::RObject ordinalData,              int computed = 0);
+bool jaspRCPP_setColumnDataAsNominal(		const std::string & columnName,	Rcpp::RObject nominalData,              int computed = 0);
+bool _jaspRCPP_setColumnDataAndType(		const std::string & columnName, Rcpp::RObject data, columnType colType, bool computed = false);
 
 void jaspRCPP_setColumnDataHelper_FactorsLevels(Rcpp::Vector<INTSXP> data, int *& outputData, size_t & numLevels, const char **& labelPointers, std::string *& labels);
 
@@ -91,7 +91,7 @@ typedef void (*sendFuncDef)(const char *);
 //Calls from jaspBase
 typedef void			(*logFuncDef)(const std::string &);
 typedef bool			(*shouldEnDecodeFuncDef)	(std::string);
-typedef bool			(*setColumnDataFuncDef)		(const std::string &, Rcpp::RObject, bool);
+typedef bool			(*setColumnDataFuncDef)		(const std::string &, Rcpp::RObject, int); //The int should be a bool really, but this way we can handle older jaspBase (as it misses this argument in it compiled code it will instead pass -1, so should have default behaviour so false)
 typedef columnType		(*getColumnTypeFuncDef)		(std::string);
 typedef int				(*getColumnAnIdFuncDef)		(std::string);
 typedef bool			(*getColumnExistsFDef)		(std::string);

--- a/R-Interface/jasprcpp.h
+++ b/R-Interface/jasprcpp.h
@@ -78,10 +78,10 @@ bool jaspRCPP_columnIsScale(				const std::string & columnName	);
 bool jaspRCPP_columnIsOrdinal(				const std::string & columnName		  );
 bool jaspRCPP_columnIsNominal(				const std::string & columnName				 );
 
-bool jaspRCPP_setColumnDataAsScale(			const std::string & columnName,	Rcpp::RObject scalarData	);
-bool jaspRCPP_setColumnDataAsOrdinal(		const std::string & columnName,	Rcpp::RObject ordinalData		);
-bool jaspRCPP_setColumnDataAsNominal(		const std::string & columnName,	Rcpp::RObject nominalData			);
-bool _jaspRCPP_setColumnDataAndType(		const std::string & columnName, Rcpp::RObject data, columnType colType);
+bool jaspRCPP_setColumnDataAsScale(			const std::string & columnName,	Rcpp::RObject scalarData,               bool computed = true);
+bool jaspRCPP_setColumnDataAsOrdinal(		const std::string & columnName,	Rcpp::RObject ordinalData,              bool computed = true);
+bool jaspRCPP_setColumnDataAsNominal(		const std::string & columnName,	Rcpp::RObject nominalData,              bool computed = true);
+bool _jaspRCPP_setColumnDataAndType(		const std::string & columnName, Rcpp::RObject data, columnType colType, bool computed = true);
 
 void jaspRCPP_setColumnDataHelper_FactorsLevels(Rcpp::Vector<INTSXP> data, int *& outputData, size_t & numLevels, const char **& labelPointers, std::string *& labels);
 
@@ -91,7 +91,7 @@ typedef void (*sendFuncDef)(const char *);
 //Calls from jaspBase
 typedef void			(*logFuncDef)(const std::string &);
 typedef bool			(*shouldEnDecodeFuncDef)	(std::string);
-typedef bool			(*setColumnDataFuncDef)		(const std::string &, Rcpp::RObject);
+typedef bool			(*setColumnDataFuncDef)		(const std::string &, Rcpp::RObject, bool);
 typedef columnType		(*getColumnTypeFuncDef)		(std::string);
 typedef int				(*getColumnAnIdFuncDef)		(std::string);
 typedef bool			(*getColumnExistsFDef)		(std::string);

--- a/R-Interface/jasprcpp_interface.h
+++ b/R-Interface/jasprcpp_interface.h
@@ -82,7 +82,7 @@ typedef int							(STDCALL *GetColumnType)				(const char* columnName);
 typedef int							(STDCALL *GetColumnAnalysisId)			(const char* columnName);
 typedef const char *				(STDCALL *CreateColumn)					(const char* columnName);
 typedef bool						(STDCALL *DeleteColumn)					(const char* columnName);
-typedef bool						(STDCALL *SetColumnDataAndType)			(const char* columnName, const char **	nominalData,	size_t length, int columnTYpe);
+typedef bool						(STDCALL *SetColumnDataAndType)			(const char* columnName, const char **	nominalData,	size_t length, int columnTYpe, bool computed);
 typedef int							(STDCALL *DataSetRowCount)              ();
 typedef const char *				(STDCALL *EnDecodeDef)					(const char *);
 typedef int							(STDCALL *DecodeTypeDef)				(const char *);


### PR DESCRIPTION
Fix for jasp-stats/INTERNAL-jasp#3035
Now they are created with the computed column setting "analysis" which means they get removed when the analysis is removed.

This adds support for also creating computedcolumns straight from R
Requires https://github.com/jasp-stats/jaspBase/pull/180

There isnt really a good testcase right now, and it is such a hassle to get a jaspBase in there that I suggest the reviewer (@boutinb ) just changes the `computed=false` in jaspRcpp to `computed=true` to verify that the bug as reported by @koenderks is fixed.

Then we can merge both the jaspBase and jasp-desktop changes and then @koenderks can add the `computed=TRUE` flag to his computedcolumn creation code and then the issue should be solved.

Ive set this up in such a way that the original behaviour is kept even with an old jaspBase (cause it doesnt pass ` computed` top jaspRcpp it passes `-1` so by checking the `int computed` for begin 1 we can handle both the older and newer jaspBase versions without a problem.