### PR TITLE
Add "update all" to modules-app

### DIFF
--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -201,6 +201,10 @@ FocusScope
 					function uninstall(moduleName) {
 						moduleLibrary.uninstallJASPModule(moduleName)
 					}
+
+					function installMany(asset_urls) {
+						moduleLibrary.installManyJASPModules(asset_urls)
+					}
 				}
 			}
 

--- a/Desktop/modules/modulelibrary.cpp
+++ b/Desktop/modules/modulelibrary.cpp
@@ -124,3 +124,17 @@ void ModuleLibrary::finishInstalling()
     _isInstalling = false;
     emit isInstallingChanged();
 }
+
+void ModuleLibrary::installManyJASPModules(const QStringList &assetUrls)
+{
+    if (auto *dynMods = Modules::DynamicModules::dynMods())
+    {
+        for (const QString & url : assetUrls) {
+            if (url.endsWith(".jaspModule")) {
+                // TODO Download asset to jaspTmpDir and
+                // dynMods->installModuleFromAssetUrl(downloadedFilePath);
+                // TODO give feedback to user about progress/errors
+            }
+        }
+    }
+}

--- a/Desktop/modules/modulelibrary.h
+++ b/Desktop/modules/modulelibrary.h
@@ -41,6 +41,7 @@ public:
 
     Q_INVOKABLE QVariantMap getEnvironmentInfo() const;
     Q_INVOKABLE void uninstallJASPModule(const QString &moduleName);
+    Q_INVOKABLE void installManyJASPModules(const QStringList &assetUrls);
     Q_INVOKABLE void startInstalling();
     Q_INVOKABLE void finishInstalling();
 


### PR DESCRIPTION
The server side logic for updating all modules from app.

Refs https://github.com/jasp-stats-modules/modules-app/issues/40

Needs https://github.com/jasp-stats-modules/modules-app/pull/86

TODO
- [ ] download assets (like https://github.com/jasp-stats-modules/jaspAcceptanceSampling/releases/download/0.95.5_82385837_R-4-5-2_Release/jaspAcceptanceSampling_0.95.5_Windows_x86-64_R-4-5-2.JASPModule)
- [ ] install assets
- [ ] show user progress