### PR TITLE
Fix some decimal separator related issues

### DIFF
--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingAxis.qml
@@ -97,7 +97,7 @@ Column
 				id					: axisBreaksRangeFrom
 				label				: qsTr("from")
 				value				: axisModel.from
-				onEditingFinished	: if(axisModel) axisModel.from = displayValue
+				onEditingFinished	: if(axisModel) axisModel.from = qmlUtils.variantToDouble(displayValue)
 				negativeValues		: true
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				max					: axisBreaksRangeSteps.value > 0 ? axisBreaksRangeTo.value : Infinity
@@ -107,7 +107,7 @@ Column
 				id					: axisBreaksRangeTo
 				label				: qsTr("to")
 				value				: axisModel.to
-				onEditingFinished	: if(axisModel) axisModel.to = displayValue
+				onEditingFinished	: if(axisModel) axisModel.to = qmlUtils.variantToDouble(displayValue)
 				negativeValues		: true
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				min					: axisBreaksRangeSteps.value > 0 ? axisBreaksRangeFrom.value : -Infinity
@@ -118,7 +118,7 @@ Column
 				label				: qsTr("steps")
 				value				: axisModel.steps
 				negativeValues		: true
-				onEditingFinished	: if(axisModel) axisModel.steps = displayValue
+				onEditingFinished	: if(axisModel) axisModel.steps = qmlUtils.variantToDouble(displayValue)
 				fieldWidth			: 2 * jaspTheme.numericFieldWidth
 			}
 
@@ -178,7 +178,7 @@ Column
 					negativeValues		: true
 					max					: axisModel.limitUpper
 					value				: axisModel.limitLower
-					onEditingFinished	: if(axisModel) axisModel.limitLower = displayValue
+					onEditingFinished	: if(axisModel) axisModel.limitLower = qmlUtils.variantToDouble(displayValue)
 					decimals			: 20
 					fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				}
@@ -189,7 +189,7 @@ Column
 					negativeValues		: true
 					min					: axisModel.limitLower
 					value				: axisModel.limitUpper
-					onEditingFinished	: if(axisModel) axisModel.limitUpper = displayValue
+					onEditingFinished	: if(axisModel) axisModel.limitUpper = qmlUtils.variantToDouble(displayValue)
 					decimals			: 20
 					fieldWidth			: 2 * jaspTheme.numericFieldWidth
 				}

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -511,7 +511,7 @@ int main(int argc, char *argv[])
 
 			QLocale::setDefault(QLocale(QLocale::English)); // make decimal points == . in at least R? Anyway, this has been here forever, ill just leave it.
 			
-			char dsteng[] = "LC_ALL=en_US";
+			char dsteng[] = "LC_ALL=en_US.UTF-8";
 			putenv(dsteng);
 
 			//Now we convert all these strings in args back to an int and a char * array.

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -511,7 +511,7 @@ int main(int argc, char *argv[])
 
 			QLocale::setDefault(QLocale(QLocale::English)); // make decimal points == . in at least R? Anyway, this has been here forever, ill just leave it.
 			
-			char dsteng[] = "LC_ALL=en_US.UTF-8";
+			char dsteng[] = "LC_ALL=en_US.UTF-8"; // See this issue about encoding problems in the results: https://github.com/jasp-stats/jasp-test-release/issues/3099
 			putenv(dsteng);
 
 			//Now we convert all these strings in args back to an int and a char * array.

--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -511,7 +511,7 @@ int main(int argc, char *argv[])
 
 			QLocale::setDefault(QLocale(QLocale::English)); // make decimal points == . in at least R? Anyway, this has been here forever, ill just leave it.
 			
-			char dsteng[] = "LC_ALL=en_US.UTF-8"; // See this issue about encoding problems in the results: https://github.com/jasp-stats/jasp-test-release/issues/3099
+			char dsteng[] = "LC_ALL=en_US.UTF-8"; // See this issue about encoding problems in the results: https://github.com/jasp-stats/jasp-test-release/issues/3099 and https://github.com/jasp-stats/jasp-issues/issues/3867 for xlsx importing
 			putenv(dsteng);
 
 			//Now we convert all these strings in args back to an int and a char * array.

