### PR TITLE
Refresh plot should restore the reference lines

### DIFF
--- a/Desktop/analysis/analysis.cpp
+++ b/Desktop/analysis/analysis.cpp
@@ -545,19 +545,23 @@ std::set<std::string> Analysis::applyPlotEdits()
 		{
 			// _plotEdits is now the sole authority for editOptions.
 			// _results stays pure engine output — never patched by us.
-			// Merge new top-level keys from the engine's fresh editOptions
-			// into _plotEdits so it stays complete without overwriting
-			// user-set values.
+			// Merge only the keys the stored edits do not have yet, so a fresh run can add what
+			// it newly describes (a "reasonNotEditable" for instance) while everything the user
+			// set stays theirs. Taking the engine's value whenever it differs would undo exactly
+			// the keys the user changed, which is what an edit is.
 			Json::Value engineEditOpts;
 			if (_editOptionsOfPlot(_results, uniqueName, engineEditOpts))
-			{
 				for (const std::string & key : engineEditOpts.getMemberNames())
-					if (!_plotEdits[uniqueName]["editOptions"].isMember(key) || _plotEdits[uniqueName]["editOptions"][key] != engineEditOpts[key])
-					{
+					if (!_plotEdits[uniqueName]["editOptions"].isMember(key))
 						_plotEdits[uniqueName]["editOptions"][key] = engineEditOpts[key];
-						reEditNames.insert(uniqueName);
-					}
-			}
+
+			// A re-run hands us a plain plot: jaspBase deliberately does not re-apply earlier
+			// edits to a freshly drawn figure (see the disabled block in writeImage.R), so every
+			// edited plot needs its edits rendered onto the new one again. Flagging only the plots
+			// whose options differ from the engine's would miss precisely the edits the engine
+			// knows nothing about: reference lines exist only in the editOptions the desktop
+			// sends, never in the ones it receives, so nothing about them can ever differ.
+			reEditNames.insert(uniqueName);
 		}
 
 		if (edit.isMember("width") && edit.isMember("height"))


### PR DESCRIPTION
This problem does not occur on development, but apparently by accident:

Development works by accident.

The difference is a tdk-only jaspBase commit, d9dffce — "Fix editImage returning original plot options instead of edited ones". It changed one line in editImage:

-      editOptions = jaspGraphs::plotEditingOptions(plot),                  # the ORIGINAL, pre-edit plot
+      editOptions = jaspGraphs::plotEditingOptions(jaspPlotCPP$plotObject) # the EDITED plot

That matters because jaspGraphs answers those two calls very differently:

Edited plot (tdk): getPlotEditingOptions.gg finds .____plotEditingOptions____$oldOptions and returns the options the desktop just sent, verbatim — references included.
Unedited plot (development): it computes fresh ones — {xAxis, yAxis, error}, desktop shapes nowhere in sight.

Then imageEdited deep-merges the response with the user's edit and stores the result as _plotEdits[name]["editOptions"]. So:

On tdk, stored = the desktop's own options echoed straight back.
On development, stored = the engine's pre-edit options unioned with the desktop's (deepOverwrite recurses into xAxis/yAxis, so the result carries keys from both shapes).

Now the trigger, which asks "does any key of the engine's fresh editOptions differ from the stored one?":

On development the stored xAxis is that union — structurally it cannot match the engine's freshly computed xAxis, so something always differs, the re-edit always fires, and the references ride along because they were never clobbered. It works, but for a reason that has nothing to do with reference lines.
On tdk, f1f74b3a7 removed exactly that pollution. Stored options now round-trip cleanly, so when you haven't touched the axes nothing differs — and the trigger goes silent.

So f1f74b3a7 is a genuine fix (its own message notes the old behaviour was "corrupting the user's plot customizations"), and it removed the accident that was hiding the desktop-side bug. The bug was always there.

What's proven vs. inferred: the code facts are verified — identical applyPlotEdits, the guard being load-time only, the d9dffce one-liner, and what jaspGraphs returns in each case. The causal link — that the union shape is what keeps the comparison unequal on development — is inferred from those, not measured. If you want it nailed down, the cheapest check is a saved .jasp from each branch: the plotEdits block in analyses.json should show a fatter xAxis on development than on tdk.