### PR TITLE
Skip VC Merge Module fatal error when JASP_SYNTAX_INTERFACE_ONLY=ON

### DIFF
--- a/Tools/CMake/Config.cmake
+++ b/Tools/CMake/Config.cmake
@@ -205,7 +205,11 @@ if(WIN32)
   else()
 
     message(CHECK_FAIL "not found.")
-    message(FATAL_ERROR "${VC_MERGE_MODULE_NAME} cannot be found.")
+    if(NOT JASP_SYNTAX_INTERFACE_ONLY)
+      message(FATAL_ERROR "${VC_MERGE_MODULE_NAME} cannot be found.")
+    else()
+      message(WARNING "${VC_MERGE_MODULE_NAME} not found — skipped (JASP_SYNTAX_INTERFACE_ONLY=ON).")
+    endif()
 
   endif()
 


### PR DESCRIPTION
## Summary

- When `JASP_SYNTAX_INTERFACE_ONLY=ON`, downgrade the missing VC Merge Module from a `FATAL_ERROR` to a `WARNING`.

The Merge Module (`Microsoft_VC143_CRT_x64.msm`) is only needed by the Windows installer (`CPack`). Building `SyntaxInterface.dll` in CI (via the `jaspSyntax` workflow) does not require it, so the unconditional `FATAL_ERROR` prevents the CI build from completing.

The `JASP_SYNTAX_INTERFACE_ONLY` option was introduced in #6219. This PR adds the matching guard to the Merge Module check.

## Test plan
- [ ] Windows CI in jaspSyntax `build-syntaxinterface` workflow completes the CMake configure step without the VC Merge Module fatal error when `-DJASP_SYNTAX_INTERFACE_ONLY=ON` is passed.
- [ ] Normal JASP Desktop Windows build still fails fast if the Merge Module is missing (i.e., when `JASP_SYNTAX_INTERFACE_ONLY=OFF`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)