### PR TITLE
Improve user experience for plot editing

### DIFF
--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
@@ -386,6 +386,48 @@ Popup
 							{
 								src:			plotImg
 							}
+
+							// Overlay shown while the engine is re-rendering
+							Rectangle
+							{
+								id:						updatingOverlay
+								anchors.fill:			parent
+								color:					jaspTheme.white
+								opacity:				plotEditorModel.updating ? 0.85 : 0.0
+								visible:				plotEditorModel.updating
+								Behavior on opacity { NumberAnimation { duration: 150 } }
+
+								ColumnLayout
+								{
+									anchors.centerIn:	parent
+									spacing:			jaspTheme.generalAnchorMargin
+
+									Image
+									{
+										source:				jaspTheme.iconPath + "loading.svg"
+										sourceSize.width:	32 * preferencesModel.uiScale
+										sourceSize.height:	32 * preferencesModel.uiScale
+										Layout.alignment:	Qt.AlignHCenter
+
+										NumberAnimation on rotation
+										{
+											from:		0
+											to:			360
+											duration:	1200
+											loops:		Animation.Infinite
+											running:	plotEditorModel.updating
+										}
+									}
+
+									JASPC.Text
+									{
+										text:				qsTr("Rerendering\u2026")
+										font:				jaspTheme.fontLabel
+										color:				jaspTheme.textEnabled
+										Layout.alignment:	Qt.AlignHCenter
+									}
+								}
+							}
 						}
 					}
 				}

--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditor.qml
@@ -421,7 +421,7 @@ Popup
 
 									JASPC.Text
 									{
-										text:				qsTr("Rerendering\u2026")
+										text:				qsTr("Rerendering…")
 										font:				jaspTheme.fontLabel
 										color:				jaspTheme.textEnabled
 										Layout.alignment:	Qt.AlignHCenter

--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -28,6 +28,9 @@ PlotEditorModel::PlotEditorModel()
 	connect(_xAxis,			&AxisModel::addToUndoStack,		this,	&PlotEditorModel::addToUndoStack);
 	connect(_yAxis,			&AxisModel::addToUndoStack,		this,	&PlotEditorModel::addToUndoStack);
 
+	_debounceTimer.setSingleShot(true);
+	connect(&_debounceTimer, &QTimer::timeout, this, &PlotEditorModel::applyPendingChanges);
+
 }
 
 void PlotEditorModel::showPlotEditor(int id, QString options)
@@ -121,6 +124,10 @@ void PlotEditorModel::reset()
 	_undo = std::stack<undoRedoData>();
 	_redo = std::stack<undoRedoData>();
 	emit unOrRedoEnabledChanged();
+
+	_debounceTimer.stop();
+	_debouncePending = false;
+	setUpdating(false);
 }
 
 
@@ -146,6 +153,8 @@ void PlotEditorModel::updatePlot(Json::Value& imageOptions)
 	_editedImgsMap[_editRequest] = imageOptions["editOptions"];
 	_editRequest++;
 	_analysis->editImage(imageOptions);
+
+	setUpdating(true);
 }
 
 void PlotEditorModel::updateOptions(Analysis *analysis)
@@ -177,6 +186,19 @@ void PlotEditorModel::updateOptions(Analysis *analysis)
 	}
 
 	_editedImgsMap.erase(request);
+
+	// If a debounced update is already queued, sync the request ID in _imgOptions
+	// to the just-processed response so that Analysis::imageEdited() does not
+	// trigger a redundant re-send. The debounce timer will handle sending the
+	// latest changes when it fires.
+	if (_debouncePending)
+	{
+		if (_analysis->imgResults().isMember("request"))
+			_imgOptions["request"] = _analysis->imgResults()["request"];
+		// Keep _updating = true since the debounce will send another request shortly
+	}
+	else
+		setUpdating(false);
 }
 
 void PlotEditorModel::somethingChanged()
