### PR TITLE
Add syntax_interface_only Conan option to skip Desktop-only dependencies

### DIFF
--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -24,16 +24,23 @@ if(USE_CONAN)
   message(STATUS "  ${CMAKE_BUILD_TYPE}")
   set(CONAN_COMPILER_RUNTIME "dynamic")
 
+  if(JASP_SYNTAX_INTERFACE_ONLY)
+    set(CONAN_SYNTAX_OPTION "-o syntax_interface_only=True")
+  else()
+    set(CONAN_SYNTAX_OPTION "")
+  endif()
 
   # We use our own recipe with some patches to cook up a functional version of freexl, so get the recipe:
-  message(STATUS "Cloning private freexl dependency")
-  set(FREEXL_VERSION "2.0.99.cci.20260225")
-  FetchContent_Declare(
-    freexl
-    GIT_REPOSITORY   https://github.com/jasp-stats/conan-recipes.git
-    GIT_TAG          620019a56c6ba94936c9844ab5c79e8db9baa06b
-  )
-  FetchContent_MakeAvailable(freexl)
+  if(NOT JASP_SYNTAX_INTERFACE_ONLY)
+    message(STATUS "Cloning freexl dependency")
+    set(FREEXL_VERSION "2.0.99.cci.20260225")
+    FetchContent_Declare(
+      freexl
+      GIT_REPOSITORY   https://github.com/jasp-stats/conan-recipes.git
+      GIT_TAG          620019a56c6ba94936c9844ab5c79e8db9baa06b
+    )
+    FetchContent_MakeAvailable(freexl)
+  endif()
 
   # Configure Conan for windows
   if(WIN32)
@@ -41,22 +48,24 @@ if(USE_CONAN)
 
     message(STATUS "  ${CONAN_COMPILER_RUNTIME}")
 
-    if(freexl_POPULATED)
-      message(STATUS "Compiling freexl dependency ${freexl_SOURCE_DIR}")
-      execute_process(
-          COMMAND_ECHO STDOUT
-          WORKING_DIRECTORY ${freexl_SOURCE_DIR}/freexl
-          COMMAND
-          conan create ${freexl_SOURCE_DIR}/freexl --version=${FREEXL_VERSION}
-          -s build_type=${CMAKE_BUILD_TYPE}
-          -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
-          -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing
-          --test-missing
-      )
-    else()
-      message(CHECK_FAIL "build freexl failed")
+    if(NOT JASP_SYNTAX_INTERFACE_ONLY)
+      if(freexl_POPULATED)
+        message(STATUS "Compiling freexl dependency ${freexl_SOURCE_DIR}")
+        execute_process(
+            COMMAND_ECHO STDOUT
+            WORKING_DIRECTORY ${freexl_SOURCE_DIR}/freexl
+            COMMAND
+            conan create ${freexl_SOURCE_DIR}/freexl --version=${FREEXL_VERSION}
+            -s build_type=${CMAKE_BUILD_TYPE}
+            -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
+            -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing
+            --test-missing
+        )
+      else()
+        message(CHECK_FAIL "build freexl failed")
+      endif()
     endif()
-        
+
     execute_process(
       COMMAND_ECHO STDOUT
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -64,28 +73,31 @@ if(USE_CONAN)
       conan install ${CONAN_FILE_PATH} --output-folder=${CMAKE_BINARY_DIR}/_conan_build
       -s build_type=${CMAKE_BUILD_TYPE}
       -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
-      -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing)
-  
+      -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing
+      ${CONAN_SYNTAX_OPTION})
+
     set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES _deps)
-    
+
       # configure conan for apple
   elseif(APPLE)
 
     set(CONAN_RESULT_FILE "conanbuild.sh")
-    
+
     # We set CC and CCX to nothing because that was the only difference between running conan in a terminal (where it worked) and in qt creator (where it did not)
     # They were set to bona fide looking xtools stuff but apparently this was too much for conan.
 
