### PR TITLE
Fix Thread issue when importing data.

### DIFF
--- a/CommonData/datasetbasenode.cpp
+++ b/CommonData/datasetbasenode.cpp
@@ -1,5 +1,6 @@
 #include "log.h"
 #include <QThread>
+#include <QPointer>
 #include "dataenums.h"
 #include "datasetbasenode.h"
 #include <QGuiApplication>
@@ -7,12 +8,32 @@
 DataSetBaseNode::DataSetBaseNode(dataSetBaseNodeType typeNode, QObject * parent) 
 	: QAbstractTableModel(nullptr), _type(typeNode), _nodeAbove(dynamic_cast<DataSetBaseNode *>(parent))
 {
-	if(QGuiApplication::instance())
-		this->moveToThread(QGuiApplication::instance()->thread());
-	else if(parent && parent->thread() != QThread::currentThread())
-		this->moveToThread(parent->thread());
+	//Nodes are built by the importers on the AsyncLoader (and QThreadPool) threads but must live on
+	//the GUI thread, because they are QAbstractItemModels that QML binds to.
+	QThread * target =	QGuiApplication::instance()	? QGuiApplication::instance()->thread()
+						:	parent						? parent->thread()
+						:							  thread();
 
-	setParent(parent);
+	if(thread() != target)
+		moveToThread(target);
+
+	//QObject::setParent() sends a ChildAdded event to the parent, and QCoreApplication::sendEvent()
+	//asserts (in debug builds) when called from a thread other than the one owning the receiver.
+	//The moveToThread() above already made our affinity match the parent's, so Qt's own "new parent
+	//is in a different thread" guard no longer catches this and the assert fires for every
+	//Column/Label/DataSet created during an import. Hand the parenting to the parent's thread instead.
+	//Only the QObject ownership is deferred; the node tree (_nodeAbove/registerNode below) is still
+	//wired up synchronously, and DataSetBaseNode::parent() returns _nodeAbove anyway.
+	if(parent)
+	{
+		if(QThread::currentThread() == target)
+			setParent(parent);
+		else
+		{
+			QPointer<DataSetBaseNode> self(this); //We might be destroyed again before the GUI thread gets round to this
+			QMetaObject::invokeMethod(parent, [self, parent]() { if(self) self->setParent(parent); }, Qt::QueuedConnection);
+		}
+	}
 	
 	if(_nodeAbove)
 		_nodeAbove->registerNode(this);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/3308

The mechanism

CommonData/datasetbasenode.cpp:9:

```
DataSetBaseNode::DataSetBaseNode(dataSetBaseNodeType typeNode, QObject * parent)
	: QAbstractTableModel(nullptr), _type(typeNode), _nodeAbove(dynamic_cast<DataSetBaseNode *>(parent))
{
	if(QGuiApplication::instance())
		this->moveToThread(QGuiApplication::instance()->thread());   // → GUI thread
	...
	setParent(parent);                                              // ← called on the *loader* thread
}

```
Every node (DataSet, Column, Label, Filter, Workspace) is force-moved to the GUI thread, and then setParent() is called from whatever thread is constructing it. In Qt 6, QObject::setParent → QObjectPrivate::setParent_helper:

```
if (threadData.loadAcquire() != parent->d_func()->threadData.loadAcquire()) {
    qWarning("QObject::setParent: Cannot set parent, new parent is in a different thread");
    parent = nullptr; return;                    // ← guard passes, both are GUI-thread now
}
parent->d_func()->children.append(q);
QChildEvent e(QEvent::ChildAdded, q);
QCoreApplication::sendEvent(parent, &e);          // ← boom

```
sendEvent → doNotify → QCoreApplicationPrivate::checkReceiverThread(), which is the Q_ASSERT_X(currentThread == thr || !thr, "QCoreApplication::sendEvent", "Cannot send events to objects owned by a different thread…") at qcoreapplication.cpp:547. It's inside #ifndef QT_NO_DEBUG — hence debug-only.

The moveToThread is what makes this fatal rather than merely noisy: without it, Qt's own guard would have printed a warning and dropped the parent. By pre-matching both thread affinities to the GUI thread, the guard is satisfied and execution reaches sendEvent from the wrong thread.

Why loading a CSV triggers it

CSV import runs on the loader thread — _loader->moveToThread(&_loaderThread) at Desktop/mainwindow.cpp:458, and beginLoad is a QueuedConnection into AsyncLoader::loadTask. So the whole chain below executes off the GUI thread:

Desktop/data/datasetloader.cpp:78 createDataSet() → CommonData/workspace.cpp:412 new DataSet(this) — only if the current shown dataset isn't empty
importer->loadDataSet() → dataSet->setColumnCount() → CommonData/dataset.cpp:438 new Column(this, colIds[c]) — this is the one that fires on a fresh start, since Workspace::createDataSet returns the existing empty sheet early
then, on top of that, InitColumnTask::run() (Desktop/data/importers/importer.cpp:46) runs on QThreadPool threads and creates labels via CommonData/column.cpp:1265 new Label(this, …) — same assert, from yet another thread

Introduced in 85024a2c0 ("Data set q etc" #5783), when DataSetBaseNode became a QAbstractTableModel.

Fix

The parenting has to happen on the thread that owns the parent. _nodeAbove/registerNode already carry the logical tree synchronously, and DataSetBaseNode::parent() shadows QObject::parent(), so the QObject parent is only doing ownership/QML duty — it can be set late:

```
QThread * target = QGuiApplication::instance() ? QGuiApplication::instance()->thread()
                 : (parent ? parent->thread() : thread());

if(thread() != target)
	moveToThread(target);

if(parent)
{
	if(QThread::currentThread() == target)	setParent(parent);
	else									QMetaObject::invokeMethod(parent, [this, parent]{ setParent(parent); }, Qt::QueuedConnection);
}
```

Note the destructors (dataset.cpp:89, column.cpp:47) only unregisterNode children and rely on QObject ownership for the actual delete, so simply dropping setParent would leak — the deferred call is needed rather than removal.
