### PR TITLE
chore: update qwebchannel.js to teep the version consistent with QtWebChannel

### DIFF
--- a/Desktop/html/js/qwebchannel.js
+++ b/Desktop/html/js/qwebchannel.js
@@ -1,53 +1,7 @@
-/****************************************************************************
-**
-** Copyright (C) 2016 The Qt Company Ltd.
-** Copyright (C) 2014 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author Milian Wolff <milian.wolff@kdab.com>
-** Contact: https://www.qt.io/licensing/
-**
-** This file is part of the QtWebChannel module of the Qt Toolkit.
-**
-** $QT_BEGIN_LICENSE:BSD$
-** Commercial License Usage
-** Licensees holding valid commercial Qt licenses may use this file in
-** accordance with the commercial license agreement provided with the
-** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and The Qt Company. For licensing terms
-** and conditions see https://www.qt.io/terms-conditions. For further
-** information use the contact form at https://www.qt.io/contact-us.
-**
-** BSD License Usage
-** Alternatively, you may use this file under the terms of the BSD license
-** as follows:
-**
-** "Redistribution and use in source and binary forms, with or without
-** modification, are permitted provided that the following conditions are
-** met:
-**   * Redistributions of source code must retain the above copyright
-**     notice, this list of conditions and the following disclaimer.
-**   * Redistributions in binary form must reproduce the above copyright
-**     notice, this list of conditions and the following disclaimer in
-**     the documentation and/or other materials provided with the
-**     distribution.
-**   * Neither the name of The Qt Company Ltd nor the names of its
-**     contributors may be used to endorse or promote products derived
-**     from this software without specific prior written permission.
-**
-**
-** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-**
-** $QT_END_LICENSE$
-**
-****************************************************************************/
+// Copyright (C) 2016 The Qt Company Ltd.
+// Copyright (C) 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author Milian Wolff <milian.wolff@kdab.com>
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+// Qt-Security score:critical reason:data-parser
 
 "use strict";
 
@@ -64,7 +18,7 @@ var QWebChannelMessageTypes = {
     response: 10,
 };
 