--- a/Desktop/results/ploteditoraxismodel.cpp
+++ b/Desktop/results/ploteditoraxismodel.cpp
@@ -195,9 +195,9 @@ bool AxisModel::setData(const QModelIndex &index, const QVariant &value, int)
 
 	if(breaks)
 	{
-		double newBreak = value.toDouble();
-
-		if(!Utils::isEqual(_breaks[entry], newBreak))
+		double newBreak;
+		
+		if(QColumnUtils::getDoubleValue(value, newBreak) && !Utils::isEqual(_breaks[entry], newBreak))
 		{
 			double oldBreak = _breaks[entry];
 

--- a/QMLComponents/controls/tableviewbase.cpp
+++ b/QMLComponents/controls/tableviewbase.cpp
@@ -230,14 +230,16 @@ QVariant TableViewBase::defaultValue(int colIndex, int rowIndex)
 	{
 	case JASPControl::ItemType::Integer:
 	{
-		if (defValue.typeId() == QMetaType::Int)		return defValue;
-		if (defValue.canConvert<int>())					return defValue.toInt();
+		int intVal;
+		if(QColumnUtils::getIntValue(defValue, intVal))
+			return intVal;
 		break;
 	}
 	case JASPControl::ItemType::Double:
 	{
-		if (defValue.typeId() == QMetaType::Double)		return defValue;
-		if (defValue.canConvert<double>())				return defValue.toDouble();
+		double dblVal;
+		if(QColumnUtils::getDoubleValue(defValue, dblVal))
+			return dblVal;
 		break;
 	}
 	case JASPControl::ItemType::String:

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -213,27 +213,12 @@ void TextInputBase::setDisplayValue()
 {
 	int		valueInt;
 	double	valueDbl;
-	bool	isInt = (_value.typeId() == QMetaType::Int),
-			isDbl = (_value.typeId() == QMetaType::Double);
-
-	if (isInt)
-		valueInt = _value.toInt();
-	else if (isDbl)
-		valueDbl = _value.toDouble();
-	else
-	{
-		isInt = QColumnUtils::getIntValue(	_value.toString(), valueInt);
-		isDbl = QColumnUtils::getDoubleValue(	_value.toString(), valueDbl);
-	}
-	
-	QString showThis = _value.toString();
-	
-	if(isInt)
-		showThis = QString::number(valueInt); //QColumnUtils::currentQLocale().toString(valueInt);
-
-	else if(isDbl) // Can be also a formula
-		showThis = QColumnUtils::doubleToString(valueDbl, false);
-
+	QString showThis	= QColumnUtils::getIntValue(_value, valueInt) ? 
+							QString::number(valueInt) 
+						:	QColumnUtils::getDoubleValue(_value, valueDbl) ? 
+								QColumnUtils::doubleToString(valueDbl, false) 
+							:	_value.toString();
+																																				  
 	setProperty("displayValue", showThis);
 }
 

--- a/QMLComponents/models/listmodelfiltereddataentry.cpp
+++ b/QMLComponents/models/listmodelfiltereddataentry.cpp
@@ -158,10 +158,10 @@ void ListModelFilteredDataEntry::initialValuesChanged()
 	else if(_tableView->initialValuesSource().toString().isEmpty())
 	{
 		int			rowCount		= requestInfo(VariableInfo::DataSetRowCount).toInt();
-		QVariant	defaultValue	= _tableView->defaultValue();
-		bool		isDbl			= false;
-		double		dblVal			= defaultValue.toDouble(&isDbl);
-		if(isDbl)
+		QVariant	defaultValue	= _tableView->defaultValue();	
+		double		dblVal;
+		
+		if(QColumnUtils::getDoubleValue(defaultValue, dblVal))
 					_initialValues	= doublevec(rowCount, dblVal);
 	}
 	fillTable();

--- a/QMLComponents/models/listmodeltableviewbase.cpp
+++ b/QMLComponents/models/listmodeltableviewbase.cpp
@@ -18,7 +18,6 @@
 
 #include "log.h"
 #include <QSize>
-#include <fstream>
 #include "analysisform.h"
 #include "listmodeltableviewbase.h"
 #include "controls/tableviewbase.h"
@@ -443,8 +442,8 @@ bool ListModelTableViewBase::valueOk(QVariant value, int col, int row)
 	bool	ok	= true;
 	JASPControl::ItemType itemType = _tableView->itemTypePerItem(col, row);
 
-	if		(itemType == JASPControl::ItemType::Double)		value.toDouble(&ok);
-	else if	(itemType == JASPControl::ItemType::Integer)	value.toInt(&ok);
+	if		(itemType == JASPControl::ItemType::Double)		ok = QColumnUtils::isDoubleValue(	value);
+	else if	(itemType == JASPControl::ItemType::Integer)	ok = QColumnUtils::isIntValue(		value);
 
 	return ok;
 }

--- a/QMLComponents/utilities/qmlutils.cpp
+++ b/QMLComponents/utilities/qmlutils.cpp
@@ -59,6 +59,26 @@ QJSValue	QmlUtils::decodeJson(const QJSValue	& val, QQuickItem * caller)
 	return tqj(v, caller);
 }
 
+double QmlUtils::variantToDouble(const QVariant &val)
+{
+	double dblVal;
+	
+	if(QColumnUtils::getDoubleValue(val, dblVal))
+		return dblVal;
+	
+	return NAN;
+}
+
+int QmlUtils::variantToInt(const QVariant &val)
+{
+	int intVal;
+	
+	if(QColumnUtils::getIntValue(val, intVal))
+		return intVal;
+	
+	return 0;
+}
+
 //Turning QMLENGINE_DOES_ALL_THE_WORK on also works fine, but has slightly less transparent errormsgs so isn't recommended
 //#define QMLENGINE_DOES_ALL_THE_WORK
 
@@ -200,11 +220,13 @@ void QmlUtils::setGlobalPropertiesInQMLContext(QQmlContext * ctxt)
 
 	bool isWindows = !isMac && !isLinux;
 
-	ctxt->setContextProperty("DEBUG_MODE",				debug);
+	ctxt->setContextProperty("PRO",						false);
 	ctxt->setContextProperty("MACOS",					isMac);
 	ctxt->setContextProperty("LINUX",					isLinux);
 	ctxt->setContextProperty("WINDOWS",					isWindows);
+	ctxt->setContextProperty("DEBUG_MODE",				debug);
 	ctxt->setContextProperty("INTERACTION_SEPARATOR",	Term::separator);
+	
 	ctxt->setContextProperty("dataSetInfo",				VariableInfo::info());
 	ctxt->setContextProperty("messages",				MessageForwarder::msgForwarder());
 	ctxt->setContextProperty("backgroundForms",			nullptr);

--- a/QMLComponents/utilities/qmlutils.h
+++ b/QMLComponents/utilities/qmlutils.h
@@ -38,6 +38,9 @@ public slots:
 
 	QJSValue	encodeJson(				const QJSValue	& val, QQuickItem * caller);
 	QJSValue	decodeJson(				const QJSValue	& val, QQuickItem * caller);
+	
+	double		variantToDouble(		const QVariant	& val);
+	int			variantToInt(			const QVariant	& val);
 
 };
 

