### PR TITLE
Group should not have a MouseArea

### DIFF
--- a/QMLComponents/controls/groupboxbase.cpp
+++ b/QMLComponents/controls/groupboxbase.cpp
@@ -2,6 +2,7 @@
 
 GroupBoxBase::GroupBoxBase(QQuickItem* parent) 
 	: JASPControl(parent) 
-{ 
-	_controlType = JASPControl::ControlType::GroupBox; 
+{
+	_controlType = JASPControl::ControlType::GroupBox;
+	_useControlMouseArea	= false;
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/3133

A JaspControl has per default a MouseArea above it, and it's used if a tooltip is needed.
In MetaAnalysis model, the VariablesForm is in a Group with an info property: this info property activates the MouseArea to have hoverEnabled on, in order to activate the tooltip. This hinders the hoverEnabled of the MouseArea around the VariablesList.

But as VariablesForm, a Group should not have a MouseArea: only JaspControl's inside the Group should have an active MouseArea.