### PR TITLE
Set custom menu at  the right place in Results when zooming

### DIFF
--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -537,7 +537,7 @@ Item
 						"functionCall"	: functionCall
 					};
 
-					customMenu.toggle(resultsView, props, (optionsJSON['rXright'] + 10 ) * preferencesModel.uiScale, optionsJSON['rY'] );
+					customMenu.toggle(resultsView, props, (optionsJSON['rXright'] + 10 ) * preferencesModel.uiScale, optionsJSON['rY'] * preferencesModel.uiScale)
 
 					customMenu.scrollOri		= resultsView.scrollPosition;
 					customMenu.menuScroll.x		= Qt.binding(function() { return -1 * (resultsView.scrollPosition.x - customMenu.scrollOri.x) / resultsView.zoomFactor; });


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3223