### PR TITLE
Do not reset all encoding when new columns are added

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -2672,6 +2672,8 @@ void DataSetPackage::checkDataSetForUpdates()
 
 	if(_dataSet->checkForUpdates(&changedCols, &missingCols, &newCols, &rowCountChanged))
 	{
+		ColumnEncoder::setCurrentColumnNames(	getColumnTypesMap());
+
 		Log::log()	<< "Updates found for DataSet " << _dataSet->id() 
 					<< "| missing cols: '" << tq(missingCols).join(",")
 					<< "' | changed cols: '" << tq(changedCols).join(",")

--- a/QMLComponents/controls/textareabase.cpp
+++ b/QMLComponents/controls/textareabase.cpp
@@ -42,13 +42,15 @@ void TextAreaBase::setUpModel()
 	{
 		_model = new ListModelTermsAvailable(this);
 		_model->setNeedsSource(_textType == TextType::TextTypeCSem || _textType == JASPControl::TextType::TextTypeMetaSem);
+		connect(VariableInfo::info(),	&VariableInfo::dataSetChanged,		this,	&TextAreaBase::checkSyntaxHandler);
 
 		if (_textType == TextType::TextTypeLavaan)
 		{
 			// Lavaan TextArea does not have a source, but the script contains variables: so it the variables types or names change, the model must be updated.
 			VariableInfo* variableInfo = VariableInfo::info();
-			connect(variableInfo,	&VariableInfo::variableNamesChanged,	_model, &ListModel::sourceVariableNamesChanged	);
-			connect(variableInfo,	&VariableInfo::variableTypeChanged,		_model, &ListModel::sourceVariableTypeChanged	);
+			connect(variableInfo,	&VariableInfo::variableNamesChanged,	_model,	&ListModel::sourceVariableNamesChanged	);
+			connect(variableInfo,	&VariableInfo::variableTypeChanged,		_model,	&ListModel::sourceVariableTypeChanged	);
+
 		}
 
 		JASPListControl::setUpModel();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2991

When an analysis adds a computed column, the column encoding is reset, so that some variables may get a new encoding. In the SEM analyses, the variables are also encoded in the options, and this encoding should be preserved when a new column is created.
Just adding the column in the encoding was not enough, since the column is first added with an unknown type, and afterwards its type is set. So to make the encoding more robust, it removes first the variables that does not exist or have a another type, and encode only the new variables (or variables with new type).