### PR TITLE
TextArea with R code should not rely on MetaAnalysis or SEM module

### DIFF
--- a/QMLComponents/boundcontrols/boundcontrolrlangtextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolrlangtextarea.cpp
@@ -93,7 +93,7 @@ void BoundControlRlangTextArea::checkSyntax()
 		Log::log() << "Warning: no non prefixed entries returned from column encoder?";
 
 
-	if (!_textArea->initialized())
+	if (!_textArea->initialized() || _langType == RLangType::RCode)
 	{
 		// Do not run the engine to check the script if the control in not yet initialized
 		_setBoundValues();
@@ -210,7 +210,7 @@ const char* BoundControlRlangTextArea::_checkSyntaxRFunctionName()
 	{
 	case RLangType::CSem:		return "jaspSem:::checkCSemModel";
 	case RLangType::MetaSem:	return "jaspMetaAnalysis::checkMetaModel";
-	case RLangType::Lavaan:
-	default:					return "jaspSem:::checkLavaanModel";
+	case RLangType::Lavaan:		return "jaspSem:::checkLavaanModel";
+	default:					return "";
 	}
 }

--- a/QMLComponents/boundcontrols/boundcontrolrlangtextarea.h
+++ b/QMLComponents/boundcontrols/boundcontrolrlangtextarea.h
@@ -25,7 +25,7 @@
 class BoundControlRlangTextArea : public BoundControlTextArea
 {
 public:
-	enum class RLangType {Lavaan, CSem, MetaSem};
+	enum class RLangType {Lavaan, CSem, MetaSem, RCode};
 
 	BoundControlRlangTextArea(TextAreaBase* textArea, RLangType type = RLangType::Lavaan);
 

--- a/QMLComponents/controls/textareabase.cpp
+++ b/QMLComponents/controls/textareabase.cpp
@@ -72,7 +72,7 @@ void TextAreaBase::setUp()
 	case TextType::TextTypeSource:		_boundControl = new BoundControlSourceTextArea(this);												break;
 	case TextType::TextTypeLavaan:		_boundControl = new BoundControlRlangTextArea(this, BoundControlRlangTextArea::RLangType::Lavaan);	break;
 	case TextType::TextTypeMetaSem:		_boundControl = new BoundControlRlangTextArea(this, BoundControlRlangTextArea::RLangType::MetaSem);	break;
-	case TextType::TextTypeRcode:		_boundControl = new BoundControlRlangTextArea(this, BoundControlRlangTextArea::RLangType::Lavaan);	break;
+	case TextType::TextTypeRcode:		_boundControl = new BoundControlRlangTextArea(this, BoundControlRlangTextArea::RLangType::RCode);	break;
 	case TextType::TextTypeCSem:		_boundControl = new BoundControlRlangTextArea(this, BoundControlRlangTextArea::RLangType::CSem);	break;
 	case TextType::TextTypeJAGSmodel:	_boundControl = new BoundControlJAGSTextArea(this);													break;
 	default:							_boundControl = new BoundControlTextArea(this);														break;


### PR DESCRIPTION
A TextArea with `textType: JASP.TextTypeRcode ` does not work since it needs jaspSem to check the (Lavaan) code.
Just remove the syntax check. Highlighting works anyway. 
This kind of TextArea is never used in a JASP modules, but might be used for a new (community) module.