### PR TITLE
bugfix: fix parsering and preview complex csv files

### DIFF
--- a/Desktop/data/importers/csv/csv.cpp
+++ b/Desktop/data/importers/csv/csv.cpp
@@ -440,105 +440,117 @@ bool CSV::readLine(vector<string> &items)
 
 	if (_utf8BufferEndPos == _utf8BufferStartPos)
 	{
-		bool success = readUtf8();
-		if ( ! success)
+		if (!readUtf8())
 			return false;
 	}
 
-	bool inQuote = false;
+	enum State { Normal, Quoted, QuotedQuote };
+	State state = Normal;
+	string currentField;
+	bool rowFinished = false;
 
 	int i = _utf8BufferStartPos;
 
-	while (true)
+	while (!rowFinished)
 	{
-		char ch = _utf8Buffer[i];
-
-		if ((unsigned char)ch >= 0xF8)  // illegal utf-8
-		{
-			ch = '.';
-			_utf8Buffer[i] = '.';
-		}
-
-		if (ch == '"')
-		{
-			if (inQuote && i + 1 < _utf8BufferEndPos && _utf8Buffer[i + 1] == '"')
-				i++;
-			else
-				inQuote = !inQuote;
-		}
-
-		if (inQuote)
-		{
-			// do nothing
-		}
-		else if (ch == _delim)
-		{
-			string token(&_utf8Buffer[_utf8BufferStartPos], i - _utf8BufferStartPos);
-			trim(token);
-
-			items.push_back(token);
-			_utf8BufferStartPos = i + 1;
-		}
-		else if (ch == '\r')
-		{
-			if (items.size() > 0 || i > _utf8BufferStartPos) {
-				string token(&_utf8Buffer[_utf8BufferStartPos], i - _utf8BufferStartPos);
-				trim(token);
-				items.push_back(token);
-			}
-
-			if (i + 1 < _utf8BufferEndPos && _utf8Buffer[i + 1] == '\n')
-				_utf8BufferStartPos = i + 2;
-			else
-				_utf8BufferStartPos = i + 1;
-
-			if (items.size() > 0)
-				break;
-		}
-		else if (ch == '\n')
-		{
-			if (items.size() > 0 || i > _utf8BufferStartPos) {
-				string token(&_utf8Buffer[_utf8BufferStartPos], i - _utf8BufferStartPos);
-				trim(token);
-				items.push_back(token);
-			}
-
-			_utf8BufferStartPos = i + 1;
-
-			if (items.size() > 0)
-				break;
-		}
-
-		if (i >= _utf8BufferEndPos - 1)
+		// If we reached the end of current buffer, load more data
+		if (i >= _utf8BufferEndPos)
 		{
 			bool success = readUtf8();
-			if (success)
+			if (!success)
 			{
-				i = -1;
-				inQuote = false;
-			}
-			else // eof
-			{
-				if (items.size() > 0 || _utf8BufferEndPos > _utf8BufferStartPos) {
-					string token(&_utf8Buffer[_utf8BufferStartPos], _utf8BufferEndPos - _utf8BufferStartPos);
-					trim(token);
-					items.push_back(token);
+				// EOF: if there is pending data, treat as last row
+				if (!currentField.empty() || !items.empty() || state != Normal)
+				{
+						boost::algorithm::replace_all(currentField, "\n", " ");
+						items.push_back(currentField);
 				}
 				_eof = true;
-				break;
+				return !items.empty();
 			}
+			i = 0; // reset index because readUtf8() resets buffer positions
+			continue;
 		}
 
+		char ch = _utf8Buffer[i];
+
+		// Replace illegal UTF-8 bytes with '.' (same as original logic)
+		if ((unsigned char)ch >= 0xF8)
+			ch = '.';
+
+		switch (state)
+		{
+		case Normal:
+			if (ch == '"')
+			{
+				// Start of a quoted field
+				state = Quoted;
+			}
+			else if (ch == _delim)
+			{
+				// End of current field
+				boost::algorithm::replace_all(currentField, "\n", " ");
+				items.push_back(currentField);
+				currentField.clear();
+				_utf8BufferStartPos = i + 1;
+			}
+			else if (ch == '\r' || ch == '\n')
+			{
+				// End of current row
+				boost::algorithm::replace_all(currentField, "\n", " ");
+				if (!currentField.empty() || !items.empty() || i > _utf8BufferStartPos)
+					items.push_back(currentField);
+				currentField.clear();
+				rowFinished = true;
+
+				// Handle line endings: consume \r\n or single \r or \n
+				if (ch == '\r' && i + 1 < _utf8BufferEndPos && _utf8Buffer[i + 1] == '\n')
+					_utf8BufferStartPos = i + 2;
+				else
+					_utf8BufferStartPos = i + 1;
+			}
+			else
+			{
+				currentField.push_back(ch);
+			}
+			break;
+
+		case Quoted:
+			if (ch == '"')
+			{
+				// Possible end of quoted field or escaped quote
+				state = QuotedQuote;
+			}
+			else
+			{
+				currentField.push_back(ch);
+			}
+			break;
+
+		case QuotedQuote:
+			if (ch == '"')
+			{
+				// Escaped double quote: add one double quote character
+				currentField.push_back('"');
+				state = Quoted;
+			}
+			else
+			{
+				// End of quoted field, fall back to Normal state and re-process current character
+				state = Normal;
+				continue;   // re-evaluate the same character
+			}
+			break;
+		}
 		i++;
 	}
 
-	for (size_t index = 0; index < items.size(); index++)
+	// Post-processing: replace newlines with spaces (same as original behavior)
+	// Note: outer quotes are already removed by the state machine – they never entered the field.
+	for (size_t index = 0; index < items.size(); ++index)
 	{
-		string item = items.at(index);
-		boost::algorithm::replace_all(item, "\n", " "); // so we should not allow newlines in values right?
-		if (item.size() >= 2 && item[0] == '"' && item[item.size()-1] == '"')
-			item = item.substr(1, item.size()-2);
-		items[index] = item;
+		string &item = items[index];
+		boost::algorithm::replace_all(item, "\n", " ");
 	}
 
 	return true;

--- a/Desktop/data/importers/csv/csv.cpp
+++ b/Desktop/data/importers/csv/csv.cpp
@@ -489,7 +489,9 @@ bool CSV::readLine(vector<string> &items)
 			else if (ch == _delim)
 			{
 				// End of current field
-				boost::algorithm::replace_all(currentField, "\n", " ");
+				boost::algorithm::replace_all(currentField, "\r\n", " ");
+				boost::algorithm::replace_all(currentField, "\n",   " ");
+				boost::algorithm::replace_all(currentField, "\r",   " ");
 				items.push_back(currentField);
 				currentField.clear();
 				_utf8BufferStartPos = i + 1;
@@ -497,7 +499,9 @@ bool CSV::readLine(vector<string> &items)
 			else if (ch == '\r' || ch == '\n')
 			{
 				// End of current row
-				boost::algorithm::replace_all(currentField, "\n", " ");
+				boost::algorithm::replace_all(currentField, "\r\n", " ");
+				boost::algorithm::replace_all(currentField, "\n",   " ");
+				boost::algorithm::replace_all(currentField, "\r",   " ");
 				if (!currentField.empty() || !items.empty() || i > _utf8BufferStartPos)
 					items.push_back(currentField);
 				currentField.clear();
@@ -550,7 +554,9 @@ bool CSV::readLine(vector<string> &items)
 	for (size_t index = 0; index < items.size(); ++index)
 	{
 		string &item = items[index];
-		boost::algorithm::replace_all(item, "\n", " ");
+				boost::algorithm::replace_all(currentField, "\r\n", " ");
+				boost::algorithm::replace_all(currentField, "\n",   " ");
+				boost::algorithm::replace_all(currentField, "\r",   " ");
 	}
 
 	return true;

--- a/Desktop/data/importers/csv/csv.cpp
+++ b/Desktop/data/importers/csv/csv.cpp
@@ -554,9 +554,9 @@ bool CSV::readLine(vector<string> &items)
 	for (size_t index = 0; index < items.size(); ++index)
 	{
 		string &item = items[index];
-				boost::algorithm::replace_all(currentField, "\r\n", " ");
-				boost::algorithm::replace_all(currentField, "\n",   " ");
-				boost::algorithm::replace_all(currentField, "\r",   " ");
+		boost::algorithm::replace_all(item, "\r\n", " ");
+		boost::algorithm::replace_all(item, "\n",   " ");
+		boost::algorithm::replace_all(item, "\r",   " ");
 	}
 
 	return true;

--- a/Desktop/data/importers/csvimporter.cpp
+++ b/Desktop/data/importers/csvimporter.cpp
@@ -28,103 +28,114 @@ CSVImporter::CSVImporter(bool askForDelimeter) : Importer(), _askForDelimeter{as
 {
 }
 
+
 ImportDataSet* CSVImporter::loadFile(const string &locator, std::function<void(int)> progressCallback)
 {
 	JASPTIMER_RESUME(CSVImporter::loadFile);
-	
+
 	ImportDataSet* result = new ImportDataSet(this);
-	stringvec colNames;
 	CSV csv(locator);
-    csv.open();
+	csv.open();
 
-	// Try to detect delimiter first
-	char detectedDelimiter = csv.delimiter();
-	char delimiter = detectedDelimiter;
-
+	// Handle delimiters
+	char delimiter = csv.delimiter();
 	if (!_synching && _askForDelimeter)
 	{
-		try {
+		try 
+		{
 			delimiter = DesktopCommunicator::singleton()->askCsvDelimiter(delimiter, QString::fromStdString(csv.firstRowsPlease()));
-		} catch (...) {
-			delimiter = detectedDelimiter;
-		}
+		} catch (...) { }
 
-		if (!delimiter)
-			return nullptr;
-
+		if (!delimiter) return nullptr;
 		DesktopCommunicator::singleton()->setKnownCsvDelimiter(delimiter);
 	}
 	else
 	{
-		char knownDelimiter = DesktopCommunicator::singleton()->knownCsvDelimiter();
-		if (knownDelimiter != '\0')
-			delimiter = knownDelimiter;
+		char known = DesktopCommunicator::singleton()->knownCsvDelimiter();
+		if (known != '\0') delimiter = known;
 	}
-
-
 	csv.setDelimiter(delimiter);
+
+	stringvec colNames;
 	csv.readLine(colNames);
+
 	vector<CSVImportColumn *> importColumns;
 	importColumns.reserve(colNames.size());
 
-	int colNo = 0;
-	for (stringvec::iterator it = colNames.begin(); it != colNames.end(); ++it, ++colNo)
+	for (size_t i = 0; i < colNames.size(); ++i)
 	{
-		string colName = *it;
-        
-		if (colName == "")
-			colName = "V" + std::to_string(colNo+1);
+		string colName = colNames[i];
+
+		if (colName.empty())
+		{
+			colName = "V" + to_string(i + 1);
+		}
 		else
 		{
-			// Colname should not be just an integer
 			try
 			{
 				if(std::to_string(std::stoi(colName)) == colName) //Check if it is a number or has more afterwards (stoi won't fail if it starts with numbers. To avoid it converting "1hahaha" into "V1hahaha")
 					colName = "V" + colName;
 			}
-            catch (...) {}
+			catch (...) {}
 		}
 
-		if (it != colNames.begin() && std::find(colNames.begin(), it, colName) != it)
-				colName = colName + "_" + std::to_string(colNo + 1);
-
-		*it = colName;
+		// Check for duplicate names by searching backward in the already processed columns
+		auto duplicateColName = [&colName](CSVImportColumn* col) { return col->name() == colName; };
+		while (std::any_of(importColumns.begin(), importColumns.end(), duplicateColName))
+		{
+			colName = colNames[i] + "_" + to_string(i + 1);
+		}
 
 		importColumns.push_back(new CSVImportColumn(result, colName, csv.numRows()));
 	}
 
-	unsigned long long progress;
+	// Read data
 	unsigned long long lastProgress = -1;
-
-	size_t columnCount = colNames.size();
-
+	size_t columnCount = importColumns.size();
 	stringvec line;
-	bool success = csv.readLine(line);
 
-	while (success)
+	while (csv.readLine(line))
 	{
-		progress = 50 * csv.pos() / csv.size();
-		if (progress != lastProgress)
+		unsigned long long progress = 50 * csv.pos() / csv.size();
+		if (progress != lastProgress) 
 		{
 			progressCallback(progress);
 			lastProgress = progress;
 		}
 
-		if (line.size() != 0) //ignore empty lines
-			for(size_t i = 0; i<columnCount; i++)
-				importColumns.at(i)->addValue(i < line.size() ? line[i] : ""); //add components and add empty vals for missing columns
+		if (line.empty()) continue; // Skip empty lines
+
+		// Dynamically expand has more elements than columns
+		if (line.size() > columnCount)
+		{
+			size_t currentRowCount = importColumns.empty() ? 0 : importColumns[0]->size();
+
+			for (size_t i = columnCount; i < line.size(); ++i) {
+				string newColName = "V" + to_string(i + 1);
+
+				CSVImportColumn* newColumn = new CSVImportColumn(result, newColName, csv.numRows());
+
+				// Pad previously read rows with empty strings to align the bounds
+				for (size_t row = 0; row < currentRowCount; ++row)
+					newColumn->addValue("");
+
+				importColumns.push_back(newColumn);
+			}
+			columnCount = line.size();
+		}
+
+		for (size_t i = 0; i < columnCount; ++i)
+			importColumns[i]->addValue(i < line.size() ? line[i] : "");
 
 		line.clear();
-		success = csv.readLine(line);
 	}
 
-	for (vector<CSVImportColumn *>::iterator it = importColumns.begin(); it != importColumns.end(); ++it)
-		result->addColumn(*it);
+	for (auto* col : importColumns)
+		result->addColumn(col);
 
-	// Build dictionary for sync.
 	result->buildDictionary();
 
 	JASPTIMER_STOP(CSVImporter::loadFile);
-
 	return result;
 }

--- a/Desktop/utilities/csvpreviewmodel.cpp
+++ b/Desktop/utilities/csvpreviewmodel.cpp
@@ -58,27 +58,100 @@ void CsvPreviewModel::updateLocale()
 
 void CsvPreviewModel::updateInternalStructure()
 {
-	// Prepare the model for a complete reset
 	beginResetModel();
-
 	_grid.clear();
-	if (_rawData.isEmpty()) {
-		endResetModel();
-		return;
+
+	if (_rawData.isEmpty()) 
+	{
+			endResetModel();
+			return;
 	}
 
-	// Split data into rows (assuming newlines separate rows)
-	QStringList rows = _rawData.split('\n', Qt::SkipEmptyParts);
-	
-	for (const QString &rowString : rows) {
-		// Split each row by the chosen delimiter
-		QStringList columns = rowString.split(_delimiter);
-		_grid.append(columns);
-	}
+	parseCsvString(_rawData, _delimiter, _grid);
 
 	endResetModel();
-	
-	clearTableForResize();
+	emit clearTableForResize();
+}
+
+void CsvPreviewModel::parseCsvString(const QString &rawData, QChar delimiter, QList<QList<QString>> &outGrid) const
+{
+	enum State { Normal, Quoted, QuotedQuote };
+	State state = Normal;
+	QString currentField;
+	QList<QString> currentRow;
+
+	auto finishField = [&]() 
+	{
+		currentField.replace('\n', ' '); // we not allowed newlines in finished data.
+		currentRow.append(currentField);
+		currentField.clear();
+	};
+
+	auto finishRow = [&]() 
+	{
+		if (!currentField.isEmpty() || !currentRow.isEmpty() || state != Normal)
+			finishField();
+
+		if (!currentRow.isEmpty()) 
+		{
+			outGrid.append(currentRow);
+			currentRow.clear();
+		}
+	};
+
+	int i = 0;
+	const int len = rawData.length();
+	while (i < len) {
+		QChar ch = rawData.at(i);
+
+		switch (state) 
+		{
+		case Normal:
+				if (ch == '"') {
+					state = Quoted;
+				} 
+				else if (ch == delimiter) 
+				{
+					finishField();
+				} 
+				else if (ch == '\n' || ch == '\r')
+				{
+					finishRow();
+					if (ch == '\r' && i + 1 < len && rawData.at(i + 1) == '\n')
+						i++;
+				}
+				else 
+				{
+					currentField.append(ch);
+				}
+				break;
+
+		case Quoted:
+				if (ch == '"') 
+				{
+					state = QuotedQuote;
+				} 
+				else 
+				{
+					currentField.append(ch);
+				}
+				break;
+
+		case QuotedQuote:
+				if (ch == '"') 
+				{
+					currentField.append('"');   // escaped quote -> add one double quote
+					state = Quoted;
+				} else 
+				{
+					state = Normal;
+					continue;
+				}
+				break;
+		}
+		i++;
+	}
+	finishRow();
 }
 
 int CsvPreviewModel::rowCount(const QModelIndex &) const

--- a/Desktop/utilities/csvpreviewmodel.cpp
+++ b/Desktop/utilities/csvpreviewmodel.cpp
@@ -82,7 +82,8 @@ void CsvPreviewModel::parseCsvString(const QString &rawData, QChar delimiter, QL
 
 	auto finishField = [&]() 
 	{
-		currentField.replace('\n', ' '); // we not allowed newlines in finished data.
+		currentField.replace('\r', ' '); // No carriage returns
+		currentField.replace('\n', ' '); // No newlines
 		currentRow.append(currentField);
 		currentField.clear();
 	};

--- a/Desktop/utilities/csvpreviewmodel.h
+++ b/Desktop/utilities/csvpreviewmodel.h
@@ -60,7 +60,8 @@ signals:
 	
 private:
 	void					updateInternalStructure();
-
+	void					parseCsvString(const QString &rawData, QChar delimiter, QList<QList<QString>> &outGrid) const;
+	
 	QString					_rawData;
 	QChar					_delimiter = ','; // Default comma
 	QList<QList<QString>>	_grid; // The parsed data

--- a/Tests/testcsvpreviewmodel.cpp
+++ b/Tests/testcsvpreviewmodel.cpp
@@ -75,5 +75,59 @@ void TestCsvPreviewModel::testDifferentDelimiters()
     QCOMPARE(model.data(model.index(0, 2), Qt::DisplayRole).toString(), QString("Col3"));
 }
 
+void TestCsvPreviewModel::testComplexCsvParsing()
+{
+    CsvPreviewModel model;
+    
+    QString rawData = 
+        "ID,Names,Gender,Age,Add.,Tel.,Text\n"
+        "1,One,M,32,ABBA,1234567891,\"test\"\"Quote\"\"\"\n"
+        "2,Two,M,21,,1234567890,\"test：\nnewlines\"\n"
+        "3,Three,F,18,,,\"this,is,text\"";
+
+    model.preparePreview(rawData.toStdString().c_str(), ',');
+
+    QCOMPARE(model.rowCount(), 4);    // header + 3 data rows
+    QCOMPARE(model.columnCount(), 7);
+
+    // Header row
+    QCOMPARE(model.data(model.index(0, 0), Qt::DisplayRole).toString(), QString("ID"));
+    QCOMPARE(model.data(model.index(0, 1), Qt::DisplayRole).toString(), QString("Names"));
+    QCOMPARE(model.data(model.index(0, 2), Qt::DisplayRole).toString(), QString("Gender"));
+    QCOMPARE(model.data(model.index(0, 3), Qt::DisplayRole).toString(), QString("Age"));
+    QCOMPARE(model.data(model.index(0, 4), Qt::DisplayRole).toString(), QString("Add."));
+    QCOMPARE(model.data(model.index(0, 5), Qt::DisplayRole).toString(), QString("Tel."));
+    QCOMPARE(model.data(model.index(0, 6), Qt::DisplayRole).toString(), QString("Text"));
+
+    QCOMPARE(model.data(model.index(1, 0), Qt::DisplayRole).toString(), QString("1"));
+    QCOMPARE(model.data(model.index(1, 1), Qt::DisplayRole).toString(), QString("\"One\""));
+    QCOMPARE(model.data(model.index(1, 2), Qt::DisplayRole).toString(), QString("\"M\""));
+    QCOMPARE(model.data(model.index(1, 3), Qt::DisplayRole).toString(), QString("32"));
+    QCOMPARE(model.data(model.index(1, 4), Qt::DisplayRole).toString(), QString("\"ABBA\""));
+    QCOMPARE(model.data(model.index(1, 5), Qt::DisplayRole).toString(), QString("1234567891"));
+    // Expected: test"Quote" (inner double quote from escaped "")
+    // The preview adds outer quotes for non-numeric strings, so final display: "test"Quote""
+    // In QString literal: "\"test\"Quote\"\""
+    QCOMPARE(model.data(model.index(1, 6), Qt::DisplayRole).toString(), QString("\"test\"Quote\"\""));
+
+    QCOMPARE(model.data(model.index(2, 0), Qt::DisplayRole).toString(), QString("2"));
+    QCOMPARE(model.data(model.index(2, 1), Qt::DisplayRole).toString(), QString("\"Two\""));
+    QCOMPARE(model.data(model.index(2, 2), Qt::DisplayRole).toString(), QString("\"M\""));
+    QCOMPARE(model.data(model.index(2, 3), Qt::DisplayRole).toString(), QString("21"));
+    QCOMPARE(model.data(model.index(2, 4), Qt::DisplayRole).toString(), QString(""));   // empty field
+    QCOMPARE(model.data(model.index(2, 5), Qt::DisplayRole).toString(), QString("1234567890"));
+    // Newline replaced with space: "test： newlines", plus outer quotes: "\"test： newlines\""
+    QCOMPARE(model.data(model.index(2, 6), Qt::DisplayRole).toString(), QString("\"test： newlines\""));
+
+    QCOMPARE(model.data(model.index(3, 0), Qt::DisplayRole).toString(), QString("3"));
+    QCOMPARE(model.data(model.index(3, 1), Qt::DisplayRole).toString(), QString("\"Three\""));
+    QCOMPARE(model.data(model.index(3, 2), Qt::DisplayRole).toString(), QString("\"F\""));
+    QCOMPARE(model.data(model.index(3, 3), Qt::DisplayRole).toString(), QString("18"));
+    QCOMPARE(model.data(model.index(3, 4), Qt::DisplayRole).toString(), QString(""));
+    QCOMPARE(model.data(model.index(3, 5), Qt::DisplayRole).toString(), QString(""));
+    // Field contains commas but is quoted as a whole, preview adds outer quotes
+    QCOMPARE(model.data(model.index(3, 6), Qt::DisplayRole).toString(), QString("\"this,is,text\""));
+}
+
 
 QTEST_MAIN(TestCsvPreviewModel)

--- a/Tests/testcsvpreviewmodel.h
+++ b/Tests/testcsvpreviewmodel.h
@@ -26,4 +26,5 @@ class TestCsvPreviewModel : public QObject
 private slots:
     void testCsvParsing();
     void testDifferentDelimiters();
+		void testComplexCsvParsing(); 
 };


### PR DESCRIPTION
Fixed: https://github.com/jasp-stats/jasp-issues/issues/4396

Original csv(please copy and paste in a text file and name to .csv):
```csv
ID,Names,Gender,Age,Add.,Tel.,Text
1,One,M,32,ABBA,1234567891,"test""Quote"""
2,Two,M,21,,1234567890,"test：
newlines"
3,Three,F,18,,,"this,is,text"
```
✗Before preview behavior:
<img width="571" height="187" alt="image" src="https://github.com/user-attachments/assets/c14be631-d395-4e21-a285-b94d6e4fc6b5" />

✓ Now preview:
<img width="607" height="263" alt="image" src="https://github.com/user-attachments/assets/45e99ba2-bf26-424f-a708-66bd6bd3431d" />

✗Before Imported behavior:
<img width="622" height="151" alt="image" src="https://github.com/user-attachments/assets/f22bf7c8-5036-4848-abdd-277446a202e1" />


✓ Now imported:
<img width="632" height="166" alt="image" src="https://github.com/user-attachments/assets/d591e294-c547-4521-97dc-a196d12d5825" />

And added a unit test for it.