### PR TITLE
Cast variable should keep their type when used as source

### DIFF
--- a/QMLComponents/models/listmodel.cpp
+++ b/QMLComponents/models/listmodel.cpp
@@ -105,18 +105,8 @@ void ListModel::_connectAllSourcesControls()
 void ListModel::_setAllowedType(Term& term) const
 {
 	columnType type = term.type();
-	if (type != columnType::unknown)
-	{
-		if (!_listView->isTypeAllowed(type))
-			term.setType(_listView->defaultType());
-		else
-		{
-			// If the real type is now allowed, change the type to its original one.
-			columnType realType = getVariableRealType(term.value());
-			if (type != realType && _listView->isTypeAllowed(realType))
-				term.setType(realType);
-		}
-	}
+	if (type != columnType::unknown  && !_listView->isTypeAllowed(type))
+		term.setType(_listView->defaultType());
 }
 
 Term ListModel::_checkTermType(const Term &term) const

--- a/QMLComponents/models/listmodelassignedinterface.cpp
+++ b/QMLComponents/models/listmodelassignedinterface.cpp
@@ -76,30 +76,3 @@ bool ListModelAssignedInterface::sourceLabelsReordered(QString columnName)
 
 	return change;
 }
-
-bool ListModelAssignedInterface::checkAllowedTerms(Terms& terms)
-{
-	if (!_availableModel) return true;
-
-	Terms notAllowedTerms, allowedTerms;
-	for (const Term& term : terms)
-	{
-		if (isAllowed(term))
-			allowedTerms.add(term);
-		else
-			notAllowedTerms.add(term);
-	}
-	if (notAllowedTerms.size() == 0) return true;
-
-	terms.set(allowedTerms);
-	if (!_availableModel->keepTerms())
-		_availableModel->addTerms(notAllowedTerms);
-
-	QString notAllowedTermsStr = notAllowedTerms.labels().join(", ");
-	if (notAllowedTerms.size() == 1)
-		listView()->addControlWarningTemporary(tr("This variable has been removed, because it is not allowed: %1").arg(notAllowedTermsStr));
-	else
-		listView()->addControlWarningTemporary(tr("These variables have been removed, because they are not allowed: %1").arg(notAllowedTermsStr));
-
-	return false;
-}

--- a/QMLComponents/models/listmodelassignedinterface.h
+++ b/QMLComponents/models/listmodelassignedinterface.h
@@ -32,7 +32,6 @@ public:
 
 	virtual void					setAvailableModel(ListModelTermsAvailable *availableModel);
 	ListModelTermsAvailable*		availableModel() const													{ return _availableModel; }
-	bool							checkAllowedTerms(Terms& terms);
 
 public slots:
 	virtual void availableTermsResetHandler(Terms termsAdded, Terms termsRemoved)				{}

--- a/QMLComponents/models/listmodeltermsassigned.cpp
+++ b/QMLComponents/models/listmodeltermsassigned.cpp
@@ -77,7 +77,16 @@ Terms ListModelTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemInde
 	else if (maxRows > 0 && dropItemIndex >= maxRows)
 		return termsToAdd;
 
-	Terms newTerms;
+
+	Terms termsToAddWithRightTypes = termsToAdd;
+	for (Term & term : termsToAddWithRightTypes)
+	{
+		// If the real type is now allowed, change the type to its original one.
+		columnType realType = getVariableRealType(term.value());
+		if (term.type() != realType && listView()->isTypeAllowed(realType))
+			term.setType(realType);
+	}
+
 
 	if (dropItemIndex < 0 && maxRows == 1)
 		dropItemIndex = 0; // for single row, per default replace old item by new one.
@@ -89,10 +98,9 @@ Terms ListModelTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemInde
 	{
 		// If we replace all the items, use beginResetModel
 		termsToSendBack = terms();
-		newTerms = termsToAdd;
 
 		beginResetModel();
-		_setTerms(newTerms);
+		_setTerms(termsToAddWithRightTypes);
 		endResetModel();
 	}
 	else
@@ -106,16 +114,16 @@ Terms ListModelTermsAssigned::addTerms(const Terms& termsToAdd, int dropItemInde
 			dropItemIndex = terms().size();
 
 		beginInsertRows(QModelIndex(), dropItemIndex, dropItemIndex + termsToAdd.size() - 1);
-		newTerms = terms();
+		Terms newTerms = terms();
 		if (dropItemIndex < terms().size())
 		{
-			newTerms.insert(dropItemIndex, termsToAdd);
+			newTerms.insert(dropItemIndex, termsToAddWithRightTypes);
 			_setTerms(newTerms);
 		}
 		else
 		{
-			newTerms.add(termsToAdd);
-			_addTerms(termsToAdd);
+			newTerms.add(termsToAddWithRightTypes);
+			_addTerms(termsToAddWithRightTypes);
 		}
 
 		endInsertRows();


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3227
The code to recast the variable (if the VariablesList allows it), was run each time a variable was set to a new VariablesList, but this should be done only when the user set manually a variable to another Variables List, not when the variables come from a source.

This issue comes after a fix for https://github.com/jasp-stats/INTERNAL-jasp/issues/3182

