### PR TITLE
Manipulating value of labels may cause a crash in debug mode.

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1624,6 +1624,8 @@ void Column::labelValueChanged(Label *label, const Json::Value & previousOrigina
 {
 	assert(_hasLabels);
 	
+	label->rememberCurrentOrigValDisplay();
+	
 	auto prevOrigV	= Label::originalValueAsString(this, previousOriginal);
 	auto oldValDis	= std::make_pair(prevOrigV, label->label());
 	bool merged		= _labelByValDis.count(label->origValDisplay()) != 0;

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1156,7 +1156,7 @@ void Column::labelsRemoveByIntsId(std::set<int> valuesToRemove, bool updateOrder
 				{
 					_labelByIntsIdMap.erase(label->intsId());
 					
-					auto valDis = std::make_pair(label->originalValueAsString(), label->label());
+					auto valDis = label->origValDisplay();
 					if(_labelByValDis.count(valDis) && _labelByValDis.at(valDis) == label)
 						_labelByValDis.erase(valDis);
 						
@@ -1762,6 +1762,8 @@ void Column::_labelMapUpdates(Label * label, const std::string & previousDisplay
 				break;
 			}
 	}
+	label->rememberCurrentOrigValDisplay();
+
 }
 
 void Column::labelsHandleAutoSort(bool doDbUpdateEtc)
@@ -1774,7 +1776,8 @@ void Column::labelsHandleAutoSort(bool doDbUpdateEtc)
 
 void Column::labelDisplayChanged(Label *label, const std::string & previousDisplay)
 {
-	auto oldValDis = std::make_pair(label->originalValueAsString(), previousDisplay);
+	auto origValStr = label->originalValueAsString();
+	auto oldValDis  = std::make_pair(origValStr, Label::processLabel(previousDisplay, origValStr));
 	bool merged		= _labelByValDis.count(label->origValDisplay()) != 0;
 	
 	if(merged)
@@ -1797,7 +1800,7 @@ void Column::labelDisplayChanged(Label *label, const std::string & previousDispl
 void Column::labelValDisplayChanged(Label *label, const std::string &previousDisplay, const Json::Value &previousOriginal)
 {
 	auto	oldOrigValS	= Label::originalValueAsString(this, previousOriginal);
-	auto	oldValDis	= std::make_pair(oldOrigValS, previousDisplay),
+	auto	oldValDis	= std::make_pair(oldOrigValS, Label::processLabel(previousDisplay, oldOrigValS)),
 			newValDis	= std::make_pair(label->originalValueAsString(), label->label());
 	bool	merged		= _labelByValDis.count(label->origValDisplay()) != 0;
 	

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1820,7 +1820,7 @@ void Column::labelValDisplayChanged(Label *label, const std::string &previousDis
 		if(_ints[r] == label->intsId())
 			_dbls[r] = newOrigValDbl;
 	
-	_labelMapUpdates(label, previousDisplay, label->originalValueAsString());
+	_labelMapUpdates(label, previousDisplay, oldOrigValS);
 
 	if(merged)
 		_dbUpdateLabelOrder();

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -1624,8 +1624,6 @@ void Column::labelValueChanged(Label *label, const Json::Value & previousOrigina
 {
 	assert(_hasLabels);
 	
-	label->rememberCurrentOrigValDisplay();
-	
 	auto prevOrigV	= Label::originalValueAsString(this, previousOriginal);
 	auto oldValDis	= std::make_pair(prevOrigV, label->label());
 	bool merged		= _labelByValDis.count(label->origValDisplay()) != 0;

--- a/Desktop/data/datasetpackage.cpp
+++ b/Desktop/data/datasetpackage.cpp
@@ -896,8 +896,8 @@ bool DataSetPackage::setLabelDisplay(const QModelIndex &index, const QString &ne
 		return false;
 	
 	beginSynchingData(false);
-	
-	if(label->setLabel(newLabel.toStdString()))
+		
+	if(label->setLabel(Label::processLabel(newLabel.toStdString(), label->originalValueAsString())))
 	{
 		aChange = true;
 		

--- a/Tests/testdebugdata.cpp
+++ b/Tests/testdebugdata.cpp
@@ -290,6 +290,49 @@ void TestDebugData::testEmptyValues()
 	QVERIFY2(contBinom->nonEmptyLevelsStrings().size() == 0,	"There should be no labels anymore!");
 }
 
+void TestDebugData::testChangeLabelValueTwice()
+{
+	QVERIFY2(_data,		"No dataset!");
+
+	Column * contBinom = _data->column("contBinom");
+	QVERIFY2(contBinom,					"No contBinom!");
+	QVERIFY2(contBinom->hasLabels(),	"contBinom should have labels");
+	QVERIFY2(contBinom->labels().size() >= 1, "contBinom has no labels!");
+
+	Label * lbl = contBinom->labels()[0];
+
+	// First value change: numeric → non-numeric string (goes through labelValDisplayChanged)
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "hello", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(lbl->originalValueAsString() == "hello",	"First value change to 'hello' failed");
+	QVERIFY2(lbl->label() == "hello",	"Lable value change to 'hello' failed");
+
+	// Second value change: non-numeric string → numeric (goes through labelValueChanged,
+	// which uses lastOrigValDisplay(). Since _labelMapUpdates no longer calls
+	// rememberCurrentOrigValDisplay(), _lastValDisMapping is stale → assert failure at line 1638)
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "5", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(lbl->originalValueAsString() == "5",		"Second value change to '5' failed");
+	QVERIFY2(lbl->label() == "hello",		"Label value should stay to 'hello' failed");
+
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "6", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(lbl->originalValueAsString() == "6",		"Third value change to '6' failed");
+	QVERIFY2(lbl->label() == "hello",		"Label value should stay to 'hello' failed");
+
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "6", int(DataSetPackage::specialRoles::label));
+	QVERIFY2(lbl->originalValueAsString() == "6",		"Label value should stay to '6' failed");
+	QVERIFY2(lbl->label() == "6",		"Label change to '6' failed");
+
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "7", int(DataSetPackage::specialRoles::label));
+	QVERIFY2(lbl->originalValueAsString() == "6",		"Label value should stay to '6' failed");
+	QVERIFY2(lbl->label() == "7",		"Label change to '7' failed");
+
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "8", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(lbl->originalValueAsString() == "8",		"Label value change to '8' failed'");
+	QVERIFY2(lbl->label() == "8",		"Label value change to '8' failed'");
+
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
+
 void TestDebugData::testChangeLabel()
 {
 	QVERIFY2(_data,		"No dataset!");

--- a/Tests/testdebugdata.cpp
+++ b/Tests/testdebugdata.cpp
@@ -425,6 +425,264 @@ QString shadContGammaMsg = QString("contGamma row 0 shadow should not be empty (
 		std::string shadContGammaMsgStr = shadContGammaMsg.toStdString();
 		QVERIFY2(!shadContGamma.empty(), shadContGammaMsgStr.c_str());
 	}
+}
 
+void TestDebugData::testDuplicateLabelPrevention()
+{
+	QVERIFY2(_data,		"No dataset!");
+	
+	Column * contBinom = _data->column("contBinom");
+	
+	if(!contBinom->hasLabels())
+		contBinom->noLabelsToLabels();
+	
+	QVERIFY2(contBinom->hasLabels(), "contBinom should have labels");
+	QVERIFY2(contBinom->labels().size() >= 2, "contBinom needs at least 2 labels");
+	
+	Label * label1 = contBinom->labels()[0];
+	Label * label2 = contBinom->labels()[1];
+	
+	std::string originalVal1 = label1->originalValueAsString();
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label2), originalVal1.c_str(), int(DataSetPackage::specialRoles::label));
+	
+	QVERIFY2(label2->label() != originalVal1.c_str(), "Duplicate label should not be created");
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label2), "NewLabel", int(DataSetPackage::specialRoles::label));
+	
+	QVERIFY2(label2->label() == "NewLabel", "Label should be successfully changed to non-duplicate");
+	
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
+
+void TestDebugData::testValueEqualsDisplayStorage()
+{
+	QVERIFY2(_data,		"No dataset!");
+	
+	Column * contBinom = _data->column("contBinom");
+	
+	if(!contBinom->hasLabels())
+		contBinom->noLabelsToLabels();
+	
+	Label * label = contBinom->labels()[0];
+	std::string currentVal = label->originalValueAsString();
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), currentVal.c_str(), int(DataSetPackage::specialRoles::label));
+	
+	double dblVal;
+	bool isNumeric = !std::isnan(ColumnUtils::getDoubleValue(currentVal, dblVal)) && !std::isnan(dblVal);
+	
+	if(isNumeric)
+	{
+		QVERIFY2(label->label() == "", "Numeric value with same display should have empty label stored");
+		QVERIFY2(label->labelDisplay() == currentVal, "Display should show the value");
+	}
+	else
+	{
+		QVERIFY2(label->label() != "", "Non-numeric should have non-empty label");
+		QVERIFY2(label->labelDisplay() == label->label(), "Display should match label");
+	}
+	
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
+
+void TestDebugData::testSequentialValueChanges()
+{
+	QVERIFY2(_data,		"No dataset!");
+	
+	Column * contBinom = _data->column("contBinom");
+	
+	if(!contBinom->hasLabels())
+		contBinom->noLabelsToLabels();
+	
+	Label * label = contBinom->labels()[0];
+	
+	std::string firstVal = label->originalValueAsString();
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "test1", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(label->originalValueAsString() == "test1", "First value change failed");
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "test2", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(label->originalValueAsString() == "test2", "Second value change failed");
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "test3", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(label->originalValueAsString() == "test3", "Third value change failed");
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "5", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(label->originalValueAsString() == "5", "String to numeric conversion failed");
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "6", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(label->originalValueAsString() == "6", "Numeric to numeric conversion failed");
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "hello", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(label->originalValueAsString() == "hello", "Numeric to string conversion failed");
+	
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
+
+void TestDebugData::testEmptyValueLabel()
+{
+	QVERIFY2(_data,		"No dataset!");
+	
+	Column * contBinom = _data->column("contBinom");
+	
+	if(!contBinom->hasLabels())
+		contBinom->noLabelsToLabels();
+	
+	Label * label = contBinom->labels()[0];
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "", int(DataSetPackage::specialRoles::value));
+	
+	QVERIFY2(label->originalValueAsString() == "", "Empty value should be stored");
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "", int(DataSetPackage::specialRoles::label));
+	
+	QVERIFY2(label->label() == "", "Empty label should be stored");
+	
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
+
+void TestDebugData::testNumericToStringConversion()
+{
+	QVERIFY2(_data,		"No dataset!");
+	
+	Column * contBinom = _data->column("contBinom");
+	
+	if(!contBinom->hasLabels())
+		contBinom->noLabelsToLabels();
+	
+	Label * label = contBinom->labels()[0];
+	
+	std::string original = label->originalValueAsString();
+	
+	double dbl;
+	bool wasNumeric = !std::isnan(ColumnUtils::getDoubleValue(original, dbl));
+	
+	if(wasNumeric)
+	{
+		DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "newstring", int(DataSetPackage::specialRoles::value));
+		
+		QVERIFY2(label->originalValueAsString() == "newstring", "Numeric to string conversion failed");
+		QVERIFY2(label->label() == "newstring", "Label should match new value");
+		
+		DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "5.5", int(DataSetPackage::specialRoles::value));
+		
+		QVERIFY2(label->originalValueAsString() == "5.5", "String to double conversion failed");
+	}
+	
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
+
+void TestDebugData::testStringToNumericConversion()
+{
+	QVERIFY2(_data,		"No dataset!");
+	
+	Column * contBinom = _data->column("contBinom");
+	
+	if(!contBinom->hasLabels())
+		contBinom->noLabelsToLabels();
+	
+	Label * label = contBinom->labels()[0];
+	
+	std::string original = label->originalValueAsString();
+	
+	double dbl;
+	bool wasNumeric = !std::isnan(ColumnUtils::getDoubleValue(original, dbl));
+	
+	if(!wasNumeric)
+	{
+		DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "42", int(DataSetPackage::specialRoles::value));
+		
+		QVERIFY2(label->originalValueAsString() == "42", "String to numeric conversion failed");
+		
+		DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "100", int(DataSetPackage::specialRoles::value));
+		
+		QVERIFY2(label->originalValueAsString() == "100", "Sequential numeric changes failed");
+	}
+	
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
+
+void TestDebugData::testBatchOperationsWithFilters()
+{
+	QVERIFY2(_data,		"No dataset!");
+	
+	Column * facFive = _data->column("facFive");
+	
+	if(!facFive->hasLabels())
+		facFive->noLabelsToLabels();
+	
+	facFive->setAutoSortByValue(false);
+	
+	Labelset labelsToDisable;
+	int count = 0;
+	for(Label * label : facFive->labels())
+	{
+		if(!label->isEmptyValue() && count < 2)
+		{
+			labelsToDisable.insert(label);
+			count++;
+		}
+	}
+	
+	for(Label * label : labelsToDisable)
+		label->setFilterAllows(false);
+	
+	QVERIFY2(facFive->hasFilter(), "Filter should be active");
+	
+	facFive->valuesReverse();
+	
+	for(Label * label : labelsToDisable)
+		QVERIFY2(!label->filterAllows(), "Filter allows should persist after reverse");
+	
+	facFive->resetFilter();
+	
+	QVERIFY2(facFive->allLabelsPassFilter(), "All labels should pass after reset");
+	
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
+
+void TestDebugData::testUndoRedoAfterLabelChanges()
+{
+	QVERIFY2(_data,		"No dataset!");
+	
+	Column * contBinom = _data->column("contBinom");
+	
+	if(!contBinom->hasLabels())
+		contBinom->noLabelsToLabels();
+	
+	Label * label = contBinom->labels()[0];
+	
+	std::string originalLabel = label->label();
+	std::string originalValue = label->originalValueAsString();
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "NewLabel", int(DataSetPackage::specialRoles::label));
+	QVERIFY2(label->label() == "NewLabel", "Label should change");
+	
+	DataSetPackage::pkg()->undoStack()->undo();
+	QVERIFY2(label->label() == originalLabel, "Undo should restore original label");
+	
+	DataSetPackage::pkg()->undoStack()->redo();
+	QVERIFY2(label->label() == "NewLabel", "Redo should reapply label change");
+	
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "NewValue", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(label->originalValueAsString() == "NewValue", "Value should change");
+	
+	DataSetPackage::pkg()->undoStack()->undo();
+	QVERIFY2(label->originalValueAsString() == originalValue, "Undo should restore original value");
+	
+	DataSetPackage::pkg()->undoStack()->redo();
+	QVERIFY2(label->originalValueAsString() == "NewValue", "Redo should reapply value change");
+	
+	DataSet loadMe(_data->id());
+	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+}
 
 QTEST_MAIN(TestDebugData)

--- a/Tests/testdebugdata.cpp
+++ b/Tests/testdebugdata.cpp
@@ -1,5 +1,6 @@
 #include "testinfo.h"
 #include "tempfiles.h"
+#include "columnutils.h"
 #include "processinfo.h"
 #include "testdebugdata.h"
 #include "utilities/qutils.h"
@@ -307,8 +308,7 @@ void TestDebugData::testChangeLabelValueTwice()
 	QVERIFY2(lbl->label() == "hello",	"Lable value change to 'hello' failed");
 
 	// Second value change: non-numeric string → numeric (goes through labelValueChanged,
-	// which uses lastOrigValDisplay(). Since _labelMapUpdates no longer calls
-	// rememberCurrentOrigValDisplay(), _lastValDisMapping is stale → assert failure at line 1638)
+	// which uses lastOrigValDisplay().
 	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "5", int(DataSetPackage::specialRoles::value));
 	QVERIFY2(lbl->originalValueAsString() == "5",		"Second value change to '5' failed");
 	QVERIFY2(lbl->label() == "hello",		"Label value should stay to 'hello' failed");
@@ -324,6 +324,10 @@ void TestDebugData::testChangeLabelValueTwice()
 	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "7", int(DataSetPackage::specialRoles::label));
 	QVERIFY2(lbl->originalValueAsString() == "6",		"Label value should stay to '6' failed");
 	QVERIFY2(lbl->label() == "7",		"Label change to '7' failed");
