### PR TITLE
Repair JAGS model

### DIFF
--- a/QMLComponents/boundcontrols/boundcontroljagstextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontroljagstextarea.cpp
@@ -112,6 +112,7 @@ void BoundControlJAGSTextArea::checkSyntax()
 
 	ListModelTermsAvailable* model = _textArea->availableModel();
 
+	// Do not init the model terms when not necessary: this can call the resetBoundValues that calls checkSyntax
 	if (model->terms() != _usedParameters.values())
 		model->initTerms(_usedParameters.values());
 }

--- a/QMLComponents/boundcontrols/boundcontroljagstextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontroljagstextarea.cpp
@@ -111,7 +111,9 @@ void BoundControlJAGSTextArea::checkSyntax()
 	setBoundValue(boundValue);
 
 	ListModelTermsAvailable* model = _textArea->availableModel();
-	model->initTerms(_usedParameters.values());
+
+	if (model->terms() != _usedParameters.values())
+		model->initTerms(_usedParameters.values());
 }
 
 

--- a/QMLComponents/boundcontrols/boundcontrolsourcetextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolsourcetextarea.cpp
@@ -47,5 +47,7 @@ void BoundControlSourceTextArea::_setSourceTerms()
 
 	for (const QString& term : list)
 		terms.append(term.trimmed());
-	_textArea->model()->initTerms(terms);
+
+	if (_textArea->model()->terms() != terms)
+		_textArea->model()->initTerms(terms);
 }

--- a/QMLComponents/boundcontrols/boundcontrolsourcetextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontrolsourcetextarea.cpp
@@ -48,6 +48,7 @@ void BoundControlSourceTextArea::_setSourceTerms()
 	for (const QString& term : list)
 		terms.append(term.trimmed());
 
+	// Do not init the model terms when not necessary: this can call the resetBoundValues that calls checkSyntax
 	if (_textArea->model()->terms() != terms)
 		_textArea->model()->initTerms(terms);
 }

--- a/QMLComponents/boundcontrols/boundcontroltextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontroltextarea.cpp
@@ -33,6 +33,7 @@ void BoundControlTextArea::bindTo(const Json::Value &value)
 
 void BoundControlTextArea::resetBoundValue()
 {
+	// checkSyntax takes care that the right boundValue is set.
 	checkSyntax();
 }
 

--- a/QMLComponents/boundcontrols/boundcontroltextarea.cpp
+++ b/QMLComponents/boundcontrols/boundcontroltextarea.cpp
@@ -33,7 +33,7 @@ void BoundControlTextArea::bindTo(const Json::Value &value)
 
 void BoundControlTextArea::resetBoundValue()
 {
-	setBoundValue(_textArea->text().toStdString());
+	checkSyntax();
 }
 
 bool BoundControlTextArea::isJsonValid(const Json::Value &optionValue) const


### PR DESCRIPTION
Applying a JAGS model triggers an error.
https://github.com/jasp-stats/jasp-desktop/pull/6170 causes the problem. It sets the bound value directly as if it is the model string. But the bound value of JAGS or R TextArea are complex: it's an object with the model string, but also with the columns used, the model with encoded columns, etc.
So use rather the checkSyntax function instead, that takes care that the right bound value is made.