### PR TITLE
Safer heartbeat check

### DIFF
--- a/Common/enginedefinitions.h
+++ b/Common/enginedefinitions.h
@@ -32,6 +32,6 @@ struct unexpectedEngineReply  : public std::runtime_error
 #define ENGINE_BORED_SHUTDOWN (30 * 60)
 
 ///Engines need some time between closing and starting to avoid problems with shared memory
-#define ENGINE_COOLDOWN 1
+#define ENGINE_COOLDOWN 200
 
 #endif // ENGINEDEFINITIONS_H

--- a/CommonData/ipcchannel.cpp
+++ b/CommonData/ipcchannel.cpp
@@ -231,6 +231,7 @@ bool IPCChannel::jaspAlive()
 	
 	if(newTimestamp  != _lastHeartBeatTimestamp) {
 		_lastHeartBeatTimestamp = newTimestamp ;
+		_startHeartAttackTimestamp = 0;
 		return true;
 	}
 
@@ -242,9 +243,17 @@ bool IPCChannel::jaspAlive()
 	
 	if(Utils::currentSeconds() - _lastHeartBeatTimestamp > _maxHeartbeatDiffS)
 	{
-		Log::log() << "heartbeat time limit exceeded, last timestamp was from " << (Utils::currentSeconds() - _lastHeartBeatTimestamp) << " seconds ago. Heartbeat file is at '" << _jaspHeartBeatPath << "'."  << std::endl;
-		return false;
+		if (_startHeartAttackTimestamp == 0)
+			// Maybe the engine is just awaken, and the Desktop not yet. Measure the heart attack only from now.
+			_startHeartAttackTimestamp = Utils::currentSeconds();
+		else if (Utils::currentSeconds() - _startHeartAttackTimestamp > _maxHeartAttackDurationS)
+		{
+			Log::log() << "heartbeat time limit exceeded, last timestamp was from " << (Utils::currentSeconds() - _lastHeartBeatTimestamp) << " seconds ago, heart attack started " << (Utils::currentSeconds() - _startHeartAttackTimestamp) << " seconds ago. Heartbeat file is at '" << _jaspHeartBeatPath << "'."  << std::endl;
+			return false;
+		}
 	}
+	else
+		_startHeartAttackTimestamp = 0;
 
 	return true;
 }

--- a/CommonData/ipcchannel.h
+++ b/CommonData/ipcchannel.h
@@ -79,10 +79,12 @@ private:
 	static bool										heartbeat(std::string path, unsigned int delayMs);
 	static std::thread								_heartbeatThread;
 
-	int64_t											_lastHeartBeatTimestamp = 0;
+	int64_t											_lastHeartBeatTimestamp = 0,
+													_startHeartAttackTimestamp = 0;
 	std::string										_jaspHeartBeatPath;
 	unsigned int									_heatbeatDelayS = 5;
-	unsigned int									_maxHeartbeatDiffS = 100;
+	unsigned int									_maxHeartbeatDiffS = 60,
+													_maxHeartAttackDurationS = 60;
 
 	std::string										_baseName,
 													_nameControl,


### PR DESCRIPTION
If the PC is asleep, when waking up, the Engine process might awake before the Desktop: when checking the hearbeat file timetamp, it will  see a quite old one. It should not stop, but still wait 60 seconds for the Desktop to wake up.

Fixes https://github.com/jasp-stats/jasp-test-release/issues/3141


