### PR TITLE
If a label original value has a double and the jasp file <0.96 doesnt have a dbl double just fix it

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1967,7 +1967,18 @@ void Column::upgradeDoublesToLabels()
 	beginBatchedLabelsDB();
 	
 	for(size_t row=0; row<_dbls.size(); row++)
-		if(!std::isnan(_dbls[row]) && _ints[row] == Label::NO_LABEL)
+		if(std::isnan(_dbls[row]))
+		{
+			if(_ints[row] == Label::NO_LABEL)
+				continue;
+			
+			Label * label = labelByIntsId(_ints[row]);
+			
+			if(label && !std::isnan(label->originalValueAsDouble()))
+				_dbls[row] = label->originalValueAsDouble();
+			
+		}
+		else if(_ints[row] == Label::NO_LABEL)
 		{
 			std::string		dblStr	= Column::doubleToDisplayString(_dbls[row], false, false);
 			Label		*	label	= labelByValue(dblStr);

--- a/CommonData/dataset.cpp
+++ b/CommonData/dataset.cpp
@@ -327,7 +327,7 @@ void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, Ver
 	Json::Reader().parse(emptyVals, emptyValsJson);
 
 	bool	do019Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.19",
-			do095Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.95";
+			do096Fix	= doUpgradeFrom != Version() && doUpgradeFrom < "0.96";
 
 	//Ideally we have the emptyvalues before loading the columns, so we get the right labels in the labeleditor, butr for older than 0.19 stuff is complicated so we do that later.
 
@@ -354,12 +354,12 @@ void DataSet::dbLoad(int index, std::function<void(float)> progressCallback, Ver
 
 
 	
-	if(do095Fix)
+	if(do096Fix)
 		beginBatchedToDB();
 	
 	if(do019Fix)	upgradeTo019(emptyValsJson);
 	
-	if(do095Fix)
+	if(do096Fix)
 	{
 		upgrade019To095();
 		endBatchedToDB();


### PR DESCRIPTION

fixes loading Bugs.jasp 4.5 showing up as a missing value fixes a part of https://github.com/jasp-stats/jasp-test-release/issues/3106

fixes a part of https://github.com/jasp-stats/jasp-test-release/issues/3106