### PR TITLE
Filter fixes - allow the user to filter out everything

### DIFF
--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -153,6 +153,7 @@ void DatabaseInterface::dataSetUpdate(int dataSetId,	const std::string & dataFil
 void DatabaseInterface::dataSetLoad(int dataSetId, std::string & dataFilePath, long & dataFileTimestamp, std::string & description, std::string & databaseJson, std::string & emptyValuesJson, int & revision, bool & dataSynch, bool & showRSyntax)
 {
 	JASPTIMER_SCOPE(DatabaseInterface::dataSetLoad);
+
 	std::function<void(sqlite3_stmt *stmt)>  prepare = [&](sqlite3_stmt *stmt)
 	{
 		sqlite3_bind_int(stmt, 1, dataSetId);

--- a/CommonData/rbridge.cpp
+++ b/CommonData/rbridge.cpp
@@ -827,22 +827,10 @@ std::vector<bool> rbridge_applyFilter(const std::string & filterCode, const std:
 
 		throw filterException(errorMsg.c_str());
 	}
-
+	
 	std::vector<bool> returnThis;
 
-	bool atLeastOneRow = false;
-	if(arrayLength == rowCount) //Only build boolvector if it matches the desired length.
-		for(int i=0; i<arrayLength; i++)
-		{
-			returnThis.push_back(arrayPointer[i]);
-			if(arrayPointer[i])
-				atLeastOneRow = true;
-		}
-
-	jaspRCPP_freeArrayPointer(&arrayPointer);
-
-	if(!atLeastOneRow)
-		throw filterException("Filtered out all data.");
+	
 
 	if(arrayLength != rowCount)
 	{
@@ -851,6 +839,11 @@ std::vector<bool> rbridge_applyFilter(const std::string & filterCode, const std:
 		errorMsg = msg.str();
 		throw filterException(errorMsg);
 	}
+	
+	for(size_t i=0; i<arrayLength; i++)
+		returnThis.push_back(arrayPointer[i]);
+	
+	jaspRCPP_freeArrayPointer(&arrayPointer);
 
 	return returnThis;
 }

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
@@ -16,7 +16,10 @@ ListView
 
 	delegate: MouseArea
 	{
-	
+		required property string type;
+		required property string columnName;
+		required property string toolTip;
+		
 		implicitWidth:  orientation === ListView.Horizontal ? elementLoader.item.width	: ListView.view.width
 		implicitHeight: orientation === ListView.Horizontal ? ListView.view.height	: elementLoader.item.height
 
@@ -112,7 +115,7 @@ ListView
 		Component { id: numberComp;			NumberDrag				{ toolTipText: listToolTip; value: listNumber;									alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: stringComp;			StringDrag				{ toolTipText: listToolTip; text: listText;										alternativeDropFunction: alternativeDropFunctionDef } }
 		Component { id: separatorComp;		Item					{ height: filterConstructor.blockDim; width: listWidth - listOfStuff.widthMargin; Rectangle { height: 1; color: jaspTheme.black; width: parent.width ; anchors.centerIn: parent }  } }
-		Component { id: defaultComp;		Text					{ text: "Something wrong!"; color: jaspTheme.red }  }
+		Component { id: defaultComp;		Text					{ text: "???"; color: jaspTheme.textDisabled }  }
 		Component {	id: columnComp;			ColumnDrag				{ columnName: listColName;	columnTypeUser:	-1;				acceptsDrops: false;	alternativeDropFunction: alternativeDropFunctionDef; maxSize: listOfStuff.maxWidth } }
 	}
 

--- a/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/ElementView.qml
@@ -16,10 +16,6 @@ ListView
 
 	delegate: MouseArea
 	{
-		required property string type;
-		required property string columnName;
-		required property string toolTip;
-		
 		implicitWidth:  orientation === ListView.Horizontal ? elementLoader.item.width	: ListView.view.width
 		implicitHeight: orientation === ListView.Horizontal ? ListView.view.height	: elementLoader.item.height
 

--- a/Desktop/components/JASP/Widgets/FilterWindow.qml
+++ b/Desktop/components/JASP/Widgets/FilterWindow.qml
@@ -77,10 +77,10 @@ FocusScope
 				{
 
 					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Abs");					*/ functionName: "abs";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("absolute value") }
-					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Standard deviation");	*/ 	functionName: "sd";				functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("standard deviation") }
-					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Variance");			*/ 	functionName: "var";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("variance") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Standard deviation");	*/ functionName: "sd";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("standard deviation") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Variance");			*/ functionName: "var";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("variance") }
 					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Sum");					*/ functionName: "sum";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("summation") }
-					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Product");				*/ functionName: "prod";			functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("product of values") }
+					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("Product");				*/ functionName: "prod";		functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("product of values") }
 					ListElement	{ type: "function";	friendlyFunctionName:	""; /* qsTr("ZScores");				*/ functionName: "zScores";		functionParameters: "values";			functionParamTypes: "number";						toolTip: qsTr("Standardizes the variable") }
 
 					ListElement	{ type: "rowfunction";	friendlyFunctionName:	""; /* qsTr("Rowwise mean") ;				*/	functionName: "rowMean";		toolTip: qsTr("Rowwise mean") }

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -113,8 +113,6 @@ QString ColumnsModel::getColumnTransformedToolTip(const QString &name, columnTyp
 
 QVariant ColumnsModel::data(const QModelIndex &index, int role) const
 {
-	if(index.row() < 0 || index.row() >= rowCount()) return QVariant();
-
 	QString				colName		= QTransposeProxyModel::data(index, int(DataSetPackage::specialRoles::name)).toString();
 	columnType			colType		= static_cast<columnType>			(QTransposeProxyModel::data(index, int(DataSetPackage::specialRoles::columnType			)).toInt());
 	computedColumnType	codeType	= static_cast<computedColumnType>	(QTransposeProxyModel::data(index, int(DataSetPackage::specialRoles::computedColumnType	)).toInt());

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -6,20 +6,20 @@
 ColumnsModel * ColumnsModel::_singleton = nullptr;
 
 ColumnsModel::ColumnsModel(DataSetTableModel *tableModel) 
-: QTransposeProxyModel(tableModel), _tableModel(tableModel)
+: QAbstractTableModel(tableModel), _tableModel(tableModel)
 {
 	assert(!_singleton);
 	_singleton = this;
 	
-	setSourceModel(tableModel);
-
 	connect(_tableModel, &DataSetTableModel::columnTypeChanged,		this, [&](QString col, int) { emit columnTypeChanged(col); });
 	connect(_tableModel, &DataSetTableModel::labelChanged,			this, [&](QString col, QString orgLabel, QString newLabel) { emit labelsChanged(col, {std::make_pair(orgLabel, newLabel) }); } );
 	connect(_tableModel, &DataSetTableModel::labelsReordered,		this, &ColumnsModel::labelsReordered	);
 	connect(_tableModel, &DataSetTableModel::emptyValuesChanged,	this, &ColumnsModel::dataSetChanged		);
+	connect(_tableModel, &DataSetTableModel::modelReset,			this, &ColumnsModel::refresh			);
+	connect(_tableModel, &DataSetTableModel::dataChanged,			this, &ColumnsModel::refresh			);
+	
 
 	auto * info = new VariableInfo(_singleton);
-
 
 	connect(this, &ColumnsModel::columnNamesChanged,					info, &VariableInfo::variableNamesChanged	);
 	connect(this, &ColumnsModel::columnsChanged,						info, &VariableInfo::variablesChanged		);
@@ -29,14 +29,14 @@ ColumnsModel::ColumnsModel(DataSetTableModel *tableModel)
 			emit VariableInfo::info()->variableTypeChanged(term);
 		} );
 
-	connect(this, &ColumnsModel::labelsChanged,							info, &VariableInfo::labelsChanged			);
-	connect(this, &ColumnsModel::labelsReordered,						info, &VariableInfo::labelsReordered		);
-	connect(this, &ColumnsModel::filterChanged,							info, &VariableInfo::filterChanged			);
-	connect(this, &ColumnsModel::dataSetChanged,						info, &VariableInfo::dataSetChanged			);
-	connect(this, &QTransposeProxyModel::columnsInserted,				info, &VariableInfo::rowCountChanged		);
-	connect(this, &QTransposeProxyModel::columnsRemoved,				info, &VariableInfo::rowCountChanged		);
-	connect(this, &QTransposeProxyModel::modelReset,					info, &VariableInfo::rowCountChanged		);
-	connect(MainWindow::singleton(), &MainWindow::dataAvailableChanged, info, &VariableInfo::dataAvailableChanged	);
+	connect(this,						&ColumnsModel::labelsChanged,				info, &VariableInfo::labelsChanged			);
+	connect(this,						&ColumnsModel::labelsReordered,				info, &VariableInfo::labelsReordered		);
+	connect(this,						&ColumnsModel::filterChanged,				info, &VariableInfo::filterChanged			);
+	connect(this,						&ColumnsModel::dataSetChanged,				info, &VariableInfo::dataSetChanged			);
+	connect(this,						&QAbstractTableModel::modelReset,			info, &VariableInfo::rowCountChanged		);
+	connect(_tableModel,				&DataSetTableModel::columnsInserted,		info, &VariableInfo::rowCountChanged		);
+	connect(_tableModel,				&DataSetTableModel::columnsRemoved,			info, &VariableInfo::rowCountChanged		);
+	connect(MainWindow::singleton(),	&MainWindow::dataAvailableChanged,			info, &VariableInfo::dataAvailableChanged	);
 }
 
 ColumnsModel::~ColumnsModel()
@@ -113,9 +113,9 @@ QString ColumnsModel::getColumnTransformedToolTip(const QString &name, columnTyp
 
 QVariant ColumnsModel::data(const QModelIndex &index, int role) const
 {
-	QString				colName		= QTransposeProxyModel::data(index, int(DataSetPackage::specialRoles::name)).toString();
-	columnType			colType		= static_cast<columnType>			(QTransposeProxyModel::data(index, int(DataSetPackage::specialRoles::columnType			)).toInt());
-	computedColumnType	codeType	= static_cast<computedColumnType>	(QTransposeProxyModel::data(index, int(DataSetPackage::specialRoles::computedColumnType	)).toInt());
+	QString				colName		=									 _tableModel->headerData(index.row(), Qt::Horizontal, int(DataSetPackage::specialRoles::name				)).toString();
+	columnType			colType		= static_cast<columnType>			(_tableModel->headerData(index.row(), Qt::Horizontal, int(DataSetPackage::specialRoles::columnType			)).toInt());
+	computedColumnType	codeType	= static_cast<computedColumnType>	(_tableModel->headerData(index.row(), Qt::Horizontal, int(DataSetPackage::specialRoles::computedColumnType	)).toInt());
 
 	switch(role)
 	{
@@ -137,6 +137,16 @@ QVariant ColumnsModel::data(const QModelIndex &index, int role) const
 	return QVariant();
 }
 
+int ColumnsModel::rowCount(const QModelIndex &) const
+{
+	return _tableModel->columnCount();
+}
+
+int ColumnsModel::columnCount(const QModelIndex &) const
+{
+	return 1;
+}
+
 QVariant ColumnsModel::provideInfo(VariableInfo::InfoType info, const QString& colName, int row) const
 {
 	ColumnsModel* colModel = ColumnsModel::singleton();
@@ -152,30 +162,34 @@ QVariant ColumnsModel::provideInfo(VariableInfo::InfoType info, const QString& c
 			return QVariant();
 
 		//remember, the model is transposed:
-		QModelIndex qColIndex = index(colIndex, 0),
-					qValIndex = index(colIndex, row);
+		QModelIndex qColIndex	= index(colIndex, 0),
+					tableCIndex	= _tableModel->index(0, colIndex),
+					tableVIndex	= _tableModel->index(row, colIndex);
 
 		//columnType	colTypeHere	= static_cast<columnType>(colTypeInt);
 
 		switch(info)
 		{
-		case VariableInfo::VariableType:				return	data(qColIndex, ColumnsModel::ColumnTypeRole).toInt();
-		case VariableInfo::DoubleValues:				return	QTransposeProxyModel::data(qColIndex,						int(DataSetPackage::specialRoles::valuesDblList));
-		case VariableInfo::TotalNumericValues:			return	QTransposeProxyModel::data(qColIndex,						int(DataSetPackage::specialRoles::nonFilteredNumericValuesCount));
-		case VariableInfo::TotalLevels:					return	QTransposeProxyModel::data(qColIndex,						int(DataSetPackage::specialRoles::nonFilteredLevels)).toStringList().length();
-		case VariableInfo::Labels:						return	QTransposeProxyModel::data(qColIndex,						int(DataSetPackage::specialRoles::nonFilteredLevels));
-		case VariableInfo::NameRole:					return	data(qColIndex, ColumnsModel::NameRole);
-		case VariableInfo::DataSetRowCount:				return  QTransposeProxyModel::columnCount();
-		case VariableInfo::DataSetValue:				return	QTransposeProxyModel::data(qValIndex,						int(DataSetPackage::specialRoles::value));
-		case VariableInfo::DataSetValues:				return	QTransposeProxyModel::data(qColIndex,						int(DataSetPackage::specialRoles::valuesStrList));
-		case VariableInfo::MaxWidth:					return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::maxColString)).toInt();
-		case VariableInfo::SignalsBlocked:				return	_tableModel->synchingData();
+		case VariableInfo::VariableType:				return					data(qColIndex, ColumnsModel::ColumnTypeRole).toInt();
+		case VariableInfo::NameRole:					return					data(qColIndex, ColumnsModel::NameRole);
+		
+		case VariableInfo::DoubleValues:				return	_tableModel->	data(tableCIndex,						int(DataSetPackage::specialRoles::valuesDblList));
+		case VariableInfo::TotalNumericValues:			return	_tableModel->	data(tableCIndex,						int(DataSetPackage::specialRoles::nonFilteredNumericValuesCount));
+		case VariableInfo::TotalLevels:					return	_tableModel->	data(tableCIndex,						int(DataSetPackage::specialRoles::nonFilteredLevels)).toStringList().length();
+		case VariableInfo::Labels:						return	_tableModel->	data(tableCIndex,						int(DataSetPackage::specialRoles::nonFilteredLevels));
+		case VariableInfo::DataSetValues:				return	_tableModel->	data(tableCIndex,						int(DataSetPackage::specialRoles::valuesStrList));
+		case VariableInfo::DataSetRowCount:				return  _tableModel->	rowCount();
+		case VariableInfo::SignalsBlocked:				return	_tableModel->	synchingData();
+		case VariableInfo::DataSetValue:				return	_tableModel->	data(tableVIndex,						int(DataSetPackage::specialRoles::value));
+		
 		case VariableInfo::VariableNames:				return	getColumnNames();
 		case VariableInfo::DataAvailable:				return	MainWindow::singleton()->dataAvailable();
-		case VariableInfo::PreviewScale:				return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::previewScale));
-		case VariableInfo::PreviewOrdinal:				return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::previewOrdinal));
-		case VariableInfo::PreviewNominal:				return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::previewNominal));
-		case VariableInfo::ColumnDescription:			return	QTransposeProxyModel::headerData(colIndex, Qt::Vertical,	int(DataSetPackage::specialRoles::description));
+		
+		case VariableInfo::MaxWidth:					return	_tableModel->headerData(colIndex, Qt::Horizontal,	int(DataSetPackage::specialRoles::maxColString)).toInt();
+		case VariableInfo::PreviewScale:				return	_tableModel->headerData(colIndex, Qt::Horizontal,	int(DataSetPackage::specialRoles::previewScale));
+		case VariableInfo::PreviewOrdinal:				return	_tableModel->headerData(colIndex, Qt::Horizontal,	int(DataSetPackage::specialRoles::previewOrdinal));
+		case VariableInfo::PreviewNominal:				return	_tableModel->headerData(colIndex, Qt::Horizontal,	int(DataSetPackage::specialRoles::previewNominal));
+		case VariableInfo::ColumnDescription:			return	_tableModel->headerData(colIndex, Qt::Horizontal,	int(DataSetPackage::specialRoles::description));
 		case VariableInfo::DataSetPointer:				return	QVariant::fromValue<void*>(DataSetPackage::pkg()->dataSet());
 		}
 	}
