### PR TITLE
bugfix: make sure set title in analysis model after renamed it

### DIFF
--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -93,6 +93,7 @@ $(document).ready(function () {
 		if (analysis === undefined) 
 			return;
 
+		analysis.model.set("title", title);
 		analysis.toolbar.setTitle(title);
 		analysis.toolbar.render();
 	}


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/jasp-test-release/issues/3155

It was because the result page was just received the new title name and render it immediately but not update (saved) it in analysis model, so reorder analysis will refresh title with old default title. now we do update in model firstly.