### PR TITLE
chore: don't reconfigure dependencies every time

### DIFF
--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -56,7 +56,6 @@ if(USE_CONAN)
     else()
       message(CHECK_FAIL "build freexl failed")
     endif()
-    file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/_deps/)
     
     execute_process(
       COMMAND_ECHO STDOUT
@@ -79,7 +78,6 @@ if(USE_CONAN)
       COMMAND_ECHO STDOUT
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       COMMAND zsh -c -l "export CC=\"\"; export CCX=\"\"; conan create ${freexl_SOURCE_DIR}/freexl --version=${FREEXL_VERSION} -s build_type=${CMAKE_BUILD_TYPE} -s os.version=${CMAKE_OSX_DEPLOYMENT_TARGET} --build=missing --test-missing")    
-    file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/_deps/)    
     
     execute_process(
         COMMAND_ECHO STDOUT

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -56,7 +56,7 @@ if(USE_CONAN)
     else()
       message(CHECK_FAIL "build freexl failed")
     endif()
-    
+        
     execute_process(
       COMMAND_ECHO STDOUT
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -66,6 +66,8 @@ if(USE_CONAN)
       -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
       -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing)
   
+    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES _deps)
+    
       # configure conan for apple
   elseif(APPLE)
 
@@ -97,7 +99,8 @@ if(USE_CONAN)
   endif()
 
   include(${CMAKE_BINARY_DIR}/_conan_build/conan_toolchain.cmake)
-
+  
+  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES _deps)
 endif()
 
 list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -614,7 +614,7 @@ if(APPLE)
   set_property(
     DIRECTORY
     APPEND
-    PROPERTY ADDITIONAL_CLEAN_FILES ${R_FRAMEWORK_PATH})
+    PROPERTY ADDITIONAL_CLEAN_FILES ${R_FRAMEWORK_PATH}/R.framework)
 
   message(CHECK_START "Checking for 'R.framework'")
   find_library(
@@ -955,6 +955,9 @@ message(STATUS "RENV_PATH              = ${RENV_PATH}")
 message(STATUS "RCPP_PATH              = ${RCPP_PATH}")
 message(STATUS "RINSIDE_PATH           = ${RINSIDE_PATH}")
 
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES _cache)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES ${R_CPP_INCLUDES_LIBRARY})
+
 # if(NOT EXISTS ${RENV_PATH})
 #     message(FATAL_ERROR "'renv' installation has failed!")
 # endif()
@@ -1035,7 +1038,7 @@ if(WIN32)
   else()
     message(CHECK_FAIL "failed")
   endif()
-
+  
 elseif(APPLE)
 
   # ----- Downloading and Building jags


### PR DESCRIPTION
On Windows cmake will reconfigure JAGS and freexl every time because '_deps' dir was removed after run conan command.The downside of doing this is that when switching branches locally or running configuration commands, everything has to be downloaded and rebuilt, increasing configuration time.

I'm not sure the impact was but we set that 10 months ago . maybe @RensDofferhoff know?

