### PR TITLE
fix assertion failures caused by iterator out-of-bounds

### DIFF
--- a/QMLComponents/models/terms.cpp
+++ b/QMLComponents/models/terms.cpp
@@ -684,8 +684,8 @@ void Terms::remove(size_t pos, size_t n)
 
 	for (; n > 0 && itr != _terms.end(); n--)
 	{
-		itr = _terms.erase(itr);
 		_valueMap.erase(itr->value());
+		itr = _terms.erase(itr);
 	}
 
 	for (; itr != _terms.end(); itr++)


### PR DESCRIPTION
On Windows MSVC **Debug** build, if you drop two variables in Paired Samples Test list then it cause assertion failures.

I think it's a matter of order here?