### PR TITLE
Restart autosave timer on modifications

### DIFF
--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -1102,6 +1102,9 @@ void DataSetPackage::setModifiedAfterAutoSave(bool value)
 		_isModifiedAfterAutoSave = value;
 		emit isModifiedAfterAutoSaveChanged();
 	}
+	
+	if(_isModifiedAfterAutoSave)
+		_autoSaveTimer.start(); //Restart the timer so that no one gets an annoying save right in the middle of doing something. Yet there will be a save when you dont do something for a while
 }
 
 


### PR DESCRIPTION
If is modified autoSave is called and enabled that means the user is doing something, so restart the autosave timer.

Even with the backgroundsaving feature it doesnt feel necessary to do the autosave all the time? We could also wait until the user stops doing stuff. For minimal interference.

If you do NOT merge https://github.com/jasp-stats/jasp-desktop/pull/6201 for the release though I think this PR is necessary! 

Otherwise this one can be merged or not.

