### PR TITLE
Double values read from QML should never use locale

### DIFF
--- a/QMLComponents/controls/textinputbase.cpp
+++ b/QMLComponents/controls/textinputbase.cpp
@@ -400,6 +400,8 @@ void TextInputBase::valueChangedSlot()
 
 void TextInputBase::setValue(QVariant value, bool useLocale)
 {
+	if (!initialized()) // The value is not set by the user, but is read from QML or from the JASP file: never use the locale in this case.
+		useLocale = false;
 	double valueDbl;
 	if(QColumnUtils::getDoubleValue(value.toString(), valueDbl, useLocale))
 		value = valueDbl;


### PR DESCRIPTION
Follow-up of https://github.com/jasp-stats/jasp-desktop/commit/db341efe70c41a1753292e1a56dc51560951b2f6