### PR TITLE
Double value set in QML should not use locale

### DIFF
--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -164,7 +164,7 @@ void TextInputBase::bindTo(const Json::Value& value)
 
 Json::Value TextInputBase::createJson() const
 {
-	QVariant value = property("displayValue");
+	QVariant value = _value;
 	if (value.toString() == "" && !_defaultValue.isNull())
 		value = _defaultValue;
 


### PR DESCRIPTION
If in QML, a DoubleField has a value like '0.1', and the locale is set to language that uses "," as  decimal separator, the value is first set in QML with a comma, and then read from the QML to set the default value (in createJson). This is wrong since when binding the value, it expects a non-locale (english) double value. 
Solution is to use the internal value "_value" (sets already when setValue is called) in createJson instead of the displayed value. This is also more logical.

A test already exists in jaspTestModule (Min Max analysis), and fortunately I ran it with a french locale to discover this bug. 