### PR TITLE
When terms are changed, TextArea should reset its boundValue

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolrlangtextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolrlangtextarea.cpp
@@ -51,6 +51,11 @@ void BoundControlRlangTextArea::bindTo(const Json::Value &value)
 
 }
 
+void BoundControlRlangTextArea::resetBoundValue()
+{
+	_setBoundValues(false);
+}
+
 Json::Value BoundControlRlangTextArea::createJson() const
 {
 	Json::Value result;
@@ -160,11 +165,13 @@ QString BoundControlRlangTextArea::rScriptDoneHandler(const QString & result)
 	return QString();
 }
 
-void BoundControlRlangTextArea::_setBoundValues()
+void BoundControlRlangTextArea::_setBoundValues(bool setModel)
 {
 	Json::Value boundValue(Json::objectValue);
 
-	boundValue["modelOriginal"] = _textArea->text().toStdString();
+	std::string text = _textArea->text().toStdString();
+
+	boundValue["modelOriginal"] = text;
 	boundValue["model"]			= _textEncoded.toStdString();
 
 	Json::Value columns(Json::arrayValue),
@@ -178,7 +185,7 @@ void BoundControlRlangTextArea::_setBoundValues()
 		value.append(column);
 	}
 
-	if (_textArea->model())
+	if (setModel && _textArea->model())
 		_textArea->model()->initTerms(terms);
 	boundValue["columns"]	= columns;
 	boundValue["value"]		= value;

--- a/QMLComponents/boundcontrols/boundcontrolrlangtextarea.h
+++ b/QMLComponents/boundcontrols/boundcontrolrlangtextarea.h
@@ -32,6 +32,7 @@ public:
 	bool		isJsonValid(const Json::Value& optionValue)		const	override;
 	Json::Value	createJson()									const	override;
 	void		bindTo(const Json::Value &value)						override;
+	void		resetBoundValue()										override;
 
 	void		checkSyntax()											override;
 	QString		rScriptDoneHandler(const QString &result)				override;
@@ -39,7 +40,7 @@ public:
 protected:
 	RLangType								_langType				= RLangType::Lavaan;
 	const char *							_checkSyntaxRFunctionName();
-	void									_setBoundValues();
+	void									_setBoundValues(bool setModel = true);
 
 	RSyntaxHighlighter*						_rLangHighlighter		= nullptr;
 

--- a/QMLComponents/boundcontrols/boundcontroltextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontroltextarea.cpp
@@ -31,6 +31,11 @@ void BoundControlTextArea::bindTo(const Json::Value &value)
 	_textArea->setText(tq(value.asString()));
 }
 
