### PR TITLE
fix showing long password in tooltip and add eye button

### DIFF
--- a/Desktop/components/JASP/Widgets/EncryptionSettingsWindow.qml
+++ b/Desktop/components/JASP/Widgets/EncryptionSettingsWindow.qml
@@ -64,6 +64,7 @@ Window
 
                 property int minWidth: controlLabel.implicitWidth + 300 * jaspTheme.uiScale
 
+                showEyeInside: true
                 control.echoMode: TextInput.Password
                 control.Keys.onReturnPressed: (event)=> { submitButton.onClicked() }
             }

--- a/Desktop/components/JASP/Widgets/EncryptionSettingsWindow.qml
+++ b/Desktop/components/JASP/Widgets/EncryptionSettingsWindow.qml
@@ -5,7 +5,7 @@ Window
 {
     id:	encryptWindow
 
-    minimumWidth:           Math.max(passwordInput.minWidth, jaspSubmission.implicitWidth, showAdvancedCheckbox.implicitWidth) + windowPadding * 2
+    minimumWidth:           Math.max(passwordInput.minWidth, jaspSubmission.implicitWidth, showAdvancedCheckbox.implicitWidth) + windowPadding * 2 + 150 * jaspTheme.uiScale 
     minimumHeight:          contentColumn.implicitHeight + (advancedSettings.visible ? advancedSettings.implicitHeight + jaspTheme.groupContentPadding : 0) + buttons.height + windowPadding * 3
     visible:                encryptionModel.visible
     title:					qsTr("Enter Encryption Settings")

--- a/Desktop/utilities/settings.cpp
+++ b/Desktop/utilities/settings.cpp
@@ -111,6 +111,7 @@ const Settings::Setting Settings::Values[] = {
     {"engineSandbox",				false	},
 #endif
 	{"remoteConfiguration",			false   },
+	
 	{"remoteConfigurationURL",		""		},
 	{"localConfigurationPath",		""		},
 	{"useConfigurationFile",		true	},

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -106,6 +106,8 @@ TextInputBase
 	property bool	editable:			true
 	property var	undoModel
 
+	property alias showEyeInside: control.showEyeInside
+
 	property double controlXOffset:		0
 	property bool	alignInGroup:		true
 
@@ -230,9 +232,10 @@ TextInputBase
 		enabled:				textField.editable
 
 		property bool tooLongText: contentWidth > (width - leftPadding - rightPadding)
+		property bool showEyeInside: false
 
 		QTC.ToolTip.text		: control.text
-		QTC.ToolTip.visible		: tooLongText && (hovered || control.activeFocus)
+		QTC.ToolTip.visible		: tooLongText && (hovered || control.activeFocus) && control.echoMode != QTC.TextInput.Password
 
 		// The acceptableInput is checked even if the user is still typing in the TextField.
 		// In this case, the error should not appear immediately (only when the user is pressing the return key, or going out of focus),
@@ -263,6 +266,27 @@ TextInputBase
 			opacity:			debug ? .3 : 1
 			visible:			textField.useExternalBorder
 			radius:				jaspTheme.jaspControlHighlightWidth
+		}
+
+		Image 
+		{
+			id:						eyeInside
+			visible:				control.showEyeInside
+			z:						2
+			source:					control.echoMode === TextInput.Password ? jaspTheme.iconPath + "/eyeOpen.png" : jaspTheme.iconPath + "/eyeClosed.png"
+			anchors.right:			control.right
+			anchors.rightMargin:	4
+			anchors.verticalCenter:	control.verticalCenter
+			width:					parent.height
+			height:					parent.height
+			
+			MouseArea 
+			{
+				anchors.fill:		parent
+				hoverEnabled:		true
+				cursorShape:		Qt.PointingHandCursor
+				onClicked:			control.echoMode = (control.echoMode === TextInput.Password) ? TextInput.Normal : TextInput.Password
+			}
 		}
 
 		onActiveFocusChanged:

--- a/QMLComponents/components/JASP/Controls/TextField.qml
+++ b/QMLComponents/components/JASP/Controls/TextField.qml
@@ -212,6 +212,28 @@ TextInputBase
 			textFormat:				textField.textFormat
 		}
 	}
+	
+	Image 
+	{
+		id:						eyeInside
+		visible:				control.showEyeInside
+		z:						20
+		source:					control.echoMode === TextInput.Password ? jaspTheme.iconPath + "/eyeOpen.png" : jaspTheme.iconPath + "/eyeClosed.png"
+		anchors.right:			control.right
+		anchors.rightMargin:	4
+		anchors.verticalCenter:	control.verticalCenter
+		width:					control.height
+		height:					control.height
+		
+		MouseArea 
+		{
+			anchors.fill:		parent
+			hoverEnabled:		true
+			cursorShape:		Qt.PointingHandCursor
+			onClicked:			control.echoMode = (control.echoMode === TextInput.Password) ? TextInput.Normal : TextInput.Password
+		}
+	}
+	
 
 	QTC.TextField
 	{
@@ -268,26 +290,6 @@ TextInputBase
 			radius:				jaspTheme.jaspControlHighlightWidth
 		}
 
-		Image 
-		{
-			id:						eyeInside
-			visible:				control.showEyeInside
-			z:						2
-			source:					control.echoMode === TextInput.Password ? jaspTheme.iconPath + "/eyeOpen.png" : jaspTheme.iconPath + "/eyeClosed.png"
-			anchors.right:			control.right
-			anchors.rightMargin:	4
-			anchors.verticalCenter:	control.verticalCenter
-			width:					parent.height
-			height:					parent.height
-			
-			MouseArea 
-			{
-				anchors.fill:		parent
-				hoverEnabled:		true
-				cursorShape:		Qt.PointingHandCursor
-				onClicked:			control.echoMode = (control.echoMode === TextInput.Password) ? TextInput.Normal : TextInput.Password
-			}
-		}
 
 		onActiveFocusChanged:
 		{


### PR DESCRIPTION
This fixed a long password showing in tooltip while inputing, that was not privacy safety:


<img width="394" height="219" alt="image" src="https://github.com/user-attachments/assets/d081c897-c37a-4ded-b951-a864a9ccf4b0" />

And add a eye icon to show/hide the password for user inputing.