### PR TITLE
Squash-merge upstream/fixRefsInteractivePlotsPersistence: interactive…

### DIFF
--- a/Desktop/analysis/analyses.cpp
+++ b/Desktop/analysis/analyses.cpp
@@ -74,7 +74,6 @@ Analysis* Analyses::createFromJaspFileEntry(Json::Value analysisData, RibbonMode
 
 	if(_nextId <= id) _nextId = id + 1;
 
-
 	Modules::UpgradeMsgs		msgs;
 	bool						wasUpgraded		= Upgrader::upgrader()->upgradeAnalysisData(DynamicModules::dynMods()->modules(), analysisData, msgs);
 	Json::Value				&	optionsJson		= analysisData["options"];

--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -33,6 +33,7 @@
 #include "gui/jaspConfiguration/jaspconfiguration.h"
 #include <QAccessible>
 #include <QScopeGuard>
+#include <functional> // for std::function in deepOverwrite lambda
 
 Analysis::Analysis(size_t id, Modules::AnalysisEntry * analysisEntry, const std::string & title, const Version & optionsVersion, const Json::Value & options) :
 	  AnalysisBase(Analyses::analyses()),
@@ -65,6 +66,9 @@ Analysis::Analysis(size_t id, Analysis * duplicateMe)
 	, _resultsMeta(						_results.get(".meta", Json::arrayValue)			)
 	, _imgResults(						duplicateMe->_imgResults						)
 	, _userData(						duplicateMe->_userData							)
+	, _plotEdits(						duplicateMe->_plotEdits							)
+	// _pendingReEdits and _editQueue are not copied; the duplicate starts
+	// with a clean edit pipeline.
 	, _imgOptions(						duplicateMe->_imgOptions						)
 	, _progress(						duplicateMe->_progress							)
 	, _id(								id												)
@@ -240,7 +244,20 @@ void Analysis::setResults(const Json::Value & results, Status status, const Json
 	_resultsMeta	= _results.get(".meta", Json::arrayValue);
 	_hasReport		= !PreferencesModel::prefs()->reportingMode() ? false : Reporter::reporter()->analysisHasReportNeeded(this);
 
+	// Two-phase plot-edit restoration after an engine re-run:
+	// Phase 1: applyPlotEdits — injects saved editOptions and sizes into the
+	//   fresh results tree, collecting names of plots whose stored dimensions
+	//   differ from what the engine produced (these need a re-render).
+	// Phase 2: applyPlotReEdits — dispatches re-edit requests to the engine for
+	//   dimension-mismatched plots so they render at the correct stored size.
+	// This avoids engine roundtrips when only editOptions changed (no dimension
+	// change), since those are already fully applied to the results tree.
+	std::set<std::string> reEditNames = applyPlotEdits();
+
 	setStatus(status);
+
+	if (status == Analysis::Complete && !reEditNames.empty())
+		applyPlotReEdits(reEditNames);
 
 	emit resultsChangedSignal(this);
 
@@ -295,22 +312,184 @@ void Analysis::imageSaved(const Json::Value & results)
 
 void Analysis::editImage(const Json::Value &options)
 {
+	// Serialise edits through a queue: only one image-edit RPC may be
+	// in flight at a time. If the analysis is already in EditImg state,
+	// queue the request and return — it will be dispatched when the
+	// current edit completes (from imageEdited's queue drain).
+	// If the last queued entry is a resize-only request for the same plot,
+	// replace it instead of appending — avoids wasted engine roundtrips.
+	if (!options.isMember("editOptions") && !_editQueue.empty())
+	{
+		Json::Value & last = _editQueue.back();
+		if (!last.isMember("editOptions") && last.get("name", "").asString() == options.get("name", "").asString())
+		{
+			last = options;
+			return;
+		}
+	}
+
+	_editQueue.push_back(options);
+
+	if (_status == EditImg)
+	{
+		Log::log() << "editImage: queued (edit in flight, queue size="
+				   << _editQueue.size() << ")" << std::endl;
+		return;
+	}
+
+	_dispatchEditImage(_editQueue.front());
+}
+
+void Analysis::_dispatchEditImage(const Json::Value &options)
+{
 	setStatus(Analysis::EditImg);
 	_imgOptions = options;
+	// Snapshot the user's original editOptions separately from _imgOptions.
+	// _imgOptionsUserEdit is only set when the request contains "editOptions"
+	// (i.e. a user-initiated edit, not a size-only re-edit). It serves as the
+	// highest-priority overlay during the deepOverwrite in imageEdited.
+	_imgOptionsUserEdit = options.isMember("editOptions") ? options : Json::nullValue;
 }
 
 void Analysis::imageEdited(const Json::Value & results)
 {
 	std::string name = _imgOptions.get("name", "").asString();
 	_imgResults = results;
+	Log::log() << "imageEdited: engine response w=" << _imgResults.get("width", -1).asInt() << " h=" << _imgResults.get("height", -1).asInt() << " hasData=" << results.isMember("data") << " hasInteractiveJson=" << results.isMember("interactiveJsonData") << std::endl;
 
 	if (name != "")
 	{
-		setEditOptionsOfPlot(name, results["editOptions"]);
+		Log::log() << "imageEdited: name='" << name << "'" << std::endl;
 
-		if (_imgResults.get("resized", false).asBool() && !_imgResults.get("error", true).asBool())
-			updatePlotSize(_imgOptions["name"].asString(), _imgResults.get("width", -1).asInt(), _imgResults.get("height", -1).asInt(), _results);
+		// Start with the engine's editOptions as base, then deep-overwrite with the
+		// user's stored editOptions. User edits win over whatever the engine returns.
+		//
+		// Why: the engine may return the original unedited plot state for operations
+		// that are not true "edits" (e.g. resize). Without merging user edits back in,
+		// the user's customizations would be silently lost on every resize.
+		//
+		// Priority: the just-submitted user edit (_imgOptionsUserEdit, now stored as
+		// the raw editOptions subtree) takes top priority over persistently stored
+		// edits (_plotEdits[name]), since the in-flight edit represents the user's
+		// most recent intent.
+		// Note: deepOverwrite is a recursive struct-merge, not a full deep merge —
+		// arrays are replaced wholesale, not merged element-by-element.
+		//
+		// The old request-ID mismatch retry was removed: queue serialization
+		// now prevents concurrent edits and the retry was dead code.
+		Json::Value mergedEditOptions = results["editOptions"];
+
+		// Guard against engine returning a non-object editOptions (e.g. null, array,
+		// empty string). In that case start with an empty object so the user's
+		// stored editOptions can be deep-merged in without being lost.
+		if (!mergedEditOptions.isObject())
+			mergedEditOptions = Json::objectValue;
+
+		std::function<void(Json::Value &, const Json::Value &)> deepOverwrite;
+		deepOverwrite = [&deepOverwrite](Json::Value & target, const Json::Value & source)
+		{
+			if (!source.isObject() || !target.isObject()) return;
+			for (const std::string & key : source.getMemberNames())
+			{
+				if (!target.isMember(key))
+					target[key] = source[key];
+				else if (target[key].isObject() && source[key].isObject())
+					deepOverwrite(target[key], source[key]);
+				else
+					target[key] = source[key];
+			}
+		};
+		if (_imgOptionsUserEdit.isMember("editOptions"))
+			deepOverwrite(mergedEditOptions, _imgOptionsUserEdit["editOptions"]);
+		else if (_plotEdits.isMember(name) && _plotEdits[name].isMember("editOptions"))
+			deepOverwrite(mergedEditOptions, _plotEdits[name]["editOptions"]);
+
+		Log::log() << "imageEdited: merged engine response (base) with user editOptions (overlay)" << std::endl;
+
+		setEditOptionsOfPlot(name, mergedEditOptions);
+
+		if (results.isMember("revision"))
+			_updatePlotField(_results, name, "revision", results["revision"]);
+
+		if (results.isMember("interactiveJsonData") && results["interactiveJsonData"].isString())
+			_updatePlotField(_results, name, "interactiveJsonData", results["interactiveJsonData"]);
+
+		if (results.isMember("data") && !results["data"].isNull())
+			_updatePlotField(_results, name, "data", results["data"]);
+
+		// Determine whether this was a user-initiated resize (type "resize",
+		// no editOptions, has width/height) vs a plot-editor edit (has editOptions).
+		// Only store dimensions when the user explicitly resized; edit operations
+		// send the current model width/height which are not the user's intent.
+		bool wasResize = !_imgOptions.isMember("editOptions")
+				&& _imgOptions.isMember("width") && _imgOptions.isMember("height");
+
+		if (wasResize)
+		{
+			int w = _imgResults.get("width", -1).asInt(),
+				h = _imgResults.get("height", -1).asInt();
+			if (w > 0 && h > 0)
+			{
+				_updatePlotField(_results, name, "width",  w);
+				_updatePlotField(_results, name, "height", h);
+			}
+		}
+
+		bool wasReEdit = _pendingReEdits.erase(name) > 0;
+		if (!wasReEdit)
+		{
+			Json::Value & plotEdits = _plotEdits[name];
+			plotEdits["editOptions"] = mergedEditOptions;
+			// Only persist dimensions from user-initiated resize operations.
+			// Edit operations carry the model's current width/height which
+			// are not the user's explicit size intent and must not overwrite
+			// previously stored resize dimensions.
+			if (wasResize)
+			{
+				int w = _imgOptions["width"].asInt(),
+					h = _imgOptions["height"].asInt();
+				if (w > 0 && h > 0)
+				{
+					plotEdits["width"]  = w;
+					plotEdits["height"] = h;
+				}
+			}
+			Log::log() << "imageEdited: stored _plotEdits for '" << name << "' (" << plotEdits.getMemberNames().size() << " keys)" << std::endl;
+		}
+		else
+		{
+			Log::log() << "imageEdited: re-edit for '" << name << "' completed, not updating _plotEdits" << std::endl;
+
+			// Interactive re-edits echo back the requested size but the
+			// engine renders at its own default dimensions. If the actual
+			// plot dimensions in _results differ from what _plotEdits
+			// expects, queue a resize to get a properly-sized PNG.
+			int actualW = -1, actualH = -1;
+			if (_getPlotDimensions(_results, name, actualW, actualH))
+			{
+				int storedW = _plotEdits.isMember(name) ? _plotEdits[name].get("width", -1).asInt() : -1;
+				int storedH = _plotEdits.isMember(name) ? _plotEdits[name].get("height", -1).asInt() : -1;
+
+				if (storedW > 0 && storedH > 0 && (actualW != storedW || actualH != storedH))
+				{
+					Log::log() << "imageEdited: dimensions mismatch (actual=" << actualW << "x" << actualH << " stored=" << storedW << "x" << storedH << "), queuing resize" << std::endl;
+					Json::Value resizeOpts;
+					resizeOpts["name"]   = name;
+					resizeOpts["type"]   = "resize";
+					resizeOpts["width"]  = storedW;
+					resizeOpts["height"] = storedH;
+					editImage(resizeOpts);
+				}
+			}
+		}
 	}
+
+	// Inject the plot name into _imgResults so JS can identify which image
+	// to update via findImagePrimitive(name). The R engine returns name=null
+	// because our imgOpts json has no "data" field (the engine relies on that
+	// field for name resolution). Without this injection, insertNewImage in JS
+	// cannot locate the correct image view in the volatile views tree.
+	_imgResults["name"] = name;
 
 	// Convert interactiveJsonData file paths to actual JSON objects for the front-end
 	_imgResults = loadPlotlyJsonInResults(_imgResults);
@@ -320,35 +499,120 @@ void Analysis::imageEdited(const Json::Value & results)
 	emit imageEditedSignal(this);
 	emit imageChanged();
 
-	//Maybe this is the wrong request, because it took a while and the user kept changing stuff in the ploteditor
-	if(_imgOptions.isMember("request") && _imgResults.isMember("request") && _imgOptions["request"].asInt() != _imgResults["request"].asInt())
-		editImage(_imgOptions);
+	// Drain the user-edit serialisation queue: pop the just-completed entry, dispatch next if any.
+	if (!_editQueue.empty())
+		_editQueue.pop_front();
+
+	if (!_editQueue.empty())
+	{
+		Log::log() << "imageEdited: draining queue — dispatching next ("
+				   << _editQueue.size() << " remaining)" << std::endl;
+		_dispatchEditImage(_editQueue.front());
+	}
 }
 
-bool Analysis::updatePlotSize(const std::string & plotName, int width, int height, Json::Value & root)
+// Applies saved plot edits after an engine re-run.
+// Returns names of plots needing engine re-render.
+//
+// _results is kept pure — engine output is never modified.
+// _plotEdits is the sole authority for user edits:
+//   - New engine editOptions keys are deep-merged into _plotEdits
+//     (filling gaps without overwriting user-set values).
+//   - Plots with editOptions are always flagged for interactive re-edit.
+//   - Plots with only dimension changes are flagged for re-edit
+//     if stored dimensions differ from engine-computed ones.
+//   - Width/height are never stamped into _results.
+std::set<std::string> Analysis::applyPlotEdits()
 {
-	if(root.isNull()) return false;
+	std::set<std::string> reEditNames;
 
-	if(root.isArray())
-		for(Json::Value & entry: root)
-			if(updatePlotSize(plotName, width, height, entry))
-				return true;
-
-	if(root.isObject())
+	if (_plotEdits.isNull())
 	{
-		if(root.isMember(plotName))
-		{
-			root[plotName]["width"]  = width;
-			root[plotName]["height"] = height;
-			return true;
-		}
-		else
-			for(const std::string & memName : root.getMemberNames())
-				if(updatePlotSize(plotName, width, height, root[memName]))
-					return true;
+		Log::log() << "applyPlotEdits: _plotEdits is null, nothing to apply" << std::endl;
+		return reEditNames;
 	}
 
-	return false;
+	Log::log() << "applyPlotEdits: _plotEdits has " << _plotEdits.getMemberNames().size() << " entries" << std::endl;
+
+	for (const std::string & uniqueName : _plotEdits.getMemberNames())
+	{
+		const Json::Value & edit = _plotEdits[uniqueName];
+
+		if (edit.isMember("editOptions"))
+		{
+			// _plotEdits is now the sole authority for editOptions.
+			// _results stays pure engine output — never patched by us.
+			// Merge new top-level keys from the engine's fresh editOptions
+			// into _plotEdits so it stays complete without overwriting
+			// user-set values.
+			Json::Value engineEditOpts;
+			if (_editOptionsOfPlot(_results, uniqueName, engineEditOpts))
+			{
+				for (const std::string & key : engineEditOpts.getMemberNames())
+					if (!_plotEdits[uniqueName]["editOptions"].isMember(key))
+						_plotEdits[uniqueName]["editOptions"][key] = engineEditOpts[key];
+				reEditNames.insert(uniqueName);
+			}
+		}
+
+		if (edit.isMember("width") && edit.isMember("height"))
+		{
+			int storedW = edit["width"].asInt(),
+				storedH = edit["height"].asInt();
+
+			if (storedW > 0 && storedH > 0)
+			{
+				int engineW = -1, engineH = -1;
+				if (_getPlotDimensions(_results, uniqueName, engineW, engineH))
+				{
+					_updatePlotField(_results, uniqueName, "width",				storedW);
+					_updatePlotField(_results, uniqueName, "height",			storedH);
+					_updatePlotField(_results, uniqueName, "originalWidth",		engineW);
+					_updatePlotField(_results, uniqueName, "originalHeight",	engineH);
+
+					if (!edit.isMember("editOptions") && (storedW != engineW || storedH != engineH))
+						reEditNames.insert(uniqueName);
+				}
+			}
+		}
+	}
+
+	return reEditNames;
+}
+
+void Analysis::applyPlotReEdits(const std::set<std::string> & plotNames)
+{
+	// Batch re-edits triggered after an engine re-run restore previously-saved
+	// edits to freshly re-run engine output. They coexist with the user-edit
+	// queue (_editQueue) — queued user edits are independent and will complete
+	// naturally via the queue drain in imageEdited.
+	_pendingReEdits.clear();
+
+	for (const std::string & uniqueName : plotNames)
+	{
+		if (_plotEdits.isNull() || !_plotEdits.isMember(uniqueName))
+			continue;
+
+		const Json::Value & edit = _plotEdits[uniqueName];
+		if (!edit.isMember("editOptions") && !edit.isMember("width"))
+			continue;
+
+		Json::Value imgOpts;
+		imgOpts["name"] = uniqueName;
+		imgOpts["type"] = "interactive";
+		if (edit.isMember("editOptions"))
+			imgOpts["editOptions"] = edit["editOptions"];
+		if (edit.isMember("width") && edit.isMember("height"))
+		{
+			imgOpts["width"]  = edit["width"];
+			imgOpts["height"] = edit["height"];
+		}
+
+		_pendingReEdits.insert(uniqueName);
+
+		Log::log() << "applyPlotReEdits: re-edit '" << uniqueName << "' type=interactive w=" << imgOpts.get("width", -1).asInt() << " h=" << imgOpts.get("height", -1).asInt() << " hasEditOpts=" << imgOpts.isMember("editOptions") << std::endl;
+		editImage(imgOpts);
+	}
 }
 
 void Analysis::rewriteImages()
@@ -461,14 +725,19 @@ Json::Value Analysis::loadPlotlyJsonInResults(Json::Value  results) const
 		{
 			Json::Value plotlyJson;
 			Json::Reader jsonReader;
+			QByteArray fileData = plotlyJsonFile.readAll();
 
-			jsonReader.parse(plotlyJsonFile.readAll().toStdString(),plotlyJson, false);
+			jsonReader.parse(fileData.toStdString(), plotlyJson, false);
+
+			if (fileData.size() > 0 && plotlyJson.isNull())
+				Log::log() << "loadPlotlyJsonInResults: parse produced null from non-empty file '" << tempFileRelativePath << "'" << std::endl;
 
 			ColumnEncoder::decodeJson(plotlyJson);
 
 			return plotlyJson;
 		}
-		return Json::Value("");
+		Log::log() << "loadPlotlyJsonInResults: FAILED to open file '" << tempFileRelativePath << "'" << std::endl;
+		return Json::Value();
 	};
 
 
@@ -476,8 +745,16 @@ Json::Value Analysis::loadPlotlyJsonInResults(Json::Value  results) const
 
 	recursiveFixer = [&loadFile, &recursiveFixer](Json::Value & results)
 	{
-		if(results.isObject() && results.isMember("interactiveJsonData") && results["interactiveJsonData"].isString() && QFileInfo::exists(tq(TempFiles::sessionDirName() + "/" + results["interactiveJsonData"].asString())))
-			results["interactiveJsonData"] = loadFile(results["interactiveJsonData"].asString());
+		if(results.isObject() && results.isMember("interactiveJsonData") && results["interactiveJsonData"].isString())
+		{
+			std::string relPath = results["interactiveJsonData"].asString();
+			if (QFileInfo::exists(tq(TempFiles::sessionDirName() + "/" + relPath)))
+			{
+				Json::Value loaded = loadFile(relPath);
+				if (!loaded.isNull())
+					results["interactiveJsonData"] = loaded;
+			}
+		}
 
 		if(results.isObject())
 			for(const std::string & member : results.getMemberNames())
@@ -508,6 +785,7 @@ Json::Value Analysis::asJSON(bool withRSource) const
 	analysisAsJson["status"]		= statusToString(_status);
 	analysisAsJson["options"]		= boundValues();
 	analysisAsJson["userdata"]		= userData();
+	analysisAsJson["plotEdits"]		= _plotEdits;
 	analysisAsJson["dynamicModule"] = _moduleData ? _moduleData->asJsonForJaspFile() : Json::objectValue;
 	analysisAsJson["saveState"]     = (_dynamicModule && _dynamicModule->descriptionQml()) ? (_dynamicModule->descriptionQml()->alwaysSaveState()  ? "always" : _dynamicModule->descriptionQml()->neverSaveState() ? "never" : "default") : "default";
 
@@ -516,7 +794,7 @@ Json::Value Analysis::asJSON(bool withRSource) const
 	
 	
 	analysisAsJson["columns"]		= Json::arrayValue;
-	
+
 	for(Column * column : DataSetPackage::pkg()->dataSet()->columns())
 		if(column->analysisId() == _id)
 			analysisAsJson["columns"].append(column->name());
@@ -543,6 +821,13 @@ void Analysis::loadResultsUserdataAndRSourcesFromJASPFile(const Json::Value & an
 {
 	Log::log() << "Now loading userdata results and R Sources for analysis " << _name << " from file." << std::endl;
 	setUserData(analysisData["userdata"]);
+	if (analysisData.isMember("plotEdits") && !analysisData["plotEdits"].isNull())
+	{
+		_plotEdits = analysisData["plotEdits"];
+		Log::log() << "loadResultsUserdata: restored _plotEdits with " << _plotEdits.getMemberNames().size() << " entries" << std::endl;
+	}
+	else
+		Log::log() << "loadResultsUserdata: no plotEdits key in saved data (or null)" << std::endl;
 	setResults(analysisData["results"], status);
 	setRSources(analysisData["rSources"]);
 
@@ -792,6 +1077,13 @@ Json::Value Analysis::editOptionsOfPlot(const std::string & uniqueName, bool emi
 	return editOptions;
 }
 
+Json::Value Analysis::editOptionsOfPlotFromEdits(const std::string & uniqueName)
+{
+	if (_plotEdits.isMember(uniqueName) && _plotEdits[uniqueName].isMember("editOptions"))
+		return _plotEdits[uniqueName]["editOptions"];
+	return editOptionsOfPlot(uniqueName, false);
+}
+
 bool Analysis::_editOptionsOfPlot(const Json::Value & results, const std::string & uniqueName, Json::Value & editOptions)
 {
 	if(results.isArray())
@@ -805,13 +1097,43 @@ bool Analysis::_editOptionsOfPlot(const Json::Value & results, const std::string
 		{
 			editOptions = results["editOptions"];
 
-			Log::log() << "Found editOptions of " << uniqueName << " and they are:\n" << editOptions.toStyledString() << std::endl;
+			Log::log() << "Found editOptions of " << uniqueName << " (" << editOptions.getMemberNames().size() << " keys)" << std::endl;
 
 			return true;
 		}
 
 		for(const std::string & member : results.getMemberNames())
 			if(_editOptionsOfPlot(results[member], uniqueName, editOptions))
+				return true;
+	}
+
+	return false;
+}
+
+bool Analysis::_getPlotDimensions(const Json::Value & results, const std::string & uniqueName, int & width, int & height) const
+{
+	if(results.isArray())
+		for(const Json::Value & entry : results)
+			if(_getPlotDimensions(entry, uniqueName, width, height))
+				return true;
+
+	if(results.isObject())
+	{
+		if(results.isMember("name") && results["name"].asString() == uniqueName && results.isMember("editOptions"))
+		{
+			// Prefer originalWidth/originalHeight (engine-computed native size
+			// captured before we stamp the user's stored dimensions into width/height).
+			// Fall back to width/height for bootstrapping: on the very first run
+			// before applyPlotEdits has written originalWidth, width still holds
+			// the engine's native size.
+			width  = results.get("originalWidth",  results.get("width",  -1).asInt()).asInt();
+			height = results.get("originalHeight", results.get("height", -1).asInt()).asInt();
+			
+			return true;
+		}
+
+		for(const std::string & member : results.getMemberNames())
+			if(_getPlotDimensions(results[member], uniqueName, width, height))
 				return true;
 	}
 
@@ -835,13 +1157,37 @@ bool Analysis::_setEditOptionsOfPlot(Json::Value & results, const std::string & 
 	{
 		if(results.isMember("name") && results["name"].asString() == uniqueName && results.isMember("editOptions"))
 		{
-			Log::log() << "Replacing editOptions of " << uniqueName << ", old:\n" << results["editOptions"].toStyledString() << "\nnew:\n" << editOptions.toStyledString() << std::endl;
+			Log::log() << "_setEditOptionsOfPlot: found '" << uniqueName << "' replacing editOptions (old keys: " << results["editOptions"].getMemberNames().size() << " new keys: " << editOptions.getMemberNames().size() << ")" << std::endl;
 			results["editOptions"] = editOptions;
 			return true;
 		}
 
 		for(const std::string & member : results.getMemberNames())
 			if(_setEditOptionsOfPlot(results[member], uniqueName, editOptions))
+				return true;
+	}
+
+	return false;
+}
+
+bool Analysis::_updatePlotField(Json::Value & results, const std::string & uniqueName, const std::string & fieldName, const Json::Value & value)
+{
+	if(results.isArray())
+		for(Json::Value & entry : results)
+			if(_updatePlotField(entry, uniqueName, fieldName, value))
+				return true;
+
+	if(results.isObject())
+	{
+		if(results.isMember("name") && results["name"].asString() == uniqueName && results.isMember("editOptions"))
+		{
+			Log::log() << "_updatePlotField: found '" << uniqueName << "' setting field='" << fieldName << "'" << std::endl;
+			results[fieldName] = value;
+			return true;
+		}
+
+		for(const std::string & member : results.getMemberNames())
+			if(_updatePlotField(results[member], uniqueName, fieldName, value))
 				return true;
 	}
 
@@ -1112,13 +1458,15 @@ void Analysis::setUserData(Json::Value userData)
 		return false;
 	};
 
-	if (_analysisForm) _analysisForm->setHasVolatileNotes(checkForVolatileNotes(_userData));
+	if (_analysisForm) 
+		_analysisForm->setHasVolatileNotes(checkForVolatileNotes(_userData));
 }
 
 void Analysis::setRSources(const Json::Value &rSources)
 {
 	_rSources.clear();
-	if (rSources.isNull() || !rSources.isObject()) return;
+	if (rSources.isNull() || !rSources.isObject()) 
+		return;
 
 	for (const std::string &sourceName : rSources.getMemberNames())
 		_rSources[sourceName] = rSources[sourceName];

--- a/Desktop/analysis/analysis.h
+++ b/Desktop/analysis/analysis.h
@@ -23,6 +23,8 @@
 #include "enginedefinitions.h"
 
 #include <set>
+#include <deque>
+#include <vector>
 #include "analysisbase.h"
 #include "utilities/qutils.h"
 #include "modules/dynamicmodules.h"
@@ -91,6 +93,7 @@ public:
 	void				setErrorInResults(const std::string	& msg);
 
 	Json::Value			editOptionsOfPlot(		const std::string & uniqueName, bool emitError = true);
+	Json::Value			editOptionsOfPlotFromEdits(const std::string & uniqueName);
 	void				setEditOptionsOfPlot(	const std::string & uniqueName, const Json::Value & editOptions);
 	bool				checkAnalysisEntry();
 
@@ -100,6 +103,8 @@ public:
 
 	const	Json::Value		&	results()			const				{ return _results;							}
 	const	Json::Value		&	userData()			const				{ return _userData;							}
+	const	Json::Value		&	plotEdits()			const				{ return _plotEdits;						}
+				void			setPlotEdits(const Json::Value & edits)				{ _plotEdits = edits;						}
 	const	std::string		&	name()				const	override	{ return _name;								}
 	const	std::string		&	qml()				const				{ return _qml;								}
 	const	std::string		&	title()				const	override	{ return _title;							}
@@ -213,9 +218,22 @@ private:
 	bool					processResultsForDependenciesToBeShownMetaTraverser(const Json::Value & array);
 	bool					_editOptionsOfPlot(const	Json::Value & results, const std::string & uniqueName,			Json::Value & editOptions);
 	bool					_setEditOptionsOfPlot(		Json::Value & results, const std::string & uniqueName, const	Json::Value & editOptions);
+	bool					_updatePlotField(			Json::Value & results, const std::string & uniqueName, const std::string & fieldName, const Json::Value & value);
+	bool					_getPlotDimensions(const Json::Value & results, const std::string & uniqueName, int & width, int & height) const;
 	void					storeUserDataEtc();
 	void					fitOldUserDataEtc();
-	bool					updatePlotSize(const std::string & plotName, int width, int height, Json::Value & root);
+	// Phase 1: stamp saved editOptions and sizes into fresh engine results.
+	// Returns names of plots whose dimensions changed (need engine re-render).
+	std::set<std::string>		applyPlotEdits();
+	
+	// Phase 2: batch-trigger engine re-edits for plots that changed dimensions.
+	// This is a separate flow from user-initiated queueing (_editQueue).
+	void					applyPlotReEdits(const std::set<std::string> & plotNames);
+	
+	// Dispatches a single image-edit to the engine. Called from the
+	// user-edit queue (editImage) and from applyPlotReEdits (batch re-edits).
+	void					_dispatchEditImage(const Json::Value &options);
+	
 	void					checkForRSources();
 	void					clearRSources();
 	void					initAnalysis();
@@ -230,10 +248,22 @@ protected:
 								_resultsMeta		= Json::nullValue,
 								_imgResults			= Json::nullValue,
 								_userData			= Json::nullValue,
+								_plotEdits			= Json::nullValue,
 								_imgOptions			= Json::nullValue,
+								// The full image-edit options submitted by the last user-initiated
+								// edit. Only set when options contains "editOptions" (not
+								// size-only re-edits). Used in imageEdited to merge the user's
+								// intended edits over the engine's response (which may be stale).
+								_imgOptionsUserEdit	= Json::nullValue,
 								_progress			= Json::nullValue,
 								_oldUserData		= Json::nullValue,
 								_oldMetaData		= Json::nullValue;
+	// Tracks which in-flight imageEdited responses belong to
+	// applyPlotReEdits (batch) rather than user-initiated edits.
+	// When set, imageEdited does NOT update _plotEdits (re-edits
+	// are just re-rendering already-stored edits).
+	std::set<std::string>		_pendingReEdits;
+	std::deque<Json::Value>		_editQueue; // Serializes user-initiated image edits: only one dispatched at a time, the rest queue up
 	std::string					_preUpgraderVersion	= "0";
 
 

--- a/Desktop/components/JASP/Widgets/MainPage.qml
+++ b/Desktop/components/JASP/Widgets/MainPage.qml
@@ -478,6 +478,7 @@ Item
 				// It would be much better to have resultsJsInterface be passed directly though..
 				// It also gives you an overview of the functions used in results html
 
+				function jsLog(msg)									{ resultsJsInterface.jsLog(msg)									}
 				function openFileTab()								{ resultsJsInterface.openFileTab()                              }
 				function saveTextToFile(fileName, html)				{ resultsJsInterface.saveTextToFile(fileName, html)             }
 				function analysisUnselected()						{ resultsJsInterface.analysisUnselected()                       }

--- a/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingReferenceLines.qml
+++ b/Desktop/components/JASP/Widgets/PlotEditor/PlotEditingReferenceLines.qml
@@ -49,7 +49,7 @@ ComponentsList
 		TextField
 		{
 			name: "lineText"
-			fieldWidth: 50 * jaspTheme.uiScale
+			fieldWidth: 150 * jaspTheme.uiScale
 			defaultValue: rowId.getData(1)
 			onValueChanged: rowId.setData(1, value)
 		}

--- a/Desktop/html/js/analyses.js
+++ b/Desktop/html/js/analyses.js
@@ -195,11 +195,11 @@ JASPWidgets.Analyses = JASPWidgets.View.extend({
 	},
 
 	getAllUserData: function () {
-		var notes = [];
+		var userData = [];
 		for (var i = 0; i < this.analyses.length; i++) {
-			notes.push(this.analyses[i].getAllUserData());
+			userData.push(this.analyses[i].getAllUserData());
 		}
-		return notes;
+		return userData;
 	},
 
 	getResultsMeta: function () {

--- a/Desktop/html/js/analysis.js
+++ b/Desktop/html/js/analysis.js
@@ -83,8 +83,6 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		var progressbarModel = new JASPWidgets.Progressbar({analysis: this});
 		this.progressbar = new JASPWidgets.ProgressbarView({ model: progressbarModel });
 
-		this.imageBeingEdited = null;
-
 
 		this.userdata = this.model.get('userdata');
 		if (this.userdata === undefined || this.userdata === null)
@@ -97,10 +95,9 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 		this.toolbar.setParent(this);
 
-		this.model.on("analysis:resizeStarted",		function (image)			{ this.imageBeingEdited = image	},																					this);
 		this.model.on("CustomOptions:changed",		function (options)			{											this.trigger("optionschanged",		this.model.get("id"), options)	},	this);
 		this.model.on("SaveImage:clicked",			function (options)			{											this.trigger("saveimage",			this.model.get("id"), options)	},	this);
-		this.model.on("EditImage:clicked",			function (image, options)	{ this.imageBeingEdited = image;			this.trigger("editimage",			this.model.get("id"), options)	},	this);
+		this.model.on("EditImage:clicked",			function (image, options)	{											this.trigger("editimage",			this.model.get("id"), options)	},	this);
 		this.model.on("InteractiveImage:clicked",	function (options)			{											this.trigger("interactiveImage",	this.model.get("id"), options)	},	this);
 		this.model.on("ShowDependencies:clicked",	function (optName)			{											this.trigger("showDependencies",	this.model.get("id"), optName)	},	this);
 
@@ -139,21 +136,42 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 		'mouseleave': '_hoveringEnd',
 	},
 
-	undoImageResize: function() {
-		if (this.imageBeingEdited !== null)
-			this.imageBeingEdited.restoreSize();
+	// Locate the image by name rather than storing a JS reference
+	// (this.imageBeingEdited). Object references go stale after re-renders
+	// because views are destroyed and recreated from meta.
+	undoImageResize: function(name) {
+		var targetImage = this.findImagePrimitive(name);
+		if (targetImage !== null)
+			targetImage.restoreSize();
 	},
 
+	// Applies the engine's image edit response to the corresponding image view.
+	// Fields updated:
+	//   revision — cache-busting, forces browser to reload the image
+	//   interactiveJsonData — plotly JSON for non-static plots
+	//   data — base64-encoded image PNG (the visible plot)
+	//   width/height — new dimensions from resize
 	insertNewImage: function(imageEditResults) {
-		if (this.imageBeingEdited !== null) {
+		var targetImage = null;
+		if (imageEditResults && imageEditResults.name) {
+			targetImage = this.findImagePrimitive(imageEditResults.name);
+		}
+		if (targetImage !== null) {
+			jasp.jsLog("insertNewImage: '" + imageEditResults.name + "' w=" + imageEditResults.width + " h=" + imageEditResults.height + " hasData=" + (!!imageEditResults.data) + " hasInteractive=" + (!!imageEditResults.interactiveJsonData));
+			var model = targetImage.model;
 			if ("revision" in imageEditResults)
-				this.imageBeingEdited.setRevision(imageEditResults["revision"]);
-
-			// Update the interactive plotly data so toggling to the interactive view shows the edited plot
+				targetImage.setRevision(imageEditResults["revision"]);
 			if ("interactiveJsonData" in imageEditResults && imageEditResults["interactiveJsonData"] !== null)
-				this.imageBeingEdited.model.set("interactiveJsonData", imageEditResults["interactiveJsonData"]);
-
-			this.imageBeingEdited.reRender();
+				model.set("interactiveJsonData", imageEditResults["interactiveJsonData"]);
+			if (imageEditResults.data)
+				model.set("data", imageEditResults.data);
+			if (imageEditResults.width)
+				model.set("width", imageEditResults.width);
+			if (imageEditResults.height)
+				model.set("height", imageEditResults.height);
+			targetImage.reRender();
+		} else {
+			jasp.jsLog("insertNewImage: SKIPPED — not found for '" + (imageEditResults ? imageEditResults.name : "null") + "'");
 		}
 	},
 
@@ -601,6 +619,28 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 	render: function () {
 
+		// Refresh userdata from the model while preserving in-flight local
+		// changes (e.g., a plot's interactive/static toggle) that may not
+		// have reached the C++ side yet via the async QWebChannel call.
+		//
+		// When the user toggles interactive/static, image.interactiveImageClicked:
+		//   1. Sets model properties (interactive, userInteractive)
+		//   2. Triggers "changed:userData" event -> onUserDataChanged -> setData
+		//   3. setData calls jasp.setUserData() via QWebChannel (async)
+		// If render() fires before the QWebChannel roundtrip completes, the
+		// model's userdata still has the old toggle state. $.extend(true, ...)
+		// overlays this.userdata.children (which has the correct in-flight local
+		// state) onto the fresh model data, so the toggle survives the race.
+		var fresh = this.model.get('userdata');
+		if (fresh) {
+			if (this.userdata && this.userdata.children && fresh.children) {
+				// Overlay local changes onto the model's fresh data so
+				// setData updates survive the round-trip race
+				$.extend(true, fresh.children, this.userdata.children);
+			}
+			this.userdata = fresh;
+		}
+
 		var results			= this.model.get("results");
 		var titleAnalysis	= this.model.get("title");
 
@@ -611,8 +651,6 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 				this.updateProgressbarInResults();
 			return this;
 		}
-
-		this.imageBeingEdited = null;
 
 		this.toolbar.$el.detach();
 		this.detachNotes();
@@ -698,6 +736,28 @@ JASPWidgets.AnalysisView = JASPWidgets.View.extend({
 
 		this.volatileViews = [];
 		this.views = [];
+	},
+
+	// Searches the volatile views tree for an imagePrimitive view whose
+	// model has the given name. "Primitive" refers to the low-level
+	// JASPWidgets.imagePrimitive view nested inside an imageView wrapper —
+	// this is the view that owns the DOM rendering.
+	findImagePrimitive: function(name) {
+		var found = null;
+		var searchViews = function(views) {
+			for (var i = 0; i < views.length && found === null; i++) {
+				var view = views[i];
+				if (!view) continue;
+				if (view.myView && view.model && view.model.get("name") === name) {
+					found = view.myView;
+					return;
+				}
+				if (view.views) searchViews(view.views);
+				if (view.localViews) searchViews(view.localViews);
+			}
+		};
+		searchViews(this.volatileViews);
+		return found;
 	},
 
 	onClose: function () {

--- a/Desktop/html/js/image.js
+++ b/Desktop/html/js/image.js
@@ -48,7 +48,12 @@ JASPWidgets.imageView = JASPWidgets.objectView.extend({
 	hasInteractive:				function() {	
 		if(!useInteractivePlots) 
 			return false; 
-		return this.model.get("interactiveJsonData") !== null && this.model.get("interactiveJsonData") !== undefined;	},
+		var ij = this.model.get("interactiveJsonData");
+		// Check for empty string: the engine serialises null JSON paths as "",
+		// which is not valid interactive data. Without this check, plots with
+		// no interactiveJsonData would spuriously show the "Interactive plot"
+		// toggle option.
+		return ij !== null && ij !== undefined && ij !== "";	},
 	saveImageClicked:			function() {	this.model.trigger("SaveImage:clicked",							{ data: this.model.get("data"), width: this.model.get("width"), height: this.model.get("height"), name: this.model.get("name")							});	},
 	editImageClicked:			function() {	this.model.trigger("EditImage:clicked",			this.myView,	{ data: this.model.get("data"), width: this.model.get("width"), height: this.model.get("height"), name: this.model.get("name"), title: this.model.get("title"), type: "interactive"		});	},
 	interactiveImageClicked:	function() {
@@ -61,10 +66,22 @@ JASPWidgets.imageView = JASPWidgets.objectView.extend({
 		
 		this.model.set("interactive",		!isCurrentlyInteractive);
 		this.model.set("userInteractive",	true);
-
+		
 		// Clear the current content and re-render
 		// this.myView.$el.empty();
 		this.myView.reRender();
+
+		// Persist the interactive/static toggle state through the userdata
+		// system. The changed:userData event bubbles to analysis.onUserDataChanged,
+		// which calls setData -> jasp.setUserData() via QWebChannel, eventually
+		// reaching C++ Analysis::setUserData. On next render, the state is
+		// restored from the model's userdata.
+		if (!this.settingUserData)
+			this.$el.trigger("changed:userData", [this.userDataDetails, [
+				{ key: 'collapsed', value: this.isCollapsed() },
+				{ key: 'userInteractive', value: this.model.get('userInteractive') },
+				{ key: 'interactive', value: this.model.get('interactive') }
+			]]);
 
 		return true;
 	},
@@ -95,6 +112,43 @@ JASPWidgets.imageView = JASPWidgets.objectView.extend({
 		this.views.push(imagePrimitive);
 
 		self.myView = imagePrimitive
+	},
+														  
+	// Overrides objectView.setUserData to handle image-specific properties
+	// (userInteractive, interactive) in addition to the standard collapsed
+	// state. This is necessary because the interactive/static toggle state
+	// lives on model properties that have no generic ancestor handling in
+	// objectView.
+	setUserData: function (details, data) {
+		this.userDataDetails = details;
+		this.settingUserData = true;
+		
+		if (data !== null) {
+			if (data.collapsed !== undefined)
+				this.model.set("collapsed", data.collapsed);
+			
+			if(data.userInteractive !== undefined)
+			{
+				this.model.set("userInteractive",	data.userInteractive)
+				this.model.set("interactive",		data.interactive)
+			}
+		}
+		
+		this.settingUserData = false;
+	},
+														  
+	// Complements objectView.getLocalUserData (which handles collapsed state
+	// and notes) with image-specific interactive toggle state. Called by
+	// analysis.getAllUserData during the userdata persistence walk.
+	getLocalUserData: function () 
+	{
+		if(!useInteractivePlots || !this.model.get("userInteractive"))
+			return null;
+		
+		return	{
+					userInteractive:	this.model.get("userInteractive"),
+					interactive:		this.model.get("interactive")
+				}
 	},
 });
 
@@ -217,11 +271,10 @@ JASPWidgets.imagePrimitive = JASPWidgets.View.extend({
 	render: function () {//interactive = false) {
 
 		var hasInteractiveError = this.model.get("interactiveConvertError") != ""
-		var hasInteractive		= !hasInteractiveError && this.model.get("interactiveJsonData") != "";
+		var hasInteractive		= !hasInteractiveError && this.model.get("interactiveJsonData") !== "";
 		
 		if (useInteractivePlots && hasInteractive && ((this.model.get("userInteractive") && this.model.get("interactive")) || (!this.model.get("userInteractive") && window.globSet.showInteractiveDefault))) {
 
-			console.log("image.js: this is where the post step to run the json happens!");
 			this.preRenderPlotly();
 
 			// Only call jQuery if there's no error

--- a/Desktop/html/js/main.js
+++ b/Desktop/html/js/main.js
@@ -59,13 +59,13 @@ $(document).ready(function () {
     if (analysis === undefined) return;
 
     if (imageEditResults.error && imageEditResults.resized)
-      analysis.undoImageResize();
+      analysis.undoImageResize(imageEditResults.name);
     else analysis.insertNewImage(imageEditResults);
   };
 
-  window.cancelImageEdit = function (id) {
+  window.cancelImageEdit = function (id, name) {
     var analysis = analyses.getAnalysis(id);
-    if (analysis !== undefined) analysis.undoImageResize();
+    if (analysis !== undefined) analysis.undoImageResize(name);
   };
 
   window.select = function (id, fromQML) {
@@ -111,7 +111,7 @@ $(document).ready(function () {
     analyses.setTitle(newTitle);
   };
 
-  window.setInteractivePlots = function (interactive) {
+  window.setUseInteractivePlots = function (interactive) {
     useInteractivePlots = interactive;
   };
   window.setAppVersion = function (version) {
@@ -646,7 +646,9 @@ $(document).ready(function () {
         jasp.showAnalysesMenu(JSON.stringify(options));
         window.menuObject = obj;
       });
-    } else jaspWidget.model.set(analysis);
+    } else {
+      jaspWidget.model.set(analysis);
+    }
 
     jaspWidget.setHasReport(analysis.hasReport);
 

--- a/Desktop/html/js/object.js
+++ b/Desktop/html/js/object.js
@@ -134,40 +134,24 @@ JASPWidgets.objectView = JASPWidgets.View.extend({
 		this.settingUserData = false;
 	},
 
-	getLocalUserData: function () {
-
-		var hasData = false;
-
+	getLocalUserData: function () 
+	{
 		var userData = {};
 
-		if (this.$el.hasClass('jasp-collapsed')) {
+		if (this.$el.hasClass('jasp-collapsed'))
 			userData.collapsed = true;
-			hasData = true;
-		}
 
-		if (this.noteBox && this.noteBox.visible) {
+		if (this.noteBox && this.noteBox.visible)
+			userData[this.noteBoxLocalKey] = 
+			{
+				text			: this.noteBox.isTextboxEmpty() ? '' : this.noteBox.model.get('text'),
+				format			: 'html',
+				visible			: this.noteBox.visible,
+				delta			: this.noteBox.model.get('delta'),
+				deltaAvailable	: this.noteBox.model.get('deltaAvailable')
+			}
 
-			var noteData = {};
-
-			if (this.noteBox.isTextboxEmpty())
-				noteData.text = '';
-			else
-				noteData.text = this.noteBox.model.get('text');
-
-			noteData.format = 'html';
-			noteData.visible = this.noteBox.visible;
-			noteData.delta = this.noteBox.model.get('delta');
-			noteData.deltaAvailable = this.noteBox.model.get('deltaAvailable')
-
-			userData[this.noteBoxLocalKey] = noteData;
-
-			hasData = true;
-		}
-
-		if (hasData)
-			return userData;
-		else
-			return null;
+		return Object.keys(userData).length > 0 ? userData : null
 	},
 
 	notesMenuClicked: function (noteType, visibility) {

--- a/Desktop/mainwindow.cpp
+++ b/Desktop/mainwindow.cpp
@@ -486,8 +486,8 @@ Q_DECLARE_METATYPE(columnType)
 void MainWindow::makeConnections()
 {
 	connect(this,					&MainWindow::saveJaspFile,							this,					&MainWindow::saveJaspFileHandler,							Qt::QueuedConnection);
-	connect(this,					&MainWindow::screenPPIChanged,						_preferences,			&PreferencesModel::setDefaultPPI							);
 	connect(this,					&MainWindow::editImageCancelled,					_resultsJsInterface,	&ResultsJsInterface::cancelImageEdit						);
+	connect(this,					&MainWindow::screenPPIChanged,						_preferences,			&PreferencesModel::setDefaultPPI							);
 	connect(this,					&MainWindow::dataAvailableChanged,					_dynamicModules,		&DynamicModules::setDataLoaded								);
 	connect(this,					&MainWindow::dataAvailableChanged,					_ribbonModel,			&RibbonModel::dataLoadedChanged								);
 	connect(this,					&MainWindow::dataAvailableChanged,					this,					&MainWindow::checkEmptyWorkspace							);
@@ -1481,7 +1481,11 @@ void MainWindow::analysisEditImageHandler(int id, QString options)
 		)
 			analysis->refresh();
 		else
-			emit editImageCancelled(id);
+		{
+			Json::Value opts;
+			Json::Reader().parse(fq(options), opts);
+			emit editImageCancelled(id, tq(opts.get("name", "").asString()));
+		}
 	}
 	else
 	{

--- a/Desktop/mainwindow.h
+++ b/Desktop/mainwindow.h
@@ -257,7 +257,7 @@ private:
 
 signals:
 	void saveJaspFile();
-	void editImageCancelled(		int			id);
+	void editImageCancelled(		int			id, QString name);
 	void updateAnalysesUserData(	QString		userData);
 	void runButtonTextChanged(		QString		runButtonText);
 	void runButtonEnabledChanged(	bool		runButtonEnabled);

--- a/Desktop/results/ploteditormodel.cpp
+++ b/Desktop/results/ploteditormodel.cpp
@@ -72,7 +72,7 @@ void PlotEditorModel::setup()
 	setWidth(				_imgOptions.get(	"width",		100).asInt());
 	setHeight(				_imgOptions.get(	"height",		100).asInt());
 
-	Json::Value editOptions		=	_name == "" || !_analysis ? Json::objectValue : _analysis->editOptionsOfPlot(_name.toStdString());
+	Json::Value editOptions		=	_name == "" || !_analysis ? Json::objectValue : _analysis->editOptionsOfPlotFromEdits(_name.toStdString());
 	editOptions["resetPlot"] = false;
 	_imgOptions["editOptions"] = editOptions;
 
@@ -163,7 +163,7 @@ void PlotEditorModel::updateOptions(Analysis *analysis)
 
 	int request = _analysis->imgResults()["request"].asInt();
 	const Json::Value& optionsSend = _editedImgsMap[request];
-	Json::Value optionsReceived = analysis->editOptionsOfPlot(_name.toStdString());
+	Json::Value optionsReceived = analysis->editOptionsOfPlotFromEdits(_name.toStdString());
 	// After editing a plot the engine returns the current edit options.
 	// These options may differ from the ones send to the engine (currently only when resetDefault is called, but later there could have other situation):
 	// in this case the plot editor options must be updated.

--- a/Desktop/results/resultsjsinterface.cpp
+++ b/Desktop/results/resultsjsinterface.cpp
@@ -87,7 +87,7 @@ void ResultsJsInterface::setResultsLoaded(bool resultsLoaded)
 
 		runJavaScript("window.setAppVersion('" + version + "')");
 #ifdef INTERACTIVE_PLOTS
-		runJavaScript("window.setInteractivePlots(true)");
+		runJavaScript("window.setUseInteractivePlots(true)");
 #endif
 
 		setGlobalJsValues();
@@ -172,6 +172,7 @@ void ResultsJsInterface::saveTempImage(int id, QString path, QByteArray data)
 void ResultsJsInterface::analysisImageEditedHandler(Analysis *analysis)
 {
 	Json::Value imgJson = analysis->imgResults();
+
 	QString	results = tq(imgJson.toStyledString());
 	results = escapeJavascriptString(results);
 	results = "window.refreshEditedImage(" + QString::number(analysis->id()) + ", JSON.parse('" + results + "'));";
@@ -180,9 +181,9 @@ void ResultsJsInterface::analysisImageEditedHandler(Analysis *analysis)
 	return;
 }
 
-void ResultsJsInterface::cancelImageEdit(int id)
+void ResultsJsInterface::cancelImageEdit(int id, const QString &name)
 {
-	runJavaScript("window.cancelImageEdit(" + QString::number(id) + ");");
+	runJavaScript("window.cancelImageEdit(" + QString::number(id) + ", '" + escapeJavascriptString(name) + "');");
 }
 
 void ResultsJsInterface::menuHiding()
@@ -454,6 +455,11 @@ void ResultsJsInterface::setFontFamily()
 		QString font = PreferencesModel::prefs()->resultFont(true);
 		runJavaScript("window.setFontFamily(\"" + escapeJavascriptString(font) + "\");");
 	}
+}
+
+void ResultsJsInterface::jsLog(QString msg)
+{
+	Log::log() << "JS: " << msg.toStdString() << std::endl;
 }
 
 void ResultsJsInterface::setLocale(QString localeId, bool thousandSeps)

--- a/Desktop/results/resultsjsinterface.h
+++ b/Desktop/results/resultsjsinterface.h
@@ -68,6 +68,7 @@ public:
 	Q_INVOKABLE void analysisEditImage(int id, QString options);
 	Q_INVOKABLE void exportAnalysisHTML(int analysisId);
 	Q_INVOKABLE void runJavaScript(const QString & js);
+	Q_INVOKABLE void jsLog(				QString msg);
 
 	//Callable from javascript through resultsJsInterfaceInterface...
 signals:
@@ -91,6 +92,7 @@ signals:
 				void prepForExport();
 	Q_INVOKABLE void exportPrepFinished();
 	Q_INVOKABLE void showRSyntaxInResults(	bool show);
+	
 
 
 public slots:
@@ -133,7 +135,7 @@ public slots:
 	void setShowInteractiveDefaultHandler(	bool			show);
 	void setFixDecimalsHandler(				QString			numDecimals);
 	void analysisImageEditedHandler(		Analysis	*	analysis);
-	void cancelImageEdit(					int				id);
+	void cancelImageEdit(					int				id, const QString & name);
 	void exportSelected(			const	QString		&	filename);
 	void setResultsPageUrl(					QString			resultsPageUrl);
 	// void setZoomInWebEngine();	// we use zoomFactor in webengine now, but let's not clean up it yet.

--- a/Engine/engine.cpp
+++ b/Engine/engine.cpp
@@ -811,7 +811,17 @@ void Engine::editImage()
 	Json::Reader().parse(result, _analysisResults, false);
 
 	if(_analysisResults.isMember("results"))
+	{
 		_analysisResults["results"]["request"] = _imageOptions.get("request", -1);
+		// When pngFile is present (jaspBase ≥ <next>), the true PNG path is
+		// provided by R and the hack is unnecessary. Older jaspBase builds won't
+		// have pngFile, so fall back to injecting the plot name as data so the
+		// C++/JS pipeline can still identify which image to update.
+		if (_analysisResults["results"].isMember("name")
+			&& !_analysisResults["results"].isMember("data")
+			&& !_analysisResults["results"].isMember("pngFile"))
+			_analysisResults["results"]["data"] = _analysisResults["results"]["name"];
+	}
 
 	_analysisStatus			= Status::complete;
 

--- a/QMLComponents/components/JASP/Controls/Form.qml
+++ b/QMLComponents/components/JASP/Controls/Form.qml
@@ -120,7 +120,7 @@ AnalysisForm
 		Rectangle
 		{
 			id:				oldFileMessagesBox
-			visible:		needsRefresh && form.hasVolatileNotes //Ill leave the text as is for now to avoid having to go back to the po again
+			visible:		needsRefresh && form.hasVolatileNotes
 			color:			jaspTheme.controlWarningBackgroundColor
 			width:			form.implicitWidth
 			height:			visible ? oldAnalysisText.height : 0

--- a/QMLComponents/controls/colorpickerbase.cpp
+++ b/QMLComponents/controls/colorpickerbase.cpp
@@ -3,7 +3,7 @@
 ColorPickerBase::ColorPickerBase(QQuickItem* parent)
 	: JASPControl(parent), BoundControlBase(this)
 {
-	_controlType = ControlType::CheckBox;
+	_controlType = ControlType::ColorPicker;
 }
 
 bool ColorPickerBase::isJsonValid(const Json::Value &value) const

--- a/QMLComponents/controls/colorpickerbase.h
+++ b/QMLComponents/controls/colorpickerbase.h
@@ -16,9 +16,6 @@ public:
 	bool		isJsonValid(const Json::Value& value)		const	override;
 	Json::Value createJson()								const	override;
 	QString		value()										const;
-
-protected:
-	QString		_value;
 };
 
 #endif // COLORPICKERBASE_H

--- a/QMLComponents/controls/rowcontrols.cpp
+++ b/QMLComponents/controls/rowcontrols.cpp
@@ -139,8 +139,13 @@ bool RowControls::addJASPControl(JASPControl *control)
 	else
 		success = true;
 
-	if (!control->name().isEmpty() && success)
-		_rowJASPControlMap[control->name()] = control;
+	if (success)
+	{
+		if (!control->name().isEmpty())
+			_rowJASPControlMap[control->name()] = control;
+		else
+			control->setUp();
+	}
 
 	return success;
 }

--- a/Tests/qmlTests/tst_repeatedMeasures.qml
+++ b/Tests/qmlTests/tst_repeatedMeasures.qml
@@ -1,0 +1,96 @@
+import QtTest
+import QtQuick
+import QtQuick.Controls
+import JASP.Controls
+
+
+TestCase
+{
+	name:		"TestVariablesListWithRowControls"
+
+	property alias form: jaspForm // The form must be in the context of the JASPControls
+
+	SignalSpy
+	{
+		id:				spyLoader
+		target:			jaspForm
+		signalName:		"formCompletedSignal"
+	}
+
+	SignalSpy
+	{
+		id:				spyFactorLevelListChanged
+		target:			repeatedMeasuresFactors.model
+		signalName:		"dataChanged"
+	}
+
+	SignalSpy
+	{
+		id:				spyRepeatedMeasuresCells
+		target:			repeatedMeasuresCells
+		signalName:		"columnsNamesChanged"
+	}
+
+
+	Form
+	{
+		id:		jaspForm
+
+		VariablesForm
+		{
+			AvailableVariablesList			{ name: "allVariablesList"; id: allVars }
+			FactorLevelList					{ name: "repeatedMeasuresFactors";	id: repeatedMeasuresFactors; title: qsTr("Repeated Measures Factors"); factorName: qsTr("RM Factor")		}
+			AssignedRepeatedMeasuresCells	{ name: "repeatedMeasuresCells";	id: repeatedMeasuresCells; title: qsTr("Repeated Measures Cells");	source: "repeatedMeasuresFactors"	}
+		}
+	}
+
+	function test_repeatedMeasures()
+	{
+		spyLoader.wait(1000)
+		compare(spyLoader.count, 1);
+		compare(allVars.count, dataSetInfo.variableCount,					"The Available VariablesList gets all variables");
+		compare(repeatedMeasuresFactors.factors.length, 1, "One default factor");
+		compare(repeatedMeasuresFactors.factors[0], "RM Factor 1", "Default factor name is \"RM Factor 1\"");
+		compare(repeatedMeasuresFactors.factorLevelMap["RM Factor 1"].length, 2, "2 default levels");
+		compare(repeatedMeasuresFactors.factorLevelMap["RM Factor 1"][0], "Level 1", "First default level is \"Level 1\"");
+		compare(repeatedMeasuresFactors.factorLevelMap["RM Factor 1"][1], "Level 2", "Second default level is \"Level 2\"");
+		compare(repeatedMeasuresCells.columnsNames.length, 2, "2 empty levels");
+		compare(repeatedMeasuresCells.count, 4, "2 empty levels + 2 empty cells");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(0,0)), "", "First row has Empty value");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(1,0)), "Level 1", "First row is Level 1");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(2,0)), "", "Second row has Empty value");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(3,0)), "Level 2", "Second row is Level 2");
+
+		spyFactorLevelListChanged.clear()
+		repeatedMeasuresFactors.model.itemChanged(1, "TEST 1")
+		spyFactorLevelListChanged.wait(400)
+		compare(repeatedMeasuresFactors.model.data(repeatedMeasuresFactors.model.index(1,0)), "TEST 1", "First Level is now TEST 1")
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(1,0)), "TEST 1", "First row is TEST 1");
+
+		spyFactorLevelListChanged.clear()
+		repeatedMeasuresFactors.model.itemChanged(3, "TEST 3")
+		spyFactorLevelListChanged.wait(400)
+		compare(repeatedMeasuresFactors.model.data(repeatedMeasuresFactors.model.index(3,0)), "TEST 3", "New Level is TEST 3")
+		compare(repeatedMeasuresFactors.model.data(repeatedMeasuresFactors.model.index(4,0)), "New Level", "New level is added")
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(5,0)), "TEST 3", "Third row is TEST 3");
+
+		spyFactorLevelListChanged.clear()
+		repeatedMeasuresFactors.model.itemChanged(5, "Extra Factor")
+		spyFactorLevelListChanged.wait(400)
+		compare(repeatedMeasuresFactors.factors.length, 2, "2 factors");
+		compare(repeatedMeasuresFactors.factors[0], "RM Factor 1", "First factor name is \"RM Factor 1\"");
+		compare(repeatedMeasuresFactors.factors[1], "Extra Factor", "Second factor name is \"Extra Factor\"");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(0,0)), "", "1st row has Empty value");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(1,0)), "TEST 1,Level 1", "1st row is TEST 1,Level 1");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(2,0)), "", "2nd row has Empty value");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(3,0)), "TEST 1,Level 2", "2nd row is TEST 1,Level 2");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(4,0)), "", "3rd row has Empty value");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(5,0)), "Level 2,Level 1", "3rd row is Level 2,Level 1");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(6,0)), "", "4th row has Empty value");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(7,0)), "Level 2,Level 2", "4th row is Level 2,Level 2");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(8,0)), "", "5th row has Empty value");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(9,0)), "TEST 3,Level 1", "5th row is TEST 3,Level 1");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(10,0)), "", "6th row has Empty value");
+		compare(repeatedMeasuresCells.model.data(repeatedMeasuresCells.model.index(11,0)), "TEST 3,Level 2", "6th row is TEST 3,Level 2");
+	}
+}


