### PR TITLE
Some fixes and tweaks for modules and the online module library

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -267,7 +267,15 @@ Json::Value Analyses::asJson() const
 
 void Analyses::saveAnalysesJsonForReload()
 {
-	_tempSave = asJson();	
+	_tempSave = asJson();
+	
+	destroyAllForms();
+	
+	for(auto & idAnalysis : _analysisMap)
+		delete idAnalysis.second;
+	
+	_analysisMap.clear();
+	_orderedIds.clear();
 }
 
 void Analyses::reloadSavedAnalysesJson()
@@ -278,6 +286,8 @@ void Analyses::reloadSavedAnalysesJson()
 	bool errorFound;
 	std::stringstream errors;
 	loadAnalysesFromJaspFileJson(_tempSave["analyses"], _tempSave["meta"], errorFound, errors, RibbonModel::singleton());
+	
+	applyToAll([](Analysis * a){ a->setBeingTranslated(true); });
 }
 
 
@@ -365,11 +375,20 @@ void Analyses::rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * mod
 			else
 			{
 				Analysis * a = keyval.second;
+				
+				//Json::Value prevBound = Json::nullValue;
+				//if(a->form())
+				//	prevBound = a->asJSON();
 
 				//This function is called once after 300 ms upon translation due to delayedUpdate in description
 				//and causes the set analysis options to be cleared without this additional flag check set at the start of translations
 				if(a->readyToCreateForm() && !a->beingTranslated())
+				{
 					a->createForm();
+					
+					//if(!prevBound.isNull())
+					//	a->form()->bindTo(prevBound);
+				}
 				a->setBeingTranslated(false);
 			}
 		}
@@ -380,13 +399,9 @@ void Analyses::rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * mod
 
 void Analyses::reloadQmlAnalysesDynamicModule(Modules::DynamicModule * module)
 {
-	saveAnalysesJsonForReload();
-	
 	for(auto idAnalysis : _analysisMap)
 		if(idAnalysis.second->dynamicModule() == module)
 			idAnalysis.second->analysisQMLFileChanged();
-	
-	reloadSavedAnalysesJson();
 }
 
 void Analyses::refreshAllAnalyses()

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -64,50 +64,19 @@ Analysis* Analyses::createFromJaspFileEntry(Json::Value analysisData, RibbonMode
 
 	if(_nextId <= id) _nextId = id + 1;
 
-	Analysis				*	analysis		= nullptr;
+	
 	Modules::UpgradeMsgs		msgs;
 	bool						wasUpgraded		= Upgrader::upgrader()->upgradeAnalysisData(analysisData, msgs);
 	Json::Value				&	optionsJson		= analysisData["options"];
-	Modules::AnalysisEntry	*	analysisEntry	= nullptr;
-
-	if(analysisData.get("dynamicModule", Json::nullValue).isNull()) //This used to be the code to load our "standard modules", seeing as how those are gone and the've become dynamic as well it should figure out somehow which one is meant
+	std::string					title			= analysisData.get("title", "").asString();
+	Modules::AnalysisEntry	*	analysisEntry	= Modules::DynamicModules::dynMods()->retrieveCorrespondingAnalysisEntry(analysisData["dynamicModule"]);
+	Analysis				*	analysis		= create(analysisData, analysisEntry, id, status, false, title, analysisData["dynamicModule"]["moduleVersion"].asString(), &optionsJson);
+	
+	if(msgs.count(Modules::analysisLog))
 	{
-		Log::log() << "It is a builtin analysis, " << std::flush;
-		
-		Json::Value	&	versionJson		= analysisData["version"];
-		Version			version			= Version(versionJson.isNull() ? "0.0.0" : versionJson.asString()); //0.0.0 as module version to be sure we show the "made with old version". If the version was given we should make sure all the modules have a version > 0.14.2
-
-		QString			name			= tq(analysisData["name"].asString()),
-						module			= analysisData["module"].asString() != "" ? tq(analysisData["module"].asString()) : "Common",
-						title			= tq(analysisData.get("title", "").asString());
-						analysisEntry	= ribbonModel->getAnalysis(module.toStdString(), name.toStdString());
-		QString			qml				= analysisEntry ? tq(analysisEntry->qml()) : name + ".qml";
-		
-		Log::log() << " titled: '" << title << "'" << std::endl;
-
-		if(!analysisEntry)
-			throw Modules::ModuleException(fq(module), "Problem loading analysis \"" + fq(name) + "\" from module \"" + fq(module) + "\". This module cannot be found in your JASP or the analysis cannot be found in it, this is likely a bug as we still ship all modules in the installer.");
-
-		if(title == "")
-			title = tq(analysisEntry->title());
-		
-		analysis = create(analysisData, analysisEntry, id, status, false, fq(title), version.asString(3), &optionsJson); 
-	}
-	else
-	{
-		std::string title			= analysisData.get("title", "").asString();
-		
-		Log::log() << "It is a dynmod analysis with title: '" << title << "'" << std::endl;
-		
-		analysisEntry		= Modules::DynamicModules::dynMods()->retrieveCorrespondingAnalysisEntry(analysisData["dynamicModule"]);
-		analysis			= create(analysisData, analysisEntry, id, status, false, title, analysisData["dynamicModule"]["moduleVersion"].asString(), &optionsJson);
-		
-		if(msgs.count(Modules::analysisLog))
-		{
-			QStringList msgAna = tq(msgs[Modules::analysisLog]);
-			analysis->setErrorInResults(fq(msgAna.join("\n")));
-		}
-	}
+		QStringList msgAna = tq(msgs[Modules::analysisLog]);
+		analysis->setErrorInResults(fq(msgAna.join("\n")));
+	}	
 
 	if(wasUpgraded)
 		analysis->setUpgradeMsgs(msgs);
