### PR TITLE
Speed up old file issue checks

### DIFF
--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -114,7 +114,6 @@ void Column::dbLoadOldIndex(int index)
 			}
 			else
 				lookForTrouble[_ints[r]] = _dbls[r];
-
 		}
 		
 		JASPTIMER_STOP(Column::dbLoadOldIndex look for trouble);

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -168,12 +168,18 @@ void Column::dbLoadOldIndex(int index)
 		_strs.clear();
 		_dbls.clear();
 		
-		//for(int row=0; row<_ints.size() && row < _dbls.size(); row++)
-		//{
-		//	//if(_ints[row] == 	
-		//	Label * l = labelByIntsId(_ints[row]);
-		//	//Log::log() << "_ints["<< row << "] == " << _ints[row] << " and  _dbls["<< row << "] == " << _dbls[row] << " label is: '" << ( !l ? "null" : l->labelDisplay()) << "'" << std::endl;
-		//}
+		
+		bool everythingIsTheSame = true;
+		
+		for(Label * label : _labels)
+			if(label->originalValueAsString(false, true) != label->label(false))
+			{
+				everythingIsTheSame = false;
+				break;
+			}
+		
+		if(everythingIsTheSame)
+			labelsToNoLabels(false);
 		
 		JASPTIMER_STOP(Column::dbLoadOldIndex load all labels);
 	}
@@ -2866,11 +2872,12 @@ void Column::setHasLabels(bool haveLabels)
 	else			labelsToNoLabels();
 }
 
-void Column::labelsToNoLabels()
+void Column::labelsToNoLabels(bool signalOthers)
 {
 	const auto size = _ints.size();
 	
-	db().transactionWriteBegin();
+	if(signalOthers)
+		db().transactionWriteBegin();
 	
 	_strs.clear();
 	_strs.reserve(size);
@@ -2903,17 +2910,17 @@ void Column::labelsToNoLabels()
 	
 	_ints.clear();
 	
-	
-
 	_hasLabels		= false;
 	_hasShadows		= false;
 	
-	db().columnSetValues(_id, _dbls, _strs);
-	db().columnSetHasLabels(_id, _hasLabels);
-	db().transactionWriteEnd();
-	
-	incRevision();
-	
+	if(signalOthers)
+	{
+		db().columnSetValues(_id, _dbls, _strs);
+		db().columnSetHasLabels(_id, _hasLabels);
+		db().transactionWriteEnd();
+		
+		incRevision();
+	}
 }
 
 void Column::noLabelsToLabels()

--- a/CommonData/column.cpp
+++ b/CommonData/column.cpp
@@ -100,6 +100,8 @@ void Column::dbLoadOldIndex(int index)
 	
 	if(true)
 	{
+		JASPTIMER_START(Column::dbLoadOldIndex look for trouble);
+		
 		bool					thisCantBeRight = false;
 		std::map<int, double>	lookForTrouble; //0.18 messed up some things, and maybe 0.19, make sure we only import logical labels. These messed up things could also be in upgraded jaspfiles...
 		
@@ -112,22 +114,29 @@ void Column::dbLoadOldIndex(int index)
 			}
 			else
 				lookForTrouble[_ints[r]] = _dbls[r];
+
 		}
+		
+		JASPTIMER_STOP(Column::dbLoadOldIndex look for trouble);
 		
 		//Turns out one label is used in conjunction with more than 1 value... That cant be right, so lets throw away all these integers		
 		if(thisCantBeRight)
 			for(size_t r=0; r<_ints.size(); r++)
 				_ints[r] = Label::NO_LABEL;
-		else // we should still check if these labels even exist and otherwise clean that up
-			for(auto intDbl : lookForTrouble)
-				if( !db().labelExists(_id, intDbl.first))
-					for(size_t r=0; r<_ints.size(); r++)
-						if(intDbl.first == _ints[r])
-							_ints[r] = Label::NO_LABEL;
+		else // we should still check if these labels even exist and otherwise clean that up too
+		{
+			intset existingLabels = db().labelsExisting(_id);
+			
+			for(size_t r=0; r<_ints.size(); r++)
+				if(existingLabels.count(_ints[r]) == 0)
+					_ints[r] = Label::NO_LABEL;
+		}
 	}
 	
 	if(std::all_of(_ints.begin(), _ints.end(), [](int i){ return i == Label::NO_LABEL || i == EmptyValues::missingValueInteger; }))
 	{
+		JASPTIMER_START(Column::dbLoadOldIndex remove all labels);
+		
 		_hasLabels = false;
 		_ints.clear();
 		labelsClear();
@@ -143,9 +152,15 @@ void Column::dbLoadOldIndex(int index)
 				_strs[row] = "";
 		}
 		
+		JASPTIMER_STOP(Column::dbLoadOldIndex remove all labels);
+		
+		
 	}
 	else
 	{
+		JASPTIMER_START(Column::dbLoadOldIndex load all labels);
+
+		
 		_hasLabels = true;
 		
 		db().labelsLoad(this);
@@ -160,6 +175,8 @@ void Column::dbLoadOldIndex(int index)
 		//	Label * l = labelByIntsId(_ints[row]);
 		//	//Log::log() << "_ints["<< row << "] == " << _ints[row] << " and  _dbls["<< row << "] == " << _dbls[row] << " label is: '" << ( !l ? "null" : l->labelDisplay()) << "'" << std::endl;
 		//}
+		
+		JASPTIMER_STOP(Column::dbLoadOldIndex load all labels);
 	}
 	
 	db().columnSetHasLabels(_id, _hasLabels);