@@ -212,8 +226,8 @@ bool ColumnsModel::absorbInfo(VariableInfo::InfoType info, const QString &colNam
 		switch(info)
 		{
 		default:										return	false;
-		case VariableInfo::DataSetValue:				return	QTransposeProxyModel::setData(qValIndex, value, int(DataSetPackage::specialRoles::value));
-		case VariableInfo::DataSetValues:				return	QTransposeProxyModel::setData(qColIndex, value,	int(DataSetPackage::specialRoles::valuesStrList));
+		case VariableInfo::DataSetValue:				return	QAbstractTableModel::setData(qValIndex, value, int(DataSetPackage::specialRoles::value));
+		case VariableInfo::DataSetValues:				return	QAbstractTableModel::setData(qColIndex, value,	int(DataSetPackage::specialRoles::valuesStrList));
 		}
 	}
 	catch(std::exception & e)

--- a/Desktop/data/columnsmodel.cpp
+++ b/Desktop/data/columnsmodel.cpp
@@ -161,7 +161,6 @@ QVariant ColumnsModel::provideInfo(VariableInfo::InfoType info, const QString& c
 		if (colIndex < 0)
 			return QVariant();
 
-		//remember, the model is transposed:
 		QModelIndex qColIndex	= index(colIndex, 0),
 					tableCIndex	= _tableModel->index(0, colIndex),
 					tableVIndex	= _tableModel->index(row, colIndex);
@@ -216,18 +215,14 @@ bool ColumnsModel::absorbInfo(VariableInfo::InfoType info, const QString &colNam
 		if (colIndex < 0)
 			return false;
 
-		//remember, the model is transposed:
-		QModelIndex qColIndex = index(colIndex, 0),
-					qValIndex = index(colIndex, row);
-
-		int			colTypeInt	= data(qColIndex, ColumnsModel::ColumnTypeRole).toInt();
-		//columnType	colTypeHere	= static_cast<columnType>(colTypeInt);
+		QModelIndex qColIndex	= _tableModel->index(0, colIndex),
+					qValIndex	= _tableModel->index(row, colIndex);
 
 		switch(info)
 		{
 		default:										return	false;
-		case VariableInfo::DataSetValue:				return	QAbstractTableModel::setData(qValIndex, value, int(DataSetPackage::specialRoles::value));
-		case VariableInfo::DataSetValues:				return	QAbstractTableModel::setData(qColIndex, value,	int(DataSetPackage::specialRoles::valuesStrList));
+		case VariableInfo::DataSetValue:				return	_tableModel->setData(qValIndex, value,	int(DataSetPackage::specialRoles::value));
+		case VariableInfo::DataSetValues:				return	_tableModel->setData(qColIndex, value,	int(DataSetPackage::specialRoles::valuesStrList));
 		}
 	}
 	catch(std::exception & e)

--- a/Desktop/data/columnsmodel.h
+++ b/Desktop/data/columnsmodel.h
@@ -8,7 +8,7 @@
 /// 
 /// Model used by the filter-drag-n-drop to give all the columns and their datatypes
 /// The columns are layed out as rows to facilitate that
-class ColumnsModel  : public QTransposeProxyModel, public VariableInfoProvider
+class ColumnsModel  : public QAbstractTableModel, public VariableInfoProvider
 {
 	Q_OBJECT
 public:
@@ -24,6 +24,8 @@ public:
 											~ColumnsModel()		override;
 
 				QVariant					data(			const QModelIndex & index, int role = Qt::DisplayRole)				const	override;
+				int							rowCount(		const QModelIndex &parent = QModelIndex())							const override;
+				int							columnCount(	const QModelIndex &parent = QModelIndex())							const override;
 				QHash<int, QByteArray>		roleNames()																			const	override;
 				int							getColumnIndex(const std::string & col)												const				{ return _tableModel->getColumnIndex(col);	}
 				QStringList					getColumnNames()																	const;
@@ -45,6 +47,7 @@ public:
 
 public slots:
 	void datasetChanged(QStringList changedColumns, QStringList missingColumns, QMap<QString, QString> changeNameColumns, bool rowCountChanged, bool hasNewColumns);
+	void refresh() { beginResetModel(); endResetModel(); }
 
 signals:
 	void columnNamesChanged(QMap<QString, QString>	changedNames);

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -640,8 +640,8 @@ QVariant DataSetPackage::headerData(int section, Qt::Orientation orientation, in
 		case int(specialRoles::maxRowHeaderString):				return QString::number(_dataSet ? _dataSet->rowCount() : 0 )		+ "XXX";
 		case Qt::TextAlignmentRole:								return QVariant(Qt::AlignCenter);
 		case int(specialRoles::filter):							return		!col ? false							: col->hasFilter() || isColumnUsedInEasyFilter(col->name());
+		case int(specialRoles::name):							[[fallthrough]];
 		case Qt::DisplayRole:									return tq(	!col ? "?"								: col->name());
-		
 		case int(specialRoles::labelsHasFilter):				return		!col ? false							: col->hasFilter();
 		case int(specialRoles::columnIsComputed):				return		!col ? false							: col->isComputed() && col->codeType() != computedColumnType::analysisNotComputed;
 		case int(specialRoles::computedColumnError):			return tq(	!col ? "?"								: col->error());
@@ -1840,27 +1840,6 @@ void DataSetPackage::columnsApply(intset columnIndexes, std::function<bool(Colum
 void DataSetPackage::columnsApply(intset columnIndexes, std::function<bool(Column * column)> applyThis)
 {
 	columnsApply(columnIndexes, [&](Column * column, int){ return applyThis(column); });
-}
-
-bool DataSetPackage::setFilterData(const std::string & rFilter, const boolvec & filterResult)
-{
-	filter()->setRFilter(rFilter);
-
-	bool someFilterValueChanged = filter()->setFilterVector(filterResult);
-	
-	if(_dataSet)
-		_dataSet->filter()->setFilterVector(filterResult);
-
-	if(someFilterValueChanged) //We could also send exactly those cells that were changed if we were feeling particularly inclined to write the code...
-	{
-		//emit dataChanged(index(0, 0, parentModelForType(parIdxType::filter)),	index(rowCount(), 0,				parentModelForType(parIdxType::filter)));
-		//This actually lets the whole application freeze when a filter is undone... -> emit dataChanged(index(0, 0, parentModelForType(parIdxType::data)),		index(rowCount(), columnCount(),	parentModelForType(parIdxType::data)));
-
-		beginResetModel();
-		endResetModel();
-	}
-
-	return someFilterValueChanged;
 }
 
 columnType DataSetPackage::getColumnType(size_t columnIndex) const

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -262,7 +262,6 @@ public:
 				bool						labelNeedsFilter(					size_t				columnIndex)				const;
 				void						labelMoveRows(						size_t				columnIndex, std::vector<size_t> rows, bool up);
 				void						labelReverse(						size_t				columnIndex);
-				bool						setFilterData(const std::string & filter, const boolvec & filterResult);
 				void						resetAllFilters();
 				std::vector<bool>			filterVector();
 				void						setFilterVectorWithoutModelUpdate(std::vector<bool> newFilterVector) { if(_dataSet) _dataSet->filter()->setFilterVector(newFilterVector); }


### PR DESCRIPTION
Allows for having no accepted filter row whatsoever.

This fixes some issues related with https://github.com/jasp-stats/jasp-issues/issues/3941
The other was that also somehow filtervalues were not always being saved to sqlite properly?

A problem here was that the `ColumnsModel` which is used for lots of things in JASP was a `QTransposeProxyModel`.
Which was used to pass on columnname, -type etc to variable views in qml *and* the columns list in the filter/computed columns. 
However, when you filter everything out the transpose model optimises all data calls away cause it knows the model is empty...

To avoid this ive turned the `ColumnsModel` into its own `QAbstractTableModel`.

All of this has as a side-effect that know you can make errors in your filter that make it empty and you can actually read your errormsgs.