### PR TITLE
Expose native column encoder context

### DIFF
--- a/Common/columnencoder.cpp
+++ b/Common/columnencoder.cpp
@@ -670,22 +670,6 @@ ColumnEncoder::colVec ColumnEncoder::columnNamesEncoded()
 	return _columnEncoder ? _columnEncoder->_encodedNames : colVec();
 }
 
-ColumnEncoder::colMap ColumnEncoder::decodingMapSnapshot()
-{
-	columnEncoder();
-	return decodingMap();
-}
-
-std::string ColumnEncoder::decodeAllWithMapping(const std::string & text, const ColumnEncoder::colMap & decodingMap)
-{
-	ColumnEncoder::colVec encodedNames;
-	for(const auto & keyVal : decodingMap)
-		encodedNames.push_back(keyVal.first);
-
-	sortVectorBigToSmall(encodedNames);
-	return replaceAll(text, decodingMap, encodedNames);
-}
-
 void ColumnEncoder::_convertPreloadingDataOption(Json::Value & options, const std::string& optionName, colsPlusTypes& colTypes)
 {
 	std::string		optionKey	= options[optionName].isMember("optionKey") ? options[optionName]["optionKey"].asString() : "";

--- a/Common/columnencoder.cpp
+++ b/Common/columnencoder.cpp
@@ -670,6 +670,22 @@ ColumnEncoder::colVec ColumnEncoder::columnNamesEncoded()
 	return _columnEncoder ? _columnEncoder->_encodedNames : colVec();
 }
 