@@ -296,7 +265,7 @@ void Analyses::reloadSavedAnalysesJson()
 	//applyToAll([](Analysis * a){ a->setBeingTranslated(true); });
 	endResetModel();
 	
-	_tempSave = Json::nullValue;
+	_tempSave = Json::nullValue; 
 }
 
 

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -293,8 +293,10 @@ void Analyses::reloadSavedAnalysesJson()
 	std::stringstream errors;
 	loadAnalysesFromJaspFileJson(_tempSave["analyses"], _tempSave["meta"], errorFound, errors, RibbonModel::singleton());
 	
-	applyToAll([](Analysis * a){ a->setBeingTranslated(true); });
+	//applyToAll([](Analysis * a){ a->setBeingTranslated(true); });
 	endResetModel();
+	
+	_tempSave = Json::nullValue;
 }
 
 
@@ -382,19 +384,12 @@ void Analyses::rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * mod
 			else
 			{
 				Analysis * a = keyval.second;
-				
-				//Json::Value prevBound = Json::nullValue;
-				//if(a->form())
-				//	prevBound = a->asJSON();
 
 				//This function is called once after 300 ms upon translation due to delayedUpdate in description
 				//and causes the set analysis options to be cleared without this additional flag check set at the start of translations
 				if(a->readyToCreateForm() && !a->beingTranslated())
 				{
 					a->createForm();
-					
-					//if(!prevBound.isNull())
-					//	a->form()->bindTo(prevBound);
 				}
 				a->setBeingTranslated(false);
 			}

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -265,6 +265,22 @@ Json::Value Analyses::asJson() const
 	return analysesJson;
 }
 
