### PR TITLE
bugfix: fix to cannot showing syntax info messages in SEM syntax input box

### DIFF
--- a/QMLComponents/components/JASP/Controls/TextArea.qml
+++ b/QMLComponents/components/JASP/Controls/TextArea.qml
@@ -239,7 +239,7 @@ TextAreaBase
 						}
 						break;
 					default:
-						infoText.text = textArea.applyScriptInfo;
+						textArea.infoText = textArea.applyScriptInfo;
 						textArea.hasScriptError = false;
 					}
 				}


### PR DESCRIPTION
Reproduce step:
1. load jaspSEM
2. imput a wrong syntax in input box
3. the error message does't showing.

This PR fix showing error:

`infoText.text = textArea.applyScriptInfo ` which iss an imperative assignment to the Text element's text. In QML, that permanently binding the `text: textArea.infoText` . After that, when the engine returns a lavaan error and C++ calls setInfoText(result) , the Text element no longer reacts.