+ColumnEncoder::colMap ColumnEncoder::decodingMapSnapshot()
+{
+	columnEncoder();
+	return decodingMap();
+}
+
+std::string ColumnEncoder::decodeAllWithMapping(const std::string & text, const ColumnEncoder::colMap & decodingMap)
+{
+	ColumnEncoder::colVec encodedNames;
+	for(const auto & keyVal : decodingMap)
+		encodedNames.push_back(keyVal.first);
+
+	sortVectorBigToSmall(encodedNames);
+	return replaceAll(text, decodingMap, encodedNames);
+}
+
 void ColumnEncoder::_convertPreloadingDataOption(Json::Value & options, const std::string& optionName, colsPlusTypes& colTypes)
 {
 	std::string		optionKey	= options[optionName].isMember("optionKey") ? options[optionName]["optionKey"].asString() : "";
@@ -827,6 +843,7 @@ void ColumnEncoder::_addTypeToColumnNamesInOptionsRecursively(Json::Value & opti
 
 ColumnEncoder::colsPlusTypes ColumnEncoder::encodeColumnNamesinOptions(Json::Value & options, bool preloadingData)
 {
+	columnEncoder();
 	colsPlusTypes getTheseCols;
 
 	_addTypeToColumnNamesInOptionsRecursively(options, preloadingData, getTheseCols);

--- a/Common/columnencoder.h
+++ b/Common/columnencoder.h
@@ -63,6 +63,7 @@ public:
 	
 	static	colVec				columnNames();
 	static	colVec				columnNamesEncoded();
+	static	const char*			extraOptionsPrefix()										{ return "JaspExtraOptions_"; }
 
 			bool				shouldEncode(const std::string & in);
 			bool				shouldDecode(const std::string & in);

--- a/Common/columnencoder.h
+++ b/Common/columnencoder.h
@@ -63,12 +63,11 @@ public:
 	
 	static	colVec				columnNames();
 	static	colVec				columnNamesEncoded();
-	static	colMap				decodingMapSnapshot();
-	static	std::string			decodeAllWithMapping(const std::string & text, const colMap & decodingMap);
 
 			bool				shouldEncode(const std::string & in);
 			bool				shouldDecode(const std::string & in);
 			void				setCurrentNames(const colTypeMap & names);
+			const colTypeMap&	currentNames() const { return _dataSetTypes; }
 			void				updateColumnTypesOnly(const colTypeMap & names);
 			void				setCurrentNames(const std::vector<std::string> & names, bool generateTypesEncoding=true);	///< Do not use! Deprecated
 			void				setCurrentColumnTypePerName(const colTypeMap & theMap);									///< Do not use! Deprecated

--- a/Common/columnencoder.h
+++ b/Common/columnencoder.h
@@ -63,6 +63,8 @@ public:
 	
 	static	colVec				columnNames();
 	static	colVec				columnNamesEncoded();
+	static	colMap				decodingMapSnapshot();
+	static	std::string			decodeAllWithMapping(const std::string & text, const colMap & decodingMap);
 
 			bool				shouldEncode(const std::string & in);
 			bool				shouldDecode(const std::string & in);
@@ -87,7 +89,7 @@ public:
 	static	std::string			encodeAll(const std::string & text) { return replaceAll(text, encodingMap(), originalNames()); }
 
 			///Replace all occurences of encoded columnNames in a string by their decoded versions, regardless of word boundaries or parentheses.
-	static	std::string			decodeAll(const std::string & text) { return replaceAll(text, decodingMap(), encodedNames());  }
+	static	std::string			decodeAll(const std::string & text) { columnEncoder(); return replaceAll(text, decodingMap(), encodedNames());  }
 
 			///Replace all occurences of columnNames in a string by their encoded versions in all json-names and string-values, regardless of word boundaries or parentheses.
 	static	void				encodeJson(Json::Value & json, bool replaceNames = false, bool replaceStrict = false);

--- a/Common/columnencoder.h
+++ b/Common/columnencoder.h
@@ -63,7 +63,6 @@ public:
 	
 	static	colVec				columnNames();
 	static	colVec				columnNamesEncoded();
-	static	const char*			extraOptionsPrefix()										{ return "JaspExtraOptions_"; }
 
 			bool				shouldEncode(const std::string & in);
 			bool				shouldDecode(const std::string & in);

--- a/Common/columnencodercontext.cpp
+++ b/Common/columnencodercontext.cpp
@@ -1,0 +1,161 @@
+//
+// Copyright (C) 2013-2025 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "columnencodercontext.h"
+
+#include <stdexcept>
+
+static Json::Value columnTypesToJson(const ColumnEncoder::colTypeMap & columnTypes)
+{
+	Json::Value columns(Json::arrayValue);
+	for(const auto & nameType : columnTypes)
+	{
+		Json::Value column(Json::objectValue);
+		column["name"] = nameType.first;
+		column["type"] = columnTypeToString(nameType.second);
+		columns.append(column);
+	}
+
+	return columns;
+}
+
+static ColumnEncoder::colTypeMap columnTypesFromJson(const Json::Value & columns, const char * fieldName)
+{
+	ColumnEncoder::colTypeMap columnTypes;
+
+	if(columns.isNull())
+		return columnTypes;
+	if(!columns.isArray())
+		throw std::runtime_error(std::string("Column encoder context field '") + fieldName + "' must be an array.");
+
+	for(const Json::Value & column : columns)
+	{
+		if(!column.isObject() || !column["name"].isString() || !column["type"].isString())
+			throw std::runtime_error(std::string("Column encoder context field '") + fieldName + "' must contain objects with string 'name' and 'type' fields.");
+
+		columnTypes[column["name"].asString()] = columnTypeFromString(column["type"].asString());
+	}
+
+	return columnTypes;
+}
+
+static Json::Value parseStringArrayJson(const char * valuesJson)
+{
+	if(!valuesJson)
+		throw std::runtime_error("Cannot decode column text from a null JSON payload.");
+
+	Json::Value values;
+	Json::Reader reader;
+	if(!reader.parse(valuesJson, values))
+		throw std::runtime_error("Could not parse column text JSON payload.");
+	if(!values.isArray())
+		throw std::runtime_error("Column text JSON payload must be an array.");
+
+	return values;
+}
+
+ColumnEncoderContext::ColumnEncoderContext(const ColumnEncoder::colTypeMap & columns, const ColumnEncoder::colTypeMap & extra)
+	: _columns(columns), _extra(extra), _supplied(true)
+{
+}
+
+ColumnEncoderContext ColumnEncoderContext::fromJson(const Json::Value & context)
+{
+	if(!context.isObject())
+		throw std::runtime_error("Column encoder context must be a JSON object.");
+
+	if(!context.isMember("version") || !context["version"].isInt())
+		throw std::runtime_error("Column encoder context must contain integer version 1.");
+	if(context["version"].asInt() != Version)
+		throw std::runtime_error("Unsupported column encoder context version.");
+
+	return ColumnEncoderContext(
+		columnTypesFromJson(context["columns"], "columns"),
+		columnTypesFromJson(context["extra"], "extra")
+	);
+}
+
+ColumnEncoderContext ColumnEncoderContext::fromJsonString(const char * contextJson)
+{
+	if(!contextJson || std::string(contextJson).empty())
+		return ColumnEncoderContext();
+
+	Json::Value context;
+	Json::Reader reader;
+	if(!reader.parse(contextJson, context))
+		throw std::runtime_error("Could not parse column encoder context JSON.");
+
+	return fromJson(context);
+}
+
+Json::Value ColumnEncoderContext::toJson() const
+{
+	Json::Value context(Json::objectValue);
+	context["version"] = Version;
+	context["columns"] = columnTypesToJson(_columns);
+	context["extra"] = columnTypesToJson(_extra);
+
+	return context;
+}
+
+ScopedColumnEncoderContext::ScopedColumnEncoderContext(const ColumnEncoderContext & context, ColumnEncoder & extraEncoder)
+	: _supplied(context.supplied()), _extraEncoder(extraEncoder)
+{
+	if(!_supplied)
+		return;
+
+	_previousColumns = ColumnEncoder::columnEncoder()->currentNames();
+	_previousExtra = _extraEncoder.currentNames();
+
+	ColumnEncoder::columnEncoder()->setCurrentNames(context.columns());
+	_extraEncoder.setCurrentNames(context.extra());
+}
+
+ScopedColumnEncoderContext::~ScopedColumnEncoderContext()
+{
+	if(!_supplied)
+		return;
+
+	ColumnEncoder::columnEncoder()->setCurrentNames(_previousColumns);
+	_extraEncoder.setCurrentNames(_previousExtra);
+}
+
+Json::Value decodeColumnTextJson(const char * valuesJson, const char * encoderContextJson, ColumnEncoder & extraEncoder)
+{
+	Json::Value values = parseStringArrayJson(valuesJson);
+	ColumnEncoderContext context = ColumnEncoderContext::fromJsonString(encoderContextJson);
+	Json::Value decodedValues(Json::arrayValue);
+	ScopedColumnEncoderContext scopedContext(context, extraEncoder);
+
+	for(const Json::Value & value : values)
+	{
+		if(value.isNull())
+		{
+			decodedValues.append(Json::Value());
+		}
+		else if(value.isString())
+		{
+			decodedValues.append(ColumnEncoder::decodeAll(value.asString()));
+		}
+		else
+		{
+			throw std::runtime_error("Column text JSON payload must contain only strings or null values.");
+		}
+	}
+
+	return decodedValues;
+}

--- a/Common/columnencodercontext.cpp
+++ b/Common/columnencodercontext.cpp
@@ -53,19 +53,17 @@ static ColumnEncoder::colTypeMap columnTypesFromJson(const Json::Value & columns
 	return columnTypes;
 }
 
-static Json::Value parseStringArrayJson(const char * valuesJson)
+static Json::Value parsePayloadJson(const char * payloadJson)
 {
-	if(!valuesJson)
+	if(!payloadJson)
 		throw std::runtime_error("Cannot decode column text from a null JSON payload.");
 
-	Json::Value values;
+	Json::Value payload;
 	Json::Reader reader;
-	if(!reader.parse(valuesJson, values))
+	if(!reader.parse(payloadJson, payload))
 		throw std::runtime_error("Could not parse column text JSON payload.");
-	if(!values.isArray())
-		throw std::runtime_error("Column text JSON payload must be an array.");
 
-	return values;
+	return payload;
 }
 
 ColumnEncoderContext::ColumnEncoderContext(const ColumnEncoder::colTypeMap & columns, const ColumnEncoder::colTypeMap & extra)
@@ -134,28 +132,13 @@ ScopedColumnEncoderContext::~ScopedColumnEncoderContext()
 	_extraEncoder.setCurrentNames(_previousExtra);
 }
 
-Json::Value decodeColumnTextJson(const char * valuesJson, const char * encoderContextJson, ColumnEncoder & extraEncoder)
+Json::Value decodeColumnJson(const char * payloadJson, const char * encoderContextJson, ColumnEncoder & extraEncoder, bool replaceNames)
 {
-	Json::Value values = parseStringArrayJson(valuesJson);
+	Json::Value payload = parsePayloadJson(payloadJson);
 	ColumnEncoderContext context = ColumnEncoderContext::fromJsonString(encoderContextJson);
-	Json::Value decodedValues(Json::arrayValue);
 	ScopedColumnEncoderContext scopedContext(context, extraEncoder);
 
-	for(const Json::Value & value : values)
-	{
-		if(value.isNull())
-		{
-			decodedValues.append(Json::Value());
-		}
-		else if(value.isString())
-		{
-			decodedValues.append(ColumnEncoder::decodeAll(value.asString()));
-		}
-		else
-		{
-			throw std::runtime_error("Column text JSON payload must contain only strings or null values.");
-		}
-	}
+	ColumnEncoder::decodeJson(payload, replaceNames);
 
-	return decodedValues;
+	return payload;
 }

--- a/Common/columnencodercontext.h
+++ b/Common/columnencodercontext.h
@@ -1,0 +1,61 @@
+//
+// Copyright (C) 2013-2025 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef COLUMNENCODERCONTEXT_H
+#define COLUMNENCODERCONTEXT_H
+
+#include "columnencoder.h"
+
+class ColumnEncoderContext
+{
+public:
+	static constexpr int Version = 1;
+
+	ColumnEncoderContext() = default;
+	ColumnEncoderContext(const ColumnEncoder::colTypeMap & columns, const ColumnEncoder::colTypeMap & extra);
+
+	static ColumnEncoderContext	fromJson(const Json::Value & context);
+	static ColumnEncoderContext	fromJsonString(const char * contextJson);
+
+	Json::Value					toJson() const;
+
+	const ColumnEncoder::colTypeMap&	columns() const		{ return _columns; }
+	const ColumnEncoder::colTypeMap&	extra() const		{ return _extra; }
+	bool								supplied() const	{ return _supplied; }
+
+private:
+	ColumnEncoder::colTypeMap	_columns;
+	ColumnEncoder::colTypeMap	_extra;
+	bool						_supplied = false;
+};
+
+class ScopedColumnEncoderContext
+{
+public:
+	ScopedColumnEncoderContext(const ColumnEncoderContext & context, ColumnEncoder & extraEncoder);
+	~ScopedColumnEncoderContext();
+
+private:
+	bool						_supplied = false;
+	ColumnEncoder				& _extraEncoder;
+	ColumnEncoder::colTypeMap	_previousColumns;
+	ColumnEncoder::colTypeMap	_previousExtra;
+};
+
+Json::Value decodeColumnTextJson(const char * valuesJson, const char * encoderContextJson, ColumnEncoder & extraEncoder);
+
+#endif // COLUMNENCODERCONTEXT_H

--- a/Common/columnencodercontext.h
+++ b/Common/columnencodercontext.h
@@ -56,6 +56,6 @@ private:
 	ColumnEncoder::colTypeMap	_previousExtra;
 };
 
-Json::Value decodeColumnTextJson(const char * valuesJson, const char * encoderContextJson, ColumnEncoder & extraEncoder);
+Json::Value decodeColumnJson(const char * payloadJson, const char * encoderContextJson, ColumnEncoder & extraEncoder, bool replaceNames = true);
 
 #endif // COLUMNENCODERCONTEXT_H

--- a/Common/log.cpp
+++ b/Common/log.cpp
@@ -15,7 +15,19 @@
 
 std::ofstream Log::_logFile;// = bofstream();
 
-std::ostream* Log::_nullStream = &std::cout;
+namespace
+{
+	class NullLogBuffer : public std::streambuf
+	{
+	protected:
+		int overflow(int c) override { return traits_type::not_eof(c); }
+	};
+
+	NullLogBuffer	nullLogBuffer;
+	std::ostream	nullLogStream(&nullLogBuffer);
+}
+
+std::ostream* Log::_nullStream = &nullLogStream;
 
 std::string Log::logFileNameBase	= "";
 

--- a/Common/log.cpp
+++ b/Common/log.cpp
@@ -15,21 +15,7 @@
 
 std::ofstream Log::_logFile;// = bofstream();
 
-namespace
-{
-	// Used before Log::init() receives an application-owned null stream. The
-	// default logType::null destination must discard output, not write to cout.
-	class NullLogBuffer : public std::streambuf
-	{
-	protected:
-		int overflow(int c) override { return traits_type::not_eof(c); }
-	};
-
-	NullLogBuffer	nullLogBuffer;
-	std::ostream	nullLogStream(&nullLogBuffer);
-}
-
-std::ostream* Log::_nullStream = &nullLogStream;
+std::ostream* Log::_nullStream = &std::cout;
 
 std::string Log::logFileNameBase	= "";
 

--- a/Common/log.cpp
+++ b/Common/log.cpp
@@ -17,6 +17,8 @@ std::ofstream Log::_logFile;// = bofstream();
 
 namespace
 {
+	// Used before Log::init() receives an application-owned null stream. The
+	// default logType::null destination must discard output, not write to cout.
 	class NullLogBuffer : public std::streambuf
 	{
 	protected:

--- a/CommonData/databridge.cpp
+++ b/CommonData/databridge.cpp
@@ -23,6 +23,7 @@
 #include "timers.h"
 
 DataBridge::DataBridge(unsigned long sessionID, bool useMemory)
+	: _extraEncodings(new ColumnEncoder(ExtraOptionsPrefix))
 {
 	JASPTIMER_START(TempFiles Attach);
 	TempFiles::attach(sessionID);

--- a/CommonData/databridge.h
+++ b/CommonData/databridge.h
@@ -21,6 +21,10 @@
 
 #include "dataset.h"
 
+#include <memory>
+
+class ColumnEncoder;
+
 class DataBridge
 {
 public:
@@ -44,6 +48,8 @@ public:
 	void					provideSpecificFileName(	const std::string & specificName,	std::string & root,	std::string & relativePath);
 	int						dataSetRowCount()		{ return static_cast<int>(provideAndUpdateDataSet()->rowCount()); }
 	void 					updateOptionsAccordingToMeta(Json::Value & options);
+	ColumnEncoder		*	extraEncodings()		{ return _extraEncodings.get(); }
+	const ColumnEncoder	*	extraEncodings() const	{ return _extraEncodings.get(); }
 
 protected:
 	bool					isColumnNameOk(const std::string & columnName);
@@ -54,6 +60,10 @@ protected:
 	DatabaseInterface	*	_db				= nullptr;
 	int						_analysisId		= -1;
 	std::function<void()>	_datasetProvidedCallback;
+
+private:
+	static constexpr const char * ExtraOptionsPrefix = "JaspExtraOptions_";
+	std::unique_ptr<ColumnEncoder>	_extraEncodings;
 };
 
 #endif // DATABRIDGE_H

--- a/CommonData/rbridge.cpp
+++ b/CommonData/rbridge.cpp
@@ -209,12 +209,12 @@ extern "C" int STDCALL rbridge_decodeColumnType(const char * in)
 
 extern "C" bool STDCALL rbridge_shouldEncodeColumnName(const char * in)
 {
-	return ColumnEncoder::columnEncoder()->shouldEncode(in);
+	return (extraEncodings && extraEncodings->shouldEncode(in)) || ColumnEncoder::columnEncoder()->shouldEncode(in);
 }
 
 extern "C" bool STDCALL rbridge_shouldDecodeColumnName(const char * in)
 {
-	return ColumnEncoder::columnEncoder()->shouldDecode(in);
+	return (extraEncodings && extraEncodings->shouldDecode(in)) || ColumnEncoder::columnEncoder()->shouldDecode(in);
 }
 
 extern "C" const char * STDCALL rbridge_encodeAllColumnNames(const char * in)

--- a/CommonData/rbridge.cpp
+++ b/CommonData/rbridge.cpp
@@ -65,12 +65,12 @@ void rbridge_setDataBridge(DataBridge * dataBridge)
 {
 	data_bridge = dataBridge;
 	rbridge_dataSet = nullptr;
+	extraEncodings = dataBridge ? dataBridge->extraEncodings() : nullptr;
 }
 
 void rbridge_clearDataBridge()
 {
-	data_bridge = nullptr;
-	rbridge_dataSet = nullptr;
+	rbridge_setDataBridge(nullptr);
 }
 
 const std::string jaspBaseDistributionSamplersR =
@@ -102,14 +102,12 @@ const std::string jaspBaseTransformPowerR =
 		#include "jaspBase_transformPower.h"
 		;
 
-void rbridge_init(DataBridge * dataBridge, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * extraEncoder, const char * resultFont, bool insideJasp)
+void rbridge_init(DataBridge * dataBridge, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, const char * resultFont, bool insideJasp)
 {
 	JASPTIMER_SCOPE(rbridge_init);
 
+	Log::log() << "Setting DataBridge and extraEncodings." << std::endl;
 	rbridge_setDataBridge(dataBridge);
-	
-	Log::log() << "Setting extraEncodings." << std::endl;
-	extraEncodings = extraEncoder;
 
 	Log::log() << "Collecting RBridgeCallBacks." << std::endl;
 	RBridgeCallBacks callbacks = {

--- a/CommonData/rbridge.h
+++ b/CommonData/rbridge.h
@@ -82,7 +82,7 @@ extern "C" {
 
 	void				rbridge_setDataBridge(DataBridge * dataBridge);
 	void				rbridge_clearDataBridge();
-	void				rbridge_init(DataBridge * dataBridge, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, ColumnEncoder * encoder, const char * resultFont, bool insideJasp = true);
+	void				rbridge_init(DataBridge * dataBridge, sendFuncDef sendToDesktopFunction, pollMessagesFuncDef pollMessagesFunction, const char * resultFont, bool insideJasp = true);
 
 	void				rbridge_memoryCleaning();
 

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -76,7 +76,7 @@ Engine::Engine(int slaveNo, unsigned long parentPID)
 	assert(_EngineInstance == NULL);
 	_EngineInstance = this;
 
-	_extraEncodings = new ColumnEncoder("JaspExtraOptions_");
+	_extraEncodings = new ColumnEncoder(ColumnEncoder::extraOptionsPrefix());
 }
 
 void Engine::initialize()

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -75,8 +75,6 @@ Engine::Engine(int slaveNo, unsigned long parentPID)
 	JASPTIMER_SCOPE(Engine Constructor);
 	assert(_EngineInstance == NULL);
 	_EngineInstance = this;
-
-	_extraEncodings = new ColumnEncoder(ColumnEncoder::extraOptionsPrefix());
 }
 
 void Engine::initialize()
@@ -88,7 +86,7 @@ void Engine::initialize()
 		std::string memoryName = "JASP-IPC-" + std::to_string(_parentPID);
 		_channel = new IPCChannel(memoryName, _engineNum, true);
 
-		rbridge_init(this, SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _extraEncodings, _resultFont.c_str());
+		rbridge_init(this, SendFunctionForJaspresults, PollMessagesFunctionForJaspResults, _resultFont.c_str());
 
 		Log::log() << "rbridge_init completed" << std::endl;
 		
@@ -679,7 +677,7 @@ void Engine::receiveAnalysisMessage(const Json::Value & jsonRequest)
 		
 		Log::log(false) << _analysisTitle << " with ID " << _analysisId << std::endl;
 		
-		_extraEncodings->setCurrentNamesFromOptionsMeta(optionsEnc);
+		extraEncodings()->setCurrentNamesFromOptionsMeta(optionsEnc);
 		
 		_analysisOptions		= optionsEnc; //store unencoded
 	}

--- a/Engine/engine.h
+++ b/Engine/engine.h
@@ -97,7 +97,6 @@ private: // Data:
 	const int						_engineNum;
 	const unsigned long				_parentPID;
 	IPCChannel					*	_channel				= nullptr;
-	ColumnEncoder				*	_extraEncodings			= nullptr;
 	engineState						_engineState			= engineState::initializing,
 									_lastRequest			= engineState::initializing;
 	Status							_analysisStatus			= Status::empty;

--- a/SyntaxInterface/CMakeLists.txt
+++ b/SyntaxInterface/CMakeLists.txt
@@ -48,6 +48,10 @@ target_compile_definitions(
 	JASP_R_INTERFACE_LIBRARY
 	)
 
+if(MSVC)
+	target_compile_options(SyntaxInterface PRIVATE /EHsc)
+endif()
+
 if(USE_QT_STATIC_LIBS)
 	target_compile_definitions(
 		SyntaxInterface

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -43,9 +43,11 @@
 #include "modules/dynamicmodule.h"
 #include "archivereader.h"
 #include "databaseinterface.h"
+#include "columnencoder.h"
 
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 #include <QtPlugin>
 #ifdef USE_QT_STATIC_LIBS
@@ -150,6 +152,98 @@ static const char* statusError(Json::Value status, const std::string & error)
 	status["error"] = error;
 	Log::log() << error << std::endl;
 	return statusResult(status);
+}
+
+static Json::Value columnDecoderSnapshotJson()
+{
+	Json::Value snapshot(Json::objectValue);
+	Json::Value columns(Json::arrayValue);
+	const ColumnEncoder::colMap decodingMap = ColumnEncoder::decodingMapSnapshot();
+
+	for(const auto & keyVal : decodingMap)
+	{
+		Json::Value column(Json::objectValue);
+		column["encoded"] = keyVal.first;
+		column["decoded"] = keyVal.second;
+		columns.append(column);
+	}
+
+	snapshot["version"] = 1;
+	snapshot["columns"] = columns;
+	return snapshot;
+}
+
+struct ColumnDecoderSnapshot
+{
+	ColumnEncoder::colMap	decodingMap;
+	bool					supplied = false;
+};
+
+static ColumnDecoderSnapshot columnDecoderMapFromSnapshot(const Json::Value & snapshot)
+{
+	ColumnDecoderSnapshot snapshotState;
+	snapshotState.supplied = true;
+	const Json::Value & columns = snapshot["columns"];
+	if(!columns.isArray())
+		return snapshotState;
+
+	for(const Json::Value & column : columns)
+		if(column.isObject() && column["encoded"].isString() && column["decoded"].isString())
+			snapshotState.decodingMap[column["encoded"].asString()] = column["decoded"].asString();
+
+	return snapshotState;
+}
+
+static ColumnDecoderSnapshot columnDecoderMapFromSnapshotString(const char * snapshotJson)
+{
+	if(!snapshotJson || std::string(snapshotJson).empty())
+		return ColumnDecoderSnapshot();
+
+	Json::Value snapshot;
+	Json::Reader reader;
+	if(!reader.parse(snapshotJson, snapshot))
+		throw std::runtime_error("Could not parse column decoder snapshot JSON.");
+
+	return columnDecoderMapFromSnapshot(snapshot);
+}
+
+static Json::Value parseStringArrayJson(const char * valuesJson)
+{
+	if(!valuesJson)
+		throw std::runtime_error("Cannot decode column text from a null JSON payload.");
+
+	Json::Value values;
+	Json::Reader reader;
+	if(!reader.parse(valuesJson, values))
+		throw std::runtime_error("Could not parse column text JSON payload.");
+	if(!values.isArray())
+		throw std::runtime_error("Column text JSON payload must be an array.");
+
+	return values;
+}
+
+static Json::Value decodeColumnTextJson(const Json::Value & values, const ColumnDecoderSnapshot & snapshot)
+{
+	Json::Value decodedValues(Json::arrayValue);
+
+	for(const Json::Value & value : values)
+	{
+		if(value.isNull())
+		{
+			decodedValues.append(Json::Value());
+		}
+		else if(value.isString())
+		{
+			const std::string text = value.asString();
+			decodedValues.append(snapshot.supplied ? ColumnEncoder::decodeAllWithMapping(text, snapshot.decodingMap) : ColumnEncoder::decodeAll(text));
+		}
+		else
+		{
+			throw std::runtime_error("Column text JSON payload must contain only strings or null values.");
+		}
+	}
+
+	return decodedValues;
 }
 
 static Json::Value analysisOptionsStatus(const char * filePath, int analysisNr)
@@ -459,11 +553,22 @@ const char* STDCALL syntaxBridgeLoadDataSetFromJaspFileStatus(const char * fileP
 
 const char* STDCALL syntaxBridgeLoadQmlAndParseOptions(const char* moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData)
 {
-	if (!init())
-	{
-		Log::log() << "Error during initialization" << std::endl;
+	Json::Value status;
+	Json::Reader reader;
+	if (!reader.parse(syntaxBridgeLoadQmlAndParseOptionsStatus(moduleName, analysisName, qmlFile, options, version, preloadData), status))
 		return "";
-	}
+	if (!status["ok"].asBool())
+		return "";
+
+	static std::string result;
+	result = status["options"].toStyledString();
+	return result.c_str();
+}
+
+const char* STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char* moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData)
+{
+	if (!init())
+		return statusError(statusBase("syntaxBridgeLoadQmlAndParseOptions"), "Error during initialization.");
 
 	std::string qmlFileStr		= qmlFile,
 				versionStr		= version,
@@ -475,8 +580,7 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptions(const char* moduleName, c
 
 	if (!form)
 	{
-		Log::log() << "Cannot create QML Form " << qmlFileStr << std::endl;
-		return "";
+		return statusError(statusBase("syntaxBridgeLoadQmlAndParseOptions"), "Cannot create QML Form " + qmlFileStr);
 	}
 
 	Json::Value parsedOptions;
@@ -484,8 +588,7 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptions(const char* moduleName, c
 
 	if (!form->parseOptions(options, parsedOptions, errorMsg))
 	{
-		Log::log() << "Error when parsing options: " << errorMsg << std::endl;
-		return "";
+		return statusError(statusBase("syntaxBridgeLoadQmlAndParseOptions"), "Error when parsing options: " + errorMsg);
 	}
 
 	gl_extraEncodings->setCurrentNamesFromOptionsMeta(parsedOptions);
@@ -494,10 +597,10 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptions(const char* moduleName, c
 
 	rbridge_setWantedCols(analysisColsTypes);
 
-	static std::string result;
-	result = parsedOptions.toStyledString();
-
-	return result.c_str();
+	Json::Value status = statusBase("syntaxBridgeLoadQmlAndParseOptions");
+	status["ok"] = true;
+	status["options"] = parsedOptions;
+	return statusResult(status);
 }
 
 const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePath, int analysisNr)
@@ -653,6 +756,42 @@ const char* STDCALL syntaxBridgeGetVariableNames()
 
 	result = jsonNames.toStyledString();
 	return result.c_str();
+}
+
+void STDCALL syntaxBridgeSetVerbose(bool verbose)
+{
+	gl_verbose = verbose;
+	Log::setDefaultDestination(verbose ? logType::cout : logType::null);
+	Log::setWhere(verbose ? logType::cout : logType::null);
+}
+
+const char* STDCALL syntaxBridgeColumnDecoderSnapshot()
+{
+	static std::string result;
+
+	result = columnDecoderSnapshotJson().toStyledString();
+	return result.c_str();
+}
+
+const char* STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const char* decoderSnapshotJson)
+{
+	static std::string result;
+
+	try
+	{
+		Json::Value values = parseStringArrayJson(valuesJson);
+		ColumnDecoderSnapshot snapshot = columnDecoderMapFromSnapshotString(decoderSnapshotJson);
+		result = decodeColumnTextJson(values, snapshot).toStyledString();
+		return result.c_str();
+	}
+	catch(const std::exception & exception)
+	{
+		return statusError(statusBase("syntaxBridgeDecodeColumnText"), exception.what());
+	}
+	catch(...)
+	{
+		return statusError(statusBase("syntaxBridgeDecodeColumnText"), "Unknown error while decoding column text.");
+	}
 }
 
 } // extern "C"

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -154,58 +154,132 @@ static const char* statusError(Json::Value status, const std::string & error)
 	return statusResult(status);
 }
 
-static Json::Value columnDecoderSnapshotJson()
+static ColumnEncoder * ensureExtraColumnEncoder()
 {
-	Json::Value snapshot(Json::objectValue);
-	Json::Value columns(Json::arrayValue);
-	const ColumnEncoder::colMap decodingMap = ColumnEncoder::decodingMapSnapshot();
+	if(!gl_extraEncodings)
+		gl_extraEncodings = new ColumnEncoder("JaspExtraOptions_");
 
-	for(const auto & keyVal : decodingMap)
+	return gl_extraEncodings;
+}
+
+static Json::Value columnTypesToJson(const ColumnEncoder::colTypeMap & columnTypes)
+{
+	Json::Value columns(Json::arrayValue);
+	for(const auto & nameType : columnTypes)
 	{
 		Json::Value column(Json::objectValue);
-		column["encoded"] = keyVal.first;
-		column["decoded"] = keyVal.second;
+		column["name"] = nameType.first;
+		column["type"] = columnTypeToString(nameType.second);
 		columns.append(column);
 	}
 
-	snapshot["version"] = 1;
-	snapshot["columns"] = columns;
-	return snapshot;
+	return columns;
 }
 
-struct ColumnDecoderSnapshot
+static ColumnEncoder::colTypeMap columnTypesFromJson(const Json::Value & columns, const char * fieldName)
 {
-	ColumnEncoder::colMap	decodingMap;
-	bool					supplied = false;
-};
+	ColumnEncoder::colTypeMap columnTypes;
 
-static ColumnDecoderSnapshot columnDecoderMapFromSnapshot(const Json::Value & snapshot)
-{
-	ColumnDecoderSnapshot snapshotState;
-	snapshotState.supplied = true;
-	const Json::Value & columns = snapshot["columns"];
+	if(columns.isNull())
+		return columnTypes;
 	if(!columns.isArray())
-		return snapshotState;
+		throw std::runtime_error(std::string("Column encoder context field '") + fieldName + "' must be an array.");
 
 	for(const Json::Value & column : columns)
-		if(column.isObject() && column["encoded"].isString() && column["decoded"].isString())
-			snapshotState.decodingMap[column["encoded"].asString()] = column["decoded"].asString();
+	{
+		if(!column.isObject() || !column["name"].isString() || !column["type"].isString())
+			throw std::runtime_error(std::string("Column encoder context field '") + fieldName + "' must contain objects with string 'name' and 'type' fields.");
 
-	return snapshotState;
+		columnTypes[column["name"].asString()] = columnTypeFromString(column["type"].asString());
+	}
+
+	return columnTypes;
 }
 
-static ColumnDecoderSnapshot columnDecoderMapFromSnapshotString(const char * snapshotJson)
+static ColumnEncoder::colTypeMap currentDatasetColumnTypes()
 {
-	if(!snapshotJson || std::string(snapshotJson).empty())
-		return ColumnDecoderSnapshot();
-
-	Json::Value snapshot;
-	Json::Reader reader;
-	if(!reader.parse(snapshotJson, snapshot))
-		throw std::runtime_error("Could not parse column decoder snapshot JSON.");
-
-	return columnDecoderMapFromSnapshot(snapshot);
+	DataSet * dataSet = gl_dataBridge ? gl_dataBridge->provideAndUpdateDataSet() : nullptr;
+	return dataSet ? dataSet->getColumnTypesMap() : ColumnEncoder::colTypeMap();
 }
+
+static Json::Value columnEncoderContextJson()
+{
+	Json::Value context(Json::objectValue);
+	context["version"] = 1;
+	context["columns"] = columnTypesToJson(currentDatasetColumnTypes());
+	context["extra"] = columnTypesToJson(gl_extraEncodings ? gl_extraEncodings->currentNames() : ColumnEncoder::colTypeMap());
+
+	return context;
+}
+
+struct ColumnEncoderContext
+{
+	ColumnEncoder::colTypeMap	columns;
+	ColumnEncoder::colTypeMap	extra;
+	bool						supplied = false;
+};
+
+static ColumnEncoderContext columnEncoderContextFromJson(const Json::Value & context)
+{
+	if(!context.isObject())
+		throw std::runtime_error("Column encoder context must be a JSON object.");
+
+	if(!context.isMember("version") || !context["version"].isInt())
+		throw std::runtime_error("Column encoder context must contain integer version 1.");
+	if(context["version"].asInt() != 1)
+		throw std::runtime_error("Unsupported column encoder context version.");
+
+	ColumnEncoderContext encoderContext;
+	encoderContext.supplied = true;
+	encoderContext.columns = columnTypesFromJson(context["columns"], "columns");
+	encoderContext.extra = columnTypesFromJson(context["extra"], "extra");
+
+	return encoderContext;
+}
+
+static ColumnEncoderContext columnEncoderContextFromString(const char * contextJson)
+{
+	if(!contextJson || std::string(contextJson).empty())
+		return ColumnEncoderContext();
+
+	Json::Value context;
+	Json::Reader reader;
+	if(!reader.parse(contextJson, context))
+		throw std::runtime_error("Could not parse column encoder context JSON.");
+
+	return columnEncoderContextFromJson(context);
+}
+
+class ScopedColumnEncoderContext
+{
+public:
+	ScopedColumnEncoderContext(const ColumnEncoderContext & context)
+		: _supplied(context.supplied)
+	{
+		if(!_supplied)
+			return;
+
+		_previousColumns = ColumnEncoder::columnEncoder()->currentNames();
+		_previousExtra = gl_extraEncodings ? gl_extraEncodings->currentNames() : ColumnEncoder::colTypeMap();
+
+		ColumnEncoder::columnEncoder()->setCurrentNames(context.columns);
+		ensureExtraColumnEncoder()->setCurrentNames(context.extra);
+	}
+
+	~ScopedColumnEncoderContext()
+	{
+		if(!_supplied)
+			return;
+
+		ColumnEncoder::columnEncoder()->setCurrentNames(_previousColumns);
+		ensureExtraColumnEncoder()->setCurrentNames(_previousExtra);
+	}
+
+private:
+	bool						_supplied = false;
+	ColumnEncoder::colTypeMap	_previousColumns;
+	ColumnEncoder::colTypeMap	_previousExtra;
+};
 
 static Json::Value parseStringArrayJson(const char * valuesJson)
 {
@@ -222,9 +296,10 @@ static Json::Value parseStringArrayJson(const char * valuesJson)
 	return values;
 }
 
-static Json::Value decodeColumnTextJson(const Json::Value & values, const ColumnDecoderSnapshot & snapshot)
+static Json::Value decodeColumnTextJson(const Json::Value & values, const ColumnEncoderContext & context)
 {
 	Json::Value decodedValues(Json::arrayValue);
+	ScopedColumnEncoderContext scopedContext(context);
 
 	for(const Json::Value & value : values)
 	{
@@ -235,7 +310,7 @@ static Json::Value decodeColumnTextJson(const Json::Value & values, const Column
 		else if(value.isString())
 		{
 			const std::string text = value.asString();
-			decodedValues.append(snapshot.supplied ? ColumnEncoder::decodeAllWithMapping(text, snapshot.decodingMap) : ColumnEncoder::decodeAll(text));
+			decodedValues.append(ColumnEncoder::decodeAll(text));
 		}
 		else
 		{
@@ -765,23 +840,23 @@ void STDCALL syntaxBridgeSetVerbose(bool verbose)
 	Log::setWhere(verbose ? logType::cout : logType::null);
 }
 
-const char* STDCALL syntaxBridgeColumnDecoderSnapshot()
+const char* STDCALL syntaxBridgeColumnEncoderContext()
 {
 	static std::string result;
 
-	result = columnDecoderSnapshotJson().toStyledString();
+	result = columnEncoderContextJson().toStyledString();
 	return result.c_str();
 }
 
-const char* STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const char* decoderSnapshotJson)
+const char* STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const char* encoderContextJson)
 {
 	static std::string result;
 
 	try
 	{
 		Json::Value values = parseStringArrayJson(valuesJson);
-		ColumnDecoderSnapshot snapshot = columnDecoderMapFromSnapshotString(decoderSnapshotJson);
-		result = decodeColumnTextJson(values, snapshot).toStyledString();
+		ColumnEncoderContext context = columnEncoderContextFromString(encoderContextJson);
+		result = decodeColumnTextJson(values, context).toStyledString();
 		return result.c_str();
 	}
 	catch(const std::exception & exception)
@@ -860,7 +935,7 @@ bool init(bool dbInMemory)
 	QmlUtils::registerQmlModuleTypes();
 
 	createDataBridge(dbInMemory);
-	gl_extraEncodings = new ColumnEncoder("JaspExtraOptions_");
+	ensureExtraColumnEncoder();
 
 	rbridge_init(gl_dataBridge, sendMessage, [](){ return false; }, gl_extraEncodings, gl_param_resultFont.c_str(), false);
 	gl_rBridgeInitialized = true;

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -46,6 +46,8 @@
 #include "columnencoder.h"
 #include "columnencodercontext.h"
 
+#include <ostream>
+#include <streambuf>
 #include <string>
 #include <vector>
 
@@ -86,6 +88,31 @@ static std::string							gl_param_resultFont				=
 #else
 	"freesans,sans-serif";
 #endif
+
+namespace
+{
+	class SyntaxBridgeNullBuffer : public std::streambuf
+	{
+	protected:
+		int overflow(int c) override { return traits_type::not_eof(c); }
+	};
+
+	SyntaxBridgeNullBuffer	gl_nullLogBuffer;
+	std::ostream			gl_nullLogStream(&gl_nullLogBuffer);
+	bool					gl_loggingInitialized = false;
+}
+
+static void configureBridgeLogging(bool verbose)
+{
+	if(!gl_loggingInitialized)
+	{
+		Log::init(&gl_nullLogStream);
+		gl_loggingInitialized = true;
+	}
+
+	Log::setDefaultDestination(verbose ? logType::cout : logType::null);
+	Log::setWhere(verbose ? logType::cout : logType::null);
+}
 
 static bool readJaspJsonEntry(Json::Value & root, const char * filePath, const char * entry, std::string * error = nullptr)
 {
@@ -150,6 +177,7 @@ static const char* statusError(Json::Value status, const std::string & error)
 {
 	status["ok"] = false;
 	status["error"] = error;
+	configureBridgeLogging(gl_verbose);
 	Log::log() << error << std::endl;
 	return statusResult(status);
 }
@@ -535,6 +563,8 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char* moduleN
 
 const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePath, int analysisNr)
 {
+	configureBridgeLogging(gl_verbose);
+
 	static std::string result;
 	result = "";
 
@@ -552,6 +582,8 @@ const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePat
 
 const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFileStatus(const char * filePath, int analysisNr)
 {
+	configureBridgeLogging(gl_verbose);
+
 	Json::Value status = analysisOptionsStatus(filePath, analysisNr);
 	if (!status["ok"].asBool() && status.isMember("error"))
 		Log::log() << status["error"].asString() << std::endl;
@@ -691,8 +723,7 @@ const char* STDCALL syntaxBridgeGetVariableNames()
 void STDCALL syntaxBridgeSetVerbose(bool verbose)
 {
 	gl_verbose = verbose;
-	Log::setDefaultDestination(verbose ? logType::cout : logType::null);
-	Log::setWhere(verbose ? logType::cout : logType::null);
+	configureBridgeLogging(verbose);
 }
 
 const char* STDCALL syntaxBridgeColumnEncoderContext()
@@ -709,7 +740,8 @@ const char* STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const c
 
 	try
 	{
-		result = decodeColumnTextJson(valuesJson, encoderContextJson, *ensureExtraColumnEncoder()).toStyledString();
+		configureBridgeLogging(gl_verbose);
+		result = decodeColumnJson(valuesJson, encoderContextJson, *ensureExtraColumnEncoder()).toStyledString();
 		return result.c_str();
 	}
 	catch(const std::exception & exception)
@@ -748,6 +780,8 @@ void sendMessage(const char * msg)
 
 bool init(bool dbInMemory)
 {
+	configureBridgeLogging(gl_verbose);
+
 	if (gl_initialized) return true;
 	gl_initialized = true;
 	gl_initializedDbInMemory = dbInMemory;

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -169,8 +169,6 @@ static const char* statusError(Json::Value status, const std::string & error)
 {
 	status["ok"] = false;
 	status["error"] = error;
-	configureBridgeLogging(gl_verbose);
-	Log::log() << error << std::endl;
 	return statusResult(status);
 }
 
@@ -557,18 +555,12 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char* moduleN
 
 const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePath, int analysisNr)
 {
-	configureBridgeLogging(gl_verbose);
-
 	static std::string result;
 	result = "";
 
 	Json::Value status = analysisOptionsStatus(filePath, analysisNr);
 	if (!status["ok"].asBool())
-	{
-		if (status.isMember("error"))
-			Log::log() << status["error"].asString() << std::endl;
 		return result.c_str();
-	}
 
 	result = status["options"].toStyledString();
 	return result.c_str();
@@ -576,11 +568,7 @@ const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePat
 
 const char* STDCALL syntaxBridgeAnalysisOptionsFromJaspFileStatus(const char * filePath, int analysisNr)
 {
-	configureBridgeLogging(gl_verbose);
-
 	Json::Value status = analysisOptionsStatus(filePath, analysisNr);
-	if (!status["ok"].asBool() && status.isMember("error"))
-		Log::log() << status["error"].asString() << std::endl;
 	return statusResult(status);
 }
 
@@ -717,7 +705,8 @@ const char* STDCALL syntaxBridgeGetVariableNames()
 void STDCALL syntaxBridgeSetVerbose(bool verbose)
 {
 	gl_verbose = verbose;
-	configureBridgeLogging(verbose);
+	if (gl_loggingInitialized)
+		configureBridgeLogging(verbose);
 }
 
 const char* STDCALL syntaxBridgeColumnEncoderContext()
@@ -734,7 +723,6 @@ const char* STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const c
 
 	try
 	{
-		configureBridgeLogging(gl_verbose);
 		result = decodeColumnJson(valuesJson, encoderContextJson, requireExtraColumnEncoder()).toStyledString();
 		return result.c_str();
 	}

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -46,8 +46,8 @@
 #include "columnencoder.h"
 #include "columnencodercontext.h"
 
-#include <ostream>
-#include <streambuf>
+#include "boost/iostreams/stream.hpp"
+#include <boost/iostreams/device/null.hpp>
 #include <string>
 #include <vector>
 
@@ -90,15 +90,8 @@ static std::string							gl_param_resultFont				=
 
 namespace
 {
-	class SyntaxBridgeNullBuffer : public std::streambuf
-	{
-	protected:
-		int overflow(int c) override { return traits_type::not_eof(c); }
-	};
-
-	SyntaxBridgeNullBuffer	gl_nullLogBuffer;
-	std::ostream			gl_nullLogStream(&gl_nullLogBuffer);
-	bool					gl_loggingInitialized = false;
+	boost::iostreams::stream<boost::iostreams::null_sink>	gl_nullLogStream((boost::iostreams::null_sink()));
+	bool													gl_loggingInitialized = false;
 }
 
 static void configureBridgeLogging(bool verbose)

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -44,10 +44,10 @@
 #include "archivereader.h"
 #include "databaseinterface.h"
 #include "columnencoder.h"
+#include "columnencodercontext.h"
 
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 #include <QtPlugin>
 #ifdef USE_QT_STATIC_LIBS
@@ -157,43 +157,9 @@ static const char* statusError(Json::Value status, const std::string & error)
 static ColumnEncoder * ensureExtraColumnEncoder()
 {
 	if(!gl_extraEncodings)
-		gl_extraEncodings = new ColumnEncoder("JaspExtraOptions_");
+		gl_extraEncodings = new ColumnEncoder(ColumnEncoder::extraOptionsPrefix());
 
 	return gl_extraEncodings;
-}
-
-static Json::Value columnTypesToJson(const ColumnEncoder::colTypeMap & columnTypes)
-{
-	Json::Value columns(Json::arrayValue);
-	for(const auto & nameType : columnTypes)
-	{
-		Json::Value column(Json::objectValue);
-		column["name"] = nameType.first;
-		column["type"] = columnTypeToString(nameType.second);
-		columns.append(column);
-	}
-
-	return columns;
-}
-
-static ColumnEncoder::colTypeMap columnTypesFromJson(const Json::Value & columns, const char * fieldName)
-{
-	ColumnEncoder::colTypeMap columnTypes;
-
-	if(columns.isNull())
-		return columnTypes;
-	if(!columns.isArray())
-		throw std::runtime_error(std::string("Column encoder context field '") + fieldName + "' must be an array.");
-
-	for(const Json::Value & column : columns)
-	{
-		if(!column.isObject() || !column["name"].isString() || !column["type"].isString())
-			throw std::runtime_error(std::string("Column encoder context field '") + fieldName + "' must contain objects with string 'name' and 'type' fields.");
-
-		columnTypes[column["name"].asString()] = columnTypeFromString(column["type"].asString());
-	}
-
-	return columnTypes;
 }
 
 static ColumnEncoder::colTypeMap currentDatasetColumnTypes()
@@ -204,121 +170,10 @@ static ColumnEncoder::colTypeMap currentDatasetColumnTypes()
 
 static Json::Value columnEncoderContextJson()
 {
-	Json::Value context(Json::objectValue);
-	context["version"] = 1;
-	context["columns"] = columnTypesToJson(currentDatasetColumnTypes());
-	context["extra"] = columnTypesToJson(gl_extraEncodings ? gl_extraEncodings->currentNames() : ColumnEncoder::colTypeMap());
-
-	return context;
-}
-
-struct ColumnEncoderContext
-{
-	ColumnEncoder::colTypeMap	columns;
-	ColumnEncoder::colTypeMap	extra;
-	bool						supplied = false;
-};
-
-static ColumnEncoderContext columnEncoderContextFromJson(const Json::Value & context)
-{
-	if(!context.isObject())
-		throw std::runtime_error("Column encoder context must be a JSON object.");
-
-	if(!context.isMember("version") || !context["version"].isInt())
-		throw std::runtime_error("Column encoder context must contain integer version 1.");
-	if(context["version"].asInt() != 1)
-		throw std::runtime_error("Unsupported column encoder context version.");
-
-	ColumnEncoderContext encoderContext;
-	encoderContext.supplied = true;
-	encoderContext.columns = columnTypesFromJson(context["columns"], "columns");
-	encoderContext.extra = columnTypesFromJson(context["extra"], "extra");
-
-	return encoderContext;
-}
-
-static ColumnEncoderContext columnEncoderContextFromString(const char * contextJson)
-{
-	if(!contextJson || std::string(contextJson).empty())
-		return ColumnEncoderContext();
-
-	Json::Value context;
-	Json::Reader reader;
-	if(!reader.parse(contextJson, context))
-		throw std::runtime_error("Could not parse column encoder context JSON.");
-
-	return columnEncoderContextFromJson(context);
-}
-
-class ScopedColumnEncoderContext
-{
-public:
-	ScopedColumnEncoderContext(const ColumnEncoderContext & context)
-		: _supplied(context.supplied)
-	{
-		if(!_supplied)
-			return;
-
-		_previousColumns = ColumnEncoder::columnEncoder()->currentNames();
-		_previousExtra = gl_extraEncodings ? gl_extraEncodings->currentNames() : ColumnEncoder::colTypeMap();
-
-		ColumnEncoder::columnEncoder()->setCurrentNames(context.columns);
-		ensureExtraColumnEncoder()->setCurrentNames(context.extra);
-	}
-
-	~ScopedColumnEncoderContext()
-	{
-		if(!_supplied)
-			return;
-
-		ColumnEncoder::columnEncoder()->setCurrentNames(_previousColumns);
-		ensureExtraColumnEncoder()->setCurrentNames(_previousExtra);
-	}
-
-private:
-	bool						_supplied = false;
-	ColumnEncoder::colTypeMap	_previousColumns;
-	ColumnEncoder::colTypeMap	_previousExtra;
-};
-
-static Json::Value parseStringArrayJson(const char * valuesJson)
-{
-	if(!valuesJson)
-		throw std::runtime_error("Cannot decode column text from a null JSON payload.");
-
-	Json::Value values;
-	Json::Reader reader;
-	if(!reader.parse(valuesJson, values))
-		throw std::runtime_error("Could not parse column text JSON payload.");
-	if(!values.isArray())
-		throw std::runtime_error("Column text JSON payload must be an array.");
-
-	return values;
-}
-
-static Json::Value decodeColumnTextJson(const Json::Value & values, const ColumnEncoderContext & context)
-{
-	Json::Value decodedValues(Json::arrayValue);
-	ScopedColumnEncoderContext scopedContext(context);
-
-	for(const Json::Value & value : values)
-	{
-		if(value.isNull())
-		{
-			decodedValues.append(Json::Value());
-		}
-		else if(value.isString())
-		{
-			const std::string text = value.asString();
-			decodedValues.append(ColumnEncoder::decodeAll(text));
-		}
-		else
-		{
-			throw std::runtime_error("Column text JSON payload must contain only strings or null values.");
-		}
-	}
-
-	return decodedValues;
+	return ColumnEncoderContext(
+		currentDatasetColumnTypes(),
+		gl_extraEncodings ? gl_extraEncodings->currentNames() : ColumnEncoder::colTypeMap()
+	).toJson();
 }
 
 static Json::Value analysisOptionsStatus(const char * filePath, int analysisNr)
@@ -854,9 +709,7 @@ const char* STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const c
 
 	try
 	{
-		Json::Value values = parseStringArrayJson(valuesJson);
-		ColumnEncoderContext context = columnEncoderContextFromString(encoderContextJson);
-		result = decodeColumnTextJson(values, context).toStyledString();
+		result = decodeColumnTextJson(valuesJson, encoderContextJson, *ensureExtraColumnEncoder()).toStyledString();
 		return result.c_str();
 	}
 	catch(const std::exception & exception)

--- a/SyntaxInterface/syntaxbridge.cpp
+++ b/SyntaxInterface/syntaxbridge.cpp
@@ -67,7 +67,6 @@ static bool									gl_jaspBaseInitialized			= false;
 static QGuiApplication			*			gl_application					= nullptr;
 static QQmlEngine				*			gl_qmlEngine					= nullptr;
 static DataBridge				*			gl_dataBridge					= nullptr;
-static ColumnEncoder			*			gl_extraEncodings				= nullptr;
 static QMap<QString, std::pair<QDateTime, AnalysisForm* > >	gl_qmlFormMap;
 static int									gl_applicationArgc				= 0;
 static std::vector<std::string>				gl_applicationArgvStorage;
@@ -182,12 +181,18 @@ static const char* statusError(Json::Value status, const std::string & error)
 	return statusResult(status);
 }
 
-static ColumnEncoder * ensureExtraColumnEncoder()
+static ColumnEncoder * extraColumnEncoder()
 {
-	if(!gl_extraEncodings)
-		gl_extraEncodings = new ColumnEncoder(ColumnEncoder::extraOptionsPrefix());
+	return gl_dataBridge ? gl_dataBridge->extraEncodings() : nullptr;
+}
 
-	return gl_extraEncodings;
+static ColumnEncoder & requireExtraColumnEncoder()
+{
+	ColumnEncoder * encoder = extraColumnEncoder();
+	if(!encoder)
+		throw std::runtime_error("Cannot access extra option encodings without an initialized DataBridge.");
+
+	return *encoder;
 }
 
 static ColumnEncoder::colTypeMap currentDatasetColumnTypes()
@@ -198,9 +203,11 @@ static ColumnEncoder::colTypeMap currentDatasetColumnTypes()
 
 static Json::Value columnEncoderContextJson()
 {
+	ColumnEncoder * extraEncoder = extraColumnEncoder();
+
 	return ColumnEncoderContext(
 		currentDatasetColumnTypes(),
-		gl_extraEncodings ? gl_extraEncodings->currentNames() : ColumnEncoder::colTypeMap()
+		extraEncoder ? extraEncoder->currentNames() : ColumnEncoder::colTypeMap()
 	).toJson();
 }
 
@@ -254,8 +261,8 @@ static void clearRequestedDataState()
 	ColumnEncoder::colTypeMap noColumns;
 	ColumnEncoder::columnEncoder()->setCurrentNames(noColumns);
 
-	if (gl_extraEncodings)
-		gl_extraEncodings->setCurrentNames(noColumns);
+	if (ColumnEncoder * encoder = extraColumnEncoder())
+		encoder->setCurrentNames(noColumns);
 }
 
 static void clearDataBridgeState()
@@ -366,12 +373,6 @@ void STDCALL syntaxBridgeShutdown()
 {
 	syntaxBridgeClearQmlState();
 	clearDataBridgeState();
-
-	if (gl_extraEncodings)
-	{
-		delete gl_extraEncodings;
-		gl_extraEncodings = nullptr;
-	}
 
 	if (gl_initialized)
 	{
@@ -549,7 +550,7 @@ const char* STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char* moduleN
 		return statusError(statusBase("syntaxBridgeLoadQmlAndParseOptions"), "Error when parsing options: " + errorMsg);
 	}
 
-	gl_extraEncodings->setCurrentNamesFromOptionsMeta(parsedOptions);
+	gl_dataBridge->extraEncodings()->setCurrentNamesFromOptionsMeta(parsedOptions);
 	gl_dataBridge->updateOptionsAccordingToMeta(parsedOptions);
 	ColumnEncoder::colsPlusTypes analysisColsTypes = ColumnEncoder::encodeColumnNamesinOptions(parsedOptions, preloadData);
 
@@ -741,7 +742,7 @@ const char* STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const c
 	try
 	{
 		configureBridgeLogging(gl_verbose);
-		result = decodeColumnJson(valuesJson, encoderContextJson, *ensureExtraColumnEncoder()).toStyledString();
+		result = decodeColumnJson(valuesJson, encoderContextJson, requireExtraColumnEncoder()).toStyledString();
 		return result.c_str();
 	}
 	catch(const std::exception & exception)
@@ -822,9 +823,8 @@ bool init(bool dbInMemory)
 	QmlUtils::registerQmlModuleTypes();
 
 	createDataBridge(dbInMemory);
-	ensureExtraColumnEncoder();
 
-	rbridge_init(gl_dataBridge, sendMessage, [](){ return false; }, gl_extraEncodings, gl_param_resultFont.c_str(), false);
+	rbridge_init(gl_dataBridge, sendMessage, [](){ return false; }, gl_param_resultFont.c_str(), false);
 	gl_rBridgeInitialized = true;
 
 	return true;
@@ -835,7 +835,7 @@ void ensureRBridgeInitialized()
 	if (gl_rBridgeInitialized)
 		return;
 
-	rbridge_init(gl_dataBridge, sendMessage, [](){ return false; }, gl_extraEncodings, gl_param_resultFont.c_str(), false);
+	rbridge_init(gl_dataBridge, sendMessage, [](){ return false; }, gl_param_resultFont.c_str(), false);
 	gl_rBridgeInitialized = true;
 }
 

--- a/SyntaxInterface/syntaxbridge_interface.h
+++ b/SyntaxInterface/syntaxbridge_interface.h
@@ -63,12 +63,16 @@ SYNTAX_INTERFACE void				STDCALL syntaxBridgeLoadDataSet(const SyntaxBridgeDataS
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeLoadDataSetFromJaspFile(const char * filePath, bool dbInMemory);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeLoadDataSetFromJaspFileStatus(const char * filePath, bool dbInMemory);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeLoadQmlAndParseOptions(const char * moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData);
+SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeLoadQmlAndParseOptionsStatus(const char * moduleName, const char* analysisName, const char* qmlFile, const char* options, const char* version, bool preloadData);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeAnalysisOptionsFromJaspFile(const char * filePath, int analysisNr);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeAnalysisOptionsFromJaspFileStatus(const char * filePath, int analysisNr);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGenerateModuleWrappers(const char* name);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGenerateAnalysisWrapper(const char* modulePath, const char* analysisName);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeParseDescription(const char* modulePath);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGetVariableNames();
+SYNTAX_INTERFACE void				STDCALL syntaxBridgeSetVerbose(bool verbose);
+SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeColumnDecoderSnapshot();
+SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const char* decoderSnapshotJson);
 
 } // extern "C"
 

--- a/SyntaxInterface/syntaxbridge_interface.h
+++ b/SyntaxInterface/syntaxbridge_interface.h
@@ -71,8 +71,8 @@ SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGenerateAnalysisWrapper(const 
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeParseDescription(const char* modulePath);
 SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeGetVariableNames();
 SYNTAX_INTERFACE void				STDCALL syntaxBridgeSetVerbose(bool verbose);
-SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeColumnDecoderSnapshot();
-SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const char* decoderSnapshotJson);
+SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeColumnEncoderContext();
+SYNTAX_INTERFACE const char*		STDCALL syntaxBridgeDecodeColumnText(const char* valuesJson, const char* encoderContextJson);
 
 } // extern "C"
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -46,12 +46,22 @@ qt_add_executable(
   $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/Desktop/JASP.exe.manifest>
 )
 
+qt_add_executable(
+  JASPTestColumnEncoderContext
+  ${SYSTEM_TYPE}
+  testcolumnencodercontext.h
+  testcolumnencodercontext.cpp
+  $<$<PLATFORM_ID:Darwin>:${_R_Framework}>
+  $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/Desktop/JASP.exe.manifest>
+)
+
 
 add_dependencies(JASPTest           JASPDesktopLib)
 add_dependencies(JASPTestDebugData  JASPDesktopLib)
 add_dependencies(JASPTestEngine     JASPDesktopLib)
 add_dependencies(JASPQuickTest      JASPDesktopLib)
 add_dependencies(JASPTestCsvPrev    JASPDesktopLib)
+add_dependencies(JASPTestColumnEncoderContext Common)
 
 target_include_directories(
   JASPTest
@@ -84,6 +94,12 @@ target_include_directories(
   JASPTestCsvPrev
   PUBLIC
   JASPDesktopLib
+)
+
+target_include_directories(
+  JASPTestColumnEncoderContext
+  PUBLIC
+  ${PROJECT_SOURCE_DIR}/Common
 )
 
 target_link_libraries(
@@ -135,6 +151,13 @@ target_link_libraries(
   Qt::Test
 )
 
+target_link_libraries(
+  JASPTestColumnEncoderContext
+  PUBLIC
+  Common
+  Qt::Test
+)
+
 target_compile_definitions(
   JASPTest
   PUBLIC TESTLIBRARY_DIR=${CMAKE_SOURCE_DIR}/Tests/TestLibrary
@@ -171,6 +194,7 @@ add_test(NAME testCsvPreview  COMMAND JASPTestCsvPrev)
 add_test(NAME testDebugData   COMMAND JASPTestDebugData)
 add_test(NAME testEngine      COMMAND JASPTestEngine)
 add_test(NAME testQuick       COMMAND JASPQuickTest)
+add_test(NAME testColumnEncoderContext COMMAND JASPTestColumnEncoderContext)
 
 
 

--- a/Tests/testcolumnencodercontext.cpp
+++ b/Tests/testcolumnencodercontext.cpp
@@ -1,0 +1,222 @@
+//
+// Copyright (C) 2026 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#include "testcolumnencodercontext.h"
+
+#include "columnencodercontext.h"
+
+#include <QtTest>
+
+#include <functional>
+#include <initializer_list>
+#include <stdexcept>
+
+namespace
+{
+constexpr const char * ExtraOptionsPrefix = "JaspExtraOptions_";
+
+ColumnEncoder::colTypeMap emptyNames()
+{
+	return ColumnEncoder::colTypeMap();
+}
+
+ColumnEncoder::colTypeMap names(std::initializer_list<std::pair<std::string, columnType>> values)
+{
+	ColumnEncoder::colTypeMap result;
+	for(const auto & value : values)
+		result[value.first] = value.second;
+	return result;
+}
+
+ColumnEncoderContext context(ColumnEncoder::colTypeMap columns, ColumnEncoder::colTypeMap extra)
+{
+	return ColumnEncoderContext(columns, extra);
+}
+
+std::string contextJson(const ColumnEncoderContext & encoderContext)
+{
+	return encoderContext.toJson().toStyledString();
+}
+
+void activateContext(const ColumnEncoderContext & encoderContext, ColumnEncoder & extraEncoder)
+{
+	ColumnEncoder::columnEncoder()->setCurrentNames(encoderContext.columns());
+	extraEncoder.setCurrentNames(encoderContext.extra());
+}
+
+std::string encodeColumn(const ColumnEncoderContext & encoderContext, ColumnEncoder & extraEncoder, const std::string & column)
+{
+	ScopedColumnEncoderContext scopedContext(encoderContext, extraEncoder);
+	return ColumnEncoder::columnEncoder()->encode(column);
+}
+
+std::string encodeExtra(const ColumnEncoderContext & encoderContext, ColumnEncoder & extraEncoder, const std::string & value)
+{
+	ScopedColumnEncoderContext scopedContext(encoderContext, extraEncoder);
+	return extraEncoder.encode(value);
+}
+
+std::string payloadJson(const ColumnEncoderContext & encoderContext, ColumnEncoder & extraEncoder,
+						const std::string & firstColumn,
+						const std::string & secondColumn,
+						const std::string & extraValue)
+{
+	const std::string encodedFirstColumn = encodeColumn(encoderContext, extraEncoder, firstColumn);
+	const std::string encodedSecondColumn = encodeColumn(encoderContext, extraEncoder, secondColumn);
+	const std::string encodedExtraValue = encodeExtra(encoderContext, extraEncoder, extraValue);
+
+	Json::Value payload(Json::objectValue);
+	payload[encodedFirstColumn] = encodedExtraValue;
+	payload[encodedExtraValue] = encodedFirstColumn;
+	payload["nested"][0] = encodedSecondColumn;
+	payload["nested"][1]["label"] = std::string("label:") + encodedExtraValue;
+	payload["nested"][1]["formula"] = encodedFirstColumn + " + " + encodedSecondColumn;
+	return payload.toStyledString();
+}
+
+Json::Value decodePayload(const std::string & payload, const std::string & encoderContextJson, ColumnEncoder & extraEncoder)
+{
+	return decodeColumnJson(payload.c_str(), encoderContextJson.c_str(), extraEncoder);
+}
+
+void verifyDecodedPayload(const Json::Value & decoded,
+						  const std::string & firstColumn,
+						  const std::string & secondColumn,
+						  const std::string & extraValue)
+{
+	QVERIFY2(decoded.isObject(), "Decoded payload should be a JSON object.");
+	QVERIFY2(decoded.isMember(firstColumn), "Encoded object member name was not decoded with the expected dataset column context.");
+	QVERIFY2(decoded.isMember(extraValue), "Encoded extra-option member name was not decoded with the expected extra-option context.");
+	QCOMPARE(QString::fromStdString(decoded[firstColumn].asString()), QString::fromStdString(extraValue));
+	QCOMPARE(QString::fromStdString(decoded[extraValue].asString()), QString::fromStdString(firstColumn));
+	QCOMPARE(QString::fromStdString(decoded["nested"][0].asString()), QString::fromStdString(secondColumn));
+	QCOMPARE(QString::fromStdString(decoded["nested"][1]["label"].asString()), QString::fromStdString("label:" + extraValue));
+	QCOMPARE(QString::fromStdString(decoded["nested"][1]["formula"].asString()), QString::fromStdString(firstColumn + " + " + secondColumn));
+}
+
+std::string captureError(const std::function<void()> & function)
+{
+	try
+	{
+		function();
+	}
+	catch(const std::exception & exception)
+	{
+		return exception.what();
+	}
+
+	return "";
+}
+}
+
+void TestColumnEncoderContext::init()
+{
+	ColumnEncoder::columnEncoder()->setCurrentNames(emptyNames());
+}
+
+void TestColumnEncoderContext::cleanup()
+{
+	ColumnEncoder::columnEncoder()->setCurrentNames(emptyNames());
+}
+
+void TestColumnEncoderContext::scopedContextsDecodeInterleavedAndRestoreLiveState()
+{
+	ColumnEncoder extraEncoder(ExtraOptionsPrefix);
+
+	const ColumnEncoderContext liveContext = context(
+		names({{"live group", columnType::nominal}, {"live score", columnType::scale}}),
+		names({{"live factor A", columnType::unknown}, {"live factor B", columnType::unknown}})
+	);
+
+	activateContext(liveContext, extraEncoder);
+
+	const std::string livePayload = payloadJson(liveContext, extraEncoder, "live group", "live score", "live factor A");
+
+	const ColumnEncoderContext firstArchiveContext = context(
+		names({{"archive A group", columnType::nominal}, {"archive A score", columnType::scale}}),
+		names({{"archive A level", columnType::unknown}})
+	);
+	const ColumnEncoderContext secondArchiveContext = context(
+		names({{"archive B group", columnType::ordinal}, {"archive B score", columnType::scale}}),
+		names({{"archive B level", columnType::unknown}})
+	);
+	const ColumnEncoderContext thirdArchiveContext = context(
+		names({{"archive C group", columnType::nominal}, {"archive C score", columnType::scale}}),
+		names({{"archive C level", columnType::unknown}})
+	);
+
+	const std::string firstArchivePayload = payloadJson(firstArchiveContext, extraEncoder, "archive A group", "archive A score", "archive A level");
+	const std::string secondArchivePayload = payloadJson(secondArchiveContext, extraEncoder, "archive B group", "archive B score", "archive B level");
+	const std::string thirdArchivePayload = payloadJson(thirdArchiveContext, extraEncoder, "archive C group", "archive C score", "archive C level");
+
+	verifyDecodedPayload(decodePayload(livePayload, "", extraEncoder), "live group", "live score", "live factor A");
+
+	verifyDecodedPayload(decodePayload(firstArchivePayload, contextJson(firstArchiveContext), extraEncoder), "archive A group", "archive A score", "archive A level");
+	verifyDecodedPayload(decodePayload(livePayload, "", extraEncoder), "live group", "live score", "live factor A");
+
+	verifyDecodedPayload(decodePayload(secondArchivePayload, contextJson(secondArchiveContext), extraEncoder), "archive B group", "archive B score", "archive B level");
+	verifyDecodedPayload(decodePayload(livePayload, "", extraEncoder), "live group", "live score", "live factor A");
+
+	verifyDecodedPayload(decodePayload(thirdArchivePayload, contextJson(thirdArchiveContext), extraEncoder), "archive C group", "archive C score", "archive C level");
+	verifyDecodedPayload(decodePayload(livePayload, "", extraEncoder), "live group", "live score", "live factor A");
+
+	verifyDecodedPayload(decodePayload(firstArchivePayload, contextJson(firstArchiveContext), extraEncoder), "archive A group", "archive A score", "archive A level");
+	verifyDecodedPayload(decodePayload(thirdArchivePayload, contextJson(thirdArchiveContext), extraEncoder), "archive C group", "archive C score", "archive C level");
+	verifyDecodedPayload(decodePayload(secondArchivePayload, contextJson(secondArchiveContext), extraEncoder), "archive B group", "archive B score", "archive B level");
+
+	verifyDecodedPayload(decodePayload(livePayload, "", extraEncoder), "live group", "live score", "live factor A");
+	QVERIFY2(ColumnEncoder::columnEncoder()->currentNames() == liveContext.columns(), "Dataset column context was not restored after scoped decodes.");
+	QVERIFY2(extraEncoder.currentNames() == liveContext.extra(), "Extra-option context was not restored after scoped decodes.");
+}
+
+void TestColumnEncoderContext::malformedContextDoesNotMutateLiveState()
+{
+	ColumnEncoder extraEncoder(ExtraOptionsPrefix);
+
+	const ColumnEncoderContext liveContext = context(
+		names({{"live group", columnType::nominal}, {"live score", columnType::scale}}),
+		names({{"live factor", columnType::unknown}})
+	);
+
+	activateContext(liveContext, extraEncoder);
+
+	const std::string livePayload = payloadJson(liveContext, extraEncoder, "live group", "live score", "live factor");
+
+	const std::string parseError = captureError([&]()
+	{
+		decodePayload(livePayload, "{not-json", extraEncoder);
+	});
+	const std::string parseErrorMessage = "Unexpected parse error: " + parseError;
+	QVERIFY2(parseError.find("Could not parse column encoder context JSON.") != std::string::npos,
+			 parseErrorMessage.c_str());
+	verifyDecodedPayload(decodePayload(livePayload, "", extraEncoder), "live group", "live score", "live factor");
+
+	const std::string schemaError = captureError([&]()
+	{
+		decodePayload(livePayload, "{\"version\":1,\"columns\":{},\"extra\":[]}", extraEncoder);
+	});
+	const std::string schemaErrorMessage = "Unexpected schema error: " + schemaError;
+	QVERIFY2(schemaError.find("Column encoder context field 'columns' must be an array.") != std::string::npos,
+			 schemaErrorMessage.c_str());
+	verifyDecodedPayload(decodePayload(livePayload, "", extraEncoder), "live group", "live score", "live factor");
+
+	QVERIFY2(ColumnEncoder::columnEncoder()->currentNames() == liveContext.columns(), "Dataset column context changed after malformed context errors.");
+	QVERIFY2(extraEncoder.currentNames() == liveContext.extra(), "Extra-option context changed after malformed context errors.");
+}
+
+QTEST_MAIN(TestColumnEncoderContext)

--- a/Tests/testcolumnencodercontext.h
+++ b/Tests/testcolumnencodercontext.h
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2026 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+#ifndef TESTCOLUMNENCODERCONTEXT_H
+#define TESTCOLUMNENCODERCONTEXT_H
+
+#include <QObject>
+
+class TestColumnEncoderContext : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void init();
+	void cleanup();
+	void scopedContextsDecodeInterleavedAndRestoreLiveState();
+	void malformedContextDoesNotMutateLiveState();
+};
+
+#endif // TESTCOLUMNENCODERCONTEXT_H


### PR DESCRIPTION
## Summary

This PR exposes the Desktop-owned encoder context needed by the jaspTools -> jaspSyntax bridge:

- replaces the exported decoder snapshot/mapping API with a serializable `ColumnEncoder` context
- keeps the context/schema/scoped restore helper in `Common/columnencodercontext.*`, next to `ColumnEncoder`
- captures dataset column names/types and extra QML option encodings from the native source state
- decodes text by temporarily restoring native `ColumnEncoder` state and then calling the normal decoder path
- removes the native `decodeAllWithMapping()` compatibility path so R cannot silently decode from a stale map
- keeps native bridge failures structured at the C ABI boundary

## Why

Encoding/decoding should remain an internal Desktop/SyntaxInterface concern. The R packages now pass around an opaque encoder context, and Desktop remains the only implementation of token replacement. That prevents incorrect replay when the live dataset has changed, and it avoids duplicating encoding rules in jaspSyntax, jaspBase, or jaspTools.

## Related PRs

- jaspSyntax R bridge API: https://github.com/jasp-stats/jaspSyntax/pull/8
- jaspBase result materialization: https://github.com/jasp-stats/jaspBase/pull/204
- jaspTools replay orchestration: https://github.com/jasp-stats/jaspTools/pull/79

## Validation

- rebuilt `SyntaxInterface` with `ninja -C build -j1 SyntaxInterface` through the local MSVC toolchain
- verified the jaspSyntax/SyntaxInterface C ABI exports with `tools/check-syntaxinterface-symbols.sh`
- ran focused jaspSyntax bridge tests against the rebuilt Desktop target: `test-desktop-jasp-contract.R`, `test-dataset-helpers.R`
- ran focused jaspBase tests: `test-result-object-decoding.R`, `test-runWrappedAnalysis.R`
- ran focused jaspTools bridge lifecycle tests: `test-jaspSyntax-lifecycle.R`
- ran R parse checks for jaspSyntax, jaspBase, and jaspTools
- ran `git diff --check`

Note: this PR should be reviewed together with the linked package PRs because the contract is intentionally split by ownership: Desktop owns token replacement, jaspSyntax exposes the bridge, jaspBase decodes JASP-owned result surfaces, and jaspTools carries the captured context through replay.