### PR TITLE
Mouse event should be blocked by the installing module overlay

### DIFF
--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -501,6 +501,14 @@ FocusScope
 			visible:		moduleStore.downloadInProgress || moduleLibrary.isInstalling
 			z:				10
 
+			MouseArea
+			{
+				anchors.fill: parent
+				propagateComposedEvents: false
+				hoverEnabled: true
+				preventStealing: true
+			}
+
 			Column
 			{
 				anchors.centerIn:	parent


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3096