### PR TITLE
In Module library, open URLs not ending with JASPModule in external browser

### DIFF
--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -140,8 +140,10 @@ FocusScope
 					moduleStore.currentDownloadRequest = request
 					request.accept()
 				}
-				else
+				else {
+					Qt.openUrlExternally(request.url)
 					request.cancel()
+				}
 			}
 
             onDownloadFinished: function(request) { //All Jasp Store module installs run via this code


### PR DESCRIPTION
Like homepage for Audit module.

To test:
1. Start JASP build from this PR
2. Open module library
3. Scroll to Audit module
4. Click house icon
5. Optional, when running from devcontainer in VS code then VS code shows dialog whether to open link
6. Opens https://koenderks.github.io/jaum/ in your default web browser.

Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3119