### PR TITLE
Update jaspBase for decoded result objects

### DIFF
--- a/Common/tempfiles.cpp
+++ b/Common/tempfiles.cpp
@@ -55,7 +55,7 @@ void TempFiles::createSessionDir()
 
 	std::filesystem::path sessionPath = _sessionDirName;
 	
-	std::cout<< "'" << sessionPath.string() << "' about to be (removed and re)created." << std::endl;
+	Log::log() << "'" << sessionPath.string() << "' about to be (removed and re)created." << std::endl;
 
 	std::filesystem::remove_all(sessionPath, error);
 	std::filesystem::create_directories(sessionPath, error);

--- a/QMLComponents/datasetprovider.cpp
+++ b/QMLComponents/datasetprovider.cpp
@@ -91,7 +91,7 @@ QVariant DataSetProvider::data(const QModelIndex & index, int role) const
 
 void DataSetProvider::loadDataSet(const std::map<std::string, stringvec > & dataSet, int threshold, bool orderLabelsByValue)
 {
-
+	beginResetModel();
 	_dataSet->beginBatchedToDB();
 
 	int rowCount = 0;
@@ -119,7 +119,7 @@ void DataSetProvider::loadDataSet(const std::map<std::string, stringvec > & data
 	_dataSet->endBatchedToDB([](float f) {});
 
 	ColumnEncoder::columnEncoder()->setCurrentNames(_dataSet->getColumnTypesMap());
-
+	endResetModel();
 }
 
 void DataSetProvider::closeDatabase()

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -46,6 +46,9 @@
 
 #include <string>
 #include <vector>
+#include <cstdlib>
+#include <ostream>
+#include <streambuf>
 
 #include <QtPlugin>
 #ifdef USE_QT_STATIC_LIBS
@@ -69,12 +72,18 @@ static int									gl_applicationArgc				= 0;
 static std::vector<std::string>				gl_applicationArgvStorage;
 static std::vector<char*>					gl_applicationArgv;
 
-static bool									gl_verbose						=
-#ifdef JASP_DEBUG
-	true;
-#else
-	false;
-#endif
+static bool									gl_verbose						= false;
+static bool									gl_logInitialized				= false;
+static bool									gl_qtMessageHandlerInstalled	= false;
+
+class NullBuffer : public std::streambuf
+{
+protected:
+	int_type overflow(int_type c) override { return traits_type::not_eof(c); }
+};
+
+static NullBuffer							gl_nullBuffer;
+static std::ostream							gl_nullStream(&gl_nullBuffer);
 
 static std::string							gl_param_resultFont				=
 #ifdef WIN32
@@ -136,6 +145,44 @@ static const char* statusResult(Json::Value status)
 	return result.c_str();
 }
 
