### PR TITLE
Check known issues per module version

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -87,14 +87,14 @@ Analysis* Analyses::createFromJaspFileEntry(Json::Value analysisData, RibbonMode
 	return analysis;
 }
 
-Analysis* Analyses::create(Modules::AnalysisEntry * analysisEntry, Json::Value* options)
+Analysis* Analyses::create(Modules::AnalysisEntry * analysisEntry, const Json::Value & options)
 {
 	return create(Json::nullValue, analysisEntry, _nextId++, Analysis::Empty, true, "", "", options);
 }
 
-Analysis* Analyses::create(const Json::Value & analysisData, Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status, bool notifyAll, std::string title, std::string moduleVersion, Json::Value *options)
+Analysis* Analyses::create(const Json::Value & analysisData, Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status, bool notifyAll, const std::string & title, const Version & loadedVersion, const Json::Value & options)
 {
-	Analysis *analysis = new Analysis(id, analysisEntry, title, moduleVersion, options);
+	Analysis *analysis = new Analysis(id, analysisEntry, title, loadedVersion, options);
 
 	analysis->checkDefaultTitleFromJASPFile(analysisData);
 	
@@ -542,12 +542,8 @@ Analysis* Analyses::createAnalysis(const QString& module, const QString& analysi
 	Modules::DynamicModule * dynamicModule = Modules::DynamicModules::dynMods()->dynamicModule(module.toStdString());
 	Json::Value options = JASPConfiguration::getInstance()->getAnalysisOptionValues(module, analysis);
 
-	if (dynamicModule) {
-		if(options != Json::nullValue)
-			return create(dynamicModule->retrieveCorrespondingAnalysisEntry(fq(analysis)), &options);
-		else
-			return create(dynamicModule->retrieveCorrespondingAnalysisEntry(fq(analysis)));
-	}
+	if (dynamicModule)
+		return create(dynamicModule->retrieveCorrespondingAnalysisEntry(fq(analysis)), options);
 	else
 		return nullptr;
 

--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -70,7 +70,7 @@ Analysis* Analyses::createFromJaspFileEntry(Json::Value analysisData, RibbonMode
 	Json::Value				&	optionsJson		= analysisData["options"];
 	std::string					title			= analysisData.get("title", "").asString();
 	Modules::AnalysisEntry	*	analysisEntry	= Modules::DynamicModules::dynMods()->retrieveCorrespondingAnalysisEntry(analysisData["dynamicModule"]);
-	Analysis				*	analysis		= create(analysisData, analysisEntry, id, status, false, title, analysisData["dynamicModule"]["moduleVersion"].asString(), &optionsJson);
+	Analysis				*	analysis		= create(analysisData, analysisEntry, id, status, false, title, analysisData["dynamicModule"]["moduleVersion"].asString(), optionsJson);
 	
 	if(msgs.count(Modules::analysisLog))
 	{
@@ -92,9 +92,9 @@ Analysis* Analyses::create(Modules::AnalysisEntry * analysisEntry, const Json::V
 	return create(Json::nullValue, analysisEntry, _nextId++, Analysis::Empty, true, "", "", options);
 }
 
-Analysis* Analyses::create(const Json::Value & analysisData, Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status, bool notifyAll, const std::string & title, const Version & loadedVersion, const Json::Value & options)
+Analysis* Analyses::create(const Json::Value & analysisData, Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status, bool notifyAll, const std::string & title, const Version & optionsVersion, const Json::Value & options)
 {
-	Analysis *analysis = new Analysis(id, analysisEntry, title, loadedVersion, options);
+	Analysis *analysis = new Analysis(id, analysisEntry, title, optionsVersion, options);
 
 	analysis->checkDefaultTitleFromJASPFile(analysisData);
 	

--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -63,9 +63,9 @@ public:
 
 	Analysis	*	createFromJaspFileEntry(Json::Value analysisData, RibbonModel* ribbonModel);
 
-	Analysis	*	create(const Json::Value & analysisData, Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Empty, bool notifyAll = true, std::string title = "", std::string moduleVersion = "", Json::Value *options = nullptr);
+	Analysis	*	create(const Json::Value & analysisData, Modules::AnalysisEntry * analysisEntry, size_t id, Analysis::Status status = Analysis::Empty, bool notifyAll = true, const std::string & title = "", const Version & loadedVersion = "", const Json::Value & options = Json::nullValue);
 	Analysis	*	create(Modules::AnalysisEntry * analysisEntry)													{ return create(Json::nullValue, analysisEntry, _nextId++);						}
-	Analysis	*	create(Modules::AnalysisEntry * analysisEntry, Json::Value* options);
+	Analysis	*	create(Modules::AnalysisEntry * analysisEntry, const Json::Value & options);
 
 	Analysis	*	operator[](size_t index)	{ return _analysisMap[_orderedIds[index]]; }
 	Analysis	*	get(size_t id) const		{ return _analysisMap.count(id) > 0 ? _analysisMap.at(id) : nullptr;	}

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -31,7 +31,7 @@
 #include "modules/description/description.h"
 #include "gui/jaspConfiguration/jaspconfiguration.h"
 
-Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::string title, std::string moduleVersion, Json::Value *data) :
+Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, const std::string & title, const Version & moduleVersion, const Json::Value & data) :
 	  AnalysisBase(Analyses::analyses(), moduleVersion),
 		_id(				id),
 		_name(			analysisEntry->function()),
@@ -41,11 +41,13 @@ Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::strin
 		_moduleData(		analysisEntry),
 		_dynamicModule(	_moduleData->dynamicModule())
 {
+	// If the moduleVersion parameter is given, this is the version this analysis was stored with (in a JASP file).
+	// This version might be not the same as the current module version: in this case, the analysis will have to be refreshed.
 	if(_moduleVersion.isEmpty() && _dynamicModule)
 		_moduleVersion = _dynamicModule->version();
 
 	if (data)
-		setBoundValues(*data); //Same story as other constructor
+		setBoundValues(data); //Same story as other constructor
 
 	_codedReferenceToAnalysisEntry	= analysisEntry->codedReference(); //We need to store this to be able to find the right analysisEntry after reloading the entries of a dynamic module (destroys analysisEntries). Or replacing the entry if a different version of the module gets loaded of course.
 	_helpFile						= dynamicModule()->helpFolderPath() + tq(analysisEntry->function());
@@ -479,6 +481,7 @@ void Analysis::setStatus(Analysis::Status status)
 		
 		_wasUpgraded		= false;
 		_storedWithoutState	= false;
+		// The analysis has been run, so its version is the same as the module version.
 		_moduleVersion		= _dynamicModule ?  _dynamicModule->version() : AppInfo::version;
 
 		if(neededRefresh != needsRefresh())

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -31,8 +31,8 @@
 #include "modules/description/description.h"
 #include "gui/jaspConfiguration/jaspconfiguration.h"
 
-Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, const std::string & title, const Version & moduleVersion, const Json::Value & data) :
-	  AnalysisBase(Analyses::analyses(), moduleVersion),
+Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, const std::string & title, const Version & optionsVersion, const Json::Value & options) :
+	  AnalysisBase(Analyses::analyses()),
 		_id(				id),
 		_name(			analysisEntry->function()),
 		_qml(			analysisEntry->qml().empty() ? _name : analysisEntry->qml()),
@@ -41,13 +41,13 @@ Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, const std:
 		_moduleData(		analysisEntry),
 		_dynamicModule(	_moduleData->dynamicModule())
 {
-	// If the moduleVersion parameter is given, this is the version this analysis was stored with (in a JASP file).
+	// If the optionsVersion parameter is given, this is the version this analysis was stored with (in a JASP file).
 	// This version might be not the same as the current module version: in this case, the analysis will have to be refreshed.
-	if(_moduleVersion.isEmpty() && _dynamicModule)
-		_moduleVersion = _dynamicModule->version();
+	if(!optionsVersion.isEmpty() && _dynamicModule)
+		_optionsFromDifferentVersion = _dynamicModule->version() != optionsVersion;
 
-	if (data)
-		setBoundValues(data); //Same story as other constructor
+	if (options)
+		setBoundValues(options); //Same story as other constructor
 
 	_codedReferenceToAnalysisEntry	= analysisEntry->codedReference(); //We need to store this to be able to find the right analysisEntry after reloading the entries of a dynamic module (destroys analysisEntries). Or replacing the entry if a different version of the module gets loaded of course.
 	_helpFile						= dynamicModule()->helpFolderPath() + tq(analysisEntry->function());
@@ -481,8 +481,7 @@ void Analysis::setStatus(Analysis::Status status)
 		
 		_wasUpgraded		= false;
 		_storedWithoutState	= false;
-		// The analysis has been run, so its version is the same as the module version.
-		_moduleVersion		= _dynamicModule ?  _dynamicModule->version() : AppInfo::version;
+		_optionsFromDifferentVersion = false;
 
 		if(neededRefresh != needsRefresh())
 			emit needsRefreshChanged();
@@ -993,8 +992,7 @@ void Analysis::setUpgradeMsgs(const Modules::UpgradeMsgs &msgs)
 
 bool Analysis::needsRefresh() const
 {
-	bool differentVersion = _moduleVersion != (_dynamicModule ? _dynamicModule->version() : AppInfo::version);
-	return _wasUpgraded || _storedWithoutState || differentVersion;
+	return _wasUpgraded || _storedWithoutState || _optionsFromDifferentVersion;
 }
 
 bool Analysis::isWaitingForModule()

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -58,7 +58,7 @@ public:
 	static Analysis::Status analysisResultsStatusToAnalysisStatus(analysisResultStatus result);
 
 						Analysis(size_t id, Analysis * duplicateMe);
-						Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, const std::string & title, const Version & moduleVersion, const Json::Value & data);
+						Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, const std::string & title, const Version & optionsVersion, const Json::Value & options);
 
 	virtual				~Analysis();
 
@@ -155,6 +155,7 @@ public:
 	void					setUpgradeMsgs(const Modules::UpgradeMsgs & msgs);
 
 	const stringvec &		upgradeMsgsForOption(const std::string & name)		const	override;
+	const Version	&		moduleVersion()										const	override	{ return _dynamicModule ? _dynamicModule->version() : AppInfo::version; }
 
 	const Json::Value			&	getRSource(const std::string & name)		const	override	{ return _rSources.count(name) > 0 ? _rSources.at(name) : Json::Value::null; }
 	Json::Value						rSources()									const;
@@ -243,6 +244,7 @@ private:
 								_lastQmlFormPath				= "";
 	bool						_isDuplicate					= false,
 								_wasUpgraded					= false,
+								_optionsFromDifferentVersion	= false,
 								_storedWithoutState				= false,
 								_tryToFixNotes					= false,
 								_hasReport						= false,

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -58,7 +58,7 @@ public:
 	static Analysis::Status analysisResultsStatusToAnalysisStatus(analysisResultStatus result);
 
 						Analysis(size_t id, Analysis * duplicateMe);
-						Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, std::string title = "", std::string moduleVersion = "", Json::Value *data = nullptr);
+						Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, const std::string & title, const Version & moduleVersion, const Json::Value & data);
 
 	virtual				~Analysis();
 

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -548,7 +548,7 @@ AnalysisEntry* DynamicModule::retrieveCorrespondingAnalysisEntry(const Json::Val
 		throw ModuleException(name(), "Tried to load an AnalysisEntry for module (" + moduleName +") from me...");
 
 	if(Version(moduleVersion) != version())
-		std::cerr << "Loading analysis based on different version of module(" << moduleName << "), but going ahead anyway. Analysis based on version: " << moduleVersion << " and actual loaded version of module is: " << version() << std::endl;
+		std::cerr << "Loading analysis based on different version of module(" << moduleName << "), but going ahead anyway. Analysis based on version: " << moduleVersion << " and actual loaded version of module is: " << version().asString() << std::endl;
 
 	std::string codedReference = jsonFromJaspFile.get("analysisEntry", "AnalysisEntry's coded reference wasn't actually specified!").asString();
 
@@ -856,7 +856,7 @@ Json::Value DynamicModule::asJsonForJaspFile(const std::string & analysisFunctio
 	Json::Value json(Json::objectValue);
 
 	json["moduleName"]			= name();
-	json["moduleVersion"]		= version();
+	json["moduleVersion"]		= version().asString();
 	json["moduleMaintainer"]	= maintainer();
 	json["moduleWebsite"]		= website();
 	json["analysisEntry"]		= analysisFunction;

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -107,8 +107,7 @@ public:
 	QString				titleQ()			const { return QString::fromStdString(title());			}
 	bool				requiresData()		const { return AnalysisEntry::requiresDataEntries(_menuEntries); }
 	std::string			author()			const { return _author;									}
-	std::string			version()			const { return _version;								}
-	QString				versionQ()			const { return QString::fromStdString(_version);		}
+	const Version	&	version()			const { return _version;								}
 	std::string			website()			const { return _website;								}
 	std::string			license()			const { return _license;								}
 	std::string			maintainer()		const { return _maintainer;								}
@@ -242,8 +241,8 @@ private:
 						_installLog			= "",
 						_maintainer,
 						_descriptionTxt,
-						_modulePackage		= "",
-						_version;
+						_modulePackage		= "";
+	Version				_version;
 	bool				_installing			= false,
 						_installed			= false,
 						_isDeveloperMod		= false,

--- a/Desktop/modules/ribbonbutton.h
+++ b/Desktop/modules/ribbonbutton.h
@@ -77,7 +77,7 @@ public:
 	bool						active()													const			{ return _active;											}
 	QString						toolTip()													const			{ return _toolTipF ? _toolTipF() : _toolTip;											}
 	bool						isBundled()													const			{ return _module && _module->isBundled();					}
-	QString						version()													const			{ return !_module ? "?" : _module->versionQ();				}
+	QString						version()													const			{ return !_module ? "?" : tq(_module->version().asString());	}
 	bool						ready()														const			{ return _ready;											}
 	bool						error()														const			{ return _error;											}
 	bool						remember()													const			{ return _remember;											}

--- a/QMLComponents/analysisbase.cpp
+++ b/QMLComponents/analysisbase.cpp
@@ -6,9 +6,8 @@
 const std::string AnalysisBase::emptyString;
 const stringvec AnalysisBase::emptyStringVec;
 
-AnalysisBase::AnalysisBase(QObject* parent, Version moduleVersion)
+AnalysisBase::AnalysisBase(QObject* parent)
 	: QObject(parent)
-	, _moduleVersion(moduleVersion)
 {
 	// If the parent object is the form, just use it. This is used in R-Syntax mode when the AnalysisForm::parseOptions creates a dummy AnalysisBase
 	_analysisForm = qobject_cast<AnalysisForm*>(parent);
@@ -16,7 +15,6 @@ AnalysisBase::AnalysisBase(QObject* parent, Version moduleVersion)
 
 AnalysisBase::AnalysisBase(QObject* parent, AnalysisBase* duplicateMe)
 	: QObject(parent)
-	, _moduleVersion(duplicateMe->moduleVersion())
 	, _boundValues(duplicateMe->boundValues())
 {
 }

--- a/QMLComponents/analysisbase.h
+++ b/QMLComponents/analysisbase.h
@@ -17,7 +17,7 @@ class AnalysisBase : public QObject
 	Q_PROPERTY(QString				qmlError				READ qmlError			WRITE setQmlError			NOTIFY qmlErrorChanged			)
 
 public:
-	explicit AnalysisBase(QObject *parent = nullptr, Version moduleVersion = AppInfo::version);
+	explicit AnalysisBase(QObject *parent = nullptr);
 	AnalysisBase(QObject *parent, AnalysisBase* duplicateMe);
 
 	virtual				bool				isOwnComputedColumn(const std::string &col)					const	{ return false; }
@@ -46,9 +46,10 @@ public:
 	virtual				void				destroyForm();
 	virtual				bool				isColumnFreeOrMine(const QString & columnName)				const	{ return false; }
 
-	virtual QVariant getConstant(const QString& key, const QVariant& defaultValue)										const	{ return defaultValue;		}
-	virtual QVariant getConstant(const QString& key, const QVariant& defaultValue, const QString& module, const QString& analysis)		const	{ return defaultValue;		}
-	virtual bool optionLocked(const QString& name) const { return false; };
+	virtual QVariant			getConstant(const QString& key, const QVariant& defaultValue)													const	{ return defaultValue;		}
+	virtual QVariant			getConstant(const QString& key, const QVariant& defaultValue, const QString& module, const QString& analysis)	const	{ return defaultValue;		}
+	virtual bool				optionLocked(const QString& name)																				const	{ return false; };
+	virtual	const Version	  &	moduleVersion()																									const	{ return AppInfo::version;	}
 
 						const Json::Value &	boundValues()												const	{ return _boundValues;		}
 						const Json::Value &	boundValue(const std::string& name,
@@ -57,9 +58,8 @@ public:
 						void				setBoundValue(const std::string& name, const Json::Value& value, const Json::Value& meta, const QVector<JASPControl::ParentKey>& parentKeys = {});
 						void				setBoundValues(const Json::Value& boundValues);
 						const Json::Value	optionsMeta()												const	{ return _boundValues.get(".meta", Json::nullValue);	}
-						void				clearBoundValues()														{ _boundValues.clear();		}
+						void				clearBoundValues()													{ _boundValues.clear();		}
 
-						const Version	  &	moduleVersion()												const	{ return _moduleVersion;	}
 
 						QQuickItem		  *	formItem()													const;
 
@@ -75,7 +75,7 @@ public slots:
 	virtual void	requestComputedColumnCreationHandler(	const std::string & columnName)						{}
 	virtual void	requestComputedColumnDestructionHandler(const std::string & columnName)						{}
 	virtual void	onUsedVariablesChanged()																	{}
-	
+
 
 signals:
 	void			sendRScriptSignal(QString script, QString controlName, bool whiteListedVersion, QString module);
@@ -93,7 +93,6 @@ protected:
 	AnalysisForm*	_analysisForm		= nullptr;
 	QQuickItem	*	_parentItem			= nullptr;
 	QString			_qmlError;
-	Version			_moduleVersion;
 
 private:
 	Json::Value		_boundValues		= Json::objectValue;

--- a/QMLComponents/analysisform.cpp
+++ b/QMLComponents/analysisform.cpp
@@ -695,9 +695,9 @@ void AnalysisForm::knownIssuesUpdated()
 	if(!_formCompleted || !_analysis)
 		return;
 
-	if(KnownIssues::issues()->hasIssues(_analysis->module(), _analysis->name()))
+	if(KnownIssues::issues()->hasIssues(_analysis->module(), _analysis->moduleVersion(), _analysis->name()))
 	{
-		const std::vector<KnownIssues::issue> & issues = KnownIssues::issues()->getIssues(_analysis->module(), _analysis->name());
+		const std::vector<KnownIssues::issue> & issues = KnownIssues::issues()->getIssues(_analysis->module(),  _analysis->moduleVersion(), _analysis->name());
 
 		for(const KnownIssues::issue & issue : issues)
 		{

--- a/QMLComponents/knownissues.cpp
+++ b/QMLComponents/knownissues.cpp
@@ -20,10 +20,14 @@ KnownIssues::KnownIssues(QObject * parent) : QObject(parent)
 {
 	assert(!_knownIssues);
 	_knownIssues = this;
+	loadKnownJson();
 }
 
 void KnownIssues::loadLocalJson(const std::string & filePath, bool saveIt)
 {
+	if (!QFileInfo::exists(tq(filePath)))
+		return;
+
 	std::ifstream readMe(filePath);
 
 	Json::Value json;
@@ -64,19 +68,27 @@ void KnownIssues::loadJson(const Json::Value & json, bool saveIt)
 	{
 		if(!json.isObject()) throw std::runtime_error("expected issues json to be an object");
 
-		const std::string version = AppInfo::version.asString();
+		const std::string jaspVersion = AppInfo::version.asString();
 
-		if(json.isMember(version))
-			for(		const std::string & module		: json[version]						.getMemberNames())
-				for(	const std::string & analysis	: json[version][module]				.getMemberNames())
+		if(json.isMember(jaspVersion))
+		{
+			const Json::Value & modulesWithKnownIssues = json[jaspVersion];
+			for( const std::string & moduleName	: modulesWithKnownIssues.getMemberNames())
+			{
+				const Json::Value & moduleWithKnownIssues	= modulesWithKnownIssues[moduleName];
+				Version				moduleVersion			= moduleWithKnownIssues["version"].asString();
+				const Json::Value & analyses				= moduleWithKnownIssues["analyses"];
+				for(const std::string & analysisName : analyses.getMemberNames())
 				{
-					const Json::Value & perAnalysis = json[version][module][analysis];
+					const Json::Value & knownIssueDescription = analyses[analysisName];
 
-					if(perAnalysis.isObject())	addIssue(module, analysis, perAnalysis);
-					if(perAnalysis.isArray())
-						for(const Json::Value & entry : perAnalysis)
-							addIssue(module, analysis, entry);
+					if(knownIssueDescription.isObject())	addIssue(moduleName, moduleVersion, analysisName, knownIssueDescription);
+					if(knownIssueDescription.isArray())
+						for(const Json::Value & entry : knownIssueDescription)
+							addIssue(moduleName, moduleVersion, analysisName, entry);
 				}
+			}
+		}
 	}
 	catch(const std::exception & e)
 	{
@@ -119,7 +131,7 @@ bool KnownIssues::knownJsonExpired() const
 	return now - modTime > EXPIRATION_TIME_SEC;
 }
 
-void KnownIssues::addIssue(const std::string & module, const std::string & analysis, const Json::Value & issueJson)
+void KnownIssues::addIssue(const std::string & module, const Version & version, const std::string & analysis, const Json::Value & issueJson)
 {
 	issue newIssue;
 
@@ -138,34 +150,37 @@ void KnownIssues::addIssue(const std::string & module, const std::string & analy
 	default:				Log::log() << "KnownIssues::addIssue got unexpected type for \"options\", so ignoring it." << std::endl;
 	}
 
-	_issues[module][analysis].push_back(newIssue);
+	_issues[std::make_pair(module, version)][analysis].push_back(newIssue);
 }
 
-bool KnownIssues::hasIssues(const std::string & module, const std::string & analysis)
+bool KnownIssues::hasIssues(const std::string & module, const Version& version, const std::string & analysis)
 {
-	return _issues.count(module) > 0 && _issues[module].count(analysis) > 0;
+	auto key = std::make_pair(module, version);
+	return _issues.count(key) > 0 && _issues[key].count(analysis) > 0;
 }
 
-bool KnownIssues::hasIssues(const std::string & module, const std::string & analysis, const std::string & option)
+bool KnownIssues::hasIssues(const std::string & module, const Version& version, const std::string & analysis, const std::string & option)
 {
-	if(!hasIssues(module, analysis)) return false;
+	if(!hasIssues(module, version, analysis)) return false;
 
-	for(const issue & anIssue : _issues[module][analysis])
+	auto key = std::make_pair(module, version);
+	for(const issue & anIssue : _issues[key][analysis])
 		if(anIssue.options.count(option) > 0)
 			return true;
 
 	return false;
 }
 
-std::string KnownIssues::issuesForAnalysis(const std::string & module, const std::string & analysis)
+std::string KnownIssues::issuesForAnalysis(const std::string & module, const Version& version, const std::string & analysis)
 {
-	if(!hasIssues(module, analysis)) return "";
+	if(!hasIssues(module, version, analysis)) return "";
 
 	std::stringstream out;
 
 	out << "<ul>";
 
-	for(const issue & anIssue : _issues[module][analysis])
+	auto key = std::make_pair(module, version);
+	for(const issue & anIssue : _issues[key][analysis])
 		out << "<li>" << anIssue.info << "</li>\n";
 
 	out << "</ul>";

--- a/QMLComponents/knownissues.cpp
+++ b/QMLComponents/knownissues.cpp
@@ -150,21 +150,19 @@ void KnownIssues::addIssue(const std::string & module, const Version & version, 
 	default:				Log::log() << "KnownIssues::addIssue got unexpected type for \"options\", so ignoring it." << std::endl;
 	}
 
-	_issues[std::make_pair(module, version)][analysis].push_back(newIssue);
+	_issues[module][version][analysis].push_back(newIssue);
 }
 
 bool KnownIssues::hasIssues(const std::string & module, const Version& version, const std::string & analysis)
 {
-	auto key = std::make_pair(module, version);
-	return _issues.count(key) > 0 && _issues[key].count(analysis) > 0;
+	return _issues.count(module) > 0 && _issues[module].count(version) > 0 && _issues[module][version].count(analysis) > 0;
 }
 
 bool KnownIssues::hasIssues(const std::string & module, const Version& version, const std::string & analysis, const std::string & option)
 {
 	if(!hasIssues(module, version, analysis)) return false;
 
-	auto key = std::make_pair(module, version);
-	for(const issue & anIssue : _issues[key][analysis])
+	for(const issue & anIssue : _issues[module][version][analysis])
 		if(anIssue.options.count(option) > 0)
 			return true;
 
@@ -179,8 +177,7 @@ std::string KnownIssues::issuesForAnalysis(const std::string & module, const Ver
 
 	out << "<ul>";
 
-	auto key = std::make_pair(module, version);
-	for(const issue & anIssue : _issues[key][analysis])
+	for(const issue & anIssue : _issues[module][version][analysis])
 		out << "<li>" << anIssue.info << "</li>\n";
 
 	out << "</ul>";

--- a/QMLComponents/knownissues.h
+++ b/QMLComponents/knownissues.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <json/json.h>
 #include "utilities/qutils.h"
+#include "version.h"
 #include "stringutils.h"
 
 ///
@@ -18,12 +19,12 @@ class KnownIssues : public QObject
 public:
 	struct issue
 	{
-		std::string	info;
-		stringset	options;
+		std::string		info;
+		stringset		options;
 	};
 
-	typedef std::map<std::string, std::vector<issue>>	issuesPerAnalysis;
-	typedef std::map<std::string, issuesPerAnalysis>	issuesPerModule;
+	typedef std::map<std::string, std::vector<issue>>						issuesPerAnalysis;
+	typedef std::map<std::pair<std::string, Version>, issuesPerAnalysis>	issuesPerModule;
 
 	explicit KnownIssues(QObject *parent = nullptr);
 
@@ -35,16 +36,16 @@ public:
 	void loadJson(const std::string & jsonTxt,	bool saveIt);
 	void loadJson(const QString     & jsonTxt,	bool saveIt) { loadJson(fq(jsonTxt), saveIt); }
 
-	bool				hasIssues(			const std::string & module, const std::string & analysis);
-	bool				hasIssues(			const std::string & module, const std::string & analysis, const std::string & option);
-	std::string			issuesForAnalysis(	const std::string & module, const std::string & analysis);
+	bool				hasIssues(			const std::string & module, const Version & version, const std::string & analysis);
+	bool				hasIssues(			const std::string & module, const Version & version, const std::string & analysis, const std::string & option);
+	std::string			issuesForAnalysis(	const std::string & module, const Version & version, const std::string & analysis);
 
-	bool				hasIssues(			const QString     & module, const QString     & analysis)								{ return hasIssues(				fq(module), fq(analysis)			 ); }
-	bool				hasIssues(			const QString     & module, const QString     & analysis, const QString     & option)	{ return hasIssues(				fq(module), fq(analysis), fq(option) ); }
-	QString				issuesForAnalysis(	const QString	  & module, const QString	  & analysis)								{ return tq(issuesForAnalysis(	fq(module), fq(analysis)			)); }
+	bool				hasIssues(			const QString     & module, const Version & version, const QString     & analysis)								{ return hasIssues(				fq(module), version, fq(analysis)				); }
+	bool				hasIssues(			const QString     & module, const Version & version, const QString     & analysis, const QString & option)		{ return hasIssues(				fq(module), version, fq(analysis), fq(option)	); }
+	QString				issuesForAnalysis(	const QString	  & module, const Version & version, const QString	  & analysis)								{ return tq(issuesForAnalysis(	fq(module), version, fq(analysis))				); }
 
-	const std::vector<issue> &	getIssues(	const std::string & module, const std::string & analysis)								{ return _issues[module][analysis]; }
-	const std::vector<issue> &	getIssues(	const QString     & module, const QString     & analysis)								{ return getIssues(fq(module), fq(analysis)); }
+	const std::vector<issue> &	getIssues(	const std::string & module, const Version & version, const std::string & analysis)								{ return _issues[std::make_pair(module, version)][analysis];	}
+	const std::vector<issue> &	getIssues(	const QString     & module, const Version & version, const QString     & analysis)								{ return getIssues(fq(module), version, fq(analysis));			}
 
 signals:
 	void knownIssuesUpdated();
@@ -55,7 +56,7 @@ private:
 	void		loadKnownJson();
 
 	void		loadLocalJson(	const std::string & filePath,	bool saveIt);
-	void		addIssue(		const std::string & module,		const std::string & analysis, const Json::Value & issue);
+	void		addIssue(		const std::string & module,		const Version & version, const std::string & analysis, const Json::Value & issue);
 
 private:
 	issuesPerModule			_issues;

--- a/QMLComponents/knownissues.h
+++ b/QMLComponents/knownissues.h
@@ -23,8 +23,9 @@ public:
 		stringset		options;
 	};
 
-	typedef std::map<std::string, std::vector<issue>>						issuesPerAnalysis;
-	typedef std::map<std::pair<std::string, Version>, issuesPerAnalysis>	issuesPerModule;
+	typedef std::map<std::string, std::vector<issue>>			issuesPerAnalysis;
+	typedef std::map<Version, issuesPerAnalysis>				issuesPerVersion;
+	typedef std::map<std::string, issuesPerVersion>				issuesPerModule;
 
 	explicit KnownIssues(QObject *parent = nullptr);
 
@@ -44,7 +45,7 @@ public:
 	bool				hasIssues(			const QString     & module, const Version & version, const QString     & analysis, const QString & option)		{ return hasIssues(				fq(module), version, fq(analysis), fq(option)	); }
 	QString				issuesForAnalysis(	const QString	  & module, const Version & version, const QString	  & analysis)								{ return tq(issuesForAnalysis(	fq(module), version, fq(analysis))				); }
 
-	const std::vector<issue> &	getIssues(	const std::string & module, const Version & version, const std::string & analysis)								{ return _issues[std::make_pair(module, version)][analysis];	}
+	const std::vector<issue> &	getIssues(	const std::string & module, const Version & version, const std::string & analysis)								{ return _issues[module][version][analysis];	}
 	const std::vector<issue> &	getIssues(	const QString     & module, const Version & version, const QString     & analysis)								{ return getIssues(fq(module), version, fq(analysis));			}
 
 signals:


### PR DESCRIPTION
Now we have a module library, the known issue check should be done per module version.

The syntax of the KnownIssues.json file is changed (from the 0.96.0 version):
```
	"0.96":
	{
		"jaspTTests":
		{
			"version": "0.95.5",
			"analyses":
			{
				"TTestIndependentSamples":
				{
					"info": "Bad error with normality Test. Please upgrade the T-Tests module",
					"options":
					[
						"normalityTest"
					]
				}
			}
		}
	}
```

To test it, just update the loaded KnownIssues.json in your AppData (for Mac: ~/Library/Application Support/JASP/JASP/KnownIssues.json).

There was also a bug I fixed: the KnownIssues.json is downloaded once per day from our server, but the json file is read only when just downloaded. If you start afterwards JASP, the local json file was not read, and no known issues were displayed. Now, it reads always the local KnownIssues json file each time JASP is started.

This is a temporary fix. I think it's better that the module self keeps their known issues (in their master branch).
Also instead of a json file, this should be a QML file, so that we can translate the warning message.

