### PR TITLE
Do not remove QML before the controls get out of focus

### DIFF
--- a/Desktop/widgets/filemenu/resourcebuttons.cpp
+++ b/Desktop/widgets/filemenu/resourcebuttons.cpp
@@ -142,8 +142,6 @@ void ResourceButtons::setSelectedButton(ButtonType selectedButton)
 		emit dataChanged(newIndex, newIndex);
 		setCurrentQML(qml(_selectedButton));
 	}
-	else
-		setCurrentQML("");
 
 	emit selectedButtonChanged(_selectedButton);
 }


### PR DESCRIPTION
Go to Preferences/Advanced, change the Module name, and click on the Ribbon (without clicking on a button), or click on the Welcome page, and go back to Preferences/Advanced: the Module name has the old value.

If I add a onActiveFocusChanged in PrefsTextInput, I don't get a signal when the FileMenu disappears. Apparently, as the FileMenu sets the QML to an empty string, the controls are deleted before they get a out of focus signal. If I remove the code that sets the QML to an empty string, then the PrefsTextInput gets a signal and onEditingFinished is called (that. sets the new value in the model).