### PR TITLE
Do not change value when default value is changed if TextField is not yet initialized

### DIFF
--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -435,7 +435,7 @@ void TextInputBase::setDefaultValue(QVariant value)
 	if(hasChanged)
 		emit defaultValueChanged();
 
-	if(curValIsDef)
+	if(curValIsDef && initialized())
 		setValue(_defaultValue, false);
 }
 


### PR DESCRIPTION
- Add a Frequencies/Multinomial analysis
- set a factor
- set Text Values to "Custom expected proportion".
- In the table, set one row to 0.
- Duplicate the analysis: the row is set back to 1

The reason for this is quite tricky: the default values of a Chi2Test Table is 1, but the default value of a DoubleField is 0. So the DoubleField (TextField in fact), get first as default value 0, then it gets the value 0, then as the default value is changed to 1, the value is set also to 1: if a TextField has the same value as its default value, and the default value afterwards is changed, the TextField gets the new default value. This behaviour is needed for some analyses that changes default values depending of some settings: if the user self did not change the value, it is expected that the TextField gets the new default value. But this behaviour should not be applied if the TextField is not yet initialized, and this solves the issue described above.


