### PR TITLE
chore: remove jaspColumnEncoder submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,6 @@
 	path = Tools/jaspTools
 	url = https://github.com/jasp-stats/jaspTools/
 	branch = master
-[submodule "Common/jaspColumnEncoder"]
-	path = Common/jaspColumnEncoder
-	url = https://github.com/jasp-stats/jaspColumnEncoder
-	branch = master
 [submodule "Engine/jaspModuleBundleManager"]
 	path = Engine/jaspModuleBundleManager
 	url = https://github.com/jasp-stats/jaspModuleBundleManager.git


### PR DESCRIPTION
We didn't remove it completely before, and it will still be added back in some build scenarios.