### PR DESCRIPTION
… plot edit persistence

Net diff of upstream branch fixRefsInteractivePlotsPersistence (31 commits) merged onto v0.98.1-dev, keeping our TDK build config, module sets, translations and test library, and keeping static plots as the default.

Core changes:
- Analysis::_plotEdits is now the sole authority for user plot edits (editOptions + width/height) and is persisted in .jasp files; restored on load and re-applied after analysis re-runs (two-phase restore: applyPlotEdits + applyPlotReEdits).
- editImage serialized through a queue (one engine RPC in flight); imageEdited deep-merges engine editOptions with user edits so stale engine responses no longer clobber customizations; resize-only requests deduplicated; request-ID retry hack removed.
- Engine/jaspBase bumped to 71e9a4b: R editImage now returns the edited plot options (was returning the original plot) and adds pngFile/jsonFile/uniqueName to the response; engine.cpp adds a compat fallback for older jaspBase.
- Results view JS: edits locate the target image by name instead of stale object refs; interactive/static toggle persisted via userdata (INTERNAL-jasp#3200); cancelImageEdit/undoImageResize take plot name; empty interactiveJsonData no longer shows a bogus interactive toggle; setInteractivePlots renamed to setUseInteractivePlots.
- PlotEditorModel reads edit options from _plotEdits (falls back to engine results), fixing NaN fields when no stored edits exist.
- QMLComponents: ColorPickerBase control type fixed (CheckBox ->
  ColorPicker); RowControls::addJASPControl calls setUp() for unnamed controls; PlotEditingReferenceLines text field widened.
- New QML test tst_repeatedMeasures.qml.

Defaults: showInteractiveDefault stays false (static plots unless the user toggles interactive); INTERACTIVE_PLOTS=TRUE, PRO TDK unchanged.

