### PR TITLE
Avoid crash when closing workspace

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1737,11 +1737,6 @@ void DataSetPackage::setColumnComputedType(size_t columnIndex, computedColumnTyp
 		return;
 
 	column->setCodeType(type);
-
-	//emit dataChanged(index(0, columnIndex), index(rowCount() - 1, columnIndex));
-	//we need to actually send lots of signals from ColumnModel but because of the undo/redo this is a bit convoluted now...
-
-	refresh();
 }
 
 void DataSetPackage::setColumnDropLevels(size_t columnIndex, dropLevelsType dropLevels)

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -905,9 +905,9 @@ void JASPControl::setUnitialized()
 	_initializedWithValue = Json::nullValue;
 }
 								 
-void JASPControl::cleanUp()									
-{ 
-	disconnect();
+void JASPControl::cleanUp()
+{
+	blockSignals(true);
 }
 
 void JASPControl::_setInitialized(const Json::Value &value)

--- a/QMLComponents/controls/jasplistcontrol.cpp
+++ b/QMLComponents/controls/jasplistcontrol.cpp
@@ -75,7 +75,7 @@ void JASPListControl::_setupSources()
 	for (SourceItem* sourceItem : _sourceItems)
 	{
 		sourceItem->deleteLater();
-		sourceItem->disconnect();
+		sourceItem->blockSignals(true);
 	}
 
 	_sourceItems = SourceItem::readAllSources(this);

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -468,7 +468,7 @@ void ListModel::selectAllItems()
 
 void ListModel::cleanUp()
 {
-	disconnect();
+	blockSignals(true);
 }
 
 void ListModel::sourceTermsReset()


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3913

When closing the workspace, the analyses are removed, and then the columns generated by the analyses (but not computed) are set to be just not computed column ( not linked to an analysis). This operation triggers the DataSetPackage to be refreshed, and sometimes this refresh crashes in the middle of Qt calls. But I don't see the need to refresh the DataSetPackage at all, so I just removed it, and since that the crashes does not occur anymore.

I have also replaced the disconect() calls to blockSignals(true) in the QML controls: the disconnect call was there to prevent some signals to be triggered though the JASP control being deleted. This disconnect is not recommended by Qt, and results in a warning that can cause a mutex deadlock in debug mode. So I just replace the disconnect by blockSignals

