### PR TITLE
Add possibility to add sub menus in Ribbon menu

### DIFF
--- a/Desktop/components/JASP/Widgets/CustomMenu.qml
+++ b/Desktop/components/JASP/Widgets/CustomMenu.qml
@@ -397,7 +397,7 @@ FocusScope
 								property bool	itemEnabled:	menu.props.hasOwnProperty("enabled") ? menu.props["enabled"][index] : (model.modelData !== undefined || model.isEnabled)
 
 
-								property double initWidth: menuItemImage.width + menuItemText.implicitWidth + (subMenuItemImage.visible ? subMenuItemImage.width : 0) + 15 * preferencesModel.uiScale
+								property double initWidth: menuItemImage.width + menuItemText.implicitWidth + (subMenuItemArrow.visible ? subMenuItemArrow.width : 0) + 15 * preferencesModel.uiScale
 
 								Image
 								{
@@ -439,7 +439,7 @@ FocusScope
 
 								Image
 								{
-									id					: subMenuItemImage
+									id					: subMenuItemArrow
 									height				: 15 * preferencesModel.uiScale
 									width				: height
 									visible				: menu.hasSubMenus
@@ -463,7 +463,7 @@ FocusScope
 									hoverEnabled	: true
 									anchors.fill	: parent
 									onClicked		: callMenuAction(index)
-									enabled			: subMenuItemImage.visible
+									enabled			: subMenuItemArrow.visible
 								}
 
 

--- a/Desktop/components/JASP/Widgets/CustomMenu.qml
+++ b/Desktop/components/JASP/Widgets/CustomMenu.qml
@@ -26,11 +26,12 @@ FocusScope
 	id							: menu
 	width						: menuRectangle.width
 	height						: menuRectangle.height
-	visible						: showMe && activeFocus
+	visible						: showMe && (activeFocus || (hasSubMenus && customSubMenu.activeFocus))
 	x							: Math.min(menuMinPos.x + (menuMinIsMin ? Math.max(0, menuX) : menuX), menuMaxPos.x - (width  + 2) )
 	y							: Math.min(menuMinPos.y + (menuMinIsMin ? Math.max(0, menuY) : menuY), menuMaxPos.y - (height + 2) )
 	property var	props		: undefined
 	property bool	hasIcons	: true
+	property bool	hasSubMenus	: false
 	property real	_iconPad	: 5 * preferencesModel.uiScale
 	property int	menuX		: menuOffset.x + menuScroll.x
 	property int	menuY		: menuOffset.y + menuScroll.y
@@ -89,7 +90,8 @@ FocusScope
 
 	onPropsChanged:
 	{
-		hasIcons = (menu.props === undefined || "undefined" === typeof(menu.props["hasIcons"])) ? true : menu.props["hasIcons"]
+		hasIcons	= (menu.props === undefined || "undefined" === typeof(menu.props["hasIcons"]))		? true	: menu.props["hasIcons"]
+		hasSubMenus = (menu.props === undefined || "undefined" === typeof(menu.props["hasSubMenus"]))	? false : menu.props["hasSubMenus"]
 
 		if (menu.props === undefined || menu.props["model"] !== resultMenuModel)
 			resultsJsInterface.runJavaScript("window.setSelection(false);")
@@ -168,6 +170,11 @@ FocusScope
 		if (menu.sourceItem !== null)
 			menu.sourceItem.forceActiveFocus()
 		menu.props['functionCall'](index)
+	}
+
+	function currentMenuItem(index)
+	{
+		return repeater.itemAt(index)
 	}
 
 	Rectangle
@@ -362,6 +369,7 @@ FocusScope
 										verticalCenter	: parent.verticalCenter
 									}
 								}
+
 								MouseArea
 								{
 									id				: mouseArea
@@ -383,7 +391,7 @@ FocusScope
 								width	: initWidth
 								height	: (isSmall ? 0.666 : 1) * jaspTheme.menuGroupTitleHeight
 
-								property double initWidth: menuItemImage.width + menuItemText.implicitWidth + 15 * preferencesModel.uiScale
+								property double initWidth: menuItemImage.width + menuItemText.implicitWidth + (subMenuItemImage.visible ? subMenuItemImage.width : 0) + 15 * preferencesModel.uiScale
 
 								Image
 								{
@@ -422,6 +430,37 @@ FocusScope
 										verticalCenter	: parent.verticalCenter
 									}
 								}
+
+								Image
+								{
+									id					: subMenuItemImage
+									height				: 15 * preferencesModel.uiScale
+									width				: height
+									visible				: menu.hasSubMenus
+
+									source				: jaspTheme.iconPath + "arrow-right.png"
+									smooth				: true
+									mipmap				: true
+									fillMode			: Image.PreserveAspectFit
+
+									verticalAlignment	: Text.AlignVCenter
+									anchors
+									{
+										right			: parent.right
+										verticalCenter	: parent.verticalCenter
+									}
+								}
+
+								MouseArea
+								{
+									id				: groupMouseArea
+									hoverEnabled	: true
+									anchors.fill	: parent
+									onClicked		: callMenuAction(index)
+									enabled			: subMenuItemImage.visible
+								}
+
+
 							}
 						}
 