+void Analyses::saveAnalysesJsonForReload()
+{
+	_tempSave = asJson();	
+}
+
+void Analyses::reloadSavedAnalysesJson()
+{
+	if(!_tempSave.isObject() || !_tempSave.isMember("analyses") || !_tempSave.isMember("meta"))
+		return;
+	
+	bool errorFound;
+	std::stringstream errors;
+	loadAnalysesFromJaspFileJson(_tempSave["analyses"], _tempSave["meta"], errorFound, errors, RibbonModel::singleton());
+}
+
+
 
 void Analyses::removeAnalysis(Analysis *analysis)
 {
@@ -364,9 +380,13 @@ void Analyses::rescanAnalysisEntriesOfDynamicModule(Modules::DynamicModule * mod
 
 void Analyses::reloadQmlAnalysesDynamicModule(Modules::DynamicModule * module)
 {
+	saveAnalysesJsonForReload();
+	
 	for(auto idAnalysis : _analysisMap)
 		if(idAnalysis.second->dynamicModule() == module)
 			idAnalysis.second->analysisQMLFileChanged();
+	
+	reloadSavedAnalysesJson();
 }
 
 void Analyses::refreshAllAnalyses()
@@ -406,75 +426,74 @@ void Analyses::loadAnalysesFromDatasetPackage(bool & errorFound, stringstream & 
 {
 	if (DataSetPackage::pkg()->hasAnalyses())
 	{
-		int				corruptAnalyses = 0;
-		stringstream	corruptionStrings;
-
 		Json::Value analysesData = DataSetPackage::pkg()->analysesData();
+		
 		if (analysesData.isNull())
 		{
 			errorFound = true;
 			errorMsg << "An error has been detected and analyses could not be loaded.";
+			return;
 		}
-		else
+		
+		Json::Value meta, analysesDataList;
+		if (!analysesData.isArray())
 		{
-			Json::Value analysesDataList = analysesData;
-			if (!analysesData.isArray())
+			analysesDataList	= analysesData.get("analyses",	analysesData);
+			meta				= analysesData.get("meta",		Json::nullValue);
+
+			if (!meta.isNull())
 			{
-				analysesDataList = analysesData.get("analyses", Json::arrayValue);
-				Json::Value meta = analysesData.get("meta",		Json::nullValue);
-
-				if (!meta.isNull())
-				{
-					QString results = tq(analysesData["meta"].toStyledString());
-					resultsMetaChanged(results);
-					emit setResultsMeta(results);
-				}
+				QString results = tq(analysesData["meta"].toStyledString());
+				resultsMetaChanged(results);
+				emit setResultsMeta(results);
 			}
-
-			JASPTIMER_START(Analyses::loadAnalysesFromDatasetPackage for analysisData : analysesDataList);
-
-			Log::log() << "Loading analyses from jasp-file, entering loop." << std::endl;
-			
-			//There is no point trying to show progress here because qml is not updated while this function runs...
-			for (Json::Value & analysisData : analysesDataList)
-			{
-				try
-				{
-					createFromJaspFileEntry(analysisData, ribbonModel);
-				}
-				catch (Modules::ModuleException modProb)
-				{
-					//Maybe show a nicer messagebox?
-					errorFound = true;
-					corruptionStrings << "\n" << (++corruptAnalyses) << ": " << modProb.what();
-					
-					Log::log() << "Caught module exception: " << modProb.what() << std::endl;
-				}
-				catch (runtime_error & e)
-				{
-					errorFound = true;
-					corruptionStrings << "\n" << (++corruptAnalyses) << ": " << e.what();
-					
-					Log::log() << "Caught runtime_error exception: " << e.what() << std::endl;
-				}
-				catch (exception & e)
-				{
-					errorFound = true;
-					corruptionStrings << "\n" << (++corruptAnalyses) << ": " << e.what();
-					
-					Log::log() << "Caught exception: " << e.what() << std::endl;
-				}
-			}
-
-			JASPTIMER_STOP(Analyses::loadAnalysesFromDatasetPackage for analysisData : analysesDataList);
 		}
-
-		if (corruptAnalyses == 1)			errorMsg << "An error was detected in an analysis. This analysis has been removed for the following reason:\n" << corruptionStrings.str();
-		else if (corruptAnalyses > 1)		errorMsg << "Errors were detected in " << corruptAnalyses << " analyses. These analyses have been removed for the following reasons:\n" << corruptionStrings.str();
-		else								Log::log() << "Loading analyses seems to have worked out fine." << std::endl;
+		
+		loadAnalysesFromJaspFileJson(analysesDataList, meta, errorFound, errorMsg, ribbonModel);
 	}
-	
+}
 
+void Analyses::loadAnalysesFromJaspFileJson(const Json::Value & analysesDataList, const Json::Value & meta, bool & errorFound, stringstream & errorMsg, RibbonModel * ribbonModel)
+{
+	int				corruptAnalyses = 0;
+	stringstream	corruptionStrings;
+
+	Log::log() << "Loading analyses from jasp-file, entering loop." << std::endl;
+	
+	//There is no point trying to show progress here because qml is not updated while this function runs...
+	for (const Json::Value & analysisData : analysesDataList)
+	{
+		try
+		{
+			createFromJaspFileEntry(analysisData, ribbonModel);
+		}
+		catch (Modules::ModuleException modProb)
+		{
+			//Maybe show a nicer messagebox?
+			errorFound = true;
+			corruptionStrings << "\n" << (++corruptAnalyses) << ": " << modProb.what();
+			
+			Log::log() << "Caught module exception: " << modProb.what() << std::endl;
+		}
+		catch (runtime_error & e)
+		{
+			errorFound = true;
+			corruptionStrings << "\n" << (++corruptAnalyses) << ": " << e.what();
+			
+			Log::log() << "Caught runtime_error exception: " << e.what() << std::endl;
+		}
+		catch (exception & e)
+		{
+			errorFound = true;
+			corruptionStrings << "\n" << (++corruptAnalyses) << ": " << e.what();
+			
+			Log::log() << "Caught exception: " << e.what() << std::endl;
+		}
+	}
+
+	if (corruptAnalyses == 1)			errorMsg << "An error was detected in an analysis. This analysis has been removed for the following reason:\n" << corruptionStrings.str();
+	else if (corruptAnalyses > 1)		errorMsg << "Errors were detected in " << corruptAnalyses << " analyses. These analyses have been removed for the following reasons:\n" << corruptionStrings.str();
+	else								Log::log() << "Loading analyses seems to have worked out fine." << std::endl;
 }
 
 void Analyses::applyToSome(std::function<bool(Analysis *analysis)> applyThis)
@@ -833,6 +852,7 @@ void Analyses::dataModeChanged(bool dataMode)
 			a->refresh();
 	});
 }
+
 
 void Analyses::resultsMetaChanged(QString json)
 {

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -267,6 +267,8 @@ Json::Value Analyses::asJson() const
 
 void Analyses::saveAnalysesJsonForReload()
 {
+	beginResetModel();
+	
 	_tempSave = asJson();
 	
 	destroyAllForms();
@@ -276,6 +278,8 @@ void Analyses::saveAnalysesJsonForReload()
 	
 	_analysisMap.clear();
 	_orderedIds.clear();
+	
+	endResetModel();
 }
 
 void Analyses::reloadSavedAnalysesJson()
@@ -283,11 +287,14 @@ void Analyses::reloadSavedAnalysesJson()
 	if(!_tempSave.isObject() || !_tempSave.isMember("analyses") || !_tempSave.isMember("meta"))
 		return;
 	
+	beginResetModel();
+	
 	bool errorFound;
 	std::stringstream errors;
 	loadAnalysesFromJaspFileJson(_tempSave["analyses"], _tempSave["meta"], errorFound, errors, RibbonModel::singleton());
 	
 	applyToAll([](Analysis * a){ a->setBeingTranslated(true); });
+	endResetModel();
 }
 
 