+static bool envFlagEnabled(const char * name)
+{
+	const char * value = std::getenv(name);
+	if (!value)
+		return false;
+
+	std::string flag(value);
+	return flag == "1" || flag == "true" || flag == "TRUE" || flag == "yes" || flag == "YES";
+}
+
+static void syntaxBridgeQtMessageHandler(QtMsgType type, const QMessageLogContext &, const QString & message)
+{
+	if (gl_verbose || type == QtFatalMsg)
+		Log::log() << fq(message) << std::endl;
+
+	if (type == QtFatalMsg)
+		std::abort();
+}
+
+static void configureLogging()
+{
+	if (!gl_logInitialized)
+	{
+		gl_verbose = envFlagEnabled("JASP_SYNTAX_VERBOSE");
+		Log::init(&gl_nullStream);
+		gl_logInitialized = true;
+	}
+
+	if (!gl_qtMessageHandlerInstalled)
+	{
+		qInstallMessageHandler(syntaxBridgeQtMessageHandler);
+		gl_qtMessageHandlerInstalled = true;
+	}
+
+	Log::setDefaultDestination(gl_verbose ? logType::cout : logType::null);
+	Log::setWhere(gl_verbose ? logType::cout : logType::null);
+}
+
 static Json::Value statusBase(const char * operation)
 {
 	Json::Value status(Json::objectValue);
@@ -148,6 +195,7 @@ static const char* statusError(Json::Value status, const std::string & error)
 {
 	status["ok"] = false;
 	status["error"] = error;
+	configureLogging();
 	Log::log() << error << std::endl;
 	return statusResult(status);
 }
@@ -303,6 +351,18 @@ void STDCALL syntaxBridgeClearNativeState()
 {
 	syntaxBridgeClearQmlState();
 	syntaxBridgeClearDataSetState();
+}
+
+void STDCALL syntaxBridgeSetVerbose(bool verbose)
+{
+	gl_verbose = verbose;
+	if (!gl_logInitialized)
+	{
+		Log::init(&gl_nullStream);
+		gl_logInitialized = true;
+	}
+	Log::setDefaultDestination(gl_verbose ? logType::cout : logType::null);
+	Log::setWhere(gl_verbose ? logType::cout : logType::null);
 }
 
 void STDCALL syntaxBridgeCleanup()
@@ -502,6 +562,8 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptions(const char* moduleName, c
 
 const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePath, int analysisNr)
 {
+	configureLogging();
+
 	static std::string result;
 	result = "";
 
@@ -519,6 +581,8 @@ const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePat
 
 const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFileStatus(const char * filePath, int analysisNr)
 {
+	configureLogging();
+
 	Json::Value status = analysisOptionsStatus(filePath, analysisNr);
 	if (!status["ok"].asBool() && status.isMember("error"))
 		Log::log() << status["error"].asString() << std::endl;
@@ -681,6 +745,8 @@ void sendMessage(const char * msg)
 
 bool init(bool dbInMemory)
 {
+	configureLogging();
+
 	if (gl_initialized) return true;
 	gl_initialized = true;
 	gl_initializedDbInMemory = dbInMemory;

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -533,10 +533,6 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char* moduleN
 	if (!form)
 		return statusError(status, "Cannot create QML form '" + qmlFileStr + "'.");
 
-	// Process pending Qt events so that any AvailableVariablesList updates
-	// queued by a preceding loadDataSet call are applied before parsing.
-	gl_application->processEvents();
-
 	Json::Value parsedOptions;
 	std::string errorMsg;
 	if (!form->parseOptions(options, parsedOptions, errorMsg))

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -517,46 +517,48 @@ const char* STDCALL syntaxBridgeLoadDataSetFromJaspFileStatus(const char * fileP
 	}
 }
 
-const char* STDCALL syntaxBridgeLoadQmlAndParseOptions(const char* moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData)
+const char* STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char* moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData)
 {
+	Json::Value status = statusBase("syntaxBridgeLoadQmlAndParseOptions");
+
 	if (!init())
-	{
-		Log::log() << "Error during initialization" << std::endl;
-		return "";
-	}
+		return statusError(status, "SyntaxInterface initialization failed.");
 
 	std::string qmlFileStr		= qmlFile,
 				versionStr		= version,
 				analysisNameStr	= analysisName,
 				moduleNameStr	= moduleName;
 
-
 	AnalysisForm* form = getQmlForm(tq(qmlFileStr));
-
 	if (!form)
-	{
-		Log::log() << "Cannot create QML Form " << qmlFileStr << std::endl;
-		return "";
-	}
+		return statusError(status, "Cannot create QML form '" + qmlFileStr + "'.");
 
 	Json::Value parsedOptions;
 	std::string errorMsg;
-
 	if (!form->parseOptions(options, parsedOptions, errorMsg))
-	{
-		Log::log() << "Error when parsing options: " << errorMsg << std::endl;
-		return "";
-	}
+		return statusError(status, errorMsg);
 
 	gl_extraEncodings->setCurrentNamesFromOptionsMeta(parsedOptions);
 	gl_dataBridge->updateOptionsAccordingToMeta(parsedOptions);
 	ColumnEncoder::colsPlusTypes analysisColsTypes = ColumnEncoder::encodeColumnNamesinOptions(parsedOptions, preloadData);
-
 	rbridge_setWantedCols(analysisColsTypes);
 
-	static std::string result;
-	result = parsedOptions.toStyledString();
+	status["ok"]		= true;
+	status["options"]	= parsedOptions;
+	return statusResult(status);
+}
 
+const char* STDCALL syntaxBridgeLoadQmlAndParseOptions(const char* moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData)
+{
+	const char* statusJson = syntaxBridgeLoadQmlAndParseOptionsStatus(moduleName, analysisName, qmlFile, options, version, preloadData);
+
+	Json::Value status;
+	Json::Reader reader;
+	if (!reader.parse(statusJson, status) || !status["ok"].asBool())
+		return "";
+
+	static std::string result;
+	result = status["options"].toStyledString();
 	return result.c_str();
 }
 

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -533,6 +533,10 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char* moduleN
 	if (!form)
 		return statusError(status, "Cannot create QML form '" + qmlFileStr + "'.");
 
+	// Process pending Qt events so that any AvailableVariablesList updates
+	// queued by a preceding loadDataSet call are applied before parsing.
+	gl_application->processEvents();
+
 	Json::Value parsedOptions;
 	std::string errorMsg;
 	if (!form->parseOptions(options, parsedOptions, errorMsg))

--- a/SyntaxInterface/syntaxbridge_interface.h
+++ b/SyntaxInterface/syntaxbridge_interface.h
@@ -59,6 +59,7 @@ SYNTAX_INTERFACE void				STDCALL syntaxBridgeShutdown();
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeClearQmlState();
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeClearDataSetState();
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeClearNativeState();
+SYNTAX_INTERFACE void				STDCALL syntaxBridgeSetVerbose(bool verbose);
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeLoadDataSet(const SyntaxBridgeDataSet* dataset, bool dbInMemory, int threshold, bool orderLabelsByValue);
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeLoadDataSetFromJaspFile(const char * filePath, bool dbInMemory);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeLoadDataSetFromJaspFileStatus(const char * filePath, bool dbInMemory);

--- a/SyntaxInterface/syntaxbridge_interface.h
+++ b/SyntaxInterface/syntaxbridge_interface.h
@@ -64,6 +64,7 @@ SYNTAX_INTERFACE void				STDCALL syntaxBridgeLoadDataSet(const SyntaxBridgeDataS
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeLoadDataSetFromJaspFile(const char * filePath, bool dbInMemory);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeLoadDataSetFromJaspFileStatus(const char * filePath, bool dbInMemory);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeLoadQmlAndParseOptions(const char * moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData);
+SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char * moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePath, int analysisNr);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeAnalysisOptionsFromJaspFileStatus(const char * filePath, int analysisNr);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGenerateModuleWrappers(const char* name);


### PR DESCRIPTION
fixes: https://github.com/jasp-stats/INTERNAL-jasp/issues/3220

﻿## Summary
- updates `Engine/jaspBase` to `8c4f861`, which decodes the R-facing result copy returned by `$toRObject()` and exposes `decodeJaspResultState()` for stored figure state
- fixes direct `jaspSyntax` replay leakage of encoded bridge column names in returned table metadata, footnotes, stored ggplot labels, and result-state figure objects
- keeps encoded names available to modules while analyses run, so model fitting and dataset lookup continue to use the backend/runtime names

## Why
The `jaspTools` JSON path already runs result/state decoding after an analysis. Direct `jaspSyntax` usage, for example `jaspSyntax::loadDataSet(myData)` followed by `jaspMixedModels::MixedModelsLMM(...); res$toRObject()`, bypasses that `jaspTools` post-processing and receives raw `jaspBase` wrapper objects.

For MixedModels this meant the model ran correctly, but `res$toRObject()` could still expose internal names such as `JaspColumn_2_Encoded` in ANOVA footnotes and ggplot labels. The owning fix is in `jaspBase`, and this PR moves Desktop to that commit.

This also removes the remaining result-state gray area from `jaspTools`: state figure decoding now has a public `jaspBase::decodeJaspResultState()` API, so `jaspTools` can delegate instead of calling `jaspBase:::decodeplot()` directly.

## Dependencies
- jaspBase: https://github.com/jasp-stats/jaspBase/pull/204
- jaspTools consumer update: https://github.com/jasp-stats/jaspTools/pull/79
- related jaspSyntax result-text decoder: https://github.com/jasp-stats/jaspSyntax/pull/8

## Verification
- `Rscript -e "pkgload::load_all('C:/JASP-Packages/jasp-desktop/Engine/jaspBase', quiet = TRUE); testthat::test_dir('tests/testthat', reporter = 'summary')"`
- Direct R 4.6 replay of the `lme4::cake`/`ABC` MixedModelsLMM example through `jaspSyntax::loadDataSet()` and `res$toRObject()`; ANOVA footnote decoded to `recipe`, plot labels decoded to `ABC` and `temperature`, and the returned object had zero scalar `jaspColumn`/`JaspColumn_` hits.
- `git diff --check`
