### PR TITLE
add a progressbar hide timer for autosaves

### DIFF
--- a/Desktop/components/JASP/Widgets/ProgressBarHolder.qml
+++ b/Desktop/components/JASP/Widgets/ProgressBarHolder.qml
@@ -28,7 +28,13 @@ Item
 		height:				120 * preferencesModel.uiScale
 		radius:				height
 		width:				Math.min(Math.max(loadingText.implicitWidth + height, parent.width * 0.5), parent.width - height)
-		anchors.centerIn:	parent
+		anchors
+		{
+			top:				parent.top
+			topMargin:			100 * jaspTheme.uiScale
+			horizontalCenter:	parent.horizontalCenter
+		}
+			
 
 		Text
 		{

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -2123,7 +2123,6 @@ void MainWindow::setProgressBarVisible(bool progressBarVisible, bool wasAutoSave
 	{
 		int64_t diff = lastShownMs == -1 ? -1 : Utils::currentMillis() - lastShownMs;
 		
-		Log::log() << "diff: " << diff << " lastShownMs: " << lastShownMs << " possible duration timer: " << (minimumShow-diff) << std::endl;
 		
 		if(!wasAutoSave || lastShownMs == -1 || diff >= minimumShow)
 			_setProgressBarVisible(false);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -154,7 +154,7 @@ MainWindow::MainWindow(Application * application) : QObject(application), _appli
 
 	_dynamicModules->registerQMLTypes();
 
-	QTimer::singleShot(0, [&]() { loadQML(); });
+	QTimer::singleShot(0, this, [&]() { loadQML(); });
 
 	_languageModel->setApplicationEngine(_qml);
 
@@ -164,9 +164,15 @@ MainWindow::MainWindow(Application * application) : QObject(application), _appli
 
 	QTimer::singleShot(0, this, [&]() { _jaspConfiguration->processConfiguration();  });
 	
+	_progressBarTimer = new QTimer(this);
+	_progressBarTimer->setSingleShot(true);
+	
+	connect(_progressBarTimer, &QTimer::timeout, this, [this](){ _setProgressBarVisible(false); });
+	
 	_languageModel->setDefaultLocaleFromCurrent(); //Make sure (Q)ColumnUtils knows whats up
 
 	Log::log() << "JASP Desktop started and Engines initalized." << std::endl;
+	
 
 	JASPTIMER_FINISH(MainWindowConstructor);
 }
@@ -1336,7 +1342,7 @@ void MainWindow::closeVariablesPage()
 
 void MainWindow::dataSetIOCompleted(FileEvent *event)
 {
-	hideProgress();
+	hideProgress(event->isTmp() && event->operation() == FileEvent::FileSave);
 	
 	if (event->operation() == FileEvent::FileNew)
 	{
@@ -1984,9 +1990,9 @@ void MainWindow::showProgress()
 	setProgressBarVisible(true);
 }
 
-void MainWindow::hideProgress()
+void MainWindow::hideProgress(bool wasAutoSave)
 {
-	setProgressBarVisible(false);
+	setProgressBarVisible(false, wasAutoSave);
 }
 
 
@@ -2098,7 +2104,41 @@ bool MainWindow::enginesInitializing()
 	return _engineSync->allEnginesInitializing();
 }
 
-void MainWindow::setProgressBarVisible(bool progressBarVisible)
+void MainWindow::setProgressBarVisible(bool progressBarVisible, bool wasAutoSave)
+{
+	if(_progressBarVisible == progressBarVisible)
+		return; 
+	
+	const int64_t	minimumShow	 = 1000; //Is this long enough?
+	
+	static int64_t lastShownMs = -1;
+	
+	if(progressBarVisible)
+	{
+		_progressBarTimer->stop();
+		lastShownMs = Utils::currentMillis();
+		_setProgressBarVisible(true);
+	}
+	else
+	{
+		int64_t diff = lastShownMs == -1 ? -1 : Utils::currentMillis() - lastShownMs;
+		
+		Log::log() << "diff: " << diff << " lastShownMs: " << lastShownMs << " possible duration timer: " << (minimumShow-diff) << std::endl;
+		
+		if(!wasAutoSave || lastShownMs == -1 || diff >= minimumShow)
+			_setProgressBarVisible(false);
+		else
+		{
+			_progressBarTimer->setInterval(minimumShow-diff);
+			_progressBarTimer->start();
+			//lastShownMs = -1;
+		}
+	}
+	
+	
+}
+
+void MainWindow::_setProgressBarVisible(bool progressBarVisible)
 {
 	if (_progressBarVisible == progressBarVisible)
 		return;

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -139,7 +139,7 @@ public slots:
 	void setImageBackgroundHandler(QString value);
 	void plotPPIChangedHandler(int ppi, bool wasUserAction);
 	void setProgressBarProgress(int progressBarProgress);
-	void setProgressBarVisible(bool progressBarVisible);
+	void setProgressBarVisible(bool progressBarVisible, bool wasAutoSave = false);
 	void setWelcomePageVisible(bool welcomePageVisible);
 	void setProgressBarStatus(QString progressBarStatus);
 	void setAnalysesAvailable(bool analysesAvailable);
@@ -187,8 +187,10 @@ public slots:
 	void	openGitHubBugReport() const;
 	void	reloadResults() const;
 
-private:
+private slots:
+	void _setProgressBarVisible(bool progressBarVisible);
 	
+private:
 	void makeConnections();
 	void initLog();
 	void initQWidgetGUIParts();
@@ -272,7 +274,7 @@ private slots:
 
 	void closeVariablesPage();
 	void showProgress();
-	void hideProgress();
+	void hideProgress(bool wasAutoSave = false);
 	void setProgressStatus(QString status, int progress);
 	void showAnalysis();
 
@@ -364,8 +366,8 @@ private:
 									_contactVisible			= false,
 									_communityVisible		= false,
 									_hadFatalError			= false;
-									
 	QFont							_defaultFont;
+	QTimer					*		_progressBarTimer		= nullptr;
 };
 
 #endif // MAINWIDGET_H


### PR DESCRIPTION
It shows the progressbar for minimum of 1 sec now. I can read fast enough to see it says "autosave", let me know if this is just me

It also moves the progressbar up a bit

implements https://github.com/jasp-stats/INTERNAL-jasp/issues/3048