--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -78,6 +78,7 @@ public:
 	bool			allFinished()	const;
 	void			setAnalysesUserData(Json::Value userData);
 	void			loadAnalysesFromDatasetPackage(bool & errorFound, std::stringstream & errorMsg, RibbonModel * ribbonModel);
+	void			loadAnalysesFromJaspFileJson(const Json::Value & analysesDataList, const Json::Value & meta, bool & errorFound, std::stringstream & errorMsg, RibbonModel * ribbonModel);
 
 	///Applies function to some or all analyses, if applyThis returns false it stops processing.
 	void		applyToSome(std::function<bool(Analysis *analysis)> applyThis);
@@ -140,6 +141,8 @@ public slots:
 	void moveAnalysesResults(Analysis* fromAnalysis, int index);
 	void showRSyntaxInResults(bool show);
 	void dataModeChanged(bool dataMode);
+	void saveAnalysesJsonForReload();
+	void reloadSavedAnalysesJson();
 
 signals:
 	void analysesUnselected();
@@ -190,7 +193,8 @@ private:
 	static Analyses				*	_singleton;
 
 	Json::Value						_resultsMeta, //Stored Notes and custom title
-									_allUserData; //Notes and stuff?
+									_allUserData, //Notes and stuff?
+									_tempSave;    //For when modules need to be reloaded
 
 	std::map<size_t, Analysis*>		_analysisMap;
 	std::vector<size_t>				_orderedIds;

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -80,7 +80,6 @@ Analysis::Analysis(size_t id, Analysis * duplicateMe)
 
 void Analysis::initAnalysis()
 {
-	setOrgBoundValues(boundValues());
 	watchQmlForm();
 	connect(&_QMLFileWatcher,	&QFileSystemWatcher::fileChanged,			this,	&Analysis::analysisQMLFileChanged,	Qt::UniqueConnection);
 	connect(this,				&Analysis::createFormWhenYouHaveAMoment,	this,	&Analysis::createForm,				Qt::QueuedConnection);

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -103,7 +103,7 @@ public:
 	const	std::string		&	title()				const	override	{ return _title;							}
 	const	std::string		&	titleDefault()		const	override	{ return _titleDefault;						}
 	const	std::string		&	rfile()				const				{ return _rfile;							}
-	const	std::string		&	module()			const	override	{ return _moduleData->dynamicModule()->name();	}
+	const	std::string			module()			const	override	{ return _moduleData && _moduleData->dynamicModule() ? _moduleData->dynamicModule()->name() : "???";	}
 			size_t				id()				const				{ return _id;								}
 			Status				status()			const				{ return _status;							}
 			QString				statusQ()			const				{ return tq(statusToString(_status));		}

--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -441,7 +441,7 @@ FocusScope
                         {
                             z:				1
 							id:				refreshButton
-                            visible:		!isBundled && !isSpecial
+                            visible:		isDevMod
                             iconSource:		jaspTheme.iconPath + "/redo.svg"
                             width:			visible ? height : 0
                             onClicked:		dynamicModules.refreshDeveloperModule();

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -557,6 +557,9 @@ void MainWindow::makeConnections()
 	connect(_dynamicModules,		&DynamicModules::reloadQmlImportPaths,				this,					&MainWindow::setQmlImportPaths,								Qt::QueuedConnection); //If this is queued this should make the loadingprocess of qml a bit less weird I think.
 	connect(_dynamicModules,		&DynamicModules::dynamicModuleUnloadBegin,			_engineSync,			&EngineSync::killModuleEngine								);
 	connect(_dynamicModules,		&DynamicModules::isModuleInstallRequestActive,		_engineSync,			&EngineSync::isModuleInstallRequestActive					);
+	
+	connect(_dynamicModules,		&DynamicModules::storeAnalysesJson,					_analyses,				&Analyses::saveAnalysesJsonForReload						);
+	connect(_dynamicModules,		&DynamicModules::reloadAnalysesJson,				_analyses,				&Analyses::reloadSavedAnalysesJson							);
 
 	connect(_languageModel,			&LanguageModel::currentLanguageChanged,				_fileMenu,				&FileMenu::refresh											);
 	connect(_languageModel,			&LanguageModel::aboutToChangeLanguage,				_analyses,				&Analyses::prepareForLanguageChange							);

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -559,7 +559,7 @@ void MainWindow::makeConnections()
 	connect(_dynamicModules,		&DynamicModules::isModuleInstallRequestActive,		_engineSync,			&EngineSync::isModuleInstallRequestActive					);
 	
 	connect(_dynamicModules,		&DynamicModules::storeAnalysesJson,					_analyses,				&Analyses::saveAnalysesJsonForReload						);
-	connect(_dynamicModules,		&DynamicModules::reloadAnalysesJson,				_analyses,				&Analyses::reloadSavedAnalysesJson							);
+	connect(_dynamicModules,		&DynamicModules::reloadAnalysesJson,				_analyses,				&Analyses::reloadSavedAnalysesJson,							Qt::QueuedConnection);
 
 	connect(_languageModel,			&LanguageModel::currentLanguageChanged,				_fileMenu,				&FileMenu::refresh											);
 	connect(_languageModel,			&LanguageModel::aboutToChangeLanguage,				_analyses,				&Analyses::prepareForLanguageChange							);

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -62,6 +62,7 @@ class DynamicModule : public QObject
 	Q_PROPERTY(bool			installing			READ installing			WRITE setInstalling			NOTIFY installingChanged		)
 	Q_PROPERTY(bool			initialized			READ initialized		WRITE setInitialized		NOTIFY initializedChanged		)
 	Q_PROPERTY(bool			isBundled			READ isBundled			WRITE setBundled			NOTIFY bundledChanged			)
+	Q_PROPERTY(bool			isDevMod			READ isDevMod										CONSTANT						)
 	Q_PROPERTY(bool			readyForUse			READ readyForUse									NOTIFY readyForUseChanged		)
 	Q_PROPERTY(QStringList	importsR			READ importsRQ										NOTIFY importsRChanged			)
 	Q_PROPERTY(bool			error				READ error											NOTIFY errorChanged				)

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -73,36 +73,6 @@ DynamicModules::~DynamicModules()
 	_singleton = nullptr;
 }
 
-void DynamicModules::initializeInstalledModules()
-{
-	std::error_code error;
-	for (std::filesystem::directory_iterator itr(_modulesInstallDirectory, error); !error && itr != std::filesystem::directory_iterator(); itr++)
-	{
-		std::string path			= itr->path().generic_string(),
-					name			= itr->path().filename().generic_string(),
-					problem			= fq(tr("Initializing module during JASP startup failed, should the module be removed?"));
-		bool		askForCleanup	= false;
-
-		//Development Module should always be fresh!
-		if(name == defaultDevelopmentModuleName())	
-			std::filesystem::remove_all(itr->path());
-		
-		else if(name.size() > 0 && name[0] != '.' && QFileInfo(tq(path)).isDir())	
-			try
-			{
-				if(!initializeModuleFromDir(path, false, true))
-					askForCleanup = true;
-			}
-			catch(ModuleException & modException)
-			{
-				askForCleanup = true;
-				problem = fq(tr("Initializing module during JASP startup failed with the following message:\n%1\n\nShould the module be removed?").arg(tq(modException.problemDescription)));
-			}
-		
-		if(askForCleanup && MessageForwarder::showYesNo(tr("Initializing module %1 failed").arg(tq(name)), tq(problem)))
-			std::filesystem::remove_all(itr->path());
-	}
-}
 
 bool DynamicModules::initializeModuleFromDir(std::string moduleDir, bool bundled, bool isCommon)
 {

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -171,11 +171,13 @@ bool DynamicModules::initializeModule(DynamicModule * module)
 		}
 		else if(oldModule)
 		{
+			emit storeAnalysesJson();
 			unloadModule(moduleName);
 			emit dynamicModuleReplaced(oldModule, module);
 			delete oldModule;
 			emit dynamicModuleChanged(module);
 			emit loadModuleTranslationFile(module);
+			emit reloadAnalysesJson();
 		}		
 
 		emit reloadQmlImportPaths();

--- a/Desktop/modules/dynamicmodules.cpp
+++ b/Desktop/modules/dynamicmodules.cpp
@@ -520,6 +520,8 @@ void DynamicModules::installJASPDeveloperModule()
 
 	try
 	{
+		emit storeAnalysesJson();
+		
 		DynamicModule * devMod = directLibpathEnabled ? new DynamicModule(this, modulePath) : new DynamicModule(this);
 
 		std::string origin	= devMod->modulePackage(),
@@ -537,11 +539,15 @@ void DynamicModules::installJASPDeveloperModule()
 		if(directLibpathEnabled) {
 			initializeModule(devMod);
 		}
+		
+		emit reloadAnalysesJson();
 	}
 	catch(ModuleException & e)
 	{
 		MessageForwarder::showWarning(tr("Problem initializing module"), tr("There was a problem loading the developer module:\n\n") + e.what());
 		setDevelopersModuleInstallButtonEnabled(true);
+		
+		emit reloadAnalysesJson();
 	}
 }
 

