### PR TITLE
fix crash during import inconsistent row count under msvc

### DIFF
--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -605,11 +605,14 @@ void DatabaseInterface::dataSetBatchedValuesUpdate(DataSet * data, Columns colum
 	
 	statement << "INSERT OR REPLACE INTO " << dataSetName(data->id()) << " (";
 
-	//Add columnnames for data we want to insert
+	//Add columnnames for data we want to insert and ensure row counts are consistent
 	for(Column * col : columns)
 	{
 		assert(col->data() == data); //Little sanity check
 		statement << "Column_" << col->id() << "_DBL"<< ", "  << "Column_" << col->id() << "_INT" << ", ";
+
+		if(col->rowCount() < data->rowCount())
+			col->setRowCount(data->rowCount());
 	}
 
 	//And the filtername and rowNumber


### PR DESCRIPTION
These line will trigger assertion of `std::vector::operator[]` under **MSVC debug build**, because of different row count.

```cpp
			_doubleTroubleBinder(	stmt,	i++, col->dbls()[rowOutside]);
			sqlite3_bind_int(		stmt,	i++, col->ints()[rowOutside]);
```

Test case: importing this minitab file in JASP: https://support.minitab.com/en-us/datasets/media/generated-content/datasets/ToothpasteSales.MWX