### PR TITLE
Set MouseArea to the right zone in a control

### DIFF
--- a/QMLComponents/components/JASP/Controls/CheckBox.qml
+++ b/QMLComponents/components/JASP/Controls/CheckBox.qml
@@ -33,6 +33,7 @@ CheckBoxBase
 	focusIndicator:		focusIndicator
 	childControlsArea:	childControlsArea
 	innerControl:		control
+	mouseAreaZone:		control
 	title:				text
 
 	default property alias	content:				childControlsArea.content

--- a/QMLComponents/components/JASP/Controls/DropDown.qml
+++ b/QMLComponents/components/JASP/Controls/DropDown.qml
@@ -305,6 +305,17 @@ ComboBoxBase
 					height:							1
 					color:							jaspTheme.focusBorderColor
 				}
+
+				MouseArea
+				{
+					anchors.fill:					parent
+					acceptedButtons:				Qt.NoButton
+					QTC.ToolTip.text:				model.info
+					QTC.ToolTip.visible:			model.info !== "" && containsMouse
+					cursorShape:					Qt.PointingHandCursor
+					hoverEnabled:					true
+					z:								10
+				}
 			}
 		}
     }

--- a/QMLComponents/components/JASP/Controls/RadioButtonGroup.qml
+++ b/QMLComponents/components/JASP/Controls/RadioButtonGroup.qml
@@ -28,6 +28,7 @@ RadioButtonsGroupBase
 	childControlsArea:	contentArea
 	focusOnTab:			false
 	shouldStealHover:	false
+	mouseAreaZone:		title !== "" ? label : control
 
 	default property alias	content:				contentArea.children
 			property bool	radioButtonsOnSameRow:	false

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -30,6 +30,7 @@ TextInputBase
 	cursorShape:		Qt.IBeamCursor
 	innerControl:		control
 	title:				text
+	mouseAreaZone:		(control.tooLongText && label !== "") ? beforeLabelRect : textField
 	
 	property alias	control:			control
 	property alias	text:				textField.label
@@ -174,8 +175,10 @@ TextInputBase
 		selectionColor:			jaspTheme.itemSelectedColor
 		enabled:				textField.editable
 
+		property bool tooLongText: contentWidth > (width - leftPadding - rightPadding)
+
 		QTC.ToolTip.text		: control.text
-		QTC.ToolTip.visible		: contentWidth > width - leftPadding - rightPadding && (hovered || control.activeFocus)
+		QTC.ToolTip.visible		: tooLongText && (hovered || control.activeFocus)
 
 		// The acceptableInput is checked even if the user is still typing in the TextField.
 		// In this case, the error should not appear immediately (only when the user is pressing the return key, or going out of focus),

--- a/QMLComponents/controls/jaspcontrol.cpp
+++ b/QMLComponents/controls/jaspcontrol.cpp
@@ -19,7 +19,7 @@ QByteArray JASPControl::_mouseAreaDef = "\
 	import QtQuick.Controls\n\
 	MouseArea {\n\
 	z:					5\n\
-	anchors.fill:		parent\n\
+	anchors.fill:		parent.mouseAreaZone\n\
 	acceptedButtons:	Qt.NoButton\n\
 	ToolTip.text:		parent ? parent.toolTip : ''\n\
 	ToolTip.visible:	ToolTip.text && containsMouse\n\
@@ -187,6 +187,8 @@ void JASPControl::componentComplete()
 
 	if (_useControlMouseArea)
 	{
+		if (!_mouseAreaZone)
+			_mouseAreaZone = this;
 		QQmlComponent* comp = getMouseAreaComponent(qmlEngine(this));
 		QVariantMap props = { {"hoverEnabled", shouldStealHover()}, {"cursorShape", cursorShape()} };
 

--- a/QMLComponents/controls/jaspcontrol.h
+++ b/QMLComponents/controls/jaspcontrol.h
@@ -48,6 +48,7 @@ class JASPControl : public QQuickItem
 	Q_PROPERTY( int									alignment				READ alignment				WRITE setAlignment													)
 	Q_PROPERTY( Qt::FocusReason						focusReason				READ getFocusReason																				)
 	Q_PROPERTY( QVariant							depends					READ explicitDepends		WRITE setExplicitDepends		NOTIFY explicitDependsChanged		)
+	Q_PROPERTY( QQuickItem						*	mouseAreaZone			READ mouseAreaZone			WRITE setMouseAreaZone			NOTIFY mouseAreaZoneChanged			)
 
 protected:
 	typedef std::set<JASPControl*>			Set;
@@ -153,6 +154,7 @@ public:
 	Qt::FocusReason		getFocusReason()			const	{ return _focusReason;					}
 	bool				dependsOnDynamicComponents() const	{ return _dependsOnDynamicComponents;	}
 	const QVariant&		explicitDepends()			const	{ return _explicitDepends;				}
+	QQuickItem		*	mouseAreaZone()				const	{ return _mouseAreaZone;				}
 
 	QString				humanFriendlyLabel()		const;
 
@@ -217,6 +219,7 @@ public slots:
 	GENERIC_SET_FUNCTION(IsDependency			, _isDependency			, isDependencyChanged			, bool			)
 	GENERIC_SET_FUNCTION(ShouldStealHover		, _shouldStealHover		, shouldStealHoverChanged		, bool			)
 	GENERIC_SET_FUNCTION(Background				, _background			, backgroundChanged				, QQuickItem*	)
+	GENERIC_SET_FUNCTION(MouseAreaZone			, _mouseAreaZone		, mouseAreaZoneChanged			, QQuickItem*	)
 	GENERIC_SET_FUNCTION(DependencyMustContain	, _dependencyMustContain, dependencyMustContainChanged	, QStringList	)
 	GENERIC_SET_FUNCTION(ExplicitDepends		, _explicitDepends		, explicitDependsChanged		, QVariant		)
 	GENERIC_SET_FUNCTION(Info					, _info					, infoChanged					, QString		)
@@ -262,6 +265,7 @@ signals:
 	void	boundValueChanged(JASPControl* control);
 	void	usedVariablesChanged();
 	void	explicitDependsChanged();
+	void	mouseAreaZoneChanged();
 
 	void					requestColumnCreation(std::string columnName, columnType columnType);
 	void					requestComputedColumnCreation(std::string columnName);
@@ -306,7 +310,9 @@ protected:
 	QQuickItem			*	_childControlsArea			= nullptr,
 						*	_innerControl				= nullptr,
 						*	_background					= nullptr,
-						*	_focusIndicator				= nullptr;
+						*	_focusIndicator				= nullptr,
+						*	_mouseAreaZone				= nullptr;
+
 
 	QColor					_defaultBorderColor;
 	float					_defaultBorderWidth			= 0;

--- a/QMLComponents/controls/radiobuttonbase.cpp
+++ b/QMLComponents/controls/radiobuttonbase.cpp
@@ -35,6 +35,25 @@ JASPControl *RadioButtonBase::group()
 	return _group;
 }
 