-    execute_process(
-      COMMAND_ECHO STDOUT
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-      COMMAND zsh -c -l "export CC=\"\"; export CCX=\"\"; conan create ${freexl_SOURCE_DIR}/freexl --version=${FREEXL_VERSION} -s build_type=${CMAKE_BUILD_TYPE} -s os.version=${CMAKE_OSX_DEPLOYMENT_TARGET} --build=missing --test-missing")    
-    
+    if(NOT JASP_SYNTAX_INTERFACE_ONLY)
+      execute_process(
+        COMMAND_ECHO STDOUT
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND zsh -c -l "export CC=\"\"; export CCX=\"\"; conan create ${freexl_SOURCE_DIR}/freexl --version=${FREEXL_VERSION} -s build_type=${CMAKE_BUILD_TYPE} -s os.version=${CMAKE_OSX_DEPLOYMENT_TARGET} --build=missing --test-missing")
+    endif()
+
     execute_process(
         COMMAND_ECHO STDOUT
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMAND zsh -c -l "export CC=\"\"; export CCX=\"\"; conan install ${CONAN_FILE_PATH} -s build_type=${CMAKE_BUILD_TYPE} -s os.version=${CMAKE_OSX_DEPLOYMENT_TARGET} --build=missing -of ${CMAKE_BINARY_DIR}/_conan_build")
-        
+        COMMAND zsh -c -l "export CC=\"\"; export CCX=\"\"; conan install ${CONAN_FILE_PATH} -s build_type=${CMAKE_BUILD_TYPE} -s os.version=${CMAKE_OSX_DEPLOYMENT_TARGET} --build=missing ${CONAN_SYNTAX_OPTION} -of ${CMAKE_BINARY_DIR}/_conan_build")
+
   endif()
 
   if(EXISTS ${CMAKE_BINARY_DIR}/_conan_build/${CONAN_RESULT_FILE})

--- a/Tools/CMake/Config.cmake
+++ b/Tools/CMake/Config.cmake
@@ -48,6 +48,7 @@ option(RUN_IWYU "Whether to run Include What You Use" OFF)
 option(INSTALL_R_MODULES "Whether or not installing R Modules" ON)
 option(BUILD_TESTS "Whether to build the test suits" OFF)
 option(USE_CONAN "Whether to use CONAN package manager" OFF)
+option(JASP_SYNTAX_INTERFACE_ONLY "Limit Conan dependencies to those needed by SyntaxInterface only" OFF)
 
 # ------------
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,27 +10,38 @@ from conan import ConanFile
 class JaspConanConfig(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeToolchain", "CMakeDeps"
-    default_options = {"brotli*:shared": True, "sqlite3*:max_column": 32767}
+    options = {"syntax_interface_only": [True, False]}
+    default_options = {
+        "brotli*:shared": True,
+        "sqlite3*:max_column": 32767,
+        "syntax_interface_only": False,
+    }
 
     def requirements(self):
+        # Core dependencies required by SyntaxInterface (CommonData, Common)
         self.requires("libiconv/1.18", force=True)
         self.requires("boost/1.86.0")
         self.requires("zlib/1.3.1")
         self.requires("libarchive/3.8.1")
         self.requires("zstd/1.5.7")
-        self.requires("jsoncpp/1.9.6")
         self.requires("openssl/3.4.1")
-        self.requires("bison/3.7.6")
-        self.requires("brotli/1.1.0")
         self.requires("sqlite3/3.49.1")
-        self.requires("gmp/6.3.0")
-        self.requires("mpfr/4.2.1")
-        self.requires("freexl/2.0.99.cci.20260225")
-        self.requires("libsodium/1.0.20")
-        # librdata is not available for Windows platforms on conan-center yet
-        if self.settings_build.os == "Macos":
-            self.requires("librdata/0.0.0.cci.20231003") 
+
+        if not self.options.syntax_interface_only:
+            # jsoncpp is vendored in Common/json/ so Conan's copy is not linked,
+            # but keep it here for the full build to avoid unexpected Conan graph changes
+            self.requires("jsoncpp/1.9.6")
+            self.requires("brotli/1.1.0")
+            self.requires("gmp/6.3.0")
+            self.requires("mpfr/4.2.1")
+            self.requires("freexl/2.0.99.cci.20260225")
+            self.requires("libsodium/1.0.20")
+            # librdata is not available for Windows platforms on conan-center yet
+            if self.settings_build.os == "Macos":
+                self.requires("librdata/0.0.0.cci.20231003")
 
     def build_requirements(self):
         self.tool_requires("cmake/3.30.0")
+        if not self.options.syntax_interface_only:
+            self.tool_requires("bison/3.7.6")
 


### PR DESCRIPTION
When building only SyntaxInterface (for jaspSyntax), the following Conan packages are not needed: jsoncpp (vendored in Common/json/), brotli (macOS app bundle only), gmp, mpfr, freexl, libsodium, librdata, and bison. Passing -DJASP_SYNTAX_INTERFACE_ONLY=ON reduces the Conan graph to the seven packages actually required by CommonData and Common.

