### PR TITLE
add a round robin test to JASP Test

### DIFF
--- a/Tests/testall.cpp
+++ b/Tests/testall.cpp
@@ -8,6 +8,7 @@
 #include "data/importers/csvimporter.h"
 #include "data/importers/odsimporter.h"
 #include "data/importers/jaspimporter.h"
+#include "data/exporters/jaspexporter.h"
 #include "data/importers/excelimporter.h"
 #include "data/importers/rdataimporter.h"
 #include "data/importers/readstatimporter.h"
@@ -160,6 +161,59 @@ void TestAll::testJaspDataImport_data()
 	}
 }
 
+void TestAll::testJaspRoundRobin_data()
+{
+	testJaspDataImport_data();
+}
+
+void TestAll::testJaspRoundRobin()
+{
+	QFETCH(QString, folder);
+	QFETCH(QString, dataFileAbsolutePath);
+
+	QDir subDir(_testLibrary());
+	subDir.cd(folder);
+
+	if(_pkg)
+		delete _pkg;
+
+	if(_importer)
+		delete _importer;
+
+	_pkg = new DataSetPackage(this);
+	
+	std::cerr << "Testing " << dataFileAbsolutePath << std::endl;
+
+	JASPImporter::loadDataSet(fq(dataFileAbsolutePath),		[](int){});
+	
+	DataSet * dataSet = _pkg->dataSet();
+	QVERIFY2(dataSet,						"No dataset!");
+	
+	Json::Value compareMe = dataSet->jsonForCompare();
+
+	JASPExporter exporter;
+	
+	std::string jaspFile = TempFiles::createSpecific("testjasp", "temp.jasp");
+	
+	std::cerr << "Storing jasp file temporarily to: " << jaspFile << std::endl;
+	
+	exporter.saveDataSet(jaspFile, [](int){});
+	
+	dataSet = nullptr;
+	
+	_pkg->reset();
+	
+	
+	QVERIFY2(_pkg->dataSet()->jsonForCompare() != compareMe, "DataSet should be different after resetting DataSetPackage!");
+	
+	JASPImporter::loadDataSet(jaspFile, [](int){});
+	
+	dataSet = _pkg->dataSet();
+	QVERIFY2(dataSet,						"No dataset!");
+	
+	QVERIFY2(dataSet->jsonForCompare() == compareMe, "DataSet should be the same after reloading!");
+}
+
 
 void TestAll::testJaspDataImport()
 {
@@ -206,8 +260,6 @@ void TestAll::testJaspDataImport()
 	QVERIFY(jsonFileIn.exists());
 
 	QFile jsonFile(jsonFilePath);
-
-	
 	
 	
 	jsonFile.open(QFile::OpenModeFlag::ReadOnly);

--- a/Tests/testall.cpp
+++ b/Tests/testall.cpp
@@ -183,35 +183,25 @@ void TestAll::testJaspRoundRobin()
 	_pkg = new DataSetPackage(this);
 	
 	std::cerr << "Testing " << dataFileAbsolutePath << std::endl;
-
 	JASPImporter::loadDataSet(fq(dataFileAbsolutePath),		[](int){});
 	
-	DataSet * dataSet = _pkg->dataSet();
-	QVERIFY2(dataSet,						"No dataset!");
+	DataSet *	dataSet		= _pkg->dataSet();
+	QVERIFY2(dataSet,			"No dataset!");
 	
-	Json::Value compareMe = dataSet->jsonForCompare();
+	Json::Value compareMe	= dataSet->jsonForCompare();
+	std::string jaspFile	= TempFiles::createSpecific("testjasp", "temp.jasp");
 
-	JASPExporter exporter;
-	
-	std::string jaspFile = TempFiles::createSpecific("testjasp", "temp.jasp");
-	
 	std::cerr << "Storing jasp file temporarily to: " << jaspFile << std::endl;
-	
-	exporter.saveDataSet(jaspFile, [](int){});
-	
-	dataSet = nullptr;
+	JASPExporter().saveDataSet(jaspFile, [](int){});
 	
 	_pkg->reset();
-	
-	
 	QVERIFY2(_pkg->dataSet()->jsonForCompare() != compareMe, "DataSet should be different after resetting DataSetPackage!");
 	
 	JASPImporter::loadDataSet(jaspFile, [](int){});
 	
 	dataSet = _pkg->dataSet();
-	QVERIFY2(dataSet,						"No dataset!");
-	
-	QVERIFY2(dataSet->jsonForCompare() == compareMe, "DataSet should be the same after reloading!");
+	QVERIFY2(dataSet,									"No dataset!");
+	QVERIFY2(dataSet->jsonForCompare() == compareMe,	"DataSet should be the same after reloading!");
 }
 
 

--- a/Tests/testall.h
+++ b/Tests/testall.h
@@ -15,6 +15,8 @@ private slots:
 	void	testDataImport_data();
 	void	testJaspDataImport();
 	void	testJaspDataImport_data();
+	void	testJaspRoundRobin_data();
+	void	testJaspRoundRobin();
 
 private:
 	DataSetPackage		*	_pkg		= nullptr;


### PR DESCRIPTION
It loads all the jasp files in the testlibrary, saves them to tempfiles, reloads them and compares the jsons. If a version cant load it's own jaspfiles it will now tell you

implements https://github.com/jasp-stats/INTERNAL-jasp/issues/3174