+void RadioButtonBase::setGroup(JASPControl *group)
+{
+	RadioButtonsGroupBase* radioButtonsGroup = qobject_cast<RadioButtonsGroupBase*>(group);
+	if (!radioButtonsGroup)
+		return;
+
+	if (_group)
+	{
+		if (_group == radioButtonsGroup) return; // Already registered
+
+		//We are already registered somewhere so lets undo that
+		_group->unregisterRadioButton(this);
+	}
+	_group = radioButtonsGroup;
+	_group->registerRadioButton(this);
+
+	emit groupChanged();
+}
+
 void RadioButtonBase::registerWithParent()
 {
 	// Warning: this slot can be called either by the Component.onCompleted of the RadioButton.qml or by a parentChanged signal
@@ -45,17 +64,7 @@ void RadioButtonBase::registerWithParent()
 		RadioButtonsGroupBase* group = qobject_cast<RadioButtonsGroupBase*>(ancestor);
 		if(group)
 		{
-			if (_group)
-			{
-				if (_group == group) return; // Already registered
-
-				//We are already registered somewhere so lets undo that
-				_group->unregisterRadioButton(this);
-			}
-			_group = group;
-			_group->registerRadioButton(this);
-
-			emit groupChanged();
+			setGroup(group);
 			return;
 		}
 		ancestor = ancestor->parentItem();

--- a/QMLComponents/controls/radiobuttonbase.h
+++ b/QMLComponents/controls/radiobuttonbase.h
@@ -28,14 +28,15 @@ class RadioButtonBase : public JASPControl
 	Q_OBJECT
 	QML_ELEMENT
 
-	Q_PROPERTY(JASPControl* group READ group NOTIFY groupChanged) // Cannot have a RadioButtonsGroupBase property: compilation error in the moc stuff.
+	Q_PROPERTY(JASPControl* group READ group WRITE setGroup NOTIFY groupChanged) // Cannot have a RadioButtonsGroupBase property: compilation error in the moc stuff.
 
 public:
 	RadioButtonBase(QQuickItem* parent = nullptr);
 
 	bool infoLabelItalic()	const	override	{ return true; }
 
-	JASPControl* group();
+	JASPControl*	group();
+	void			setGroup(JASPControl* group);
 
 public slots:
 	Q_INVOKABLE void registerWithParent();

--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -46,6 +46,7 @@ QHash<int, QByteArray> ListModel::roleNames() const
 	if(setMe)
 	{
 		roles[TypeRole]						= "type";
+		roles[InfoRole]						= "info";
 		roles[SelectedRole]					= "selected";
 		roles[SelectableRole]				= "selectable";
 		roles[ColumnTypeRole]				= "columnType";
@@ -522,6 +523,7 @@ QVariant ListModel::data(const QModelIndex &index, int role) const
 	{
 	case Qt::DisplayRole:
 	case ListModel::NameRole:			return term.label();
+	case ListModel::InfoRole:			return term.info();
 	case ListModel::SelectableRole:		return !term.value().isEmpty() && term.isDraggable();
 	case ListModel::SelectedRole:		return _selectedItems.contains(row);
 	case ListModel::TypeRole:			return listView()->containsVariables() ? "variable" : "";

--- a/QMLComponents/models/listmodel.h
+++ b/QMLComponents/models/listmodel.h
@@ -41,6 +41,7 @@ public:
 	enum ListModelRoles
 	{
         NameRole = Qt::UserRole + 1,
+		InfoRole,
 		TypeRole,
 		SelectedRole,
 		SelectableRole,


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2916

The tooltip is activated by a MouseArea for each control. This MouseArea used to fill the whole control area, but it should not be always the case:

-  for CheckBox: only the inner control CheckBox should have this MouseArea, not its sub groups
-  for RadioButtonGroup: only the RadioButtonGroup lable should get this MouseArea, each RadioButton should have its own MouseArea
- for TextField, a special MouseArea is set in case the content of the TextField is wider than its own width: this special MouseArea is used to activate a tooltip to show the value of the TextField. In this case the MouseArea should cover only the label of the TextField.
- for DropDown: an extra MouseArea is set for each value of the DropDown, so that if there is an info for a value, this info can be dsplayed in a tooltip.

To allow these cases, a MouseAreaZone property is added, that can be adjusted for each situation.