### PR TITLE
chore: librdata can now build with conan on MSVC

### DIFF
--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -32,6 +32,7 @@ if(USE_CONAN)
 
   # We use our own recipe with some patches to cook up a functional version of freexl, so get the recipe:
   if(NOT JASP_SYNTAX_INTERFACE_ONLY)
+  
     message(STATUS "Cloning freexl dependency")
     set(FREEXL_VERSION "2.0.99.cci.20260225")
     FetchContent_Declare(
@@ -40,6 +41,16 @@ if(USE_CONAN)
       GIT_TAG          620019a56c6ba94936c9844ab5c79e8db9baa06b
     )
     FetchContent_MakeAvailable(freexl)
+
+    message(STATUS "Cloning librdata dependency")
+    set(LIBRDATA_VERSION "0.0.0.cci.20231003")
+    FetchContent_Declare(
+      librdata
+      GIT_REPOSITORY   https://github.com/shun2wang/librdata-conan-recipe.git
+      GIT_TAG          809abb80dfe7271d2521d0e9f01fdd2c2594c58c
+    )
+    FetchContent_MakeAvailable(librdata)
+
   endif()
 
   # Configure Conan for windows
@@ -64,6 +75,23 @@ if(USE_CONAN)
       else()
         message(CHECK_FAIL "build freexl failed")
       endif()
+
+      if(librdata_POPULATED)
+      message(STATUS "Compiling librdata dependency ${librdata_SOURCE_DIR}")
+      execute_process(
+          COMMAND_ECHO STDOUT
+          WORKING_DIRECTORY ${librdata_SOURCE_DIR}/librdata
+          COMMAND
+          conan create ${librdata_SOURCE_DIR}/librdata --version=${LIBRDATA_VERSION}
+          -s build_type=${CMAKE_BUILD_TYPE}
+          -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
+          -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing
+          --test-missing
+      )
+      else()
+        message(CHECK_FAIL "build librdata failed")
+      endif()
+
     endif()
 
     execute_process(

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -63,6 +63,7 @@ if(USE_CONAN)
       if(freexl_POPULATED)
         message(STATUS "Compiling freexl dependency ${freexl_SOURCE_DIR}")
         execute_process(
+            ECHO_OUTPUT_VARIABLE
             COMMAND_ECHO STDOUT
             WORKING_DIRECTORY ${freexl_SOURCE_DIR}/freexl
             COMMAND
@@ -79,6 +80,7 @@ if(USE_CONAN)
       if(librdata_POPULATED)
       message(STATUS "Compiling librdata dependency ${librdata_SOURCE_DIR}")
       execute_process(
+          ECHO_OUTPUT_VARIABLE
           COMMAND_ECHO STDOUT
           WORKING_DIRECTORY ${librdata_SOURCE_DIR}/librdata
           COMMAND

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -43,11 +43,11 @@ if(USE_CONAN)
     FetchContent_MakeAvailable(freexl)
 
     message(STATUS "Cloning librdata dependency")
-    set(LIBRDATA_VERSION "0.0.0.cci.20231003")
+    set(LIBRDATA_VERSION "0.0.0.cci.20260518")
     FetchContent_Declare(
       librdata
       GIT_REPOSITORY   https://github.com/shun2wang/librdata-conan-recipe.git
-      GIT_TAG          809abb80dfe7271d2521d0e9f01fdd2c2594c58c
+      GIT_TAG          58edaa556ed3589b8d170e09d30afe20613f4201
     )
     FetchContent_MakeAvailable(librdata)
 

--- a/Tools/CMake/Conan.cmake
+++ b/Tools/CMake/Conan.cmake
@@ -63,7 +63,6 @@ if(USE_CONAN)
       if(freexl_POPULATED)
         message(STATUS "Compiling freexl dependency ${freexl_SOURCE_DIR}")
         execute_process(
-            ECHO_OUTPUT_VARIABLE
             COMMAND_ECHO STDOUT
             WORKING_DIRECTORY ${freexl_SOURCE_DIR}/freexl
             COMMAND
@@ -80,11 +79,10 @@ if(USE_CONAN)
       if(librdata_POPULATED)
       message(STATUS "Compiling librdata dependency ${librdata_SOURCE_DIR}")
       execute_process(
-          ECHO_OUTPUT_VARIABLE
           COMMAND_ECHO STDOUT
-          WORKING_DIRECTORY ${librdata_SOURCE_DIR}/librdata
+          WORKING_DIRECTORY ${librdata_SOURCE_DIR}
           COMMAND
-          conan create ${librdata_SOURCE_DIR}/librdata --version=${LIBRDATA_VERSION}
+          conan create ${librdata_SOURCE_DIR} --version=${LIBRDATA_VERSION}
           -s build_type=${CMAKE_BUILD_TYPE}
           -c tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}
           -s compiler.runtime=${CONAN_COMPILER_RUNTIME} --build=missing

--- a/Tools/CMake/Libraries.cmake
+++ b/Tools/CMake/Libraries.cmake
@@ -268,6 +268,7 @@ if(WIN32)
   include(FindRToolsDLLPath)
   
   find_package(freexl 2.0.99 REQUIRED)
+  find_package(librdata 0.0.0 REQUIRED)
   find_package(libsodium 1.0.20 REQUIRED)
 
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class JaspConanConfig(ConanFile):
             self.requires("mpfr/4.2.1")
             self.requires("freexl/2.0.99.cci.20260225")
             self.requires("libsodium/1.0.20")
-            self.requires("librdata/0.0.0.cci.20231003")
+            self.requires("librdata/0.0.0.cci.20260518")
 
     def build_requirements(self):
         self.tool_requires("cmake/3.30.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,9 +36,7 @@ class JaspConanConfig(ConanFile):
             self.requires("mpfr/4.2.1")
             self.requires("freexl/2.0.99.cci.20260225")
             self.requires("libsodium/1.0.20")
-            # librdata is not available for Windows platforms on conan-center yet
-            if self.settings_build.os == "Macos":
-                self.requires("librdata/0.0.0.cci.20231003")
+            self.requires("librdata/0.0.0.cci.20231003")
 
     def build_requirements(self):
         self.tool_requires("cmake/3.30.0")


### PR DESCRIPTION
I tried enable msvc build and submit it to conan upstream but they rejected,see: https://github.com/conan-io/conan-center-index/pull/30014  ,so we can use recipe by ourself.

If ReadStat conan version(https://github.com/jasp-stats/jasp-desktop/pull/6063) on build bot can be fixed, then all of dependencies can be used by Conan.