### PR TITLE
Start utility engine slightly more on demand

### DIFF
--- a/Desktop/components/JASP/Widgets/ModulesMenu.qml
+++ b/Desktop/components/JASP/Widgets/ModulesMenu.qml
@@ -17,8 +17,15 @@ FocusScope
 
 	property bool opened: false //should be from some model
 	property int currentIndex: preferencesModel.developerMode ? -3 : -1  // -2, -3 denote install module and developer mode buttons
+	
+	onVisibleChanged: engineSync.activateUtilEngine = visible
 
-	onOpenedChanged: if(!opened) ribbonModel.highlightedModuleIndex = -1; else forceActiveFocus();
+	onOpenedChanged: {
+		
+		if(!opened) ribbonModel.highlightedModuleIndex = -1; else forceActiveFocus();
+		
+		
+	}
 
 	Keys.onEscapePressed:	closeAndFocusRibbon();
 	Keys.onRightPressed:	closeAndFocusRibbon();

--- a/Desktop/engine/enginesync.cpp
+++ b/Desktop/engine/enginesync.cpp
@@ -130,12 +130,15 @@ EngineSync::~EngineSync()
 
 int EngineSync::rowCount(const QModelIndex &) const
 {
-	return _engines.size();
+	return _engines.size() + int(_rCmder != nullptr);
 }
 
 std::vector<EngineRepresentation*>  EngineSync::orderedEngines() const
 {
 	std::vector<EngineRepresentation*> ordered(_engines.begin(), _engines.end());
+	
+	if(_rCmder)
+		ordered.push_back(_rCmder);
 
 	std::sort(ordered.begin(), ordered.end(), [](EngineRepresentation * l, EngineRepresentation * r) { return l->channelNumber() < r->channelNumber(); });
 
@@ -430,8 +433,10 @@ void EngineSync::process()
         if(_rCmder->module() != "" && !_rCmder->moduleLoaded() && !_rCmder->moduleLoading())
             _rCmder->moduleLoad();
     }
-    else {
-        createRCmdEngine(); //just create this by default to run certain bits of utility like module install/remove
+    else 
+	{
+		if(_activateUtilEngine)
+			createRCmdEngine(); //Dont just create this by default because it causes crashes on waking from long sleeps...
     }
 	
 	restartKilledAndStoppedEngines();
@@ -1437,19 +1442,22 @@ void EngineSync::destroyEngine(EngineRepresentation * engine)
 		});
 	}
 
-	if(engine->module() != "")	_moduleEngines.erase(engine->module());
-	else
+	if(engine != _rCmder)
 	{
-		std::string modName = "";
-
-		for(const auto & nameEngine : _moduleEngines)
-			if(nameEngine.second == engine)
-				modName = nameEngine.first;
-
-		_moduleEngines.erase(modName);
+		if(engine->module() != "")	_moduleEngines.erase(engine->module());
+		else
+		{
+			std::string modName = "";
+	
+			for(const auto & nameEngine : _moduleEngines)
+				if(nameEngine.second == engine)
+					modName = nameEngine.first;
+	
+			_moduleEngines.erase(modName);
+		}
+	
+		_engines.erase(engine);
 	}
-
-	_engines.erase(engine);
 
 	delete engine;
 
@@ -1468,4 +1476,21 @@ void EngineSync::stopAndDestroyEngine(EngineRepresentation * engine)
 {
 	engine->shutEngineDown();
 	destroyEngine(engine);
+}
+
+bool EngineSync::activateUtilEngine() const
+{
+	return _activateUtilEngine;
+}
+
+void EngineSync::setActivateUtilEngine(bool newActivateUtilEngine)
+{
+	if (_activateUtilEngine == newActivateUtilEngine)
+		return;
+	
+	_activateUtilEngine = newActivateUtilEngine;
+	emit activateUtilEngineChanged();
+	
+	
+	
 }

