### PR TITLE
i18n: remove unnecessary qsTr from test suites

### DIFF
--- a/Tests/qmlTests/tst_tabViewManual.qml
+++ b/Tests/qmlTests/tst_tabViewManual.qml
@@ -33,7 +33,7 @@ TestCase
 				TextField
 				{
 					name: 				"Hypothesis"
-					startValue:			qsTr("H") + (rowIndex + 1)
+					startValue:			"H" + (rowIndex + 1)
 				}
 				IntegerField
 				{


### PR DESCRIPTION
cause translators do not know what is it.