### PR TITLE
bugfix: make the tooltip background color style consistently

### DIFF
--- a/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
+++ b/Desktop/components/JASP/Widgets/AnalysisFormExpander.qml
@@ -134,7 +134,6 @@ DropArea
 			timeout:		jaspTheme.toolTipTimeout
 			delay:			jaspTheme.toolTipDelay
 			font:			jaspTheme.font
-			background:		Rectangle { color:	jaspTheme.tooltipBackgroundColor }
 			visible:		mouseArea.containsMouse && !analysesModel.moving && analysesModel.rowCount() > 1
 			y:				mouseArea.mouseY
 			x:				mouseArea.mouseX + 5

--- a/Desktop/components/JASP/Widgets/JASPSplitHandle.qml
+++ b/Desktop/components/JASP/Widgets/JASPSplitHandle.qml
@@ -44,7 +44,6 @@ Rectangle
 		timeout:		jaspTheme.toolTipTimeout
 		delay:			jaspTheme.toolTipDelay
 		font:			jaspTheme.font
-		background:		Rectangle { color:	jaspTheme.tooltipBackgroundColor }
 		visible:		handleRoot.dragEnabled && hoverMouse.containsMouse && handleRoot.toolTipDrag !== ""
 		y:				hoverMouse.mouseY + 10
 		x:				parent.width / 2
@@ -112,7 +111,6 @@ Rectangle
 				timeout:		jaspTheme.toolTipTimeout
 				delay:			jaspTheme.toolTipDelay
 				font:			jaspTheme.font
-				background:		Rectangle { color:	jaspTheme.tooltipBackgroundColor }
 				visible:		handleRoot.toolTipArrow !== "" && arrowMouse.containsMouse
 				y:				arrowMouse.mouseY + 15
 				x:				parent.width / 2

--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -290,7 +290,6 @@ Window
 	{
 		//These properties override those for ALL attached ToolTips in the application
 		//ToolTip.toolTip shouldn't be changed anywhere else otherwise we get hard to debug behaviour
-		ToolTip.toolTip.background:		Rectangle { color: jaspTheme.tooltipBackgroundColor }
 		ToolTip.toolTip.contentItem:	Text
 		{
 			font:			jaspTheme.font


### PR DESCRIPTION
Before: （e.g. the split view handle on Linux)
<img width="381" height="122" alt="image" src="https://github.com/user-attachments/assets/28ff9ac9-a6f5-4894-9f94-cf52f45974c3" />

After:

<img width="381" height="122" alt="image" src="https://github.com/user-attachments/assets/701d20f0-a4f1-4ca5-b3d2-4bc2645c86a5" />
