### PR TITLE
FormulaFields from JASP file do not get always the right value

### DIFF
--- a/Desktop/modules/installedmodules.cpp
+++ b/Desktop/modules/installedmodules.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include "gui/preferencesmodel.h"
 #include "log.h"
+#include "resultstesting/compareresults.h"
 
 
 const std::string InstalledModules::settingsPath = "modules-settings.json";
@@ -77,7 +78,7 @@ std::vector<InstalledModules::ModuleInfo> InstalledModules::getModules() {
 		}
 	}
 
-	if(!PreferencesModel::prefs()->developerMode())
+	if(!PreferencesModel::prefs()->developerMode() && !resultXmlCompare::compareResults::theOne()->testMode())
 		modules.erase("jaspTestModule");
 
 

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -103,6 +103,17 @@ QVariant AnalysisForm::getConstant(QString key, QVariant defaultValue, QString m
 	return defaultValue;
 }
 
+QVariant AnalysisForm::options() const
+{
+	return jsonToQVariant(_analysis->boundValues());
+}
+
+void AnalysisForm::setOptions(const QVariantMap &options)
+{
+	_analysis->setOrgBoundValues(qvariantToJson(options));
+	setAnalysisUp();
+}
+
 void AnalysisForm::itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &value)
 {
 	if (change == ItemChange::ItemSceneChange && !value.window)

--- a/QMLComponents/analysisform.h
+++ b/QMLComponents/analysisform.h
@@ -147,6 +147,8 @@ public:
 	Q_INVOKABLE QVariant    getConstant(QString key, QVariant defaultValue) const;
 	Q_INVOKABLE QVariant    getConstant(QString key, QVariant defaultValue, QString module, QString analysis) const;
 	Q_INVOKABLE bool		initialized()			const	{ return _initialized; }
+	Q_INVOKABLE QVariant	options()				const;
+	Q_INVOKABLE void		setOptions(const QVariantMap& options);
 	QString					generateWrapper(const QString& moduleName, const QString& analysisName, const QString& qmlFileName, const QString& analysisTitle, bool preloadData);
 	bool					parseOptions(std::string rawOptions, Json::Value& parsedOptions, std::string& errorMsg);
 	void					setAnalysis(AnalysisBase *	analysis);

--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -49,24 +49,24 @@ void TextInputBase::bindTo(const Json::Value& value)
 	{
 	case TextInputType::IntegerInputType:
 		int intVal;
-		if (value.isNumeric())		
+		if (value.isNumeric())
 			_value = value.asInt();
-		
+
 		else if (value.isString() && QColumnUtils::getIntValue(tq(value.asString()), intVal))
 			_value = intVal;
-		
+
 		break;
-		
+
 	case TextInputType::NumberInputType:
 	case TextInputType::PercentIntputType:
 	{
 		double dblVal = 0;
-		if (value.isNumeric())		
+		if (value.isNumeric())
 			dblVal = value.asDouble();
-		
+
 		else if (value.isString() && !QColumnUtils::getDoubleValue(tq(value.asString()), dblVal, false)) // value comes from the analyses.json: it's already an english format string
 			dblVal = NAN;
-			
+
 		_value = dblVal; //Stored as the user enters (so 0-100), but sent in json / 100 through
 		//This mean the "bound value" is 0...1 so:
 		if(_inputType == TextInputType::PercentIntputType)
@@ -102,7 +102,9 @@ void TextInputBase::bindTo(const Json::Value& value)
 			if (!strValue.isEmpty() && !QColumnUtils::getDoubleValue(strValue, dblVal, false)) // value comes from the analyses.json: it's already an english format string
 			{
 				setIsRCode();
-				runRScript("as.character(" + _value.toString() + ")", true);
+				_value = strValue;
+				// The analysis is not yet stored in analyses, and running a script now won't work
+				// But as the real value is used to check constraints, and this is the intialization of the form, we can expect that the value fulfills the constraints.
 				setRealValue = false;
 			}
 			else
@@ -118,32 +120,32 @@ void TextInputBase::bindTo(const Json::Value& value)
 	}
 	case TextInputType::ComputedColumnType:
 	{
-		if (value.isString())	
+		if (value.isString())
 			_value = tq(value.asString());
-		
+
 		setIsColumn(true);
 		checkIfColumnIsFreeOrMine();
 		break;
 	}
 	case TextInputType::CheckColumnFreeOrMineType:
 	{
-		if (value.isString())	
+		if (value.isString())
 			_value = tq(value.asString());
-		
+
 		checkIfColumnIsFreeOrMine();
 		break;
 	}
 	case TextInputType::AddColumnType:
 	{
-		if (value.isString())	
+		if (value.isString())
 			_value = tq(value.asString());
-		
+
 		columnType	colType		= static_cast<columnType>(property("columnType").toInt());
 		setIsColumn(false, colType);
 		checkIfColumnIsFreeOrMine();
 		break;
 	}
-		
+
 	default:
 		if (value.isString())
 			_value = tq(value.asString());
@@ -163,7 +165,7 @@ void TextInputBase::bindTo(const Json::Value& value)
 Json::Value TextInputBase::createJson() const
 {
 	QVariant value = property("displayValue");
-	if (value.toString() == "" && !_defaultValue.isNull())	
+	if (value.toString() == "" && !_defaultValue.isNull())
 		value = _defaultValue;
 
 	return _getJsonValue(value);
@@ -213,12 +215,12 @@ void TextInputBase::setDisplayValue()
 {
 	int		valueInt;
 	double	valueDbl;
-	QString showThis	= QColumnUtils::getIntValue(_value, valueInt) ? 
-							QString::number(valueInt) 
-						:	QColumnUtils::getDoubleValue(_value, valueDbl) ? 
-								QColumnUtils::doubleToString(valueDbl, false) 
+	QString showThis	= QColumnUtils::getIntValue(_value, valueInt) ?
+							QString::number(valueInt)
+						:	QColumnUtils::getDoubleValue(_value, valueDbl) ?
+								QColumnUtils::doubleToString(valueDbl, false)
 							:	_value.toString();
-																																				  
+
 	setProperty("displayValue", showThis);
 }
 
@@ -273,7 +275,7 @@ void TextInputBase::rScriptDoneHandler(const QString &result)
 
 QString TextInputBase::friendlyName() const
 {
-	switch (_inputType)	
+	switch (_inputType)
 	{
 	case TextInputType::IntegerInputType:			return tr("Integer Field");
 	case TextInputType::NumberInputType:			return tr("Double Field");
@@ -288,25 +290,25 @@ QString TextInputBase::friendlyName() const
 	}
 }
 
-QVariant TextInputBase::defaultValue() const	
-{ 
+QVariant TextInputBase::defaultValue() const
+{
 	return _defaultValue;
 }
 
-QVariant TextInputBase::value() const	
-{ 
-	QVariant showThis = _value.isNull() ? _defaultValue : _value; 
-	
-	return showThis;	
+QVariant TextInputBase::value() const
+{
+	QVariant showThis = _value.isNull() ? _defaultValue : _value;
+
+	return showThis;
 }
 
 void TextInputBase::checkIfColumnIsFreeOrMine()
 {
 	QString val = _value.toString();
-	
+
 	if(val.isEmpty())
 		return;
-	
+
 	if(form() && !form()->isColumnFreeOrMine(val))
 	{
 		setHasScriptError(true);
@@ -314,7 +316,7 @@ void TextInputBase::checkIfColumnIsFreeOrMine()
 	}
 	else
 		setHasScriptError(false);
-		
+
 }
 
 bool TextInputBase::encodeValue() const
@@ -356,10 +358,10 @@ Json::Value TextInputBase::_getJsonValue(QVariant value) const
 	double	valueDbl;
 	bool	isInt,
 			isDbl;
-	
+
 	isInt = QColumnUtils::getIntValue(		value.toString(), valueInt);
 	isDbl = QColumnUtils::getDoubleValue(	value.toString(), valueDbl, false); // value is already an english format converted double
-	
+
 	switch (_inputType)
 	{
 	case TextInputBase::FormulaType:			return isDbl ? Json::Value(valueDbl) : fq(value.toString()); // Keep it as string and do not try to make it an integer or a double
@@ -376,15 +378,15 @@ Json::Value TextInputBase::_getJsonValue(QVariant value) const
 		{
 			isInt = QColumnUtils::getIntValue(		chunk, valueInt);
 			isDbl = QColumnUtils::getDoubleValue(	chunk, valueDbl, false);
-			
+
 			if (isInt || isDbl)
 				values.append(isDbl ? valueDbl : double(valueInt));
 		}
 		return values;
 	}
-	default:	
-		return isInt ? Json::Value(valueInt) 
-					 : isDbl ? Json::Value(valueDbl) 
+	default:
+		return isInt ? Json::Value(valueInt)
+					 : isDbl ? Json::Value(valueDbl)
 							 : fq(value.toString());
 	}
 }
@@ -400,11 +402,11 @@ void TextInputBase::setValue(QVariant value, bool useLocale)
 {
 	double valueDbl;
 	if(QColumnUtils::getDoubleValue(value.toString(), valueDbl, useLocale))
-		value = valueDbl;	
-	
+		value = valueDbl;
+
 	bool hasChanged = _value != value;
 	_value = value;
-	
+
 	if(_inputType == TextInputType::ComputedColumnType || _inputType == TextInputType::AddColumnType || _inputType == TextInputType::CheckColumnFreeOrMineType)
 		checkIfColumnIsFreeOrMine();
 
@@ -424,15 +426,15 @@ void TextInputBase::setDefaultValue(QVariant value)
 	double valueDbl;
 	if(QColumnUtils::getDoubleValue(value.toString(), valueDbl, false)) // Don't use locale with default value: they are set by the analysis, not by the user.
 		value = valueDbl;
-		
+
 	bool	hasChanged	= _defaultValue !=  value,
 			curValIsDef	= _defaultValue == _value;
-	
+
 	_defaultValue = value;
-	
+
 	if(hasChanged)
 		emit defaultValueChanged();
-	
+
 	if(curValIsDef)
 		setValue(_defaultValue, false);
 }

--- a/QMLComponents/utilities/qutils.cpp
+++ b/QMLComponents/utilities/qutils.cpp
@@ -317,6 +317,71 @@ QPoint maxQModelIndex(const QItemSelection &list)
 	return QPoint(c, r);
 }
 
+
+QVariant jsonToQVariant(const Json::Value & jsonValue)
+{
+	switch(jsonValue.type())
+	{
+	case Json::intValue:		return jsonValue.asInt();
+	case Json::uintValue:		return jsonValue.asUInt();
+	case Json::realValue:		return jsonValue.asDouble();
+	case Json::stringValue:		return tq(jsonValue.asString());
+	case Json::booleanValue:	return jsonValue.asBool();
+	case Json::arrayValue:
+	{
+		QVariantList varValues;
+		for (const Json::Value& value : jsonValue)
+			varValues.push_back(jsonToQVariant(value));
+		return varValues;
+	}
+	case Json::objectValue:
+	{
+		QVariantMap varValues;
+		for (const std::string& optionName : jsonValue.getMemberNames())
+			varValues[tq(optionName)] = jsonToQVariant(jsonValue[optionName]);
+		return varValues;
+	}
+	default:
+		return QVariant();
+	}
+}
+
+Json::Value qvariantToJson(const QVariant & varValue)
+{
+	switch (varValue.typeId())
+	{
+	case QMetaType::Int:		return varValue.toInt();
+	case QMetaType::UInt:		return varValue.toUInt();
+	case QMetaType::Long:
+	case QMetaType::LongLong:	return varValue.toLongLong();
+	case QMetaType::ULong:
+	case QMetaType::ULongLong:	return varValue.toULongLong();
+	case QMetaType::Bool:		return varValue.toBool();
+	case QMetaType::QString:	return fq(varValue.toString());
+	case QMetaType::QVariantList:
+	{
+		Json::Value jsonArray(Json::arrayValue);
+		for (const QVariant& value : varValue.toList())
+			jsonArray.append(qvariantToJson(value));
+		return jsonArray;
+	}
+	case QMetaType::QVariantMap:
+	{
+		Json::Value jsonObject(Json::objectValue);
+		QMapIterator<QString, QVariant> it(varValue.toMap() );
+		while (it.hasNext())
+		{
+			it.next();
+			jsonObject[fq(it.key())] = qvariantToJson(it.value());
+		}
+		return jsonObject;
+	}
+	default:
+		return Json::nullValue;
+	}
+}
+
+
 QLocale QColumnUtils::_lastQLocale = QLocale();
 QString QColumnUtils::_lastQLocaleId = "C";
 

--- a/QMLComponents/utilities/qutils.h
+++ b/QMLComponents/utilities/qutils.h
@@ -66,6 +66,8 @@ inline	QList<int>							tql(const std::set<int>						 & from)	{ return QList<int
 		QJSValue							tqj(const Json::Value						 & json,	const QQuickItem * qItem);
 		QPoint								minQModelIndex(const QItemSelection			 & list);
 		QPoint								maxQModelIndex(const QItemSelection			 & list);
+		QVariant							jsonToQVariant(const Json::Value & jsonValue);
+		Json::Value							qvariantToJson(const QVariant & varValue);
 
 template<typename T> inline		std::vector<T>	fq(QVector<T>		in) { return in.toStdVector();				}
 template<typename T> inline		QVector<T>		tq(std::vector<T>	in) { return QVector<T>::fromStdVector(in); }

--- a/Tests/qmlTests/tst_formulaField.qml
+++ b/Tests/qmlTests/tst_formulaField.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import QtTest
+import JASP.Controls
+
+TestCase
+{
+	name:		"TestFormulafield"
+
+	property alias form: jaspForm // The form must be in the context of the JASPControls
+
+
+	SignalSpy
+	{
+		id:				spyLoader
+		target:			jaspForm
+		signalName:		"formCompletedSignal"
+	}
+
+	Form
+	{
+		id:		jaspForm
+
+		Text
+		{
+			id: dummyText
+			text: qsTr("Dummy")
+		}
+
+		FormulaField
+		{
+			id:						formulaField
+			defaultValue:			"1"
+			min:					1
+			name:					"formulaField"
+		}
+	}
+
+	function test_expressionValue()
+	{
+		spyLoader.wait(1000)
+		compare(spyLoader.count, 1);
+		compare(formulaField.displayValue,	"1");
+		compare(formulaField.value,			1);
+		formulaField.value =				"1+3"
+		compare(formulaField.displayValue,	"1+3");
+		compare(formulaField.value,			"1+3");
+		//compare(formulaField.realValue,		"4"); // Cannot check this, as long as the unit test does not have an engine.
+
+		formulaField.value =				.1
+		dummyText.forceActiveFocus();		// The error will be triggered when the control loses the focus
+		compare(formulaField.hasError, true, "The value must be bigger than 1")
+
+
+		var options = jaspForm.options()
+		options["formulaField"] = "1+2"
+		jaspForm.setOptions(options)					// This mimic the loading of a JASP file having these options
+		compare(formulaField.displayValue,	"1+2");
+		compare(formulaField.value,			"1+2");
+	}
+
+}


### PR DESCRIPTION
Bug found when testing jaspTextModule "Test Input Field" analysis. It is reproduceable with any analysis using FormulaField (as Frequencies Binomial Test, Test Value field).

- Set an expression like 1/3 (different than the default)
- Duplicate -> default value is set instead of 1/3
- Or Save the file, and open it -> default value is set instead of 1/3

The expression 1/3 is well stored in JASP file (in the option json), but when reading it, the `_value` property was not set.

It should run a R script in the engine to solve the expression. But this does not work since the analysis is not yet stored in the analyses object (and signals are not yet set between this analysis and analyses).
But as the real value is used only to check the constraints (min or max value for example), and as the problem occurs during the initialization of the analysis (using value from a JASP file, or from default values), we can expect that the constraints are fulfilled, and so we don't need to know the real value.

