### PR TITLE
add fileSystemWriteVirtualization on msix

### DIFF
--- a/Tools/windows/msix/AppxManifest-nightly.xml.in
+++ b/Tools/windows/msix/AppxManifest-nightly.xml.in
@@ -5,7 +5,9 @@
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:uap6="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"
   xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
-  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10">
 
 <Identity Name="JASP.SIDELOAD.NIGHTLY"
         Version="@JASP_VERSION_MAJOR@.@JASP_VERSION_MINOR@.@JASP_VERSION_PATCH@@JASP_VERSION_MSIX_PATCH_POSTFIX@.@JASP_VERSION_TWEAK@"

--- a/Tools/windows/msix/AppxManifest-nightly.xml.in
+++ b/Tools/windows/msix/AppxManifest-nightly.xml.in
@@ -16,6 +16,13 @@
   <DisplayName>JASP</DisplayName>
   <PublisherDisplayName>JASP</PublisherDisplayName>
   <Logo>Assets\StoreLogo.png</Logo>
+  <!--file system write virtualization exclusion ensures that configuration and logs are written directly to the system's actual AppData directory, preventing issues during upgrades and url access. -->
+  <virtualization:FileSystemWriteVirtualization>
+    <virtualization:ExcludedDirectories>
+      <virtualization:ExcludedDirectory>$(KnownFolder:RoamingAppData)\JASP</virtualization:ExcludedDirectory>
+      <virtualization:ExcludedDirectory>$(KnownFolder:LocalAppData)\JASP</virtualization:ExcludedDirectory>
+    </virtualization:ExcludedDirectories>
+  </virtualization:FileSystemWriteVirtualization>
 </Properties>
 
 <Resources>
@@ -28,6 +35,7 @@
 
 <Capabilities>
   <rescap:Capability Name="runFullTrust"/>
+  <rescap:Capability Name="unvirtualizedResources" />
 </Capabilities>
 
 <Applications>

--- a/Tools/windows/msix/AppxManifest-standalone.xml.in
+++ b/Tools/windows/msix/AppxManifest-standalone.xml.in
@@ -16,6 +16,13 @@
   <DisplayName>JASP</DisplayName>
   <PublisherDisplayName>JASP</PublisherDisplayName>
   <Logo>Assets\StoreLogo.png</Logo>
+  <!--file system write virtualization exclusion ensures that configuration and logs are written directly to the system's actual AppData directory, preventing issues during upgrades and url access. -->
+  <virtualization:FileSystemWriteVirtualization>
+    <virtualization:ExcludedDirectories>
+      <virtualization:ExcludedDirectory>$(KnownFolder:RoamingAppData)\JASP</virtualization:ExcludedDirectory>
+      <virtualization:ExcludedDirectory>$(KnownFolder:LocalAppData)\JASP</virtualization:ExcludedDirectory>
+    </virtualization:ExcludedDirectories>
+  </virtualization:FileSystemWriteVirtualization>
 </Properties>
 
 <Resources>
@@ -28,6 +35,7 @@
 
 <Capabilities>
   <rescap:Capability Name="runFullTrust"/>
+  <rescap:Capability Name="unvirtualizedResources" />
 </Capabilities>
 
 <Applications>

--- a/Tools/windows/msix/AppxManifest-standalone.xml.in
+++ b/Tools/windows/msix/AppxManifest-standalone.xml.in
@@ -5,7 +5,9 @@
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:uap6="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"
   xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
-  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10">
 
 <Identity Name="JASP.STANDALONE"
         Version="@JASP_VERSION_MAJOR@.@JASP_VERSION_MINOR@.@JASP_VERSION_PATCH@@JASP_VERSION_MSIX_PATCH_POSTFIX@.@JASP_VERSION_TWEAK@"

