### PR TITLE
Make file menu wide enough even in long translations

### DIFF
--- a/Desktop/components/JASP/Widgets/FileMenu/Database.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/Database.qml
@@ -43,7 +43,7 @@ QC.ScrollView
             id				: menuHeader
 			headertext		: qsTr("Database")
             helpfile:		"filemenu/Database"
-            anchorMe        : false
+            addMargin:      false
             width:			scrollDB.width - (2 * jaspTheme.generalMenuMargin)
             x:				jaspTheme.generalMenuMargin
 

--- a/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/FileMenu.qml
@@ -360,7 +360,7 @@ FocusScope
 			property real otherColumnsWidth:	actionMenu.width + resourceMenu.width
 			property bool aButtonVisible:		resourceRepeaterId.count > 0 && fileMenuModel.resourceButtons.currentQML !== ''
 
-			property real desiredWidth:			Math.min(mainWindowRoot.width - otherColumnsWidth, 600 * preferencesModel.uiScale)
+			property real desiredWidth:			Math.min(mainWindowRoot.width - otherColumnsWidth, Math.max(showSelectedSubScreen.item ? showSelectedSubScreen.item.implicitWidth : 0, 600 * preferencesModel.uiScale))
 			property real desiredX:				otherColumnsWidth - (aButtonVisible ? 0 : desiredWidth)
 
 			property string previousQML: ""

--- a/Desktop/components/JASP/Widgets/FileMenu/MenuHeader.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/MenuHeader.qml
@@ -10,7 +10,7 @@ Item
 	property bool	toolseparator:	true
 	property string headertext:		""
 	property string helpfile:		""
-	property bool	anchorMe:		true
+	property bool	addMargin:		true
 
 	function showHelp()
 	{
@@ -18,15 +18,9 @@ Item
 			helpModel.showOrTogglePage(helpfile);
 	}
 
+	x:						addMargin ? jaspTheme.generalMenuMargin : 0
+	width:					parent.width - (addMargin ? 2 * jaspTheme.generalMenuMargin : 0)
 	height:					jaspTheme.menuHeaderHeight