@@ -188,8 +210,19 @@ void PlotEditorModel::somethingChanged()
 	if(newImgOptions != _imgOptions)
 	{
 		_imgOptions = newImgOptions;
-		updatePlot(_imgOptions);
+
+		// Debounce: wait for a pause in changes before sending to the engine.
+		// This prevents flooding the engine during rapid slider dragging, etc.
+		_debouncePending = true;
+		_debounceTimer.start(250);
 	}
+}
+
+void PlotEditorModel::applyPendingChanges()
+{
+	_debouncePending = false;
+	_imgOptions["intermediate"] = true;
+	updatePlot(_imgOptions);
 }
 
 
@@ -368,6 +401,15 @@ void PlotEditorModel::setLoading(bool loading)
 	
 	_loading = loading;
 	emit loadingChanged(_loading);
+}
+
+void PlotEditorModel::setUpdating(bool updating)
+{
+	if (_updating == updating)
+		return;
+
+	_updating = updating;
+	emit updatingChanged(_updating);
 }
 
 References *PlotEditorModel::references() const

--- a/Desktop/results/ploteditormodel.h
+++ b/Desktop/results/ploteditormodel.h
@@ -4,6 +4,7 @@
 #include <QUrl>
 #include <stack>
 #include <QObject>
+#include <QTimer>
 #include <json/json.h>
 #include "ploteditoraxismodel.h"
 #include "ploteditorcoordinates.h"
@@ -35,6 +36,7 @@ class PlotEditorModel : public QObject
 	Q_PROPERTY(AxisModel *				yAxis			READ yAxis									NOTIFY dummyAxisChanged			)
 	Q_PROPERTY(double					ppi				READ ppi									NOTIFY ppiChanged				)
 	Q_PROPERTY(bool						loading			READ loading		WRITE setLoading		NOTIFY loadingChanged			)
+	Q_PROPERTY(bool						updating		READ updating								NOTIFY updatingChanged			)
 	Q_PROPERTY(bool						undoEnabled		READ undoEnabled							NOTIFY unOrRedoEnabledChanged	)
 	Q_PROPERTY(bool						redoEnabled		READ redoEnabled							NOTIFY unOrRedoEnabledChanged	)
 	Q_PROPERTY(AxisModel *				currentAxis		READ currentAxis							NOTIFY currentAxisChanged		)
@@ -63,6 +65,8 @@ public:
 	AxisModel			*	yAxis()		const { return _yAxis;		}
 	double					ppi()		const {	return _ppi;		}
 	bool					loading()	const { return _loading;	}
+	bool					updating()	const { return _updating;	}
+	void					setUpdating(bool updating);
 	void					reset();
 
 	bool					undoEnabled()	const {	return _undo.size() > 0;	}
@@ -87,6 +91,7 @@ signals:
 	void ppiChanged();// TODO, refresh all
 	void resetPlotChanged(		bool		resetPlot		);
 	void loadingChanged(		bool		loading			);
+	void updatingChanged(		bool		updating			);
 	void unOrRedoEnabledChanged();
 	
 
@@ -120,6 +125,7 @@ public slots:
 	//QString clickHitsElement(double x, double y) const;
 
 	void addToUndoStack();
+	void applyPendingChanges();
 
 	void undoSomething(); //No need to do Q_INVOKABLE for slots, they are always available from QML
 	void redoSomething();
@@ -148,11 +154,14 @@ private:
 	bool						_visible		= false,
 								_goBlank		= false,
 								_loading		= false,
+								_updating		= false,
 								_validOptions	= false,
-								_blockChanges	= false;
+								_blockChanges	= false,
+								_debouncePending= false;
 	int							_width,
 								_height;
 	double						_ppi;
+	QTimer						_debounceTimer;
 
 	static int					_editRequest;
 


### PR DESCRIPTION
Implement a "debounce timer" to avoid that requests "pile up" and the engine is still busy rendering request 1 while in the meantime 4 other requests arrived (which would be rendered in order before).

Also adds a nice overlay so users know when the plot is being rerendered.

