### PR TITLE
Make the build process honor the R_REPOSITORY variable when it's defined

### DIFF
--- a/Modules/install-renv.R.in
+++ b/Modules/install-renv.R.in
@@ -2,6 +2,7 @@
 #
 
 RENV_LIBRARY <- "@RENV_LIBRARY@"
+CRAN_REPO    <- "@R_REPOSITORY@"
 
 mkdir <- function(paths) {
   for (path in paths)
@@ -10,8 +11,6 @@ mkdir <- function(paths) {
 }
 mkdir(c(RENV_LIBRARY))
 
-repos <-  "https://packagemanager.posit.co/cran/latest"
-# alternative to 'http://cloud.r-project.org'
 if (!dir.exists(file.path(RENV_LIBRARY, "renv"))) {
   if (@IS_FLATPAK_USED@) {
     cat("Installing renv from cellar\n")
@@ -20,11 +19,11 @@ if (!dir.exists(file.path(RENV_LIBRARY, "renv"))) {
       lib          = RENV_LIBRARY,
       INSTALL_opts ='--no-multiarch --no-docs --no-test-load') # --no-test-load is dubious here
   } else {
-    cat(paste0(c("Installing renv from '", paste(repos), "'\n")))
+    cat(paste0(c("Installing renv from '", paste(CRAN_REPO), "'\n")))
     install.packages(
       pkgs         = "renv",
       lib          = RENV_LIBRARY,
-      repos        = repos,
+      repos        = CRAN_REPO,
       INSTALL_opts ='--no-multiarch --no-docs --no-test-load') # --no-test-load is dubious here
   }
 } else {

--- a/Modules/install-tools.R.in
+++ b/Modules/install-tools.R.in
@@ -1,12 +1,13 @@
 # Generated from install-tools.R.in
 #
 
-JASP_MODULE_BUNDLE_MANAGER_LIBRARY 	<- "@JASP_MODULE_BUNDLE_MANAGER_LIBRARY@"
-RENV_LIBRARY                		    <- "@RENV_LIBRARY@"
-R_CPP_INCLUDES_LIBRARY              <- "@R_CPP_INCLUDES_LIBRARY@"
+JASP_MODULE_BUNDLE_MANAGER_LIBRARY <- "@JASP_MODULE_BUNDLE_MANAGER_LIBRARY@"
+RENV_LIBRARY                       <- "@RENV_LIBRARY@"
+R_CPP_INCLUDES_LIBRARY             <- "@R_CPP_INCLUDES_LIBRARY@"
+CRAN_REPO                          <- "@R_REPOSITORY@"
 
-ENGINE                 <- file.path("@PROJECT_SOURCE_DIR@", "Engine")
-MODULES                <- file.path("@PROJECT_SOURCE_DIR@", "Modules")
+ENGINE  <- file.path("@PROJECT_SOURCE_DIR@", "Engine")
+MODULES <- file.path("@PROJECT_SOURCE_DIR@", "Modules")
 
 mkdir <- function(paths) {
   for (path in paths)
@@ -16,16 +17,27 @@ mkdir <- function(paths) {
 mkdir(c(R_CPP_INCLUDES_LIBRARY, JASP_MODULE_BUNDLE_MANAGER_LIBRARY))
 
 .libPaths(RENV_LIBRARY)
-options(repos = c(CRAN = "https://packagemanager.posit.co/cran/latest"))
-options(INSTALL_opts = "--no-test-load")
-cat("Restoring Rcpp & RInside\n")
+options(repos = c(CRAN = CRAN_REPO), INSTALL_opts = "--no-test-load")
+
+if (as.logical(@USER_R_REPO@)) {
+  # If someone sets R_REPOSITORY in the build environment, that should get precedence over repos recorded in lockfiles.
+  options(renv.config.repos.override = CRAN_REPO)
+  message(
+    "Using R_REPOSITORY = '",
+    CRAN_REPO,
+    "' as defined in the build environment over any repositories defined in the renv lockfiles."
+  )
+}
+
+message("Restoring Rcpp & RInside\n")
+
 renv::restore(
   library  = R_CPP_INCLUDES_LIBRARY,
   lockfile = file.path(MODULES, "Rcpp_RInside.lock"),
   clean    = TRUE
 )
 
-cat("restoring jaspModuleBundleManager deps\n")
+message("restoring jaspModuleBundleManager deps\n")
 
 renv::restore(
     lockfile = file.path("@PROJECT_SOURCE_DIR@", "Engine", "jaspModuleBundleManager", "renv.lock"),
@@ -34,7 +46,7 @@ renv::restore(
     prompt   = FALSE
 )
 
-cat("installing jaspModuleBundleManager\n")
+message("installing jaspModuleBundleManager\n")
 
 install.packages(
     file.path("@PROJECT_SOURCE_DIR@", "Engine", "jaspModuleBundleManager"),

--- a/Tools/CMake/R.cmake
+++ b/Tools/CMake/R.cmake
@@ -36,6 +36,15 @@
 set(JASP_STATIC_IS_DOWN_AGAIN OFF CACHE BOOL "Turn ON to try to get R from CRAN instead")
 set(STATIC_DEVELOPMENT_REPOSITORY "https://static.jasp-stats.org/development/")
 
+if(NOT DEFINED R_REPOSITORY)
+  set(R_REPOSITORY "https://packagemanager.posit.co/cran/latest")
+  set(USER_R_REPO "FALSE")
+else()
+  set(USER_R_REPO "TRUE")
+endif()
+
+message(STATUS "Using R_REPOSITORY = ${R_REPOSITORY} as the CRAN mirror for R packages.")
+
 if(APPLE)
     set(XQUARTZ_VERSION "2.8.5")
 endif()
@@ -870,6 +879,7 @@ execute_process(
 )
 
 else()
+
 ##################
 # renv bootstrap  
 configure_file(${PROJECT_SOURCE_DIR}/Modules/install-renv.R.in

--- a/Tools/local-build-modules.R.in
+++ b/Tools/local-build-modules.R.in
@@ -1,4 +1,4 @@
-options(repos='https://cran.r-project.org')
+options(repos="@R_REPOSITORY@")
 options(jaspRemoteCellarRedownload=FALSE)
 Sys.setenv(GITHUB_PAT="@GITHUB_PAT@")
 


### PR DESCRIPTION
# Why

In theory, the user can specify a value for `R_REPOSITORY` to tell CMAKE how to defined the CRAN mirror that will be use for downloading R packages. In practice, this variable is ignored in most places where it would be useful. In particular:

- The CRAN mirror is hard-coded to "https://packagemanager.posit.co/cran/latest" when installing/restoring **renv**, **Rcpp** and **RInside**.
- When installing/restoring the module bundler stuff, **renv** uses whatever CRAN mirror is defined in the lockfile.

I may be the only person on Earth who cares, but this behavior completely breaks the build process for me. The PPM version resolution system tends to break for those of us who run weird-ass Linux distros that Posit can't correctly categorize by parsing standard system info. So, the build crashes for me at the stage of bootstrapping **renv** because "https://packagemanager.posit.co/cran/latest" resolves to an invalid URL.

# What

In `R.cmake`, I've added a little check to see if the `R_REPOSITORY` variable is defined.

- If defined:
  - Use the user-defined mirror for installing R packages
  - Use the user-defined mirror to restore module bundler packages
- If not defined: 
  - Use the previously hard-coded mirror to install packages
  - Use the mirrors defined in the lockfiles when restoring module bundler packages

# How

Hopefully, with as light a touch as possible. I don't have any system other than my freaky-deaky Debian machine on which to test these changes. That said, I don't think any of these changes should break the build process on other platforms. Of course, I could be completely misunderstanding the build process, in which case, all bets are off.