### PR TITLE
fix decimal reading from xlsx on non en_us locale systems (like german)

### DIFF
--- a/Desktop/data/importers/excel/excel.cpp
+++ b/Desktop/data/importers/excel/excel.cpp
@@ -18,7 +18,7 @@
 #include "excel.h"
 #include "utilities/qutils.h"
 #include <stringutils.h>
-
+#include <columnutils.h>
 #include <QFileInfo>
 #include <QDebug>
 
@@ -95,7 +95,7 @@ void Excel::getCellValue(uint32_t &row, uint16_t &col, std::string &cellValue)
 		cellValue = std::to_string(cell.value.int_value);
 		break;
 	case FREEXL_CELL_DOUBLE:
-		cellValue = std::to_string(cell.value.double_value);
+		cellValue = ColumnUtils::doubleToStringMaxPrec(cell.value.double_value, false);
 		break;
 	case FREEXL_CELL_NULL:
 	default:

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -510,6 +510,9 @@ int main(int argc, char *argv[])
 
 
 			QLocale::setDefault(QLocale(QLocale::English)); // make decimal points == . in at least R? Anyway, this has been here forever, ill just leave it.
+			
+			char dsteng[] = "LC_ALL=en_US";
+			putenv(dsteng);
 
 			//Now we convert all these strings in args back to an int and a char * array.
 			//But to keep things easy, we are going to copy the old argv to avoid duplication (or messing up the executable name)

--- a/Tests/testall.h
+++ b/Tests/testall.h
@@ -6,6 +6,7 @@ class Importer;
 class TestAll: public QObject
 {
     Q_OBJECT
+	
 private slots:
     void    initTestCase();
     void    init();


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-issues/issues/3867

To test the issue run jasp with a run-environment setting of `LC_ALL=de_DE`
This will make reading decimals fail for the xlsx from the issue.
Then using this branch it will work fine.

A thing to keep in mind: the unittest JASPTest needs to be run in an LC_ALL=en_US locale.
I guess later we can also see about adding tests in different locales.