### PR TITLE
Add apptainer definition file for building containerized JASP

### DIFF
--- a/jasp.def
+++ b/jasp.def
@@ -1,0 +1,88 @@
+Bootstrap: docker
+From: mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04
+
+
+%post
+	# GITHUB_PAT must be set to a valid access token: https://github.com/jasp-stats/jasp-desktop/blob/stable/Docs/development/jasp-building-guide.md#github_pat
+	export GITHUB_PAT=""	
+	if [ -z "${GITHUB_PAT}" ]; then
+		echo "GITHUB_PAT must be set to valid access token to build JASP.  "
+		echo "see https://github.com/jasp-stats/jasp-desktop/blob/stable/Docs/development/jasp-building-guide.md#github_pat"
+		exit 1	
+	fi
+	export DEBIAN_FRONTEND=noninteractive
+	export QT_VERSION=6.8.3
+	export QT_MODULES="qtpositioning qtwebchannel qtwebengine qtwebsockets qtwebview debug_info qt5compat qtshadertools qtwaylandcompositor"
+	apt update -y
+	
+	# 1) Base OS packages per Docs/development/jasp-build-guide-linux.md
+	apt install -y \
+	    ca-certificates curl git gnupg software-properties-common \
+	    build-essential cmake ninja-build \
+	    autoconf bison flex \
+	    g++ gfortran \
+	    zlib1g zlib1g-dev \
+	    libssl-dev \
+	    libgl1-mesa-dev \
+	    libsqlite3-dev \
+	    libarchive13 libarchive-dev \
+	    libxkbcommon-dev libxkbcommon-x11-dev libxcb-xkb-dev libxcb-xinerama0 libxcb-cursor0 \
+	    libglpk-dev \
+	    libminizip-dev \
+	    libfreexl-dev \
+	    libboost-dev libboost-filesystem-dev libboost-system-dev libboost-date-time-dev libboost-timer-dev libboost-chrono-dev \
+	    librdata-dev jags \
+	    libnss3-dev libnspr4-dev libxcomposite-dev libxdamage-dev libxrandr-dev libxtst-dev libxi-dev libasound2-dev libxkbfile-dev libxcb-icccm4-dev libxcb-shape0-dev libxcb-keysyms1-dev \
+	    libjsoncpp25 libjsoncpp-dev libxcb-xkb1 \
+	    r-base \
+	    libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libwebp-dev \
+	    libcairo2-dev libgsl-dev \
+	    fonts-noto-cjk fonts-arphic-ukai fonts-arphic-uming fonts-wqy-zenhei fonts-wqy-microhei \
+	    patchelf \
+	    pkg-config \
+
+
+	# 2) Install R from CRAN Ubuntu repo for a recent R (or use distro one if sufficient)
+	# 3) JAGS (use distro for convenience; can be replaced by source build later)
+	# 4) Python + pip tooling for aqtinstall (Qt online installer alternative)
+    	echo "deb https://cloud.r-project.org/bin/linux/ubuntu noble-cran40/" | tee /etc/apt/sources.list.d/cran-r.list
+    	curl -fsSL https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/cran.gpg
+   	apt-get update 
+	apt-get install -y --no-install-recommends r-base r-base-dev jags \
+	    python3 python3-pip python3-venv
+	
+	# 5) Create venv for aqtinstall and install aqtinstall there
+	python3 -m venv /opt/aqt-venv
+    	/opt/aqt-venv/bin/pip install --no-cache-dir aqtinstall
+
+	# 6) Install Qt 6.7.x with required modules via aqt from venv
+    	/opt/aqt-venv/bin/aqt install-qt -O /opt/Qt linux desktop ${QT_VERSION} linux_gcc_64 -m ${QT_MODULES}
+    	ln -s /opt/Qt/${QT_VERSION}/linux_gcc_64/bin/qmake /usr/local/bin/qmake || true
+
+	# 7) Install Qt Creator and other tools
+	/opt/aqt-venv/bin/aqt install-tool -O /opt/Qt linux desktop tools_qtcreator qt.tools.qtcreator
+    	/opt/aqt-venv/bin/aqt install-tool -O /opt/Qt linux desktop tools_cmake 
+    	/opt/aqt-venv/bin/aqt install-tool -O /opt/Qt linux desktop tools_ninja
+
+	# 8) Install readstat
+	cd /opt
+	wget https://github.com/WizardMac/ReadStat/releases/download/v1.1.9/readstat-1.1.9.tar.gz
+        tar -xzf readstat-*.tar.gz 
+	cd readstat-*/
+        ./configure 
+	make CFLAGS='-Wno-error=use-after-free' CXXFLAGS='-Wno-error=use-after-free' 
+	make install
+
+	cd /opt
+	git clone -b stable https://github.com/jasp-stats/jasp-desktop.git
+	cd jasp-desktop
+	git submodule update --init
+	
+	# Build step from linux build guide
+        export Qt6_DIR=/opt/Qt/6.8.3/gcc_64/lib/cmake
+	CMAKE_PREFIX_PATH=/opt/Qt/6.8.3/gcc_64/lib/cmake/ cmake -GNinja  -S . -B jasp-build
+	cmake --build jasp-build --target all -j6
+	
+
+%runscript
+	/opt/jasp-desktop/jasp-build/Desktop/JASP


### PR DESCRIPTION
I am research facilitator at the University of Florida's HiPerGator HPC cluster.   We wanted to provide JASP for our users, but we do not have flatpak or Docker on our system.   I converted the Dockerfile in .devcontainer to a definition file that can be used with Apptainer to build a container.  