--- a/Desktop/components/JASP/Widgets/CustomMenu.qml
+++ b/Desktop/components/JASP/Widgets/CustomMenu.qml
@@ -73,11 +73,7 @@ FocusScope
 		case Qt.Key_Return:
 		case Qt.Key_Space:
 			if (currentIndex > -1)
-			{
 				callMenuAction(currentIndex)
-				menu.currentIndex = -1;
-			}
-			closeMenu();
 			break;
 		case Qt.Key_Escape:
 			menu.currentIndex = -1;
@@ -118,7 +114,7 @@ FocusScope
 		menu.showMe			= true;
 
 		menu.forceActiveFocus();
-
+		navigate(1)
 	}
 
 	function hide()
@@ -385,11 +381,21 @@ FocusScope
 						{
 							id: menuGroupTitle
 
-							Item
+							Rectangle
 							{
 								id		: menuItem
 								width	: initWidth
 								height	: (isSmall ? 0.666 : 1) * jaspTheme.menuGroupTitleHeight
+								color	: (model.modelData === undefined) && !menuItem.itemEnabled
+												? "transparent"
+												: groupMouseArea.pressed || index == currentIndex
+													? jaspTheme.buttonColorPressed
+													: groupMouseArea.containsMouse
+														? jaspTheme.buttonColorHovered
+														: "transparent"
+
+								property bool	itemEnabled:	menu.props.hasOwnProperty("enabled") ? menu.props["enabled"][index] : (model.modelData !== undefined || model.isEnabled)
+
 
 								property double initWidth: menuItemImage.width + menuItemText.implicitWidth + (subMenuItemImage.visible ? subMenuItemImage.width : 0) + 15 * preferencesModel.uiScale
 

--- a/Desktop/components/JASP/Widgets/DataTableView.qml
+++ b/Desktop/components/JASP/Widgets/DataTableView.qml
@@ -165,7 +165,7 @@ FocusScope
 					"functionCall": function (index)
 					{
 						menuFunctions[index]();
-						customMenu.hide()
+						customMenu.hideMenus()
 					}
 				};
 

--- a/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
+++ b/Desktop/components/JASP/Widgets/DataTableViewColumnHeader.qml
@@ -76,7 +76,7 @@ Rectangle
 				var functionCall      = function (index)
 				{
 					colIcon.setColumnType(columnTypesModel.getType(index));
-					customMenu.hide()
+					customMenu.hideMenus()
 				}
 
 				var props = {

--- a/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
+++ b/Desktop/components/JASP/Widgets/FilterConstructor/JASPColumn.qml
@@ -151,7 +151,7 @@ Item
 				var functionCall      = function (index)
 				{
 					columnTypeUser = columnTypesModel.getType(index)
-					customMenu.hide()
+					customMenu.hideMenus()
 				}
 
 				var props = {

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -509,7 +509,7 @@ Item
 						var name		= customMenu.props['model'].getName(index);
 						var jsfunction	= customMenu.props['model'].getJSFunction(index);
 
-						customMenu.hide()
+						customMenu.hideMenus()
 
 						if (name === 'hasExportResults')				{ fileMenuModel.exportResultsInteractive();		return; }
 						if (name === 'hasRefreshAllAnalyses')			{ resultsJsInterface.refreshAllAnalyses();		return;	}

--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -151,6 +151,11 @@ Window
 			id:			customMenu
 			z:			5
 		}
+		CustomMenu
+		{
+			id:			customSubMenu
+			z:			6
+		}
 
 		FileMenu
 		{

--- a/Desktop/components/JASP/Widgets/MainWindow.qml
+++ b/Desktop/components/JASP/Widgets/MainWindow.qml
@@ -150,6 +150,12 @@ Window
 		{
 			id:			customMenu
 			z:			5
+			
+			function hideMenus() 
+			{
+				customMenu.hide();
+				customSubMenu.hide();
+			}
 		}
 		CustomMenu
 		{
@@ -239,7 +245,7 @@ Window
 			{
 				if(customMenu.visible)
 				{
-					customMenu.hide()
+					customMenu.hideMenus()
 					mouse.accepted = false;
 				}
 

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonBar.qml
@@ -177,7 +177,7 @@ FocusScope
 			modulesPlusButton.showPressed = false;
 			isFileMenuPressed             = false;
 			ribbonMenu.focusOut();
-			customMenu.hide()
+			customMenu.hideMenus()
 		}
 
 		anchors
@@ -227,7 +227,7 @@ FocusScope
 
 			fileMenuModel.visible = false;
 			isFileMenuPressed     = false;
-			customMenu.hide()
+			customMenu.hideMenus()
 			ribbonMenu.focusOut();
 		}
 

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -109,29 +109,34 @@ Item
 
 		var functionCall = function (index)
 		{
-			var analysisName  = customMenu.props['model'].getAnalysisFunction(index);
-			var analysisTitle = customMenu.props['model'].getAnalysisTitle(index);
-			var analysisQML   = customMenu.props['model'].getAnalysisQML(index);
-            
-			messages.log("showMyMenu() for " + ribbonButton.moduleName + " name " + analysisName + " title " + analysisTitle)
+			var menuModel	= customMenu.props['model']
+			var subMenuModel = menuModel.getSubMenu(index)
+			if (subMenuModel)
+				showMySubMenu(subMenuModel, index)
+			else
+			{
+				var analysisName  = menuModel.getAnalysisFunction(index);
+				var analysisTitle = menuModel.getAnalysisTitle(index);
+				var analysisQML   = menuModel.getAnalysisQML(index);
 
-			ribbonModel.analysisClicked(analysisName, analysisQML, analysisTitle, ribbonButton.moduleName)
-			customMenu.hide();
-			customMenu.focus = false;
+				messages.log("showMyMenu() for " + ribbonButton.moduleName + " name " + analysisName + " title " + analysisTitle)
+
+				ribbonModel.analysisClicked(analysisName, analysisQML, analysisTitle, ribbonButton.moduleName)
+				customMenu.hide();
+				customMenu.focus = false;
+			}
 		}
 
-		// Key Navigation with Up or Down. Only navigate valid analysis items
-		//	@index
-		//	@direction: +1 or -1
 		var navigateFunc = function (index, direction)
 		{
 			let nextIndex = mod(index + direction, customMenu.props['model'].rowCount());
+			let hasSubMenus = customMenu.hasSubMenus
 			while(true)
 			{
 				let name	  = customMenu.props['model'].getAnalysisFunction(nextIndex);
 				let isEnabled = customMenu.props['model'].isAnalysisEnabled(nextIndex);
 
-				if (name !== "" && name !== '???' && isEnabled)
+				if ((hasSubMenus || (name !== "" && name !== '???')) && isEnabled)
 					break;
 
 				nextIndex = mod(nextIndex + direction, customMenu.props['model'].rowCount());
@@ -154,9 +159,9 @@ Item
 		var props =
 		{
 			"model"					: ribbonButton.menu,
-
 			"functionCall"			: functionCall,
 			"hasIcons"				: ribbonButton.menu.hasIcons(),
+			"hasSubMenus"			: ribbonButton.menu.hasSubMenus(),
 			"navigateFunc"			: navigateFunc,
 			"parentNavigateFunc"	: parentNavigateFunc
 		};
@@ -165,6 +170,69 @@ Item
 
 		myMenuOpen = Qt.binding(function() { return customMenu.visible && customMenu.sourceItem == ribbonButton; });
 
+	}
+
+	function showMySubMenu(subMenu, menuIndex)
+	{
+
+		if (subMenu.rowCount() === 0)
+			return
+
+		var functionCall = function (index)
+		{
+			var menuModel		= customSubMenu.props['model']
+			var analysisName	= menuModel.getAnalysisFunction(index);
+			var analysisTitle	= menuModel.getAnalysisTitle(index);
+			var analysisQML		= menuModel.getAnalysisQML(index);
+
+			messages.log("showMyMenu() for " + ribbonButton.moduleName + " name " + analysisName + " title " + analysisTitle)
+
+			ribbonModel.analysisClicked(analysisName, analysisQML, analysisTitle, ribbonButton.moduleName)
+			customSubMenu.hide();
+			customSubMenu.focus = false;
+		}
+
+		// Key Navigation with Up or Down. Only navigate valid analysis items
+		//	@index
+		//	@direction: +1 or -1
+		var navigateFunc = function (index, direction)
+		{
+			let nextIndex = mod(index + direction, customSubMenu.props['model'].rowCount());
+			while(true)
+			{
+				let name	  = customSubMenu.props['model'].getAnalysisFunction(nextIndex);
+				let isEnabled = customSubMenu.props['model'].isAnalysisEnabled(nextIndex);
+
+				if (name !== "" && name !== '???' && isEnabled)
+					break;
+
+				nextIndex = mod(nextIndex + direction, customSubMenu.props['model'].rowCount());
+			}
+			return nextIndex;
+		}
+
+		// Forward navigation call to parent list
+		//	@index
+		//	@direction: +1 or -1
+		var parentNavigateFunc = function (direction)
+		{
+			customSubMenu.hide()
+			customMenu.forceActiveFocus();
+		}
+
+		var props =
+		{
+			"model"					: subMenu,
+			"functionCall"			: functionCall,
+			"hasIcons"				: subMenu.hasIcons(),
+			"navigateFunc"			: navigateFunc,
+			"parentNavigateFunc"	: parentNavigateFunc
+		};
+
+		let subItem = customMenu.currentMenuItem(menuIndex)
+		let offsetY = subItem.mapToItem(ribbonButton, 0, 0).y
+
+		customSubMenu.toggle(ribbonButton, props, customMenu.width, offsetY);
 	}
 
 	Rectangle

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -138,6 +138,7 @@ Item
 				let name	  = menuModel.getAnalysisFunction(nextIndex);
 				let isEnabled = menuModel.isAnalysisEnabled(nextIndex);
 
+				// If it is disabled, and not an anlysis entry, nor a group with a submenu: skip it
 				if ((hasSubMenus || (name !== "" && name !== '???')) && isEnabled)
 					break;
 

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -103,43 +103,45 @@ Item
 
 	function showMyMenu()
 	{
-
 		if (ribbonButton.menu.rowCount() <= 1)
 			return
 
 		var functionCall = function (index)
 		{
-			var menuModel	= customMenu.props['model']
-			var subMenuModel = menuModel.getSubMenu(index)
+			let menuModel	= customMenu.props['model']
+
+			if (index < 0 || index >= menuModel.rowCount())
+				return;
+
+			let subMenuModel = menuModel.getSubMenu(index)
 			if (subMenuModel)
 				showMySubMenu(subMenuModel, index)
 			else
 			{
-				var analysisName  = menuModel.getAnalysisFunction(index);
-				var analysisTitle = menuModel.getAnalysisTitle(index);
-				var analysisQML   = menuModel.getAnalysisQML(index);
-
-				messages.log("showMyMenu() for " + ribbonButton.moduleName + " name " + analysisName + " title " + analysisTitle)
-
-				ribbonModel.analysisClicked(analysisName, analysisQML, analysisTitle, ribbonButton.moduleName)
+				ribbonModel.analysisClicked(menuModel.getAnalysisFunction(index), menuModel.getAnalysisQML(index), menuModel.getAnalysisTitle(index), ribbonButton.moduleName)
 				customMenu.hide();
 				customMenu.focus = false;
 			}
 		}
 
+		// Key Navigation with Up or Down. Only navigate valid analysis items
+		//	@index
+		//	@direction: +1 or -1
 		var navigateFunc = function (index, direction)
 		{
-			let nextIndex = mod(index + direction, customMenu.props['model'].rowCount());
+			let menuModel	= customMenu.props['model']
+			let nextIndex = mod(index + direction, menuModel.rowCount());
 			let hasSubMenus = customMenu.hasSubMenus
+
 			while(true)
 			{
-				let name	  = customMenu.props['model'].getAnalysisFunction(nextIndex);
-				let isEnabled = customMenu.props['model'].isAnalysisEnabled(nextIndex);
+				let name	  = menuModel.getAnalysisFunction(nextIndex);
+				let isEnabled = menuModel.isAnalysisEnabled(nextIndex);
 
 				if ((hasSubMenus || (name !== "" && name !== '???')) && isEnabled)
 					break;
 
-				nextIndex = mod(nextIndex + direction, customMenu.props['model'].rowCount());
+				nextIndex = mod(nextIndex + direction, menuModel.rowCount());
 			}
 			return nextIndex;
 		}
@@ -149,11 +151,19 @@ Item
 		//	@direction: +1 or -1
 		var parentNavigateFunc = function (direction)
 		{
-			customMenu.hide()
-			jaspRibbons.forceActiveFocus();
-			jaspRibbons.navigateFunction(direction);
-			if (buttonList.currentItem)
-				buttonList.currentItem.showMyMenu();
+			let menuModel		= customMenu.props['model']
+			let subMenuModel	= subMenuModel = menuModel.getSubMenu(customMenu.currentIndex)
+
+			if (direction === 1 && subMenuModel)
+				showMySubMenu(subMenuModel, customMenu.currentIndex)
+			else
+			{
+				customMenu.hide()
+				jaspRibbons.forceActiveFocus();
+				jaspRibbons.navigateFunction(direction);
+				if (buttonList.currentItem)
+					buttonList.currentItem.showMyMenu();
+			}
 		}
 
 		var props =
@@ -174,20 +184,17 @@ Item
 
 	function showMySubMenu(subMenu, menuIndex)
 	{
-
 		if (subMenu.rowCount() === 0)
 			return
 
-		var functionCall = function (index)
+		var subMenuFunctionCall = function (index)
 		{
-			var menuModel		= customSubMenu.props['model']
-			var analysisName	= menuModel.getAnalysisFunction(index);
-			var analysisTitle	= menuModel.getAnalysisTitle(index);
-			var analysisQML		= menuModel.getAnalysisQML(index);
+			let subMenuModel	= customSubMenu.props['model']
 
-			messages.log("showMyMenu() for " + ribbonButton.moduleName + " name " + analysisName + " title " + analysisTitle)
+			if (index < 0 || index >= subMenuModel.rowCount())
+				return;
 
-			ribbonModel.analysisClicked(analysisName, analysisQML, analysisTitle, ribbonButton.moduleName)
+			ribbonModel.analysisClicked(subMenuModel.getAnalysisFunction(index), subMenuModel.getAnalysisQML(index), subMenuModel.getAnalysisTitle(index), ribbonButton.moduleName)
 			customSubMenu.hide();
 			customSubMenu.focus = false;
 		}
@@ -195,18 +202,22 @@ Item
 		// Key Navigation with Up or Down. Only navigate valid analysis items
 		//	@index
 		//	@direction: +1 or -1
-		var navigateFunc = function (index, direction)
+		var subMenuNavigateFunc = function (index, direction)
 		{
-			let nextIndex = mod(index + direction, customSubMenu.props['model'].rowCount());
+			let subMenuModel	= customSubMenu.props['model']
+			let nextIndex		= mod(index + direction, subMenuModel.rowCount());
+			let startIndex		= nextIndex
 			while(true)
 			{
-				let name	  = customSubMenu.props['model'].getAnalysisFunction(nextIndex);
-				let isEnabled = customSubMenu.props['model'].isAnalysisEnabled(nextIndex);
+				let name	  = subMenuModel.getAnalysisFunction(nextIndex);
+				let isEnabled = subMenuModel.isAnalysisEnabled(nextIndex);
 
 				if (name !== "" && name !== '???' && isEnabled)
 					break;
 
-				nextIndex = mod(nextIndex + direction, customSubMenu.props['model'].rowCount());
+				nextIndex = mod(nextIndex + direction,subMenuModel .rowCount());
+				if (nextIndex === startIndex)
+					break;
 			}
 			return nextIndex;
 		}
@@ -214,7 +225,7 @@ Item
 		// Forward navigation call to parent list
 		//	@index
 		//	@direction: +1 or -1
-		var parentNavigateFunc = function (direction)
+		var subMenuParentNavigateFunc = function (direction)
 		{
 			customSubMenu.hide()
 			customMenu.forceActiveFocus();
@@ -223,10 +234,10 @@ Item
 		var props =
 		{
 			"model"					: subMenu,
-			"functionCall"			: functionCall,
+			"functionCall"			: subMenuFunctionCall,
 			"hasIcons"				: subMenu.hasIcons(),
-			"navigateFunc"			: navigateFunc,
-			"parentNavigateFunc"	: parentNavigateFunc
+			"navigateFunc"			: subMenuNavigateFunc,
+			"parentNavigateFunc"	: subMenuParentNavigateFunc
 		};
 
 		let subItem = customMenu.currentMenuItem(menuIndex)

--- a/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/RibbonButton.qml
@@ -56,7 +56,7 @@ Item
 	{
 		if (event.key === Qt.Key_Escape)
 		{
-			customMenu.hide();
+			customMenu.hideMenus();
 		}
 		else if (event.key === Qt.Key_Return || event.key === Qt.Key_Space)
 		{
@@ -79,7 +79,7 @@ Item
 		if (!ribbonButton.focus)
 		{
 			myMenuOpen = false;
-			customMenu.hide();
+			customMenu.hideMenus();
 		}
 	}
 
@@ -87,14 +87,14 @@ Item
 	{
 		if (ribbonButton.menu.rowCount() === 0) //Probably special?
 		{
-			customMenu.hide()
+			customMenu.hideMenus()
             messages.log("startOrShowMenu() for " + ribbonButton.moduleName)
 			ribbonModel.analysisClicked("", "", "", ribbonButton.moduleName)
 
 		}
 		else if (ribbonButton.menu.rowCount() === 1)
 		{
-			customMenu.hide()
+			customMenu.hideMenus()
 			ribbonModel.analysisClicked(ribbonButton.menu.getFirstAnalysisFunction(), ribbonButton.menu.getFirstAnalysisQML(), ribbonButton.menu.getFirstAnalysisTitle(), ribbonButton.moduleName)
 		}
 		else
@@ -119,7 +119,7 @@ Item
 			else
 			{
 				ribbonModel.analysisClicked(menuModel.getAnalysisFunction(index), menuModel.getAnalysisQML(index), menuModel.getAnalysisTitle(index), ribbonButton.moduleName)
-				customMenu.hide();
+				customMenu.hideMenus();
 				customMenu.focus = false;
 			}
 		}
@@ -159,7 +159,7 @@ Item
 				showMySubMenu(subMenuModel, customMenu.currentIndex)
 			else
 			{
-				customMenu.hide()
+				customMenu.hideMenus()
 				jaspRibbons.forceActiveFocus();
 				jaspRibbons.navigateFunction(direction);
 				if (buttonList.currentItem)
@@ -372,7 +372,7 @@ Item
 				if (myMenuOpen)
 				{
 					ribbonButton.focus = false;
-					customMenu.hide();
+					customMenu.hideMenus();
 				}
 				else
 				{

--- a/Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
+++ b/Desktop/components/JASP/Widgets/Ribbon/Ribbons.qml
@@ -137,8 +137,8 @@ Item
 		ALTNavigation.strategy:				AssignmentStrategy.INDEXED
 		ALTNavigation.requestedPostfix:		"M"
 
-		onDragStarted:					customMenu.hide()
-		onMovementStarted:				customMenu.hide()
+		onDragStarted:					customMenu.hideMenus()
+		onMovementStarted:				customMenu.hideMenus()
 		Keys.onPressed: (event) =>
 		{
 			if (event.key === Qt.Key_Left || event.key === Qt.Key_Backtab)

--- a/Desktop/modules/description/description.cpp
+++ b/Desktop/modules/description/description.cpp
@@ -218,7 +218,7 @@ std::vector<AnalysisEntry*> Description::menuEntries() const
 			AnalysisEntry *analysisEntry = entry->convertToAnalysisEntry(requiresDataDef(), preloadData());
 			if (analysisEntry != nullptr)
 			{
-				if (analysisEntry->isGroupTitle() && previousEntry != nullptr && !previousEntry->isSeparator())
+				if (!useSubMenus() && analysisEntry->isGroupTitle() && previousEntry != nullptr && !previousEntry->isSeparator())
 					entries.push_back(new AnalysisEntry()); // Add a separator
 				entries.push_back(analysisEntry);
 				previousEntry = analysisEntry;
@@ -253,6 +253,14 @@ void Description::setAlwaysSaveState(bool newAlwaysSaveState)
 		return;
 	_alwaysSaveState = newAlwaysSaveState;
 	emit alwaysSaveStateChanged();
+}
+
+void Description::setUseSubMenus(bool useSubMenus)
+{
+	if (_useSubMenus == useSubMenus)
+		return;
+	_useSubMenus = useSubMenus;
+	emit useSubMenusChanged();
 }
 
 bool Description::neverSaveState() const

--- a/Desktop/modules/description/description.h
+++ b/Desktop/modules/description/description.h
@@ -40,6 +40,7 @@ class Description : public QQuickItem
 	Q_PROPERTY(bool						hasWrappers		READ hasWrappers		WRITE setHasWrappers		NOTIFY hasWrappersChanged		)
 	Q_PROPERTY(bool						alwaysSaveState	READ alwaysSaveState	WRITE setAlwaysSaveState	NOTIFY alwaysSaveStateChanged	)
 	Q_PROPERTY(bool						neverSaveState	READ neverSaveState		WRITE setNeverSaveState		NOTIFY neverSaveStateChanged	)
+	Q_PROPERTY(bool						useSubMenus		READ useSubMenus		WRITE setUseSubMenus		NOTIFY useSubMenusChanged		)
 
 public:
 	Description(QQuickItem *parent = nullptr);
@@ -63,6 +64,7 @@ public:
 	bool			hasWrappers()		const { return _hasWrappers;				}
 	bool			alwaysSaveState()	const;	
 	bool			neverSaveState()	const;
+	bool			useSubMenus()		const { return _useSubMenus;				}
 
 	void	addChild(	DescriptionChildBase * child);
 	void	removeChild(DescriptionChildBase * child);
@@ -72,7 +74,7 @@ public:
 
 	
 	
-	
+
 	
 public slots:
 	void setName(					QString						name			);
@@ -91,7 +93,8 @@ public slots:
 	void setHasWrappers(			bool						hasWrappers		);
 	void setNeverSaveState(			bool						newNeverSaveState);
 	void setAlwaysSaveState(		bool						newAlwaysSaveState);
-	
+	void setUseSubMenus(			bool						useSubMenus);
+
 signals:
 	void titleChanged(				QString						title			);
 	void iconChanged(				QString						icon			);
@@ -110,7 +113,8 @@ signals:
 	void childChanged();
 	void alwaysSaveStateChanged();
 	void neverSaveStateChanged();
-	
+	void useSubMenusChanged();
+
 private:
 	void					setUpDelayedUpdate();
 	void					connectChangesToDelay();
@@ -128,7 +132,8 @@ private:
 							_hasWrappers		= false,
 							_preloadData		= true,
 							_alwaysSaveState	= false,
-							_neverSaveState		= false;
+							_neverSaveState		= false,
+							_useSubMenus		= false;
 	DynamicModule		*	_dynMod				= nullptr;
 	QList<EntryBase*>		_entries;
 	QTimer					_timer;

--- a/Desktop/modules/dynamicmodule.cpp
+++ b/Desktop/modules/dynamicmodule.cpp
@@ -911,6 +911,11 @@ stringset DynamicModule::requiredModules() const
 	return out;
 }
 
+bool DynamicModule::useSubMenus() const
+{
+	return _description->useSubMenus();
+}
+
 QString DynamicModule::patchLibPathHelperFunc(QString libpath) {
 #ifdef __APPLE__
 	

--- a/Desktop/modules/dynamicmodule.h
+++ b/Desktop/modules/dynamicmodule.h
@@ -116,7 +116,7 @@ public:
 	std::string			modulePackage()		const { return _modulePackage;							}
 	bool				isCommon()			const { return _isCommon;								}
 	bool				hasWrappers()		const { return _hasWrappers;							}
-
+	bool				useSubMenus()		const;
 	bool				isDevMod()			const { return _isDeveloperMod;							}
 	bool				error()				const { return _status == moduleStatus::error;			}
 	bool				readyForUse()		const { return _status == moduleStatus::readyForUse;	}

--- a/Desktop/modules/menumodel.cpp
+++ b/Desktop/modules/menumodel.cpp
@@ -46,6 +46,7 @@ void MenuModel::_setEntries(const Modules::AnalysisEntries & entries)
 	_subMenus.clear();
 	if (_module && _module->useSubMenus() && !_isSubMenu)
 	{
+		// Keep only the main entries, and add submenus
 		Modules::AnalysisEntries mainEntries, subEntries;
 		QString currentGroupTitle;
 		// If the first items are not group items, then add them to the main menu.

--- a/Desktop/modules/menumodel.cpp
+++ b/Desktop/modules/menumodel.cpp
@@ -146,6 +146,9 @@ Modules::AnalysisEntry *MenuModel::getAnalysisEntry(const std::string& func)
 
 QVariant MenuModel::getSubMenu(int index) const
 {
+	if (index < 0 || index >= analysisEntries().size())
+		return QVariant();
+
 	QString title = getAnalysisTitle(index);
 	if (_subMenus.count(title))
 		return QVariant::fromValue(_subMenus.at(title));

--- a/Desktop/modules/menumodel.cpp
+++ b/Desktop/modules/menumodel.cpp
@@ -24,15 +24,77 @@
 MenuModel::MenuModel(RibbonButton *parent, Modules::DynamicModule * module)
 	: QAbstractListModel(parent), _ribbonButton(parent), _module(module)
 {
+	_setEntries(module->menu());
 
+	connect(module, &Modules::DynamicModule::descriptionReloaded, this, [this](Modules::DynamicModule * module) {_setEntries(module->menu()); });
 }
 
-MenuModel::MenuModel(RibbonButton * parent, Modules::AnalysisEntries * entries)
-: QAbstractListModel(parent), _ribbonButton(parent), _entries(entries)
+MenuModel::MenuModel(RibbonButton * parent, const Modules::AnalysisEntries & entries)
+: QAbstractListModel(parent), _ribbonButton(parent)
 {
-	for(const auto * entry : *_entries)
+	_setEntries(entries);
+}
+
+MenuModel::MenuModel(RibbonButton *parent, Modules::DynamicModule * module, const Modules::AnalysisEntries & entries, bool isSubMenu)
+	: QAbstractListModel(parent), _ribbonButton(parent), _module(module), _isSubMenu(isSubMenu)
+{
+	_setEntries(entries);
+}
+
+void MenuModel::_setEntries(const Modules::AnalysisEntries & entries)
+{
+	_subMenus.clear();
+	if (_module && _module->useSubMenus() && !_isSubMenu)
+	{
+		Modules::AnalysisEntries mainEntries, subEntries;
+		QString currentGroupTitle;
+		// If the first items are not group items, then add them to the main menu.
+		// When a group item is found, all items afterwards are set in a submenu, until another group item is found.
+		for(auto * entry : entries)
+		{
+			if (entry->isGroupTitle())
+			{
+				mainEntries.push_back(entry);	// Add the Group to the main menu
+				if (!currentGroupTitle.isEmpty())
+				{
+					// The group is complete: add a subMenu
+					_subMenus[currentGroupTitle] = new MenuModel(_ribbonButton, _module, subEntries, true);
+					subEntries.clear();
+				}
+				currentGroupTitle = tq(entry->title());
+			}
+			else if (currentGroupTitle.isEmpty())
+				mainEntries.push_back(entry); // No group item found yet: add it to the main menu.
+			else
+				subEntries.push_back(entry);
+		}
+		_entries = mainEntries;
+
+		if (!subEntries.empty() && !currentGroupTitle.isEmpty())
+			_subMenus[currentGroupTitle] = new MenuModel(_ribbonButton, _module, subEntries, true);
+	}
+	else
+		_entries = entries;
+
+	_hasIcons = false;
+	for(const auto * entry : _entries)
 		if(entry->icon() != "")
 			_hasIcons = true;
+}
+
+
+void MenuModel::setDynamicModule(Modules::DynamicModule *module)
+{
+	if (_module == module)
+		return;
+
+	beginResetModel();
+
+	_module = module;
+	_setEntries(module->menu());
+	connect(module, &Modules::DynamicModule::descriptionReloaded, this, [this](Modules::DynamicModule * module) {_setEntries(module->menu()); });
+
+	endResetModel();
 }
 
 QVariant MenuModel::data(const QModelIndex &index, int role) const
@@ -82,9 +144,18 @@ Modules::AnalysisEntry *MenuModel::getAnalysisEntry(const std::string& func)
 	return nullptr;
 }
 
+QVariant MenuModel::getSubMenu(int index) const
+{
+	QString title = getAnalysisTitle(index);
+	if (_subMenus.count(title))
+		return QVariant::fromValue(_subMenus.at(title));
+
+	return QVariant();
+}
+
 const std::vector<Modules::AnalysisEntry*> &	MenuModel::analysisEntries() const
 {
-	return _module ? _module->menu() : *_entries;
+	return _entries;
 }
 
 bool MenuModel::isAnalysisEnabled(int index)

--- a/Desktop/modules/menumodel.h
+++ b/Desktop/modules/menumodel.h
@@ -46,13 +46,8 @@ public:
 	};
 
 	MenuModel(RibbonButton * parent, Modules::DynamicModule		* module);
-	MenuModel(RibbonButton * parent, Modules::AnalysisEntries	* entries = new Modules::AnalysisEntries()); //The default new entries is to make sure that analysisEntries() has something to return for special buttons without their own entries
-
-	~MenuModel()
-	{
-		delete _entries;
-		_entries = nullptr;
-	}
+	MenuModel(RibbonButton * parent, Modules::DynamicModule		* module, const Modules::AnalysisEntries	& entries, bool isSubMenu);
+	MenuModel(RibbonButton * parent, const Modules::AnalysisEntries	& entries = Modules::AnalysisEntries()); //The default new entries is to make sure that analysisEntries() has something to return for special buttons without their own entries
 
 	int										rowCount(const QModelIndex &parent = QModelIndex())			const override	{	return analysisEntries().size();	}
 	QVariant								data(const QModelIndex &index, int role = Qt::DisplayRole)	const override;
@@ -69,17 +64,25 @@ public:
 	Q_INVOKABLE QString						getAnalysisFunction(int index)								const			{	return QString::fromStdString(analysisEntries().at(index)->function());	}
 	Q_INVOKABLE QString						getAnalysisTitle(	int index)								const			{	return QString::fromStdString(analysisEntries().at(index)->title());	}
 	Q_INVOKABLE QString						getAnalysisQML(		int index)								const			{	return QString::fromStdString(analysisEntries().at(index)->qml());	}
+	Q_INVOKABLE QVariant					getSubMenu(			int index)								const;
 	Q_INVOKABLE bool						iconSmall(			int index)								const			{	return analysisEntries().at(index)->smallIcon();	}
 	Q_INVOKABLE bool						isAnalysisEnabled(	int index);
-	void									setDynamicModule(Modules::DynamicModule * module)							{ beginResetModel(); _module = module; endResetModel(); }
+	void									setDynamicModule(Modules::DynamicModule * module);
 
-	Q_INVOKABLE bool						hasIcons()													const			{	return _hasIcons; }
+	Q_INVOKABLE bool						hasIcons()													const			{	return _hasIcons;	}
+	Q_INVOKABLE bool						hasSubMenus()												const			{	return _subMenus.size() > 0; }
+
 
 private:
+	void									_setEntries(const Modules::AnalysisEntries & entries);
+
+
 	RibbonButton				*	_ribbonButton	= nullptr;
 	Modules::DynamicModule		*	_module			= nullptr;
-	Modules::AnalysisEntries	*	_entries		= nullptr;		//For special buttons
+	Modules::AnalysisEntries		_entries;		//For special buttons
 	bool							_hasIcons		= false;
+	std::map<QString, MenuModel *>	_subMenus;
+	bool							_isSubMenu		= false;
 };
 
 #endif

--- a/Desktop/modules/menumodel.h
+++ b/Desktop/modules/menumodel.h
@@ -79,7 +79,7 @@ private:
 
 	RibbonButton				*	_ribbonButton	= nullptr;
 	Modules::DynamicModule		*	_module			= nullptr;
-	Modules::AnalysisEntries		_entries;		//For special buttons
+	Modules::AnalysisEntries		_entries;
 	bool							_hasIcons		= false;
 	std::map<QString, MenuModel *>	_subMenus;
 	bool							_isSubMenu		= false;

--- a/Desktop/modules/ribbonbutton.cpp
+++ b/Desktop/modules/ribbonbutton.cpp
@@ -66,7 +66,7 @@ RibbonButton::RibbonButton(QObject *parent,	std::string name, std::function<std:
 RibbonButton::RibbonButton(QObject *parent, std::string name,	std::function<std::string()> titleF, std::string icon, Modules::AnalysisEntries * funcEntries, std::function<QString()> toolTipF, bool enabled, bool remember, bool defaultActiveBinding)
 	: QObject(parent), _enabled(enabled), _defaultActiveBinding(defaultActiveBinding), _remember(remember), _special(true), _module(nullptr)
 {
-	_menuModel = new MenuModel(this, funcEntries);
+	_menuModel = new MenuModel(this, *funcEntries);
 
 	setRequiresData(AnalysisEntry::requiresDataEntries(*funcEntries));
 	setModuleName(name);

--- a/Desktop/modules/ribbonbutton.h
+++ b/Desktop/modules/ribbonbutton.h
@@ -50,7 +50,7 @@ class RibbonButton : public QObject
 	Q_PROPERTY(bool		ready			READ ready				WRITE setReady				NOTIFY readyChanged			)
 	Q_PROPERTY(bool		error			READ error				WRITE setError				NOTIFY errorChanged			)
 	Q_PROPERTY(bool		remember		READ remember			WRITE setRemember			NOTIFY rememberChanged		)
-	Q_PROPERTY(bool separator READ separator WRITE setSeparator NOTIFY separatorChanged)
+	Q_PROPERTY(bool		separator		READ separator			WRITE setSeparator			NOTIFY separatorChanged)
 
 public:
 

--- a/QMLComponents/components/JASP/Controls/SortMenuButton.qml
+++ b/QMLComponents/components/JASP/Controls/SortMenuButton.qml
@@ -23,7 +23,7 @@ MenuButton
 		var functionCall = function (index)
 		{
 			sortMenuModel.clickSortItem(index)
-			customMenu.hide()
+			customMenu.hideMenus()
 		}
 
 		var props = {

--- a/QMLComponents/components/JASP/Controls/VariablesList.qml
+++ b/QMLComponents/components/JASP/Controls/VariablesList.qml
@@ -577,7 +577,7 @@ VariablesListBase
 						var functionCall = function (index)
 						{
 							variablesList.setVariableType(itemRectangle.rank, variablesList.allowedTypesModel.getType(index))
-							customMenu.hide()
+							customMenu.hideMenus()
 						}
 
 						var props =


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3145

If the number of analyses for one module is big, it can be interesting to have the possibility to have sub-menus.
This is the case for the Distributions module.
For this I have added a the 'useSubMenus` property in Description.qml: if this property is set to true, all Group Title items in Description.qml becomes main menus of all the following analysis items, until the next Group Title item.

To test it, just use one Module with Group Titles and set the `useSubMenus` to true.
