### PR TITLE
bugfix: handling locale environment variable to fix i18n and encoding

### DIFF
--- a/Desktop/main.cpp
+++ b/Desktop/main.cpp
@@ -490,8 +490,15 @@ int main(int argc, char *argv[])
 
 			QLocale::setDefault(QLocale(QLocale::English)); // make decimal points == . in at least R? Anyway, this has been here forever, ill just leave it.
 			
-			char dsteng[] = "LC_ALL=en_US.UTF-8"; // See this issue about encoding problems in the results: https://github.com/jasp-stats/jasp-test-release/issues/3099 and https://github.com/jasp-stats/jasp-issues/issues/3867 for xlsx importing
-			putenv(dsteng);
+            // This is issue about encoding problems in the results:
+            std::vector<std::string> localeEnv = {
+                "LC_ALL=",                  // https://github.com/jasp-stats/jasp-issues/issues/4394
+                "LC_NUMERIC=en_US.UTF-8"    // https://github.com/jasp-stats/jasp-test-release/issues/3099 and https://github.com/jasp-stats/jasp-issues/issues/3867 for xlsx importing
+            };
+
+            for (size_t i = 0; i < localeEnv.size(); i++) {
+                putenv(&localeEnv[i][0]);
+            }
 
 			//Now we convert all these strings in args back to an int and a char * array.
 			//But to keep things easy, we are going to copy the old argv to avoid duplication (or messing up the executable name)


### PR DESCRIPTION
fix: https://github.com/jasp-stats/jasp-issues/issues/4394

Note: I cannot be entirely sure that I can test this situation: https://github.com/jasp-stats/jasp-issues/issues/3867

While I still believe we shouldn't touch any system locale environment variables, as completely placing JASP in any random other language system environment makes it difficult to guarantee that other parts won't have problems, the real fix should probably always start from the data import and display chain.

However, at least set LC_ALL to any value is not the most recommended approach in any case.

see also: https://www.gnu.org/software/gettext/manual/gettext.html#Locale-Environment-Variables