### PR TITLE
Turn of interactive plots by default and try not to show interactive plots if they are broken or missing

### DIFF
--- a/Desktop/html/js/image.js
+++ b/Desktop/html/js/image.js
@@ -45,7 +45,8 @@ JASPWidgets.imageView = JASPWidgets.objectView.extend({
 	isEditable:					function() {	return this.model.get("error") === null;						},
 	isConvertible:				function() {	return this.model.get("error") === null && this.model.get("convertible") ===  true;	},
 	hasCollapse:				function() {	return this.$el.hasClass('jasp-collection-item')	=== false;	},
-	hasInteractive:				function() {	return this.model.get("interactiveJsonData") !== null && this.model.get("interactiveJsonData") !== undefined;	},
+	hasConvertError:			function() {	return this.model.get("interactiveConvertError") !== null	&& this.model.get("interactiveConvertError") !== undefined	&& this.model.get("interactiveConvertError") !== "";	},
+	hasInteractive:				function() {	return !this.hasConvertError() && this.model.get("interactiveJsonData") !== null		&& this.model.get("interactiveJsonData") !== undefined		&& this.model.get("interactiveJsonData") !== "";	},
 	saveImageClicked:			function() {	this.model.trigger("SaveImage:clicked",							{ data: this.model.get("data"), width: this.model.get("width"), height: this.model.get("height"), name: this.model.get("name")							});	},
 	editImageClicked:			function() {	this.model.trigger("EditImage:clicked",			this.myView,	{ data: this.model.get("data"), width: this.model.get("width"), height: this.model.get("height"), name: this.model.get("name"), title: this.model.get("title"), type: "interactive"		});	},
 	interactiveImageClicked:	function() {
@@ -56,7 +57,7 @@ JASPWidgets.imageView = JASPWidgets.objectView.extend({
 		if(!wasUserInteractive && this.hasInteractive())
 			isCurrentlyInteractive = window.globSet.showInteractiveDefault
 		
-		this.model.set("interactive",		!isCurrentlyInteractive);
+		this.model.set("interactive",		this.hasInteractive() && !isCurrentlyInteractive);
 		this.model.set("userInteractive",	true);
 
 		// Clear the current content and re-render
@@ -213,7 +214,10 @@ JASPWidgets.imagePrimitive = JASPWidgets.View.extend({
 
 	render: function () {//interactive = false) {
 
-		var hasInteractive = this.model.get("interactiveJsonData") !== null && this.model.get("interactiveJsonData") !== undefined;
+		var hasInteractive = this.model.get("interactiveJsonData") !== null && this.model.get("interactiveJsonData") !== undefined && this.model.get("interactiveJsonData") !== "";
+
+		if(this.model.get("interactive") && this.model.get("interactiveConvertError") != "")
+			this.model.set("interactive", false)
 		
 		if (hasInteractive && ((this.model.get("userInteractive") && this.model.get("interactive")) || (!this.model.get("userInteractive") && window.globSet.showInteractiveDefault))) {
 
@@ -225,6 +229,10 @@ JASPWidgets.imagePrimitive = JASPWidgets.View.extend({
 			if (!error) {
 				this.plotlyRetryCount = 0; // Reset retry counter
 				jQuery(document).ready(() => this.renderPlotlyIfDivExists());
+			}
+			else
+			{
+				
 			}
 
 		} else {

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -116,7 +116,7 @@ const Settings::Setting Settings::Values[] = {
 	{"useConfigurationFile",		true	},
 	{"startMaximized",				false	},
 	{"storeStateEtc",				false	},
-	{"showInteractiveDefault",		true	},
+	{"showInteractiveDefault",		false	},
 	{"autoSaveOn",					true	},
 	{"autoSaveInterval",			5*60	},
 };	


### PR DESCRIPTION
Not sure if it works, but belongs with https://github.com/jasp-stats/external-issues/issues/22

I think some changes are also required in jaspGraphs for better errorhandling