--- a/Desktop/engine/enginesync.h
+++ b/Desktop/engine/enginesync.h
@@ -33,26 +33,35 @@ class EngineSync : public QAbstractListModel
 {
 	Q_OBJECT
 	
+	Q_PROPERTY(bool activateUtilEngine	READ activateUtilEngine WRITE setActivateUtilEngine NOTIFY activateUtilEngineChanged)
+	
 public:
-
-	EngineSync(QObject *parent);
-	~EngineSync();
-
-	void start();
-	void killProcessTimer();
-	bool allEnginesInitializing(std::set<EngineRepresentation *> these = {}); ///< If `these` isn't filled all engines are checked
-
-	static EngineSync * singleton() { return _singleton; }
-
-    EngineRepresentation *	createNewEngine(bool addToEngines = true, int overrideChannel = -1, bool privileged = false);
+							EngineSync(const EngineSync &)	= delete;
+							EngineSync(EngineSync &&)		= delete;
+	EngineSync				&operator=(const EngineSync &)	= delete;
+	EngineSync				&operator=(EngineSync &&)		= delete;
+	
+							EngineSync(QObject *parent);
+							~EngineSync();
+	
+	void					start();
+	void					killProcessTimer();
+	bool					allEnginesInitializing(std::set<EngineRepresentation *> these =	{}); ///< If `these` isn't filled all engines are checked
+	
+	static EngineSync	*	singleton() { return _singleton; }
+	
+	EngineRepresentation *	createNewEngine(bool addToEngines = true,  int overrideChannel = -1, bool privileged = false);
 	EngineRepresentation *	createRCmdEngine();
+	
+	int						rowCount(const QModelIndex & = QModelIndex()) const override;
+	QVariant				data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+	QHash<int, QByteArray>	roleNames() const override;
+	
+	std::string				currentStateForDebug() const;
 
-	int						rowCount(const QModelIndex & = QModelIndex())				const override;
-	QVariant				data(const QModelIndex &index, int role = Qt::DisplayRole)	const override;
-	QHash<int, QByteArray>	roleNames()													const override;
-
-	std::string	currentStateForDebug() const;
-
+	bool					activateUtilEngine() const;
+	void					setActivateUtilEngine(bool newActivateUtilEngine);
+	
 public slots:
 	void		destroyEngine(EngineRepresentation * engine);
 	void		stopAndDestroyEngine(EngineRepresentation * engine);
@@ -107,11 +116,13 @@ signals:
 	void		reloadData();
 	void		checkDataSetForUpdates();
 
+	void		activateUtilEngineChanged();
+	
 private:
 	//These process functions can request a new engine to be started:
 	stringset	processRCodeQueue();
 	bool		processComputedColumnQueue();
-    bool    processDynamicModules();
+    bool		processDynamicModules();
 	stringset	processAnalysisRequests();	///< Returns modules that still need an engine
 	
 	void		processLogCfgRequests();
@@ -168,7 +179,8 @@ private:
 	RFilterStore					*	_waitingFilter					= nullptr;
 	bool								_stopProcessing					= false,
 										_dataMode						= false,
-										_filterRunning					= false;
+										_filterRunning					= false,
+										_activateUtilEngine				= false;
 	int									_filterCurrentRequestID			= 0;
 	std::string							_memoryName,
 										_engineInfo;
@@ -183,7 +195,6 @@ private:
 	EngineRepresentation			*	_rCmder				= nullptr;	///< For those special occassions where you just want to shout at R in a more personal manner
 	IPCChannel						*	_rCmderChannel		= nullptr;	///< The channel for shouting at R in a more personal manner
 	std::vector<int64_t>				_engineStopTimes;				///< Here we keep track of how long ago it is an engine shut down, this way we can give it a slight time between closing and starting an engine. To avoid shared memory problems on windows.
-
 };
 
 #endif // ENGINESYNC_H


### PR DESCRIPTION
instead of always starting the utility engine (which could cause crashes on waking from sleep) when its not running we only do so if the modules menu has been opened. Also makes the engine visible in the engineswindow