+	
+	QVERIFY2(lbl->label() != lbl->originalValueAsString(), "value and label ought to be different!");
+	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "7", int(DataSetPackage::specialRoles::value));
+	QVERIFY2(lbl->label() == lbl->originalValueAsString(), "value and label ought to be same now!");
 
 	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(lbl), "8", int(DataSetPackage::specialRoles::value));
 	QVERIFY2(lbl->originalValueAsString() == "8",		"Label value change to '8' failed'");
@@ -420,40 +424,11 @@ void TestDebugData::testShadowDisplay()
 	std::string dispContGamma = contGamma->getDisplay(0, false, false);
 	std::string shadContGamma = contGamma->getShadow(0, false, false);
 	
-QString shadContGammaMsg = QString("contGamma row 0 shadow should not be empty (val='%1', disp='%2', shad='%3')")
+	QString shadContGammaMsg = QString("contGamma row 0 shadow should not be empty (val='%1', disp='%2', shad='%3')")
 				.arg(valContGamma.c_str()).arg(dispContGamma.c_str()).arg(shadContGamma.c_str());
-		std::string shadContGammaMsgStr = shadContGammaMsg.toStdString();
-		QVERIFY2(!shadContGamma.empty(), shadContGammaMsgStr.c_str());
-	}
-}
-
-void TestDebugData::testDuplicateLabelPrevention()
-{
-	QVERIFY2(_data,		"No dataset!");
 	
-	Column * contBinom = _data->column("contBinom");
+	QVERIFY2(!shadContGamma.empty(), shadContGammaMsg.toStdString().c_str());
 	
-	if(!contBinom->hasLabels())
-		contBinom->noLabelsToLabels();
-	
-	QVERIFY2(contBinom->hasLabels(), "contBinom should have labels");
-	QVERIFY2(contBinom->labels().size() >= 2, "contBinom needs at least 2 labels");
-	
-	Label * label1 = contBinom->labels()[0];
-	Label * label2 = contBinom->labels()[1];
-	
-	std::string originalVal1 = label1->originalValueAsString();
-	
-	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label2), originalVal1.c_str(), int(DataSetPackage::specialRoles::label));
-	
-	QVERIFY2(label2->label() != originalVal1.c_str(), "Duplicate label should not be created");
-	
-	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label2), "NewLabel", int(DataSetPackage::specialRoles::label));
-	
-	QVERIFY2(label2->label() == "NewLabel", "Label should be successfully changed to non-duplicate");
-	
-	DataSet loadMe(_data->id());
-	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
 }
 
 void TestDebugData::testValueEqualsDisplayStorage()
