### PR TITLE
Add moving waves to progress overlay and make overlay less wide

### DIFF
--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls as QTC
 import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
 import JASP.Controls
 import QtWebEngine
 import QtWebChannel
@@ -566,10 +567,19 @@ FocusScope
 		Rectangle
 		{
 			id:				progressOverlay
-			anchors.fill:	parent
+			anchors
+			{
+				left:		moduleStoreContainer.left
+				right:		moduleStoreContainer.right
+				top:		moduleStoreContainer.top
+				bottom:		moduleStoreContainer.bottom
+			}
 			color:			jaspTheme.grayDarker
             visible:		moduleStore.downloadInProgress || moduleLibrary.isInstalling || moduleStore.batchTotal > 0
 			z:				10
+			clip:			true
+			property real	waveHeight:		86 * preferencesModel.uiScale
+			property real	waveWidth:		1400 * preferencesModel.uiScale
 
 			MouseArea
 			{
@@ -579,8 +589,59 @@ FocusScope
 				preventStealing: true
 			}
 
+			Image
+			{
+				id:						overlayTopWave
+				z:						1
+				opacity:				0.35
+				fillMode:				Image.TileHorizontally
+				horizontalAlignment:	Image.AlignHCenter
+				height:					sourceSize.height
+				width:					progressOverlay.width + progressOverlay.waveWidth
+				sourceSize.width:		progressOverlay.waveWidth
+				sourceSize.height:		progressOverlay.waveHeight
+				source:					jaspTheme.iconPath + "jasp-wave-down-blue-120.svg"
+				cache:					false
+				anchors.top:			parent.top
+
+				NumberAnimation on x
+				{
+					from:		0
+					to:			-progressOverlay.waveWidth
+					duration:	8000
+					loops:		Animation.Infinite
+					running:	progressOverlay.visible
+				}
+			}
+
+			Image
+			{
+				id:						overlayBottomWave
+				z:						1
+				opacity:				0.35
+				fillMode:				overlayTopWave.fillMode
+				horizontalAlignment:	Image.AlignHCenter
+				height:					overlayTopWave.height
+				width:					progressOverlay.width + progressOverlay.waveWidth
+				sourceSize.width:		overlayTopWave.sourceSize.width
+				sourceSize.height:		overlayTopWave.sourceSize.height
+				source:					jaspTheme.iconPath + "jasp-wave-up-green-120.svg"
+				cache:					false
+				anchors.bottom:			parent.bottom
+
+				NumberAnimation on x
+				{
+					from:		0
+					to:			-progressOverlay.waveWidth
+					duration:	8000
+					loops:		Animation.Infinite
+					running:	progressOverlay.visible
+				}
+			}
+
 			Column
 			{
+				z:					2
 				anchors.centerIn:	parent
 				spacing:			10 * preferencesModel.uiScale
 				width:				300 * preferencesModel.uiScale

--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -574,7 +574,7 @@ FocusScope
 				top:		moduleStoreContainer.top
 				bottom:		moduleStoreContainer.bottom
 			}
-			color:			jaspTheme.grayDarker
+			color:			jaspTheme.fileMenuColorBackground
             visible:		moduleStore.downloadInProgress || moduleLibrary.isInstalling || moduleStore.batchTotal > 0
 			z:				10
 			clip:			true
@@ -655,7 +655,7 @@ FocusScope
                         let progress = moduleStore.batchTotal > 0 ? qsTr(" (%1/%2)").arg(moduleStore.batchCurrent).arg(moduleStore.batchTotal) : "";
                         return progress + " " + action + " " + name + "...";
                     }
-                    color:				"white"
+                    color:				jaspTheme.black
 					font.pixelSize:		16 * preferencesModel.uiScale
 					anchors.horizontalCenter: parent.horizontalCenter
 				}
@@ -691,7 +691,7 @@ FocusScope
 					{
 						anchors.centerIn:	parent
 						text:				moduleStore.downloadTotal > 0 ? Math.round((moduleStore.downloadProgress / moduleStore.downloadTotal) * 100) + "%" : "0%"
-						color:				"white"
+						color:				jaspTheme.black
 						font.pixelSize:		12 * preferencesModel.uiScale
 					}
 				}

--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -321,6 +321,7 @@ FocusScope
 			contentHeight:			workspaceSpecs.visible ? workspaceSpecs.height : modules.height
 			contentWidth:			width
 			width:                  visible ? 340 * preferencesModel.uiScale : 0
+			clip:					true
 
 			anchors
 			{

--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls as QTC
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 import JASP.Controls
 import QtWebEngine
 import QtWebChannel


### PR DESCRIPTION
Fixes [#3135](https://github.com/jasp-stats/INTERNAL-jasp/issues/3135)



https://github.com/user-attachments/assets/d659d850-705a-4527-a0cb-300e6c711a46


https://github.com/user-attachments/assets/4e750105-661f-4f3b-8077-fae2c8c5b418