-var QWebChannel = function(transport, initCallback)
+var QWebChannel = function(transport, initCallback, converters)
 {
     if (typeof transport !== "object" || typeof transport.send !== "function") {
         console.error("The QWebChannel expects a transport object with a send function and onmessage callback property." +
@@ -74,6 +28,43 @@ var QWebChannel = function(transport, initCallback)
 
     var channel = this;
     this.transport = transport;
+
+    var converterRegistry =
+    {
+        Date : function(response) {
+            if (typeof response === "string"
+                && response.match(
+                        /^-?\d+-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d*)?([-+\u2212](\d{2}):(\d{2})|Z)?$/)) {
+                var date = new Date(response);
+                if (!isNaN(date))
+                    return date;
+            }
+            return undefined; // Return undefined if current converter is not applicable
+        }
+    };
+
+    this.usedConverters = [];
+
+    this.addConverter = function(converter)
+    {
+        if (typeof converter === "string") {
+            if (converterRegistry.hasOwnProperty(converter))
+                this.usedConverters.push(converterRegistry[converter]);
+            else
+                console.error("Converter '" + converter + "' not found");
+        } else if (typeof converter === "function") {
+            this.usedConverters.push(converter);
+        } else {
+            console.error("Invalid converter object type " + typeof converter);
+        }
+    }
+
+    if (Array.isArray(converters)) {
+        for (const converter of converters)
+            this.addConverter(converter);
+    } else if (converters !== undefined) {
+        this.addConverter(converters);
+    }
 
     this.send = function(data)
     {
@@ -151,15 +142,14 @@ var QWebChannel = function(transport, initCallback)
 
     this.handlePropertyUpdate = function(message)
     {
-        for (var i in message.data) {
-            var data = message.data[i];
+        message.data.forEach(data => {
             var object = channel.objects[data.object];
             if (object) {
                 object.propertyUpdate(data.signals, data.properties);
             } else {
                 console.warn("Unhandled property update: " + data.object + "::" + data.signal);
             }
-        }
+        });
         channel.exec({type: QWebChannelMessageTypes.idle});
     }
 
@@ -169,13 +159,15 @@ var QWebChannel = function(transport, initCallback)
     };
 
     channel.exec({type: QWebChannelMessageTypes.init}, function(data) {
-        for (var objectName in data) {
-            var object = new QObject(objectName, data[objectName], channel);
+        for (const objectName of Object.keys(data)) {
+            new QObject(objectName, data[objectName], channel);
         }
+
         // now unwrap properties, which might reference other registered objects
-        for (var objectName in channel.objects) {
+        for (const objectName of Object.keys(channel.objects)) {
             channel.objects[objectName].unwrapProperties();
         }
+
         if (initCallback) {
             initCallback(channel);
         }
@@ -200,18 +192,25 @@ function QObject(name, data, webChannel)
 
     this.unwrapQObject = function(response)
     {
+        for (const converter of webChannel.usedConverters) {
+            var result = converter(response);
+            if (result !== undefined)
+                return result;
+        }
+
         if (response instanceof Array) {
             // support list of objects
-            var ret = new Array(response.length);
-            for (var i = 0; i < response.length; ++i) {
-                ret[i] = object.unwrapQObject(response[i]);
-            }
-            return ret;
+            return response.map(qobj => object.unwrapQObject(qobj))
         }
-        if (!response
-            || !response["__QObject*__"]
-            || response.id === undefined) {
+        if (!(response instanceof Object))
             return response;
+
+        if (!response["__QObject*__"] || response.id === undefined) {
+            var jObj = {};
+            for (const propName of Object.keys(response)) {
+                jObj[propName] = object.unwrapQObject(response[propName]);
+            }
+            return jObj;
         }
 
         var objectId = response.id;
@@ -231,13 +230,7 @@ function QObject(name, data, webChannel)
                 // just assigning {} though would not have the desired effect, but the
                 // below also ensures all external references will see the empty map
                 // NOTE: this detour is necessary to workaround QTBUG-40021
-                var propertyNames = [];
-                for (var propertyName in qObject) {
-                    propertyNames.push(propertyName);
-                }
-                for (var idx in propertyNames) {
-                    delete qObject[propertyNames[idx]];
-                }
+                Object.keys(qObject).forEach(name => delete qObject[name]);
             }
         });
         // here we are already initialized, and thus must directly unwrap the properties
@@ -247,7 +240,7 @@ function QObject(name, data, webChannel)
 
     this.unwrapProperties = function()
     {
-        for (var propertyIdx in object.__propertyCache__) {
+        for (const propertyIdx of Object.keys(object.__propertyCache__)) {
             object.__propertyCache__[propertyIdx] = object.unwrapQObject(object.__propertyCache__[propertyIdx]);
         }
     }
@@ -266,9 +259,16 @@ function QObject(name, data, webChannel)
                 object.__objectSignals__[signalIndex] = object.__objectSignals__[signalIndex] || [];
                 object.__objectSignals__[signalIndex].push(callback);
 
-                if (!isPropertyNotifySignal && signalName !== "destroyed") {
-                    // only required for "pure" signals, handled separately for properties in propertyUpdate
-                    // also note that we always get notified about the destroyed signal
+                // only required for "pure" signals, handled separately for properties in propertyUpdate
+                if (isPropertyNotifySignal)
+                    return;
+
+                // also note that we always get notified about the destroyed signal
+                if (signalName === "destroyed" || signalName === "destroyed()" || signalName === "destroyed(QObject*)")
+                    return;
+
+                // and otherwise we only need to be connected only once
+                if (object.__objectSignals__[signalIndex].length == 1) {
                     webChannel.exec({
                         type: QWebChannelMessageTypes.connectToSignal,
                         object: object.__id__,
@@ -281,13 +281,11 @@ function QObject(name, data, webChannel)
                     console.error("Bad callback given to disconnect from signal " + signalName);
                     return;
                 }
-                object.__objectSignals__[signalIndex] = object.__objectSignals__[signalIndex] || [];
-                var idx = object.__objectSignals__[signalIndex].indexOf(callback);
-                if (idx === -1) {
-                    console.error("Cannot find connection of signal " + signalName + " to " + callback.name);
-                    return;
-                }
-                object.__objectSignals__[signalIndex].splice(idx, 1);
+                // This makes a new list. This is important because it won't interfere with
+                // signal processing if a disconnection happens while emittig a signal
+                object.__objectSignals__[signalIndex] = (object.__objectSignals__[signalIndex] || []).filter(function(c) {
+                  return c != callback;
+                });
                 if (!isPropertyNotifySignal && object.__objectSignals__[signalIndex].length === 0) {
                     // only required for "pure" signals, handled separately for properties in propertyUpdate
                     webChannel.exec({
@@ -316,12 +314,12 @@ function QObject(name, data, webChannel)
     this.propertyUpdate = function(signals, propertyMap)
     {
         // update property cache
-        for (var propertyIndex in propertyMap) {
+        for (const propertyIndex of Object.keys(propertyMap)) {
             var propertyValue = propertyMap[propertyIndex];
-            object.__propertyCache__[propertyIndex] = propertyValue;
+            object.__propertyCache__[propertyIndex] = this.unwrapQObject(propertyValue);
         }
 
-        for (var signalName in signals) {
+        for (const signalName of Object.keys(signals)) {
             // Invoke all callbacks, as signalEmitted() does not. This ensures the
             // property cache is updated before the callbacks are invoked.
             invokeSignalCallbacks(signalName, signals[signalName]);
@@ -330,27 +328,44 @@ function QObject(name, data, webChannel)
 
     this.signalEmitted = function(signalName, signalArgs)
     {
-        invokeSignalCallbacks(signalName, signalArgs);
+        invokeSignalCallbacks(signalName, this.unwrapQObject(signalArgs));
     }
 
     function addMethod(methodData)
     {
         var methodName = methodData[0];
         var methodIdx = methodData[1];
+
+        // Fully specified methods are invoked by id, others by name for host-side overload resolution
+        var invokedMethod = methodName[methodName.length - 1] === ')' ? methodIdx : methodName
+
         object[methodName] = function() {
             var args = [];
             var callback;
+            var errCallback;
             for (var i = 0; i < arguments.length; ++i) {
-                if (typeof arguments[i] === "function")
-                    callback = arguments[i];
+                var argument = arguments[i];
+                if (typeof argument === "function")
+                    callback = argument;
                 else
-                    args.push(arguments[i]);
+                    args.push(argument);
+            }
+
+            var result;
+            // during test, webChannel.exec synchronously calls the callback
+            // therefore, the promise must be constucted before calling
+            // webChannel.exec to ensure the callback is set up
+            if (!callback && (typeof(Promise) === 'function')) {
+              result = new Promise(function(resolve, reject) {
+                callback = resolve;
+                errCallback = reject;
+              });
             }
 
             webChannel.exec({
                 "type": QWebChannelMessageTypes.invokeMethod,
                 "object": object.__id__,
-                "method": methodIdx,
+                "method": invokedMethod,
                 "args": args
             }, function(response) {
                 if (response !== undefined) {
@@ -358,8 +373,12 @@ function QObject(name, data, webChannel)
                     if (callback) {
                         (callback)(result);
                     }
+                } else if (errCallback) {
+                  (errCallback)();
                 }
             });
+
+            return result;
         };
     }
 
@@ -398,11 +417,12 @@ function QObject(name, data, webChannel)
                     return;
                 }
                 object.__propertyCache__[propertyIndex] = value;
+                var valueToSend = value;
                 webChannel.exec({
                     "type": QWebChannelMessageTypes.setProperty,
                     "object": object.__id__,
                     "property": propertyIndex,
-                    "value": value
+                    "value": valueToSend
                 });
             }
         });
@@ -417,10 +437,16 @@ function QObject(name, data, webChannel)
 
     data.signals.forEach(function(signal) { addSignal(signal, false); });
 
-    for (var name in data.enums) {
-        object[name] = data.enums[name];
-    }
+    Object.assign(object, data.enums);
 }
+
+QObject.prototype.toJSON = function() {
+    if (this.__id__ === undefined) return {};
+    return {
+        id: this.__id__,
+        "__QObject*__": true
+    };
+};
 
 //required for use with nodejs
 if (typeof module === 'object') {


### PR DESCRIPTION
We haven't updated it in over 6 years, and the QWebChannel object has undergone many changes. This helps us stay consistent with the upstream version and avoid unforeseen incompatibility bugs. I also carefully examined the implementation of the objects in qwebchannel.js and our initialization and calling code; it is designed for good compatibility and is currently being called correctly. It has been tested and appears harmless.

Now the version of qwebchannel.js is from version 6.10.3