### PR TITLE
Look at the modules requested before trying to load all analyses

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -410,7 +410,7 @@ void Analyses::setAnalysesUserData(Json::Value userData)
 
 void Analyses::loadAnalysesFromDatasetPackage(bool & errorFound, stringstream & errorMsg, RibbonModel * ribbonModel)
 {
-	if (DataSetPackage::pkg()->hasAnalyses())
+	if (DataSetPackage::pkg()->hasAnalysesData())
 	{
 		Json::Value analysesData = DataSetPackage::pkg()->analysesData();
 		
@@ -445,6 +445,32 @@ void Analyses::loadAnalysesFromJaspFileJson(const Json::Value & analysesDataList
 	stringstream	corruptionStrings;
 
 	Log::log() << "Loading analyses from jasp-file, entering loop." << std::endl;
+	const auto & _installed = Modules::DynamicModules::dynMods()->moduleNames();
+	stringset	modules, 
+				missing, 
+				installed(_installed.begin(), _installed.end());
+	
+	for (const Json::Value & analysisData : analysesDataList)
+		if(analysisData.isMember("dynamicModule"))
+		{
+			const auto & module = analysisData["dynamicModule"]["moduleName"].asString();
+			modules.insert(module);
+			
+			if(!installed.count(module))
+				missing.insert(module);
+		}
+	
+	if(missing.size() > 0)
+	{
+		errorFound = true;
+		errorMsg << "Missing modules:";
+		for(auto & n : missing)
+			errorMsg << " " << n;
+		errorMsg << "\n";
+		
+		emit suggestModulesInstall(tql(modules));
+	}
+	
 	
 	//There is no point trying to show progress here because qml is not updated while this function runs...
 	for (const Json::Value & analysisData : analysesDataList)

--- a/Desktop/analysis/analyses.h
+++ b/Desktop/analysis/analyses.h
@@ -172,6 +172,8 @@ signals:
 	bool developerMode();
 	void setResultsMeta(QString json);
 	void moveAnalyses(quint64 fromId, quint64 toId);
+	
+	void suggestModulesInstall(QStringList);
 
 	Column *			requestComputedColumnCreation(		const std::string & columnName, Analysis *source);
 	bool				requestColumnCreation(				const std::string & columnName, Analysis *source, columnType type);

--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -189,18 +189,17 @@ FocusScope
 				}
 
 
-				property bool	downloadInProgress: false;
-				property bool	installInProgress: false;
+				property bool		downloadInProgress: false;
+				property bool		installInProgress: false;
 				property int		downloadProgress;
 				property int		downloadTotal;
 				property var		currentDownloadRequest: null;
-
-                property bool    isInitiatingDownload: false
-                property var     downloadQueue: []
-                property bool    isProcessingQueue: false
-                property int     batchTotal: 0
-                property int     batchCurrent: 0
-                property string  currentModuleName: ""
+                property bool		isInitiatingDownload: false
+                property var		downloadQueue: []
+                property bool		isProcessingQueue: false
+                property int		batchTotal: 0
+                property int		batchCurrent: 0
+                property string		currentModuleName: ""
 
                 function triggerNextDownload() {
                     if (isInitiatingDownload || downloadInProgress || moduleLibrary.isInstalling) { //To many double triggers of signals to guard against
@@ -232,6 +231,15 @@ FocusScope
                         }
                     }
                 }
+				
+				Connections
+				{
+					target:		analyses
+					
+					function onSuggestModulesInstall(names)
+					{
+						runJavaScript("???");
+					}
 
 				webChannel.registeredObjects:	[ moduleStoreWebChannel ]
 

--- a/Desktop/data/datasetpackage.h
+++ b/Desktop/data/datasetpackage.h
@@ -150,7 +150,7 @@ public:
 				QString				description()						const;
 				QString				currentFile()						const	{ return _currentFile;						 }
 				QString				autoSavedFileName()					const;
-				bool				hasAnalyses()						const	{ return _analysesData.size() > 0;				}
+				bool				hasAnalysesData()						const	{ return _analysesData.size() > 0;				}
 				bool				synchingData()						const	{ return _synchingData;								}
 				std::string			dataFilePath()						const	{ return _dataSet ? _dataSet->dataFilePath() : "";  }
 				bool				dataFileCanHaveLabels()				const;


### PR DESCRIPTION
Send out a signal that is caught in ModulesMenu.qml to show and select the missing modules That last part is still missing however

Belongs with https://github.com/jasp-stats/INTERNAL-jasp/issues/3159 to try and improve the handling of missing modules

