### PR TITLE
fix files URI scheme in html image source

### DIFF
--- a/Desktop/html/js/image.js
+++ b/Desktop/html/js/image.js
@@ -449,7 +449,7 @@ JASPWidgets.imagePrimitive = JASPWidgets.View.extend({
 	_getHTMLImage: function (htmlImageFormatData, width, height, exportParams) {
 		var html = "";
 		if (exportParams.htmlImageFormat === JASPWidgets.ExportProperties.htmlImageFormat.temporary)
-			html = '<img src="file://' + htmlImageFormatData.temporary + '" style="width:' + width + 'px; height:' + height + 'px;" />';
+			html = '<img src="file:///' + htmlImageFormatData.temporary + '" style="width:' + width + 'px; height:' + height + 'px;" />';
 		else if (exportParams.htmlImageFormat === JASPWidgets.ExportProperties.htmlImageFormat.embedded)
 			html = '<div style="background-image : url(data:image/png;base64,' + htmlImageFormatData.embedded + '); background-size:' + width + 'px ' + height + 'px; width:' + width + 'px; height:' + height + 'px;"></div>';
 		else if (exportParams.htmlImageFormat === JASPWidgets.ExportProperties.htmlImageFormat.resource)


### PR DESCRIPTION
This helps alleviate some issues with pasting images in certain office software(e.g. WPS Office).

I intend to keep this PR separate from https://github.com/jasp-stats/jasp-desktop/pull/6233, because they are different things.
see: https://en.wikipedia.org/wiki/File_URI_scheme, `file:///path`  here 3rd `/` means empty hostname, is robust solution mayebe.