--- a/CommonData/column.h
+++ b/CommonData/column.h
@@ -85,7 +85,7 @@ public:
 
 			bool					initFromLookups(const std::string & newName, size_t rows, const std::function<std::string(size_t)> valueLookup, const std::function<std::string(size_t)> labelLookup, const std::string & title, columnType desiredType, const stringset & emptyValues, int threshold, bool orderLabelsByValue);
 			bool					overwriteDataAndType(	stringvec		data, columnType colType, bool computed);
-			void					labelsToNoLabels();
+			void					labelsToNoLabels(bool signalOthers = true);
 			void					noLabelsToLabels();
 			
 			bool					allLabelsPassFilter()	const;

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -1537,6 +1537,19 @@ bool DatabaseInterface::labelExists(int	columnId, int intsId)
 	});
 }
 
+intset DatabaseInterface::labelsExisting(int columnId)
+{
+	JASPTIMER_SCOPE(DatabaseInterface::dataSetGetFilter);
+	intset ints;
+			
+	runStatements(
+				"SELECT id FROM Labels WHERE columnId = ?;", 
+				[&](sqlite3_stmt *stmt) { sqlite3_bind_int(stmt, 1, columnId); },
+				[&](size_t row, sqlite3_stmt * stmt){ ints.insert( sqlite3_column_int(stmt, 0)); });
+	
+	return ints;
+}
+
 int DatabaseInterface::labelAdd(int columnId, int value, const std::string & label, bool filterAllows, const	std::string & description, const std::string & originalValueJson)
 {
 	JASPTIMER_SCOPE(DatabaseInterface::labelAdd);

--- a/CommonData/databaseinterface.cpp
+++ b/CommonData/databaseinterface.cpp
@@ -1539,11 +1539,11 @@ bool DatabaseInterface::labelExists(int	columnId, int intsId)
 
 intset DatabaseInterface::labelsExisting(int columnId)
 {
-	JASPTIMER_SCOPE(DatabaseInterface::dataSetGetFilter);
+	JASPTIMER_SCOPE(DatabaseInterface::labelsExisting);
 	intset ints;
 			
 	runStatements(
-				"SELECT id FROM Labels WHERE columnId = ?;", 
+				"SELECT value FROM Labels WHERE columnId = ?;", 
 				[&](sqlite3_stmt *stmt) { sqlite3_bind_int(stmt, 1, columnId); },
 				[&](size_t row, sqlite3_stmt * stmt){ ints.insert( sqlite3_column_int(stmt, 0)); });
 	

--- a/CommonData/databaseinterface.h
+++ b/CommonData/databaseinterface.h
@@ -190,6 +190,7 @@ public:
 	void		labelLoad(		int id,	int & columnId,	int & value,	 std::string & label, bool & filterAllows,		std::string & description,				std::string & originalValueJson,	int & order, bool & userAdded);
 	void		labelSetOrder(	int id, int order);
 	bool		labelExists(	int	columnId, int intsId);
+	intset		labelsExisting(	int columnId);
 	void		labelsLoad(			Column  * column);
 	void		labelsLoad(	const	Columns & columns);//, std::function<void(float)> progressCallback);
 	void		labelsWrite(const	Columns & columns, std::function<void(float)> progressCallback);
@@ -214,6 +215,7 @@ public:
 	void		close();					///< Closes the loaded database and disconnects
 	void		load();						///< Loads a sqlite database from sessiondir (after loading a jaspfile)
 
+	
 	
 private:
 	sqlite3	*	_db();

--- a/R-Interface/jasprcpp.cpp
+++ b/R-Interface/jasprcpp.cpp
@@ -1167,16 +1167,16 @@ Rcpp::DataFrame jaspRCPP_readDataSetHeaderSEXP(SEXP columns, SEXP columnsAsNumer
 
 Rcpp::IntegerVector jaspRCPP_makeFactor(Rcpp::IntegerVector v, char** levels, int nbLevels, bool ordinal)
 {
-#ifdef JASP_DEBUG
-	std::cout << "jaspRCPP_makeFactor:\n\tlevels:\n\t\tnum: " << nbLevels << "\n\t\tstrs:\n";
-	for(int i=0; i<nbLevels; i++)
-		std::cout << "\t\t\t'" << levels[i] << "'\n";
-	std::cout << "intVec: ";
-
-	for(int i=0; i<v.size(); i++)
-		std::cout << v[i] << (i < v.size() - 1 ? ", " : "" );
-	std::cout << std::endl;
-#endif
+//#ifdef JASP_DEBUG
+//	std::cout << "jaspRCPP_makeFactor:\n\tlevels:\n\t\tnum: " << nbLevels << "\n\t\tstrs:\n";
+//	for(int i=0; i<nbLevels; i++)
+//		std::cout << "\t\t\t'" << levels[i] << "'\n";
+//	std::cout << "intVec: ";
+//
+//	for(int i=0; i<v.size(); i++)
+//		std::cout << v[i] << (i < v.size() - 1 ? ", " : "" );
+//	std::cout << std::endl;
+//#endif
 
 	Rcpp::CharacterVector labels(nbLevels);
 	for (int i = 0; i < nbLevels; i++)


### PR DESCRIPTION
Instead of doing a lot of dbcalls to check a single thing (possibly repeatedly) and within a nested loop split it off and make sure to collect all labels at once

fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3259

