### PR TITLE
builder: add vcs-browser to fix flatpak build linker warnings

### DIFF
--- a/Tools/flatpak/org.jaspstats.JASP.appdata.xml
+++ b/Tools/flatpak/org.jaspstats.JASP.appdata.xml
@@ -33,6 +33,7 @@
 	<url type="homepage">http://www.jasp-stats.org</url>
 	<url type="bugtracker">https://github.com/jasp-stats/jasp-issues/issues</url>
 	<url type="donation">https://jasp-stats.org/donate/</url>
+	<url type="vcs-browser">https://github.com/jasp-stats/jasp-desktop</url>
   <branding>
   <color type="primary" scheme_preference="light">#14a1e3</color>
   <color type="primary" scheme_preference="dark">#14a1e3</color>


### PR DESCRIPTION
Work with https://github.com/flathub/org.jaspstats.JASP/pull/172

Resolve the linter of https://github.com/flathub/org.jaspstats.JASP/pull/172#issuecomment-3794403782