### PR TITLE
enh: use zoomFactor to scale results page and disable js solutions for now

### DIFF
--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -318,6 +318,8 @@ Item
 
 			url:					resultsJsInterface.resultsPageUrl
 
+			zoomFactor:				resultsJsInterface.zoom
+
 			onContextMenuRequested: (request) => request.accepted = true
 
 			backgroundColor:		jaspTheme.uiBackground

--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -39,7 +39,8 @@ $(document).ready(function () {
 
 	analysesGlobal 			= analyses
 
-	window.setZoom			= function (zoom)			{ document.body.style.zoom = "" + Math.floor(zoom * 100) + "%";	}
+	// see webengineView zoomFactor, disabled js solutions for now
+	// window.setZoom			= function (zoom)			{ document.body.style.zoom = "" + Math.floor(zoom * 100) + "%";	}
 	window.reRenderAnalyses = function ()				{ analyses.reRender();											}
 	window.moveAnalyses		= function (fromId, toId)	{ analyses.move(fromId, toId);									}
 

--- a/Desktop/results/resultsjsinterface.cpp
+++ b/Desktop/results/resultsjsinterface.cpp
@@ -44,7 +44,7 @@ ResultsJsInterface::ResultsJsInterface(QObject *parent) : QObject(parent)
 {
 	_singleton = this;
 
-	connect(this, &ResultsJsInterface::zoomChanged,					this, &ResultsJsInterface::setZoomInWebEngine);
+	// connect(this, &ResultsJsInterface::zoomChanged,					this, &ResultsJsInterface::setZoomInWebEngine);
 	connect(this, &ResultsJsInterface::runJavaScriptSignalQueued,	this, &ResultsJsInterface::runJavaScriptSignal, Qt::QueuedConnection);
 	
 
@@ -65,10 +65,10 @@ void ResultsJsInterface::setZoom(double zoom)
 	emit zoomChanged();
 }
 
-void ResultsJsInterface::setZoomInWebEngine()
-{
-	runJavaScript("window.setZoom(" + QString::number(_webEngineZoom) + ")");
-}
+// void ResultsJsInterface::setZoomInWebEngine()
+// {
+// 	runJavaScript("window.setZoom(" + QString::number(_webEngineZoom) + ")");
+// }
 
 void ResultsJsInterface::setResultsLoaded(bool resultsLoaded)
 {

--- a/Desktop/results/resultsjsinterface.h
+++ b/Desktop/results/resultsjsinterface.h
@@ -135,7 +135,7 @@ public slots:
 	void cancelImageEdit(					int				id);
 	void exportSelected(			const	QString		&	filename);
 	void setResultsPageUrl(					QString			resultsPageUrl);
-	void setZoomInWebEngine();
+	// void setZoomInWebEngine();	// we use zoomFactor in webengine now, but let's not clean up it yet.
 	void setResultsLoaded(					bool			resultsLoaded);
 	void setScrollAtAll(					bool			scrollAtAll);
 	


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/3214

To use js/css zoom the page is not the same behavior with zoom by browser(zoomFactor).