+void BoundControlTextArea::resetBoundValue()
+{
+	setBoundValue(_textArea->text().toStdString());
+}
+
 bool BoundControlTextArea::isJsonValid(const Json::Value &optionValue) const
 {
 	return optionValue.type() == Json::stringValue;

--- a/QMLComponents/boundcontrols/boundcontroltextarea.h
+++ b/QMLComponents/boundcontrols/boundcontroltextarea.h
@@ -33,6 +33,7 @@ public:
 	bool					isJsonValid(const Json::Value& optionValue) const	override;
 	Json::Value				createJson()								const	override;
 	void					bindTo(const Json::Value& value)					override;
+	void					resetBoundValue()									override;
 
 	virtual	void			checkSyntax();
 	virtual QString			rScriptDoneHandler(const QString &result)	{ throw std::runtime_error("runRScript done but handler not implemented!\nImplement an override for RScriptDoneHandler!\nResult was: " + result.toStdString()); };

--- a/QMLComponents/components/JASP/Controls/TextArea.qml
+++ b/QMLComponents/components/JASP/Controls/TextArea.qml
@@ -13,18 +13,18 @@ TextAreaBase
 	implicitWidth:		width
 	focusIndicator:		flickableRectangle
 	innerControl:		control
+	infoText:			applyScriptInfo
+
 	
 	property alias	control				: control
 	property alias	wrapMode			: control.wrapMode
 	property alias	text				: control.text
-	property string applyScriptInfo		: Qt.platform.os == "osx" ? qsTr("\u2318 + Enter to apply") : qsTr("Ctrl + Enter to apply")
-	property alias  infoText			: infoText.text
+	property string applyScriptInfo		: Qt.platform.os === "osx" ? qsTr("\u2318 + Enter to apply") : qsTr("Ctrl + Enter to apply")
 	property alias  font				: control.font
 	property alias  textDocument		: control.textDocument
 	property bool   trim				: false
 	property var    modelParameterView	: null
 	property string separator			: "\n"
-	property var	separators			: []
 	property alias	radius				: flickableRectangle.radius
 	property alias	placeholderText		: control.placeholderText
 	property var	undoModel
@@ -208,6 +208,7 @@ TextAreaBase
 	Text
 	{
 		id:						infoText
+		text:					textArea.infoText
 		z:						2
 		anchors.bottom:			parent.bottom
 		anchors.right:			parent.right
@@ -216,7 +217,6 @@ TextAreaBase
 		rightPadding:			leftPadding
 		bottomPadding:			3 * preferencesModel.uiScale
 		topPadding:				bottomPadding
-		text:					textArea.applyScriptInfo
 		font:					jaspTheme.font
 		horizontalAlignment:	Text.AlignHCenter
 		verticalAlignment:		Text.AlignVCenter

--- a/QMLComponents/controls/textareabase.cpp
+++ b/QMLComponents/controls/textareabase.cpp
@@ -80,15 +80,6 @@ void TextAreaBase::setUp()
 
 	JASPListControl::setUp();
 
-	QList<QVariant> separators = property("separators").toList();
-	if (separators.isEmpty())
-		_separators.push_back(property("separator").toString());
-	else
-	{
-		for (QVariant& separator : separators)
-			_separators.push_back(separator.toString());
-	}
-
 	//If "rowCount" changes on VariableInfo it means a column has been added or removed, this means the model should be reencoded and checked
 	//Fixes https://github.com/jasp-stats/jasp-issues/issues/2462
 	connect(VariableInfo::info(),	&VariableInfo::rowCountChanged,		this,		&TextAreaBase::checkSyntaxMaybeHandler);
@@ -103,12 +94,12 @@ void TextAreaBase::rScriptDoneHandler(const QString & result)
 	if (error.isEmpty())
 	{
 		setHasScriptError(false);
-		setProperty("infoText", tr("Model applied"));
+		setInfoText(tr("Model applied"));
 	}
 	else
 	{
 		setHasScriptError(true);
-		setProperty("infoText", result);
+		setInfoText(result);
 	}
 }
 
@@ -126,8 +117,8 @@ void TextAreaBase::termsChangedHandler()
 {
 	JASPListControl::termsChangedHandler();
 
-	if ((_textType == TextType::TextTypeLavaan || _textType == TextType::TextTypeMetaSem || _textType == TextType::TextTypeCSem) && form() && initialized())
-		form()->refreshAnalysis();
+	if (initialized())
+		resetBoundValue();
 }
 
 void TextAreaBase::_setInitialized(const Json::Value &value)

--- a/QMLComponents/controls/textareabase.h
+++ b/QMLComponents/controls/textareabase.h
@@ -36,11 +36,14 @@ class TextAreaBase : public JASPListControl, public BoundControl
 	Q_OBJECT
 	QML_ELEMENT
 
+	Q_PROPERTY( QString		infoText			READ infoText				WRITE setInfoText			NOTIFY infoTextChanged							)
 	Q_PROPERTY( TextType	textType			READ textType				WRITE setTextType			NOTIFY textTypeChanged							)
 	Q_PROPERTY( bool		hasScriptError		READ hasScriptError			WRITE setHasScriptError		NOTIFY hasScriptErrorChanged					)
 	Q_PROPERTY( bool		autoCheckSyntax		READ autoCheckSyntax		WRITE setAutoCheckSyntax	NOTIFY autoCheckSyntaxChanged					)
 	Q_PROPERTY( bool		checkSyntax			READ checkSyntax			WRITE setCheckSyntax		NOTIFY checkSyntaxChanged						)
 	Q_PROPERTY( QString		variableSeparator	READ variableSeparator		WRITE setVariableSeparator	NOTIFY variableSeparatorChanged					)
+	Q_PROPERTY( QStringList	separators			READ separators				WRITE setSeparators			NOTIFY separatorsChanged						)
+
 
 public:
 	TextAreaBase(QQuickItem* parent = nullptr);
@@ -69,8 +72,9 @@ public:
 
 	TextType					textType()									const				{ return _textType;										}
 	bool						hasScriptError()							const				{ return _hasScriptError;								}
-	const QList<QString>&		separators()								const				{ return _separators;									}
+	const QStringList		&	separators()								const				{ return _separators;									}
 	QString						variableSeparator()							const				{ return _variableSeparator;							}
+	const QString			&	infoText()									const				{ return _infoText;										}
 	QString						text();
 	void						setText(const QString& text);
 
@@ -84,6 +88,8 @@ public slots:
 	GENERIC_SET_FUNCTION(AutoCheckSyntax,		_autoCheckSyntax,		autoCheckSyntaxChanged,		bool		)
 	GENERIC_SET_FUNCTION(CheckSyntax,			_checkSyntax,			checkSyntaxChanged,			bool		)
 	GENERIC_SET_FUNCTION(VariableSeparator,		_variableSeparator,		variableSeparatorChanged,	QString		)
+	GENERIC_SET_FUNCTION(InfoText,				_infoText,				infoTextChanged,			QString		)
+	GENERIC_SET_FUNCTION(Separators,			_separators,			separatorsChanged,			QStringList	)
 
 	void	checkSyntaxHandler()		{ if(_checkSyntax)		_boundControl->checkSyntax();		}
 	void	checkSyntaxMaybeHandler()	{ if(_autoCheckSyntax)	checkSyntaxHandler();				}
@@ -96,6 +102,8 @@ signals:
 	void	autoCheckSyntaxChanged();
 	void	checkSyntaxChanged();
 	void	variableSeparatorChanged();
+	void	infoTextChanged();
+	void	separatorsChanged();
 
 protected slots:
 	void	termsChangedHandler()		override;
@@ -108,9 +116,10 @@ protected:
 	bool						_hasScriptError			= false,
 								_autoCheckSyntax		= true,
 								_checkSyntax			= true;
-	QString						_variableSeparator		= "_";
-	QList<QString>				_separators;
-	
+	QString						_variableSeparator		= "_",
+								_infoText;
+	QStringList					_separators;
+
 	ListModelTermsAvailable*	_model					= nullptr;
 };
 


### PR DESCRIPTION
In SEM, the analyses are unnecessarily refreshed when the dataset is changed or when a tab is added.
This is due to the fact that when a model changes its terms, it calls the termsChanged signal so that controls reset their bound values (and change some properties in case). For TextArea, instead of resetting the BoundValues, the whole analysis is refreshed: this does the work, but can be quite expensive. So instead of refreshing the analysis, just reset the bound values.

Also the `infoText` and the `separators` are set as property in TextAreaBase, instead of defining them in QML.