--- a/QMLComponents/utilities/qutils.cpp
+++ b/QMLComponents/utilities/qutils.cpp
@@ -325,9 +325,44 @@ bool QColumnUtils::getIntValue(const QString &value, int &intValue)
 	return ColumnUtils::getIntValue(fq(value), intValue);
 }
 
+bool QColumnUtils::getIntValue(const QVariant &value, int &intValue)
+{
+	if(value.typeId() == QMetaType::Int)// || value.canConvert<int>())
+	{
+		intValue = value.toInt();
+		return true;
+	}
+	else if(value.typeId() == QMetaType::QString)
+	{
+		return getIntValue(value.toString(), intValue);	
+	}
+	
+	return false;
+}
+
 bool QColumnUtils::getDoubleValue(const QString &value, double &doubleValue, bool useLocale)
 {
 	return ColumnUtils::getDoubleValue(fq(value), doubleValue, useLocale);
+}
+
+bool QColumnUtils::getDoubleValue(const QVariant &value, double &doubleValue, bool useLocale)
+{
+	if(value.typeId() == QMetaType::Int)
+	{
+		doubleValue = value.toInt();
+		return true;
+	}
+	else if(value.typeId() == QMetaType::Double)// || value.canConvert<double>())
+	{
+		doubleValue = value.toDouble();	
+		return true;
+	}
+	else if(value.typeId() == QMetaType::QString)
+	{
+		return getDoubleValue(value.toString(), doubleValue, useLocale);	
+	}
+	
+	return false;
 }
 
 doubleset QColumnUtils::getDoubleValues(const QStringList &values, bool stripNAN)