--- a/Desktop/modules/dynamicmodules.h
+++ b/Desktop/modules/dynamicmodules.h
@@ -147,6 +147,8 @@ signals:
 	void moduleEnabledChanged(QString moduleName, bool enabled);
 	void dataLoadedChanged(bool dataLoaded);
 	void loadedModulesChanged();
+	void reloadAnalysesJson();
+	void storeAnalysesJson();
 
 private:
 	Modules::DynamicModule	*	requestModuleForSomethingAndRemoveIt(std::set<std::string> & theSet);

--- a/Desktop/modules/dynamicmodules.h
+++ b/Desktop/modules/dynamicmodules.h
@@ -50,7 +50,6 @@ public:
 							~DynamicModules() override;
 	static DynamicModules * dynMods()	{ return _singleton; }
 
-	void					initializeInstalledModules();
 	void					registerQMLTypes();
 
 	bool					unpackAndInstallModule(		const	std::string & moduleZipFilename);

--- a/Desktop/modules/installedmodules.cpp
+++ b/Desktop/modules/installedmodules.cpp
@@ -73,7 +73,7 @@ std::vector<InstalledModules::ModuleInfo> InstalledModules::getModules() {
 	auto modulesAll = getAllAvailableModules();
 	std::map<std::string, InstalledModules::ModuleInfo> modules;
 	for(const auto& module : modulesAll) { //remove duplicates take highest version
-		if(modules.find(module.name) == modules.end() || modules[module.name].version >= module.version) {
+		if(modules.find(module.name) == modules.end() || modules[module.name] < module) {
 			modules[module.name] = module;
 		}
 	}
@@ -88,10 +88,10 @@ std::vector<InstalledModules::ModuleInfo> InstalledModules::getModules() {
 	std::ifstream in(settings);
 	Json::Value root;
 	Json::Reader().parse(in, root);
-	Json::Value commonNamesJson = root.get("common", Json::arrayValue);
-	Json::Value extraNamesJson = root.get("extra", Json::arrayValue);
-	if(!commonNamesJson.isArray()) commonNamesJson = Json::arrayValue;
-	if(!extraNamesJson.isArray()) extraNamesJson = Json::arrayValue;
+	Json::Value commonNamesJson = root.get("common", Json::arrayValue),
+				extraNamesJson	= root.get("extra", Json::arrayValue);
+	if(!commonNamesJson.isArray())	commonNamesJson = Json::arrayValue;
+	if(!extraNamesJson.isArray())	extraNamesJson = Json::arrayValue;
 
 
 	std::vector<InstalledModules::ModuleInfo> orderedModules = {};

--- a/Desktop/modules/installedmodules.cpp
+++ b/Desktop/modules/installedmodules.cpp
@@ -95,14 +95,14 @@ std::vector<InstalledModules::ModuleInfo> InstalledModules::getModules() {
 
 
 	std::vector<InstalledModules::ModuleInfo> orderedModules = {};
-	for(auto name : commonNamesJson) {
+	for(auto & name : commonNamesJson) {
 		if(modules.find(name.asString()) != modules.end()) {
 			modules[name.asString()].common = true;
 			orderedModules.push_back(modules[name.asString()]);
 			modules.erase(name.asString());
 		}
 	}
-	for(auto& name : extraNamesJson) {
+	for(auto & name : extraNamesJson) {
 		if(modules.find(name.asString()) != modules.end()) {
 			orderedModules.push_back(modules[name.asString()]);
 			modules.erase(name.asString());

--- a/Desktop/modules/installedmodules.h
+++ b/Desktop/modules/installedmodules.h
@@ -38,11 +38,12 @@ class InstalledModules {
 public:
 
 	struct ModuleInfo {
-		std::string name = "";
-		std::string libpath = "";
-		bool common = false;
-		bool bundled = false;
-		BundleVersion version;
+		std::string 	name	= "",
+						libpath = "";
+		bool			common	= false,
+						bundled	= false;
+		BundleVersion	version;
+
 	};
 
 	static std::vector<ModuleInfo> getAllAvailableModules();
@@ -58,5 +59,22 @@ private:
 	static const std::string settingsPath;
 
 };
+
+
+inline bool operator<(const InstalledModules::ModuleInfo & lhs, const InstalledModules::ModuleInfo & rhs)
+{
+	if(lhs.name != rhs.name)
+		return lhs.name < rhs.name;
+	
+	if(lhs.version != rhs.version)
+		return lhs.version < rhs.version;
+	
+	//If it is the same version we should prioritize the one the user installed, so this one is smaller than if it isnt bundled while the other is.
+	return !lhs.bundled && rhs.bundled;
+};
+
+inline bool operator> (const InstalledModules::ModuleInfo & lhs, const InstalledModules::ModuleInfo & rhs) { return rhs < lhs; }
+inline bool operator<=(const InstalledModules::ModuleInfo & lhs, const InstalledModules::ModuleInfo & rhs) { return !(lhs > rhs); }
+inline bool operator>=(const InstalledModules::ModuleInfo & lhs, const InstalledModules::ModuleInfo & rhs) { return !(lhs < rhs); }
 
 #endif // INSTALLEDMODULES_H

--- a/Desktop/modules/modulelibrary.cpp
+++ b/Desktop/modules/modulelibrary.cpp
@@ -62,27 +62,21 @@ QVariantMap ModuleLibrary::getEnvironmentInfo() const
     QVariantMap envInfo;
     envInfo["version"] = QString(AppInfo::version.asString(3).c_str());
     
-    auto platform = DynamicRuntimeInfo::getRuntimeEnvironment();
-	auto arch = DynamicRuntimeInfo::getMicroArch();
+    auto platform	= DynamicRuntimeInfo::getRuntimeEnvironment();
+	auto arch		= DynamicRuntimeInfo::getMicroArch();
+	
     std::string platformArch;
-	if(platform == RuntimeEnvironment::MAC)
-		platformArch = arch == MicroArch::AARCH64 ? "MacOS_arm64" : "MacOS_x86_64";
-	else if(platform == RuntimeEnvironment::FLATPAK)
-		platformArch = arch == MicroArch::AARCH64 ? "Flatpak_aarch64" : "Flatpak_x86_64";
-	else if(platform == RuntimeEnvironment::LINUX_LOCAL)
-        // When developing within devcontainer then jaspModule files with Flatpak_x86_64 also work?
-		platformArch = arch == MicroArch::AARCH64 ? "Flatpak_aarch64" : "Flatpak_x86_64";
-	else
-		platformArch = "Windows_x86-64";
-    envInfo["arch"] = QString::fromStdString(platformArch);
-    // Preferences needed in webapp
-    envInfo["developerMode"] = PreferencesModel::prefs()->developerMode();
-    envInfo["theme"] = PreferencesModel::prefs()->currentThemeName().replace("Theme", "");
-    envInfo["font"] = PreferencesModel::prefs()->interfaceFont();
-    // do replace to enforce BCP 47 language tag format
-    envInfo["language"] = PreferencesModel::prefs()->languageCode().replace("_", "-");
-
-    envInfo["installedModules"] = installedModulesInfo();
+	if(platform == RuntimeEnvironment::MAC)					platformArch = arch == MicroArch::AARCH64 ? "MacOS_arm64" : "MacOS_x86_64";
+	else if(platform == RuntimeEnvironment::FLATPAK)		platformArch = arch == MicroArch::AARCH64 ? "Flatpak_aarch64" : "Flatpak_x86_64";
+	else if(platform == RuntimeEnvironment::LINUX_LOCAL)	platformArch = arch == MicroArch::AARCH64 ? "Flatpak_aarch64" : "Flatpak_x86_64";      // When developing within devcontainer then jaspModule files with Flatpak_x86_64 also work? No...
+	else													platformArch = "Windows_x86-64";
+	
+    envInfo["arch"]					= tq(platformArch);
+    envInfo["developerMode"]		= PreferencesModel::prefs()->developerMode();						// Preferences needed in webapp
+    envInfo["theme"]				= PreferencesModel::prefs()->currentThemeName().replace("Theme", "");
+    envInfo["font"]					= PreferencesModel::prefs()->interfaceFont();
+    envInfo["language"]				= PreferencesModel::prefs()->languageCode().replace("_", "-");		// do replace to enforce BCP 47 language tag format
+    envInfo["installedModules"]		= installedModulesInfo();
     envInfo["uninstallableModules"] = getUninstallableModules();
     return envInfo;
 }
@@ -97,7 +91,7 @@ QVariantMap ModuleLibrary::installedModulesInfo() const
 {
     QVariantMap installedModules;
     for (auto const& [key, val] : InstalledModules::getInstalledModuleVersions())
-        installedModules[QString::fromStdString(key)] = QString::fromStdString(val);
+        installedModules[tq(key)] = tq(val);
     return installedModules;
 }
 

--- a/Desktop/modules/ribbonmodel.cpp
+++ b/Desktop/modules/ribbonmodel.cpp
@@ -242,6 +242,7 @@ QVariant RibbonModel::data(const QModelIndex &index, int role) const
 	case ModuleNameRole:	return ribbonButtonModelAt(row)->nameQ();
 	case ModuleRole:		return QVariant::fromValue(ribbonButtonModelAt(row)->dynamicModule());
 	case BundledRole:		return ribbonButtonModelAt(row)->isBundled();
+	case DevModRole:		return ribbonButtonModelAt(row)->dynamicModule() && ribbonButtonModelAt(row)->dynamicModule()->isDevMod();
 	case VersionRole:		return ribbonButtonModelAt(row)->version();
 	case SpecialRole:		return ribbonButtonModelAt(row)->isSpecial();
 	case ClusterRole:		//To Do!?
@@ -263,6 +264,7 @@ QHash<int, QByteArray> RibbonModel::roleNames() const
 		{ ModuleRole,		"dynamicModule"		},
 		{ ActiveRole,		"active"			},
 		{ BundledRole,		"isBundled"			},
+		{ DevModRole,		"isDevMod"			},
 		{ VersionRole,		"moduleVersion"		},
 		{ SpecialRole,		"isSpecial"			}
 	};

--- a/Desktop/modules/ribbonmodel.h
+++ b/Desktop/modules/ribbonmodel.h
@@ -50,6 +50,7 @@ public:
 		ModuleRole,
 		ActiveRole,
 		BundledRole,
+		DevModRole,
 		VersionRole,
 		SpecialRole
 	};

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -44,6 +44,8 @@ void AnalysisBase::destroyForm()
 	}
 	else
 		Log::log(false) << " it has no AnalysisForm." << std::endl;
+	
+	_analysisForm = nullptr;
 }
 
 void AnalysisBase::createForm(QQuickItem* parentItem)

--- a/QMLComponents/analysisbase.h
+++ b/QMLComponents/analysisbase.h
@@ -28,7 +28,7 @@ public:
 	virtual				bool				isDuplicate()												const	{ return false;				}
 	virtual				bool				wasUpgraded()												const	{ return false;				}
 	virtual				bool				needsRefresh()												const	{ return false;				}
-	virtual				const std::string & module()													const	{ return emptyString;		}
+	virtual				const std::string   module()													const	{ return emptyString;		}
 	virtual				const std::string & name()														const	{ return emptyString;		}
 	virtual				const std::string & title()														const	{ return emptyString;		}
 	virtual				const std::string & titleDefault()												const	{ return emptyString;		}

--- a/QMLComponents/analysisbase.h
+++ b/QMLComponents/analysisbase.h
@@ -51,15 +51,13 @@ public:
 	virtual bool optionLocked(const QString& name) const { return false; };
 
 						const Json::Value &	boundValues()												const	{ return _boundValues;		}
-						const Json::Value &	orgBoundValues()											const	{ return _orgBoundValues;	}
 						const Json::Value &	boundValue(const std::string& name,
 														 const QVector<JASPControl::ParentKey>& parentKeys = {});
 
 						void				setBoundValue(const std::string& name, const Json::Value& value, const Json::Value& meta, const QVector<JASPControl::ParentKey>& parentKeys = {});
 						void				setBoundValues(const Json::Value& boundValues);
-						void				setOrgBoundValues(const Json::Value& orgBoundValues)				{ _orgBoundValues = orgBoundValues; }
 						const Json::Value	optionsMeta()												const	{ return _boundValues.get(".meta", Json::nullValue);	}
-						void				clearOptions()														{ _boundValues.clear();		}
+						void				clearBoundValues()														{ _boundValues.clear();		}
 
 						const Version	  &	moduleVersion()												const	{ return _moduleVersion;	}
 
@@ -98,9 +96,7 @@ protected:
 	Version			_moduleVersion;
 
 private:
-	Json::Value		_boundValues		= Json::objectValue,
-					_orgBoundValues		= Json::objectValue;
-
+	Json::Value		_boundValues		= Json::objectValue;
 
 
 protected:

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -672,9 +672,10 @@ void AnalysisForm::setAnalysisUp()
 
 	_setUpControls();
 
-	Json::Value defaultOptions = _analysis->orgBoundValues();
-	_analysis->clearOptions();
-	bindTo(defaultOptions);
+	Json::Value defaultOptions	= _analysis->orgBoundValues(),
+				prevOptions		= _analysis->boundValues();
+	//_analysis->clearOptions();
+	bindTo(prevOptions.isArray() && prevOptions.size() > 0 ? prevOptions : defaultOptions);
 	lockOptions();
 
 	blockValueChangeSignal(false, false);

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -674,7 +674,6 @@ void AnalysisForm::setAnalysisUp()
 
 	Json::Value defaultOptions	= _analysis->orgBoundValues(),
 				prevOptions		= _analysis->boundValues();
-	//_analysis->clearOptions();
 	bindTo(prevOptions.isArray() && prevOptions.size() > 0 ? prevOptions : defaultOptions);
 	lockOptions();
 

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -110,7 +110,7 @@ QVariant AnalysisForm::options() const
 
 void AnalysisForm::setOptions(const QVariantMap &options)
 {
-	_analysis->setOrgBoundValues(qvariantToJson(options));
+	_analysis->setBoundValues(qvariantToJson(options));
 	setAnalysisUp();
 }
 
@@ -156,7 +156,7 @@ void AnalysisForm::runScriptRequestDone(const QString& result, const QString& co
 			if (_rSyntax->parseRSyntaxOptions(options))
 			{
 				blockValueChangeSignal(true);
-				_analysis->clearOptions();
+				_analysis->clearBoundValues();
 				bindTo(Json::nullValue);
 				// Some controls generate extra controls (rowComponents): these extra controls must be first destroyed, because they may disturb the binding of other controls
 				// For this, bind all controls to null and wait for the controls to be completely destroyed.
@@ -672,9 +672,10 @@ void AnalysisForm::setAnalysisUp()
 
 	_setUpControls();
 
-	Json::Value defaultOptions	= _analysis->orgBoundValues(),
-				prevOptions		= _analysis->boundValues();
-	bindTo(prevOptions.isArray() && prevOptions.size() > 0 ? prevOptions : defaultOptions);
+	// When reading from JASP file or when reloading the QML file, the boundValues are set to the analysis. But now each control must be set to its value.
+	Json::Value initialOptions	= _analysis->boundValues();
+	_analysis->clearBoundValues(); // The boundValues will be reset by the bindTo method. Clear the boundValues to prevent existing options from interferring when resetting values.
+	bindTo(initialOptions);
 	lockOptions();
 
 	blockValueChangeSignal(false, false);

--- a/QMLComponents/utilities/appdirs.cpp
+++ b/QMLComponents/utilities/appdirs.cpp
@@ -92,9 +92,7 @@ QString AppDirs::bundledModulesDir()
 #else  //Normal linux build
 	folder = programDir().absoluteFilePath("../Modules") + '/';
 #endif
-	// @Joris, I think these guys should be one level up,
-	// they are not binaries, so, they should not be in
-	// the binary folder in my opinion.
+
 	return folder;
 }
 


### PR DESCRIPTION
- Adds a "isDevMod" role to ribbonmodel to make sure only development modules show a "refresh" icon
- Sort the modules as the get loaded on startup (in the correct order) to have newer version and/or user-installed modules have preference over the others.
- Make sure to store the analyses json before reloading the dynamic modules to recreate the analyses at the end. This probably also applies upgrades and should fix https://github.com/jasp-stats/jasp-test-release/issues/3128

I open it now as a draft to remove the edits I made that weren't helpful and because some other things probably need to be retested (like language changing etc and devmodule installs)