### PR TITLE
Allow link in Module Library

### DIFF
--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -182,6 +182,13 @@ FocusScope
 				url:                    preferencesModel.checkUpdates ? preferencesModel.moduleLibraryURL : "about:blank"
 				profile:                moduleStoreProfile
 
+				onNewWindowRequested: (request) =>
+				{
+					Qt.openUrlExternally(request.requestedUrl);
+					request.accept();
+				}
+
+
 				property bool	downloadInProgress: false;
 				property bool	installInProgress: false;
 				property int		downloadProgress;


### PR DESCRIPTION
In the Module Library, a module may have a link to a home page (cf Audit module).
This link does not work because the WebEngineView does not allow this per default.