### PR TITLE
Add functions in syntaxbridge so that jaspSyntax can read JASP file

### DIFF
--- a/CommonData/archivereader.cpp
+++ b/CommonData/archivereader.cpp
@@ -54,7 +54,7 @@ void ArchiveReader::openEntry(const string &archivePath, const string &entryPath
 
 	if (_archiveExists)
 	{
-        _archive = archive_read_new();
+		_archive = archive_read_new();
 		archive_read_support_filter_all(_archive);
 		archive_read_support_format_all(_archive);
 
@@ -66,8 +66,8 @@ void ArchiveReader::openEntry(const string &archivePath, const string &entryPath
 
 		if (r == ARCHIVE_OK)
 		{
-            _isOpen = true;
-            bool success = false;
+					_isOpen = true;
+			bool	success = false;
 
             archive_entry * entry;
 			while (archive_read_next_header(_archive, &entry) == ARCHIVE_OK)
@@ -270,3 +270,97 @@ vector<string> ArchiveReader::getEntryPaths(const string &archivePath, const str
 	}
 	return files;
 }
+
+ManifestInfo::ManifestInfo(const std::string & _jaspArchiveVersion, const std::string & _jaspVersion) :
+	jaspArchiveVersion{_jaspArchiveVersion}, jaspVersion{_jaspVersion}
+{
+}
+
+ManifestInfo ArchiveReader::readManifest(const std::string &path)
+{
+	static const std::string manifestName = "manifest.json";
+
+	ManifestInfo info;
+	ArchiveReader	manifestReader;
+	manifestReader.openEntry(path, manifestName); //separate from constructor to avoid a failed close (because an exception in constructor messes up destructor)
+	int64_t         size				= manifestReader.bytesAvailable();
+	int             errorCode;
+
+	if (size > 0)
+	{
+		std::string manifestStr = manifestReader.readAllData(sizeof(char), errorCode);
+
+		if (errorCode != 0)
+			throw std::runtime_error("Could not read manifest of JASP archive.");
+
+		Json::Reader    parser;
+		Json::Value     manifest;
+		parser.parse(manifestStr, manifest);
+
+		info.jaspArchiveVersion	= manifest.get("jaspArchiveVersion", "").asString();
+		info.jaspVersion		= manifest.get("jaspVersion",		"").asString();
+	}
+
+	if (info.jaspArchiveVersion.empty())
+		throw std::runtime_error("Archive missing version information.");
+
+	return info;
+}
+
+bool ArchiveReader::parseJsonEntry(Json::Value &root, const std::string &path,  const std::string &entry, bool required)
+{
+	//Not particularly happy about the way we need to add a delete at every return here. Would be better to not use `new` and just instantiate a scoped var
+	//But that would require removing some `std::runtime_error` from `openEntry` in the `ArchiveReader` constructor.
+	// And this is not the time to rewrite too many things.
+	ArchiveReader * dataEntry = NULL;
+	try
+	{
+		dataEntry = new ArchiveReader(path, entry);
+	}
+	catch(...)
+	{
+		return false;
+	}
+
+	if (!dataEntry->archiveExists())
+	{
+		delete dataEntry;
+		throw std::runtime_error("The selected JASP archive '" + path + "' could not be found.");
+	}
+
+	if (!dataEntry->exists())
+	{
+		delete dataEntry;
+
+		if (required)
+			throw std::runtime_error("Entry '" + entry + "' could not be found in JASP archive.");
+
+		return false;
+	}
+
+	int64_t size = dataEntry->bytesAvailable();
+	if (size > 0)
+	{
+		char *data = new char[size];
+		int64_t startOffset = dataEntry->pos();
+		int errorCode = 0;
+		while (dataEntry->readData(&data[dataEntry->pos() - startOffset], 8016, errorCode) > 0 && errorCode == 0) ;
+
+		if (errorCode < 0)
+		{
+			delete dataEntry;
+			throw std::runtime_error("Could not read Entry '" + entry + "' in JASP archive.");
+		}
+
+		Json::Reader jsonReader;
+		jsonReader.parse(data, (char*)(data + (size * sizeof(char))), root);
+
+		delete[] data;
+	}
+
+	dataEntry->close();
+
+	delete dataEntry;
+	return true;
+}
+

--- a/CommonData/archivereader.h
+++ b/CommonData/archivereader.h
@@ -25,6 +25,16 @@
 #include <functional>
 
 #include <archive.h>
+#include "json/json.h"
+
+struct ManifestInfo
+{
+	std::string jaspArchiveVersion,
+				jaspVersion;
+
+	ManifestInfo() {}
+	ManifestInfo(const std::string & _jaspArchiveVersion, const std::string & _jaspVersion);
+};
 
 /**
  * @brief The ArchiveReader class - Reads archives.
@@ -35,8 +45,8 @@
 class ArchiveReader
 {
 public:
-    ArchiveReader(){};
-    ArchiveReader(const std::string &archivePath, const std::string &entryPath);
+	ArchiveReader(){}
+	ArchiveReader(const std::string &archivePath, const std::string &entryPath);
 	ArchiveReader(ArchiveReader && other) = default;
 
 	~ArchiveReader();
@@ -127,7 +137,11 @@ public:
 	 */
 	std::string extension() const;
 
-    static std::vector<std::string> getEntryPaths(const std::string &archivePath, const std::string &entryBaseDirectory = std::string());
+	static std::vector<std::string> getEntryPaths(const std::string &archivePath, const std::string &entryBaseDirectory = std::string());
+
+	static ManifestInfo readManifest(const std::string & path);
+
+	static bool parseJsonEntry(Json::Value &root, const std::string &path, const std::string &entry, bool required);
 
 private:
 
@@ -140,6 +154,7 @@ private:
 								_currentRead	= 0;
 	std::string					_archivePath,
 								_entryPath;
+
 
 };
 

--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -194,6 +194,7 @@ public:
 
     void        preloadInterfaceForThread();
 	void		close();					///< Closes the loaded database and disconnects
+	void		load();						///< Loads a sqlite database from sessiondir (after loading a jaspfile)
 
 	
 private:
@@ -204,7 +205,6 @@ private:
 	void		_runStatementsRepeatedly(	const std::string & statements, std::function<bool(	std::function<void(sqlite3_stmt *stmt)> **	bindParameters, size_t row)> bindParameterFactory, std::function<void(size_t row, size_t repetition, sqlite3_stmt *stmt)> * processRow = nullptr, bool ignoreFails = false);
 
 	void		create();					///< Creates a new sqlite database in sessiondir and loads it
-	void		load();						///< Loads a sqlite database from sessiondir (after loading a jaspfile)
 
 	std::map<std::thread::id, sqlite3*>		_dbs;
 	std::thread::id							_dbCreator;

--- a/Desktop/data/importers/jaspimporter.cpp
+++ b/Desktop/data/importers/jaspimporter.cpp
@@ -89,10 +89,10 @@ void JASPImporter::loadDataSet(const std::string &path, std::function<void(int)>
 	{
 		if (DataSetPackage::pkg()->jaspVersion() < JASPImporter::minJaspVersion)
 			throw LoaderException(
-					fq(tr("The JASP file is too old (%1) and is not supported anymore.\n"
-						"Load and save it first in an intermediate JASP version (between %2 and 0.96.1) to upgrade your JASP file to a compatible version")
-				.arg(DataSetPackage::pkg()->jaspVersion().isEmpty() ? "older than " + (JASPImporter::minJaspVersion.asString()) : DataSetPackage::pkg()->jaspVersion().asString())
-				.arg(JASPImporter::minJaspVersion.asString())));
+				fq(tr("The JASP file is too old (%1) and is not supported anymore.\n"
+					  "Load and save it first in an intermediate JASP version (between %2 and 0.96.1) to upgrade your JASP file to a compatible version")
+					   .arg(DataSetPackage::pkg()->jaspVersion().isEmpty() ? "older than " + (JASPImporter::minJaspVersion.asString()) : DataSetPackage::pkg()->jaspVersion().asString())
+					   .arg(JASPImporter::minJaspVersion.asString())));
 		else
 			throw LoaderException("The file version is too new.\nPlease update to the latest version of JASP to view this file.");
 	}
@@ -120,7 +120,10 @@ JASPImporter::Compatibility JASPImporter::isCompatible(const std::string &path)
 {
 	try
 	{
-		readManifest(path);
+		ManifestInfo info = ArchiveReader::readManifest(path);
+		DataSetPackage::pkg()->setArchiveVersion(	Version(info.jaspArchiveVersion));
+		DataSetPackage::pkg()->setJaspVersion(		Version(info.jaspVersion));
+
 		return isCompatible();
 	}
 	catch(...)
@@ -136,7 +139,7 @@ void JASPImporter::loadDataArchive(const std::string &path, std::function<void(i
     //Store sqlite into tempfiles:
 	//ArchiveReader(path, DatabaseInterface::singleton()->dbFile(true)+"-wal").writeEntryToTempFiles([&](float p){ progressCallback(1.333 * p); });
 	//ArchiveReader(path, DatabaseInterface::singleton()->dbFile(true)+"-shm").writeEntryToTempFiles([&](float p){ progressCallback(2.333 * p); });
-	ArchiveReader(path, DatabaseInterface::singleton()->dbFile(true)).writeEntryToTempFiles([&](float p){ progressCallback(33.333 * p); });
+    ArchiveReader(path, DatabaseInterface::singleton()->dbFile(true)).writeEntryToTempFiles([&](float p){ progressCallback(33.333 * p); });
 	
 	DataSetPackage::pkg()->loadDataSet([&](float p){ progressCallback(33.333 + 33.333 * p); });
 
@@ -160,7 +163,7 @@ void JASPImporter::loadJASPArchive(const std::string &path, std::function<void(i
 	JASPTIMER_SCOPE(JASPImporter::loadJASPArchive_1_00 read analyses.json);
 	Json::Value analysesData;
 
-	if (parseJsonEntry(analysesData, path, "analyses.json", false))
+	if (ArchiveReader::parseJsonEntry(analysesData, path, "analyses.json", false))
 	{
 		stringvec resources = ArchiveReader::getEntryPaths(path, "resources");
 	
@@ -188,96 +191,6 @@ void JASPImporter::loadJASPArchive(const std::string &path, std::function<void(i
 
 
 	progressCallback(100); //"Initializing Analyses & Results",
-}
-
-void JASPImporter::readManifest(const std::string &path)
-{
-	bool            foundVersion		= false;
-	std::string     manifestName		= "manifest.json";
-	ArchiveReader	manifestReader;
-	manifestReader.openEntry(path, manifestName); //separate from constructor to avoid a failed close (because an exception in constructor messes up destructor)
-    int64_t         size				= manifestReader.bytesAvailable();
-    int             errorCode;
-
-	if (size > 0)
-	{
-		std::string manifestStr = manifestReader.readAllData(sizeof(char), errorCode);
-
-		if (errorCode != 0)
-			throw LoaderException("Could not read manifest of JASP archive.");
-
-		Json::Reader    parser;
-		Json::Value     manifest;
-		parser.parse(manifestStr, manifest);
-
-		std::string jaspArchiveVersionStr	= manifest.get("jaspArchiveVersion", "").asString();
-		std::string jaspVersionStr			= manifest.get("jaspVersion",		"").asString();
-
-		foundVersion = ! jaspArchiveVersionStr.empty();
-
-		DataSetPackage::pkg()->setArchiveVersion(	Version(jaspArchiveVersionStr));
-		DataSetPackage::pkg()->setJaspVersion(		Version(jaspVersionStr));
-	}
-
-	if ( ! foundVersion)
-		throw LoaderException("Archive missing version information.");
-}
-
-bool JASPImporter::parseJsonEntry(Json::Value &root, const std::string &path,  const std::string &entry, bool required)
-{
-	//Not particularly happy about the way we need to add a delete at every return here. Would be better to not use `new` and just instantiate a scoped var
-	//But that would require removing some `std::runtime_error` from `openEntry` in the `ArchiveReader` constructor. 
-	// And this is not the time to rewrite too many things.
-	ArchiveReader * dataEntry = NULL;
-	try
-	{
-		dataEntry = new ArchiveReader(path, entry);
-	}
-	catch(...)
-	{
-		return false;
-	}
-	
-	if (!dataEntry->archiveExists())
-	{
-		delete dataEntry;
-		throw LoaderException("The selected JASP archive '" + path + "' could not be found.");
-	}
-
-	if (!dataEntry->exists())
-	{
-		delete dataEntry;
-		
-		if (required)
-			throw LoaderException("Entry '" + entry + "' could not be found in JASP archive.");
-
-		return false;
-	}
-
-    int64_t size = dataEntry->bytesAvailable();
-	if (size > 0)
-	{
-		char *data = new char[size];
-        int64_t startOffset = dataEntry->pos();
-		int errorCode = 0;
-		while (dataEntry->readData(&data[dataEntry->pos() - startOffset], 8016, errorCode) > 0 && errorCode == 0) ;
-
-		if (errorCode < 0)
-		{
-			delete dataEntry;
-			throw LoaderException("Could not read Entry '" + entry + "' in JASP archive.");
-		}
-
-		Json::Reader jsonReader;
-		jsonReader.parse(data, (char*)(data + (size * sizeof(char))), root);
-
-		delete[] data;
-	}
-
-	dataEntry->close();
-
-	delete dataEntry;
-	return true;
 }
 
 JASPImporter::Compatibility JASPImporter::isCompatible()

--- a/Desktop/data/importers/jaspimporter.h
+++ b/Desktop/data/importers/jaspimporter.h
@@ -44,8 +44,6 @@ private:
 	static void loadDataArchive(		const std::string &path, std::function<void(int)> progressCallback);
 	static void loadJASPArchive(		const std::string &path, std::function<void(int)> progressCallback);
 
-	static bool parseJsonEntry(Json::Value &root, const std::string &path, const std::string &entry, bool required);
-	static void readManifest(const std::string &path);
 	static Compatibility isCompatible();
 
 	static const Version maxSupportedJaspArchiveVersion;

--- a/QMLComponents/datasetprovider.cpp
+++ b/QMLComponents/datasetprovider.cpp
@@ -57,7 +57,7 @@ void DataSetProvider::resetDataSet()
 		_dataSet->dbDelete();
 		delete _dataSet;
 	}
-	
+
 	_dataSet = new DataSet();
 }
 
@@ -111,6 +111,20 @@ void DataSetProvider::loadDataSet(const std::map<std::string, stringvec > & data
 
 	ColumnEncoder::columnEncoder()->setCurrentNames(_dataSet->getColumnTypesMap());
 
+}
+
+void DataSetProvider::loadDatabase(const Version & jaspVersion)
+{
+	delete _dataSet;
+
+	_db->close();
+	_db->load();
+	_db->upgradeDBFromVersion(jaspVersion);
+
+	_dataSet = new DataSet(0);
+	_dataSet->dbLoad(1, [](float p) {}, jaspVersion);
+
+	ColumnEncoder::columnEncoder()->setCurrentNames(_dataSet->getColumnTypesMap());
 }
 
 QVariantList DataSetProvider::_getDoubleList(Column * column) const

--- a/QMLComponents/datasetprovider.cpp
+++ b/QMLComponents/datasetprovider.cpp
@@ -121,7 +121,7 @@ void DataSetProvider::loadDatabase(const Version & jaspVersion)
 	_db->load();
 	_db->upgradeDBFromVersion(jaspVersion);
 
-	_dataSet = new DataSet(0);
+	_dataSet = new DataSet(0); // Setting 0 for "do nothing" because otherwise we can't pass on jaspVersion
 	_dataSet->dbLoad(1, [](float p) {}, jaspVersion);
 
 	ColumnEncoder::columnEncoder()->setCurrentNames(_dataSet->getColumnTypesMap());

--- a/QMLComponents/datasetprovider.h
+++ b/QMLComponents/datasetprovider.h
@@ -41,6 +41,8 @@ public:
 	QVariant					data(		const QModelIndex & index, int role = Qt::DisplayRole)						const	override;
 
 	void						loadDataSet(const std::map<std::string, stringvec > & dataSet, int threshold = 10, bool orderLabelsByValue = true);
+	void						loadDatabase(const Version & jaspVersion);
+
 	QVariant					provideInfo(VariableInfo::InfoType info, const QString& colName = "", int row = 0)		const	override;
 	bool						absorbInfo(	VariableInfo::InfoType info, const QString& name, int row, QVariant value)			override;
 	QAbstractItemModel		*	providerModel()																					override	{ return this;	}

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -39,6 +39,7 @@
 #include "dirs.h"
 #include "utilities/appdirs.h"
 #include "modules/dynamicmodule.h"
+#include "archivereader.h"
 
 #include <QtPlugin>
 #ifdef USE_QT_STATIC_LIBS
@@ -261,6 +262,70 @@ const char* STDCALL syntaxBridgeParseDescription(const char* modulePath)
 
 	return result.c_str();
 }
+
+void STDCALL syntaxBridgeLoadDataSetFromJaspFile(const char * filePath, bool dbInMemory)
+{
+	if (!init(dbInMemory))
+	{
+		Log::log() << "Error during initialization" << std::endl;
+		return;
+	}
+
+	ArchiveReader(filePath, DatabaseInterface::singleton()->dbFile(true)).writeEntryToTempFiles([](float p){});
+	ManifestInfo info = ArchiveReader::readManifest(filePath);
+
+	DataSetProvider* provider = DataSetProvider::getProvider(dbInMemory, false);
+
+	provider->loadDatabase(info.jaspVersion);
+}
+
+const char*	STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePath, int analysisNr)
+{
+	if (!init())
+	{
+		Log::log() << "Error during initialization" << std::endl;
+		return "";
+	}
+
+	static std::string result;
+
+	result = "";
+	Json::Value analysesData;
+
+	if (ArchiveReader::parseJsonEntry(analysesData, filePath, "analyses.json", false))
+	{
+		Json::Value analysesDataList = analysesData.get("analyses",	analysesData);
+		if (analysisNr < analysesDataList.size())
+			result = analysesDataList[analysisNr]["options"].toStyledString();
+		else
+			Log::log() << "Analyis number is higher than the number of analyses (" << analysesDataList.size() << ") in the JASP file" << std::endl;
+	}
+	else
+		Log::log() << "Fail to open or read the JASP file " << filePath << std::endl;
+
+
+	return result.c_str();
+}
+
+const char*	STDCALL syntaxBridgeGetVariableNames()
+{
+	DataSetProvider* provider = DataSetProvider::getProvider(false, false);
+	if (!provider)
+		return "";
+
+	static std::string result;
+
+	QStringList names = provider->provideInfo(VariableInfo::VariableNames).toStringList();
+	Json::Value jsonNames(Json::arrayValue);
+
+	for (const QString & name : names)
+		jsonNames.append(fq(name));
+
+	result = jsonNames.toStyledString();
+
+	return result.c_str();
+}
+
 
 
 } // extern "C"
@@ -498,8 +563,6 @@ ModuleInfo parseDescription(const QString & modulePath)
 
 	return moduleInfo;
 }
-
-
 
 
 

--- a/SyntaxInterface/syntaxbridge_interface.h
+++ b/SyntaxInterface/syntaxbridge_interface.h
@@ -54,10 +54,14 @@ struct SyntaxBridgeDataSet {
 
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeCleanup();
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeLoadDataSet(const SyntaxBridgeDataSet* dataset, bool dbInMemory, int threshold, bool orderLabelsByValue);
+SYNTAX_INTERFACE void				STDCALL syntaxBridgeLoadDataSetFromJaspFile(const char * filePath, bool dbInMemory);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeLoadQmlAndParseOptions(const char * moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData);
+SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePath, int analysisNr);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGenerateModuleWrappers(const char* name);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGenerateAnalysisWrapper(const char* modulePath, const char* analysisName);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeParseDescription(const char* modulePath);
+SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGetVariableNames();
+
 
 } // extern "C"
 


### PR DESCRIPTION
jaspSyntax should be able to read JASP files in order to load its database, and also to get the options of an analysis in this JASP file.

When this PR is merged, I will then update the jaspSyntax so that it can use these functions.