### PR TITLE
Reset delay and timeout each time the ToolTip is used.

### DIFF
--- a/Desktop/components/JASP/Style/ToolTip.qml
+++ b/Desktop/components/JASP/Style/ToolTip.qml
@@ -23,6 +23,11 @@ QtC.ToolTip {
 		color: jaspTheme.textEnabled
 	}
 
-	timeout:	jaspTheme.toolTipTimeout
 	delay:		jaspTheme.toolTipDelay
+	timeout:	jaspTheme.toolTipTimeout
+
+	// Each time the ToolTip is used, QML resets the delay and timeout to the defualt values (delay: 0 and timeout: -1)
+	onDelayChanged: if (delay === 0) delay = jaspTheme.toolTipDelay
+	onTimeoutChanged: if (timeout === -1) timeout = jaspTheme.toolTipTimeout
+
 }

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -174,6 +174,8 @@ TextInputBase
 		selectionColor:			jaspTheme.itemSelectedColor
 		enabled:				textField.editable
 
+		QTC.ToolTip.text		: control.text
+		QTC.ToolTip.visible		: contentWidth > width - leftPadding - rightPadding && (hovered || control.activeFocus)
 
 		// The acceptableInput is checked even if the user is still typing in the TextField.
 		// In this case, the error should not appear immediately (only when the user is pressing the return key, or going out of focus),


### PR DESCRIPTION
Also reset the ToolTip in TextField (when value is wider than its field width), that was unfortunately removed in the previous PR.