@@ -475,12 +450,12 @@ void TestDebugData::testValueEqualsDisplayStorage()
 	
 	if(isNumeric)
 	{
-		QVERIFY2(label->label() == "", "Numeric value with same display should have empty label stored");
+		QVERIFY2(label->label(false)   == "", "Numeric value with same display should have empty label stored");
 		QVERIFY2(label->labelDisplay() == currentVal, "Display should show the value");
 	}
 	else
 	{
-		QVERIFY2(label->label() != "", "Non-numeric should have non-empty label");
+		QVERIFY2(label->label(false)   != "", "Non-numeric should have non-empty label");
 		QVERIFY2(label->labelDisplay() == label->label(), "Display should match label");
 	}
 	
@@ -649,40 +624,42 @@ void TestDebugData::testBatchOperationsWithFilters()
 	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
 }
 
-void TestDebugData::testUndoRedoAfterLabelChanges()
-{
-	QVERIFY2(_data,		"No dataset!");
-	
-	Column * contBinom = _data->column("contBinom");
-	
-	if(!contBinom->hasLabels())
-		contBinom->noLabelsToLabels();
-	
-	Label * label = contBinom->labels()[0];
-	
-	std::string originalLabel = label->label();
-	std::string originalValue = label->originalValueAsString();
-	
-	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "NewLabel", int(DataSetPackage::specialRoles::label));
-	QVERIFY2(label->label() == "NewLabel", "Label should change");
-	
-	DataSetPackage::pkg()->undoStack()->undo();
-	QVERIFY2(label->label() == originalLabel, "Undo should restore original label");
-	
-	DataSetPackage::pkg()->undoStack()->redo();
-	QVERIFY2(label->label() == "NewLabel", "Redo should reapply label change");
-	
-	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "NewValue", int(DataSetPackage::specialRoles::value));
-	QVERIFY2(label->originalValueAsString() == "NewValue", "Value should change");
-	
-	DataSetPackage::pkg()->undoStack()->undo();
-	QVERIFY2(label->originalValueAsString() == originalValue, "Undo should restore original value");
-	
-	DataSetPackage::pkg()->undoStack()->redo();
-	QVERIFY2(label->originalValueAsString() == "NewValue", "Redo should reapply value change");
-	
-	DataSet loadMe(_data->id());
-	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
-}
+
+// The following test would require actually using the undo model commands
+//void TestDebugData::testUndoRedoAfterLabelChanges()
+//{
+//	QVERIFY2(_data,		"No dataset!");
+//	
+//	Column * contBinom = _data->column("contBinom");
+//	
+//	if(!contBinom->hasLabels())
+//		contBinom->noLabelsToLabels();
+//	
+//	Label * label = contBinom->labels()[0];
+//	
+//	std::string originalLabel = label->label();
+//	std::string originalValue = label->originalValueAsString();
+//	
+//	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "NewLabel", int(DataSetPackage::specialRoles::label));
+//	QVERIFY2(label->label() == "NewLabel", "Label should change");
+//	
+//	DataSetPackage::pkg()->undoStack()->undo();
+//	QVERIFY2(label->label() == originalLabel, "Undo should restore original label");
+//	
+//	DataSetPackage::pkg()->undoStack()->redo();
+//	QVERIFY2(label->label() == "NewLabel", "Redo should reapply label change");
+//	
+//	DataSetPackage::pkg()->setData(DataSetPackage::pkg()->indexForSubNode(label), "NewValue", int(DataSetPackage::specialRoles::value));
+//	QVERIFY2(label->originalValueAsString() == "NewValue", "Value should change");
+//	
+//	DataSetPackage::pkg()->undoStack()->undo();
+//	QVERIFY2(label->originalValueAsString() == originalValue, "Undo should restore original value");
+//	
+//	DataSetPackage::pkg()->undoStack()->redo();
+//	QVERIFY2(label->originalValueAsString() == "NewValue", "Redo should reapply value change");
+//	
+//	DataSet loadMe(_data->id());
+//	QVERIFY2(_data->jsonForCompare() == loadMe.jsonForCompare(), "DataSet isnt the same after dbload!");
+//}
 
 QTEST_MAIN(TestDebugData)