@@ -340,9 +375,19 @@ bool QColumnUtils::isIntValue(const QString &value)
 	return ColumnUtils::isIntValue(fq(value));
 }
 
+bool QColumnUtils::isIntValue(const QVariant &value)
+{
+	return value.typeId() == QMetaType::Int || (value.typeId() == QMetaType::QString && isIntValue(value.toString()));
+}
+
 bool QColumnUtils::isDoubleValue(const QString &value)
 {
 	return ColumnUtils::isDoubleValue(fq(value));
+}
+
+bool QColumnUtils::isDoubleValue(const QVariant &value)
+{
+	return value.typeId() == QMetaType::Double || value.typeId() == QMetaType::Int || (value.typeId() == QMetaType::QString && isDoubleValue(value.toString())); 
 }
 
 void QColumnUtils::setOmitGroupSeparatorOnQLocale(QLocale & locale)

--- a/QMLComponents/utilities/qutils.h
+++ b/QMLComponents/utilities/qutils.h
@@ -100,11 +100,15 @@ class QColumnUtils
 {
 public:	
 	static bool					getIntValue(	const QString		& value, int	& intValue);
+	static bool					getIntValue(	const QVariant		& value, int	& intValue);
 	static bool					getDoubleValue(	const QString		& value, double	& doubleValue, bool useLocale = true);
+	static bool					getDoubleValue(	const QVariant		& value, double	& doubleValue, bool useLocale = true);
 	static doubleset			getDoubleValues(const QStringList	& values, bool stripNAN = true);
 
 	static bool					isIntValue(		const QString		& value);
+	static bool					isIntValue(		const QVariant		& value);
 	static bool					isDoubleValue(	const QString		& value);
+	static bool					isDoubleValue(	const QVariant		& value);
 	
 	static QLocale				currentQLocale();
 	
@@ -112,7 +116,6 @@ public:
 	static QString				doubleToString(			double dbl, bool sepas = true, int precision = 10);
 	static QString				doubleToStringMaxPrec(	double dbl, bool sepas = true);
 	static QString				currencyString(			double money, const QString &symbol = QString());
-	
 	
     static void					setOmitGroupSeparatorOnQLocale(QLocale & locale);
 	static void					setCallbacksAndDefaultLocale(const QLocale & locale, bool useThousandSeps);


### PR DESCRIPTION
Hopefully  jasp-stats/jasp-test-release#30
Make sure you can enter locale-correct doubles and ints in filteredDataEntry and the ploteditor ticks etc.
Fixes https://github.com/jasp-stats/jasp-test-release/issues/3103

Also adds a PRO var to the QML environment.