--- a/Tools/windows/msix/AppxManifest-store-beta.xml.in
+++ b/Tools/windows/msix/AppxManifest-store-beta.xml.in
@@ -16,6 +16,13 @@
   <DisplayName>JASP Beta</DisplayName>
   <PublisherDisplayName>JASP</PublisherDisplayName>
   <Logo>Assets\StoreLogo.png</Logo>
+  <!--file system write virtualization exclusion ensures that configuration and logs are written directly to the system's actual AppData directory, preventing issues during upgrades and url access. -->
+  <virtualization:FileSystemWriteVirtualization>
+    <virtualization:ExcludedDirectories>
+      <virtualization:ExcludedDirectory>$(KnownFolder:RoamingAppData)\JASP</virtualization:ExcludedDirectory>
+      <virtualization:ExcludedDirectory>$(KnownFolder:LocalAppData)\JASP</virtualization:ExcludedDirectory>
+    </virtualization:ExcludedDirectories>
+  </virtualization:FileSystemWriteVirtualization>
 </Properties>
 
 <Resources>
@@ -28,6 +35,7 @@
 
 <Capabilities>
   <rescap:Capability Name="runFullTrust"/>
+  <rescap:Capability Name="unvirtualizedResources" />
 </Capabilities>
 
 <Applications>

--- a/Tools/windows/msix/AppxManifest-store-beta.xml.in
+++ b/Tools/windows/msix/AppxManifest-store-beta.xml.in
@@ -5,7 +5,9 @@
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:uap6="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"
   xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
-  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10">
 
 <Identity Name="45842JASP.JASPBeta"
         Version="@JASP_VERSION_MAJOR@.@JASP_VERSION_MINOR@.@JASP_VERSION_PATCH@@JASP_VERSION_MSIX_PATCH_POSTFIX@.@JASP_VERSION_TWEAK@"

--- a/Tools/windows/msix/AppxManifest-store.xml.in
+++ b/Tools/windows/msix/AppxManifest-store.xml.in
@@ -16,6 +16,13 @@
   <DisplayName>JASP</DisplayName>
   <PublisherDisplayName>JASP</PublisherDisplayName>
   <Logo>Assets\StoreLogo.png</Logo>
+ <!--file system write virtualization exclusion ensures that configuration and logs are written directly to the system's actual AppData directory, preventing issues during upgrades and url access. -->
+  <virtualization:FileSystemWriteVirtualization>
+    <virtualization:ExcludedDirectories>
+      <virtualization:ExcludedDirectory>$(KnownFolder:RoamingAppData)\JASP</virtualization:ExcludedDirectory>
+      <virtualization:ExcludedDirectory>$(KnownFolder:LocalAppData)\JASP</virtualization:ExcludedDirectory>
+    </virtualization:ExcludedDirectories>
+  </virtualization:FileSystemWriteVirtualization>
 </Properties>
 
 <Resources>
@@ -28,6 +35,7 @@
 
 <Capabilities>
   <rescap:Capability Name="runFullTrust"/>
+  <rescap:Capability Name="unvirtualizedResources" />
 </Capabilities>
 
 <Applications>

--- a/Tools/windows/msix/AppxManifest-store.xml.in
+++ b/Tools/windows/msix/AppxManifest-store.xml.in
@@ -5,7 +5,9 @@
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:uap6="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"
   xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
-  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10">
 
 <Identity Name="45842JASP.JASP"
         Version="@JASP_VERSION_MAJOR@.@JASP_VERSION_MINOR@.1@JASP_VERSION_PATCH@@JASP_VERSION_MSIX_PATCH_POSTFIX@.@JASP_VERSION_TWEAK@"


### PR DESCRIPTION
maybe a solution for https://github.com/jasp-stats/INTERNAL-jasp/issues/3217 and https://github.com/jasp-stats/jasp-issues/issues/4292

Refer: https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-virtualization-filesystemwritevirtualization

Could some one make a MS Store beta version and test it with me?

How to actually test it: You need to build two versions, one before the other. Based on the first version, create logs and configurations, then upgrade to the second version and see if the previous settings still exist.