-	anchors
-	{
-		top:				!anchorMe ? undefined : parent.top
-		left:				!anchorMe ? undefined : parent.left
-		right:				!anchorMe ? undefined : parent.right
-		leftMargin:			!anchorMe ? undefined : jaspTheme.generalMenuMargin
-		rightMargin:		!anchorMe ? undefined : jaspTheme.generalMenuMargin
-	}
 
 	Label
 	{

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsAdvanced.qml
@@ -1,585 +1,554 @@
 import QtQuick
-import QtQuick.Controls
 import JASP.Widgets
 import JASP.Controls
 
 PrefsScrollView
 {
 	id:						scrollPrefs
-	
-	Column
+
+	MenuHeader
 	{
-		width:			scrollPrefs.width
-		spacing:		jaspTheme.rowSpacing
+		id:				menuHeader
+		headertext:		qsTr("Advanced Preferences")
+		helpfile:		"preferences/PrefsAdvanced"
+		addMargin:		false
+	}
 
-		MenuHeader
+
+	PrefsGroupRect
+	{
+		title:				qsTr("Modules options")
+
+		CheckBox
 		{
-			id:				menuHeader
-			headertext:		qsTr("Advanced Preferences")
-			helpfile:		"preferences/PrefsAdvanced"
-			anchorMe:		false
-			width:			scrollPrefs.width - (2 * jaspTheme.generalMenuMargin)
-			x:				jaspTheme.generalMenuMargin
+			id:					rememberModulesSelected
+			label:				qsTr("Remember enabled modules")
+			checked:			preferencesModel.modulesRemember
+			onCheckedChanged:	preferencesModel.modulesRemember = checked
+			toolTip:			qsTr("Continue where you left of the next time JASP starts.\nEnabling this option makes JASP remember which Modules you've enabled.")
+			focus:				true
+			KeyNavigation.tab:	cranRepoUrl
 		}
 
-
-		PrefsGroupRect
+		Item
 		{
-			title:				qsTr("Modules options")
+			id:		cranRepoUrlItem
+			width:	parent.width
+			height:	cranRepoUrl.height
 
-			CheckBox
+			Label
 			{
-				id:					rememberModulesSelected
-				label:				qsTr("Remember enabled modules")
-				checked:			preferencesModel.modulesRemember
-				onCheckedChanged:	preferencesModel.modulesRemember = checked
-				toolTip:			qsTr("Continue where you left of the next time JASP starts.\nEnabling this option makes JASP remember which Modules you've enabled.")
-				focus:				true
-				KeyNavigation.tab:	cranRepoUrl
-			}
+				id:		cranRepoUrlLabel
+				text:	qsTr("Change the CRAN repository: ")
 
-			Item
-			{
-				id:		cranRepoUrlItem
-				width:	parent.width
-				height:	cranRepoUrl.height
-
-				Label
+				anchors
 				{
-					id:		cranRepoUrlLabel
-					text:	qsTr("Change the CRAN repository: ")
-
-					anchors
-					{
-						left:			parent.left
-						verticalCenter:	parent.verticalCenter
-						margins:		jaspTheme.generalAnchorMargin
-					}
-				}
-
-				PrefsTextInput
-				{
-					id:					cranRepoUrl
-
-					text:				preferencesModel.cranRepoURL
-					onEditingFinished:	preferencesModel.cranRepoURL = text
-					nextEl:				githubPatDefault
-
-					height:				browseDeveloperFolderButton.height
-					anchors
-					{
-						left:			cranRepoUrlLabel.right
-						right:			parent.right
-						margins:		jaspTheme.generalAnchorMargin
-					}
-
-					KeyNavigation.tab:	githubPatDefault
+					left:			parent.left
+					verticalCenter:	parent.verticalCenter
+					margins:		jaspTheme.generalAnchorMargin
 				}
 			}
 
-			CheckBox
+			PrefsTextInput
 			{
-				id:					githubPatDefault
-				label:				qsTr("Use default PAT for Github")
-				checked:			preferencesModel.githubPatUseDefault
-				onCheckedChanged:	preferencesModel.githubPatUseDefault = checked
-				toolTip:			qsTr("Either use the bundled GITHUB_PAT or, if available, use the one set in environment variables.")
+				id:					cranRepoUrl
 
-				KeyNavigation.tab:		githubPatCustomToken
-			}
+				text:				preferencesModel.cranRepoURL
+				onEditingFinished:	preferencesModel.cranRepoURL = text
+				nextEl:				githubPatDefault
 
-			Item
-			{
-				id:			githubPatCustomTokenItem
-				width:		parent.width
-				height:		cranRepoUrl.height
-				enabled:	!preferencesModel.githubPatUseDefault
-
-				Label
+				height:				browseDeveloperFolderButton.height
+				anchors
 				{
-					id:					githubPatCustomLabel
-					text:				qsTr("Private GITHUB_PAT:")
-
-					anchors
-					{
-						left:			parent.left
-						verticalCenter:	parent.verticalCenter
-						leftMargin:		jaspTheme.subOptionOffset
-					}
+					left:			cranRepoUrlLabel.right
+					right:			parent.right
+					margins:		jaspTheme.generalAnchorMargin
 				}
 
-				PrefsTextInput
-				{
-					id:					githubPatCustomToken
-
-					text:				preferencesModel.githubPatCustom
-					onEditingFinished:	preferencesModel.githubPatCustom = text
-
-					nextEl:				developerMode
-
-					height:				browseDeveloperFolderButton.height
-					anchors
-					{
-						left:			githubPatCustomLabel.right
-						right:			parent.right
-						margins:		jaspTheme.generalAnchorMargin
-					}
-
-					textInput.echoMode:	TextInput.Password
-
-					KeyNavigation.tab:		developerMode
-				}
-			}
-
-			CheckBox
-			{
-				id:					developerMode
-				label:				qsTr("Developer mode")
-				checked:			preferencesModel.developerMode
-				onCheckedChanged:	preferencesModel.developerMode = checked
-				toolTip:			qsTr("To use JASP Modules enable this option.")
-				
-				KeyNavigation.tab:	generateMarkdown
-			}
-
-			CheckBox
-			{
-				id:					generateMarkdown
-				label:				qsTr("Generate markdown files for help")
-				toolTip:			qsTr("Enabling this will generate markdown helpfile from the info at qml options.")
-				checked:			preferencesModel.generateMarkdown
-				onCheckedChanged:	preferencesModel.generateMarkdown = checked
-				visible:			preferencesModel.developerMode
-				enabled:			preferencesModel.developerMode
-				KeyNavigation.tab:	moduleLibraryUrl
-
-			}
-
-			Item
-			{
-				id:			moduleLibraryUrlItem
-				width:		parent.width
-				height:		moduleLibraryUrl.height
-				visible:	preferencesModel.developerMode
-				enabled:	preferencesModel.developerMode
-
-				Label
-				{
-					id:			moduleLibraryUrlLabel
-					text:		qsTr("Module library URL: ")
-
-					anchors
-					{
-						left:			parent.left
-						verticalCenter: parent.verticalCenter
-						margins:		jaspTheme.generalAnchorMargin
-					}
-				}
-
-				PrefsTextInput
-				{
-					id:					moduleLibraryUrl
-
-					text:				preferencesModel.moduleLibraryURL
-					onEditingFinished:	preferencesModel.moduleLibraryURL = text
-					nextEl:				cleanModulesFolder
-
-					height:				browseDeveloperFolderButton.height
-					anchors
-					{
-						left:		moduleLibraryUrlLabel.right
-						right:		parent.right
-						margins:	jaspTheme.generalAnchorMargin
-					}
-
-					KeyNavigation.tab:	cleanModulesFolder
-				}
-			}
-	
-			RoundedButton
-			{	
-				id:					cleanModulesFolder
-				text:				qsTr("Clear installed modules and packages")
-                toolTip:			qsTr("This will erase the 'renv', 'Modules' and development Module folders in the appdata.")
-				onClicked:			mainWindow.clearModulesFoldersUser();
-
-				KeyNavigation.tab:		directLibpathDevModEnabled
-				activeFocusOnTab:		true
+				KeyNavigation.tab:	githubPatDefault
 			}
 		}
 
-		
-		PrefsGroupRect
+		CheckBox
 		{
-			id:					editDeveloperFolder
-			title:				qsTr("Development module")
+			id:					githubPatDefault
+			label:				qsTr("Use default PAT for Github")
+			checked:			preferencesModel.githubPatUseDefault
+			onCheckedChanged:	preferencesModel.githubPatUseDefault = checked
+			toolTip:			qsTr("Either use the bundled GITHUB_PAT or, if available, use the one set in environment variables.")
+
+			KeyNavigation.tab:		githubPatCustomToken
+		}
+
+		Item
+		{
+			id:			githubPatCustomTokenItem
+			width:		parent.width
+			height:		cranRepoUrl.height
+			enabled:	!preferencesModel.githubPatUseDefault
+
+			Label
+			{
+				id:					githubPatCustomLabel
+				text:				qsTr("Private GITHUB_PAT:")
+
+				anchors
+				{
+					left:			parent.left
+					verticalCenter:	parent.verticalCenter
+					leftMargin:		jaspTheme.subOptionOffset
+				}
+			}
+
+			PrefsTextInput
+			{
+				id:					githubPatCustomToken
+
+				text:				preferencesModel.githubPatCustom
+				onEditingFinished:	preferencesModel.githubPatCustom = text
+
+				nextEl:				developerMode
+
+				height:				browseDeveloperFolderButton.height
+				anchors
+				{
+					left:			githubPatCustomLabel.right
+					right:			parent.right
+					margins:		jaspTheme.generalAnchorMargin
+				}
+
+				textInput.echoMode:	TextInput.Password
+
+				KeyNavigation.tab:		developerMode
+			}
+		}
+
+		CheckBox
+		{
+			id:					developerMode
+			label:				qsTr("Developer mode")
+			checked:			preferencesModel.developerMode
+			onCheckedChanged:	preferencesModel.developerMode = checked
+			toolTip:			qsTr("To use JASP Modules enable this option.")
+
+			KeyNavigation.tab:	generateMarkdown
+		}
+
+		CheckBox
+		{
+			id:					generateMarkdown
+			label:				qsTr("Generate markdown files for help")
+			toolTip:			qsTr("Enabling this will generate markdown helpfile from the info at qml options.")
+			checked:			preferencesModel.generateMarkdown
+			onCheckedChanged:	preferencesModel.generateMarkdown = checked
 			visible:			preferencesModel.developerMode
 			enabled:			preferencesModel.developerMode
+			KeyNavigation.tab:	moduleLibraryUrl
+
+		}
+
+		Item
+		{
+			id:			moduleLibraryUrlItem
+			width:		parent.width
+			height:		moduleLibraryUrl.height
+			visible:	preferencesModel.developerMode
+			enabled:	preferencesModel.developerMode
+
+			Label
+			{
+				id:			moduleLibraryUrlLabel
+				text:		qsTr("Module library URL: ")
+
+				anchors
+				{
+					left:			parent.left
+					verticalCenter: parent.verticalCenter
+					margins:		jaspTheme.generalAnchorMargin
+				}
+			}
+
+			PrefsTextInput
+			{
+				id:					moduleLibraryUrl
+
+				text:				preferencesModel.moduleLibraryURL
+				onEditingFinished:	preferencesModel.moduleLibraryURL = text
+				nextEl:				cleanModulesFolder
+
+				height:				browseDeveloperFolderButton.height
+				anchors
+				{
+					left:		moduleLibraryUrlLabel.right
+					right:		parent.right
+					margins:	jaspTheme.generalAnchorMargin
+				}
+
+				KeyNavigation.tab:	cleanModulesFolder
+			}
+		}
+
+		RoundedButton
+		{
+			id:					cleanModulesFolder
+			text:				qsTr("Clear installed modules and packages")
+			toolTip:			qsTr("This will erase the 'renv', 'Modules' and development Module folders in the appdata.")
+			onClicked:			mainWindow.clearModulesFoldersUser();
+
+			KeyNavigation.tab:		directLibpathDevModEnabled
+			activeFocusOnTab:		true
+		}
+	}
+
+
+	PrefsGroupRect
+	{
+		id:					editDeveloperFolder
+		title:				qsTr("Development module")
+		visible:			preferencesModel.developerMode
+		enabled:			preferencesModel.developerMode
+
+		CheckBox
+		{
+			id:					directLibpathDevModEnabled
+			label:				qsTr("Enable renv mode") //We should really remove the old way and this checkbox
+			checked:			preferencesModel.directLibpathEnabled
+			onCheckedChanged:	preferencesModel.directLibpathEnabled = checked
+			toolTip:			qsTr("Load modules from a binary in an R-library instead of installing it from sources.")
+			visible:			preferencesModel.developerMode
+
+			KeyNavigation.tab:	browseDeveloperFolderButton
+		}
+
+
+		Item
+		{
+			width:				parent.width
+			height:				browseDeveloperFolderButton.height
+			enabled:			preferencesModel.developerMode && !preferencesModel.directLibpathEnabled
+			visible:			preferencesModel.developerMode && !preferencesModel.directLibpathEnabled
+
+
+			RoundedButton
+			{
+				id:						browseDeveloperFolderButton
+				text:					qsTr("Source folder:")
+				onClicked:				preferencesModel.browseDeveloperFolder()
+				anchors.left:			parent.left
+				anchors.leftMargin:		jaspTheme.subOptionOffset
+				toolTip:				qsTr("Browse to your JASP Module folder.")
+
+				KeyNavigation.tab:		developerFolderText.textInput
+				activeFocusOnTab:		true
+
+			}
+
+			PrefsTextInput
+			{
+				id:					developerFolderText
+
+				text:				preferencesModel.developerFolder
+				onEditingFinished:	preferencesModel.developerFolder = text
+				nextEl:				directLibPathLabel
+
+				height:				browseDeveloperFolderButton.height
+				anchors
+				{
+					left:			browseDeveloperFolderButton.right
+					right:			parent.right
+					margins:		jaspTheme.generalAnchorMargin
+				}
+			}
+		}
+
+		Item
+		{
+			id:					directLibpath
+			enabled:			preferencesModel.directLibpathEnabled
+			visible:			preferencesModel.developerMode && preferencesModel.directLibpathEnabled
+			width:				parent.width
+			height:				cranRepoUrl.height
+
+			RoundedButton
+			{
+				id:						directLibPathLabel
+				text:					qsTr("Project library:")
+				width:					Math.max(directDevModName.implicitWidth, directLibPathLabel.implicitWidth)
+				onClicked:				preferencesModel.browseDeveloperLibPathFolder()
+				activeFocusOnTab:		true
+				KeyNavigation.tab:		directLibpathFolder.textInput
+				KeyNavigation.backtab:	directLibpathDevModEnabled
+
+				anchors
+				{
+					left:			parent.left
+					verticalCenter:	parent.verticalCenter
+					leftMargin:		jaspTheme.subOptionOffset
+				}
+
+
+			}
+
+			PrefsTextInput
+			{
+				id:					directLibpathFolder
+
+				text:				preferencesModel.directLibpathFolder
+				onEditingFinished:	preferencesModel.directLibpathFolder = text
+
+				nextEl:				moduleName
+
+				height:				browseDeveloperFolderButton.height
+				anchors
+				{
+					left:			directLibPathLabel.right
+					right:			parent.right
+					margins:		jaspTheme.generalAnchorMargin
+				}
+
+				KeyNavigation.tab:	moduleName
+
+				toolTip:			qsTr("Choose the R library where you installed the development module")
+			}
+		}
+
+		Item {
+
+			id:					directDevMod
+			enabled:			preferencesModel.developerMode &&preferencesModel.directLibpathEnabled
+			visible:			preferencesModel.developerMode && preferencesModel.directLibpathEnabled
+			width:				parent.width
+			height:				cranRepoUrl.height
+
+			Label
+			{
+				id:					directDevModName
+				text:				qsTr("Module name:")
+				width:				Math.max(directDevModName.implicitWidth, directLibPathLabel.implicitWidth)
+
+				anchors
+				{
+					left:			parent.left
+					verticalCenter:	parent.verticalCenter
+					leftMargin:		jaspTheme.subOptionOffset
+				}
+			}
+
+			PrefsTextInput
+			{
+				id:					moduleName
+
+				text:				preferencesModel.directDevModName
+				onEditingFinished:	preferencesModel.directDevModName = text
+
+				nextEl:				useConf
+
+				height:				browseDeveloperFolderButton.height
+				anchors
+				{
+					left:			directDevModName.right
+					right:			parent.right
+					margins:		jaspTheme.generalAnchorMargin
+				}
+
+				KeyNavigation.tab:	useConf
+				toolTip:			qsTr("Enter the (package)name of the development module you want to load")
+			}
+		}
+	}
+
+	PrefsGroupRect
+	{
+		title:				qsTr("Configuration file options")
+
+		CheckBox
+		{
+			id:					useConf
+			label:				qsTr("Use a configuration file.")
+			checked:			preferencesModel.useConfigurationFile
+			onCheckedChanged:	preferencesModel.useConfigurationFile = checked
+			toolTip:			qsTr("Use a configuration file.")
+
+			KeyNavigation.tab:		useRemoteConf
+		}
+
+		Column  {
+			visible:	preferencesModel.useConfigurationFile
+			width:		parent.width
+			spacing:	jaspTheme.rowSpacing
 
 			CheckBox
 			{
-				id:					directLibpathDevModEnabled
-				label:				qsTr("Enable renv mode") //We should really remove the old way and this checkbox
-				checked:			preferencesModel.directLibpathEnabled
-				onCheckedChanged:	preferencesModel.directLibpathEnabled = checked
-				toolTip:			qsTr("Load modules from a binary in an R-library instead of installing it from sources.")
-				visible:			preferencesModel.developerMode
+				id:					useRemoteConf
+				label:				qsTr("Use remote configuration file.")
+				checked:			preferencesModel.remoteConfiguration
+				onCheckedChanged:	preferencesModel.remoteConfiguration = checked
+				toolTip:			qsTr("Use the remote configuration file pointed to by URL")
 
-				KeyNavigation.tab:	browseDeveloperFolderButton
-			}
-
-
-			Item
-			{
-				width:				parent.width
-				height:				browseDeveloperFolderButton.height
-				enabled:			preferencesModel.developerMode && !preferencesModel.directLibpathEnabled
-				visible:			preferencesModel.developerMode && !preferencesModel.directLibpathEnabled
-
-
-				RoundedButton
-				{
-					id:						browseDeveloperFolderButton
-					text:					qsTr("Source folder:")
-					onClicked:				preferencesModel.browseDeveloperFolder()
-					anchors.left:			parent.left
-					anchors.leftMargin:		jaspTheme.subOptionOffset
-					toolTip:				qsTr("Browse to your JASP Module folder.")
-
-					KeyNavigation.tab:		developerFolderText.textInput
-					activeFocusOnTab:		true
-
-				}
-
-				PrefsTextInput
-				{
-					id:					developerFolderText
-
-					text:				preferencesModel.developerFolder
-					onEditingFinished:	preferencesModel.developerFolder = text
-					nextEl:				directLibPathLabel
-
-					height:				browseDeveloperFolderButton.height
-					anchors
-					{
-						left:			browseDeveloperFolderButton.right
-						right:			parent.right
-						margins:		jaspTheme.generalAnchorMargin
-					}
-				}
+				KeyNavigation.tab:		remoteConfURL
 			}
 
 			Item
 			{
-				id:					directLibpath
-				enabled:			preferencesModel.directLibpathEnabled
-				visible:			preferencesModel.developerMode && preferencesModel.directLibpathEnabled
-				width:				parent.width
-				height:				cranRepoUrl.height
-
-				RoundedButton
-				{
-					id:						directLibPathLabel
-					text:					qsTr("Project library:")
-					width:					Math.max(directDevModName.implicitWidth, directLibPathLabel.implicitWidth)
-					onClicked:				preferencesModel.browseDeveloperLibPathFolder()
-					activeFocusOnTab:		true
-					KeyNavigation.tab:		directLibpathFolder.textInput
-					KeyNavigation.backtab:	directLibpathDevModEnabled
-
-					anchors
-					{
-						left:			parent.left
-						verticalCenter:	parent.verticalCenter
-						leftMargin:		jaspTheme.subOptionOffset
-					}
-
-
-				}
-
-				PrefsTextInput
-				{
-					id:					directLibpathFolder
-
-					text:				preferencesModel.directLibpathFolder
-					onEditingFinished:	preferencesModel.directLibpathFolder = text
-
-					nextEl:				moduleName
-
-					height:				browseDeveloperFolderButton.height
-					anchors
-					{
-						left:			directLibPathLabel.right
-						right:			parent.right
-						margins:		jaspTheme.generalAnchorMargin
-					}
-
-					KeyNavigation.tab:	moduleName
-
-					toolTip:			qsTr("Choose the R library where you installed the development module")
-				}
-			}
-
-			Item {
-
-				id:					directDevMod
-				enabled:			preferencesModel.developerMode &&preferencesModel.directLibpathEnabled
-				visible:			preferencesModel.developerMode && preferencesModel.directLibpathEnabled
-				width:				parent.width
-				height:				cranRepoUrl.height
+				id:		remoteConfItem
+				width:	parent.width
+				height:	cranRepoUrl.height
+				enabled: preferencesModel.remoteConfiguration
 
 				Label
 				{
-					id:					directDevModName
-					text:				qsTr("Module name:")
-					width:				Math.max(directDevModName.implicitWidth, directLibPathLabel.implicitWidth)
+					id:		remoteSettingsLabel
+					text:	qsTr("Configuration URL: ")
+					width:	Math.max(remoteSettingsLabel.implicitWidth, browseLocalconfButton.implicitWidth)
 
 					anchors
 					{
 						left:			parent.left
 						verticalCenter:	parent.verticalCenter
-						leftMargin:		jaspTheme.subOptionOffset
 					}
 				}
 
 				PrefsTextInput
 				{
-					id:					moduleName
+					id:					remoteConfURL
 
-					text:				preferencesModel.directDevModName
-					onEditingFinished:	preferencesModel.directDevModName = text
-
-					nextEl:				useConf
+					text:				preferencesModel.remoteConfigurationURL
+					onEditingFinished:	preferencesModel.remoteConfigurationURL = text
 
 					height:				browseDeveloperFolderButton.height
 					anchors
 					{
-						left:			directDevModName.right
+						left:			remoteSettingsLabel.right
 						right:			parent.right
 						margins:		jaspTheme.generalAnchorMargin
 					}
 
-					KeyNavigation.tab:	useConf
-					toolTip:			qsTr("Enter the (package)name of the development module you want to load")
+					KeyNavigation.tab:	localconf
 				}
-			}
-		}
-		
-		PrefsGroupRect
-		{
-			title:				qsTr("Configuration file options")
-
-			CheckBox
-			{
-				id:					useConf
-				label:				qsTr("Use a configuration file.")
-				checked:			preferencesModel.useConfigurationFile
-				onCheckedChanged:	preferencesModel.useConfigurationFile = checked
-				toolTip:			qsTr("Use a configuration file.")
-
-				KeyNavigation.tab:		useRemoteConf
-			}
-
-			Column  {
-				visible:	preferencesModel.useConfigurationFile
-				width:		parent.width
-				spacing:	jaspTheme.rowSpacing
-
-				CheckBox
-				{
-					id:					useRemoteConf
-					label:				qsTr("Use remote configuration file.")
-					checked:			preferencesModel.remoteConfiguration
-					onCheckedChanged:	preferencesModel.remoteConfiguration = checked
-					toolTip:			qsTr("Use the remote configuration file pointed to by URL")
-
-					KeyNavigation.tab:		remoteConfURL
-				}
-
-				Item
-				{
-					id:		remoteConfItem
-					width:	parent.width
-					height:	cranRepoUrl.height
-					enabled: preferencesModel.remoteConfiguration
-
-					Label
-					{
-						id:		remoteSettingsLabel
-						text:	qsTr("Configuration URL: ")
-						width:	Math.max(remoteSettingsLabel.implicitWidth, browseLocalconfButton.implicitWidth)
-
-						anchors
-						{
-							left:			parent.left
-							verticalCenter:	parent.verticalCenter
-						}
-					}
-
-					PrefsTextInput
-					{
-						id:					remoteConfURL
-
-						text:				preferencesModel.remoteConfigurationURL
-						onEditingFinished:	preferencesModel.remoteConfigurationURL = text
-
-						height:				browseDeveloperFolderButton.height
-						anchors
-						{
-							left:			remoteSettingsLabel.right
-							right:			parent.right
-							margins:		jaspTheme.generalAnchorMargin
-						}
-
-						KeyNavigation.tab:	localconf
-					}
-				}
-
-				Item
-				{
-					id:					localconf
-					//enabled:			!preferencesModel.remoteConfiguration
-					width:				parent.width
-					height:				browseLocalconfButton.height
-
-					RoundedButton
-					{
-						id:					browseLocalconfButton
-						width:				Math.max(remoteSettingsLabel.implicitWidth, browseLocalconfButton.implicitWidth)
-						text:				qsTr("Select configuration file")
-						onClicked:			preferencesModel.browseConfigurationFile()
-						anchors.left:		parent.left
-						toolTip:			qsTr("Select configuration file.")
-
-						KeyNavigation.tab:		browseLocalconfFolderText.textInput
-						activeFocusOnTab:		true
-					}
-
-					PrefsTextInput
-					{
-						id:					browseLocalconfFolderText
-
-						text:				preferencesModel.localConfigurationPATH
-						onEditingFinished:	preferencesModel.localConfigurationPATH = text
-						nextEl:				logToFile
-
-						height:				browseLocalconfButton.height
-						anchors
-						{
-							left:			browseLocalconfButton.right
-							right:			parent.right
-							margins:		jaspTheme.generalAnchorMargin
-						}
-					}
-				}
-			}
-		}
-
-
-		PrefsGroupRect
-		{
-			id:		loggingGroup
-			title:	qsTr("Logging options")
-
-			CheckBox
-			{
-				id:					logToFile
-				label:				qsTr("Log to file")
-				checked:			preferencesModel.logToFile
-				onCheckedChanged:	preferencesModel.logToFile = checked
-				toolTip:			qsTr("To store debug-logs of JASP in a file, check this box.")
-
-				KeyNavigation.tab:		maxLogFilesSpinBox
 			}
 
 			Item
 			{
-				id:					loggingSubGroup
-				x:					jaspTheme.subOptionOffset
-				height:				maxLogFilesSpinBox.height
-				width:				showLogs.x + showLogs.width
-				enabled:			preferencesModel.logToFile
-
-
-				SpinBox
-				{
-					id:					maxLogFilesSpinBox
-					value:				preferencesModel.logFilesMax
-					onValueChanged:		if(value !== "") preferencesModel.logFilesMax = value
-					from:				5 //Less than 5 makes no sense as on release you get 1 for Desktop and 4 from the Engines
-					to:					1000000
-					defaultValue:		10
-					stepSize:			1
-
-					KeyNavigation.tab:	showLogs
-					text:				qsTr("Max logfiles to keep: ")
-
-					anchors
-					{
-						leftMargin:	jaspTheme.generalAnchorMargin
-						left:		parent.left
-						top:		showLogs.top
-						bottom:		showLogs.bottom
-					}
-				}
+				id:					localconf
+				//enabled:			!preferencesModel.remoteConfiguration
+				width:				parent.width
+				height:				browseLocalconfButton.height
 
 				RoundedButton
 				{
-					id:			showLogs
-					text:		qsTr("Show logs")
-					onClicked:	mainWindow.showLogFolder();
+					id:					browseLocalconfButton
+					width:				Math.max(remoteSettingsLabel.implicitWidth, browseLocalconfButton.implicitWidth)
+					text:				qsTr("Select configuration file")
+					onClicked:			preferencesModel.browseConfigurationFile()
+					anchors.left:		parent.left
+					toolTip:			qsTr("Select configuration file.")
+
+					KeyNavigation.tab:		browseLocalconfFolderText.textInput
+					activeFocusOnTab:		true
+				}
+
+				PrefsTextInput
+				{
+					id:					browseLocalconfFolderText
+
+					text:				preferencesModel.localConfigurationPATH
+					onEditingFinished:	preferencesModel.localConfigurationPATH = text
+					nextEl:				logToFile
+
+					height:				browseLocalconfButton.height
 					anchors
 					{
-						margins:	jaspTheme.generalAnchorMargin
-						left:		maxLogFilesSpinBox.right
+						left:			browseLocalconfButton.right
+						right:			parent.right
+						margins:		jaspTheme.generalAnchorMargin
 					}
-
-					KeyNavigation.tab:		maxEngineCount
-					activeFocusOnTab:		true
 				}
 			}
 		}
-		
-		PrefsGroupRect
+	}
+
+
+	PrefsGroupRect
+	{
+		id:		loggingGroup
+		title:	qsTr("Logging options")
+
+		CheckBox
 		{
-			id:		engineGroup
-			title:	qsTr("Engine options")
-			
+			id:					logToFile
+			label:				qsTr("Log to file")
+			checked:			preferencesModel.logToFile
+			onCheckedChanged:	preferencesModel.logToFile = checked
+			toolTip:			qsTr("To store debug-logs of JASP in a file, check this box.")
+
+			KeyNavigation.tab:		maxLogFilesSpinBox
+			columns:			2
+
 			SpinBox
 			{
-				id:					maxEngineCount
-				value:				preferencesModel.maxEngines
-				onValueChanged:		if(value != "") preferencesModel.maxEngines = value
-				from:				1
-				to:					preferencesModel.maxEnginesAdmin > 0 ? preferencesModel.maxEnginesAdmin : 16
-				defaultValue:		Math.max(preferencesModel.maxEnginesAdmin, 4)
+				id:					maxLogFilesSpinBox
+				value:				preferencesModel.logFilesMax
+				onValueChanged:		if(value !== "") preferencesModel.logFilesMax = value
+				from:				5 //Less than 5 makes no sense as on release you get 1 for Desktop and 4 from the Engines
+				to:					1000000
+				defaultValue:		10
 				stepSize:			1
 
-				KeyNavigation.tab:	engineSandbox
-				activeFocusOnTab:			true
-				text:				qsTr("Maximum number of engines: ")
-			}
-
-			CheckBox
-			{
-				id:					engineSandbox
-				visible:			Qt.platform.os === "windows"
-				enabled:			Qt.platform.os === "windows"
-				label:				qsTr("Sandbox engines")
-				checked:			preferencesModel.engineSandbox
-				onCheckedChanged:	preferencesModel.engineSandbox = checked
-				toolTip:			qsTr("Strengthen security on Windows by isolating Engines running R-code")
-
-				KeyNavigation.tab:		showEnginesWindow
+				KeyNavigation.tab:	showLogs
+				text:				qsTr("Max logfiles to keep: ")
 			}
 
 			RoundedButton
 			{
-				id:					showEnginesWindow
-				text:				qsTr("Show engines")
-				onClicked:			mainWindow.showEnginesWindow()
+				id:			showLogs
+				text:		qsTr("Show logs")
+				onClicked:	mainWindow.showLogFolder();
+
+				KeyNavigation.tab:		maxEngineCount
 				activeFocusOnTab:		true
 			}
+		}
+	}
+
+	PrefsGroupRect
+	{
+		id:		engineGroup
+		title:	qsTr("Engine options")
+
+		SpinBox
+		{
+			id:					maxEngineCount
+			value:				preferencesModel.maxEngines
+			onValueChanged:		if(value != "") preferencesModel.maxEngines = value
+			from:				1
+			to:					preferencesModel.maxEnginesAdmin > 0 ? preferencesModel.maxEnginesAdmin : 16
+			defaultValue:		Math.max(preferencesModel.maxEnginesAdmin, 4)
+			stepSize:			1
+
+			KeyNavigation.tab:	engineSandbox
+			activeFocusOnTab:			true
+			text:				qsTr("Maximum number of engines: ")
+		}
+
+		CheckBox
+		{
+			id:					engineSandbox
+			visible:			Qt.platform.os === "windows"
+			enabled:			Qt.platform.os === "windows"
+			label:				qsTr("Sandbox engines")
+			checked:			preferencesModel.engineSandbox
+			onCheckedChanged:	preferencesModel.engineSandbox = checked
+			toolTip:			qsTr("Strengthen security on Windows by isolating Engines running R-code")
+
+			KeyNavigation.tab:		showEnginesWindow
+		}
+
+		RoundedButton
+		{
+			id:					showEnginesWindow
+			text:				qsTr("Show engines")
+			onClicked:			mainWindow.showEnginesWindow()
+			activeFocusOnTab:		true
 		}
 	}
 }

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsData.qml
@@ -8,309 +8,296 @@ PrefsScrollView
 {
 	id:                     scrollPrefs
 
-	Column
+	MenuHeader
 	{
+		id:			menuHeader
+		headertext:	qsTr("Data Preferences")
+		helpfile:	"preferences/PrefsData"
+		addMargin:	false
+	}
 
-		width:		scrollPrefs.width
-		spacing:	jaspTheme.rowSpacing
+	PrefsGroupRect
+	{
+		id:				spreadSheetEditor
+		title:			qsTr("External spreadsheet editor (for data synchronization)")
 
-		MenuHeader
+		Item
 		{
-			id:			menuHeader
-			headertext:	qsTr("Data Preferences")
-			helpfile:	"preferences/PrefsData"
-			anchorMe:	false
-			width:		scrollPrefs.width - (2 * jaspTheme.generalMenuMargin)
-			x:			jaspTheme.generalMenuMargin
-		}
+			height:		editCustomEditor.y + editCustomEditor.height
+			width:		parent.width
 
-		PrefsGroupRect
-		{
-			id:				spreadSheetEditor
-			title:			qsTr("External spreadsheet editor (for data synchronization)")
+			CheckBox
+			{
+				id:                     useDefaultEditor
+				label:                  qsTr("Use default spreadsheet editor")
+				checked:                LINUX || preferencesModel.useDefaultEditor
+				onCheckedChanged:       preferencesModel.useDefaultEditor = checked
+				enabled:                !LINUX
+				focus:					true
+				KeyNavigation.tab:      editCustomEditor
+			}
+
+			Label
+			{
+				id:					linuxInfo
+				text:				qsTr("<i>On Linux the default spreadsheet editor is always used.</i>")
+				visible:			LINUX
+				textFormat:			Text.StyledText
+
+				anchors
+				{
+					top:			useDefaultEditor.bottom
+					left:			useDefaultEditor.left
+					leftMargin:		jaspTheme.subOptionOffset
+				}
+			}
 
 			Item
 			{
-				height:		editCustomEditor.y + editCustomEditor.height
-				width:		parent.width
+				id:					editCustomEditor
+				enabled:			!LINUX && !preferencesModel.useDefaultEditor
+				width:				parent.width
+				height:				browseEditorButton.height
+				anchors.top:		useDefaultEditor.bottom
 
-				CheckBox
+				RoundedButton
 				{
-					id:                     useDefaultEditor
-					label:                  qsTr("Use default spreadsheet editor")
-					checked:                LINUX || preferencesModel.useDefaultEditor
-					onCheckedChanged:       preferencesModel.useDefaultEditor = checked
-					enabled:                !LINUX
-					focus:					true
-					KeyNavigation.tab:      editCustomEditor
+					id:					browseEditorButton
+					text:				qsTr("Select custom editor")
+					onClicked:			preferencesModel.browseSpreadsheetEditor()
+					anchors.left:		parent.left
+					anchors.leftMargin: jaspTheme.subOptionOffset
+
+					KeyNavigation.tab:      customEditorText
+					activeFocusOnTab:		true
 				}
 
-				Label
+				Rectangle
 				{
-					id:					linuxInfo
-					text:				qsTr("<i>On Linux the default spreadsheet editor is always used.</i>")
-					visible:			LINUX
-					textFormat:			Text.StyledText
-
 					anchors
 					{
-						top:			useDefaultEditor.bottom
-						left:			useDefaultEditor.left
-						leftMargin:		jaspTheme.subOptionOffset
+						left:			browseEditorButton.right
+						right:			parent.right
+						top:			parent.top
+						bottom:			parent.bottom
 					}
-				}
 
-				Item
-				{
-					id:					editCustomEditor
-					enabled:			!LINUX && !preferencesModel.useDefaultEditor
-					width:				parent.width
 					height:				browseEditorButton.height
-					anchors.top:		useDefaultEditor.bottom
+					color:				jaspTheme.white
+					border.color:		jaspTheme.buttonBorderColor
+					border.width:		1
 
-					RoundedButton
+					TextInput
 					{
-						id:					browseEditorButton
-						text:				qsTr("Select custom editor")
-						onClicked:			preferencesModel.browseSpreadsheetEditor()
-						anchors.left:		parent.left
-						anchors.leftMargin: jaspTheme.subOptionOffset
+						id:					customEditorText
+						text:				preferencesModel.customEditor
+						clip:				true
+						font:				jaspTheme.font
+						onTextChanged:		preferencesModel.customEditor = text
+						color:				jaspTheme.textEnabled
 
-						KeyNavigation.tab:      customEditorText
-						activeFocusOnTab:		true
-					}
+						KeyNavigation.tab:      autoSave
 
-					Rectangle
-					{
 						anchors
 						{
-							left:			browseEditorButton.right
+							left:			parent.left
 							right:			parent.right
-							top:			parent.top
-							bottom:			parent.bottom
+							verticalCenter:	parent.verticalCenter
+							margins:		jaspTheme.generalAnchorMargin
 						}
 
-						height:				browseEditorButton.height
-						color:				jaspTheme.white
-						border.color:		jaspTheme.buttonBorderColor
-						border.width:		1
-
-						TextInput
+						Connections
 						{
-							id:					customEditorText
-							text:				preferencesModel.customEditor
-							clip:				true
-							font:				jaspTheme.font
-							onTextChanged:		preferencesModel.customEditor = text
-							color:				jaspTheme.textEnabled
-
-							KeyNavigation.tab:      autoSave
-
-							anchors
-							{
-								left:			parent.left
-								right:			parent.right
-								verticalCenter:	parent.verticalCenter
-								margins:		jaspTheme.generalAnchorMargin
-							}
-
-							Connections
-							{
-								target:					preferencesModel
-								function onCustomEditorChanged(customEditor) { customEditorText.text = customEditor; }
-							}
+							target:					preferencesModel
+							function onCustomEditorChanged(customEditor) { customEditorText.text = customEditor; }
 						}
 					}
 				}
 			}
 		}
-		
-		PrefsGroupRect
+	}
+
+	PrefsGroupRect
+	{
+		id:				savingRect
+		title:			qsTr("Save settings")
+
+		CheckBox
 		{
-			id:				savingRect
-			title:			qsTr("Save settings")
+			id:					autoSave
+			label:				qsTr("Automatically save a backup of your workspace")
+			checked:			preferencesModel.autoSaveAtAll
+			onCheckedChanged:	preferencesModel.autoSaveAtAll = checked
+			toolTip:			qsTr("When enabled this will save a copy of your workspace in a folder next to the logs. If JASP crashes with otherwise unsaved changes this backup will make sure you don't lose all your work.")
 
-			CheckBox
-			{
-				id:					autoSave
-				label:				qsTr("Automatically save a backup of your workspace")
-				checked:			preferencesModel.autoSaveAtAll
-				onCheckedChanged:	preferencesModel.autoSaveAtAll = checked
-				toolTip:			qsTr("When enabled this will save a copy of your workspace in a folder next to the logs. If JASP crashes with otherwise unsaved changes this backup will make sure you don't lose all your work.")
-	
-				KeyNavigation.tab:	autoSaveInterval
-			}
-			
-			SpinBox
-			{
-				id:					autoSaveInterval
-				text:				qsTr("Autosave interval in minutes")
-				value:				preferencesModel.autoSaveIntervalSec / 60
-				onValueChanged:		preferencesModel.autoSaveIntervalSec = (value  * 60)
-				from:				1
-
-				KeyNavigation.tab:	orderByDefault
-
-				toolTip:	qsTr("Interval in minutes between autosaves.")
-			}
-			
+			KeyNavigation.tab:	autoSaveInterval
 		}
 
-		
-		PrefsGroupRect
+		SpinBox
 		{
-			id:				importRect
-			title:			qsTr("Import settings")
-		
-			CheckBox
-			{
-				id:					orderByDefault
-				label:				qsTr("Order labels by value by default")
-				checked:			preferencesModel.orderByValueByDefault
-				onCheckedChanged:	preferencesModel.orderByValueByDefault = checked
-				toolTip:			qsTr("This might incur a slowdown while loading very large datasets with lots of scalars. Think 1 million+ rows of random floating point numbers.\nIf you find that loading of such a file is slow you can disable this option.")
-	
-				KeyNavigation.tab:	thresholdScale
-			}
-		
-		
-			SpinBox
-			{
-				id:					thresholdScale
-				text:				qsTr("Threshold for Scale")
-				value:				preferencesModel.thresholdScale
-				onValueChanged:		preferencesModel.thresholdScale = value
+			id:					autoSaveInterval
+			text:				qsTr("Autosave interval in minutes")
+			value:				preferencesModel.autoSaveIntervalSec / 60
+			onValueChanged:		preferencesModel.autoSaveIntervalSec = (value  * 60)
+			from:				1
 
-				KeyNavigation.tab:	resetDataWithThresholdButton
+			KeyNavigation.tab:	orderByDefault
 
-				toolTip:	qsTr("If a variable has more distinct integer values than this it will be interpreted as scale.")
-
-				Button
-				{
-					id:				resetDataWithThresholdButton
-					label:			qsTr("Reset types of loaded variables")
-					visible:		mainWindow.dataAvailable
-					onClicked:		mainWindow.resetVariableTypes()
-					anchors
-					{
-						top:		thresholdScale.top
-						left:		thresholdScale.right
-						leftMargin: jaspTheme.generalAnchorMargin
-					}
-
-					KeyNavigation.tab:	maxScaleLevels
-				}
-			}
-
-			SpinBox
-			{
-				id:					maxScaleLevels
-				text:				qsTr("Maximum allowed levels for scale when used as nominal/ordinal")
-				value:				preferencesModel.maxScaleLevels
-				onValueChanged:		preferencesModel.maxScaleLevels = value
-
-				KeyNavigation.tab:	missingValueDataLabelInput
-
-				toolTip:	qsTr("For analysis accepting only nominal or ordinal for some variables, if a scale variable is used, JASP checks whether the number of levels of this variable exceeds this maximum.")
-			}
-
+			toolTip:	qsTr("Interval in minutes between autosaves.")
 		}
-		
 
-		PrefsGroupRect
+	}
+
+
+	PrefsGroupRect
+	{
+		id:				importRect
+		title:			qsTr("Import settings")
+
+		CheckBox
 		{
-			id:				missingValuesSettings
-			title:			qsTr("Missing values setting")
+			id:					orderByDefault
+			label:				qsTr("Order labels by value by default")
+			checked:			preferencesModel.orderByValueByDefault
+			onCheckedChanged:	preferencesModel.orderByValueByDefault = checked
+			toolTip:			qsTr("This might incur a slowdown while loading very large datasets with lots of scalars. Think 1 million+ rows of random floating point numbers.\nIf you find that loading of such a file is slow you can disable this option.")
 
-			Item
+			KeyNavigation.tab:	thresholdScale
+		}
+
+
+		SpinBox
+		{
+			id:					thresholdScale
+			text:				qsTr("Threshold for Scale")
+			value:				preferencesModel.thresholdScale
+			onValueChanged:		preferencesModel.thresholdScale = value
+
+			KeyNavigation.tab:	resetDataWithThresholdButton
+
+			toolTip:	qsTr("If a variable has more distinct integer values than this it will be interpreted as scale.")
+
+			Button
 			{
-				id:				missingValueDataLabelItem
-				height:			missingValueDataLabelInput.height
-				width:			parent.width
-
-				Label
+				id:				resetDataWithThresholdButton
+				label:			qsTr("Reset types of loaded variables")
+				visible:		mainWindow.dataAvailable
+				onClicked:		mainWindow.resetVariableTypes()
+				anchors
 				{
-					id:					missingValueDataLabelLabel
-					text:				qsTr("Show missing values as: ")
-
-					anchors
-					{
-						left:			parent.left
-						verticalCenter:	parent.verticalCenter
-					}
+					top:		thresholdScale.top
+					left:		thresholdScale.right
+					leftMargin: jaspTheme.generalAnchorMargin
 				}
 
-				PrefsTextInput
+				KeyNavigation.tab:	maxScaleLevels
+			}
+		}
+
+		SpinBox
+		{
+			id:					maxScaleLevels
+			text:				qsTr("Maximum allowed levels for scale when used as nominal/ordinal")
+			value:				preferencesModel.maxScaleLevels
+			onValueChanged:		preferencesModel.maxScaleLevels = value
+
+			KeyNavigation.tab:	missingValueDataLabelInput
+
+			toolTip:	qsTr("For analysis accepting only nominal or ordinal for some variables, if a scale variable is used, JASP checks whether the number of levels of this variable exceeds this maximum.")
+		}
+
+	}
+
+
+	PrefsGroupRect
+	{
+		id:				missingValuesSettings
+		title:			qsTr("Missing values setting")
+
+		Item
+		{
+			id:				missingValueDataLabelItem
+			height:			missingValueDataLabelInput.height
+			width:			parent.width
+
+			Label
+			{
+				id:					missingValueDataLabelLabel
+				text:				qsTr("Show missing values as: ")
+
+				anchors
 				{
-					id:					missingValueDataLabelInput
-
-					text:				preferencesModel.dataLabelNA
-					onEditingFinished:	preferencesModel.dataLabelNA = text
-					nextEl:				missingValuesList
-
-					anchors
-					{
-						left:		missingValueDataLabelLabel.right
-						right:		parent.right
-					}
+					left:			parent.left
+					verticalCenter:	parent.verticalCenter
 				}
 			}
 
-			Item
+			PrefsTextInput
 			{
-				width:			parent.width
-				height:			missingValuesList.height
+				id:					missingValueDataLabelInput
 
-				PrefsMissingValues
+				text:				preferencesModel.dataLabelNA
+				onEditingFinished:	preferencesModel.dataLabelNA = text
+				nextEl:				missingValuesList
+
+				anchors
 				{
-					id:							missingValuesList
-					model:						preferencesModel
-					showResetWorkspaceButton:	true
-					resetButtonLabel:			qsTr("Reset with standard values")
-					resetButtonTooltip:			qsTr("Reset missing values with the standard JASP missing values")
-					KeyNavigation.tab:			WINDOWS ? noBomNative : useDefaultEditor
+					left:		missingValueDataLabelLabel.right
+					right:		parent.right
 				}
 			}
 		}
 
-		PrefsGroupRect
+		Item
 		{
-			visible:	WINDOWS
-			enabled:	WINDOWS
-			title:		qsTr("Windows workaround")
+			width:			parent.width
+			height:			missingValuesList.height
 
-			CheckBox
+			PrefsMissingValues
 			{
-				id:					noBomNative
-				label:				qsTr("Assume CSV is the selected codepage, when no BOM is specified.")
-				checked:			preferencesModel.windowsNoBomNative
-				onCheckedChanged:	preferencesModel.windowsNoBomNative = checked
-				toolTip:			qsTr("See documentation for more information ")
-
-				KeyNavigation.tab:		codePageSelection
+				id:							missingValuesList
+				model:						preferencesModel
+				showResetWorkspaceButton:	true
+				resetButtonLabel:			qsTr("Reset with standard values")
+				resetButtonTooltip:			qsTr("Reset missing values with the standard JASP missing values")
+				KeyNavigation.tab:			WINDOWS ? noBomNative : useDefaultEditor
 			}
+		}
+	}
 
-			/*ErrorMessage
-			{
-				text: WINDOWS && windowsCodePagesHelper.error ? qsTr("Some problem occured loading the available codepages...") : ""
-			}*/
+	PrefsGroupRect
+	{
+		visible:	WINDOWS
+		enabled:	WINDOWS
+		title:		qsTr("Windows workaround")
+
+		CheckBox
+		{
+			id:					noBomNative
+			label:				qsTr("Assume CSV is the selected codepage, when no BOM is specified.")
+			checked:			preferencesModel.windowsNoBomNative
+			onCheckedChanged:	preferencesModel.windowsNoBomNative = checked
+			toolTip:			qsTr("See documentation for more information ")
+
+			KeyNavigation.tab:		codePageSelection
+		}
 
 
-			DropDown
-			{
-				id:			 			codePageSelection
-				enabled:				preferencesModel.windowsNoBomNative && WINDOWS //&& !windowsCodePagesHelper.error
-				toolTip:				qsTr("See documentation for more information ")
-				values:			 		WINDOWS ? windowsCodePagesHelper.codePageIDs : []
-				addEmptyValue:			true
-				showEmptyValueAsNormal:	true
-				addLineAfterEmptyValue:	true
-				placeholderText:		qsTr("Choose codepage here")
-				startValue:				WINDOWS ? windowsCodePagesHelper.codePageID : ""
-				onValueChanged: 		if(WINDOWS) windowsCodePagesHelper.codePageID = value
 
-				KeyNavigation.tab:		useDefaultEditor
-			}
+		DropDown
+		{
+			id:			 			codePageSelection
+			enabled:				preferencesModel.windowsNoBomNative && WINDOWS //&& !windowsCodePagesHelper.error
+			toolTip:				qsTr("See documentation for more information ")
+			values:			 		WINDOWS ? windowsCodePagesHelper.codePageIDs : []
+			addEmptyValue:			true
+			showEmptyValueAsNormal:	true
+			addLineAfterEmptyValue:	true
+			placeholderText:		qsTr("Choose codepage here")
+			startValue:				WINDOWS ? windowsCodePagesHelper.codePageID : ""
+			onValueChanged: 		if(WINDOWS) windowsCodePagesHelper.codePageID = value
+
+			KeyNavigation.tab:		useDefaultEditor
 		}
 	}
 }

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsGroupRect.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsGroupRect.qml
@@ -11,13 +11,13 @@ Rectangle
 	border.color:	jaspTheme.fileMenuLightBorder
 	border.width:	1
 
+	width:			parent.width
 	implicitHeight:	contentColumn.y + contentColumn.height + jaspTheme.generalAnchorMargin
 	height:			implicitHeight
-	implicitWidth:	parent.width - (jaspTheme.generalAnchorMargin * 2)
-	width:			implicitWidth
-	x:				jaspTheme.generalAnchorMargin
-	y:				jaspTheme.generalAnchorMargin
-
+	implicitWidth:	Math.max(
+						titleText.anchors.leftMargin + titleText.implicitWidth + jaspTheme.generalAnchorMargin,
+						contentColumn.anchors.leftMargin + contentColumn.implicitWidth + jaspTheme.generalAnchorMargin
+					)
 
 			property alias title:		titleText.text
 			property alias spacing:		contentColumn.spacing
@@ -31,7 +31,6 @@ Rectangle
 		anchors.top:		parent.top
 		anchors.left:		parent.left
 		color:				jaspTheme.textEnabled
-		text:				""
 		height:				text !== "" ? implicitHeight : 0
 	}
 
