### PR TITLE
Bundle icu.dll in Windows installer for Server 2019 compatibility

### DIFF
--- a/Tools/CMake/Install.cmake
+++ b/Tools/CMake/Install.cmake
@@ -47,7 +47,7 @@ set(FILES_EXCLUDE_PATTERN
     ".*(\\.bib|\\.Rnw|\\.cpp|\\.c|\\.pdf|\\.html|\\.f|\\.dSYM|\\.log|\\.bak|\\.deb|\\.DS_Store|\\.Rhistory|\\.pdb)$"
 )
 set(FOLDERS_EXCLUDE_PATTERN
-	".*(/doc|/examples|/man|/html|/demo|/i386|/bib|/gfortran|/BH|/announce|/test|/tinytest|/tests)$"
+ ".*(/doc|/examples|/man|/html|/demo|/i386|/bib|/gfortran|/BH|/announce|/test|/tinytest|/tests)$"
 )
 
 # See here, http://cmake.org/cmake/help/v3.22/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html
@@ -110,8 +110,8 @@ if(APPLE)
     REGEX ${R_PROGRAMS_PATTERN} EXCLUDE
   )
 
-    #copy R executables separately as PROGRAMS so they have execution permissions
-	file(GLOB R_EXECUTABLES LIST_DIRECTORIES false "${_R_Framework}/Resources/bin/*")
+  #copy R executables separately as PROGRAMS so they have execution permissions
+  file(GLOB R_EXECUTABLES LIST_DIRECTORIES false "${_R_Framework}/Resources/bin/*")
   install(
     PROGRAMS ${R_EXECUTABLES}
     DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/bin/
@@ -124,48 +124,48 @@ if(APPLE)
 
 
   if(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
-	  install(
-		  FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libgfortran.5.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
-	  )
-      install(
-		  FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libgfortran.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
-	  )
-      install(
-		  FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libquadmath.0.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
-	  )
-      install(
-		  FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libquadmath.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
-	  )
-      install(
-		  FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libgcc_s.1.1.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
-	  )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libgfortran.5.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
+   )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libgfortran.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
+   )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libquadmath.0.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
+   )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libquadmath.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
+   )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/arm64/gfortran/lib/libgcc_s.1.1.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/arm64/gfortran/lib/
+   )
   endif()
   if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
-	  install(
-		  FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libgfortran.5.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
-	  )
-      install(
-		  FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libgfortran.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
-	  )
-      install(
-		  FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libquadmath.0.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
-	  )
-      install(
-		  FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libquadmath.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
-	  )
-      install(
-		  FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libgcc_s.1.1.dylib
-		  DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
-	  )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libgfortran.5.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
+   )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libgfortran.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
+   )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libquadmath.0.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
+   )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libquadmath.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
+   )
+    install(
+    FILES ${_R_Framework}/Resources/opt/R/x86_64/gfortran/lib/libgcc_s.1.1.dylib
+    DESTINATION ${JASP_INSTALL_FRAMEWORKDIR}/R.Framework/Resources/opt/R/x86_64/gfortran/lib/
+   )
   endif()
 
 
@@ -243,10 +243,10 @@ if(LINUX)
   #install(DIRECTORY ${MODULES_RENV_ROOT_PATH}/
   #        DESTINATION ${JASP_INSTALL_PREFIX}/lib64/renv-root)
 