--- a/Tests/testdebugdata.h
+++ b/Tests/testdebugdata.h
@@ -21,6 +21,14 @@ private slots:
 	void    testReverseLabels();
     void    testReverseNumericals();
 	void	testShadowDisplay();
+	void	testDuplicateLabelPrevention();
+	void	testValueEqualsDisplayStorage();
+	void	testSequentialValueChanges();
+	void	testEmptyValueLabel();
+	void	testNumericToStringConversion();
+	void	testStringToNumericConversion();
+	void	testBatchOperationsWithFilters();
+	void	testUndoRedoAfterLabelChanges();
 	
 private:
 	DataSetPackage		*	_pkg		= nullptr;

--- a/Tests/testdebugdata.h
+++ b/Tests/testdebugdata.h
@@ -17,6 +17,7 @@ private slots:
 	void    testColumnStuff();
 	void	testEmptyValues();
 	void	testChangeLabel();
+	void	testChangeLabelValueTwice();
 	void    testReverseLabels();
     void    testReverseNumericals();
 	void	testShadowDisplay();

--- a/Tests/testdebugdata.h
+++ b/Tests/testdebugdata.h
@@ -21,14 +21,13 @@ private slots:
 	void    testReverseLabels();
     void    testReverseNumericals();
 	void	testShadowDisplay();
