### PR TITLE
Change tuples in Paired VariablesList when variable name is changed

### DIFF
--- a/QMLComponents/models/listmodelmultitermsassigned.cpp
+++ b/QMLComponents/models/listmodelmultitermsassigned.cpp
@@ -149,6 +149,19 @@ void ListModelMultiTermsAssigned::availableTermsResetHandler(Terms , Terms terms
 		removeTerms(indexes);
 }
 
+void ListModelMultiTermsAssigned::sourceVariableNamesChanged(QMap<QString, QString> map)
+{
+	// Update first _tuples, then call the parent to handle the variables names changed
+	for (Terms& terms : _tuples)
+	{
+		for (const Term& term : terms)
+			if (map.contains(term.label()))
+				terms.replaceVariableName(fq(term.label()), fq(map[term.label()]));
+	}
+
+	ListModelAssignedInterface::sourceVariableNamesChanged(map);
+}
+
 void ListModelMultiTermsAssigned::_setTerms()
 {
 	Terms newTerms;

--- a/QMLComponents/models/listmodelmultitermsassigned.h
+++ b/QMLComponents/models/listmodelmultitermsassigned.h
@@ -37,6 +37,8 @@ public:
 
 public slots:
 	void			availableTermsResetHandler(Terms termsToAdd, Terms termsToRemove)							override;
+	void			sourceVariableNamesChanged(QMap<QString, QString> map)										override;
+
 
 private:
 	void			_setTerms();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3973

The _tuples member of ListModelMultiTermsAssigned must be also updated when a variable name is changed.