-if(NOT FLATPAK_USED) #because flatpak already puts renv-cache in /app/lib64 anyway
-  install(DIRECTORY ${MODULES_RENV_CACHE_PATH}/
+  if(NOT FLATPAK_USED) #because flatpak already puts renv-cache in /app/lib64 anyway
+    install(DIRECTORY ${MODULES_RENV_CACHE_PATH}/
           DESTINATION ${JASP_INSTALL_PREFIX}/lib64/renv-cache)
-endif()
+  endif()
 
   #Flatpak wrapper that sets some environment variables that JASP needs
   install(PROGRAMS ${CMAKE_SOURCE_DIR}/Tools/flatpak/org.jaspstats.JASP
@@ -404,22 +404,23 @@ if(WIN32)
           ${RTOOLS_LIBBZ2_DLL}
           ${RTOOLS_LIBLZMA_DLL}
           ${RTOOLS_LIBICONV_DLL}
+          ${SYSTEM_ICU_DLL}
           ${_LIB_R_INTERFACE_DLL}
     DESTINATION .)
 
 
-	#modules
-	install(
-		DIRECTORY ${MODULES_BINARY_PATH}/binary_pkgs ${MODULES_BINARY_PATH}/manifests ${MODULES_BINARY_PATH}/Tools
-		DESTINATION ${JASP_INSTALL_MODULEDIR}
-		REGEX ${FILES_EXCLUDE_PATTERN} EXCLUDE
-		REGEX ${FOLDERS_EXCLUDE_PATTERN} EXCLUDE)
+  #modules
+  install(
+  DIRECTORY ${MODULES_BINARY_PATH}/binary_pkgs ${MODULES_BINARY_PATH}/manifests ${MODULES_BINARY_PATH}/Tools
+  DESTINATION ${JASP_INSTALL_MODULEDIR}
+  REGEX ${FILES_EXCLUDE_PATTERN} EXCLUDE
+  REGEX ${FOLDERS_EXCLUDE_PATTERN} EXCLUDE)
 
-	install(
-		FILES ${MODULES_BINARY_PATH}/modules-settings.json
-		DESTINATION ${JASP_INSTALL_MODULEDIR}
-	)
+  install(
+  FILES ${MODULES_BINARY_PATH}/modules-settings.json
+  DESTINATION ${JASP_INSTALL_MODULEDIR}
+ )
 
-  endif()
+endif()
 
 list(POP_BACK CMAKE_MESSAGE_CONTEXT)

--- a/Tools/CMake/Libraries.cmake
+++ b/Tools/CMake/Libraries.cmake
@@ -192,8 +192,8 @@ if(LINUX)
 
     # ---- libsodium ----
     message(CHECK_START "Looking for `libsodium`")
-      set(libsodium_INCLUDE_DIR /usr/include /app/lib64/)
-      set(LIBSODIUM_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /app/include/)
+    set(libsodium_INCLUDE_DIR /usr/include /app/lib64/)
+    set(LIBSODIUM_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /app/include/)
 
     message(CHECK_START "Looking for libsodium.so")
     find_library(libsodium_LIBRARIES libsodium.so
@@ -212,8 +212,8 @@ if(LINUX)
 
     # ---- FreeXL ----
     message(CHECK_START "Looking for `libfreexl`")
-      set(LIBFREEXL_INCLUDE_DIRS /usr/include /app/lib64/)
-      set(LIBFREEXL_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /app/include/)
+    set(LIBFREEXL_INCLUDE_DIRS /usr/include /app/lib64/)
+    set(LIBFREEXL_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /app/include/)
 
     message(CHECK_START "Looking for libfreexl.so")
     find_library(LIBFREEXL_LIBRARIES libfreexl.so
@@ -232,8 +232,8 @@ if(LINUX)
 
     # ---- librdata ----
     message(CHECK_START "Looking for `librdata`")
-      set(LIBRDATA_INCLUDE_DIRS /usr/include/ /usr/include/rdata /usr/local/include /usr/local/include/rdata /app/include)
-      set(LIBRDATA_LIBRARY_DIRS /usr/local/lib /usr/lib /app/lib64 /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
+    set(LIBRDATA_INCLUDE_DIRS /usr/include/ /usr/include/rdata /usr/local/include /usr/local/include/rdata /app/include)
+    set(LIBRDATA_LIBRARY_DIRS /usr/local/lib /usr/lib /app/lib64 /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
 
     message(CHECK_START "Looking for librdata.so")
     find_library(LIBRDATA_LIBRARIES librdata.so
@@ -290,6 +290,16 @@ if(WIN32 AND NOT JASP_SYNTAX_INTERFACE_ONLY)
   find_rtools_dll_path(RTOOLS_LIBGCC_S_SEH_DLL    "libgcc_s_seh-1.dll")
   find_rtools_dll_path(RTOOLS_LIBREADSTAT_DLL_A   "libreadstat.dll.a")
   find_rtools_dll_path(RTOOLS_LIBWINPTHREAD_DLL   "libwinpthread-1.dll")
+
+  # ICU DLL: needed by Qt 6.1+ on Windows Server 2019 (build < 18362)
+  find_file(SYSTEM_ICU_DLL
+    NAMES icu.dll
+    PATHS "C:/Windows/System32"
+    DOC "Combined ICU DLL for older Windows systems"
+  )
+  if(NOT SYSTEM_ICU_DLL)
+    message(WARNING "icu.dll not found — JASP may fail to start on Windows Server 2019")
+  endif()
 
 endif()
 


### PR DESCRIPTION
Qt 6.1+ links against the combined icu.dll which is only present on Windows 10 build 18362 (1903) and later. Windows Server 2019 (build 17763) has the older split DLLs (icuin.dll, icuuc.dll) but not the combined one, causing JASP to fail to start.

Find icu.dll from System32 on the build machine (which runs modern Windows) and include it in the MSI/MSIX installer alongside the other runtime DLLs.

Should Fix: https://github.com/jasp-stats/jasp-issues/issues/4159