-	void	testDuplicateLabelPrevention();
 	void	testValueEqualsDisplayStorage();
 	void	testSequentialValueChanges();
 	void	testEmptyValueLabel();
 	void	testNumericToStringConversion();
 	void	testStringToNumericConversion();
 	void	testBatchOperationsWithFilters();
-	void	testUndoRedoAfterLabelChanges();
+	//void	testUndoRedoAfterLabelChanges();
 	
 private:
 	DataSetPackage		*	_pkg		= nullptr;


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3236
A unit test is added in testdebugdata.

First fix was to add rememberCurrentOrigValDisplay when _labelMapUpdates is called.

But a second fix is necessary:
```
 The real bug: _labelByValDis keys are built via origValDisplay() which calls processLabel(label, value). For a numeric label whose display equals its value (e.g., _label="6",
  origVal=6), processLabel("6","6") returns "" — so the map key is ("6","").

  But when labelDisplayChanged is later called with previousDisplay="6" (the raw _label), it was constructing oldValDis = ("6","6") — which doesn't exist in the map, failing the
  assert at line 1806.

  The same mismatch existed in labelValDisplayChanged and labelsRemoveByIntsId. Three fixes applied:

  1. labelDisplayChanged:1799 — wrap previousDisplay in Label::processLabel(previousDisplay, origValStr)
  2. labelValDisplayChanged:1822 — wrap previousDisplay in Label::processLabel(previousDisplay, oldOrigValS)
  3. labelsRemoveByIntsId:1159 — replace std::make_pair(label->originalValueAsString(), label->label()) with label->origValDisplay(), which already applies processLabel internally

```