@@ -39,6 +38,7 @@ Rectangle
 	{
 		id:					contentColumn
 		spacing:			jaspTheme.generalAnchorMargin
+		width:				parent.width - anchors.leftMargin - jaspTheme.generalAnchorMargin
 
 		anchors
 		{
@@ -47,9 +47,6 @@ Rectangle
 
 			left:			parent.left
 			leftMargin:		(titleText.text !== "" ? jaspTheme.subOptionOffset : 0) + jaspTheme.generalAnchorMargin
-
-			right:			parent.right
-			rightMargin:	jaspTheme.generalAnchorMargin
 		}
 	}
 }

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsResults.qml
@@ -7,221 +7,217 @@ PrefsScrollView
 {
 	id:						scrollPrefs
 
-	Column
+	MenuHeader
 	{
-		width:			scrollPrefs.width
-		spacing:		jaspTheme.rowSpacing
+		id:				menuHeader
+		headertext:		qsTr("Results Preferences")
+		helpfile:		"preferences/PrefsResults"
+		addMargin:		false
+	}
 
-		MenuHeader
+
+	PrefsGroupRect
+	{
+		id:				tableOptions
+		title:			qsTr("Table options")
+
+		CheckBox
 		{
-			id:				menuHeader
-			headertext:		qsTr("Results Preferences")
-			helpfile:		"preferences/PrefsResults"
-			anchorMe:		false
-			width:			scrollPrefs.width - (2 * jaspTheme.generalMenuMargin)
-			x:				jaspTheme.generalMenuMargin
+			id:						displayExactPVals
+			label:					qsTr("Display exact p-values")
+			checked:				preferencesModel.exactPValues
+			onCheckedChanged:		preferencesModel.exactPValues = checked
+			focus:					true
+			KeyNavigation.tab:		useNormalizedNotation
 		}
 
-
-		PrefsGroupRect
+		CheckBox
 		{
-			title:			qsTr("Table options")
+			id:						useNormalizedNotation
+			label:					qsTr("Use exponent notation") //the default now is normalizedNotation. https://github.com/jasp-stats/INTERNAL-jasp/issues/1872
+			checked:				!preferencesModel.normalizedNotation
+			onCheckedChanged:		preferencesModel.normalizedNotation = !checked
+			KeyNavigation.tab:		fixDecs
 
-			CheckBox
-			{
-				id:						displayExactPVals
-				label:					qsTr("Display exact p-values")
-				checked:				preferencesModel.exactPValues
-				onCheckedChanged:		preferencesModel.exactPValues = checked
-				focus:					true
-				KeyNavigation.tab:		useNormalizedNotation
-			}
-
-			CheckBox
-			{
-				id:						useNormalizedNotation
-				label:					qsTr("Use exponent notation") //the default now is normalizedNotation. https://github.com/jasp-stats/INTERNAL-jasp/issues/1872
-				checked:				!preferencesModel.normalizedNotation
-				onCheckedChanged:		preferencesModel.normalizedNotation = !checked
-				KeyNavigation.tab:		fixDecs
-
-			}
-
-			Item
-			{
-				height:						fixDecs.height
-				width:						fixDecs.width + numDecs.width
-
-				CheckBox
-				{
-					id:						fixDecs
-					label:					qsTr("Fix the number of decimals")
-					checked:				preferencesModel.fixedDecimals
-					onCheckedChanged:		preferencesModel.fixedDecimals = checked
-					
-					KeyNavigation.tab:			numDecs
-				}
-
-				SpinBox
-				{
-					id:						numDecs
-					value:					preferencesModel.numDecimals
-					onValueChanged:			preferencesModel.numDecimals = value
-					enabled:				preferencesModel.fixedDecimals
-
-					KeyNavigation.tab:			useDefaultPPICheckbox
-
-					anchors
-					{
-						left:				fixDecs.right
-						leftMargin:			jaspTheme.generalAnchorMargin
-						verticalCenter:		parent.verticalCenter
-					}
-				}
-			}
-		}
-		
-		PrefsGroupRect
-		{
-			title:				qsTr("Plot options")
-
-			CheckBox
-			{
-				id:					useDefaultPPICheckbox
-				label:				qsTr("Use PPI of screen in plots: ") + "(" + preferencesModel.defaultPPI + ")"
-				checked:			preferencesModel.useDefaultPPI
-				onCheckedChanged:	preferencesModel.useDefaultPPI = checked
-				height:				implicitHeight * preferencesModel.uiScale
-				toolTip:			qsTr("Use the Pixels Per Inch of your screen to render your plots.")
-				
-
-				KeyNavigation.tab:		customPPISpinBox
-			}
-
-			SpinBox
-			{
-				id:						customPPISpinBox
-				value:					preferencesModel.customPPI
-				onValueChanged:			preferencesModel.customPPI = value
-				from:					16
-				to:						2000
-				stepSize:				16
-
-				text:					qsTr("Custom PPI: ")
-				enabled:				!preferencesModel.useDefaultPPI
-
-				x:						jaspTheme.subOptionOffset
-
-				KeyNavigation.tab:			whiteBackgroundButton
-			}
-
-			RadioButtonGroup
-			{
-				title:					qsTr("Image background color")
-
-				RadioButton
-				{
-					id:					whiteBackgroundButton
-					text:				qsTr("White")
-					checked:			preferencesModel.whiteBackground
-					onCheckedChanged:	preferencesModel.whiteBackground = checked
-					toolTip:			qsTr("This makes the background of all plots white, quite useful if you want to use it in LaTeX or submit it to a journal.")
-
-					KeyNavigation.tab:      transparentBackgroundButton
-				}
-
-				RadioButton
-				{
-					id:					transparentBackgroundButton
-					text:				qsTr("Transparent")
-					checked:			!preferencesModel.whiteBackground
-					onCheckedChanged:	preferencesModel.whiteBackground = !checked
-					toolTip:			qsTr("This makes the background of all plots transparent, quite useful if you want to use it seamlessly on any background that isn't white.")
-
-					KeyNavigation.tab:		pdfOrientationLandscape
-				}
-			}
-		}
-
-		PrefsGroupRect
-		{
-			title:				qsTr("PDF Settings")
-
-			RadioButtonGroup
-			{
-				id:		pdfOrientation
-				title:	qsTr("Orientation")
-
-				RadioButton
-				{
-					id:					pdfOrientationPortrait
-					label:				qsTr("Portrait")
-					checked:			!preferencesModel.pdfLandscape
-					onCheckedChanged:	if (checked) preferencesModel.pdfLandscape = false
-
-					KeyNavigation.tab:	pdfOrientationLandscape
-				}
-
-				RadioButton
-				{
-					id:					pdfOrientationLandscape
-					label:				qsTr("Landscape")
-					checked:			preferencesModel.pdfLandscape
-					onCheckedChanged:	if (checked) preferencesModel.pdfLandscape = true
-
-					KeyNavigation.tab:	pdfPageSize
-				}
-			}
-
-			DropDown
-			{
-				id:				pdfPageSize
-				label:			qsTr("Page size")
-				values:			preferencesModel.pdfPageSizeModel
-				startValue: 	preferencesModel.pdfPageSize
-				onValueChanged: preferencesModel.pdfPageSize = value
-
-				KeyNavigation.tab:		showRSyntaxInResults
-			}
-
-		}
-
-		PrefsGroupRect
-		{
-			title:				qsTr("Miscellaneous options")
-
-			CheckBox
-			{
-				id:					showRSyntaxInResults
-				label:				qsTr("Show R syntax")
-				checked:			preferencesModel.showRSyntaxInResults
-				onCheckedChanged:	preferencesModel.showRSyntaxInResults = checked
-				height:				implicitHeight * preferencesModel.uiScale
-				toolTip:			qsTr("Add R syntax for each analysis")
-				
-
-				KeyNavigation.tab:		displayExactPVals
-			}
-			
-			CheckBox
-			{
-				id:					storeStateEtc
-				label:				qsTr("Store analysis state and plot in jasp-files")
-				checked:			preferencesModel.storeStateEtc
-				onCheckedChanged:	preferencesModel.storeStateEtc = checked
-				height:				implicitHeight * preferencesModel.uiScale
-				toolTip:			qsTr("Enabling this can cause filesize of jaspfiles to increase, sometimes by a lot.")
-				
-
-				KeyNavigation.tab:		displayExactPVals
-			}
 		}
 
 		Item
 		{
-			id:		extraSpaceForScrolling
-			width:	1
-			height:	1
+			height:						fixDecs.height
+			width:						fixDecs.width + numDecs.width
+
+			CheckBox
+			{
+				id:						fixDecs
+				label:					qsTr("Fix the number of decimals")
+				checked:				preferencesModel.fixedDecimals
+				onCheckedChanged:		preferencesModel.fixedDecimals = checked
+
+				KeyNavigation.tab:			numDecs
+			}
+
+			SpinBox
+			{
+				id:						numDecs
+				value:					preferencesModel.numDecimals
+				onValueChanged:			preferencesModel.numDecimals = value
+				enabled:				preferencesModel.fixedDecimals
+
+				KeyNavigation.tab:			useDefaultPPICheckbox
+
+				anchors
+				{
+					left:				fixDecs.right
+					leftMargin:			jaspTheme.generalAnchorMargin
+					verticalCenter:		parent.verticalCenter
+				}
+			}
 		}
+	}
+
+	PrefsGroupRect
+	{
+		id:					plotOptions
+		title:				qsTr("Plot options")
+
+		CheckBox
+		{
+			id:					useDefaultPPICheckbox
+			label:				qsTr("Use PPI of screen in plots: ") + "(" + preferencesModel.defaultPPI + ")"
+			checked:			preferencesModel.useDefaultPPI
+			onCheckedChanged:	preferencesModel.useDefaultPPI = checked
+			height:				implicitHeight * preferencesModel.uiScale
+			toolTip:			qsTr("Use the Pixels Per Inch of your screen to render your plots.")
+
+
+			KeyNavigation.tab:		customPPISpinBox
+		}
+
+		SpinBox
+		{
+			id:						customPPISpinBox
+			value:					preferencesModel.customPPI
+			onValueChanged:			preferencesModel.customPPI = value
+			from:					16
+			to:						2000
+			stepSize:				16
+
+			text:					qsTr("Custom PPI: ")
+			enabled:				!preferencesModel.useDefaultPPI
+
+			x:						jaspTheme.subOptionOffset
+
+			KeyNavigation.tab:			whiteBackgroundButton
+		}
+
+		RadioButtonGroup
+		{
+			title:					qsTr("Image background color")
+
+			RadioButton
+			{
+				id:					whiteBackgroundButton
+				text:				qsTr("White")
+				checked:			preferencesModel.whiteBackground
+				onCheckedChanged:	preferencesModel.whiteBackground = checked
+				toolTip:			qsTr("This makes the background of all plots white, quite useful if you want to use it in LaTeX or submit it to a journal.")
+
+				KeyNavigation.tab:      transparentBackgroundButton
+			}
+
+			RadioButton
+			{
+				id:					transparentBackgroundButton
+				text:				qsTr("Transparent")
+				checked:			!preferencesModel.whiteBackground
+				onCheckedChanged:	preferencesModel.whiteBackground = !checked
+				toolTip:			qsTr("This makes the background of all plots transparent, quite useful if you want to use it seamlessly on any background that isn't white.")
+
+				KeyNavigation.tab:		pdfOrientationLandscape
+			}
+		}
+	}
+
+	PrefsGroupRect
+	{
+		id:					pdfSettings
+		title:				qsTr("PDF Settings")
+
+		RadioButtonGroup
+		{
+			id:		pdfOrientation
+			title:	qsTr("Orientation")
+
+			RadioButton
+			{
+				id:					pdfOrientationPortrait
+				label:				qsTr("Portrait")
+				checked:			!preferencesModel.pdfLandscape
+				onCheckedChanged:	if (checked) preferencesModel.pdfLandscape = false
+
+				KeyNavigation.tab:	pdfOrientationLandscape
+			}
+
+			RadioButton
+			{
+				id:					pdfOrientationLandscape
+				label:				qsTr("Landscape")
+				checked:			preferencesModel.pdfLandscape
+				onCheckedChanged:	if (checked) preferencesModel.pdfLandscape = true
+
+				KeyNavigation.tab:	pdfPageSize
+			}
+		}
+
+		DropDown
+		{
+			id:				pdfPageSize
+			label:			qsTr("Page size")
+			values:			preferencesModel.pdfPageSizeModel
+			startValue: 	preferencesModel.pdfPageSize
+			onValueChanged: preferencesModel.pdfPageSize = value
+
+			KeyNavigation.tab:		showRSyntaxInResults
+		}
+
+	}
+
+	PrefsGroupRect
+	{
+		id:					miscellaneousOptions
+		title:				qsTr("Miscellaneous options")
+
+		CheckBox
+		{
+			id:					showRSyntaxInResults
+			label:				qsTr("Show R syntax")
+			checked:			preferencesModel.showRSyntaxInResults
+			onCheckedChanged:	preferencesModel.showRSyntaxInResults = checked
+			height:				implicitHeight * preferencesModel.uiScale
+			toolTip:			qsTr("Add R syntax for each analysis")
+
+
+			KeyNavigation.tab:		displayExactPVals
+		}
+
+		CheckBox
+		{
+			id:					storeStateEtc
+			label:				qsTr("Store analysis state and plot in jasp-files")
+			checked:			preferencesModel.storeStateEtc
+			onCheckedChanged:	preferencesModel.storeStateEtc = checked
+			height:				implicitHeight * preferencesModel.uiScale
+			toolTip:			qsTr("Enabling this can cause filesize of jaspfiles to increase, sometimes by a lot.")
+
+
+			KeyNavigation.tab:		displayExactPVals
+		}
+	}
+
+	Item
+	{
+		id:		extraSpaceForScrolling
+		width:	1
+		height:	1
 	}
 }

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsScrollView.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsScrollView.qml
@@ -6,12 +6,25 @@ import JASP.Controls
 
 Item 
 {
+	id: viewRoot
 	Keys.onLeftPressed:		resourceMenu.forceActiveFocus();
-	
-	default property alias content:		stackEmHere.data
+
+	default property alias content:		stackEmHere.children
 	property alias scrollView:			scrollView
 	property Item flickable:			stackEmHere.parent ? stackEmHere.parent.parent : undefined //hacky way to get to the flickable inside ScrollView
+
+	function setMaxImplicitWidth()
+	{
+		implicitWidth = Qt.binding(function() {
+			var m = 0
+			for (var i = 0; i < stackEmHere.children.length; i++)
+				m = Math.max(stackEmHere.children[i].implicitWidth, m)
+			return m + 2 * jaspTheme.generalMenuMargin
+		})
+	}
 	
+	Component.onCompleted: setMaxImplicitWidth()
+
 	ScrollView 
 	{
 		id:						scrollView
@@ -21,7 +34,10 @@ Item
 		
 		Column
 		{
-			id:		stackEmHere
+			id:			stackEmHere
+			spacing:	jaspTheme.rowSpacing
+			width:		viewRoot.width - 2 * jaspTheme.generalMenuMargin
+			x:			jaspTheme.generalMenuMargin
 		}
 	}
 	
@@ -46,7 +62,7 @@ Item
 			right:		parent.right
 			bottom:		parent.bottom
 		}
