### PR TITLE
enh: also read column description from minitab and fix crash under msvc

### DIFF
--- a/Desktop/data/importers/minitab/mwx.cpp
+++ b/Desktop/data/importers/minitab/mwx.cpp
@@ -54,7 +54,9 @@ void Minitab::getColumns(std::vector<MwxImportColumn *> &columns, ImportDataSet 
 		// seems name rules is valid in JASP
 		std::string name = varBody.get("Name", "V" + std::to_string(i + 1)).asString();
 		names.push_back(name);
-
+		
+		std::string colDesc = varBody.get("Desc", name).asString();
+		
 		stringvec levels;
 		std::map<std::string, std::string> textToIdMap;
 		parseOrdering(varBody, levels, textToIdMap);
@@ -72,6 +74,8 @@ void Minitab::getColumns(std::vector<MwxImportColumn *> &columns, ImportDataSet 
 
 		auto impCol = new MwxImportColumn(dataSet, name, levels, type);
 
+		impCol->setTitle(colDesc);
+		
 		if (varDataBody.isMember("TextData"))
 		{
 			for (const auto &val : varDataBody["TextData"])

--- a/Desktop/data/importers/minitab/mwx.cpp
+++ b/Desktop/data/importers/minitab/mwx.cpp
@@ -90,6 +90,11 @@ void Minitab::getColumns(std::vector<MwxImportColumn *> &columns, ImportDataSet 
 				impCol->addValue(val.isNull() ? "" : ColumnUtils::doubleToStringMaxPrec(val.asDouble(), false));
 		}
 
+		while (impCol->size() < _numRows)
+		{
+				impCol->addValue("");  //filling to keep col length consistently
+		}
+
 		columns.push_back(impCol);
 	}
 }


### PR DESCRIPTION
- fix crash during import inconsistent row count under msvc
- also read column description from minitab