### PR TITLE
Fix TabView collapsing to zero height after model reset

### DIFF
--- a/QMLComponents/components/JASP/Controls/TabView.qml
+++ b/QMLComponents/components/JASP/Controls/TabView.qml
@@ -370,7 +370,14 @@ ComponentsListBase
 		}
 
 		currentIndex		: itemTabBar.currentIndex
-		onCurrentIndexChanged: height = Qt.binding( function() { return currentIndex >= 0 ? rep.itemAt(currentIndex).height : 0; });
+
+		// Height of the currently shown tab, pushed by the wrappers below.
+		// Do not pull it via rep.itemAt(currentIndex).height in a binding: itemAt() is not
+		// notifiable, so after a model reset (which destroys and recreates the delegates
+		// without necessarily changing currentIndex) such a binding would keep referencing
+		// a destroyed item and the whole TabView would collapse to height 0.
+		property real currentTabHeight: 0
+		height				: (rep.count > 0 && itemStack.currentIndex >= 0) ? currentTabHeight : 0
 
 		Repeater
 		{
@@ -384,10 +391,15 @@ ComponentsListBase
 				width	: itemStack.width
 				height	: rowComponentItem ? rowComponentItem.height : 0
 
+				readonly property bool isCurrent: StackLayout.isCurrentItem
+				onIsCurrentChanged	: if (isCurrent) itemStack.currentTabHeight = height
+				onHeightChanged		: if (isCurrent) itemStack.currentTabHeight = height
+
 				Component.onCompleted:
 				{
 					rowComponentItem.parent = tabViewWrapper
 					rowComponentItem.width = Qt.binding(function() {return itemStack.width})
+					if (isCurrent) itemStack.currentTabHeight = height
 				}
 			}
 		}


### PR DESCRIPTION

## Problem

TabViews with dynamic `values`/`source` intermittently collapse to zero height (tab bar visible, content folded to nothing) and stay collapsed. Most visible in jaspSem's Moderated Nonlinear Factor Analysis, which nests TabViews 3 levels deep with `values:` recomputed from checkbox states and factor lists.

## Root cause

`itemStack` (the StackLayout holding tab content) got its height via:

```qml
onCurrentIndexChanged: height = Qt.binding( function() { return currentIndex >= 0 ? rep.itemAt(currentIndex).height : 0; });
```

Two defects:

1. The binding is only installed once `currentIndex` changes. If it never does (single tab, or index staying at 0), no height binding exists at all.
2. `Repeater.itemAt()` is a plain function — not notifiable. Any `values`/`source` change triggers a full model reset (`ListModel::_initTerms` → `beginResetModel()`), destroying and recreating all delegates. If `currentIndex` stays the same, the binding's only tracked dependencies are `currentIndex` and the **destroyed** wrapper's `height` — it never re-evaluates, keeps referencing the dead item, and the TabView collapses to 0. The collapse latches: StackLayout writes height 0 onto the current item, and since row controls are cached C++-side, nothing re-triggers the binding.

With nested TabViews, a collapse at any level zeroes the level above → the whole stack folds.

## Fix

Push-based height tracking: each delegate pushes its height into `itemStack.currentTabHeight` whenever it is the current item (`StackLayout.isCurrentItem` attached property, plus `Component.onCompleted` for creation ordering). Freshly created delegates after a model reset always announce their height, so no stale references are possible. `height` on `itemStack` is now a plain declarative binding with guards for empty model / index −1.

No public API change (`content`, `currentIndex` alias, add/remove tabs untouched). SEM/PLSSEM `content:`-style usage unaffected — their initial-height case (defect 1) is fixed too.

## Test checklist (jaspSem MNLFA, dataset with ≥6 scale variables)

1. Moderation Options: check/uncheck the invariance checkboxes one by one, incl. unchecking a tab other than the selected one → no fold-up.
2. Same-count resets: swap which checkboxes are checked → inner tabs never fold.
3. Factors: add a 3rd factor while the "Factors" tab is selected (adds "Covariances" entry), remove back to 1, rename factors, add/remove indicators → outer TabViews keep height.
4. Switch tabs at all 3 levels, incl. to a tab whose content grew while hidden.
5. Collapse/re-expand both Sections; also trigger a reset while collapsed, then expand.
6. Plots section: repeat 1–4; toggle interaction terms.
7. Resize window, change interface scale → no fold-ups.
8. Console: no `TypeError: Cannot read property 'height' of null`, no binding-loop warnings.
9. Regression SEM/PLS-SEM: model TextArea tab has correct height at first open; add/remove/rename tabs; multi-line lavaan syntax grows the TabView.
10. Save/reload a .jasp file with populated nested tabs → all levels render at full height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