-		
+
 		upsideDown:	false
 		extraSpace:	flickable.contentHeight - (flickable.contentY + flickable.height)
 	}

--- a/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
+++ b/Desktop/components/JASP/Widgets/FileMenu/PrefsUI.qml
@@ -15,435 +15,426 @@ PrefsScrollView
 		visible = true;
 	}
 
-	Connections
+	MenuHeader
 	{
-		target:				preferencesModel
-		function onCurrentThemeNameChanged(name)	{ scrollPrefs.resetMe(); }
+		id:				menuHeader
+		headertext:		qsTr("User Interface Options")
+		helpfile:		"preferences/PrefsUI"
+		addMargin:		false
+
+		Connections
+		{
+			target:				preferencesModel
+			function onCurrentThemeNameChanged(name)	{ scrollPrefs.resetMe(); }
+		}
+
+		Connections
+		{
+			target:				languageModel
+			function onCurrentLanguageChanged()			{ scrollPrefs.resetMe(); }
+		}
 	}
 
-	Connections
+	PrefsGroupRect
 	{
-		target:				languageModel
-		function onCurrentLanguageChanged()			{ scrollPrefs.resetMe(); }
-	}
+		id:		fontGroup
+		title:	qsTr("Fonts")
 
-	Column
-	{
-		width:			scrollPrefs.width
-		spacing:		jaspTheme.rowSpacing
-		z:				100
-
-		MenuHeader
+		Item
 		{
-			id:				menuHeader
-			headertext:		qsTr("User Interface Options")
-			helpfile:		"preferences/PrefsUI"
-			anchorMe:		false
-			width:			scrollPrefs.width - (2 * jaspTheme.generalMenuMargin)
-			x:				jaspTheme.generalMenuMargin
-		}
-
-		PrefsGroupRect
-		{
-			id:		fontGroup
-			title:	qsTr("Fonts")
-
-			Item
-			{
-				visible: false;
-				// If the defaultInterfaceFont etc does not exist on the machine, then the default font of the machine is used.
-				// These (invisible) Text items are just to ask what will be the real font used.
-				
-				Text
-				{
-					
-					id:				 defaultInterfaceFont
-					font.family:	 preferencesModel.defaultInterfaceFont
-					text:			 fontInfo.family
-				}
-				
-				Text
-				{
-					id:			 	defaultRCodeFont
-					text:			fontInfo.family
-					font.family:	preferencesModel.defaultCodeFont
-				}
-				
-				Text
-				{
-					id: 			defaultResultFont
-					text: 			fontInfo.family
-					font.family: 	preferencesModel.defaultResultFont
-				}
-			}
-
-			Group
-			{
-				width:			parent.width
-				
-				DropDown 
-				{
-					id:			 			interfaceFonts
-					label:					qsTr("Interface:")
-					values:			 		preferencesModel.allInterfaceFonts
-					addEmptyValue:			true
-					showEmptyValueAsNormal:	true
-					addLineAfterEmptyValue:	true
-					placeholderText:		qsTr("default: %1").arg(defaultInterfaceFont.fontInfo.family)
-					startValue:				preferencesModel.interfaceFont
-					onValueChanged: 		preferencesModel.interfaceFont = (currentIndex <= 0 ? "" : value)
-					focus:					true
-					KeyNavigation.tab:		codeFonts
-				}
-			
-				DropDown
-				{
-					id:							codeFonts
-					label:						qsTr("R, JAGS, or lavaan code:")
-					values:		 				preferencesModel.allCodeFonts
-					addEmptyValue:		 		true
-					showEmptyValueAsNormal:		true
-					addLineAfterEmptyValue:		true
-					placeholderText:		 	qsTr("default: %1").arg(defaultRCodeFont.fontInfo.family)
-					startValue:				 	preferencesModel.codeFont
-					onValueChanged:				preferencesModel.codeFont = (currentIndex <= 0 ? "" : value)
-
-					KeyNavigation.tab:			resultFonts
-				}
-
-				DropDown
-				{
-					id:							resultFonts
-					label:						qsTr("Result & help:")
-					values:						preferencesModel.allResultFonts
-					addEmptyValue:				true
-					showEmptyValueAsNormal:		true
-					addLineAfterEmptyValue:		true
-					placeholderText: 			qsTr("default: %1").arg(defaultResultFont.fontInfo.family)
-					startValue: 				preferencesModel.resultFont
-					onValueChanged: 			preferencesModel.resultFont = (currentIndex <= 0 ? "" : value)
-
-					KeyNavigation.tab: 			qtTextRendering
-				}
-			}
-			
-
-			CheckBox
-			{
-				id:					qtTextRendering
-				label:				qsTr("Use Qt's text rendering")
-				checked:			preferencesModel.guiQtTextRender
-				onCheckedChanged:	preferencesModel.guiQtTextRender = checked
-				toolTip:			qsTr("If disabled will switch the textrendering to native.")
-
-
-				KeyNavigation.tab:		lightThemeButton
-			}
-		}
-
-		PrefsGroupRect
-		{
-			title:		qsTr("Themes")
-
-			RadioButtonGroup
-			{
-				id:			themes
-
-				RadioButton
-				{
-					id:					lightThemeButton
-					label:				qsTr("Light theme")
-					checked:			preferencesModel.currentThemeName === "lightTheme"
-					onCheckedChanged:	if (checked) preferencesModel.currentThemeName  =  "lightTheme"
-					toolTip:			qsTr("Switches to a light theme, this is the default and original flavour of JASP.")
-
-					KeyNavigation.tab:		darkThemeButton
-				}
-
-				RadioButton
-				{
-					id:					darkThemeButton
-					label:				qsTr("Dark theme")
-					checked:			preferencesModel.currentThemeName === "darkTheme"
-					onCheckedChanged:	if (checked) preferencesModel.currentThemeName  =  "darkTheme"
-					toolTip:			qsTr("Switches to a dark theme, makes JASP a lot easier on the eyes for those night owls out there.")
-					
-					KeyNavigation.tab:		languages
-				}
-			}
-		}
-
-		PrefsGroupRect
-		{
-			id:		languageGroup
-			title:	qsTr("Preferred language")
-			
-			
-			DropDown
-			{
-				id:							languages
-				label:						qsTr("Choose language")
-				source:						languageModel
-				startValue: 				languageModel.currentLanguage
-				onValueChanged: 			languageModel.currentLanguage = value
-
-				KeyNavigation.tab: 			useThousandsSeparator
-				
-			}
-			
-			CheckBox
-			{
-				id:							useThousandsSeparator
-				label:						qsTr("Use thousands separators")
-				checked:					languageModel.useThousandSeps
-				onCheckedChanged:			languageModel.useThousandSeps = checked
-				toolTip:					qsTr("Disable to remove thousands separators from all numbers.")
-				
-				KeyNavigation.tab:			useAlternativeLocale
-			}
-			
-			CheckBox
-			{
-				id:							useAlternativeLocale
-				label:						qsTr("Use an alternative language and territory dependent display for numbers")
-				checked:					languageModel.useAlternativeLocale
-				onCheckedChanged:			languageModel.useAlternativeLocale = checked
-				toolTip:					qsTr("Use the locale specified below for display of numbers and currency.") //dates and times will have to be added later
-				
-				KeyNavigation.tab:			alternativeLocaleTerritory
-			}
-			
-			RowLayout
-			{
-				spacing:		jaspTheme.generalAnchorMargin
-				
-				Group
-				{
-					enabled:					languageModel.useAlternativeLocale
-					
-					DropDown
-					{
-						id:							alternativeLocaleLanguage
-						label:						qsTr("Alt. language")
-						values:		 				languageModel.altLanguages
-						startValue:				 	languageModel.currentAltLanguage
-						onValueChanged:				if(value != "") languageModel.currentAltLanguage = value
-						addEmptyValue:				false
-						KeyNavigation.tab:			alternativeLocaleTerritory
-						control.width:				Math.max(alternativeLocaleLanguage.control.implicitWidth, alternativeLocaleTerritory.control.implicitWidth)
-					}
-					
-					DropDown
-					{
-						id:							alternativeLocaleTerritory
-						label:						qsTr("Alt. territory")
-						values:		 				languageModel.altTerritories
-						startValue:				 	languageModel.currentAltTerritory
-						value:						languageModel.currentAltTerritory
-						onValueChanged:				if(value != "") languageModel.currentAltTerritory = value
-						addEmptyValue:				false
-						KeyNavigation.tab:			altnavcheckbox
-						control.width:				Math.max(alternativeLocaleLanguage.control.implicitWidth, alternativeLocaleTerritory.control.implicitWidth)
-					}
-					
-				}
-				
-				Item{ width: jaspTheme.generalAnchorMargin}
-				
-				Rectangle
-				{
-					implicitWidth:		exampleFormattingText.implicitWidth
-					implicitHeight:		exampleFormattingText.implicitHeight
-					
-					color:				jaspTheme.white
-					border.width:		1
-					border.color:		jaspTheme.borderColor
-					radius:				jaspTheme.borderRadius
-					
-					Text
-					{
-						id:					exampleFormattingText
-		
-						text:				languageModel.exampleFormatting
-						color:				jaspTheme.textEnabled
-						font.pixelSize:		Math.round(12 * preferencesModel.uiScale)
-						font.family:		preferencesModel.interfaceFont
-						wrapMode:			Text.WordWrap
-						padding:			jaspTheme.itemPadding
-					}
-				}
-			}
-			
+			visible: false;
+			// If the defaultInterfaceFont etc does not exist on the machine, then the default font of the machine is used.
+			// These (invisible) Text items are just to ask what will be the real font used.
 
 			Text
 			{
-				id:					translationDocLink
 
-				text:				qsTr("Help us translate or improve JASP in your language")
-				color:				jaspTheme.blue
-				font.pixelSize:		Math.round(12 * preferencesModel.uiScale)
-				font.family:		preferencesModel.interfaceFont
-				font.underline:		true
+				id:				 defaultInterfaceFont
+				font.family:	 preferencesModel.defaultInterfaceFont
+				text:			 fontInfo.family
+			}
 
-				MouseArea
+			Text
+			{
+				id:			 	defaultRCodeFont
+				text:			fontInfo.family
+				font.family:	preferencesModel.defaultCodeFont
+			}
+
+			Text
+			{
+				id: 			defaultResultFont
+				text: 			fontInfo.family
+				font.family: 	preferencesModel.defaultResultFont
+			}
+		}
+
+		Group
+		{
+			width:			parent.width
+
+			DropDown
+			{
+				id:			 			interfaceFonts
+				label:					qsTr("Interface:")
+				values:			 		preferencesModel.allInterfaceFonts
+				addEmptyValue:			true
+				showEmptyValueAsNormal:	true
+				addLineAfterEmptyValue:	true
+				placeholderText:		qsTr("default: %1").arg(defaultInterfaceFont.fontInfo.family)
+				startValue:				preferencesModel.interfaceFont
+				onValueChanged: 		preferencesModel.interfaceFont = (currentIndex <= 0 ? "" : value)
+				focus:					true
+				KeyNavigation.tab:		codeFonts
+			}
+
+			DropDown
+			{
+				id:							codeFonts
+				label:						qsTr("R, JAGS, or lavaan code:")
+				values:		 				preferencesModel.allCodeFonts
+				addEmptyValue:		 		true
+				showEmptyValueAsNormal:		true
+				addLineAfterEmptyValue:		true
+				placeholderText:		 	qsTr("default: %1").arg(defaultRCodeFont.fontInfo.family)
+				startValue:				 	preferencesModel.codeFont
+				onValueChanged:				preferencesModel.codeFont = (currentIndex <= 0 ? "" : value)
+
+				KeyNavigation.tab:			resultFonts
+			}
+
+			DropDown
+			{
+				id:							resultFonts
+				label:						qsTr("Result & help:")
+				values:						preferencesModel.allResultFonts
+				addEmptyValue:				true
+				showEmptyValueAsNormal:		true
+				addLineAfterEmptyValue:		true
+				placeholderText: 			qsTr("default: %1").arg(defaultResultFont.fontInfo.family)
+				startValue: 				preferencesModel.resultFont
+				onValueChanged: 			preferencesModel.resultFont = (currentIndex <= 0 ? "" : value)
+
+				KeyNavigation.tab: 			qtTextRendering
+			}
+		}
+
+
+		CheckBox
+		{
+			id:					qtTextRendering
+			label:				qsTr("Use Qt's text rendering")
+			checked:			preferencesModel.guiQtTextRender
+			onCheckedChanged:	preferencesModel.guiQtTextRender = checked
+			toolTip:			qsTr("If disabled will switch the textrendering to native.")
+
+
+			KeyNavigation.tab:		lightThemeButton
+		}
+	}
+
+	PrefsGroupRect
+	{
+		title:		qsTr("Themes")
+
+		RadioButtonGroup
+		{
+			id:			themes
+
+			RadioButton
+			{
+				id:					lightThemeButton
+				label:				qsTr("Light theme")
+				checked:			preferencesModel.currentThemeName === "lightTheme"
+				onCheckedChanged:	if (checked) preferencesModel.currentThemeName  =  "lightTheme"
+				toolTip:			qsTr("Switches to a light theme, this is the default and original flavour of JASP.")
+
+				KeyNavigation.tab:		darkThemeButton
+			}
+
+			RadioButton
+			{
+				id:					darkThemeButton
+				label:				qsTr("Dark theme")
+				checked:			preferencesModel.currentThemeName === "darkTheme"
+				onCheckedChanged:	if (checked) preferencesModel.currentThemeName  =  "darkTheme"
+				toolTip:			qsTr("Switches to a dark theme, makes JASP a lot easier on the eyes for those night owls out there.")
+
+				KeyNavigation.tab:		languages
+			}
+		}
+	}
+
+	PrefsGroupRect
+	{
+		id:		languageGroup
+		title:	qsTr("Preferred language")
+
+
+		DropDown
+		{
+			id:							languages
+			label:						qsTr("Choose language")
+			source:						languageModel
+			startValue: 				languageModel.currentLanguage
+			onValueChanged: 			languageModel.currentLanguage = value
+
+			KeyNavigation.tab: 			useThousandsSeparator
+
+		}
+
+		CheckBox
+		{
+			id:							useThousandsSeparator
+			label:						qsTr("Use thousands separators")
+			checked:					languageModel.useThousandSeps
+			onCheckedChanged:			languageModel.useThousandSeps = checked
+			toolTip:					qsTr("Disable to remove thousands separators from all numbers.")
+
+			KeyNavigation.tab:			useAlternativeLocale
+		}
+
+		CheckBox
+		{
+			id:							useAlternativeLocale
+			label:						qsTr("Use an alternative language and territory dependent display for numbers")
+			checked:					languageModel.useAlternativeLocale
+			onCheckedChanged:			languageModel.useAlternativeLocale = checked
+			toolTip:					qsTr("Use the locale specified below for display of numbers and currency.") //dates and times will have to be added later
+
+			KeyNavigation.tab:			alternativeLocaleTerritory
+		}
+
+		RowLayout
+		{
+			spacing:		jaspTheme.generalAnchorMargin
+
+			Group
+			{
+				enabled:					languageModel.useAlternativeLocale
+
+				DropDown
 				{
-					id:				mouseAreaTranslationDocLink
-					anchors.fill:	parent
-					onClicked:		Qt.openUrlExternally("https://jasp-stats.org/translation-guidelines")
-					cursorShape:	Qt.PointingHandCursor
+					id:							alternativeLocaleLanguage
+					label:						qsTr("Alt. language")
+					values:		 				languageModel.altLanguages
+					startValue:				 	languageModel.currentAltLanguage
+					onValueChanged:				if(value != "") languageModel.currentAltLanguage = value
+					addEmptyValue:				false
+					KeyNavigation.tab:			alternativeLocaleTerritory
+					control.width:				Math.max(alternativeLocaleLanguage.control.implicitWidth, alternativeLocaleTerritory.control.implicitWidth)
+				}
+
+				DropDown
+				{
+					id:							alternativeLocaleTerritory
+					label:						qsTr("Alt. territory")
+					values:		 				languageModel.altTerritories
+					startValue:				 	languageModel.currentAltTerritory
+					value:						languageModel.currentAltTerritory
+					onValueChanged:				if(value != "") languageModel.currentAltTerritory = value
+					addEmptyValue:				false
+					KeyNavigation.tab:			altnavcheckbox
+					control.width:				Math.max(alternativeLocaleLanguage.control.implicitWidth, alternativeLocaleTerritory.control.implicitWidth)
+				}
+
+			}
+
+			Item{ width: jaspTheme.generalAnchorMargin}
+
+			Rectangle
+			{
+				implicitWidth:		exampleFormattingText.implicitWidth
+				implicitHeight:		exampleFormattingText.implicitHeight
+
+				color:				jaspTheme.white
+				border.width:		1
+				border.color:		jaspTheme.borderColor
+				radius:				jaspTheme.borderRadius
+
+				Text
+				{
+					id:					exampleFormattingText
+
+					text:				languageModel.exampleFormatting
+					color:				jaspTheme.textEnabled
+					font.pixelSize:		Math.round(12 * preferencesModel.uiScale)
+					font.family:		preferencesModel.interfaceFont
+					wrapMode:			Text.WordWrap
+					padding:			jaspTheme.itemPadding
 				}
 			}
+		}
+
+
+		Text
+		{
+			id:					translationDocLink
+
+			text:				qsTr("Help us translate or improve JASP in your language")
+			color:				jaspTheme.blue
+			font.pixelSize:		Math.round(12 * preferencesModel.uiScale)
+			font.family:		preferencesModel.interfaceFont
+			font.underline:		true
+
+			MouseArea
+			{
+				id:				mouseAreaTranslationDocLink
+				anchors.fill:	parent
+				onClicked:		Qt.openUrlExternally("https://jasp-stats.org/translation-guidelines")
+				cursorShape:	Qt.PointingHandCursor
+			}
+		}
+
+	}
+
+	PrefsGroupRect
+	{
+		title: qsTr("Accessibility options")
+
+
+		CheckBox
+		{
+			id:					altnavcheckbox
+			label:				qsTr("ALT-Navigation mode")
+			checked:			preferencesModel.ALTNavModeActive
+			onCheckedChanged:	preferencesModel.ALTNavModeActive = checked
+			toolTip:			qsTr("Whether ALT-Navigation mode is active or not.")
+
+			KeyNavigation.tab:	checkForUpdates
+		}
+	}
+
+	PrefsGroupRect
+	{
+		title: qsTr("Check for updates")
+
+		CheckBox
+		{
+			id:					checkForUpdates
+			label:				qsTr("Daily automatic check for updates & known issues")
+			checked:			preferencesModel.checkUpdates
+			onCheckedChanged:	preferencesModel.checkUpdates = checked
+			toolTip:			qsTr("JASP doesn't share any of your data when it gets updates, not even which version of JASP you are using.\nIt does share your IP-address with the server but that is required for internet to function.\n\nThe list of known issues it downloads is rarely used, mostly the issues are at [jasp-issues](https://github.com/jasp-stats/jasp-issues/issues). However if we realize a terrible error has slipped into an analysis this will show you *in the analysis* that there is something you should take into account. Luckily we almost never need to use it.")
+
+			KeyNavigation.tab:	uiScaleSpinBox
 
 		}
 
-		PrefsGroupRect
+	}
+
+	PrefsGroupRect
+	{
+		title: qsTr("Miscellaneous options")
+
+		SpinBox
 		{
-			title: qsTr("Accessibility options")
+			id:						uiScaleSpinBox
+			value:					Math.round(preferencesModel.uiScale * 100)
+			onEditingFinished:		preferencesModel.uiScale = value / 100
+			from:					20
+			to:						300
+			stepSize:				10
+			decimals:				0
+			text:					qsTr("Zoom (%): ")
+			toolTip:				qsTr("Increase or decrease the size of the interface elements (text, buttons, etc).")
+			KeyNavigation.tab:		ribbonBarSpinBox
 
-
-			CheckBox
-			{
-				id:					altnavcheckbox
-				label:				qsTr("ALT-Navigation mode")
-				checked:			preferencesModel.ALTNavModeActive
-				onCheckedChanged:	preferencesModel.ALTNavModeActive = checked
-				toolTip:			qsTr("Whether ALT-Navigation mode is active or not.")
-
-				KeyNavigation.tab:	checkForUpdates
-			}
-		}
-		
-		PrefsGroupRect
-		{
-			title: qsTr("Check for updates")
-			
-			CheckBox
-			{
-				id:					checkForUpdates
-				label:				qsTr("Daily automatic check for updates & known issues")
-				checked:			preferencesModel.checkUpdates
-				onCheckedChanged:	preferencesModel.checkUpdates = checked
-				toolTip:			qsTr("JASP doesn't share any of your data when it gets updates, not even which version of JASP you are using.\nIt does share your IP-address with the server but that is required for internet to function.\n\nThe list of known issues it downloads is rarely used, mostly the issues are at [jasp-issues](https://github.com/jasp-stats/jasp-issues/issues). However if we realize a terrible error has slipped into an analysis this will show you *in the analysis* that there is something you should take into account. Luckily we almost never need to use it.")
-
-				KeyNavigation.tab:	uiScaleSpinBox
-
-			}
-
+			widthLabel:				Math.max(uiScaleSpinBox.implicitWidthLabel,Math.max(ribbonBarSpinBox.implicitWidthLabel, uiMaxFlickVelocity.implicitWidthLabel))
 		}
 
-		PrefsGroupRect
+		SpinBox
 		{
-			title: qsTr("Miscellaneous options")
+			id:						ribbonBarSpinBox
+			value:					Math.round(preferencesModel.ribbonBarHeightScale * 100)
+			onValueChanged:			if(value!= "") preferencesModel.ribbonBarHeightScale = value / 100
+			from:					10
+			to:						500
+			stepSize:				10
+			decimals:				0
+			text:					qsTr("Ribbon scale (%): ")
+			toolTip:				qsTr("Set the scale of height of the ribbon.")
+			KeyNavigation.tab:		uiMaxFlickVelocity
 
-			SpinBox
-			{
-				id:						uiScaleSpinBox
-				value:					Math.round(preferencesModel.uiScale * 100)
-				onEditingFinished:		preferencesModel.uiScale = value / 100
-				from:					20
-				to:						300
-				stepSize:				10
-				decimals:				0
-				text:					qsTr("Zoom (%): ")
-				toolTip:				qsTr("Increase or decrease the size of the interface elements (text, buttons, etc).")
-				KeyNavigation.tab:		ribbonBarSpinBox
+			widthLabel:				uiScaleSpinBox.widthLabel
+		}
 
-				widthLabel:				Math.max(uiScaleSpinBox.implicitWidthLabel,Math.max(ribbonBarSpinBox.implicitWidthLabel, uiMaxFlickVelocity.implicitWidthLabel))
-			}
-			
-			SpinBox
-			{
-				id:						ribbonBarSpinBox
-				value:					Math.round(preferencesModel.ribbonBarHeightScale * 100)
-				onValueChanged:			if(value!= "") preferencesModel.ribbonBarHeightScale = value / 100
-				from:					10
-				to:						500
-				stepSize:				10
-				decimals:				0
-				text:					qsTr("Ribbon scale (%): ")
-				toolTip:				qsTr("Set the scale of height of the ribbon.")
-				KeyNavigation.tab:		uiMaxFlickVelocity
-
-				widthLabel:				uiScaleSpinBox.widthLabel
-			}
-
-			SpinBox
-			{
-				id:						uiMaxFlickVelocity
-				value:					preferencesModel.maxFlickVelocity
-				onValueChanged:			if(value !== "") preferencesModel.maxFlickVelocity = value
-				from:					100
-				to:						3000
-				stepSize:				100
-				decimals:				0
-				text:					qsTr("Scroll speed (pix/s): ")
-				toolTip:				qsTr("Set the speed with which you can scroll in the options, dataviewer and other places.")
-				widthLabel:				uiScaleSpinBox.widthLabel
-				KeyNavigation.tab:		safeGraphicsMode
-			}
+		SpinBox
+		{
+			id:						uiMaxFlickVelocity
+			value:					preferencesModel.maxFlickVelocity
+			onValueChanged:			if(value !== "") preferencesModel.maxFlickVelocity = value
+			from:					100
+			to:						3000
+			stepSize:				100
+			decimals:				0
+			text:					qsTr("Scroll speed (pix/s): ")
+			toolTip:				qsTr("Set the speed with which you can scroll in the options, dataviewer and other places.")
+			widthLabel:				uiScaleSpinBox.widthLabel
+			KeyNavigation.tab:		safeGraphicsMode
+		}
 
 
-			CheckBox
-			{
-				id:					safeGraphicsMode
-				label:				qsTr("Safe graphics mode")
-				checked:			preferencesModel.safeGraphics
-				onCheckedChanged:	preferencesModel.safeGraphics = checked
-				toolTip:			qsTr("Switches to a \"safer\" mode for graphics aka software rendering.\nIt will make your interface slower but if you have some problems (weird glitches, cannot see results or anything even) might fix them.\nAnalyses will still be just as fast though.")
-				
-				KeyNavigation.tab:	startMaximized
+		CheckBox
+		{
+			id:					safeGraphicsMode
+			label:				qsTr("Safe graphics mode")
+			checked:			preferencesModel.safeGraphics
+			onCheckedChanged:	preferencesModel.safeGraphics = checked
+			toolTip:			qsTr("Switches to a \"safer\" mode for graphics aka software rendering.\nIt will make your interface slower but if you have some problems (weird glitches, cannot see results or anything even) might fix them.\nAnalyses will still be just as fast though.")
 
-			}
-			
-			CheckBox
-			{
-				id:					startMaximized
-				label:				qsTr("Start maximized")
-				checked:			preferencesModel.startMaximized
-				onCheckedChanged:	preferencesModel.startMaximized = checked
-				toolTip:			qsTr("Should JASP open its window maximized on startup?")
-				
-				KeyNavigation.tab:	disableAnimations
+			KeyNavigation.tab:	startMaximized
 
-			}
+		}
 
-			CheckBox
-			{
-				id:					disableAnimations
-				label:				qsTr("Disable animations")
-				checked:			preferencesModel.disableAnimations
-				onCheckedChanged:	preferencesModel.disableAnimations = checked
-				toolTip:			enabled ? qsTr("Turns off all animations, this is implied when \"Safe Graphics Mode\" is on.") : qsTr("Already disabled animations because \"Safe Graphics Mode\" is on")
+		CheckBox
+		{
+			id:					startMaximized
+			label:				qsTr("Start maximized")
+			checked:			preferencesModel.startMaximized
+			onCheckedChanged:	preferencesModel.startMaximized = checked
+			toolTip:			qsTr("Should JASP open its window maximized on startup?")
 
-				enabled:			!preferencesModel.safeGraphics
+			KeyNavigation.tab:	disableAnimations
 
-				KeyNavigation.tab:			useNativeFileDialog
-			}
+		}
+
+		CheckBox
+		{
+			id:					disableAnimations
+			label:				qsTr("Disable animations")
+			checked:			preferencesModel.disableAnimations
+			onCheckedChanged:	preferencesModel.disableAnimations = checked
+			toolTip:			enabled ? qsTr("Turns off all animations, this is implied when \"Safe Graphics Mode\" is on.") : qsTr("Already disabled animations because \"Safe Graphics Mode\" is on")
+
+			enabled:			!preferencesModel.safeGraphics
+
+			KeyNavigation.tab:			useNativeFileDialog
+		}
 
 
-			CheckBox
-			{
-				id:					useNativeFileDialog
-				label:				qsTr("Use native file dialogs")
-				checked:			preferencesModel.useNativeFileDialog
-				onCheckedChanged:	preferencesModel.useNativeFileDialog = checked
-				toolTip:			qsTr("If disabled it will not use your operating system's file dialogs but those made by Qt. This might solve some problems on Windows where JASP crashes on pressing \"Browse\".")
+		CheckBox
+		{
+			id:					useNativeFileDialog
+			label:				qsTr("Use native file dialogs")
+			checked:			preferencesModel.useNativeFileDialog
+			onCheckedChanged:	preferencesModel.useNativeFileDialog = checked
+			toolTip:			qsTr("If disabled it will not use your operating system's file dialogs but those made by Qt. This might solve some problems on Windows where JASP crashes on pressing \"Browse\".")
 
-				KeyNavigation.tab:	reportingMode
+			KeyNavigation.tab:	reportingMode
 
-			}
+		}
 
-			CheckBox
-			{
-				id:					reportingMode
-				label:				qsTr("Reporting mode")
-				checked:			preferencesModel.reportingMode
-				onCheckedChanged:	preferencesModel.reportingMode = checked
-				toolTip:			qsTr("Whether JASP should run in reporting mode or not.")
-				visible:			preferencesModel.developerMode
+		CheckBox
+		{
+			id:					reportingMode
+			label:				qsTr("Reporting mode")
+			checked:			preferencesModel.reportingMode
+			onCheckedChanged:	preferencesModel.reportingMode = checked
+			toolTip:			qsTr("Whether JASP should run in reporting mode or not.")
+			visible:			preferencesModel.developerMode
 
-				KeyNavigation.tab:	interfaceFonts
-			}
+			KeyNavigation.tab:	interfaceFonts
 		}
 	}
 }

--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -268,9 +268,6 @@ FocusScope
 				MenuHeader
 				{
 					headertext:	qsTr("Workspace settings")
-					anchorMe:	false
-					width:		parent.width - (2 * jaspTheme.generalMenuMargin)
-					x:			jaspTheme.generalMenuMargin
 				}
 
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3024 (at least for the File Menu)

The FileMenu.qml takes into account the implicitWidth of its loaded item to determine its width.